### PR TITLE
Api product integration tests

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
 import io.gravitee.apim.gateway.tests.sdk.plugin.PluginRegister;
 import io.gravitee.apim.gateway.tests.sdk.runner.ApiConfigurer;
 import io.gravitee.apim.gateway.tests.sdk.runner.ApiDeployer;
+import io.gravitee.apim.gateway.tests.sdk.runner.ApiProductDeployer;
 import io.gravitee.apim.gateway.tests.sdk.runner.DictionaryDeployer;
 import io.gravitee.apim.gateway.tests.sdk.runner.OrganizationConfigurer;
 import io.gravitee.apim.gateway.tests.sdk.runner.SharedPolicyGroupDeployer;
@@ -35,6 +36,7 @@ import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.gateway.dictionary.model.Dictionary;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
 import io.gravitee.gateway.platform.organization.ReactableOrganization;
 import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
@@ -88,7 +90,8 @@ public abstract class AbstractGatewayTest
         OrganizationConfigurer,
         DictionaryDeployer,
         ApplicationContextAware,
-        SharedPolicyGroupDeployer {
+        SharedPolicyGroupDeployer,
+        ApiProductDeployer {
 
     private static final ObjectMapper objectMapper = new GraviteeMapper();
     protected static final PlaceholderSymbols DEFAULT_PLACEHOLDER_SYMBOLS = new PlaceholderSymbols("${", "}");
@@ -118,6 +121,8 @@ public abstract class AbstractGatewayTest
     private Consumer<String> apiUndeployer;
     private Consumer<ReactableSharedPolicyGroup> sharedPolicyGroupDeployer;
     private BiConsumer<String, String> sharedPolicyGroupUndeployer;
+    private Consumer<ReactableApiProduct> apiProductDeployer;
+    private Consumer<String> apiProductUndeployer;
     protected Vertx vertx;
 
     /**
@@ -343,6 +348,32 @@ public abstract class AbstractGatewayTest
     }
 
     @Override
+    public void setDeployApiProductCallback(Consumer<ReactableApiProduct> apiProductDeployer) {
+        this.apiProductDeployer = apiProductDeployer;
+    }
+
+    @Override
+    public void setUndeployApiProductCallback(Consumer<String> apiProductUndeployer) {
+        this.apiProductUndeployer = apiProductUndeployer;
+    }
+
+    @Override
+    public void deployApiProduct(ReactableApiProduct reactableApiProduct) {
+        apiProductDeployer.accept(reactableApiProduct);
+    }
+
+    @Override
+    public void undeployApiProduct(String apiProductId) {
+        apiProductUndeployer.accept(apiProductId);
+    }
+
+    @Override
+    public void redeployApiProduct(ReactableApiProduct reactableApiProduct) {
+        undeployApiProduct(reactableApiProduct.getId());
+        deployApiProduct(reactableApiProduct);
+    }
+
+    @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
     }
@@ -366,6 +397,17 @@ public abstract class AbstractGatewayTest
     public void ensureMinimalRequirementForOrganization(ReactableSharedPolicyGroup reactableSharedPolicyGroup) {
         if (!StringUtils.hasText(reactableSharedPolicyGroup.getEnvironmentId())) {
             reactableSharedPolicyGroup.getDefinition().setEnvironmentId(DEFAULT_ID);
+        }
+    }
+
+    /**
+     * Ensures the API Product has the minimal requirement to be run properly.
+     * - add a default environment id ("DEFAULT") if not set
+     * @param reactableApiProduct to deploy
+     */
+    public void ensureMinimalRequirementForApiProduct(ReactableApiProduct reactableApiProduct) {
+        if (!StringUtils.hasText(reactableApiProduct.getEnvironmentId())) {
+            reactableApiProduct.setEnvironmentId(DEFAULT_ID);
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/GatewayTestingExtension.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/GatewayTestingExtension.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.gateway.tests.sdk;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApiProducts;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployOrganization;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployOrganizations;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeploySharedPolicyGroups;
@@ -80,6 +81,7 @@ public class GatewayTestingExtension
             startGateway(context);
             deployOrganizationForClass(context);
             deploySharedPolicyGroupsForClass(context);
+            deployApiProductsForClass(context);
             deployApisForClass(context);
         } catch (Exception e) {
             LOGGER.error("Before all error: ", e);
@@ -101,6 +103,7 @@ public class GatewayTestingExtension
     public void beforeEach(ExtensionContext context) throws Exception {
         deployOrganizationForMethod(context);
         deploySharedPolicyGroupsForMethod(context);
+        deployApiProductsForMethod(context);
         if (context.getRequiredTestMethod().isAnnotationPresent(DeployApi.class)) {
             LOGGER.debug("Deploying apis for test {}", context.getRequiredTestMethod().getName());
             final DeployApi annotation = context.getRequiredTestMethod().getAnnotation(DeployApi.class);
@@ -185,6 +188,10 @@ public class GatewayTestingExtension
             LOGGER.debug("Clear test method's shared policy groups");
             gatewayRunner.undeploySharedPolicyGroupForTest();
         }
+        if (context.getRequiredTestMethod().isAnnotationPresent(DeployApiProducts.class)) {
+            LOGGER.debug("Clear test method's API Products");
+            gatewayRunner.undeployApiProductForTest();
+        }
         if (context.getRequiredTestMethod().isAnnotationPresent(DeployOrganization.class)) {
             LOGGER.debug("Clear organization");
             gatewayRunner.undeployOrganizationForTest();
@@ -205,6 +212,9 @@ public class GatewayTestingExtension
         }
         if (requiredTestClass.isAnnotationPresent(DeploySharedPolicyGroups.class)) {
             gatewayRunner.undeploySharedPolicyGroupForClass();
+        }
+        if (requiredTestClass.isAnnotationPresent(DeployApiProducts.class)) {
+            gatewayRunner.undeployApiProductForClass();
         }
         if (requiredTestClass.isAnnotationPresent(DeployOrganization.class)) {
             gatewayRunner.undeployOrganizationForClass();
@@ -252,6 +262,35 @@ public class GatewayTestingExtension
         if (requiredTestClass.isAnnotationPresent(DeploySharedPolicyGroups.class)) {
             for (String sharedPolicyGroupDefinition : requiredTestClass.getAnnotation(DeploySharedPolicyGroups.class).value()) {
                 gatewayRunner.deploySharedPolicyGroupForClass(sharedPolicyGroupDefinition);
+            }
+        }
+    }
+
+    private void deployApiProductsForClass(final ExtensionContext context) throws IOException {
+        final Class<?> requiredTestClass = context.getRequiredTestClass();
+        if (requiredTestClass.isAnnotationPresent(DeployApiProducts.class)) {
+            for (String apiProductDefinition : requiredTestClass.getAnnotation(DeployApiProducts.class).value()) {
+                gatewayRunner.deployApiProductForClass(apiProductDefinition);
+            }
+        }
+    }
+
+    private void deployApiProductsForMethod(ExtensionContext context) throws Exception {
+        List<String> deployApiProducts = new ArrayList<>();
+        if (context.getRequiredTestMethod().isAnnotationPresent(DeployApiProducts.class)) {
+            final DeployApiProducts annotation = context.getRequiredTestMethod().getAnnotation(DeployApiProducts.class);
+            deployApiProducts.addAll(Arrays.asList(annotation.value()));
+        }
+
+        if (!deployApiProducts.isEmpty()) {
+            LOGGER.debug("Deploying API Products for test {}", context.getRequiredTestMethod().getName());
+            for (String apiProductDefinition : deployApiProducts) {
+                try {
+                    gatewayRunner.deployApiProductForTest(apiProductDefinition);
+                } catch (Exception e) {
+                    exception = e;
+                    throw e;
+                }
             }
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/annotations/DeployApiProducts.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/annotations/DeployApiProducts.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.annotations;
+
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <pre>
+ * {@code @DeployApiProducts} is a type and method level annotation that is used to deploy one or many API Product on the gateway.
+ *</pre>
+ *
+ * This annotation is flagged with {@link Inherited}. Subclasses do not have to reuse it explicitly if they want to use the same one from parent class.
+ *
+ * @see ReactableApiProduct as the model to deploy
+ * @author GraviteeSource Team
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface DeployApiProducts {
+    String[] value();
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestContainer.java
@@ -16,7 +16,6 @@
 package io.gravitee.apim.gateway.tests.sdk.container;
 
 import io.gravitee.apim.gateway.tests.sdk.connector.fakes.MessageStorage;
-import io.gravitee.apim.gateway.tests.sdk.license.PermissiveLicenseManager;
 import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.SubscriptionService;
@@ -26,7 +25,6 @@ import io.gravitee.gateway.standalone.GatewayContainer;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.cluster.ClusterManager;
-import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.node.container.NodeFactory;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.gravitee.node.plugin.cache.standalone.StandaloneCacheManager;
@@ -56,7 +54,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 
 /**
  * This class allows to extend the {@link GatewayContainer} in order to override the {@link NodeFactory}
@@ -71,7 +68,6 @@ public class GatewayTestContainer extends GatewayContainer {
 
     /**
      * Constructor with action to execute once the boot application context has been created.
-     * This allows for setting up specific requirements for testing (e.g. customizing gravitee yaml configuration, registering boot plugins, ...)
      *
      * @param onBootApplicationContextCreated actions to execute once Spring context is created and before starting components.
      */
@@ -87,28 +83,10 @@ public class GatewayTestContainer extends GatewayContainer {
     }
 
     @Override
-    protected List<Class<?>> bootstrapClasses() {
-        List<Class<?>> classes = super.bootstrapClasses();
-        classes.add(GatewayTestNodeContainerConfiguration.class);
-        return classes;
-    }
-
-    @Override
     protected void startBootstrapComponents(AnnotationConfigApplicationContext ctx) {
         // Execute operations before starting bootstrap components (e.g.: the boot application context has been created).
         onBootApplicationContextCreated.accept(ctx);
         super.startBootstrapComponents(ctx);
-    }
-
-    @Configuration
-    public static class GatewayTestNodeContainerConfiguration {
-
-        // Force use of the PermissiveLicenseManager
-        @Primary
-        @Bean
-        public LicenseManager licenseManager() {
-            return new PermissiveLicenseManager();
-        }
     }
 
     @Configuration

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/license/PermissiveLicenseManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/license/PermissiveLicenseManager.java
@@ -41,17 +41,22 @@ public class PermissiveLicenseManager extends AbstractService<LicenseManager> im
     @Nullable
     @Override
     public License getOrganizationLicense(String organizationId) {
-        return PERMISSIVE_LICENSE;
+        return getLicense();
     }
 
     @Override
     public @NonNull License getOrganizationLicenseOrPlatform(String organizationId) {
-        return PERMISSIVE_LICENSE;
+        return getLicense();
     }
 
     @NonNull
     @Override
     public License getPlatformLicense() {
+        return getLicense();
+    }
+
+    /** Override in subclasses to provide a different license (e.g. UniverseTierLicense). */
+    protected License getLicense() {
         return PERMISSIVE_LICENSE;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/license/UniverseTierLicense.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/license/UniverseTierLicense.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.license;
+
+/**
+ * A test license that reports the "universe" tier, required for features such as API Products.
+ * Use this via {@link UniverseTierLicenseManager} in tests that deploy API Products.
+ */
+class UniverseTierLicense extends PermissiveLicense {
+
+    @Override
+    public String getTier() {
+        return "universe";
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/license/UniverseTierLicenseManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/license/UniverseTierLicenseManager.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.license;
+
+import io.gravitee.node.api.license.License;
+
+/**
+ * A test {@link LicenseManager} that always returns a {@link UniverseTierLicense}.
+ * Used for tests that require the "universe" license tier (e.g. API Products).
+ * Automatically wired when the test class deploys API Products via
+ * {@link io.gravitee.apim.gateway.tests.sdk.annotations.DeployApiProducts}.
+ */
+public class UniverseTierLicenseManager extends PermissiveLicenseManager {
+
+    private static final UniverseTierLicense UNIVERSE_TIER_LICENSE = new UniverseTierLicense();
+
+    @Override
+    protected License getLicense() {
+        return UNIVERSE_TIER_LICENSE;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/ApiProductDefinition.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/ApiProductDefinition.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.runner;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * JSON definition for API Product used by the test SDK to load from classpath.
+ *
+ * @author GraviteeSource Team
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+class ApiProductDefinition {
+
+    private String id;
+    private String name;
+    private String description;
+    private String version;
+    private Set<String> apiIds;
+    private String environmentId;
+    private String environmentHrid;
+    private String organizationId;
+    private String organizationHrid;
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/ApiProductDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/ApiProductDeployer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.runner;
+
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import java.util.function.Consumer;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface ApiProductDeployer {
+    void setDeployApiProductCallback(Consumer<ReactableApiProduct> apiProductDeployer);
+
+    void setUndeployApiProductCallback(Consumer<String> apiProductUndeployer);
+
+    void deployApiProduct(ReactableApiProduct reactableApiProduct);
+
+    void redeployApiProduct(ReactableApiProduct reactableApiProduct);
+
+    void undeployApiProduct(String apiProductId);
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApiProducts;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployOrganization;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
@@ -30,6 +31,8 @@ import io.gravitee.apim.gateway.tests.sdk.converters.ApiDeploymentPreparer;
 import io.gravitee.apim.gateway.tests.sdk.converters.LegacyApiDeploymentPreparer;
 import io.gravitee.apim.gateway.tests.sdk.converters.NativeApiDeploymentPreparer;
 import io.gravitee.apim.gateway.tests.sdk.converters.V4ApiDeploymentPreparer;
+import io.gravitee.apim.gateway.tests.sdk.license.PermissiveLicenseManager;
+import io.gravitee.apim.gateway.tests.sdk.license.UniverseTierLicenseManager;
 import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
 import io.gravitee.apim.gateway.tests.sdk.plugin.PluginManifestLoader;
 import io.gravitee.apim.gateway.tests.sdk.policy.KeylessPolicy;
@@ -54,7 +57,9 @@ import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
 import io.gravitee.gateway.dictionary.DictionaryManager;
 import io.gravitee.gateway.dictionary.model.Dictionary;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.gravitee.gateway.handlers.api.manager.ApiProductManager;
 import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
 import io.gravitee.gateway.handlers.sharedpolicygroup.manager.SharedPolicyGroupManager;
 import io.gravitee.gateway.platform.organization.ReactableOrganization;
@@ -62,6 +67,7 @@ import io.gravitee.gateway.platform.organization.manager.OrganizationManager;
 import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.standalone.vertx.VertxEmbeddedContainer;
+import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.node.api.server.ServerManager;
 import io.gravitee.node.container.spring.env.GraviteeYamlPropertySource;
 import io.gravitee.node.plugins.service.ServiceManager;
@@ -109,6 +115,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -130,7 +137,9 @@ import lombok.SneakyThrows;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
@@ -161,7 +170,11 @@ public class GatewayRunner {
         "A shared policy group has already been deployed with id {%s}";
     public static final String CANNOT_UNDEPPLOY_CLASS_API_MESSAGE = "An API deployed at class level cannot be undeployed (id {%s})";
     public static final String CANNOT_UNDEPPLOY_CLASS_SPG_MESSAGE =
-        "A Shared Policy Group deployed at class level cannot be undeployed (id {%s})";
+        "A shared policy group deployed at class level cannot be undeployed (id {%s})";
+    public static final String API_PRODUCT_ALREADY_DEPLOYED_MESSAGE = "An API Product has already been deployed with id {%s}";
+    public static final String CANNOT_UNDEPLOY_CLASS_API_PRODUCT_MESSAGE =
+        "An API Product deployed at class level cannot be undeployed (id {%s})";
+    private static final String AT_CLASS_LEVEL = " at class level";
 
     private final GatewayConfigurationBuilder gatewayConfigurationBuilder;
     private final AbstractGatewayTest testInstance;
@@ -175,6 +188,8 @@ public class GatewayRunner {
     private final Map<String, ReactableOrganization> deployedOrganizationsForTest;
     private final Map<SharedPolicyGroupKey, ReactableSharedPolicyGroup> deployedSharedPolicyGroupsForTestClass;
     private final Map<SharedPolicyGroupKey, ReactableSharedPolicyGroup> deployedSharedPolicyGroupsForTest;
+    private final Map<String, ReactableApiProduct> deployedApiProductsForTestClass;
+    private final Map<String, ReactableApiProduct> deployedApiProductsForTest;
     private GatewayTestContainer gatewayContainer;
     private VertxEmbeddedContainer vertxContainer;
     private Path tempDir;
@@ -195,6 +210,8 @@ public class GatewayRunner {
         this.deployedOrganizationsForTest = new HashMap<>();
         this.deployedSharedPolicyGroupsForTestClass = new HashMap<>();
         this.deployedSharedPolicyGroupsForTest = new HashMap<>();
+        this.deployedApiProductsForTestClass = new HashMap<>();
+        this.deployedApiProductsForTest = new HashMap<>();
 
         // Allow test instance to access api deployed at class level
         testInstance.setDeployedClassApis(this.deployedForTestClass);
@@ -224,11 +241,14 @@ public class GatewayRunner {
             // prepare Gateway
             configure(gatewayConfiguration);
 
-            // create Gateway
-            gatewayContainer = new GatewayTestContainer(context -> {
-                // add extra configuration to gravitee.yaml
-                applyOnGraviteeYaml(context, gatewayConfiguration.yamlProperties());
+            // create Gateway — use UniverseTierLicenseManager if the test class deploys API Products
+            final LicenseManager licenseManager = testClassUsesApiProducts()
+                ? new UniverseTierLicenseManager()
+                : new PermissiveLicenseManager();
 
+            gatewayContainer = new GatewayTestContainer(context -> {
+                registerTestLicenseManager(context, licenseManager);
+                applyOnGraviteeYaml(context, gatewayConfiguration.yamlProperties());
                 // secret provider plugins need to be set up during boot to ensure a proper resolution of secrets during startup.
                 registerSecretProvider(context);
             });
@@ -242,6 +262,8 @@ public class GatewayRunner {
             testInstance.setUndeployCallback(this::undeployFromTest);
             testInstance.setDeploySharedPolicyGroupCallback(this::deploySharedPolicyGroupFromTest);
             testInstance.setUndeploySharedPolicyGroupCallback(this::undeploySharedPolicyGroupFromTest);
+            testInstance.setDeployApiProductCallback(this::deployOrRedeployApiProductFromTest);
+            testInstance.setUndeployApiProductCallback(this::undeployApiProductFromTest);
 
             // register plugins
 
@@ -486,6 +508,39 @@ public class GatewayRunner {
         );
     }
 
+    public void deployApiProductForClass(String apiProductDefinitionPath) throws IOException {
+        final ReactableApiProduct reactableApiProduct = loadApiProductDefinition(apiProductDefinitionPath);
+        if (deployedApiProductsForTestClass.containsKey(reactableApiProduct.getId())) {
+            throw new PreconditionViolationException(String.format(API_PRODUCT_ALREADY_DEPLOYED_MESSAGE, reactableApiProduct.getId()));
+        }
+        deployApiProduct(reactableApiProduct, deployedApiProductsForTestClass);
+    }
+
+    public void deployApiProductForTest(String apiProductDefinitionPath) throws IOException {
+        final ReactableApiProduct reactableApiProduct = loadApiProductDefinition(apiProductDefinitionPath);
+        if (
+            deployedApiProductsForTestClass.containsKey(reactableApiProduct.getId()) ||
+            deployedApiProductsForTest.containsKey(reactableApiProduct.getId())
+        ) {
+            throw new PreconditionViolationException(String.format(API_PRODUCT_ALREADY_DEPLOYED_MESSAGE, reactableApiProduct.getId()));
+        }
+        deployApiProduct(reactableApiProduct, deployedApiProductsForTest);
+    }
+
+    private void deployApiProduct(ReactableApiProduct reactableApiProduct, Map<String, ReactableApiProduct> deployedApiProducts) {
+        ApiProductManager apiProductManager = gatewayContainer.applicationContext().getBean(ApiProductManager.class);
+
+        testInstance.ensureMinimalRequirementForApiProduct(reactableApiProduct);
+        reactableApiProduct.setDeployedAt(new Date());
+
+        try {
+            apiProductManager.register(reactableApiProduct);
+        } catch (Exception e) {
+            throw new IllegalStateException("An error occurred deploying the API Product %s".formatted(reactableApiProduct.getId()), e);
+        }
+        deployedApiProducts.put(reactableApiProduct.getId(), reactableApiProduct);
+    }
+
     public void deployForClass(String apiDefinitionPath) throws IOException {
         deployForClass(apiDefinitionPath, null);
     }
@@ -529,7 +584,7 @@ public class GatewayRunner {
      */
     private void deployFromTest(ReactableApi<?> reactableApi) {
         if (deployedForTestClass.containsKey(reactableApi.getId())) {
-            throw new PreconditionViolationException(String.format(API_ALREADY_DEPLOYED_MESSAGE + " at class level", reactableApi.getId()));
+            throw new PreconditionViolationException(String.format(API_ALREADY_DEPLOYED_MESSAGE + AT_CLASS_LEVEL, reactableApi.getId()));
         }
         if (deployedForTest.containsKey(reactableApi.getId())) {
             undeploy(reactableApi);
@@ -563,7 +618,7 @@ public class GatewayRunner {
             )
         ) {
             throw new PreconditionViolationException(
-                String.format(SPG_ALREADY_DEPLOYED_MESSAGE + " at class level", reactableSharedPolicyGroup.getId())
+                String.format(SPG_ALREADY_DEPLOYED_MESSAGE + AT_CLASS_LEVEL, reactableSharedPolicyGroup.getId())
             );
         }
         if (
@@ -592,6 +647,30 @@ public class GatewayRunner {
                 .getBean(SharedPolicyGroupManager.class);
             sharedPolicyGroupManager.unregister(sharedPolicyGroup);
             deployedSharedPolicyGroupsForTest.remove(new SharedPolicyGroupKey(sharedPolicyGroup, environmentId));
+        }
+    }
+
+    private void deployOrRedeployApiProductFromTest(ReactableApiProduct reactableApiProduct) {
+        if (deployedApiProductsForTestClass.containsKey(reactableApiProduct.getId())) {
+            throw new PreconditionViolationException(
+                String.format(API_PRODUCT_ALREADY_DEPLOYED_MESSAGE + AT_CLASS_LEVEL, reactableApiProduct.getId())
+            );
+        }
+        if (deployedApiProductsForTest.containsKey(reactableApiProduct.getId())) {
+            undeployApiProduct(reactableApiProduct);
+            deployedApiProductsForTest.remove(reactableApiProduct.getId());
+        }
+        deployApiProduct(reactableApiProduct, deployedApiProductsForTest);
+    }
+
+    private void undeployApiProductFromTest(String apiProductId) {
+        if (deployedApiProductsForTestClass.containsKey(apiProductId)) {
+            throw new PreconditionViolationException(String.format(CANNOT_UNDEPLOY_CLASS_API_PRODUCT_MESSAGE, apiProductId));
+        }
+        if (deployedApiProductsForTest.containsKey(apiProductId)) {
+            ReactableApiProduct product = deployedApiProductsForTest.get(apiProductId);
+            undeployApiProduct(product);
+            deployedApiProductsForTest.remove(apiProductId);
         }
     }
 
@@ -701,6 +780,21 @@ public class GatewayRunner {
     public void undeploySharedPolicyGroup(ReactableSharedPolicyGroup reactableSharedPolicyGroup) {
         SharedPolicyGroupManager sharedPolicyGroupManager = gatewayContainer.applicationContext().getBean(SharedPolicyGroupManager.class);
         sharedPolicyGroupManager.unregister(reactableSharedPolicyGroup.getId());
+    }
+
+    public void undeployApiProductForClass() {
+        deployedApiProductsForTestClass.forEach((key, value) -> undeployApiProduct(value));
+        deployedApiProductsForTestClass.clear();
+    }
+
+    public void undeployApiProductForTest() {
+        deployedApiProductsForTest.forEach((key, value) -> undeployApiProduct(value));
+        deployedApiProductsForTest.clear();
+    }
+
+    private void undeployApiProduct(ReactableApiProduct reactableApiProduct) {
+        ApiProductManager apiProductManager = gatewayContainer.applicationContext().getBean(ApiProductManager.class);
+        apiProductManager.unregister(reactableApiProduct.getId());
     }
 
     /**
@@ -926,6 +1020,21 @@ public class GatewayRunner {
         return new ReactableSharedPolicyGroup(sharedPolicyGroup);
     }
 
+    private ReactableApiProduct loadApiProductDefinition(String apiProductDefinitionPath) throws IOException {
+        final ApiProductDefinition definition = loadResource(apiProductDefinitionPath, ApiProductDefinition.class);
+        return ReactableApiProduct.builder()
+            .id(definition.getId())
+            .name(definition.getName())
+            .description(definition.getDescription())
+            .version(definition.getVersion())
+            .apiIds(definition.getApiIds() != null ? definition.getApiIds() : Set.of())
+            .environmentId(definition.getEnvironmentId())
+            .environmentHrid(definition.getEnvironmentHrid())
+            .organizationId(definition.getOrganizationId())
+            .organizationHrid(definition.getOrganizationHrid())
+            .build();
+    }
+
     private <T> T loadResource(String resourcePath, Class<T> toClass) throws IOException {
         String definition = cacheDefinition.computeIfAbsent(resourcePath, path -> {
             try {
@@ -1069,6 +1178,32 @@ public class GatewayRunner {
             return Optional.ofNullable(apiAsJson.get("environmentId").asText());
         }
         return Optional.empty();
+    }
+
+    private void registerTestLicenseManager(ApplicationContext context, LicenseManager licenseManager) {
+        // AnnotationConfigApplicationContext uses DefaultListableBeanFactory; required for destroySingleton/registerSingleton.
+        DefaultListableBeanFactory beanFactory = (DefaultListableBeanFactory) ((ConfigurableApplicationContext) context).getBeanFactory();
+        String beanName = "licenseManager";
+        if (beanFactory.containsSingleton(beanName)) beanFactory.destroySingleton(beanName);
+        beanFactory.registerSingleton(beanName, licenseManager);
+    }
+
+    /**
+     * Returns {@code true} if the test class needs a "universe" tier license.
+     * Detected via {@link DeployApiProducts} annotation on the test class (including inherited)
+     * or any of its methods (including inherited from parent classes).
+     */
+    private boolean testClassUsesApiProducts() {
+        Class<?> testClass = testInstance.getClass();
+        if (testClass.isAnnotationPresent(DeployApiProducts.class)) {
+            return true;
+        }
+        for (Class<?> c = testClass; c != null; c = c.getSuperclass()) {
+            if (Arrays.stream(c.getDeclaredMethods()).anyMatch(method -> method.isAnnotationPresent(DeployApiProducts.class))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ApiProductDeployTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ApiProductDeployTestCase.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApiProducts;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.gravitee.gateway.handlers.api.manager.ApiProductManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies API Product deploy/undeploy lifecycle in the gateway test SDK.
+ *
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@EnableForGatewayTestingExtensionTesting
+class ApiProductDeployTestCase extends AbstractGatewayTest {
+
+    @Nested
+    @DeployApiProducts("/api-products/product-1.json")
+    @DisplayName("Class-level API Product deployment")
+    class ClassLevelDeployment {
+
+        @Test
+        @DisplayName("Should deploy API Product at class level and find it in registry")
+        void should_deploy_api_product_at_class_level() {
+            ApiProductManager apiProductManager = getBean(ApiProductManager.class);
+            ReactableApiProduct product = apiProductManager.get("api-product-1");
+
+            assertThat(product).isNotNull();
+            assertThat(product.getId()).isEqualTo("api-product-1");
+            assertThat(product.getName()).isEqualTo("Test API Product");
+            assertThat(product.getEnvironmentId()).isEqualTo("DEFAULT");
+            assertThat(product.getApiIds()).containsExactlyInAnyOrderElementsOf(java.util.Set.of("api-1", "api-2"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Method-level API Product deployment")
+    class MethodLevelDeployment {
+
+        @Test
+        @DeployApiProducts("/api-products/product-1.json")
+        @DisplayName("Should deploy API Product at method level and find it in registry")
+        void should_deploy_api_product_at_method_level() {
+            ApiProductManager apiProductManager = getBean(ApiProductManager.class);
+            ReactableApiProduct product = apiProductManager.get("api-product-1");
+
+            assertThat(product).isNotNull();
+            assertThat(product.getId()).isEqualTo("api-product-1");
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/resources/api-products/product-1.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/resources/api-products/product-1.json
@@ -1,0 +1,8 @@
+{
+  "id": "api-product-1",
+  "name": "Test API Product",
+  "description": "API Product for SDK tests",
+  "version": "1.0",
+  "apiIds": ["api-1", "api-2"],
+  "environmentId": "DEFAULT"
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4IntegrationTest.java
@@ -1,0 +1,547 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_APIKEY_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApiProducts;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.gravitee.gateway.handlers.api.registry.ApiProductPlanDefinitionCache;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.gravitee.policy.jwt.JWTPolicy;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.gravitee.policy.mtls.MtlsPolicy;
+import io.gravitee.policy.mtls.configuration.MtlsPolicyConfiguration;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductV4IntegrationTest {
+
+    private static final String PRODUCT_RESOURCE = "/api-products/product-with-two-apis.json";
+    private static final String PRODUCT_ID = "api-product-integration-1";
+    private static final String PRODUCT_A_ID = "api-product-a";
+    private static final String PRODUCT_B_ID = "api-product-b";
+    private static final String ENV_ID = "DEFAULT";
+    private static final String API_1_ID = "my-api-v4-1";
+    private static final String API_2_ID = "my-api-v4-2";
+    private static final String API_3_ID = "my-api-v4-3";
+
+    private static final String API_1_PATH = "/test-1";
+    private static final String API_2_PATH = "/test-2";
+    private static final String API_3_PATH = "/test-3";
+
+    private static final String KEY_ALPHA = "api-key-alpha";
+    private static final String KEY_BETA = "api-key-beta";
+
+    @Nested
+    @DeployApi({ "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" })
+    class CreationBootstrapScenarios extends TestPreparer {
+
+        @Test
+        @DeployApiProducts(PRODUCT_RESOURCE)
+        void should_allow_access_with_valid_product_plan_and_subscription(HttpClient client) {
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+            allowKeyForApi(KEY_ALPHA, API_2_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 200);
+        }
+
+        @Test
+        @DeployApiProducts(PRODUCT_RESOURCE)
+        void should_grow_from_one_api_to_three_apis_without_reissuing_key(HttpClient client) {
+            redeployApiProduct(product(PRODUCT_ID, Set.of(API_1_ID)));
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 401);
+            assertStatus(client, API_3_PATH, KEY_ALPHA, 401);
+
+            redeployApiProduct(product(PRODUCT_ID, Set.of(API_1_ID, API_2_ID, API_3_ID)));
+            allowKeyForApi(KEY_ALPHA, API_2_ID);
+            allowKeyForApi(KEY_ALPHA, API_3_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_3_PATH, KEY_ALPHA, 200);
+        }
+
+        @Test
+        void should_isolate_access_when_same_api_is_shared_across_two_products(HttpClient client) {
+            deployApiProduct(product(PRODUCT_A_ID, Set.of(API_1_ID)));
+            deployApiProduct(product(PRODUCT_B_ID, Set.of(API_1_ID)));
+
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+            allowKeyForApi(KEY_BETA, API_1_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_1_PATH, KEY_BETA, 200);
+
+            redeployApiProduct(product(PRODUCT_A_ID, Set.of(API_2_ID)));
+            denyKeyForApi(KEY_ALPHA, API_1_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 401);
+            assertStatus(client, API_1_PATH, KEY_BETA, 200);
+        }
+    }
+
+    @Nested
+    @DeployApi({ "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" })
+    class UpdateScenarios extends TestPreparer {
+
+        @Test
+        @DeployApiProducts(PRODUCT_RESOURCE)
+        void should_allow_existing_key_on_newly_added_api_after_membership_update(HttpClient client) {
+            redeployApiProduct(product(PRODUCT_ID, Set.of(API_1_ID)));
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 401);
+
+            redeployApiProduct(product(PRODUCT_ID, Set.of(API_1_ID, API_2_ID)));
+            allowKeyForApi(KEY_ALPHA, API_2_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 200);
+        }
+
+        @Test
+        @DeployApiProducts(PRODUCT_RESOURCE)
+        void should_return_401_for_removed_api_and_keep_200_for_remaining_apis(HttpClient client) {
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+            allowKeyForApi(KEY_ALPHA, API_2_ID);
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 200);
+
+            redeployApiProduct(product(PRODUCT_ID, Set.of(API_1_ID)));
+            denyKeyForApi(KEY_ALPHA, API_2_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 401);
+        }
+    }
+
+    @Nested
+    class DeletionScenarios extends TestPreparer {
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        @DeployApiProducts(PRODUCT_RESOURCE)
+        void should_return_401_for_all_product_apis_after_product_deletion(HttpClient client) {
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+            allowKeyForApi(KEY_ALPHA, API_2_ID);
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 200);
+
+            undeployApiProduct(PRODUCT_ID);
+            denyKeyForApi(KEY_ALPHA, API_1_ID);
+            denyKeyForApi(KEY_ALPHA, API_2_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 401);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 401);
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        @DeployApiProducts(PRODUCT_RESOURCE)
+        void should_return_401_when_api_is_detached_from_product_but_api_itself_is_still_deployed(HttpClient client) {
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+            allowKeyForApi(KEY_ALPHA, API_2_ID);
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 200);
+
+            redeployApiProduct(product(PRODUCT_ID, Set.of(API_2_ID)));
+            denyKeyForApi(KEY_ALPHA, API_1_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 401);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 200);
+        }
+    }
+
+    @Nested
+    class PlanStateScenarios extends TestPreparer {
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_produce_deterministic_blocked_or_error_outcome_when_plan_is_not_published(HttpClient client) {
+            final String productId = "plan-state-d1-product";
+            final String planId = "plan-state-d1-plan";
+            final String key = "plan-state-d1-key";
+
+            deployApiProduct(product(productId, Set.of(API_1_ID, API_2_ID)));
+            registerProductApiKeyPlanWithStatus(productId, planId, PlanStatus.STAGING);
+            allowKeyForApiAndPlan(key, API_1_ID, planId);
+            allowKeyForApiAndPlan(key, API_2_ID, planId);
+
+            int api1Status = getStatus(client, API_1_PATH, key);
+            int api2Status = getStatus(client, API_2_PATH, key);
+
+            assertThat(api1Status).isEqualTo(api2Status);
+            assertThat(api1Status).isEqualTo(401);
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_keep_deterministic_access_outcome_after_plan_deprecation_transition(HttpClient client) {
+            final String productId = "plan-state-d2-product";
+            final String planId = "plan-state-d2-plan";
+            final String key = "plan-state-d2-key";
+
+            deployApiProduct(product(productId, Set.of(API_1_ID, API_2_ID)));
+            registerProductApiKeyPlanWithStatus(productId, planId, PlanStatus.PUBLISHED);
+            allowKeyForApiAndPlan(key, API_1_ID, planId);
+            allowKeyForApiAndPlan(key, API_2_ID, planId);
+
+            int preTransitionApi1Status = getStatus(client, API_1_PATH, key);
+            int preTransitionApi2Status = getStatus(client, API_2_PATH, key);
+            assertDeterministicStatus(preTransitionApi1Status, preTransitionApi2Status);
+
+            registerProductApiKeyPlanWithStatus(productId, planId, PlanStatus.DEPRECATED);
+
+            int api1Status = getStatus(client, API_1_PATH, key);
+            int api2Status = getStatus(client, API_2_PATH, key);
+            assertDeterministicStatus(api1Status, api2Status);
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_keep_deterministic_access_outcome_after_plan_close_or_delete_transition(HttpClient client) {
+            final String productId = "plan-state-d4-product";
+            final String planId = "plan-state-d4-plan";
+            final String key = "plan-state-d4-key";
+
+            deployApiProduct(product(productId, Set.of(API_1_ID, API_2_ID)));
+            registerProductApiKeyPlanWithStatus(productId, planId, PlanStatus.PUBLISHED);
+            allowKeyForApiAndPlan(key, API_1_ID, planId);
+            allowKeyForApiAndPlan(key, API_2_ID, planId);
+
+            int preTransitionApi1Status = getStatus(client, API_1_PATH, key);
+            int preTransitionApi2Status = getStatus(client, API_2_PATH, key);
+            assertDeterministicStatus(preTransitionApi1Status, preTransitionApi2Status);
+
+            // Simulate plan close/delete by removing product plans from cache.
+            getBean(ApiProductPlanDefinitionCache.class).unregister(productId);
+
+            int api1Status = getStatus(client, API_1_PATH, key);
+            int api2Status = getStatus(client, API_2_PATH, key);
+            assertDeterministicStatus(api1Status, api2Status);
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_register_and_resolve_api_product_plan_security_types_for_api_key_jwt_and_mtls() {
+            final String productId = "plan-state-d3-product";
+            deployApiProduct(product(productId, Set.of(API_1_ID)));
+            registerProductPlans(
+                productId,
+                List.of(
+                    productPlan("plan-state-d3-apikey", "api-key", PlanStatus.PUBLISHED),
+                    productPlan("plan-state-d3-jwt", "jwt", PlanStatus.PUBLISHED),
+                    productPlan("plan-state-d3-mtls", "mtls", PlanStatus.PUBLISHED)
+                )
+            );
+
+            ApiProductRegistry apiProductRegistry = getBean(ApiProductRegistry.class);
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = apiProductRegistry.getApiProductPlanEntriesForApi(API_1_ID, ENV_ID);
+
+            assertThat(entries).isNotEmpty();
+            assertThat(entries)
+                .filteredOn(entry -> productId.equals(entry.apiProductId()))
+                .isNotEmpty();
+            assertThat(
+                entries
+                    .stream()
+                    .filter(entry -> productId.equals(entry.apiProductId()))
+                    .map(entry -> entry.plan().getSecurity().getType())
+                    .toList()
+            ).containsExactlyInAnyOrder("api-key", "jwt", "mtls");
+        }
+    }
+
+    @Nested
+    class SubscriptionStateScenarios extends TestPreparer {
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        @DeployApiProducts(PRODUCT_RESOURCE)
+        void should_return_401_after_subscription_is_revoked_or_cancelled(HttpClient client) {
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+
+            denyKeyForApi(KEY_ALPHA, API_1_ID);
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 401);
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        @DeployApiProducts(PRODUCT_RESOURCE)
+        void should_keep_key_isolation_when_two_apps_are_subscribed_and_one_key_is_revoked(HttpClient client) {
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+            allowKeyForApi(KEY_BETA, API_1_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_1_PATH, KEY_BETA, 200);
+
+            denyKeyForApi(KEY_ALPHA, API_1_ID);
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 401);
+            assertStatus(client, API_1_PATH, KEY_BETA, 200);
+        }
+    }
+
+    @GatewayTest
+    // Empty @DeployApiProducts({}) signals that this test class needs the "universe" license tier for API Product features.
+    @DeployApiProducts({})
+    static class TestPreparer extends AbstractGatewayTest {
+
+        private final Set<String> manuallyDeployedApiProducts = new HashSet<>();
+
+        @BeforeEach
+        void setupSecurityDefaults() {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+            when(getBean(ApiKeyService.class).getByApiAndKey(anyString(), anyString())).thenReturn(Optional.empty());
+            when(getBean(SubscriptionService.class).getByApiAndSecurityToken(anyString(), any(), anyString())).thenReturn(Optional.empty());
+        }
+
+        @AfterEach
+        void cleanupManuallyDeployedApiProducts() {
+            Set.copyOf(manuallyDeployedApiProducts).forEach(this::undeployApiProduct);
+        }
+
+        @Override
+        public void deployApiProduct(ReactableApiProduct reactableApiProduct) {
+            manuallyDeployedApiProducts.add(reactableApiProduct.getId());
+            super.deployApiProduct(reactableApiProduct);
+        }
+
+        @Override
+        public void undeployApiProduct(String apiProductId) {
+            manuallyDeployedApiProducts.remove(apiProductId);
+            super.undeployApiProduct(apiProductId);
+        }
+
+        @Override
+        public void redeployApiProduct(ReactableApiProduct reactableApiProduct) {
+            manuallyDeployedApiProducts.add(reactableApiProduct.getId());
+            super.redeployApiProduct(reactableApiProduct);
+        }
+
+        @Override
+        public void configureApi(io.gravitee.gateway.reactor.ReactableApi<?> api, Class<?> definitionClass) {
+            if (isV4Api(definitionClass)) {
+                final io.gravitee.definition.model.v4.Api apiDefinition = (io.gravitee.definition.model.v4.Api) api.getDefinition();
+                configurePlans(apiDefinition, Set.of("api-key"));
+            }
+        }
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.put(
+                "api-key",
+                PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+            );
+            policies.put("jwt", PolicyBuilder.build("jwt", JWTPolicy.class, JWTPolicyConfiguration.class));
+            policies.put("mtls", PolicyBuilder.build("mtls", MtlsPolicy.class, MtlsPolicyConfiguration.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        void assertStatus(HttpClient client, String path, String apiKey, int expectedStatus) {
+            client
+                .rxRequest(GET, path)
+                .flatMap(request -> {
+                    request.putHeader("X-Gravitee-Api-Key", apiKey);
+                    return request.rxSend();
+                })
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(expectedStatus);
+                    return response.rxBody();
+                })
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertNoErrors()
+                .assertComplete();
+        }
+
+        int getStatus(HttpClient client, String path, String apiKey) {
+            return client
+                .rxRequest(GET, path)
+                .flatMap(request -> {
+                    request.putHeader("X-Gravitee-Api-Key", apiKey);
+                    return request.rxSend();
+                })
+                .map(response -> response.statusCode())
+                .blockingGet();
+        }
+
+        void assertDeterministicStatus(int firstStatus, int secondStatus) {
+            assertThat(firstStatus).isEqualTo(secondStatus);
+            assertThat(firstStatus).isIn(200, 401);
+        }
+
+        void allowKeyForApi(String key, String apiId) {
+            ApiKey apiKey = new ApiKey();
+            apiKey.setApi(apiId);
+            apiKey.setApplication("application-id");
+            apiKey.setSubscription("subscription-" + key);
+            apiKey.setPlan(PLAN_APIKEY_ID);
+            apiKey.setKey(key);
+            apiKey.setRevoked(false);
+            apiKey.setExpireAt(new Date(System.currentTimeMillis() + 60_000));
+
+            Subscription subscription = new Subscription();
+            subscription.setApplication("application-id");
+            subscription.setApplicationName("Application");
+            subscription.setId("subscription-" + key);
+            subscription.setApi(apiId);
+            subscription.setPlan(PLAN_APIKEY_ID);
+
+            when(getBean(ApiKeyService.class).getByApiAndKey(eq(apiId), eq(key))).thenReturn(Optional.of(apiKey));
+            when(getBean(SubscriptionService.class).getByApiAndSecurityToken(eq(apiId), any(), eq(PLAN_APIKEY_ID))).thenReturn(
+                Optional.of(subscription)
+            );
+        }
+
+        void denyKeyForApi(String key, String apiId) {
+            when(getBean(ApiKeyService.class).getByApiAndKey(eq(apiId), eq(key))).thenReturn(Optional.empty());
+        }
+
+        void allowKeyForApiAndPlan(String key, String apiId, String planId) {
+            ApiKey apiKey = new ApiKey();
+            apiKey.setApi(apiId);
+            apiKey.setApplication("application-id");
+            apiKey.setSubscription("subscription-" + key);
+            apiKey.setPlan(planId);
+            apiKey.setKey(key);
+            apiKey.setRevoked(false);
+            apiKey.setExpireAt(new Date(System.currentTimeMillis() + 60_000));
+
+            Subscription subscription = new Subscription();
+            subscription.setApplication("application-id");
+            subscription.setApplicationName("Application");
+            subscription.setId("subscription-" + key);
+            subscription.setApi(apiId);
+            subscription.setPlan(planId);
+
+            when(getBean(ApiKeyService.class).getByApiAndKey(eq(apiId), eq(key))).thenReturn(Optional.of(apiKey));
+            when(getBean(SubscriptionService.class).getByApiAndSecurityToken(eq(apiId), any(), eq(planId))).thenReturn(
+                Optional.of(subscription)
+            );
+        }
+
+        void registerProductApiKeyPlanWithStatus(String apiProductId, String planId, PlanStatus status) {
+            getBean(ApiProductPlanDefinitionCache.class).register(apiProductId, List.of(productApiKeyPlan(planId, status)));
+        }
+
+        void registerProductPlans(String apiProductId, List<Plan> plans) {
+            getBean(ApiProductPlanDefinitionCache.class).register(apiProductId, plans);
+        }
+
+        ReactableApiProduct product(String productId, Set<String> apiIds) {
+            return ReactableApiProduct.builder()
+                .id(productId)
+                .name("Product-" + productId)
+                .description("Scenario product " + productId)
+                .version("1.0.0")
+                .apiIds(apiIds)
+                .environmentId(ENV_ID)
+                .build();
+        }
+
+        private Plan productApiKeyPlan(String planId, PlanStatus status) {
+            return productPlan(planId, "api-key", status);
+        }
+
+        Plan productPlan(String planId, String securityType, PlanStatus status) {
+            return Plan.builder()
+                .id(planId)
+                .name("ProductPlan-" + planId)
+                .security(PlanSecurity.builder().type(securityType).build())
+                .status(status)
+                .mode(PlanMode.STANDARD)
+                .build();
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4SecurityIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4SecurityIntegrationTest.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.JWT_CLIENT_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.JWT_SECRET;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_MTLS_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configureTrustedHttpClient;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.generateJWT;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getUrl;
+import static io.gravitee.policy.jwt.alg.Signature.HMAC_HS256;
+import static io.gravitee.policy.v3.jwt.resolver.KeyResolver.GIVEN_KEY;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApiProducts;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.integration.tests.plan.mtls.WithCert;
+import io.gravitee.common.security.PKCS7Utils;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.handlers.api.ReactableApiProduct;
+import io.gravitee.gateway.handlers.api.registry.ApiProductPlanDefinitionCache;
+import io.gravitee.gateway.handlers.api.services.SubscriptionCacheService;
+import io.gravitee.gateway.reactive.api.policy.SecurityToken;
+import io.gravitee.gateway.security.core.SubscriptionTrustStoreLoaderManager;
+import io.gravitee.node.api.certificate.KeyStoreLoader;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.gravitee.policy.jwt.JWTPolicy;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.gravitee.policy.mtls.MtlsPolicy;
+import io.gravitee.policy.mtls.configuration.MtlsPolicyConfiguration;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * API Product integration tests for security enforcement (JWT, mTLS).
+ * Management/lifecycle tests remain in {@link ApiProductV4IntegrationTest}.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductV4SecurityIntegrationTest {
+
+    private static final String ENV_ID = "DEFAULT";
+    private static final String API_1_ID = "my-api-v4-1";
+    private static final String API_1_PATH = "/test-1";
+
+    @Nested
+    class JwtSecurityTypeScenarios extends SecurityTestPreparer {
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_return_200_success_with_jwt_and_subscription_on_the_api_product_api(HttpClient client) throws Exception {
+            final String productId = "jwt-product-success";
+            final String planId = "jwt-product-plan-success";
+            registerProductPlans(productId, List.of(productJwtPlan(planId, PlanStatus.PUBLISHED)));
+            deployApiProduct(product(productId, Set.of(API_1_ID)));
+            allowJwtSubscriptionForApiAndPlan(API_1_ID, planId, JWT_CLIENT_ID);
+
+            int status = getStatusWithHeader(client, API_1_PATH, "Authorization", "Bearer " + generateJWT(5000));
+            assertThat(status).isEqualTo(200);
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_return_401_unauthorized_with_wrong_security_on_the_api_product_api(HttpClient client) {
+            final String productId = "jwt-product-wrong-security";
+            final String planId = "jwt-product-plan-wrong-security";
+            registerProductPlans(productId, List.of(productJwtPlan(planId, PlanStatus.PUBLISHED)));
+            deployApiProduct(product(productId, Set.of(API_1_ID)));
+
+            assertThat(getStatus(client, API_1_PATH)).isEqualTo(401);
+            assertThat(getStatusWithHeader(client, API_1_PATH, "Authorization", "Bearer a-jwt-token")).isEqualTo(401);
+            assertThat(getStatusWithHeader(client, API_1_PATH, "X-Gravitee-Api-Key", "an-api-key")).isEqualTo(401);
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_return_401_unauthorized_with_expired_jwt_and_subscription_on_the_api_product_api(HttpClient client) throws Exception {
+            final String productId = "jwt-product-expired";
+            final String planId = "jwt-product-plan-expired";
+            registerProductPlans(productId, List.of(productJwtPlan(planId, PlanStatus.PUBLISHED)));
+            deployApiProduct(product(productId, Set.of(API_1_ID)));
+            allowJwtSubscriptionForApiAndPlan(API_1_ID, planId, JWT_CLIENT_ID);
+
+            int status = getStatusWithHeader(client, API_1_PATH, "Authorization", "Bearer " + generateJWT(-5000));
+            assertThat(status).isEqualTo(401);
+        }
+    }
+
+    @Nested
+    class MtlsSecurityTypeScenarios extends SecurityTestPreparer {
+
+        private SubscriptionTrustStoreLoaderManager subscriptionTrustStoreLoaderManager;
+
+        @Override
+        protected void configureGateway(GatewayConfigurationBuilder config) {
+            config
+                .httpSecured(true)
+                .set("http.ssl.clientAuth", "request")
+                .set("http.ssl.keystore.type", KeyStoreLoader.CERTIFICATE_FORMAT_SELF_SIGNED);
+        }
+
+        @Override
+        protected void configureHttpClient(
+            HttpClientOptions options,
+            GatewayDynamicConfig.Config gatewayConfig,
+            ParameterContext parameterContext
+        ) {
+            boolean withCert = parameterContext.findAnnotation(WithCert.class).isPresent();
+            configureTrustedHttpClient(options, gatewayConfig.httpPort(), withCert);
+        }
+
+        @BeforeEach
+        void setupMtlsSubscriptionTrustStore() {
+            subscriptionTrustStoreLoaderManager = getBean(SubscriptionTrustStoreLoaderManager.class);
+            final SubscriptionCacheService subscriptionService = (SubscriptionCacheService) getBean(SubscriptionService.class);
+            when(subscriptionService.getByApiAndSecurityToken(any(), any(), any())).thenCallRealMethod();
+            ReflectionTestUtils.setField(subscriptionService, "subscriptionTrustStoreLoaderManager", subscriptionTrustStoreLoaderManager);
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_be_able_to_call_api_product_with_mtls_plan(@WithCert HttpClient client) throws Exception {
+            final String productId = "mtls-product-success";
+            final String planId = PLAN_MTLS_ID;
+            registerProductPlans(productId, List.of(productPlan(planId, "mtls", PlanStatus.PUBLISHED)));
+            deployApiProduct(product(productId, Set.of(API_1_ID)));
+
+            Subscription subscription = mtlsSubscription(API_1_ID, planId, false);
+            subscriptionTrustStoreLoaderManager.registerSubscription(subscription, Set.of());
+            try {
+                assertThat(getStatus(client, API_1_PATH)).isEqualTo(200);
+            } finally {
+                subscriptionTrustStoreLoaderManager.unregisterSubscription(subscription);
+            }
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_be_able_to_call_api_product_with_mtls_plan_and_several_cert(@WithCert HttpClient client) throws Exception {
+            final String productId = "mtls-product-multi-cert";
+            final String planId = PLAN_MTLS_ID;
+            registerProductPlans(productId, List.of(productPlan(planId, "mtls", PlanStatus.PUBLISHED)));
+            deployApiProduct(product(productId, Set.of(API_1_ID)));
+
+            Subscription subscription = mtlsSubscription(API_1_ID, planId, true);
+            subscriptionTrustStoreLoaderManager.registerSubscription(subscription, Set.of());
+            try {
+                assertThat(getStatus(client, API_1_PATH)).isEqualTo(200);
+            } finally {
+                subscriptionTrustStoreLoaderManager.unregisterSubscription(subscription);
+            }
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_not_be_able_to_call_api_product_with_mtls_plan_if_no_cert_in_request(HttpClient client) {
+            final String productId = "mtls-product-no-cert";
+            final String planId = PLAN_MTLS_ID;
+            registerProductPlans(productId, List.of(productPlan(planId, "mtls", PlanStatus.PUBLISHED)));
+            deployApiProduct(product(productId, Set.of(API_1_ID)));
+
+            assertThat(getStatus(client, API_1_PATH)).isEqualTo(401);
+        }
+
+        private Subscription mtlsSubscription(String apiId, String planId, boolean withPkcs7Bundle) throws IOException {
+            final Subscription subscription = new Subscription();
+            subscription.setApi(apiId);
+            subscription.setApplication("application-id");
+            subscription.setApplicationName("Application");
+            subscription.setId("subscription-mtls-" + planId);
+            subscription.setPlan(planId);
+            final String clientCertificate = Files.readString(Paths.get(getUrl("plans/mtls/client.cer").getPath()));
+            if (withPkcs7Bundle) {
+                final String clientCertificate2 = Files.readString(Paths.get(getUrl("plans/mtls/client2.cer").getPath()));
+                subscription.setClientCertificate(
+                    Base64.getEncoder().encodeToString(PKCS7Utils.createBundle(List.of(clientCertificate, clientCertificate2)))
+                );
+            } else {
+                subscription.setClientCertificate(Base64.getEncoder().encodeToString(clientCertificate.getBytes()));
+            }
+            return subscription;
+        }
+    }
+
+    @GatewayTest
+    // Empty @DeployApiProducts({}) signals that this test class needs the "universe" license tier for API Product features.
+    @DeployApiProducts({})
+    static class SecurityTestPreparer extends AbstractGatewayTest {
+
+        private final Set<String> manuallyDeployedApiProducts = new HashSet<>();
+
+        @BeforeEach
+        void setupSecurityDefaults() {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+            when(getBean(ApiKeyService.class).getByApiAndKey(anyString(), anyString())).thenReturn(Optional.empty());
+            when(getBean(SubscriptionService.class).getByApiAndSecurityToken(any(), any(), any())).thenReturn(Optional.empty());
+        }
+
+        @AfterEach
+        void cleanupManuallyDeployedApiProducts() {
+            Set.copyOf(manuallyDeployedApiProducts).forEach(this::undeployApiProduct);
+        }
+
+        @Override
+        public void deployApiProduct(ReactableApiProduct reactableApiProduct) {
+            manuallyDeployedApiProducts.add(reactableApiProduct.getId());
+            super.deployApiProduct(reactableApiProduct);
+        }
+
+        @Override
+        public void undeployApiProduct(String apiProductId) {
+            manuallyDeployedApiProducts.remove(apiProductId);
+            super.undeployApiProduct(apiProductId);
+        }
+
+        @Override
+        public void redeployApiProduct(ReactableApiProduct reactableApiProduct) {
+            manuallyDeployedApiProducts.add(reactableApiProduct.getId());
+            super.redeployApiProduct(reactableApiProduct);
+        }
+
+        @Override
+        public void configureApi(io.gravitee.gateway.reactor.ReactableApi<?> api, Class<?> definitionClass) {
+            if (isV4Api(definitionClass)) {
+                final io.gravitee.definition.model.v4.Api apiDefinition = (io.gravitee.definition.model.v4.Api) api.getDefinition();
+                configurePlans(apiDefinition, Set.of("api-key"));
+            }
+        }
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.put(
+                "api-key",
+                PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+            );
+            policies.put("jwt", PolicyBuilder.build("jwt", JWTPolicy.class, JWTPolicyConfiguration.class));
+            policies.put("mtls", PolicyBuilder.build("mtls", MtlsPolicy.class, MtlsPolicyConfiguration.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        int getStatus(HttpClient client, String path) {
+            return client
+                .rxRequest(GET, path)
+                .flatMap(HttpClientRequest::rxSend)
+                .map(response -> response.statusCode())
+                .blockingGet();
+        }
+
+        int getStatusWithHeader(HttpClient client, String path, String headerName, String headerValue) {
+            return client
+                .rxRequest(GET, path)
+                .flatMap(request -> {
+                    request.putHeader(headerName, headerValue);
+                    return request.rxSend();
+                })
+                .map(response -> response.statusCode())
+                .blockingGet();
+        }
+
+        void allowJwtSubscriptionForApiAndPlan(String apiId, String planId, String clientId) {
+            Subscription subscription = new Subscription();
+            subscription.setApplication("application-id");
+            subscription.setApplicationName("Application");
+            subscription.setId("subscription-jwt-" + planId);
+            subscription.setApi(apiId);
+            subscription.setPlan(planId);
+            when(
+                getBean(SubscriptionService.class).getByApiAndSecurityToken(
+                    eq(apiId),
+                    argThat(
+                        securityToken ->
+                            securityToken.getTokenType().equals(SecurityToken.TokenType.CLIENT_ID.name()) &&
+                            securityToken.getTokenValue().equals(clientId)
+                    ),
+                    eq(planId)
+                )
+            ).thenReturn(Optional.of(subscription));
+        }
+
+        void registerProductPlans(String apiProductId, List<Plan> plans) {
+            getBean(ApiProductPlanDefinitionCache.class).register(apiProductId, plans);
+        }
+
+        ReactableApiProduct product(String productId, Set<String> apiIds) {
+            return ReactableApiProduct.builder()
+                .id(productId)
+                .name("Product-" + productId)
+                .description("Scenario product " + productId)
+                .version("1.0.0")
+                .apiIds(apiIds)
+                .environmentId(ENV_ID)
+                .build();
+        }
+
+        Plan productPlan(String planId, String securityType, PlanStatus status) {
+            return Plan.builder()
+                .id(planId)
+                .name("ProductPlan-" + planId)
+                .security(PlanSecurity.builder().type(securityType).build())
+                .status(status)
+                .mode(PlanMode.STANDARD)
+                .build();
+        }
+
+        Plan productJwtPlan(String planId, PlanStatus status) {
+            try {
+                JWTPolicyConfiguration configuration = new JWTPolicyConfiguration();
+                configuration.setSignature(HMAC_HS256);
+                configuration.setResolverParameter(JWT_SECRET);
+                configuration.setPublicKeyResolver(GIVEN_KEY);
+                return Plan.builder()
+                    .id(planId)
+                    .name("ProductPlan-" + planId)
+                    .security(
+                        PlanSecurity.builder().type("jwt").configuration(new ObjectMapper().writeValueAsString(configuration)).build()
+                    )
+                    .status(status)
+                    .mode(PlanMode.STANDARD)
+                    .build();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to create JWT product plan configuration", e);
+            }
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/api-products/product-with-two-apis.json
+++ b/gravitee-apim-integration-tests/src/test/resources/api-products/product-with-two-apis.json
@@ -1,0 +1,8 @@
+{
+  "id": "api-product-integration-1",
+  "name": "Integration Test API Product",
+  "description": "API Product for integration tests - contains two APIs",
+  "version": "1.0",
+  "apiIds": ["my-api-v4-1", "my-api-v4-2"],
+  "environmentId": "DEFAULT"
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-product/api-1.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-product/api-1.json
@@ -1,0 +1,37 @@
+{
+  "id": "my-api-v4-1",
+  "name": "my-api-v4-1",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [{"path": "/test-1"}],
+      "entrypoints": [{"type": "http-proxy"}]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {"target": "http://localhost:8080/endpoint"},
+          "sharedConfigurationOverride": {"http": {"connectTimeout": 3000, "readTimeout": 60000}}
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [{"type": "http", "path": "/", "pathOperator": "START_WITH", "methods": ["GET"]}]
+    }
+  ],
+  "analytics": {"enabled": false}
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-product/api-2.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-product/api-2.json
@@ -1,0 +1,37 @@
+{
+  "id": "my-api-v4-2",
+  "name": "my-api-v4-2",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [{"path": "/test-2"}],
+      "entrypoints": [{"type": "http-proxy"}]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {"target": "http://localhost:8080/endpoint"},
+          "sharedConfigurationOverride": {"http": {"connectTimeout": 3000, "readTimeout": 60000}}
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [{"type": "http", "path": "/", "pathOperator": "START_WITH", "methods": ["GET"]}]
+    }
+  ],
+  "analytics": {"enabled": false}
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-product/api-3.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/api-product/api-3.json
@@ -1,0 +1,37 @@
+{
+  "id": "my-api-v4-3",
+  "name": "my-api-v4-3",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [{ "path": "/test-3" }],
+      "entrypoints": [{ "type": "http-proxy" }]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": { "target": "http://localhost:8080/endpoint" },
+          "sharedConfigurationOverride": { "http": { "connectTimeout": 3000, "readTimeout": 60000 } }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [{ "type": "http", "path": "/", "pathOperator": "START_WITH", "methods": ["GET"] }]
+    }
+  ],
+  "analytics": { "enabled": false }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12663

## Description

Adds integration tests for API Products in the gateway, including SDK support for deploying API Products in tests and tests for lifecycle, membership changes, plan states, subscription states, and security (API Key, JWT, mTLS).

## Test Scenarios Covered

### ApiProductV4IntegrationTest

**Creation & Bootstrap**

- Access with valid product plan and subscription — `should_allow_access_with_valid_product_plan_and_subscription`
- Product membership growth (1→3 APIs) without reissuing key — `should_grow_from_one_api_to_three_apis_without_reissuing_key`
- Access isolation when same API is shared across two products — `should_isolate_access_when_same_api_is_shared_across_two_products`

**Updates**

- Existing key works on newly added API after membership update — `should_allow_existing_key_on_newly_added_api_after_membership_update`
- 401 for removed API, 200 for remaining APIs after membership shrink — `should_return_401_for_removed_api_and_keep_200_for_remaining_apis`

**Deletion**

- 401 for all APIs after product deletion — `should_return_401_for_all_product_apis_after_product_deletion`
- 401 when API detached from product (API still deployed) — `should_return_401_when_api_is_detached_from_product_but_api_itself_is_still_deployed`

**Plan State**

- Deterministic blocked/error when plan is not published (STAGING) — `should_produce_deterministic_blocked_or_error_outcome_when_plan_is_not_published`
- Deterministic outcome after plan deprecation — `should_keep_deterministic_access_outcome_after_plan_deprecation_transition`
- Deterministic outcome after plan close/delete — `should_keep_deterministic_access_outcome_after_plan_close_or_delete_transition`
- Plan security types (api-key, jwt, mtls) registration and resolution — `should_register_and_resolve_api_product_plan_security_types_for_api_key_jwt_and_mtls`

**Subscription State**

- 401 after subscription revoked/cancelled — `should_return_401_after_subscription_is_revoked_or_cancelled`
- Key isolation when two apps subscribed, one key revoked — `should_keep_key_isolation_when_two_apps_are_subscribed_and_one_key_is_revoked`

### ApiProductV4SecurityIntegrationTest

**JWT**

- 200 with valid JWT and subscription — `should_return_200_success_with_jwt_and_subscription_on_the_api_product_api`
- 401 with wrong security type (API key or invalid JWT when JWT expected) — `should_return_401_unauthorized_with_wrong_security_on_the_api_product_api`
- 401 with expired JWT — `should_return_401_unauthorized_with_expired_jwt_and_subscription_on_the_api_product_api`

**mTLS**

- 200 with valid client certificate — `should_be_able_to_call_api_product_with_mtls_plan`
- 200 with multiple client certificates (PKCS7 bundle) — `should_be_able_to_call_api_product_with_mtls_plan_and_several_cert`
- 401 when no client certificate in request — `should_not_be_able_to_call_api_product_with_mtls_plan_if_no_cert_in_request`

## Additional Context

- **SDK changes:** `@DeployApiProducts` annotation, `UniverseTierLicenseManager` for universe tier, `GatewayTestContainer` license registration
- **License:** Tests use `@DeployApiProducts({})` on preparer classes to enable universe tier license
- **Resources:** API Product JSON at `api-products/product-with-two-apis.json`; APIs at `apis/v4/http/api-product/api-1.json`, `api-2.json`, `api-3.json`
