### PR TITLE
feat(kafka-explorer): add message browsing and live tail

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/pom.xml
@@ -59,6 +59,14 @@
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-sse</artifactId>
+        </dependency>
 
         <!-- Jackson -->
         <dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
@@ -38,6 +38,7 @@ public interface KafkaClusterDomainService {
         String offsetMode,
         Long offsetValue,
         String keyFilter,
+        String valueFilter,
         int limit
     );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.kafkaexplorer.domain.domain_service;
 
 import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrowseMessagesResult;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupsPage;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
@@ -30,4 +31,13 @@ public interface KafkaClusterDomainService {
     BrokerInfo describeBroker(KafkaClusterConfiguration config, int brokerId);
     ConsumerGroupsPage listConsumerGroups(KafkaClusterConfiguration config, String nameFilter, String topicFilter, int page, int perPage);
     ConsumerGroupDetail describeConsumerGroup(KafkaClusterConfiguration config, String groupId);
+    BrowseMessagesResult browseMessages(
+        KafkaClusterConfiguration config,
+        String topicName,
+        Integer partition,
+        String offsetMode,
+        Long offsetValue,
+        String keyFilter,
+        int limit
+    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
@@ -41,4 +41,14 @@ public interface KafkaClusterDomainService {
         String valueFilter,
         int limit
     );
+    void tailMessages(
+        KafkaClusterConfiguration config,
+        String topicName,
+        Integer partition,
+        String keyFilter,
+        String valueFilter,
+        int maxMessages,
+        int durationSeconds,
+        MessageConsumer consumer
+    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/MessageConsumer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/MessageConsumer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.domain_service;
+
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaMessage;
+
+/**
+ * Callback for streaming Kafka messages.
+ * Returns false if the client has disconnected and the tail should stop.
+ */
+@FunctionalInterface
+public interface MessageConsumer {
+    boolean accept(KafkaMessage message);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/BrowseMessagesResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/BrowseMessagesResult.java
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.kafkaexplorer.domain.exception;
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
 
-public enum TechnicalCode {
-    INVALID_PARAMETERS,
-    CONNECTION_FAILED,
-    AUTHENTICATION_FAILED,
-    TIMEOUT,
-    INTERRUPTED,
-    TOPIC_NOT_FOUND,
-}
+import java.util.List;
+
+public record BrowseMessagesResult(List<KafkaMessage> messages, int totalFetched) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/KafkaHeader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/KafkaHeader.java
@@ -13,13 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.kafkaexplorer.domain.exception;
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
 
-public enum TechnicalCode {
-    INVALID_PARAMETERS,
-    CONNECTION_FAILED,
-    AUTHENTICATION_FAILED,
-    TIMEOUT,
-    INTERRUPTED,
-    TOPIC_NOT_FOUND,
-}
+public record KafkaHeader(String key, String value) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/KafkaMessage.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/model/KafkaMessage.java
@@ -13,13 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.kafkaexplorer.domain.exception;
+package io.gravitee.rest.api.kafkaexplorer.domain.model;
 
-public enum TechnicalCode {
-    INVALID_PARAMETERS,
-    CONNECTION_FAILED,
-    AUTHENTICATION_FAILED,
-    TIMEOUT,
-    INTERRUPTED,
-    TOPIC_NOT_FOUND,
-}
+import java.util.List;
+
+public record KafkaMessage(int partition, long offset, long timestamp, String key, String value, List<KafkaHeader> headers) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/BrowseMessagesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/BrowseMessagesUseCase.java
@@ -48,6 +48,7 @@ public class BrowseMessagesUseCase {
             input.offsetMode(),
             input.offsetValue(),
             input.keyFilter(),
+            input.valueFilter(),
             input.limit()
         );
         return new Output(result);
@@ -61,6 +62,7 @@ public class BrowseMessagesUseCase {
         String offsetMode,
         Long offsetValue,
         String keyFilter,
+        String valueFilter,
         int limit
     ) {}
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/BrowseMessagesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/BrowseMessagesUseCase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
+import io.gravitee.rest.api.kafkaexplorer.domain.UseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrowseMessagesResult;
+
+@UseCase
+public class BrowseMessagesUseCase {
+
+    private final ClusterCrudService clusterCrudService;
+    private final KafkaClusterDomainService kafkaClusterDomainService;
+    private final ObjectMapper objectMapper;
+
+    public BrowseMessagesUseCase(
+        ClusterCrudService clusterCrudService,
+        KafkaClusterDomainService kafkaClusterDomainService,
+        ObjectMapper objectMapper
+    ) {
+        this.clusterCrudService = clusterCrudService;
+        this.kafkaClusterDomainService = kafkaClusterDomainService;
+        this.objectMapper = objectMapper;
+    }
+
+    public Output execute(Input input) {
+        var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
+        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var result = kafkaClusterDomainService.browseMessages(
+            config,
+            input.topicName(),
+            input.partition(),
+            input.offsetMode(),
+            input.offsetValue(),
+            input.keyFilter(),
+            input.limit()
+        );
+        return new Output(result);
+    }
+
+    public record Input(
+        String clusterId,
+        String environmentId,
+        String topicName,
+        Integer partition,
+        String offsetMode,
+        Long offsetValue,
+        String keyFilter,
+        int limit
+    ) {}
+
+    public record Output(BrowseMessagesResult browseMessagesResult) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/TailMessagesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/TailMessagesUseCase.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
+import io.gravitee.rest.api.kafkaexplorer.domain.UseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
+import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.MessageConsumer;
+
+@UseCase
+public class TailMessagesUseCase {
+
+    private final ClusterCrudService clusterCrudService;
+    private final KafkaClusterDomainService kafkaClusterDomainService;
+    private final ObjectMapper objectMapper;
+
+    public TailMessagesUseCase(
+        ClusterCrudService clusterCrudService,
+        KafkaClusterDomainService kafkaClusterDomainService,
+        ObjectMapper objectMapper
+    ) {
+        this.clusterCrudService = clusterCrudService;
+        this.kafkaClusterDomainService = kafkaClusterDomainService;
+        this.objectMapper = objectMapper;
+    }
+
+    public void execute(Input input, MessageConsumer consumer) {
+        var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
+        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        kafkaClusterDomainService.tailMessages(
+            config,
+            input.topicName(),
+            input.partition(),
+            input.keyFilter(),
+            input.valueFilter(),
+            input.maxMessages(),
+            input.durationSeconds(),
+            consumer
+        );
+    }
+
+    public record Input(
+        String clusterId,
+        String environmentId,
+        String topicName,
+        Integer partition,
+        String keyFilter,
+        String valueFilter,
+        int maxMessages,
+        int durationSeconds
+    ) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
@@ -28,6 +28,7 @@ import io.gravitee.plugin.configurations.ssl.pem.PEMTrustStore;
 import io.gravitee.plugin.configurations.ssl.pkcs12.PKCS12KeyStore;
 import io.gravitee.plugin.configurations.ssl.pkcs12.PKCS12TrustStore;
 import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
+import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.MessageConsumer;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerDetail;
@@ -367,11 +368,19 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
             Map<String, Map<TopicPartition, OffsetAndMetadata>> allOffsets;
             if (hasTopicFilter) {
                 // Resolve topic partitions once to restrict the offset fetch to this topic only
-                TopicDescription topicDesc = adminClient
-                    .describeTopics(List.of(topicFilter))
-                    .allTopicNames()
-                    .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                    .get(topicFilter);
+                TopicDescription topicDesc;
+                try {
+                    topicDesc = adminClient
+                        .describeTopics(List.of(topicFilter))
+                        .allTopicNames()
+                        .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                        .get(topicFilter);
+                } catch (ExecutionException e) {
+                    if (e.getCause() instanceof org.apache.kafka.common.errors.UnknownTopicOrPartitionException) {
+                        return new ConsumerGroupsPage(List.of(), 0, page, perPage);
+                    }
+                    throw e;
+                }
                 List<TopicPartition> topicPartitions = topicDesc
                     .partitions()
                     .stream()
@@ -478,42 +487,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
         String valueFilter,
         int limit
     ) {
-        // First, use AdminClient to verify topic exists and get partition info
-        List<TopicPartition> targetPartitions = withAdminClient(config, adminClient -> {
-            TopicDescription description;
-            try {
-                description = adminClient
-                    .describeTopics(List.of(topicName))
-                    .allTopicNames()
-                    .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                    .get(topicName);
-            } catch (ExecutionException e) {
-                if (e.getCause() instanceof org.apache.kafka.common.errors.UnknownTopicOrPartitionException) {
-                    throw new KafkaExplorerException("Topic '" + topicName + "' not found", TechnicalCode.TOPIC_NOT_FOUND, e);
-                }
-                throw e;
-            }
-
-            if (description == null) {
-                throw new KafkaExplorerException("Topic '" + topicName + "' not found", TechnicalCode.TOPIC_NOT_FOUND);
-            }
-
-            if (partition != null) {
-                if (partition < 0 || partition >= description.partitions().size()) {
-                    throw new KafkaExplorerException(
-                        "Partition " + partition + " does not exist for topic '" + topicName + "'",
-                        TechnicalCode.INVALID_PARAMETERS
-                    );
-                }
-                return List.of(new TopicPartition(topicName, partition));
-            }
-
-            return description
-                .partitions()
-                .stream()
-                .map(p -> new TopicPartition(topicName, p.partition()))
-                .toList();
-        });
+        List<TopicPartition> targetPartitions = resolvePartitions(config, topicName, partition);
 
         // Then, use Consumer to fetch messages
         return withConsumer(config, limit * targetPartitions.size(), consumer -> {
@@ -571,14 +545,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
 
             List<KafkaMessage> allMessages = new ArrayList<>();
             for (ConsumerRecord<String, String> record : records) {
-                List<KafkaHeader> headers = new ArrayList<>();
-                for (Header header : record.headers()) {
-                    String headerValue = header.value() != null ? new String(header.value()) : null;
-                    headers.add(new KafkaHeader(header.key(), headerValue));
-                }
-                allMessages.add(
-                    new KafkaMessage(record.partition(), record.offset(), record.timestamp(), record.key(), record.value(), headers)
-                );
+                allMessages.add(toKafkaMessage(record));
             }
 
             int totalFetched = allMessages.size();
@@ -608,6 +575,98 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
 
             return new BrowseMessagesResult(allMessages, totalFetched);
         });
+    }
+
+    @Override
+    public void tailMessages(
+        KafkaClusterConfiguration config,
+        String topicName,
+        Integer partition,
+        String keyFilter,
+        String valueFilter,
+        int maxMessages,
+        int durationSeconds,
+        MessageConsumer consumer
+    ) {
+        List<TopicPartition> targetPartitions = resolvePartitions(config, topicName, partition);
+
+        withConsumer(config, 500, kafkaConsumer -> {
+            kafkaConsumer.assign(targetPartitions);
+            kafkaConsumer.seekToEnd(targetPartitions);
+
+            long deadline = System.currentTimeMillis() + (durationSeconds * 1000L);
+            int sent = 0;
+            String lowerKeyFilter = (keyFilter != null && !keyFilter.isBlank()) ? keyFilter.toLowerCase() : null;
+            String lowerValueFilter = (valueFilter != null && !valueFilter.isBlank()) ? valueFilter.toLowerCase() : null;
+
+            while (System.currentTimeMillis() < deadline && sent < maxMessages) {
+                ConsumerRecords<String, String> records = kafkaConsumer.poll(Duration.ofMillis(500));
+                for (ConsumerRecord<String, String> record : records) {
+                    KafkaMessage msg = toKafkaMessage(record);
+
+                    if (lowerKeyFilter != null && (msg.key() == null || !msg.key().toLowerCase().contains(lowerKeyFilter))) {
+                        continue;
+                    }
+                    if (lowerValueFilter != null && (msg.value() == null || !msg.value().toLowerCase().contains(lowerValueFilter))) {
+                        continue;
+                    }
+
+                    if (!consumer.accept(msg)) {
+                        return null;
+                    }
+                    sent++;
+                    if (sent >= maxMessages) break;
+                }
+            }
+            return null;
+        });
+    }
+
+    private List<TopicPartition> resolvePartitions(KafkaClusterConfiguration config, String topicName, Integer partition) {
+        return withAdminClient(config, adminClient -> {
+            TopicDescription description;
+            try {
+                description = adminClient
+                    .describeTopics(List.of(topicName))
+                    .allTopicNames()
+                    .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .get(topicName);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof org.apache.kafka.common.errors.UnknownTopicOrPartitionException) {
+                    throw new KafkaExplorerException("Topic '" + topicName + "' not found", TechnicalCode.TOPIC_NOT_FOUND, e);
+                }
+                throw e;
+            }
+
+            if (description == null) {
+                throw new KafkaExplorerException("Topic '" + topicName + "' not found", TechnicalCode.TOPIC_NOT_FOUND);
+            }
+
+            if (partition != null) {
+                if (partition < 0 || partition >= description.partitions().size()) {
+                    throw new KafkaExplorerException(
+                        "Partition " + partition + " does not exist for topic '" + topicName + "'",
+                        TechnicalCode.INVALID_PARAMETERS
+                    );
+                }
+                return List.of(new TopicPartition(topicName, partition));
+            }
+
+            return description
+                .partitions()
+                .stream()
+                .map(p -> new TopicPartition(topicName, p.partition()))
+                .toList();
+        });
+    }
+
+    private KafkaMessage toKafkaMessage(ConsumerRecord<String, String> record) {
+        List<KafkaHeader> headers = new ArrayList<>();
+        for (Header header : record.headers()) {
+            String headerValue = header.value() != null ? new String(header.value()) : null;
+            headers.add(new KafkaHeader(header.key(), headerValue));
+        }
+        return new KafkaMessage(record.partition(), record.offset(), record.timestamp(), record.key(), record.value(), headers);
     }
 
     @FunctionalInterface

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
@@ -475,6 +475,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
         String offsetMode,
         Long offsetValue,
         String keyFilter,
+        String valueFilter,
         int limit
     ) {
         // First, use AdminClient to verify topic exists and get partition info
@@ -588,6 +589,15 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
                 allMessages = allMessages
                     .stream()
                     .filter(m -> m.key() != null && m.key().toLowerCase().contains(lowerFilter))
+                    .toList();
+            }
+
+            // Apply value filter if provided
+            if (valueFilter != null && !valueFilter.isBlank()) {
+                String lowerFilter = valueFilter.toLowerCase();
+                allMessages = allMessages
+                    .stream()
+                    .filter(m -> m.value() != null && m.value().toLowerCase().contains(lowerFilter))
                     .toList();
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
@@ -33,12 +33,15 @@ import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerLogDirEntry;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrowseMessagesResult;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroup;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupMember;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupOffset;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupsPage;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaHeader;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaMessage;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaTopic;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.MemberAssignment;
@@ -75,13 +78,20 @@ import org.apache.kafka.clients.admin.ListTopicsOptions;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -455,6 +465,179 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
 
             return new ConsumerGroupDetail(groupId, state, coordinator, partitionAssignor, members, offsets);
         });
+    }
+
+    @Override
+    public BrowseMessagesResult browseMessages(
+        KafkaClusterConfiguration config,
+        String topicName,
+        Integer partition,
+        String offsetMode,
+        Long offsetValue,
+        String keyFilter,
+        int limit
+    ) {
+        // First, use AdminClient to verify topic exists and get partition info
+        List<TopicPartition> targetPartitions = withAdminClient(config, adminClient -> {
+            TopicDescription description;
+            try {
+                description = adminClient
+                    .describeTopics(List.of(topicName))
+                    .allTopicNames()
+                    .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .get(topicName);
+            } catch (ExecutionException e) {
+                if (e.getCause() instanceof org.apache.kafka.common.errors.UnknownTopicOrPartitionException) {
+                    throw new KafkaExplorerException("Topic '" + topicName + "' not found", TechnicalCode.TOPIC_NOT_FOUND, e);
+                }
+                throw e;
+            }
+
+            if (description == null) {
+                throw new KafkaExplorerException("Topic '" + topicName + "' not found", TechnicalCode.TOPIC_NOT_FOUND);
+            }
+
+            if (partition != null) {
+                if (partition < 0 || partition >= description.partitions().size()) {
+                    throw new KafkaExplorerException(
+                        "Partition " + partition + " does not exist for topic '" + topicName + "'",
+                        TechnicalCode.INVALID_PARAMETERS
+                    );
+                }
+                return List.of(new TopicPartition(topicName, partition));
+            }
+
+            return description
+                .partitions()
+                .stream()
+                .map(p -> new TopicPartition(topicName, p.partition()))
+                .toList();
+        });
+
+        // Then, use Consumer to fetch messages
+        return withConsumer(config, limit * targetPartitions.size(), consumer -> {
+            consumer.assign(targetPartitions);
+
+            String mode = offsetMode != null ? offsetMode : "NEWEST";
+            switch (mode) {
+                case "OLDEST":
+                    consumer.seekToBeginning(targetPartitions);
+                    break;
+                case "TIMESTAMP":
+                    if (offsetValue == null) {
+                        throw new KafkaExplorerException(
+                            "offsetValue is required when offsetMode is TIMESTAMP",
+                            TechnicalCode.INVALID_PARAMETERS
+                        );
+                    }
+                    Map<TopicPartition, Long> timestampMap = new HashMap<>();
+                    for (TopicPartition tp : targetPartitions) {
+                        timestampMap.put(tp, offsetValue);
+                    }
+                    Map<TopicPartition, OffsetAndTimestamp> timestampOffsets = consumer.offsetsForTimes(timestampMap);
+                    for (TopicPartition tp : targetPartitions) {
+                        OffsetAndTimestamp oat = timestampOffsets.get(tp);
+                        if (oat != null) {
+                            consumer.seek(tp, oat.offset());
+                        } else {
+                            consumer.seekToEnd(List.of(tp));
+                        }
+                    }
+                    break;
+                case "SPECIFIC":
+                    if (offsetValue == null) {
+                        throw new KafkaExplorerException(
+                            "offsetValue is required when offsetMode is SPECIFIC",
+                            TechnicalCode.INVALID_PARAMETERS
+                        );
+                    }
+                    for (TopicPartition tp : targetPartitions) {
+                        consumer.seek(tp, offsetValue);
+                    }
+                    break;
+                case "NEWEST":
+                default:
+                    Map<TopicPartition, Long> endOffsets = consumer.endOffsets(targetPartitions);
+                    for (TopicPartition tp : targetPartitions) {
+                        long endOffset = endOffsets.getOrDefault(tp, 0L);
+                        consumer.seek(tp, Math.max(0, endOffset - limit));
+                    }
+                    break;
+            }
+
+            // Poll messages
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(TIMEOUT_SECONDS));
+
+            List<KafkaMessage> allMessages = new ArrayList<>();
+            for (ConsumerRecord<String, String> record : records) {
+                List<KafkaHeader> headers = new ArrayList<>();
+                for (Header header : record.headers()) {
+                    String headerValue = header.value() != null ? new String(header.value()) : null;
+                    headers.add(new KafkaHeader(header.key(), headerValue));
+                }
+                allMessages.add(
+                    new KafkaMessage(record.partition(), record.offset(), record.timestamp(), record.key(), record.value(), headers)
+                );
+            }
+
+            int totalFetched = allMessages.size();
+
+            // Apply key filter if provided
+            if (keyFilter != null && !keyFilter.isBlank()) {
+                String lowerFilter = keyFilter.toLowerCase();
+                allMessages = allMessages
+                    .stream()
+                    .filter(m -> m.key() != null && m.key().toLowerCase().contains(lowerFilter))
+                    .toList();
+            }
+
+            // Limit results
+            if (allMessages.size() > limit) {
+                allMessages = allMessages.subList(0, limit);
+            }
+
+            return new BrowseMessagesResult(allMessages, totalFetched);
+        });
+    }
+
+    @FunctionalInterface
+    private interface ConsumerAction<T> {
+        T execute(KafkaConsumer<String, String> consumer) throws Exception;
+    }
+
+    private <T> T withConsumer(KafkaClusterConfiguration config, int maxPollRecords, ConsumerAction<T> action) {
+        List<Path> tempFiles = new ArrayList<>();
+        Properties properties = buildConsumerProperties(config, maxPollRecords, tempFiles);
+        try (KafkaConsumer<String, String> consumer = createConsumer(properties)) {
+            return action.execute(consumer);
+        } catch (ExecutionException e) {
+            throw handleExecutionException(e);
+        } catch (TimeoutException e) {
+            throw new KafkaExplorerException("Connection to Kafka cluster timed out", TechnicalCode.TIMEOUT, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExplorerException("Connection to Kafka cluster was interrupted", TechnicalCode.INTERRUPTED, e);
+        } catch (KafkaExplorerException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new KafkaExplorerException("Failed to connect to Kafka cluster", TechnicalCode.CONNECTION_FAILED, e);
+        } finally {
+            deleteTempFiles(tempFiles);
+        }
+    }
+
+    protected KafkaConsumer<String, String> createConsumer(Properties properties) {
+        return new KafkaConsumer<>(properties);
+    }
+
+    private Properties buildConsumerProperties(KafkaClusterConfiguration config, int maxPollRecords, List<Path> tempFiles) {
+        Properties properties = buildProperties(config, tempFiles);
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
+        return properties;
     }
 
     private record LagResult(long totalLag, int numTopics) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/mapper/KafkaExplorerMapper.java
@@ -18,16 +18,20 @@ package io.gravitee.rest.api.kafkaexplorer.mapper;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerLogDirEntry;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrowseMessagesResult;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroup;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupsPage;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaClusterInfo;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaHeader;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaMessage;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaNode;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaTopic;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicConfigEntry;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicPartitionDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.BrowseMessagesResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.ConsumerGroupSummary;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeBrokerResponse;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterResponse;
@@ -107,4 +111,14 @@ public interface KafkaExplorerMapper {
     io.gravitee.rest.api.kafkaexplorer.rest.model.ConsumerGroupOffset map(
         io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupOffset offset
     );
+
+    io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaMessage map(KafkaMessage message);
+
+    List<io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaMessage> mapMessages(List<KafkaMessage> messages);
+
+    io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaHeader map(KafkaHeader header);
+
+    default BrowseMessagesResponse map(BrowseMessagesResult result) {
+        return new BrowseMessagesResponse().data(mapMessages(result.messages())).totalFetched(result.totalFetched());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
@@ -336,6 +336,7 @@ public class KafkaExplorerResource {
                     offsetMode,
                     request.getOffsetValue(),
                     request.getKeyFilter(),
+                    request.getValueFilter(),
                     limit
                 )
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.kafkaexplorer.resource;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.BrowseMessagesUseCase;
@@ -24,6 +25,7 @@ import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeKafkaClusterUs
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeTopicUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListConsumerGroupsUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListTopicsUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.TailMessagesUseCase;
 import io.gravitee.rest.api.kafkaexplorer.mapper.KafkaExplorerMapper;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.BrowseMessagesRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeBrokerRequest;
@@ -43,13 +45,21 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.sse.Sse;
+import jakarta.ws.rs.sse.SseEventSink;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.CustomLog;
 
+@CustomLog
 public class KafkaExplorerResource {
 
     @Inject
@@ -72,6 +82,16 @@ public class KafkaExplorerResource {
 
     @Inject
     private DescribeConsumerGroupUseCase describeConsumerGroupUseCase;
+
+    @Inject
+    private TailMessagesUseCase tailMessagesUseCase;
+
+    @Inject
+    private ObjectMapper objectMapper;
+
+    private static final AtomicInteger activeTailStreams = new AtomicInteger(0);
+    // Cap concurrent tail streams to prevent resource exhaustion on the management API
+    private static final int MAX_TAIL_STREAMS = 256;
 
     @POST
     @Path("/describe-cluster")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.kafkaexplorer.resource;
 
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.BrowseMessagesUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeBrokerUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeConsumerGroupUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeKafkaClusterUseCase;
@@ -24,6 +25,7 @@ import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeTopicUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListConsumerGroupsUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListTopicsUseCase;
 import io.gravitee.rest.api.kafkaexplorer.mapper.KafkaExplorerMapper;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.BrowseMessagesRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeBrokerRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeClusterRequest;
 import io.gravitee.rest.api.kafkaexplorer.rest.model.DescribeConsumerGroupRequest;
@@ -49,6 +51,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 public class KafkaExplorerResource {
+
+    @Inject
+    private BrowseMessagesUseCase browseMessagesUseCase;
 
     @Inject
     private DescribeBrokerUseCase describeBrokerUseCase;
@@ -287,5 +292,153 @@ public class KafkaExplorerResource {
                 .entity(new KafkaExplorerError().message(e.getMessage()).technicalCode(e.getTechnicalCode().name()))
                 .build();
         }
+    }
+
+    @POST
+    @Path("/browse-messages")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @GraviteeLicenseFeature("apim-native-kafka-explorer")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLUSTER, acls = RolePermissionAction.READ) })
+    public Response browseMessages(BrowseMessagesRequest request, @QueryParam("limit") @DefaultValue("50") int limit) {
+        if (request == null || request.getClusterId() == null || request.getClusterId().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new KafkaExplorerError().message("clusterId is required").technicalCode(TechnicalCode.INVALID_PARAMETERS.name()))
+                .build();
+        }
+
+        if (request.getTopicName() == null || request.getTopicName().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(new KafkaExplorerError().message("topicName is required").technicalCode(TechnicalCode.INVALID_PARAMETERS.name()))
+                .build();
+        }
+
+        if (limit < 1 || limit > 1000) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                .entity(
+                    new KafkaExplorerError()
+                        .message("limit must be between 1 and 1000")
+                        .technicalCode(TechnicalCode.INVALID_PARAMETERS.name())
+                )
+                .build();
+        }
+
+        var offsetMode = request.getOffsetMode() != null ? request.getOffsetMode().name() : "NEWEST";
+
+        try {
+            var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
+            var result = browseMessagesUseCase.execute(
+                new BrowseMessagesUseCase.Input(
+                    request.getClusterId(),
+                    environmentId,
+                    request.getTopicName(),
+                    request.getPartition(),
+                    offsetMode,
+                    request.getOffsetValue(),
+                    request.getKeyFilter(),
+                    limit
+                )
+            );
+            return Response.ok(KafkaExplorerMapper.INSTANCE.map(result.browseMessagesResult())).build();
+        } catch (KafkaExplorerException e) {
+            return Response.status(Response.Status.BAD_GATEWAY)
+                .entity(new KafkaExplorerError().message(e.getMessage()).technicalCode(e.getTechnicalCode().name()))
+                .build();
+        }
+    }
+
+    @GET
+    @Path("/tail-messages")
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    @GraviteeLicenseFeature("apim-native-kafka-explorer")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLUSTER, acls = RolePermissionAction.READ) })
+    public void tailMessages(
+        @QueryParam("clusterId") String clusterId,
+        @QueryParam("topicName") String topicName,
+        @QueryParam("partition") Integer partition,
+        @QueryParam("keyFilter") String keyFilter,
+        @QueryParam("valueFilter") String valueFilter,
+        @QueryParam("maxMessages") @DefaultValue("1000") int maxMessages,
+        @QueryParam("durationSeconds") @DefaultValue("30") int durationSeconds,
+        @Context SseEventSink eventSink,
+        @Context Sse sse
+    ) {
+        if (clusterId == null || clusterId.isBlank()) {
+            throw badRequest("clusterId is required");
+        }
+
+        if (topicName == null || topicName.isBlank()) {
+            throw badRequest("topicName is required");
+        }
+
+        if (maxMessages < 1 || maxMessages > 5000) {
+            throw badRequest("maxMessages must be between 1 and 5000");
+        }
+
+        if (durationSeconds < 1 || durationSeconds > 300) {
+            throw badRequest("durationSeconds must be between 1 and 300");
+        }
+
+        if (activeTailStreams.get() >= MAX_TAIL_STREAMS) {
+            throw new WebApplicationException(
+                Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity(new KafkaExplorerError().message("Too many active tail streams").technicalCode(TechnicalCode.TIMEOUT.name()))
+                    .type(MediaType.APPLICATION_JSON_TYPE)
+                    .build()
+            );
+        }
+
+        var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
+
+        activeTailStreams.incrementAndGet();
+        try {
+            tailMessagesUseCase.execute(
+                new TailMessagesUseCase.Input(
+                    clusterId,
+                    environmentId,
+                    topicName,
+                    partition,
+                    keyFilter,
+                    valueFilter,
+                    maxMessages,
+                    durationSeconds
+                ),
+                message -> {
+                    if (eventSink.isClosed()) return false;
+                    try {
+                        eventSink.send(
+                            sse.newEventBuilder().name("message").data(String.class, objectMapper.writeValueAsString(message)).build()
+                        );
+                        return true;
+                    } catch (Exception e) {
+                        return false;
+                    }
+                }
+            );
+            if (!eventSink.isClosed()) {
+                eventSink.send(sse.newEventBuilder().name("done").data("{}").build());
+            }
+        } catch (KafkaExplorerException e) {
+            if (!eventSink.isClosed()) {
+                eventSink.send(sse.newEventBuilder().name("error").data(e.getMessage()).build());
+            }
+        } catch (Exception e) {
+            log.error("Unexpected error during tail", e);
+            if (!eventSink.isClosed()) {
+                eventSink.send(sse.newEventBuilder().name("error").data("An unexpected error occurred").build());
+            }
+        } finally {
+            activeTailStreams.decrementAndGet();
+            eventSink.close();
+        }
+    }
+
+    private WebApplicationException badRequest(String message) {
+        return new WebApplicationException(
+            Response.status(Response.Status.BAD_REQUEST)
+                .entity(new KafkaExplorerError().message(message).technicalCode(TechnicalCode.INVALID_PARAMETERS.name()))
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .build()
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -717,6 +717,9 @@ components:
                 keyFilter:
                     type: string
                     description: Optional case-insensitive contains match on message key
+                valueFilter:
+                    type: string
+                    description: Optional case-insensitive contains match on message value
 
         BrowseMessagesResponse:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -211,6 +211,49 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/KafkaExplorerError"
 
+    /kafka-explorer/browse-messages:
+        post:
+            tags:
+                - Kafka Explorer
+            summary: Browse messages from a Kafka topic
+            description: |
+                Connects to a Kafka cluster and reads messages from a topic for debugging purposes.
+                Uses ephemeral consumer (no consumer group) with assign/seek.
+            operationId: browseMessages
+            parameters:
+                - name: limit
+                  in: query
+                  schema:
+                      type: integer
+                      default: 50
+                      maximum: 1000
+                  description: Maximum number of messages to return (1-1000)
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/BrowseMessagesRequest"
+            responses:
+                "200":
+                    description: Messages from the topic
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/BrowseMessagesResponse"
+                "400":
+                    description: Invalid parameters
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+                "502":
+                    description: Connection failure
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/KafkaExplorerError"
+
     /kafka-explorer/describe-consumer-group:
         post:
             tags:
@@ -641,6 +684,80 @@ components:
                 lag:
                     type: integer
                     format: int64
+
+        BrowseMessagesRequest:
+            type: object
+            required:
+                - clusterId
+                - topicName
+            properties:
+                clusterId:
+                    type: string
+                    description: ID of the Cluster to connect to
+                topicName:
+                    type: string
+                    description: Name of the topic to browse
+                partition:
+                    type: integer
+                    format: int32
+                    description: Optional partition number. If null, reads from all partitions
+                offsetMode:
+                    type: string
+                    enum:
+                        - NEWEST
+                        - OLDEST
+                        - TIMESTAMP
+                        - SPECIFIC
+                    default: NEWEST
+                    description: How to determine the starting offset
+                offsetValue:
+                    type: integer
+                    format: int64
+                    description: Timestamp in ms (when offsetMode=TIMESTAMP) or offset (when offsetMode=SPECIFIC)
+                keyFilter:
+                    type: string
+                    description: Optional case-insensitive contains match on message key
+
+        BrowseMessagesResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/KafkaMessage"
+                totalFetched:
+                    type: integer
+                    format: int32
+                    description: Total number of messages fetched before filtering
+
+        KafkaMessage:
+            type: object
+            properties:
+                partition:
+                    type: integer
+                    format: int32
+                offset:
+                    type: integer
+                    format: int64
+                timestamp:
+                    type: integer
+                    format: int64
+                key:
+                    type: string
+                value:
+                    type: string
+                headers:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/KafkaHeader"
+
+        KafkaHeader:
+            type: object
+            properties:
+                key:
+                    type: string
+                value:
+                    type: string
 
         KafkaExplorerError:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -254,6 +254,66 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/KafkaExplorerError"
 
+    /kafka-explorer/tail-messages:
+        get:
+            tags:
+                - Kafka Explorer
+            summary: Tail messages from a Kafka topic via SSE
+            description: |
+                Opens an SSE stream that tails new messages from a topic in real-time.
+                Events: 'message' (KafkaMessage JSON), 'done' (stream ended), 'error' (error occurred).
+            operationId: tailMessages
+            parameters:
+                - name: clusterId
+                  in: query
+                  required: true
+                  schema:
+                      type: string
+                  description: ID of the Cluster to connect to
+                - name: topicName
+                  in: query
+                  required: true
+                  schema:
+                      type: string
+                  description: Name of the topic to tail
+                - name: partition
+                  in: query
+                  schema:
+                      type: integer
+                      format: int32
+                  description: Optional partition number
+                - name: keyFilter
+                  in: query
+                  schema:
+                      type: string
+                  description: Optional case-insensitive key filter
+                - name: valueFilter
+                  in: query
+                  schema:
+                      type: string
+                  description: Optional case-insensitive value filter
+                - name: maxMessages
+                  in: query
+                  schema:
+                      type: integer
+                      default: 1000
+                      maximum: 5000
+                  description: Maximum number of messages (1-5000)
+                - name: durationSeconds
+                  in: query
+                  schema:
+                      type: integer
+                      default: 30
+                      maximum: 300
+                  description: Maximum duration in seconds (1-300)
+            responses:
+                "200":
+                    description: SSE stream of messages
+                    content:
+                        text/event-stream:
+                            schema:
+                                type: string
+
     /kafka-explorer/describe-consumer-group:
         post:
             tags:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/BrowseMessagesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/BrowseMessagesUseCaseTest.java
@@ -67,7 +67,7 @@ class BrowseMessagesUseCaseTest {
         clusterDomainService.givenBrowseMessagesResult(expectedResult);
 
         var result = useCase.execute(
-            new BrowseMessagesUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my-topic", null, "NEWEST", null, null, 50)
+            new BrowseMessagesUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my-topic", null, "NEWEST", null, null, null, 50)
         );
 
         assertThat(result.browseMessagesResult()).isEqualTo(expectedResult);
@@ -83,7 +83,9 @@ class BrowseMessagesUseCaseTest {
         clusterDomainService.givenException(new KafkaExplorerException("Topic not found", TechnicalCode.TOPIC_NOT_FOUND));
 
         assertThatThrownBy(() ->
-            useCase.execute(new BrowseMessagesUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "missing-topic", null, "NEWEST", null, null, 50))
+            useCase.execute(
+                new BrowseMessagesUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "missing-topic", null, "NEWEST", null, null, null, 50)
+            )
         )
             .isInstanceOf(KafkaExplorerException.class)
             .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.TOPIC_NOT_FOUND));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/BrowseMessagesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/BrowseMessagesUseCaseTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClusterCrudServiceInMemory;
