### PR TITLE
fix: use default value for dynamic properties for form validation

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/main/resources/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-dynamicproperties/gravitee-apim-plugin-apiservice-dynamicproperties-http/src/main/resources/schemas/schema-form.json
@@ -91,7 +91,9 @@
   ],
   "gioExternalDefinitions": {
     "maxConcurrentConnections": {
+      "type": "integer",
       "description": "Hide the field because in the case of Http Dynamic Properties, the number of concurrent connections is fixed to 1.",
+      "default": 1,
       "x-schema-form": {
         "type": "hidden"
       }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12875

## Description

Http Dynamic Properties for V4 APIs has been migrated to use the Common Http Schema Configuration.
There is a particular way for this plugin: `maxConcurrentConnection` setting is force to 1, as we want sequential calls.

It has been addressed by hiding the field in the UI thanks to

```json
"x-schema-form": {
        "type": "hidden"
      }
```

However, even if hidden, the form in the UI is not set with valid default value, making the form invalid.
This fixes the problem, allowing to save the form