### PR TITLE
feat(console): enable API product subscription for applications

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.html
@@ -19,25 +19,42 @@
   <h2 mat-dialog-title class="title">Create a subscription</h2>
 
   <mat-dialog-content class="subscription-creation">
-    <label id="api-label">Search an API</label>
+    <label id="api-label">Search an API or API Product</label>
     <mat-form-field aria-labelledby="api-label">
       <mat-icon matPrefix>search</mat-icon>
-      <mat-label>Search an API by name</mat-label>
-      <input matInput type="search" [matAutocomplete]="auto" formControlName="selectedApi" />
+      <mat-label>Search an API or API Product by name</mat-label>
+      <input matInput type="search" [matAutocomplete]="auto" formControlName="selectedReference" />
 
-      <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayApi" (optionSelected)="onApiSelection($event.option.value)">
-        @for (api of apis$ | async; track api.id) {
-          <mat-option [value]="api">
+      <mat-autocomplete
+        #auto="matAutocomplete"
+        [displayWith]="displayReference"
+        (optionSelected)="onReferenceSelection($event.option.value)"
+      >
+        @for (item of searchResults$ | async; track item.value.id) {
+          <mat-option [value]="item">
             <div class="subscription-creation__api-option">
-              <gio-avatar [src]="api._links?.pictureUrl.toString()" [name]="api.name" [size]="32" [roundedBorder]="true"></gio-avatar>
-              {{ api.name }} - {{ api.apiVersion }}
-              <small>({{ api.primaryOwner?.displayName }})</small>
+              <gio-avatar
+                [src]="item.type === 'API' ? item.value._links?.pictureUrl?.toString() : null"
+                [name]="item.value.name"
+                [size]="32"
+                [roundedBorder]="true"
+              ></gio-avatar>
+              <div class="subscription-creation__api-option__text">
+                <span class="subscription-creation__api-option__name">
+                  {{ item.value.name }}
+                  @if (item.type === 'API' ? item.value.apiVersion : item.value.version) {
+                    - {{ item.type === 'API' ? item.value.apiVersion : item.value.version }}
+                  }
+                  ({{ item.value.primaryOwner?.displayName }})
+                </span>
+                <span class="subscriptions__table__reference-type">{{ item.type === 'API' ? 'API' : 'API Product' }}</span>
+              </div>
             </div>
           </mat-option>
         }
 
-        @if ((apis$ | async)?.length === 0) {
-          <mat-option disabled>No API found</mat-option>
+        @if ((searchResults$ | async)?.length === 0) {
+          <mat-option disabled>No API or API Product found</mat-option>
         }
       </mat-autocomplete>
     </mat-form-field>

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.scss
@@ -1,7 +1,3 @@
-@use 'sass:map';
-@use '@angular/material/index' as mat;
-@use '@gravitee/ui-particles-angular/index' as gio;
-
 .subscription-creation {
   display: flex;
   flex-direction: column;
@@ -11,6 +7,19 @@
     display: flex;
     flex-direction: row;
     gap: 8px;
-    align-items: center;
+    align-items: flex-start;
+
+    &__text {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
   }
+}
+
+::ng-deep .subscriptions__table__reference-type {
+  display: block;
+  font-size: 12px;
+  color: var(--gio-text-disabled-color, #757575);
+  margin-top: 2px;
 }

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.spec.ts
@@ -45,6 +45,7 @@ import {
   getEntrypointConnectorSchema,
   Plan,
 } from '../../../../../entities/management-api-v2';
+import { ApiProduct } from '../../../../../entities/management-api-v2/api-product';
 import { ApiKeyMode, Application } from '../../../../../entities/application/Application';
 import { fakeSubscriptionPage } from '../../../../../entities/subscription/subscription.fixture';
 import { PlanSecurityType } from '../../../../../entities/plan';
@@ -169,7 +170,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
 
         await dialogHarness.searchApi(API_NAME);
         tick(100);
-        expectApiSearchPost(API);
+        expectApiSearchPost('my-api', [API], []);
 
         await dialogHarness.selectApi(API_NAME);
         expectSubscribableApiPlansGet([API_KEY_PLAN, fakePlanV4({ apiId: API_ID, security: { type: 'JWT' } })]);
@@ -195,7 +196,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
 
         await dialogHarness.searchApi(API_NAME);
         tick(100);
-        expectApiSearchPost(API);
+        expectApiSearchPost('my-api', [API], []);
 
         await dialogHarness.selectApi(API_NAME);
         expectSubscribableApiPlansGet([API_KEY_PLAN, fakePlanV4({ apiId: API_ID, security: { type: 'JWT' } })]);
@@ -221,7 +222,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
 
         await dialogHarness.searchApi(API_NAME);
         tick(100);
-        expectApiSearchPost(fakeApiFederated({ id: API_ID, name: API_NAME }));
+        expectApiSearchPost('my-api', [fakeApiFederated({ id: API_ID, name: API_NAME })], []);
 
         await dialogHarness.selectApi(API_NAME);
         expectSubscribableApiPlansGet([API_KEY_PLAN, fakePlanFederated({ apiId: API_ID, security: { type: 'JWT' } })]);
@@ -245,7 +246,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
 
         await dialogHarness.searchApi(API_NAME);
         tick(200);
-        expectApiSearchPost(API);
+        expectApiSearchPost('my-api', [API], []);
         await dialogHarness.selectApi(API_NAME);
 
         const plan = fakePlanV4({ apiId: API_ID, security: { type: planType }, commentRequired: false, generalConditions: null });
@@ -268,7 +269,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
 
         await dialogHarness.searchApi(API_NAME);
         tick(100);
-        expectApiSearchPost(API);
+        expectApiSearchPost('my-api', [API], []);
         await dialogHarness.selectApi(API_NAME);
 
         const plan = fakePlanV4({
@@ -302,7 +303,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
 
         await dialogHarness.searchApi(API_NAME);
         tick(100);
-        expectApiSearchPost(API);
+        expectApiSearchPost('my-api', [API], []);
         await dialogHarness.selectApi(API_NAME);
 
         const plan = fakePlanV4({
@@ -331,7 +332,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
 
       await dialogHarness.searchApi(API_NAME);
       tick(100);
-      expectApiSearchPost(API);
+      expectApiSearchPost('my-api', [API], []);
       await dialogHarness.selectApi(API_NAME);
 
       const plan = fakePlanV4({
@@ -362,7 +363,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
 
       await dialogHarness.searchApi(API_NAME);
       tick(100);
-      expectApiSearchPost(API);
+      expectApiSearchPost('my-api', [API], []);
       await dialogHarness.selectApi(API_NAME);
 
       const plan = fakePlanV4({
@@ -384,7 +385,7 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
 
       await dialogHarness.searchApi(API_NAME);
       tick(100);
-      expectApiSearchPost(API);
+      expectApiSearchPost('my-api', [API], []);
       await dialogHarness.selectApi(API_NAME);
 
       const pushPlan = fakePlanV4({ apiId: API_ID, security: null, mode: 'PUSH', commentRequired: false, generalConditions: null });
@@ -399,6 +400,57 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
       expectApiSubscriptionsPostRequest(subscription, pushPlan.id, null, 'PUSH');
       expect(routerNavigateSpy).toHaveBeenCalledWith(['.', expect.anything()], expect.anything());
     }));
+
+    describe('With API Product', () => {
+      const API_PRODUCT_ID = 'api-product-id';
+      const API_PRODUCT_NAME = 'my-api-product';
+      const API_PRODUCT: ApiProduct = {
+        id: API_PRODUCT_ID,
+        name: API_PRODUCT_NAME,
+        version: '1',
+        primaryOwner: { id: 'owner-id', displayName: 'Product owner' },
+      };
+      const API_PRODUCT_PLAN = fakePlanV4({
+        id: 'product-plan-id',
+        name: 'Product plan',
+        apiId: API_PRODUCT_ID,
+        security: { type: 'API_KEY' },
+        commentRequired: false,
+        generalConditions: null,
+      });
+
+      it('should create a subscription for an API Product', fakeAsync(async () => {
+        await init();
+
+        await dialogHarness.searchApi(API_PRODUCT_NAME);
+        tick(100);
+        expectApiSearchPost(API_PRODUCT_NAME, [], [API_PRODUCT]);
+
+        await dialogHarness.selectApi(API_PRODUCT_NAME);
+        expectSubscribableApiProductPlansGet(API_PRODUCT_ID, [API_PRODUCT_PLAN]);
+
+        await dialogHarness.selectPlan(API_PRODUCT_PLAN.name);
+        await dialogHarness.createSubscription();
+
+        const subscription = fakeNewSubscriptionEntity();
+        expectApiSubscriptionsPostRequest(subscription, API_PRODUCT_PLAN.id);
+        expect(routerNavigateSpy).toHaveBeenCalledWith(['.', expect.anything()], expect.anything());
+      }));
+
+      it('should trigger both API and API Product search when typing in the reference field', fakeAsync(async () => {
+        await init();
+
+        await dialogHarness.searchApi(API_NAME);
+        tick(100);
+        expectApiSearchPost('my-api', [API], [API_PRODUCT]);
+
+        await dialogHarness.selectApi(API_NAME);
+        expectSubscribableApiPlansGet([
+          fakePlanV4({ apiId: API_ID, security: { type: 'API_KEY' } }),
+          fakePlanV4({ apiId: API_ID, security: { type: 'JWT' } }),
+        ]);
+      }));
+    });
   });
 
   const expectSubscriptionsGetRequest = (
@@ -433,19 +485,31 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
       .flush(ENTRYPOINT_LIST);
   };
 
-  const expectApiSearchPost = (api: Api) => {
-    const req = httpTestingController.expectOne({
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_search?page=1&perPage=9999&manageOnly=false`,
-      method: 'POST',
-    });
-    expect(req.request.body).toEqual({ query: 'my-api' });
-    req.flush(fakePagedResult([api]));
+  const expectApiSearchPost = (query: string, apis: Api[], apiProducts: unknown[] = []) => {
+    const apiReq = httpTestingController.expectOne((req): boolean => req.method === 'POST' && req.url.includes('/apis/_search'));
+    expect(apiReq.request.body).toEqual({ query });
+    apiReq.flush(fakePagedResult(apis));
+
+    const productReq = httpTestingController.expectOne(
+      (req): boolean => req.method === 'POST' && req.url.includes('/api-products/_search'),
+    );
+    expect(productReq.request.body).toEqual({ query });
+    productReq.flush(fakePagedResult(apiProducts));
   };
 
   const expectSubscribableApiPlansGet = (plans: Plan[] = []) => {
     httpTestingController
       .expectOne({
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans?page=1&perPage=9999&subscribableBy=${APPLICATION_ID}`,
+        method: 'GET',
+      })
+      .flush(fakePagedResult(plans));
+  };
+
+  const expectSubscribableApiProductPlansGet = (apiProductId: string, plans: Plan[] = []) => {
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${apiProductId}/plans?page=1&perPage=9999&subscribableBy=${APPLICATION_ID}`,
         method: 'GET',
       })
       .flush(fakePagedResult(plans));

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.ts
@@ -16,7 +16,7 @@
 import { Component, DestroyRef, inject, Inject } from '@angular/core';
 import { FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { Observable, of } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, map, share, switchMap, tap } from 'rxjs/operators';
+import { combineLatestWith, debounceTime, distinctUntilChanged, filter, map, share, switchMap, tap } from 'rxjs/operators';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { GioJsonSchema } from '@gravitee/ui-particles-angular';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -25,7 +25,10 @@ import { toNewSubscriptionEntity } from './application-subscription-creation-dia
 
 import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
 import { Api, Plan, PlanV4 } from '../../../../../entities/management-api-v2';
+import { ApiProduct } from '../../../../../entities/management-api-v2/api-product';
 import { ApiPlanV2Service } from '../../../../../services-ngx/api-plan-v2.service';
+import { ApiProductPlanV2Service } from '../../../../../services-ngx/api-product-plan-v2.service';
+import { ApiProductV2Service } from '../../../../../services-ngx/api-product-v2.service';
 import { ApplicationService } from '../../../../../services-ngx/application.service';
 import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
 import { ApiKeyMode, Application } from '../../../../../entities/application/Application';
@@ -37,8 +40,10 @@ import {
   ApplicationSubscriptionCreationDialogResult,
 } from '../list/application-subscription-list.component';
 
+export type SearchResultItem = { type: 'API'; value: Api } | { type: 'API_PRODUCT'; value: ApiProduct };
+
 type SubscriptionCreationForm = FormGroup<{
-  selectedApi: FormControl<string | Api>;
+  selectedReference: FormControl<string | SearchResultItem>;
   selectedPlan: FormControl<Plan>;
   request?: FormControl<string>;
   apiKeyMode?: FormControl<ApiKeyMode>;
@@ -63,23 +68,37 @@ export class ApplicationSubscriptionCreationDialogComponent {
   protected application: Application;
   protected selectedSchema: GioJsonSchema;
   protected form: SubscriptionCreationForm = new FormGroup({
-    selectedApi: new FormControl(null),
+    selectedReference: new FormControl(null),
     selectedPlan: new FormControl(null, [Validators.required]),
   });
   protected plans$: Observable<Plan[]>;
-  protected apis$: Observable<Api[]> = this.form.controls.selectedApi.valueChanges.pipe(
+  private readonly SEARCH_PAGE_SIZE = 20;
+  protected searchResults$: Observable<SearchResultItem[]> = this.form.controls.selectedReference.valueChanges.pipe(
     distinctUntilChanged(),
     debounceTime(100),
     filter(term => typeof term === 'string'),
-    switchMap((term: string) => (term.length > 0 ? this.apiService.search({ query: term }, null, 1, 9999, false) : of(null))),
-    tap(_ => this.resetForm()),
-    map(response => response?.data),
+    switchMap((term: string) => {
+      if (term.length === 0) return of([]);
+      this.resetForm();
+      const apis$ = this.apiService
+        .search({ query: term }, null, 1, this.SEARCH_PAGE_SIZE, false)
+        .pipe(map(res => (res?.data ?? []).map(value => ({ type: 'API' as const, value }))));
+      const products$ = this.apiProductService
+        .search({ query: term }, undefined, 1, this.SEARCH_PAGE_SIZE)
+        .pipe(map(res => (res?.data ?? []).map(value => ({ type: 'API_PRODUCT' as const, value }))));
+      return apis$.pipe(
+        combineLatestWith(products$),
+        map(([apis, products]) => [...apis, ...products].sort((a, b) => a.value.name.localeCompare(b.value.name))),
+      );
+    }),
     share(),
   );
 
   constructor(
     private readonly apiService: ApiV2Service,
+    private readonly apiProductService: ApiProductV2Service,
     private readonly apiPlanService: ApiPlanV2Service,
+    private readonly apiProductPlanService: ApiProductPlanV2Service,
     private readonly applicationService: ApplicationService,
     private readonly environmentSettingsService: EnvironmentSettingsService,
     private readonly connectorPluginsV2Service: ConnectorPluginsV2Service,
@@ -133,26 +152,39 @@ export class ApplicationSubscriptionCreationDialogComponent {
     });
   }
 
-  protected displayApi(api: Api) {
-    return api?.name;
+  protected displayReference(item: string | SearchResultItem) {
+    if (typeof item === 'string') return item;
+    return item?.value?.name ?? '';
   }
 
-  protected onApiSelection(selectedApi: Api) {
+  protected onReferenceSelection(item: SearchResultItem) {
     this.resetForm();
-    this.plans$ = this.apiPlanService.listSubscribablePlans(selectedApi.id, this.application.id).pipe(
-      map(response => response.data),
-      share(),
-      takeUntilDestroyed(this.destroyRef),
-    );
-    this.isFederatedApi = selectedApi.definitionVersion === 'FEDERATED';
-    if (selectedApi.definitionVersion === 'V4') {
-      this.availableSubscriptionEntrypoints = selectedApi.listeners
-        .filter(listener => listener.type === 'SUBSCRIPTION')
-        .flatMap(listener => listener.entrypoints)
-        .map(listener => {
-          const entrypoint = this.entrypointsMap.get(listener.type);
-          return entrypoint ? { type: listener.type, name: entrypoint.name, icon: entrypoint.icon } : null;
-        });
+    if (item.type === 'API') {
+      const api = item.value;
+      this.plans$ = this.apiPlanService.listSubscribablePlans(api.id, this.application.id).pipe(
+        map(response => response.data),
+        share(),
+        takeUntilDestroyed(this.destroyRef),
+      );
+      this.isFederatedApi = api.definitionVersion === 'FEDERATED';
+      if (api.definitionVersion === 'V4') {
+        this.availableSubscriptionEntrypoints = api.listeners
+          .filter(listener => listener.type === 'SUBSCRIPTION')
+          .flatMap(listener => listener.entrypoints)
+          .map(listener => {
+            const entrypoint = this.entrypointsMap.get(listener.type);
+            return entrypoint ? { type: listener.type, name: entrypoint.name, icon: entrypoint.icon } : null;
+          });
+      }
+    } else {
+      const apiProduct = item.value;
+      this.plans$ = this.apiProductPlanService.listSubscribablePlans(apiProduct.id, this.application.id).pipe(
+        map(response => response.data),
+        share(),
+        takeUntilDestroyed(this.destroyRef),
+      );
+      this.isFederatedApi = false;
+      this.availableSubscriptionEntrypoints = [];
     }
   }
 
@@ -202,6 +234,7 @@ export class ApplicationSubscriptionCreationDialogComponent {
             !this.isFederatedApi &&
               this.canUseSharedApiKeys &&
               this.application.api_key_mode === ApiKeyMode.UNSPECIFIED &&
+              plan.apiId != null &&
               this.apiKeySubscriptions.some(subscription => subscription?.api !== plan.apiId),
           ),
         ),

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.harness.ts
@@ -23,7 +23,7 @@ import { MatSelectHarness } from '@angular/material/select/testing';
 
 export class ApplicationSubscriptionCreationDialogHarness extends ComponentHarness {
   static hostSelector = 'application-subscription-creation-dialog';
-  private getApiInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="selectedApi"]' }));
+  private getApiInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="selectedReference"]' }));
   private getApiAutoComplete = this.locatorFor(MatAutocompleteHarness);
   private getPlansRadioGroup = this.locatorFor(MatRadioGroupHarness.with({ selector: '[formControlName="selectedPlan"]' }));
   private getApiKeyModeRadioGroup = this.locatorForOptional(MatRadioGroupHarness.with({ selector: '[formControlName="apiKeyMode"]' }));

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-plan-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-plan-v2.service.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
@@ -70,5 +70,10 @@ export class ApiProductPlanV2Service {
 
   public close(apiProductId: string, planId: string): Observable<Plan> {
     return this.http.post<Plan>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/plans/${planId}/_close`, {});
+  }
+
+  public listSubscribablePlans(apiProductId: string, applicationId: string): Observable<ApiPlansResponse> {
+    const params = new HttpParams().appendAll({ page: 1, perPage: 9999, subscribableBy: applicationId });
+    return this.http.get<ApiPlansResponse>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/plans`, { params });
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12983

## Description

Allow applications to subscribe to API Products directly from the Console. Users can select a product and choose an available product-level plan, following the existing subscription workflow (auto or approval-based).

Upon successful subscription, the application gains access to all APIs included in the API Product with product-level security enforcement (API Key, JWT, mTLS).

Applications automatically gain access to newly added APIs in the subscribedproduct and lose access if APIs are removed.


https://github.com/user-attachments/assets/817d0051-15fd-4e30-9df2-cb7080aa2e8c



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