+import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrowseMessagesResult;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaHeader;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaMessage;
+import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceInMemory;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class BrowseMessagesUseCaseTest {
+
+    private static final String CLUSTER_ID = "cluster-1";
+    private static final String ENVIRONMENT_ID = "env-1";
+
+    private final ClusterCrudServiceInMemory clusterCrudService = new ClusterCrudServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final KafkaClusterDomainServiceInMemory clusterDomainService = new KafkaClusterDomainServiceInMemory();
+
+    private BrowseMessagesUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        clusterCrudService.reset();
+        useCase = new BrowseMessagesUseCase(clusterCrudService, clusterDomainService, objectMapper);
+    }
+
+    @Test
+    void should_return_browse_messages_result() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        var expectedResult = new BrowseMessagesResult(
+            List.of(
+                new KafkaMessage(0, 42L, 1700000000000L, "key-1", "{\"hello\":\"world\"}", List.of(new KafkaHeader("h1", "v1"))),
+                new KafkaMessage(1, 10L, 1700000001000L, "key-2", "plain text", List.of())
+            ),
+            2
+        );
+        clusterDomainService.givenBrowseMessagesResult(expectedResult);
+
+        var result = useCase.execute(
+            new BrowseMessagesUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my-topic", null, "NEWEST", null, null, 50)
+        );
+
+        assertThat(result.browseMessagesResult()).isEqualTo(expectedResult);
+        assertThat(result.browseMessagesResult().messages()).hasSize(2);
+        assertThat(result.browseMessagesResult().totalFetched()).isEqualTo(2);
+    }
+
+    @Test
+    void should_propagate_kafka_explorer_exception() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        clusterDomainService.givenException(new KafkaExplorerException("Topic not found", TechnicalCode.TOPIC_NOT_FOUND));
+
+        assertThatThrownBy(() ->
+            useCase.execute(new BrowseMessagesUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "missing-topic", null, "NEWEST", null, null, 50))
+        )
+            .isInstanceOf(KafkaExplorerException.class)
+            .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.TOPIC_NOT_FOUND));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/TailMessagesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/TailMessagesUseCaseTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.domain.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClusterCrudServiceInMemory;
+import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
+import io.gravitee.rest.api.kafkaexplorer.domain.exception.TechnicalCode;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrowseMessagesResult;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaHeader;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.KafkaMessage;
+import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceInMemory;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class TailMessagesUseCaseTest {
+
+    private static final String CLUSTER_ID = "cluster-1";
+    private static final String ENVIRONMENT_ID = "env-1";
+
+    private final ClusterCrudServiceInMemory clusterCrudService = new ClusterCrudServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final KafkaClusterDomainServiceInMemory clusterDomainService = new KafkaClusterDomainServiceInMemory();
+
+    private TailMessagesUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        clusterCrudService.reset();
+        useCase = new TailMessagesUseCase(clusterCrudService, clusterDomainService, objectMapper);
+    }
+
+    @Test
+    void should_deliver_messages_to_consumer() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        var messages = List.of(
+            new KafkaMessage(0, 42L, 1700000000000L, "key-1", "{\"hello\":\"world\"}", List.of(new KafkaHeader("h1", "v1"))),
+            new KafkaMessage(1, 10L, 1700000001000L, "key-2", "plain text", List.of())
+        );
+        clusterDomainService.givenBrowseMessagesResult(new BrowseMessagesResult(messages, 2));
+
+        List<KafkaMessage> received = new ArrayList<>();
+        useCase.execute(new TailMessagesUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my-topic", null, null, null, 1000, 30), message -> {
+            received.add(message);
+            return true;
+        });
+
+        assertThat(received).hasSize(2);
+        assertThat(received.get(0).key()).isEqualTo("key-1");
+        assertThat(received.get(1).key()).isEqualTo("key-2");
+    }
+
+    @Test
+    void should_propagate_kafka_explorer_exception() {
+        var clusterConfig = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        clusterCrudService.create(Cluster.builder().id(CLUSTER_ID).environmentId(ENVIRONMENT_ID).configuration(clusterConfig).build());
+
+        clusterDomainService.givenException(new KafkaExplorerException("Topic not found", TechnicalCode.TOPIC_NOT_FOUND));
+
+        assertThatThrownBy(() ->
+            useCase.execute(
+                new TailMessagesUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "missing-topic", null, null, null, 1000, 30),
+                message -> true
+            )
+        )
+            .isInstanceOf(KafkaExplorerException.class)
+            .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.TOPIC_NOT_FOUND));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
 import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
