### PR TITLE
feat(kafka-explorer): show consumer groups in topic detail

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
@@ -28,6 +28,6 @@ public interface KafkaClusterDomainService {
     TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage);
     TopicDetail describeTopic(KafkaClusterConfiguration config, String topicName);
     BrokerInfo describeBroker(KafkaClusterConfiguration config, int brokerId);
-    ConsumerGroupsPage listConsumerGroups(KafkaClusterConfiguration config, String nameFilter, int page, int perPage);
+    ConsumerGroupsPage listConsumerGroups(KafkaClusterConfiguration config, String nameFilter, String topicFilter, int page, int perPage);
     ConsumerGroupDetail describeConsumerGroup(KafkaClusterConfiguration config, String groupId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCase.java
@@ -41,11 +41,17 @@ public class ListConsumerGroupsUseCase {
     public Output execute(Input input) {
         var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
         var config = cluster.getKafkaClusterConfiguration(objectMapper);
-        var consumerGroupsPage = kafkaClusterDomainService.listConsumerGroups(config, input.nameFilter(), input.page(), input.perPage());
+        var consumerGroupsPage = kafkaClusterDomainService.listConsumerGroups(
+            config,
+            input.nameFilter(),
+            input.topicFilter(),
+            input.page(),
+            input.perPage()
+        );
         return new Output(consumerGroupsPage);
     }
 
-    public record Input(String clusterId, String environmentId, String nameFilter, int page, int perPage) {}
+    public record Input(String clusterId, String environmentId, String nameFilter, String topicFilter, int page, int perPage) {}
 
     public record Output(ConsumerGroupsPage consumerGroupsPage) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
@@ -70,9 +70,8 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
-import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
 import org.apache.kafka.clients.admin.ListTopicsOptions;
-import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
@@ -333,12 +332,20 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
     }
 
     @Override
-    public ConsumerGroupsPage listConsumerGroups(KafkaClusterConfiguration config, String nameFilter, int page, int perPage) {
+    public ConsumerGroupsPage listConsumerGroups(
+        KafkaClusterConfiguration config,
+        String nameFilter,
+        String topicFilter,
+        int page,
+        int perPage
+    ) {
         return withAdminClient(config, adminClient -> {
-            // Step 1: List all consumer groups (cheap call)
+            boolean hasTopicFilter = topicFilter != null && !topicFilter.isBlank();
+
+            // Step 1: List all consumer groups
             Collection<ConsumerGroupListing> listings = adminClient.listConsumerGroups().all().get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-            // Step 2: Filter by nameFilter (case-insensitive contains)
+            // Step 2: Filter by name
             List<String> filteredGroupIds = listings
                 .stream()
                 .map(ConsumerGroupListing::groupId)
@@ -346,9 +353,33 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
                 .sorted()
                 .toList();
 
+            // Step 3: Filter by topic — fetch only the target topic's partition offsets, then filter in-memory
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> allOffsets;
+            if (hasTopicFilter) {
+                // Resolve topic partitions once to restrict the offset fetch to this topic only
+                TopicDescription topicDesc = adminClient
+                    .describeTopics(List.of(topicFilter))
+                    .allTopicNames()
+                    .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .get(topicFilter);
+                List<TopicPartition> topicPartitions = topicDesc
+                    .partitions()
+                    .stream()
+                    .map(p -> new TopicPartition(topicFilter, p.partition()))
+                    .toList();
+
+                allOffsets = fetchAllGroupOffsets(adminClient, filteredGroupIds, topicPartitions);
+                filteredGroupIds = filteredGroupIds
+                    .stream()
+                    .filter(groupId -> !allOffsets.getOrDefault(groupId, Map.of()).isEmpty())
+                    .toList();
+            } else {
+                allOffsets = null;
+            }
+
             int totalCount = filteredGroupIds.size();
 
-            // Step 3: Paginate
+            // Step 4: Paginate
             int fromIndex = Math.min(page * perPage, totalCount);
             int toIndex = Math.min(fromIndex + perPage, totalCount);
             List<String> pageGroupIds = filteredGroupIds.subList(fromIndex, toIndex);
@@ -357,20 +388,26 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
                 return new ConsumerGroupsPage(List.of(), totalCount, page, perPage);
             }
 
-            // Step 4: Describe consumer groups for the current page only
+            // Step 5: Batch-fetch offsets for page groups (reuse pre-fetched data when topicFilter was set)
+            final Map<String, Map<TopicPartition, OffsetAndMetadata>> pageOffsets = hasTopicFilter
+                ? allOffsets
+                : fetchAllGroupOffsets(adminClient, pageGroupIds, null);
+
+            // Step 6: Describe consumer groups for the current page
             Map<String, ConsumerGroupDescription> descriptions = adminClient
                 .describeConsumerGroups(pageGroupIds)
                 .all()
                 .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-            // Step 5: Best-effort lag calculation + topic count
+            // Step 7: Compute lag from pre-fetched offsets
             List<ConsumerGroup> groups = pageGroupIds
                 .stream()
                 .map(groupId -> {
                     ConsumerGroupDescription desc = descriptions.get(groupId);
                     String state = desc.state() != null ? desc.state().name() : "UNKNOWN";
                     int membersCount = desc.members().size();
-                    LagResult lagResult = computeLagResult(adminClient, groupId);
+                    var groupOffsets = pageOffsets.getOrDefault(groupId, Map.of());
+                    LagResult lagResult = computeLagResultFromOffsets(adminClient, groupOffsets, hasTopicFilter ? topicFilter : null);
                     KafkaNode coordinator = toKafkaNode(desc.coordinator());
                     return new ConsumerGroup(groupId, state, membersCount, lagResult.totalLag(), lagResult.numTopics(), coordinator);
                 })
@@ -422,28 +459,78 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
 
     private record LagResult(long totalLag, int numTopics) {}
 
-    private LagResult computeLagResult(AdminClient adminClient, String groupId) {
+    /**
+     * Batch-fetches committed offsets for multiple consumer groups in a single Kafka call.
+     * When topicPartitions is non-null, only offsets for those partitions are requested,
+     * reducing network payload and broker-side work.
+     */
+    private Map<String, Map<TopicPartition, OffsetAndMetadata>> fetchAllGroupOffsets(
+        AdminClient adminClient,
+        List<String> groupIds,
+        List<TopicPartition> topicPartitions
+    ) {
         try {
-            Map<TopicPartition, OffsetAndMetadata> committedOffsets = adminClient
-                .listConsumerGroupOffsets(groupId)
-                .partitionsToOffsetAndMetadata()
-                .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            Map<String, ListConsumerGroupOffsetsSpec> specs = new HashMap<>();
+            for (String groupId : groupIds) {
+                var spec = new ListConsumerGroupOffsetsSpec();
+                if (topicPartitions != null) {
+                    spec.topicPartitions(topicPartitions);
+                }
+                specs.put(groupId, spec);
+            }
 
-            if (committedOffsets.isEmpty()) {
+            Map<String, Map<TopicPartition, OffsetAndMetadata>> result = new HashMap<>();
+            var batchResult = adminClient.listConsumerGroupOffsets(specs);
+            for (String groupId : groupIds) {
+                try {
+                    Map<TopicPartition, OffsetAndMetadata> offsets = batchResult
+                        .partitionsToOffsetAndMetadata(groupId)
+                        .get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                    result.put(groupId, offsets);
+                } catch (Exception e) {
+                    result.put(groupId, Map.of());
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            return Map.of();
+        }
+    }
+
+    /**
+     * Computes lag from pre-fetched offsets (no additional listConsumerGroupOffsets call).
+     * If topicFilter is non-null, only partitions for that topic are considered.
+     */
+    private LagResult computeLagResultFromOffsets(
+        AdminClient adminClient,
+        Map<TopicPartition, OffsetAndMetadata> committedOffsets,
+        String topicFilter
+    ) {
+        try {
+            Map<TopicPartition, OffsetAndMetadata> filtered = committedOffsets;
+            if (topicFilter != null && !topicFilter.isBlank()) {
+                filtered = committedOffsets
+                    .entrySet()
+                    .stream()
+                    .filter(e -> e.getKey().topic().equals(topicFilter))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            }
+
+            if (filtered.isEmpty()) {
                 return new LagResult(0, 0);
             }
 
-            int numTopics = (int) committedOffsets.keySet().stream().map(TopicPartition::topic).distinct().count();
+            int numTopics = (int) filtered.keySet().stream().map(TopicPartition::topic).distinct().count();
 
             Map<TopicPartition, OffsetSpec> endOffsetRequests = new HashMap<>();
-            for (TopicPartition tp : committedOffsets.keySet()) {
+            for (TopicPartition tp : filtered.keySet()) {
                 endOffsetRequests.put(tp, OffsetSpec.latest());
             }
 
             var endOffsets = adminClient.listOffsets(endOffsetRequests).all().get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
             long totalLag = 0;
-            for (var entry : committedOffsets.entrySet()) {
+            for (var entry : filtered.entrySet()) {
                 TopicPartition tp = entry.getKey();
                 long committed = entry.getValue().offset();
                 var endOffsetResult = endOffsets.get(tp);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
@@ -240,7 +240,14 @@ public class KafkaExplorerResource {
             var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
             int page0Based = page - 1;
             var result = listConsumerGroupsUseCase.execute(
-                new ListConsumerGroupsUseCase.Input(request.getClusterId(), environmentId, request.getNameFilter(), page0Based, perPage)
+                new ListConsumerGroupsUseCase.Input(
+                    request.getClusterId(),
+                    environmentId,
+                    request.getNameFilter(),
+                    request.getTopicFilter(),
+                    page0Based,
+                    perPage
+                )
             );
             return Response.ok(KafkaExplorerMapper.INSTANCE.map(result.consumerGroupsPage(), page, perPage)).build();
         } catch (KafkaExplorerException e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -530,6 +530,9 @@ components:
                 nameFilter:
                     type: string
                     description: Optional filter to match consumer group IDs (case-insensitive contains)
+                topicFilter:
+                    type: string
+                    description: Optional filter to only return consumer groups that have committed offsets for this topic
 
         ListConsumerGroupsResponse:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCaseTest.java
@@ -63,7 +63,7 @@ class ListConsumerGroupsUseCaseTest {
         );
         clusterDomainService.givenConsumerGroups(allGroups);
 
-        var result = useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, 0, 25));
+        var result = useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, null, 0, 25));
 
         assertThat(result.consumerGroupsPage().data()).hasSize(2);
         assertThat(result.consumerGroupsPage().totalCount()).isEqualTo(2);
@@ -84,7 +84,7 @@ class ListConsumerGroupsUseCaseTest {
         );
         clusterDomainService.givenConsumerGroups(allGroups);
 
-        var result = useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my", 0, 25));
+        var result = useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my", null, 0, 25));
 
         assertThat(result.consumerGroupsPage().data()).hasSize(2);
         assertThat(result.consumerGroupsPage().data().get(0).groupId()).isEqualTo("my-group");
@@ -99,7 +99,7 @@ class ListConsumerGroupsUseCaseTest {
 
         clusterDomainService.givenException(new KafkaExplorerException("Connection failed", TechnicalCode.CONNECTION_FAILED));
 
-        assertThatThrownBy(() -> useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, 0, 25)))
+        assertThatThrownBy(() -> useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, null, 0, 25)))
             .isInstanceOf(KafkaExplorerException.class)
             .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.CONNECTION_FAILED));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
@@ -123,7 +123,13 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
     }
 
     @Override
-    public ConsumerGroupsPage listConsumerGroups(KafkaClusterConfiguration config, String nameFilter, int page, int perPage) {
+    public ConsumerGroupsPage listConsumerGroups(
+        KafkaClusterConfiguration config,
+        String nameFilter,
+        String topicFilter,
+        int page,
+        int perPage
+    ) {
         if (exception != null) {
             throw exception;
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_ListConsumerGroups.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_ListConsumerGroups.java
@@ -85,6 +85,33 @@ class KafkaExplorerResourceIntegrationTest_ListConsumerGroups extends AbstractKa
     }
 
     @Test
+    void should_filter_consumer_groups_by_topic() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID).topicFilter("__consumer_offsets");
+
+        var response = resource.listConsumerGroups(request, 1, 10);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (ListConsumerGroupsResponse) response.getEntity();
+        assertThat(body.getData()).isNotEmpty();
+        assertThat(body.getData()).anyMatch(g -> g.getGroupId().equals(CONSUMER_GROUP_ID));
+    }
+
+    @Test
+    void should_return_empty_when_topic_filter_matches_no_group() {
+        givenClusterWithConfig(Map.of("bootstrapServers", plaintextBootstrapServers(), "security", Map.of("protocol", "PLAINTEXT")));
+
+        var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID).topicFilter("non-existent-topic-xyz");
+
+        var response = resource.listConsumerGroups(request, 1, 10);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        var body = (ListConsumerGroupsResponse) response.getEntity();
+        assertThat(body.getData()).isEmpty();
+    }
+
+    @Test
     void should_return_400_when_request_is_null() {
         var response = resource.listConsumerGroups(null, 1, 10);
 

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail-page.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail-page.component.html
@@ -15,4 +15,11 @@
     limitations under the License.
 
 -->
-<gke-topic-detail [topicDetail]="topicDetail()" [loading]="loading()" (back)="onBack()" />
+<gke-topic-detail
+  [topicDetail]="topicDetail()"
+  [consumerGroups]="consumerGroups()"
+  [loading]="loading()"
+  (back)="onBack()"
+  (browseMessages)="onBrowseMessages()"
+  (consumerGroupSelect)="onConsumerGroupSelect($event)"
+/>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail-page.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail-page.component.spec.ts
@@ -23,7 +23,12 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { TopicDetailHarness } from './topic-detail/topic-detail.harness';
 import { TopicDetailPageComponent } from './topic-detail-page.component';
-import { fakeDescribeTopicResponse, fakeKafkaNode, fakeTopicPartitionDetail } from '../../models/kafka-cluster.fixture';
+import {
+  fakeDescribeTopicResponse,
+  fakeKafkaNode,
+  fakeListConsumerGroupsResponse,
+  fakeTopicPartitionDetail,
+} from '../../models/kafka-cluster.fixture';
 import { KafkaExplorerStore } from '../../services/kafka-explorer-store.service';
 
 describe('TopicDetailPageComponent', () => {
@@ -63,15 +68,21 @@ describe('TopicDetailPageComponent', () => {
     httpTesting.verify();
   });
 
+  function flushConsumerGroups(response = fakeListConsumerGroupsResponse()) {
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/list-consumer-groups').flush(response);
+    fixture.detectChanges();
+  }
+
   function flushTopic(response = fakeDescribeTopicResponse()) {
     httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-topic').flush(response);
-    fixture.detectChanges();
+    flushConsumerGroups();
   }
 
   it('should call describeTopic on init with route param', () => {
     const req = httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-topic');
     expect(req.request.body).toEqual({ clusterId: 'test-cluster-id', topicName: 'my-topic' });
     req.flush(fakeDescribeTopicResponse());
+    flushConsumerGroups();
   });
 
   it('should display topic name', async () => {
@@ -152,5 +163,48 @@ describe('TopicDetailPageComponent', () => {
     await harness.clickBack();
 
     expect(router.navigate).toHaveBeenCalledWith(['..'], { relativeTo: route });
+  });
+
+  it('should call listConsumerGroups with topicFilter on init', () => {
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-topic').flush(fakeDescribeTopicResponse());
+    const req = httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/list-consumer-groups');
+    expect(req.request.body).toEqual({ clusterId: 'test-cluster-id', nameFilter: undefined, topicFilter: 'my-topic' });
+    expect(req.request.params.get('perPage')).toBe('100');
+    req.flush(fakeListConsumerGroupsResponse());
+  });
+
+  it('should display consumer groups table', async () => {
+    flushTopic();
+
+    const harness = await loader.getHarness(TopicDetailHarness);
+    const rows = await harness.getConsumerGroupsRows();
+    expect(rows.length).toBe(3);
+    expect(rows[0]['groupId']).toBe('my-group');
+    expect(rows[0]['membersCount']).toBe('2');
+    expect(rows[0]['coordinator']).toContain('kafka-broker-0.example.com');
+  });
+
+  it('should navigate to consumer group on select', async () => {
+    flushTopic();
+
+    fixture.componentInstance.onConsumerGroupSelect('my-group');
+
+    expect(router.navigate).toHaveBeenCalledWith(['../../consumer-groups', 'my-group'], { relativeTo: route });
+  });
+
+  it('should show browse messages button', async () => {
+    flushTopic();
+
+    const harness = await loader.getHarness(TopicDetailHarness);
+    expect(await harness.hasBrowseMessagesButton()).toBe(true);
+  });
+
+  it('should navigate to messages on browse messages click', async () => {
+    flushTopic();
+
+    const harness = await loader.getHarness(TopicDetailHarness);
+    await harness.clickBrowseMessages();
+
+    expect(router.navigate).toHaveBeenCalledWith(['messages'], { relativeTo: route });
   });
 });

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail-page.component.ts
@@ -18,7 +18,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { TopicDetailComponent } from './topic-detail/topic-detail.component';
-import { DescribeTopicResponse } from '../../models/kafka-cluster.model';
+import { ConsumerGroupSummary, DescribeTopicResponse } from '../../models/kafka-cluster.model';
 import { KafkaExplorerStore } from '../../services/kafka-explorer-store.service';
 import { KafkaExplorerService } from '../../services/kafka-explorer.service';
 
@@ -36,6 +36,7 @@ export class TopicDetailPageComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   topicDetail = signal<DescribeTopicResponse | undefined>(undefined);
+  consumerGroups = signal<ConsumerGroupSummary[]>([]);
   loading = signal(false);
 
   ngOnInit() {
@@ -54,9 +55,26 @@ export class TopicDetailPageComponent implements OnInit {
           this.loading.set(false);
         },
       });
+
+    this.service
+      .listConsumerGroups(this.store.baseURL(), this.store.clusterId(), undefined, 1, 100, topicName)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: response => {
+          this.consumerGroups.set(response.data);
+        },
+      });
   }
 
   onBack() {
     this.router.navigate(['..'], { relativeTo: this.route });
+  }
+
+  onBrowseMessages() {
+    this.router.navigate(['messages'], { relativeTo: this.route });
+  }
+
+  onConsumerGroupSelect(groupId: string) {
+    this.router.navigate(['../../consumer-groups', groupId], { relativeTo: this.route });
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.html
@@ -24,6 +24,11 @@
     @if (topicDetail()?.internal) {
       <gke-badge>Internal</gke-badge>
     }
+    <span class="topic-detail__spacer"></span>
+    <button mat-stroked-button class="topic-detail__browse-btn" (click)="browseMessages.emit()">
+      <mat-icon>search</mat-icon>
+      Browse Messages
+    </button>
   </div>
 
   @if (loading()) {
@@ -102,6 +107,62 @@
           <tr mat-header-row *matHeaderRowDef="configColumns"></tr>
           <tr mat-row *matRowDef="let row; columns: configColumns"></tr>
         </table>
+      </mat-card-content>
+    </mat-card>
+
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Consumer Groups</mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        @if (consumerGroups().length === 0) {
+          <p class="topic-detail__empty">No consumer groups found</p>
+        } @else {
+          <table mat-table [dataSource]="consumerGroups()">
+            <ng-container matColumnDef="groupId">
+              <th mat-header-cell *matHeaderCellDef>Group ID</th>
+              <td mat-cell *matCellDef="let g">
+                <a
+                  class="topic-detail__link"
+                  tabindex="0"
+                  (click)="consumerGroupSelect.emit(g.groupId)"
+                  (keydown.enter)="consumerGroupSelect.emit(g.groupId)"
+                  >{{ g.groupId }}</a
+                >
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="membersCount">
+              <th mat-header-cell *matHeaderCellDef>Active Consumers</th>
+              <td mat-cell *matCellDef="let g">{{ g.membersCount }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="totalLag">
+              <th mat-header-cell *matHeaderCellDef>Messages Behind</th>
+              <td mat-cell *matCellDef="let g">
+                {{ g.totalLag }}
+                @if (g.totalLag > 0) {
+                  <gke-badge color="warning">lagging</gke-badge>
+                }
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="coordinator">
+              <th mat-header-cell *matHeaderCellDef>Coordinator</th>
+              <td mat-cell *matCellDef="let g">{{ g.coordinator?.host }}:{{ g.coordinator?.port }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="state">
+              <th mat-header-cell *matHeaderCellDef>State</th>
+              <td mat-cell *matCellDef="let g">
+                <gke-badge [color]="stateColor(g.state)">{{ g.state }}</gke-badge>
+              </td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="consumerGroupColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: consumerGroupColumns"></tr>
+          </table>
+        }
       </mat-card-content>
     </mat-card>
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.scss
@@ -33,6 +33,16 @@
     overflow-x: auto;
   }
 
+  &__link {
+    cursor: pointer;
+  }
+
+  &__empty {
+    color: var(--mat-sys-on-surface-variant, #49454f);
+    padding: 16px 0;
+    margin: 0;
+  }
+
   table {
     width: 100%;
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.ts
@@ -21,8 +21,15 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatTableModule } from '@angular/material/table';
 
-import { BadgeComponent } from '../../../components/badge/badge.component';
-import { DescribeTopicResponse } from '../../../models/kafka-cluster.model';
+import { BadgeColor, BadgeComponent } from '../../../components/badge/badge.component';
+import { ConsumerGroupSummary, DescribeTopicResponse } from '../../../models/kafka-cluster.model';
+
+const STATE_COLORS: Record<string, BadgeColor> = {
+  stable: 'success',
+  empty: 'default',
+  rebalancing: 'warning',
+  dead: 'error',
+};
 
 @Component({
   selector: 'gke-topic-detail',
@@ -33,10 +40,18 @@ import { DescribeTopicResponse } from '../../../models/kafka-cluster.model';
 })
 export class TopicDetailComponent {
   topicDetail = input<DescribeTopicResponse | undefined>();
+  consumerGroups = input<ConsumerGroupSummary[]>([]);
   loading = input(false);
 
   back = output<void>();
+  browseMessages = output<void>();
+  consumerGroupSelect = output<string>();
 
   partitionColumns = ['id', 'leader', 'replicas', 'isr', 'offline'];
   configColumns = ['name', 'value', 'source', 'readOnly', 'sensitive'];
+  consumerGroupColumns = ['groupId', 'membersCount', 'totalLag', 'coordinator', 'state'];
+
+  stateColor(state: string | undefined): BadgeColor {
+    return STATE_COLORS[state?.toLowerCase() ?? ''] ?? 'default';
+  }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.harness.ts
@@ -18,8 +18,6 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
 
-import { BadgeHarness } from '../../../components/badge/badge.harness';
-
 export class TopicDetailHarness extends ComponentHarness {
   static hostSelector = 'gke-topic-detail';
 
@@ -27,7 +25,8 @@ export class TopicDetailHarness extends ComponentHarness {
   private readonly getBackButton = this.locatorFor(MatButtonHarness.with({ selector: '[mat-icon-button]' }));
   private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
   private readonly getTitle = this.locatorFor('.topic-detail__title');
-  private readonly getInternalBadge = this.locatorForOptional(BadgeHarness);
+  private readonly getHeader = this.locatorFor('.topic-detail__header');
+  private readonly getBrowseMessagesButton = this.locatorForOptional(MatButtonHarness.with({ selector: '.topic-detail__browse-btn' }));
 
   async getTopicName() {
     const title = await this.getTitle();
@@ -35,7 +34,9 @@ export class TopicDetailHarness extends ComponentHarness {
   }
 
   async isInternal() {
-    return (await this.getInternalBadge()) !== null;
+    const header = await this.getHeader();
+    const text = await header.text();
+    return text.includes('Internal');
   }
 
   async isLoading() {
@@ -58,6 +59,27 @@ export class TopicDetailHarness extends ComponentHarness {
     const tables = await this.getTables();
     if (tables.length < 2) return [];
     const rows = await tables[1].getRows();
+    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+  }
+
+  async hasConsumerGroupsCard() {
+    const tables = await this.getTables();
+    return tables.length >= 3;
+  }
+
+  async hasBrowseMessagesButton() {
+    return (await this.getBrowseMessagesButton()) !== null;
+  }
+
+  async clickBrowseMessages() {
+    const button = await this.getBrowseMessagesButton();
+    await button!.click();
+  }
+
+  async getConsumerGroupsRows() {
+    const tables = await this.getTables();
+    if (tables.length < 3) return [];
+    const rows = await tables[2].getRows();
     return parallel(() => rows.map(row => row.getCellTextByColumnName()));
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/kafka-explorer/kafka-explorer.component.spec.ts
@@ -23,7 +23,12 @@ import { provideRouter, Router, RouterOutlet } from '@angular/router';
 
 import { KafkaExplorerHarness } from './kafka-explorer.harness';
 import { KAFKA_EXPLORER_ROUTES } from './kafka-explorer.routes';
-import { fakeDescribeClusterResponse, fakeDescribeTopicResponse, fakeListTopicsResponse } from '../models/kafka-cluster.fixture';
+import {
+  fakeDescribeClusterResponse,
+  fakeDescribeTopicResponse,
+  fakeListConsumerGroupsResponse,
+  fakeListTopicsResponse,
+} from '../models/kafka-cluster.fixture';
 import { KAFKA_EXPLORER_BASE_URL } from '../services/kafka-explorer-config.token';
 
 @Component({
@@ -156,6 +161,7 @@ describe('KafkaExplorerComponent', () => {
     await fixture.whenStable();
 
     httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-topic').flush(fakeDescribeTopicResponse());
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/list-consumer-groups').flush(fakeListConsumerGroupsResponse());
     fixture.detectChanges();
 
     const detailHarness = await harness.getTopicDetailHarness();
@@ -180,6 +186,7 @@ describe('KafkaExplorerComponent', () => {
     await fixture.whenStable();
 
     httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/describe-topic').flush(fakeDescribeTopicResponse());
+    httpTesting.expectOne(req => req.url === '/api/v2/kafka-explorer/list-consumer-groups').flush(fakeListConsumerGroupsResponse());
     fixture.detectChanges();
 
     const detailHarness = await harness.getTopicDetailHarness();

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
@@ -60,14 +60,13 @@ export class KafkaExplorerService {
     nameFilter?: string,
     page = 1,
     perPage = 25,
+    topicFilter?: string,
   ): Observable<ListConsumerGroupsResponse> {
-    return this.http.post<ListConsumerGroupsResponse>(
-      `${baseURL}/kafka-explorer/list-consumer-groups`,
-      { clusterId, nameFilter },
-      {
-        params: { page: page.toString(), perPage: perPage.toString() },
-      },
-    );
+    const body: Record<string, unknown> = { clusterId, nameFilter };
+    if (topicFilter) body['topicFilter'] = topicFilter;
+    return this.http.post<ListConsumerGroupsResponse>(`${baseURL}/kafka-explorer/list-consumer-groups`, body, {
+      params: { page: page.toString(), perPage: perPage.toString() },
+    });
   }
 
   describeConsumerGroup(baseURL: string, clusterId: string, groupId: string): Observable<DescribeConsumerGroupResponse> {


### PR DESCRIPTION
## Summary
- Add `topicFilter` parameter to `listConsumerGroups` to filter consumer groups by topic they consume from (OpenAPI spec, domain/infra, unit & integration tests)
- Display consumer groups in the topic detail page with navigation to consumer group detail
- Add a "Browse" button in topic detail for message browsing

https://gravitee.atlassian.net/browse/APIM-12789


https://github.com/user-attachments/assets/fabc4884-a0ad-4e65-9f83-8c3dfff7345f


## Test plan
- [x] Verify consumer groups are listed in topic detail page, filtered by topic
- [ ] Verify clicking a consumer group navigates to its detail page
- [ ] Verify the Browse button navigates to the message browsing view
- [ ] Verify the `topicFilter` query parameter works on the `listConsumerGroups` endpoint
- [ ] Verify integration tests pass for the new filter