+import io.gravitee.rest.api.kafkaexplorer.domain.model.BrowseMessagesResult;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroup;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupsPage;
@@ -37,7 +38,13 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
     private BrokerInfo brokerInfo;
     private List<ConsumerGroup> consumerGroups;
     private ConsumerGroupDetail consumerGroupDetail;
+    private BrowseMessagesResult browseMessagesResult;
     private KafkaExplorerException exception;
+
+    public void givenBrowseMessagesResult(BrowseMessagesResult result) {
+        this.browseMessagesResult = result;
+        this.exception = null;
+    }
 
     public void givenClusterInfo(KafkaClusterInfo info) {
         this.result = info;
@@ -77,6 +84,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
         this.brokerInfo = null;
         this.consumerGroups = null;
         this.consumerGroupDetail = null;
+        this.browseMessagesResult = null;
     }
 
     @Override
@@ -153,5 +161,21 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
             throw exception;
         }
         return consumerGroupDetail;
+    }
+
+    @Override
+    public BrowseMessagesResult browseMessages(
+        KafkaClusterConfiguration config,
+        String topicName,
+        Integer partition,
+        String offsetMode,
+        Long offsetValue,
+        String keyFilter,
+        int limit
+    ) {
+        if (exception != null) {
+            throw exception;
+        }
+        return browseMessagesResult;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
@@ -171,6 +171,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
         String offsetMode,
         Long offsetValue,
         String keyFilter,
+        String valueFilter,
         int limit
     ) {
         if (exception != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service;
 
 import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
 import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
+import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.MessageConsumer;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrowseMessagesResult;
@@ -178,5 +179,28 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
             throw exception;
         }
         return browseMessagesResult;
+    }
+
+    @Override
+    public void tailMessages(
+        KafkaClusterConfiguration config,
+        String topicName,
+        Integer partition,
+        String keyFilter,
+        String valueFilter,
+        int maxMessages,
+        int durationSeconds,
+        MessageConsumer consumer
+    ) {
+        if (exception != null) {
+            throw exception;
+        }
+        if (browseMessagesResult != null) {
+            for (var msg : browseMessagesResult.messages()) {
+                if (!consumer.accept(msg)) {
+                    break;
+                }
+            }
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/AbstractKafkaExplorerResourceIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/AbstractKafkaExplorerResourceIntegrationTest.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeKafkaClusterUs
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeTopicUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListConsumerGroupsUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.ListTopicsUseCase;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.TailMessagesUseCase;
 import io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service.KafkaClusterDomainServiceImpl;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.File;
@@ -84,6 +85,8 @@ abstract class AbstractKafkaExplorerResourceIntegrationTest {
                 new DescribeConsumerGroupUseCase(clusterCrudService, clusterService, objectMapper)
             );
             injectField(resource, "browseMessagesUseCase", new BrowseMessagesUseCase(clusterCrudService, clusterService, objectMapper));
+            injectField(resource, "tailMessagesUseCase", new TailMessagesUseCase(clusterCrudService, clusterService, objectMapper));
+            injectField(resource, "objectMapper", objectMapper);
         } catch (Exception e) {
             throw new RuntimeException("Failed to set up integration test", e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/AbstractKafkaExplorerResourceIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/AbstractKafkaExplorerResourceIntegrationTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.kafkaexplorer.resource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inmemory.ClusterCrudServiceInMemory;
 import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.rest.api.kafkaexplorer.domain.use_case.BrowseMessagesUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeBrokerUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeConsumerGroupUseCase;
 import io.gravitee.rest.api.kafkaexplorer.domain.use_case.DescribeKafkaClusterUseCase;
@@ -82,6 +83,7 @@ abstract class AbstractKafkaExplorerResourceIntegrationTest {
                 "describeConsumerGroupUseCase",
                 new DescribeConsumerGroupUseCase(clusterCrudService, clusterService, objectMapper)
             );
+            injectField(resource, "browseMessagesUseCase", new BrowseMessagesUseCase(clusterCrudService, clusterService, objectMapper));
         } catch (Exception e) {
             throw new RuntimeException("Failed to set up integration test", e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_BrowseMessages.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_BrowseMessages.java
@@ -147,7 +147,7 @@ class KafkaExplorerResourceIntegrationTest_BrowseMessages extends AbstractKafkaE
             .clusterId(CLUSTER_ID)
             .topicName(BROWSE_TOPIC)
             .valueFilter("index\":0")
-            .offsetMode(BrowseMessagesRequest.OffsetModeEnum.OLDEST);
+            .offsetMode(BrowseMessagesRequest.OffsetModeEnum.EARLIEST);
 
         var response = resource.browseMessages(request, 50);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_BrowseMessages.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_BrowseMessages.java
@@ -147,7 +147,7 @@ class KafkaExplorerResourceIntegrationTest_BrowseMessages extends AbstractKafkaE
             .clusterId(CLUSTER_ID)
             .topicName(BROWSE_TOPIC)
             .valueFilter("index\":0")
-            .offsetMode(BrowseMessagesRequest.OffsetModeEnum.EARLIEST);
+            .offsetMode(BrowseMessagesRequest.OffsetModeEnum.OLDEST);
 
         var response = resource.browseMessages(request, 50);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_BrowseMessages.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_BrowseMessages.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.kafkaexplorer.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.kafkaexplorer.rest.model.BrowseMessagesRequest;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.BrowseMessagesResponse;
+import io.gravitee.rest.api.kafkaexplorer.rest.model.KafkaExplorerError;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class KafkaExplorerResourceIntegrationTest_BrowseMessages extends AbstractKafkaExplorerResourceIntegrationTest {
+
+    private static final String BROWSE_TOPIC = "browse-messages-test";
+
+    @BeforeAll
+    static void createTestTopicAndProduceMessages() throws Exception {
+        var adminProps = new Properties();
+        adminProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+        try (var admin = AdminClient.create(adminProps)) {
+            admin.createTopics(List.of(new NewTopic(BROWSE_TOPIC, 2, (short) 1))).all().get(10, TimeUnit.SECONDS);
+        }
+
+        var producerProps = new Properties();
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, plaintextBootstrapServers());
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        try (var producer = new KafkaProducer<String, String>(producerProps)) {
+            for (int i = 0; i < 5; i++) {
+                var record = new ProducerRecord<>(BROWSE_TOPIC, i % 2, "key-" + i, "{\"index\":" + i + "}");
+                record.headers().add(new RecordHeader("test-header", ("value-" + i).getBytes()));
+                producer.send(record).get(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    @Test
+    void should_return_200_with_messages_using_newest_mode() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new BrowseMessagesRequest().clusterId(CLUSTER_ID).topicName(BROWSE_TOPIC);
+
+        var response = resource.browseMessages(request, 50);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (BrowseMessagesResponse) response.getEntity();
+        assertThat(body.getData()).isNotEmpty();
+        assertThat(body.getTotalFetched()).isGreaterThanOrEqualTo(body.getData().size());
+        body
+            .getData()
+            .forEach(msg -> {
+                assertThat(msg.getPartition()).isGreaterThanOrEqualTo(0);
+                assertThat(msg.getOffset()).isGreaterThanOrEqualTo(0);
+                assertThat(msg.getTimestamp()).isGreaterThan(0);
+                assertThat(msg.getKey()).startsWith("key-");
+                assertThat(msg.getValue()).contains("index");
+                assertThat(msg.getHeaders()).isNotEmpty();
+            });
+    }
+
+    @Test
+    void should_return_200_with_messages_using_oldest_mode() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new BrowseMessagesRequest()
+            .clusterId(CLUSTER_ID)
+            .topicName(BROWSE_TOPIC)
+            .offsetMode(BrowseMessagesRequest.OffsetModeEnum.OLDEST);
+
+        var response = resource.browseMessages(request, 50);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (BrowseMessagesResponse) response.getEntity();
+        assertThat(body.getData()).hasSize(5);
+    }
+
+    @Test
+    void should_return_200_with_messages_filtered_by_partition() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new BrowseMessagesRequest()
+            .clusterId(CLUSTER_ID)
+            .topicName(BROWSE_TOPIC)
+            .partition(0)
+            .offsetMode(BrowseMessagesRequest.OffsetModeEnum.OLDEST);
+
+        var response = resource.browseMessages(request, 50);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (BrowseMessagesResponse) response.getEntity();
+        assertThat(body.getData()).isNotEmpty();
+        body.getData().forEach(msg -> assertThat(msg.getPartition()).isEqualTo(0));
+    }
+
+    @Test
+    void should_return_200_with_messages_filtered_by_key() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new BrowseMessagesRequest()
+            .clusterId(CLUSTER_ID)
+            .topicName(BROWSE_TOPIC)
+            .keyFilter("key-0")
+            .offsetMode(BrowseMessagesRequest.OffsetModeEnum.OLDEST);
+
+        var response = resource.browseMessages(request, 50);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (BrowseMessagesResponse) response.getEntity();
+        assertThat(body.getData()).isNotEmpty();
+        body.getData().forEach(msg -> assertThat(msg.getKey()).containsIgnoringCase("key-0"));
+    }
+
+    @Test
+    void should_return_200_with_messages_filtered_by_value() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new BrowseMessagesRequest()
+            .clusterId(CLUSTER_ID)
+            .topicName(BROWSE_TOPIC)
+            .valueFilter("index\":0")
+            .offsetMode(BrowseMessagesRequest.OffsetModeEnum.OLDEST);
+
+        var response = resource.browseMessages(request, 50);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (BrowseMessagesResponse) response.getEntity();
+        assertThat(body.getData()).isNotEmpty();
+        body.getData().forEach(msg -> assertThat(msg.getValue()).containsIgnoringCase("index\":0"));
+    }
+
+    @Test
+    void should_return_200_with_limited_messages() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new BrowseMessagesRequest()
+            .clusterId(CLUSTER_ID)
+            .topicName(BROWSE_TOPIC)
+            .offsetMode(BrowseMessagesRequest.OffsetModeEnum.OLDEST);
+
+        var response = resource.browseMessages(request, 2);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (BrowseMessagesResponse) response.getEntity();
+        assertThat(body.getData()).hasSizeLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void should_return_400_when_cluster_id_missing() {
+        var request = new BrowseMessagesRequest().topicName(BROWSE_TOPIC);
+
+        var response = resource.browseMessages(request, 50);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_400_when_topic_name_missing() {
+        var request = new BrowseMessagesRequest().clusterId(CLUSTER_ID);
+
+        var response = resource.browseMessages(request, 50);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("INVALID_PARAMETERS");
+    }
+
+    @Test
+    void should_return_400_when_limit_out_of_range() {
+        var request = new BrowseMessagesRequest().clusterId(CLUSTER_ID).topicName(BROWSE_TOPIC);
+
+        var response = resource.browseMessages(request, 0);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getMessage()).contains("limit");
+    }
+
+    @Test
+    void should_return_502_when_broker_unreachable() {
+        givenClusterWithConfig(Map.of("bootstrapServers", "localhost:19092", "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new BrowseMessagesRequest().clusterId(CLUSTER_ID).topicName(BROWSE_TOPIC);
+
+        var response = resource.browseMessages(request, 50);
+
+        assertThat(response.getStatus()).isEqualTo(502);
+        var error = (KafkaExplorerError) response.getEntity();
+        assertThat(error.getTechnicalCode()).isEqualTo("CONNECTION_FAILED");
+    }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.html
@@ -21,6 +21,9 @@
   [totalFetched]="totalFetched()"
   [partitionCount]="partitionCount()"
   [loading]="loading()"
+  [tailActive]="tailActive()"
   (back)="onBack()"
-  (search)="onSearch($event)"
+  (browseMessages)="onSearch($event)"
+  (startTail)="onStartTail($event)"
+  (stopTail)="onStopTail()"
 />

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.html
@@ -1,0 +1,26 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<gke-messages-browser
+  [topicName]="topicName"
+  [messages]="messages()"
+  [totalFetched]="totalFetched()"
+  [partitionCount]="partitionCount()"
+  [loading]="loading()"
+  (back)="onBack()"
+  (search)="onSearch($event)"
+/>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.spec.ts
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { MessagesBrowserHarness } from './messages/messages-browser.harness';
+import { MessagesPageComponent } from './messages-page.component';
+import { fakeBrowseMessagesResponse, fakeDescribeTopicResponse, fakeTopicPartitionDetail } from '../../models/kafka-cluster.fixture';
+import { KafkaExplorerStore } from '../../services/kafka-explorer-store.service';
+
+describe('MessagesPageComponent', () => {
+  let fixture: ComponentFixture<MessagesPageComponent>;
+  let httpTesting: HttpTestingController;
+  let loader: HarnessLoader;
+
+  const router = { navigate: jest.fn() };
+  const route = { snapshot: { params: { topicName: 'my-topic' } } };
+
+  beforeEach(async () => {
+    router.navigate.mockClear();
+
+    await TestBed.configureTestingModule({
+      imports: [MessagesPageComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        KafkaExplorerStore,
+        provideNoopAnimations(),
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: route },
+      ],
+    }).compileComponents();
+
+    httpTesting = TestBed.inject(HttpTestingController);
+    const store = TestBed.inject(KafkaExplorerStore);
+    store.baseURL.set('/api/v2');
+    store.clusterId.set('test-cluster-id');
+
+    fixture = TestBed.createComponent(MessagesPageComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  function flushInitialRequests(topicResponse = fakeDescribeTopicResponse(), messagesResponse = fakeBrowseMessagesResponse()) {
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-topic').flush(topicResponse);
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/browse-messages').flush(messagesResponse);
+    fixture.detectChanges();
+  }
+
+  it('should call describeTopic and browseMessages on init', () => {
+    const topicReq = httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-topic');
+    expect(topicReq.request.body).toEqual({ clusterId: 'test-cluster-id', topicName: 'my-topic' });
+
+    const messagesReq = httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/browse-messages');
+    expect(messagesReq.request.body).toEqual({ clusterId: 'test-cluster-id', topicName: 'my-topic', offsetMode: 'NEWEST' });
+    expect(messagesReq.request.params.get('limit')).toBe('50');
+
+    topicReq.flush(fakeDescribeTopicResponse());
+    messagesReq.flush(fakeBrowseMessagesResponse());
+  });
+
+  it('should display topic name in title', async () => {
+    flushInitialRequests();
+
+    const harness = await loader.getHarness(MessagesBrowserHarness);
+    expect(await harness.getTopicName()).toContain('my-topic');
+  });
+
+  it('should display messages table', async () => {
+    flushInitialRequests();
+
+    const harness = await loader.getHarness(MessagesBrowserHarness);
+    const rows = await harness.getMessagesRows();
+    expect(rows.length).toBe(3);
+    expect(rows[0]['partition']).toBeDefined();
+    expect(rows[0]['offset']).toBeDefined();
+  });
+
+  it('should navigate back on back button click', async () => {
+    flushInitialRequests();
+
+    const harness = await loader.getHarness(MessagesBrowserHarness);
+    await harness.clickBack();
+
+    expect(router.navigate).toHaveBeenCalledWith(['..'], { relativeTo: route });
+  });
+
+  it('should fetch messages on fetch button click', async () => {
+    flushInitialRequests();
+
+    const harness = await loader.getHarness(MessagesBrowserHarness);
+    await harness.clickFetch();
+
+    const req = httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/browse-messages');
+    expect(req.request.body.clusterId).toBe('test-cluster-id');
+    expect(req.request.body.topicName).toBe('my-topic');
+    req.flush(fakeBrowseMessagesResponse());
+  });
+
+  it('should show empty message when no messages', async () => {
+    flushInitialRequests(fakeDescribeTopicResponse(), { data: [], totalFetched: 0 });
+
+    const harness = await loader.getHarness(MessagesBrowserHarness);
+    expect(await harness.hasEmptyMessage()).toBe(true);
+  });
+
+  it('should pass search options to browseMessages on search', async () => {
+    flushInitialRequests();
+
+    fixture.componentInstance.onSearch({
+      partition: 1,
+      offsetMode: 'OLDEST',
+      offsetValue: 100,
+      keyFilter: 'order',
+      limit: 10,
+    });
+
+    const req = httpTesting.expectOne(r => r.url === '/api/v2/kafka-explorer/browse-messages');
+    expect(req.request.body).toEqual({
+      clusterId: 'test-cluster-id',
+      topicName: 'my-topic',
+      partition: 1,
+      offsetMode: 'OLDEST',
+      offsetValue: 100,
+      keyFilter: 'order',
+    });
+    expect(req.request.params.get('limit')).toBe('10');
+    req.flush(fakeBrowseMessagesResponse());
+  });
+
+  it('should pass valueFilter to browseMessages when provided', async () => {
+    flushInitialRequests();
+
+    fixture.componentInstance.onSearch({
+      offsetMode: 'OLDEST',
+      keyFilter: 'key-1',
+      valueFilter: 'hello',
+      limit: 50,
+    });
+
+    const req = httpTesting.expectOne(r => r.url === '/api/v2/kafka-explorer/browse-messages');
+    expect(req.request.body).toEqual({
+      clusterId: 'test-cluster-id',
+      topicName: 'my-topic',
+      offsetMode: 'OLDEST',
+      keyFilter: 'key-1',
+      valueFilter: 'hello',
+    });
+    expect(req.request.params.get('limit')).toBe('50');
+    req.flush(fakeBrowseMessagesResponse());
+  });
+
+  it('should pass valueFilter to browseMessages when provided', async () => {
+    flushInitialRequests();
+
+    fixture.componentInstance.onSearch({
+      offsetMode: 'OLDEST',
+      keyFilter: 'key-1',
+      valueFilter: 'hello',
+      limit: 50,
+    });
+
+    const req = httpTesting.expectOne(r => r.url === '/api/v2/kafka-explorer/browse-messages');
+    expect(req.request.body).toEqual({
+      clusterId: 'test-cluster-id',
+      topicName: 'my-topic',
+      offsetMode: 'OLDEST',
+      keyFilter: 'key-1',
+      valueFilter: 'hello',
+    });
+    expect(req.request.params.get('limit')).toBe('50');
+    req.flush(fakeBrowseMessagesResponse());
+  });
+
+  it('should set partitionCount after describeTopic response', async () => {
+    flushInitialRequests(
+      fakeDescribeTopicResponse({ partitions: [fakeTopicPartitionDetail({ id: 0 }), fakeTopicPartitionDetail({ id: 1 })] }),
+    );
+
+    expect(fixture.componentInstance.partitionCount()).toBe(2);
+  });
+
+  it('should set tailActive to true when onStartTail is called', () => {
+    flushInitialRequests();
+
+    fixture.componentInstance.onStartTail({
+      partition: undefined,
+      keyFilter: undefined,
+      valueFilter: undefined,
+      maxMessages: 1000,
+      durationSeconds: 30,
+    });
+
+    expect(fixture.componentInstance.tailActive()).toBe(true);
+    expect(fixture.componentInstance.messages()).toEqual([]);
+    expect(fixture.componentInstance.totalFetched()).toBe(0);
+
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/tail-messages');
+
+    fixture.componentInstance.onStopTail();
+  });
+
+  it('should set tailActive to false when onStopTail is called', () => {
+    flushInitialRequests();
+
+    fixture.componentInstance.onStartTail({
+      partition: undefined,
+      keyFilter: undefined,
+      valueFilter: undefined,
+      maxMessages: 1000,
+      durationSeconds: 30,
+    });
+
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/tail-messages');
+
+    fixture.componentInstance.onStopTail();
+
+    expect(fixture.componentInstance.tailActive()).toBe(false);
+  });
+
+  it('should clean up tail subscription on destroy', () => {
+    flushInitialRequests();
+
+    fixture.componentInstance.onStartTail({
+      partition: undefined,
+      keyFilter: undefined,
+      valueFilter: undefined,
+      maxMessages: 1000,
+      durationSeconds: 30,
+    });
+
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/tail-messages');
+
+    fixture.destroy();
+
+    expect(fixture.componentInstance.tailActive()).toBe(false);
+  });
+
+  it('should send tail request with correct parameters', () => {
+    flushInitialRequests();
+
+    fixture.componentInstance.onStartTail({
+      partition: 2,
+      keyFilter: 'order',
+      valueFilter: 'completed',
+      maxMessages: 500,
+      durationSeconds: 60,
+    });
+
+    const req = httpTesting.expectOne(r => r.url === '/api/v2/kafka-explorer/tail-messages');
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('clusterId')).toBe('test-cluster-id');
+    expect(req.request.params.get('topicName')).toBe('my-topic');
+    expect(req.request.params.get('partition')).toBe('2');
+    expect(req.request.params.get('keyFilter')).toBe('order');
+    expect(req.request.params.get('valueFilter')).toBe('completed');
+    expect(req.request.params.get('maxMessages')).toBe('500');
+    expect(req.request.params.get('durationSeconds')).toBe('60');
+
+    fixture.componentInstance.onStopTail();
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { BrowseMessagesOptions, MessagesBrowserComponent } from './messages/messages-browser.component';
+import { KafkaMessage } from '../../models/kafka-cluster.model';
+import { KafkaExplorerStore } from '../../services/kafka-explorer-store.service';
+import { KafkaExplorerService } from '../../services/kafka-explorer.service';
+
+@Component({
+  selector: 'gke-messages-page',
+  standalone: true,
+  imports: [MessagesBrowserComponent],
+  templateUrl: './messages-page.component.html',
+})
+export class MessagesPageComponent implements OnInit {
+  store = inject(KafkaExplorerStore);
+  private readonly service = inject(KafkaExplorerService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
+
+  topicName = '';
+  partitionCount = signal(0);
+  messages = signal<KafkaMessage[]>([]);
+  totalFetched = signal(0);
+  loading = signal(false);
+
+  ngOnInit() {
+    this.topicName = this.route.snapshot.params['topicName'];
+
+    // Fetch topic info to get partition count
+    this.service
+      .describeTopic(this.store.baseURL(), this.store.clusterId(), this.topicName)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: detail => this.partitionCount.set(detail.partitions.length),
+      });
+
+    // Initial fetch with defaults
+    this.fetchMessages({ offsetMode: 'NEWEST', limit: 50 });
+  }
+
+  onSearch(options: BrowseMessagesOptions) {
+    this.fetchMessages(options);
+  }
+
+  onBack() {
+    this.router.navigate(['..'], { relativeTo: this.route });
+  }
+
+  private fetchMessages(options: BrowseMessagesOptions) {
+    this.loading.set(true);
+    this.service
+      .browseMessages(this.store.baseURL(), this.store.clusterId(), this.topicName, {
+        partition: options.partition,
+        offsetMode: options.offsetMode,
+        offsetValue: options.offsetValue,
+        keyFilter: options.keyFilter,
+        limit: options.limit,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: result => {
+          this.messages.set(result.data);
+          this.totalFetched.set(result.totalFetched);
+          this.loading.set(false);
+        },
+        error: err => {
+          this.store.error.set(err?.error?.message ?? 'Failed to browse messages');
+          this.loading.set(false);
+        },
+      });
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.ts
@@ -72,6 +72,7 @@ export class MessagesPageComponent implements OnInit {
         offsetMode: options.offsetMode,
         offsetValue: options.offsetValue,
         keyFilter: options.keyFilter,
+        valueFilter: options.valueFilter,
         limit: options.limit,
       })
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages-page.component.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { Component, DestroyRef, OnDestroy, OnInit, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 
-import { BrowseMessagesOptions, MessagesBrowserComponent } from './messages/messages-browser.component';
+import { BrowseMessagesOptions, MessagesBrowserComponent, TailMessagesOptions } from './messages/messages-browser.component';
 import { KafkaMessage } from '../../models/kafka-cluster.model';
 import { KafkaExplorerStore } from '../../services/kafka-explorer-store.service';
 import { KafkaExplorerService } from '../../services/kafka-explorer.service';
@@ -28,7 +29,7 @@ import { KafkaExplorerService } from '../../services/kafka-explorer.service';
   imports: [MessagesBrowserComponent],
   templateUrl: './messages-page.component.html',
 })
-export class MessagesPageComponent implements OnInit {
+export class MessagesPageComponent implements OnInit, OnDestroy {
   store = inject(KafkaExplorerStore);
   private readonly service = inject(KafkaExplorerService);
   private readonly router = inject(Router);
@@ -40,6 +41,8 @@ export class MessagesPageComponent implements OnInit {
   messages = signal<KafkaMessage[]>([]);
   totalFetched = signal(0);
   loading = signal(false);
+  tailActive = signal(false);
+  private tailSubscription: Subscription | null = null;
 
   ngOnInit() {
     this.topicName = this.route.snapshot.params['topicName'];
@@ -62,6 +65,49 @@ export class MessagesPageComponent implements OnInit {
 
   onBack() {
     this.router.navigate(['..'], { relativeTo: this.route });
+  }
+
+  onStartTail(options: TailMessagesOptions) {
+    this.tailActive.set(true);
+    this.messages.set([]);
+    this.totalFetched.set(0);
+
+    this.tailSubscription = this.service
+      .tailMessages(this.store.baseURL(), this.store.clusterId(), this.topicName, {
+        partition: options.partition,
+        keyFilter: options.keyFilter,
+        valueFilter: options.valueFilter,
+        maxMessages: options.maxMessages,
+        durationSeconds: options.durationSeconds,
+      })
+      .subscribe({
+        next: message => {
+          const current = this.messages();
+          const updated = [message, ...current].slice(0, options.maxMessages);
+          this.messages.set(updated);
+          this.totalFetched.set(this.totalFetched() + 1);
+        },
+        error: (err: unknown) => {
+          this.tailActive.set(false);
+          this.tailSubscription = null;
+          const message = err instanceof Error ? err.message : 'Tail stream failed';
+          this.store.error.set(message);
+        },
+        complete: () => {
+          this.tailActive.set(false);
+          this.tailSubscription = null;
+        },
+      });
+  }
+
+  onStopTail() {
+    this.tailSubscription?.unsubscribe();
+    this.tailSubscription = null;
+    this.tailActive.set(false);
+  }
+
+  ngOnDestroy() {
+    this.onStopTail();
   }
 
   private fetchMessages(options: BrowseMessagesOptions) {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.html
@@ -50,8 +50,14 @@
 
         @if (offsetMode() === 'TIMESTAMP') {
           <mat-form-field class="messages-browser__control">
-            <mat-label>Timestamp (ms)</mat-label>
-            <input matInput type="number" [ngModel]="offsetValue()" (ngModelChange)="offsetValue.set($event)" />
+            <mat-label>Timestamp</mat-label>
+            <input
+              matInput
+              type="datetime-local"
+              step="1"
+              [ngModel]="timestampInput()"
+              (ngModelChange)="onTimestampChange($event)"
+            />
           </mat-form-field>
         }
 

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.html
@@ -1,0 +1,175 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="messages-browser">
+  <div class="messages-browser__header">
+    <button mat-icon-button (click)="back.emit()">
+      <mat-icon>arrow_back</mat-icon>
+    </button>
+    <h3 class="messages-browser__title">Messages - {{ topicName() }}</h3>
+  </div>
+
+  <mat-card class="messages-browser__controls">
+    <mat-card-content>
+      <div class="messages-browser__controls-row">
+        <mat-form-field class="messages-browser__control">
+          <mat-label>Partition</mat-label>
+          <mat-select [value]="selectedPartition()" (selectionChange)="selectedPartition.set($event.value)">
+            <mat-option [value]="undefined">All</mat-option>
+            @for (p of partitionOptions; track p) {
+              @if (p !== undefined) {
+                <mat-option [value]="p">{{ p }}</mat-option>
+              }
+            }
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field class="messages-browser__control">
+          <mat-label>Offset Mode</mat-label>
+          <mat-select [value]="offsetMode()" (selectionChange)="offsetMode.set($event.value)">
+            <mat-option value="NEWEST">Newest</mat-option>
+            <mat-option value="OLDEST">Oldest</mat-option>
+            <mat-option value="TIMESTAMP">Timestamp</mat-option>
+            <mat-option value="SPECIFIC">Specific Offset</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        @if (offsetMode() === 'TIMESTAMP') {
+          <mat-form-field class="messages-browser__control">
+            <mat-label>Timestamp (ms)</mat-label>
+            <input matInput type="number" [ngModel]="offsetValue()" (ngModelChange)="offsetValue.set($event)" />
+          </mat-form-field>
+        }
+
+        @if (offsetMode() === 'SPECIFIC') {
+          <mat-form-field class="messages-browser__control">
+            <mat-label>Offset</mat-label>
+            <input matInput type="number" [ngModel]="offsetValue()" (ngModelChange)="offsetValue.set($event)" />
+          </mat-form-field>
+        }
+
+        <mat-form-field class="messages-browser__control">
+          <mat-label>Key filter</mat-label>
+          <input matInput [ngModel]="keyFilter()" (ngModelChange)="keyFilter.set($event)" />
+        </mat-form-field>
+
+        <mat-form-field class="messages-browser__control messages-browser__control--small">
+          <mat-label>Limit</mat-label>
+          <input matInput type="number" [ngModel]="limit()" (ngModelChange)="limit.set($event)" min="1" max="100" />
+        </mat-form-field>
+
+        <button mat-raised-button color="primary" class="messages-browser__fetch-btn" (click)="onFetch()" [disabled]="loading()">
+          Fetch
+        </button>
+      </div>
+    </mat-card-content>
+  </mat-card>
+
+  @if (loading()) {
+    <mat-progress-bar mode="indeterminate" />
+  }
+
+  @if (messages().length > 0) {
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>{{ messages().length }} messages ({{ totalFetched() }} fetched)</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <table
+          mat-table
+          [dataSource]="sortedMessages()"
+          matSort
+          (matSortChange)="onSortChange($event)"
+          [matSortActive]="sortActive()"
+          [matSortDirection]="sortDirection()"
+          class="messages-browser__table"
+        >
+          <ng-container matColumnDef="partition">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Partition</th>
+            <td mat-cell *matCellDef="let m">{{ m.partition }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="offset">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Offset</th>
+            <td mat-cell *matCellDef="let m">{{ m.offset }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="timestamp">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Timestamp</th>
+            <td mat-cell *matCellDef="let m">{{ m.timestamp | date: 'yyyy-MM-dd HH:mm:ss.SSS' }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="key">
+            <th mat-header-cell *matHeaderCellDef>Key</th>
+            <td mat-cell *matCellDef="let m">{{ truncate(m.key, 40) }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="value">
+            <th mat-header-cell *matHeaderCellDef>Value</th>
+            <td mat-cell *matCellDef="let m">{{ truncate(m.value) }}</td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns" class="messages-browser__row" (click)="onRowClick(row)"></tr>
+        </table>
+      </mat-card-content>
+    </mat-card>
+  }
+
+  @if (!loading() && messages().length === 0 && totalFetched() >= 0) {
+    <mat-card>
+      <mat-card-content>
+        <p class="messages-browser__empty">No messages found.</p>
+      </mat-card-content>
+    </mat-card>
+  }
+
+  @if (expandedMessage(); as msg) {
+    <mat-card class="messages-browser__detail">
+      <mat-card-header>
+        <mat-card-title>Message Detail - Partition {{ msg.partition }}, Offset {{ msg.offset }}</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <div class="messages-browser__detail-section">
+          <strong>Key:</strong>
+          <pre class="messages-browser__pre">{{ msg.key }}</pre>
+        </div>
+        <div class="messages-browser__detail-section">
+          <strong>Value:</strong>
+          <pre class="messages-browser__pre">{{ isJson(msg.value) ? formatJson(msg.value) : msg.value }}</pre>
+        </div>
+        @if (msg.headers && msg.headers.length > 0) {
+          <div class="messages-browser__detail-section">
+            <strong>Headers:</strong>
+            <table mat-table [dataSource]="msg.headers" class="messages-browser__headers-table">
+              <ng-container matColumnDef="key">
+                <th mat-header-cell *matHeaderCellDef>Key</th>
+                <td mat-cell *matCellDef="let h">{{ h.key }}</td>
+              </ng-container>
+              <ng-container matColumnDef="value">
+                <th mat-header-cell *matHeaderCellDef>Value</th>
+                <td mat-cell *matCellDef="let h">{{ h.value }}</td>
+              </ng-container>
+              <tr mat-header-row *matHeaderRowDef="['key', 'value']"></tr>
+              <tr mat-row *matRowDef="let row; columns: ['key', 'value']"></tr>
+            </table>
+          </div>
+        }
+      </mat-card-content>
+    </mat-card>
+  }
+</div>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.html
@@ -23,6 +23,11 @@
     <h3 class="messages-browser__title">Messages - {{ topicName() }}</h3>
   </div>
 
+  <mat-button-toggle-group [value]="mode()" (change)="mode.set($event.value)" class="messages-browser__mode-toggle">
+    <mat-button-toggle value="batch">Batch</mat-button-toggle>
+    <mat-button-toggle value="live">Live</mat-button-toggle>
+  </mat-button-toggle-group>
+
   <mat-card class="messages-browser__controls">
     <mat-card-content>
       <div class="messages-browser__controls-row">
@@ -38,34 +43,30 @@
           </mat-select>
         </mat-form-field>
 
-        <mat-form-field class="messages-browser__control">
-          <mat-label>Offset Mode</mat-label>
-          <mat-select [value]="offsetMode()" (selectionChange)="offsetMode.set($event.value)">
-            <mat-option value="NEWEST">Newest</mat-option>
-            <mat-option value="OLDEST">Oldest</mat-option>
-            <mat-option value="TIMESTAMP">Timestamp</mat-option>
-            <mat-option value="SPECIFIC">Specific Offset</mat-option>
-          </mat-select>
-        </mat-form-field>
-
-        @if (offsetMode() === 'TIMESTAMP') {
+        @if (mode() === 'batch') {
           <mat-form-field class="messages-browser__control">
-            <mat-label>Timestamp</mat-label>
-            <input
-              matInput
-              type="datetime-local"
-              step="1"
-              [ngModel]="timestampInput()"
-              (ngModelChange)="onTimestampChange($event)"
-            />
+            <mat-label>Offset Mode</mat-label>
+            <mat-select [value]="offsetMode()" (selectionChange)="offsetMode.set($event.value)">
+              <mat-option value="NEWEST">Newest</mat-option>
+              <mat-option value="OLDEST">Oldest</mat-option>
+              <mat-option value="TIMESTAMP">Timestamp</mat-option>
+              <mat-option value="SPECIFIC">Specific Offset</mat-option>
+            </mat-select>
           </mat-form-field>
-        }
 
-        @if (offsetMode() === 'SPECIFIC') {
-          <mat-form-field class="messages-browser__control">
-            <mat-label>Offset</mat-label>
-            <input matInput type="number" [ngModel]="offsetValue()" (ngModelChange)="offsetValue.set($event)" />
-          </mat-form-field>
+          @if (offsetMode() === 'TIMESTAMP') {
+            <mat-form-field class="messages-browser__control">
+              <mat-label>Timestamp</mat-label>
+              <input matInput type="datetime-local" step="1" [ngModel]="timestampInput()" (ngModelChange)="onTimestampChange($event)" />
+            </mat-form-field>
+          }
+
+          @if (offsetMode() === 'SPECIFIC') {
+            <mat-form-field class="messages-browser__control">
+              <mat-label>Offset</mat-label>
+              <input matInput type="number" [ngModel]="offsetValue()" (ngModelChange)="offsetValue.set($event)" />
+            </mat-form-field>
+          }
         }
 
         <mat-form-field class="messages-browser__control">
@@ -78,14 +79,35 @@
           <input matInput [ngModel]="valueFilter()" (ngModelChange)="valueFilter.set($event)" />
         </mat-form-field>
 
-        <mat-form-field class="messages-browser__control messages-browser__control--small">
-          <mat-label>Limit</mat-label>
-          <input matInput type="number" [ngModel]="limit()" (ngModelChange)="limit.set($event)" min="1" max="100" />
-        </mat-form-field>
+        @if (mode() === 'batch') {
+          <mat-form-field class="messages-browser__control messages-browser__control--small">
+            <mat-label>Limit</mat-label>
+            <input matInput type="number" [ngModel]="limit()" (ngModelChange)="limit.set($event)" min="1" max="1000" />
+          </mat-form-field>
 
-        <button mat-raised-button color="primary" class="messages-browser__fetch-btn" (click)="onFetch()" [disabled]="loading()">
-          Fetch
-        </button>
+          <button mat-raised-button color="primary" class="messages-browser__fetch-btn" (click)="onFetch()" [disabled]="loading()">
+            Fetch
+          </button>
+        }
+
+        @if (mode() === 'live') {
+          <mat-form-field class="messages-browser__control messages-browser__control--small">
+            <mat-label>Duration (s)</mat-label>
+            <input matInput type="number" [ngModel]="tailDuration()" (ngModelChange)="tailDuration.set($event)" min="1" max="300" />
+          </mat-form-field>
+
+          <mat-form-field class="messages-browser__control messages-browser__control--small">
+            <mat-label>Max messages</mat-label>
+            <input matInput type="number" [ngModel]="tailMaxMessages()" (ngModelChange)="tailMaxMessages.set($event)" min="1" max="5000" />
+          </mat-form-field>
+
+          @if (!tailActive()) {
+            <button mat-raised-button color="primary" class="messages-browser__fetch-btn" (click)="onStartTail()">Start</button>
+          } @else {
+            <button mat-raised-button color="warn" class="messages-browser__fetch-btn" (click)="onStopTail()">Stop</button>
+            <mat-spinner diameter="24" class="messages-browser__tail-spinner" />
+          }
+        }
       </div>
     </mat-card-content>
   </mat-card>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.html
@@ -67,6 +67,11 @@
           <input matInput [ngModel]="keyFilter()" (ngModelChange)="keyFilter.set($event)" />
         </mat-form-field>
 
+        <mat-form-field class="messages-browser__control">
+          <mat-label>Value filter</mat-label>
+          <input matInput [ngModel]="valueFilter()" (ngModelChange)="valueFilter.set($event)" />
+        </mat-form-field>
+
         <mat-form-field class="messages-browser__control messages-browser__control--small">
           <mat-label>Limit</mat-label>
           <input matInput type="number" [ngModel]="limit()" (ngModelChange)="limit.set($event)" min="1" max="100" />

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.scss
@@ -42,6 +42,12 @@
     &--small {
       max-width: 80px;
     }
+
+    input[type='datetime-local']::-webkit-calendar-picker-indicator {
+      display: block;
+      opacity: 1;
+      cursor: pointer;
+    }
   }
 
   &__fetch-btn {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.scss
@@ -54,6 +54,10 @@
     align-self: center;
   }
 
+  &__tail-spinner {
+    align-self: center;
+  }
+
   &__table {
     width: 100%;
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.scss
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-.topic-detail {
+.messages-browser {
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -29,31 +29,63 @@
     margin: 0;
   }
 
-  &__spacer {
-    flex: 1;
+  &__controls-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
   }
 
-  &__browse-btn {
-    mat-icon {
-      margin-right: 4px;
+  &__control {
+    min-width: 140px;
+
+    &--small {
+      max-width: 80px;
     }
+  }
+
+  &__fetch-btn {
+    align-self: center;
+  }
+
+  &__table {
+    width: 100%;
+  }
+
+  &__row {
+    cursor: pointer;
+
+    &:hover {
+      background-color: var(--mat-sys-surface-variant, rgba(0, 0, 0, 0.04));
+    }
+  }
+
+  &__empty {
+    text-align: center;
+    color: var(--mat-sys-on-surface-variant, #49454f);
+    padding: 24px;
+  }
+
+  &__detail-section {
+    margin-bottom: 16px;
+  }
+
+  &__pre {
+    background-color: var(--mat-sys-surface-variant, #f5f5f5);
+    padding: 12px;
+    border-radius: 4px;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+    font-family: monospace;
+    font-size: 13px;
+  }
+
+  &__headers-table {
+    width: 100%;
   }
 
   mat-card-content {
     overflow-x: auto;
-  }
-
-  &__link {
-    cursor: pointer;
-  }
-
-  &__empty {
-    color: var(--mat-sys-on-surface-variant, #49454f);
-    padding: 16px 0;
-    margin: 0;
-  }
-
-  table {
-    width: 100%;
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.spec.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { MessagesBrowserComponent } from './messages-browser.component';
+import { MessagesBrowserHarness } from './messages-browser.harness';
+import { fakeKafkaMessage } from '../../../models/kafka-cluster.fixture';
+
+describe('MessagesBrowserComponent', () => {
+  let fixture: ComponentFixture<MessagesBrowserComponent>;
+  let harness: MessagesBrowserHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MessagesBrowserComponent],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MessagesBrowserComponent);
+    fixture.componentRef.setInput('topicName', 'test-topic');
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, MessagesBrowserHarness);
+  });
+
+  it('should display topic name', async () => {
+    expect(await harness.getTopicName()).toContain('test-topic');
+  });
+
+  it('should show empty message when no messages', async () => {
+    expect(await harness.hasEmptyMessage()).toBe(true);
+  });
+
+  it('should display messages table when messages are provided', async () => {
+    fixture.componentRef.setInput('messages', [
+      fakeKafkaMessage({ partition: 0, offset: 42, key: 'key-1' }),
+      fakeKafkaMessage({ partition: 1, offset: 10, key: 'key-2' }),
+    ]);
+    fixture.componentRef.setInput('totalFetched', 2);
+    fixture.detectChanges();
+
+    const rows = await harness.getMessagesRows();
+    expect(rows.length).toBe(2);
+    expect(rows[0]['partition']).toBe('0');
+    expect(rows[0]['offset']).toBe('42');
+    expect(rows[0]['key']).toContain('key-1');
+  });
+
+  it('should emit back event on back button click', async () => {
+    const spy = jest.fn();
+    fixture.componentInstance.back.subscribe(spy);
+
+    await harness.clickBack();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should emit search event on fetch button click', async () => {
+    const spy = jest.fn();
+    fixture.componentInstance.search.subscribe(spy);
+
+    await harness.clickFetch();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        offsetMode: 'NEWEST',
+        limit: 50,
+      }),
+    );
+  });
+
+  it('should show loading bar when loading', async () => {
+    fixture.componentRef.setInput('loading', true);
+    fixture.detectChanges();
+
+    expect(await harness.isLoading()).toBe(true);
+  });
+
+  it('should not show loading bar when not loading', async () => {
+    fixture.componentRef.setInput('loading', false);
+    fixture.detectChanges();
+
+    expect(await harness.isLoading()).toBe(false);
+  });
+
+  it('should compute partitionOptions from partitionCount', () => {
+    fixture.componentRef.setInput('partitionCount', 3);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.partitionOptions).toEqual([undefined, 0, 1, 2]);
+  });
+
+  it('should return only undefined when partitionCount is 0', () => {
+    fixture.componentRef.setInput('partitionCount', 0);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.partitionOptions).toEqual([undefined]);
+  });
+
+  it('should toggle expanded message on row click', () => {
+    const msg1 = fakeKafkaMessage({ partition: 0, offset: 42 });
+    const msg2 = fakeKafkaMessage({ partition: 1, offset: 10 });
+
+    fixture.componentInstance.onRowClick(msg1);
+    expect(fixture.componentInstance.expandedMessage()).toBe(msg1);
+
+    fixture.componentInstance.onRowClick(msg1);
+    expect(fixture.componentInstance.expandedMessage()).toBeNull();
+
+    fixture.componentInstance.onRowClick(msg2);
+    expect(fixture.componentInstance.expandedMessage()).toBe(msg2);
+  });
+
+  describe('truncate', () => {
+    it('should return empty string for null', () => {
+      expect(fixture.componentInstance.truncate(null)).toBe('');
+    });
+
+    it('should return value if shorter than maxLength', () => {
+      expect(fixture.componentInstance.truncate('hello', 10)).toBe('hello');
+    });
+
+    it('should truncate and add ellipsis if longer than maxLength', () => {
+      expect(fixture.componentInstance.truncate('hello world', 5)).toBe('hello...');
+    });
+  });
+
+  describe('formatJson', () => {
+    it('should return empty string for null', () => {
+      expect(fixture.componentInstance.formatJson(null)).toBe('');
+    });
+
+    it('should pretty-print valid JSON', () => {
+      expect(fixture.componentInstance.formatJson('{"a":1}')).toBe('{\n  "a": 1\n}');
+    });
+
+    it('should return original value for invalid JSON', () => {
+      expect(fixture.componentInstance.formatJson('not json')).toBe('not json');
+    });
+  });
+
+  describe('isJson', () => {
+    it('should return false for null', () => {
+      expect(fixture.componentInstance.isJson(null)).toBe(false);
+    });
+
+    it('should return true for valid JSON', () => {
+      expect(fixture.componentInstance.isJson('{"a":1}')).toBe(true);
+    });
+
+    it('should return false for invalid JSON', () => {
+      expect(fixture.componentInstance.isJson('not json')).toBe(false);
+    });
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.spec.ts
@@ -71,7 +71,7 @@ describe('MessagesBrowserComponent', () => {
 
   it('should emit search event on fetch button click', async () => {
     const spy = jest.fn();
-    fixture.componentInstance.search.subscribe(spy);
+    fixture.componentInstance.browseMessages.subscribe(spy);
 
     await harness.clickFetch();
 

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, computed, input, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSelectModule } from '@angular/material/select';
+import { Sort, MatSortModule, SortDirection } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+
+import { KafkaMessage, OffsetMode } from '../../../models/kafka-cluster.model';
+
+export interface BrowseMessagesOptions {
+  partition?: number;
+  offsetMode: OffsetMode;
+  offsetValue?: number;
+  keyFilter?: string;
+  limit: number;
+}
+
+@Component({
+  selector: 'gke-messages-browser',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatCardModule,
+    MatTableModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressBarModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatSortModule,
+    DatePipe,
+  ],
+  templateUrl: './messages-browser.component.html',
+  styleUrls: ['./messages-browser.component.scss'],
+})
+export class MessagesBrowserComponent {
+  topicName = input.required<string>();
+  messages = input<KafkaMessage[]>([]);
+  totalFetched = input(0);
+  partitionCount = input(0);
+  loading = input(false);
+
+  back = output<void>();
+  search = output<BrowseMessagesOptions>();
+
+  selectedPartition = signal<number | undefined>(undefined);
+  offsetMode = signal<OffsetMode>('NEWEST');
+  offsetValue = signal<number | undefined>(undefined);
+  keyFilter = signal('');
+  limit = signal(50);
+
+  expandedMessage = signal<KafkaMessage | null>(null);
+
+  sortActive = signal('timestamp');
+  sortDirection = signal<SortDirection>('desc');
+
+  sortedMessages = computed(() => {
+    const msgs = this.messages();
+    const active = this.sortActive();
+    const direction = this.sortDirection();
+    if (!active || direction === '') return msgs;
+
+    const factor = direction === 'asc' ? 1 : -1;
+    return [...msgs].sort((a, b) => {
+      switch (active) {
+        case 'timestamp':
+          return (a.timestamp - b.timestamp) * factor;
+        case 'partition':
+          return (a.partition - b.partition) * factor;
+        case 'offset':
+          return (a.offset - b.offset) * factor;
+        default:
+          return 0;
+      }
+    });
+  });
+
+  displayedColumns = ['partition', 'offset', 'timestamp', 'key', 'value'];
+
+  get partitionOptions(): (number | undefined)[] {
+    const options: (number | undefined)[] = [undefined];
+    for (let i = 0; i < this.partitionCount(); i++) {
+      options.push(i);
+    }
+    return options;
+  }
+
+  onSortChange(sort: Sort) {
+    this.sortActive.set(sort.active);
+    this.sortDirection.set(sort.direction);
+  }
+
+  onFetch() {
+    this.sortActive.set('timestamp');
+    this.sortDirection.set(this.offsetMode() === 'NEWEST' ? 'desc' : 'asc');
+
+    this.search.emit({
+      partition: this.selectedPartition(),
+      offsetMode: this.offsetMode(),
+      offsetValue: this.offsetValue(),
+      keyFilter: this.keyFilter() || undefined,
+      limit: this.limit(),
+    });
+  }
+
+  onRowClick(message: KafkaMessage) {
+    this.expandedMessage.set(this.expandedMessage() === message ? null : message);
+  }
+
+  truncate(value: string | null | undefined, maxLength = 80): string {
+    if (!value) return '';
+    return value.length > maxLength ? value.substring(0, maxLength) + '...' : value;
+  }
+
+  formatJson(value: string | null | undefined): string {
+    if (!value) return '';
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2);
+    } catch {
+      return value;
+    }
+  }
+
+  isJson(value: string | null | undefined): boolean {
+    if (!value) return false;
+    try {
+      JSON.parse(value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.ts
@@ -17,11 +17,13 @@ import { CommonModule, DatePipe } from '@angular/common';
 import { Component, computed, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { Sort, MatSortModule, SortDirection } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
@@ -37,6 +39,16 @@ export interface BrowseMessagesOptions {
   limit: number;
 }
 
+export type BrowseMode = 'batch' | 'live';
+
+export interface TailMessagesOptions {
+  partition?: number;
+  keyFilter?: string;
+  valueFilter?: string;
+  maxMessages: number;
+  durationSeconds: number;
+}
+
 @Component({
   selector: 'gke-messages-browser',
   standalone: true,
@@ -47,7 +59,9 @@ export interface BrowseMessagesOptions {
     MatTableModule,
     MatIconModule,
     MatButtonModule,
+    MatButtonToggleModule,
     MatProgressBarModule,
+    MatProgressSpinnerModule,
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
@@ -64,8 +78,16 @@ export class MessagesBrowserComponent {
   partitionCount = input(0);
   loading = input(false);
 
+  tailActive = input(false);
+
   back = output<void>();
-  search = output<BrowseMessagesOptions>();
+  browseMessages = output<BrowseMessagesOptions>();
+  startTail = output<TailMessagesOptions>();
+  stopTail = output<void>();
+
+  mode = signal<BrowseMode>('batch');
+  tailDuration = signal(30);
+  tailMaxMessages = signal(1000);
 
   selectedPartition = signal<number | undefined>(undefined);
   offsetMode = signal<OffsetMode>('NEWEST');
@@ -125,7 +147,7 @@ export class MessagesBrowserComponent {
     this.sortActive.set('timestamp');
     this.sortDirection.set(this.offsetMode() === 'NEWEST' ? 'desc' : 'asc');
 
-    this.search.emit({
+    this.browseMessages.emit({
       partition: this.selectedPartition(),
       offsetMode: this.offsetMode(),
       offsetValue: this.offsetValue(),
@@ -133,6 +155,20 @@ export class MessagesBrowserComponent {
       valueFilter: this.valueFilter() || undefined,
       limit: this.limit(),
     });
+  }
+
+  onStartTail() {
+    this.startTail.emit({
+      partition: this.selectedPartition(),
+      keyFilter: this.keyFilter() || undefined,
+      valueFilter: this.valueFilter() || undefined,
+      maxMessages: this.tailMaxMessages(),
+      durationSeconds: this.tailDuration(),
+    });
+  }
+
+  onStopTail() {
+    this.stopTail.emit();
   }
 
   onRowClick(message: KafkaMessage) {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.ts
@@ -70,6 +70,7 @@ export class MessagesBrowserComponent {
   selectedPartition = signal<number | undefined>(undefined);
   offsetMode = signal<OffsetMode>('NEWEST');
   offsetValue = signal<number | undefined>(undefined);
+  timestampInput = signal('');
   keyFilter = signal('');
   valueFilter = signal('');
   limit = signal(50);
@@ -108,6 +109,11 @@ export class MessagesBrowserComponent {
       options.push(i);
     }
     return options;
+  }
+
+  onTimestampChange(value: string) {
+    this.timestampInput.set(value);
+    this.offsetValue.set(value ? new Date(value).getTime() : undefined);
   }
 
   onSortChange(sort: Sort) {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.ts
@@ -33,6 +33,7 @@ export interface BrowseMessagesOptions {
   offsetMode: OffsetMode;
   offsetValue?: number;
   keyFilter?: string;
+  valueFilter?: string;
   limit: number;
 }
 
@@ -70,6 +71,7 @@ export class MessagesBrowserComponent {
   offsetMode = signal<OffsetMode>('NEWEST');
   offsetValue = signal<number | undefined>(undefined);
   keyFilter = signal('');
+  valueFilter = signal('');
   limit = signal(50);
 
   expandedMessage = signal<KafkaMessage | null>(null);
@@ -122,6 +124,7 @@ export class MessagesBrowserComponent {
       offsetMode: this.offsetMode(),
       offsetValue: this.offsetValue(),
       keyFilter: this.keyFilter() || undefined,
+      valueFilter: this.valueFilter() || undefined,
       limit: this.limit(),
     });
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.harness.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, parallel } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+
+export class MessagesBrowserHarness extends ComponentHarness {
+  static hostSelector = 'gke-messages-browser';
+
+  private readonly getBackButton = this.locatorFor(MatButtonHarness.with({ selector: '[mat-icon-button]' }));
+  private readonly getFetchButton = this.locatorFor(MatButtonHarness.with({ text: /Fetch/ }));
+  private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
+  private readonly getTitle = this.locatorFor('.messages-browser__title');
+  private readonly getTables = this.locatorForAll(MatTableHarness);
+  private readonly getSelects = this.locatorForAll(MatSelectHarness);
+  private readonly getEmptyMessage = this.locatorForOptional('.messages-browser__empty');
+  private readonly getDetail = this.locatorForOptional('.messages-browser__detail');
+
+  async getTopicName() {
+    const title = await this.getTitle();
+    return title.text();
+  }
+
+  async isLoading() {
+    return (await this.getProgressBar()) !== null;
+  }
+
+  async clickBack() {
+    const button = await this.getBackButton();
+    await button.click();
+  }
+
+  async clickFetch() {
+    const button = await this.getFetchButton();
+    await button.click();
+  }
+
+  async getMessagesRows() {
+    const tables = await this.getTables();
+    if (tables.length < 1) return [];
+    const rows = await tables[0].getRows();
+    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+  }
+
+  async clickMessageRow(index: number) {
+    const rows = await this.locatorForAll('.messages-browser__row')();
+    if (index < rows.length) {
+      await rows[index].click();
+    }
+  }
+
+  async hasEmptyMessage() {
+    return (await this.getEmptyMessage()) !== null;
+  }
+
+  async hasDetail() {
+    return (await this.getDetail()) !== null;
+  }
+
+  async getOffsetModeSelect() {
+    const selects = await this.getSelects();
+    return selects.length > 1 ? selects[1] : undefined;
+  }
+
+  async selectOffsetMode(mode: string) {
+    const select = await this.getOffsetModeSelect();
+    if (select) {
+      await select.open();
+      const options = await select.getOptions({ text: mode });
+      if (options.length > 0) {
+        await options[0].click();
+      }
+    }
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.html
@@ -25,10 +25,12 @@
       <gke-badge>Internal</gke-badge>
     }
     <span class="topic-detail__spacer"></span>
-    <button mat-stroked-button class="topic-detail__browse-btn" (click)="browseMessages.emit()">
-      <mat-icon>search</mat-icon>
-      Browse Messages
-    </button>
+    @if (topicDetail()) {
+      <button mat-stroked-button class="topic-detail__browse-btn" (click)="browseMessages.emit()">
+        <mat-icon>search</mat-icon>
+        Browse Messages
+      </button>
+    }
   </div>
 
   @if (loading()) {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.harness.ts
@@ -23,6 +23,7 @@ export class TopicDetailHarness extends ComponentHarness {
 
   private readonly getTables = this.locatorForAll(MatTableHarness);
   private readonly getBackButton = this.locatorFor(MatButtonHarness.with({ selector: '[mat-icon-button]' }));
+  private readonly getBrowseMessagesButton = this.locatorForOptional(MatButtonHarness.with({ text: /Browse Messages/ }));
   private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
   private readonly getTitle = this.locatorFor('.topic-detail__title');
   private readonly getHeader = this.locatorFor('.topic-detail__header');
@@ -46,6 +47,17 @@ export class TopicDetailHarness extends ComponentHarness {
   async clickBack() {
     const button = await this.getBackButton();
     await button.click();
+  }
+
+  async hasBrowseMessagesButton() {
+    return (await this.getBrowseMessagesButton()) !== null;
+  }
+
+  async clickBrowseMessages() {
+    const button = await this.getBrowseMessagesButton();
+    if (button) {
+      await button.click();
+    }
   }
 
   async getPartitionsRows() {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.harness.ts
@@ -23,7 +23,6 @@ export class TopicDetailHarness extends ComponentHarness {
 
   private readonly getTables = this.locatorForAll(MatTableHarness);
   private readonly getBackButton = this.locatorFor(MatButtonHarness.with({ selector: '[mat-icon-button]' }));
-  private readonly getBrowseMessagesButton = this.locatorForOptional(MatButtonHarness.with({ text: /Browse Messages/ }));
   private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
   private readonly getTitle = this.locatorFor('.topic-detail__title');
   private readonly getHeader = this.locatorFor('.topic-detail__header');
@@ -47,17 +46,6 @@ export class TopicDetailHarness extends ComponentHarness {
   async clickBack() {
     const button = await this.getBackButton();
     await button.click();
-  }
-
-  async hasBrowseMessagesButton() {
-    return (await this.getBrowseMessagesButton()) !== null;
-  }
-
-  async clickBrowseMessages() {
-    const button = await this.getBrowseMessagesButton();
-    if (button) {
-      await button.click();
-    }
   }
 
   async getPartitionsRows() {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.routes.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.routes.ts
@@ -20,6 +20,7 @@ import { BrokerDetailPageComponent } from '../features/brokers/broker-detail-pag
 import { BrokersPageComponent } from '../features/brokers/brokers-page.component';
 import { ConsumerGroupDetailPageComponent } from '../features/consumer-groups/consumer-group-detail-page.component';
 import { ConsumerGroupsPageComponent } from '../features/consumer-groups/consumer-groups-page.component';
+import { MessagesPageComponent } from '../features/topics/messages-page.component';
 import { TopicDetailPageComponent } from '../features/topics/topic-detail-page.component';
 import { TopicsPageComponent } from '../features/topics/topics-page.component';
 
@@ -33,6 +34,7 @@ export const KAFKA_EXPLORER_ROUTES: Routes = [
       { path: 'brokers/:brokerId', component: BrokerDetailPageComponent },
       { path: 'topics', component: TopicsPageComponent },
       { path: 'topics/:topicName', component: TopicDetailPageComponent },
+      { path: 'topics/:topicName/messages', component: MessagesPageComponent },
       { path: 'consumer-groups', component: ConsumerGroupsPageComponent },
       { path: 'consumer-groups/:groupId', component: ConsumerGroupDetailPageComponent },
     ],

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.fixture.ts
@@ -16,6 +16,7 @@
 import {
   BrokerDetail,
   BrokerLogDirEntry,
+  BrowseMessagesResponse,
   DescribeBrokerResponse,
   ConsumerGroupMember,
   ConsumerGroupOffset,
@@ -23,6 +24,8 @@ import {
   DescribeClusterResponse,
   DescribeConsumerGroupResponse,
   DescribeTopicResponse,
+  KafkaHeader,
+  KafkaMessage,
   KafkaNode,
   KafkaTopic,
   ListConsumerGroupsResponse,
@@ -246,6 +249,38 @@ export function fakeDescribeConsumerGroupResponse(overrides: Partial<DescribeCon
       fakeConsumerGroupOffset({ topic: 'my-topic', partition: 0, committedOffset: 50, endOffset: 100, lag: 50 }),
       fakeConsumerGroupOffset({ topic: 'my-topic', partition: 1, committedOffset: 80, endOffset: 100, lag: 20 }),
     ],
+    ...overrides,
+  };
+}
+
+export function fakeKafkaHeader(overrides: Partial<KafkaHeader> = {}): KafkaHeader {
+  return {
+    key: 'content-type',
+    value: 'application/json',
+    ...overrides,
+  };
+}
+
+export function fakeKafkaMessage(overrides: Partial<KafkaMessage> = {}): KafkaMessage {
+  return {
+    partition: 0,
+    offset: 42,
+    timestamp: 1700000000000,
+    key: 'order-123',
+    value: '{"orderId":"123","status":"completed"}',
+    headers: [fakeKafkaHeader()],
+    ...overrides,
+  };
+}
+
+export function fakeBrowseMessagesResponse(overrides: Partial<BrowseMessagesResponse> = {}): BrowseMessagesResponse {
+  return {
+    data: [
+      fakeKafkaMessage({ partition: 0, offset: 42, key: 'order-123' }),
+      fakeKafkaMessage({ partition: 0, offset: 41, key: 'order-122', timestamp: 1699999999000 }),
+      fakeKafkaMessage({ partition: 1, offset: 10, key: 'order-121', timestamp: 1699999998000 }),
+    ],
+    totalFetched: 3,
     ...overrides,
   };
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/models/kafka-cluster.model.ts
@@ -146,3 +146,24 @@ export interface DescribeConsumerGroupResponse {
   members: ConsumerGroupMember[];
   offsets: ConsumerGroupOffset[];
 }
+
+export type OffsetMode = 'NEWEST' | 'OLDEST' | 'TIMESTAMP' | 'SPECIFIC';
+
+export interface KafkaHeader {
+  key: string;
+  value: string;
+}
+
+export interface KafkaMessage {
+  partition: number;
+  offset: number;
+  timestamp: number;
+  key: string;
+  value: string;
+  headers: KafkaHeader[];
+}
+
+export interface BrowseMessagesResponse {
+  data: KafkaMessage[];
+  totalFetched: number;
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
@@ -18,12 +18,14 @@ import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import {
+  BrowseMessagesResponse,
   DescribeBrokerResponse,
   DescribeClusterResponse,
   DescribeTopicResponse,
   ListTopicsResponse,
   DescribeConsumerGroupResponse,
   ListConsumerGroupsResponse,
+  OffsetMode,
 } from '../models/kafka-cluster.model';
 
 @Injectable({
@@ -71,5 +73,22 @@ export class KafkaExplorerService {
 
   describeConsumerGroup(baseURL: string, clusterId: string, groupId: string): Observable<DescribeConsumerGroupResponse> {
     return this.http.post<DescribeConsumerGroupResponse>(`${baseURL}/kafka-explorer/describe-consumer-group`, { clusterId, groupId });
+  }
+
+  browseMessages(
+    baseURL: string,
+    clusterId: string,
+    topicName: string,
+    options?: { partition?: number; offsetMode?: OffsetMode; offsetValue?: number; keyFilter?: string; limit?: number },
+  ): Observable<BrowseMessagesResponse> {
+    const limit = options?.limit ?? 50;
+    const body: Record<string, unknown> = { clusterId, topicName };
+    if (options?.partition != null) body['partition'] = options.partition;
+    if (options?.offsetMode) body['offsetMode'] = options.offsetMode;
+    if (options?.offsetValue != null) body['offsetValue'] = options.offsetValue;
+    if (options?.keyFilter) body['keyFilter'] = options.keyFilter;
+    return this.http.post<BrowseMessagesResponse>(`${baseURL}/kafka-explorer/browse-messages`, body, {
+      params: { limit: limit.toString() },
+    });
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
@@ -79,7 +79,14 @@ export class KafkaExplorerService {
     baseURL: string,
     clusterId: string,
     topicName: string,
-    options?: { partition?: number; offsetMode?: OffsetMode; offsetValue?: number; keyFilter?: string; limit?: number },
+    options?: {
+      partition?: number;
+      offsetMode?: OffsetMode;
+      offsetValue?: number;
+      keyFilter?: string;
+      valueFilter?: string;
+      limit?: number;
+    },
   ): Observable<BrowseMessagesResponse> {
     const limit = options?.limit ?? 50;
     const body: Record<string, unknown> = { clusterId, topicName };
@@ -87,6 +94,7 @@ export class KafkaExplorerService {
     if (options?.offsetMode) body['offsetMode'] = options.offsetMode;
     if (options?.offsetValue != null) body['offsetValue'] = options.offsetValue;
     if (options?.keyFilter) body['keyFilter'] = options.keyFilter;
+    if (options?.valueFilter) body['valueFilter'] = options.valueFilter;
     return this.http.post<BrowseMessagesResponse>(`${baseURL}/kafka-explorer/browse-messages`, body, {
       params: { limit: limit.toString() },
     });

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpEventType } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
@@ -22,6 +22,7 @@ import {
   DescribeBrokerResponse,
   DescribeClusterResponse,
   DescribeTopicResponse,
+  KafkaMessage,
   ListTopicsResponse,
   DescribeConsumerGroupResponse,
   ListConsumerGroupsResponse,
@@ -98,5 +99,86 @@ export class KafkaExplorerService {
     return this.http.post<BrowseMessagesResponse>(`${baseURL}/kafka-explorer/browse-messages`, body, {
       params: { limit: limit.toString() },
     });
+  }
+
+  tailMessages(
+    baseURL: string,
+    clusterId: string,
+    topicName: string,
+    options?: { partition?: number; keyFilter?: string; valueFilter?: string; maxMessages?: number; durationSeconds?: number },
+  ): Observable<KafkaMessage> {
+    const queryParams: Record<string, string> = { clusterId, topicName };
+    if (options?.partition != null) queryParams['partition'] = options.partition.toString();
+    if (options?.keyFilter) queryParams['keyFilter'] = options.keyFilter;
+    if (options?.valueFilter) queryParams['valueFilter'] = options.valueFilter;
+    if (options?.maxMessages) queryParams['maxMessages'] = options.maxMessages.toString();
+    if (options?.durationSeconds) queryParams['durationSeconds'] = options.durationSeconds.toString();
+
+    return new Observable<KafkaMessage>(subscriber => {
+      let lastParsedLength = 0;
+      let buffer = '';
+
+      const subscription = this.http
+        .get(`${baseURL}/kafka-explorer/tail-messages`, {
+          params: queryParams,
+          responseType: 'text',
+          observe: 'events',
+          reportProgress: true,
+        })
+        .subscribe({
+          next: event => {
+            if (event.type === HttpEventType.DownloadProgress && event.partialText) {
+              const newText = event.partialText.substring(lastParsedLength);
+              lastParsedLength = event.partialText.length;
+              buffer = this.processSseBuffer(buffer + newText, subscriber);
+            } else if (event.type === HttpEventType.Response) {
+              const remaining = typeof event.body === 'string' ? event.body.substring(lastParsedLength) : '';
+              if (remaining || buffer) {
+                this.processSseBuffer(buffer + remaining, subscriber);
+              }
+              subscriber.complete();
+            }
+          },
+          error: err => subscriber.error(err),
+        });
+
+      return () => subscription.unsubscribe();
+    });
+  }
+
+  private processSseBuffer(
+    buffer: string,
+    subscriber: { next: (msg: KafkaMessage) => void; complete: () => void; error: (err: unknown) => void },
+  ): string {
+    const blocks = buffer.split('\n\n');
+    const incomplete = blocks.pop() ?? '';
+
+    for (const block of blocks) {
+      if (!block.trim()) continue;
+
+      let eventName = '';
+      let data = '';
+      for (const line of block.split('\n')) {
+        if (line.startsWith('event:')) eventName = line.slice(6).trim();
+        else if (line.startsWith('data:')) data = line.slice(5).trim();
+      }
+
+      if (eventName === 'message' && data) {
+        try {
+          subscriber.next(JSON.parse(data));
+        } catch (e) {
+          subscriber.error(new Error('Failed to parse SSE message data'));
+          return '';
+        }
+      } else if (eventName === 'done') {
+        subscriber.complete();
+        return '';
+      } else if (eventName === 'error') {
+        subscriber.error(new Error(data || 'SSE stream error'));
+        return '';
+      }
+    }
+
+    return incomplete;
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts
@@ -32,6 +32,8 @@ export * from './lib/features/topics/topics/topics.component';
 export * from './lib/features/topics/topics-page.component';
 export * from './lib/features/topics/topic-detail/topic-detail.component';
 export * from './lib/features/topics/topic-detail-page.component';
+export * from './lib/features/topics/messages/messages-browser.component';
+export * from './lib/features/topics/messages-page.component';
 export * from './lib/features/consumer-groups/consumer-groups/consumer-groups.component';
 export * from './lib/features/consumer-groups/consumer-groups-page.component';
 export * from './lib/features/consumer-groups/consumer-group-detail/consumer-group-detail.component';


### PR DESCRIPTION
## Summary

- **Message browsing**: browse topic messages with offset modes (latest, earliest, timestamp), partition filter, key/value filters, and configurable limit
- **Live tail**: real-time SSE streaming using `HttpServletResponse` for unbuffered delivery, with max messages and duration controls
- **Error handling**: surface tail stream errors to the user via `store.error` banner
- **UI**: date-time picker for timestamp offset mode, value filter input

## Video

https://github.com/user-attachments/assets/8e0728c0-bf29-4df0-a974-033378264a89
