### PR TITLE
feat: Added subscription changes for API product

### DIFF
--- a/gravitee-apim-console-webui/src/entities/subscription/subscription.spec.ts
+++ b/gravitee-apim-console-webui/src/entities/subscription/subscription.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DEFAULT_SUBSCRIPTION_FILTER_STATUSES, SUBSCRIPTION_STATUS_DISPLAY, SubscriptionStatus } from './subscription';
+
+describe('subscription entity', () => {
+  describe('SUBSCRIPTION_STATUS_DISPLAY', () => {
+    it('should contain all subscription statuses with display metadata', () => {
+      const expectedStatuses: SubscriptionStatus[] = ['ACCEPTED', 'CLOSED', 'PAUSED', 'PENDING', 'REJECTED', 'RESUMED'];
+      expect(SUBSCRIPTION_STATUS_DISPLAY.map(s => s.id)).toEqual(expectedStatuses);
+      SUBSCRIPTION_STATUS_DISPLAY.forEach(entry => {
+        expect(entry).toHaveProperty('id');
+        expect(entry).toHaveProperty('name');
+        expect(entry).toHaveProperty('badge');
+        expect(typeof entry.name).toBe('string');
+        expect(entry.name.length).toBeGreaterThan(0);
+        expect(['success', 'neutral', 'accent', 'warning']).toContain(entry.badge);
+      });
+    });
+  });
+
+  describe('DEFAULT_SUBSCRIPTION_FILTER_STATUSES', () => {
+    it('should be ACCEPTED, PAUSED, PENDING', () => {
+      expect(DEFAULT_SUBSCRIPTION_FILTER_STATUSES).toEqual(['ACCEPTED', 'PAUSED', 'PENDING']);
+    });
+
+    it('should only contain valid SubscriptionStatus values', () => {
+      const validStatusSet = new Set(SUBSCRIPTION_STATUS_DISPLAY.map(s => s.id));
+      DEFAULT_SUBSCRIPTION_FILTER_STATUSES.forEach(status => {
+        expect(validStatusSet.has(status)).toBe(true);
+      });
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-console-webui/src/entities/subscription/subscription.ts
@@ -19,6 +19,31 @@ import { DefinitionVersion } from '../management-api-v2';
 
 export type SubscriptionStatus = 'PENDING' | 'REJECTED' | 'ACCEPTED' | 'CLOSED' | 'PAUSED' | 'RESUMED';
 
+export const SUBSCRIPTION_STATUS_DISPLAY: { id: SubscriptionStatus; name: string; badge: string }[] = [
+  { id: 'ACCEPTED', name: 'Accepted', badge: 'success' },
+  { id: 'CLOSED', name: 'Closed', badge: 'neutral' },
+  { id: 'PAUSED', name: 'Paused', badge: 'accent' },
+  { id: 'PENDING', name: 'Pending', badge: 'warning' },
+  { id: 'REJECTED', name: 'Rejected', badge: 'warning' },
+  { id: 'RESUMED', name: 'Resumed', badge: 'neutral' },
+];
+
+export const DEFAULT_SUBSCRIPTION_FILTER_STATUSES: SubscriptionStatus[] = ['ACCEPTED', 'PAUSED', 'PENDING'];
+
+export type SubscriptionsTableDS = {
+  id: string;
+  securityType: string;
+  isSharedApiKey: boolean;
+  plan: string;
+  application: string;
+  createdAt: Date;
+  processedAt: Date;
+  startingAt: Date;
+  endAt: Date;
+  status: string;
+  statusBadge: string;
+};
+
 export type SubscriptionOrigin = 'KUBERNETES' | 'MANAGEMENT';
 
 export interface SubscriptionPage {

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -89,6 +89,26 @@ export const API_PRODUCTS_ROUTES: Routes = [
           },
         },
       },
+      {
+        path: 'consumers/subscriptions',
+        loadComponent: () =>
+          import('./subscriptions/list/api-product-subscription-list.component').then(m => m.ApiProductSubscriptionListComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-subscription-r'],
+          },
+        },
+      },
+      {
+        path: 'consumers/subscriptions/:subscriptionId',
+        loadComponent: () =>
+          import('./subscriptions/edit/api-product-subscription-edit.component').then(m => m.ApiProductSubscriptionEditComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-subscription-r'],
+          },
+        },
+      },
     ],
   },
 ];

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -246,15 +246,28 @@ export class ApiProductNavigationComponent {
       { displayName: 'Configuration', routerLink: 'configuration', icon: 'gio:settings' },
       { displayName: 'APIs', routerLink: 'apis', icon: 'gio:cloud-settings' },
     ];
-    if (this.permissionService.hasAnyMatching(['api_product-plan-r'])) {
-      items.push({
-        displayName: 'Consumers',
-        routerLink: 'consumers/plans',
-        icon: 'gio:cloud-consumers',
-        header: { title: 'Consumers', subtitle: 'Manage how your API Product is consumed' },
-        tabs: [{ displayName: 'Plans', routerLink: 'consumers/plans' }],
-      });
+
+    const hasPlanRead = this.permissionService.hasAnyMatching(['api_product-plan-r']);
+    const hasSubscriptionRead = this.permissionService.hasAnyMatching(['api_product-subscription-r']);
+    if (!hasPlanRead && !hasSubscriptionRead) {
+      return items;
     }
+
+    const tabs: ApiProductTabMenuItem[] = [];
+    if (hasPlanRead) {
+      tabs.push({ displayName: 'Plans', routerLink: 'consumers/plans' });
+    }
+    if (hasSubscriptionRead) {
+      tabs.push({ displayName: 'Subscriptions', routerLink: 'consumers/subscriptions' });
+    }
+
+    items.push({
+      displayName: 'Consumers',
+      routerLink: 'consumers',
+      icon: 'gio:users',
+      header: { title: 'Consumers', subtitle: 'Manage how your API Product is consumed' },
+      tabs,
+    });
 
     return items;
   }
@@ -263,11 +276,22 @@ export class ApiProductNavigationComponent {
     if (!item.routerLink) {
       return false;
     }
-    return this.router.isActive(this.router.createUrlTree([item.routerLink], { relativeTo: this.activatedRoute }), {
-      paths: 'subset',
-      queryParams: 'subset',
-      fragment: 'ignored',
-      matrixParams: 'ignored',
-    });
+    const routingOptions = {
+      paths: 'subset' as const,
+      queryParams: 'subset' as const,
+      fragment: 'ignored' as const,
+      matrixParams: 'ignored' as const,
+    };
+    const baseActive = this.router.isActive(
+      this.router.createUrlTree([item.routerLink], { relativeTo: this.activatedRoute }),
+      routingOptions,
+    );
+    if (item.tabs?.length) {
+      const anyTabActive = item.tabs.some(tab =>
+        this.router.isActive(this.router.createUrlTree([tab.routerLink], { relativeTo: this.activatedRoute }), routingOptions),
+      );
+      return baseActive || anyTabActive;
+    }
+    return baseActive;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { rxResource, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { Router, ActivatedRoute } from '@angular/router';
 import { catchError, EMPTY, filter, map, of, switchMap } from 'rxjs';
@@ -43,7 +43,6 @@ const API_PRODUCT_PLAN_TYPES = ['API_KEY', 'JWT', 'MTLS'] as const;
   templateUrl: './api-product-plan-list.component.html',
   styleUrls: ['./api-product-plan-list.component.scss'],
   standalone: true,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [PlanListComponent],
 })
 export class ApiProductPlanListComponent {
@@ -213,7 +212,7 @@ export class ApiProductPlanListComponent {
         width: '500px',
         data: {
           title: 'Deprecate plan',
-          content: `A deprecated plan is no longer available on the Developer Portal and new subscriptions to the plan cannot be created. Existing subscriptions are maintained.<br /><br />Are you sure you want to deprecate the plan: ${plan.name}?`,
+          content: `A deprecated plan can no longer be used for new subscriptions. Existing subscriptions are maintained.<br /><br />Are you sure you want to deprecate the plan: ${plan.name}?`,
           confirmButton: 'Deprecate',
         },
         role: 'alertdialog',

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.html
@@ -1,0 +1,42 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<form [formGroup]="form" (ngSubmit)="onClose()">
+  <h2 mat-dialog-title>Transfer your subscription</h2>
+
+  <mat-dialog-content>
+    @if (plans().length > 0) {
+      @if (showGeneralConditionsMsg()) {
+        <div>Plans with general conditions cannot be used</div>
+      }
+      <mat-radio-group formControlName="selectedPlanId" aria-label="Select a plan" class="transfer-dialog__radio-group">
+        @for (plan of plans(); track plan.id) {
+          <mat-radio-button [value]="plan.id" [disabled]="!!plan.generalConditions">{{ plan.name }}</mat-radio-button>
+        }
+      </mat-radio-group>
+    } @else {
+      <div>No transferable plans available</div>
+    }
+  </mat-dialog-content>
+
+  <mat-dialog-actions class="actions">
+    <button mat-flat-button type="button" [mat-dialog-close]="undefined">Cancel</button>
+    @if (plans().length > 0) {
+      <button color="primary" type="submit" mat-raised-button aria-label="Transfer subscription" [disabled]="form.invalid">Transfer</button>
+    }
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.scss
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.transfer-dialog {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  &__radio-group {
+    display: flex;
+    flex-direction: column;
+    margin: 0.9375rem 0;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+}
+
+.actions {
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/components/dialogs/api-product-subscription-transfer-dialog.component.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { catchError, map, of } from 'rxjs';
+import { MatButtonModule } from '@angular/material/button';
+import { MatRadioModule } from '@angular/material/radio';
+
+import { ApiProductPlanV2Service } from '../../../../../services-ngx/api-product-plan-v2.service';
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
+import { PlanSecurityType } from '../../../../../entities/management-api-v2';
+
+export interface ApiProductSubscriptionTransferDialogData {
+  apiProductId: string;
+  currentPlanId: string;
+  securityType: PlanSecurityType;
+}
+
+export interface ApiProductSubscriptionTransferDialogResult {
+  selectedPlanId: string;
+}
+
+interface PlanVM {
+  id: string;
+  name: string;
+  generalConditions: string;
+}
+
+@Component({
+  selector: 'api-product-subscription-transfer-dialog',
+  templateUrl: './api-product-subscription-transfer-dialog.component.html',
+  styleUrls: ['./api-product-subscription-transfer-dialog.component.scss'],
+  standalone: true,
+  imports: [ReactiveFormsModule, MatButtonModule, MatDialogModule, MatRadioModule],
+})
+export class ApiProductSubscriptionTransferDialogComponent {
+  private readonly dialogRef =
+    inject<MatDialogRef<ApiProductSubscriptionTransferDialogComponent, ApiProductSubscriptionTransferDialogResult>>(MatDialogRef);
+  private readonly data = inject<ApiProductSubscriptionTransferDialogData>(MAT_DIALOG_DATA);
+  private readonly planService = inject(ApiProductPlanV2Service);
+  private readonly snackBarService = inject(SnackBarService);
+
+  protected readonly form = new FormGroup({
+    selectedPlanId: new FormControl('', { validators: [Validators.required], nonNullable: true }),
+  });
+
+  protected readonly plans = toSignal(
+    this.planService.list(this.data.apiProductId, [this.data.securityType], ['PUBLISHED'], undefined, undefined, 1, 9999).pipe(
+      map(response =>
+        response.data
+          .filter(plan => plan.id !== this.data.currentPlanId)
+          .map((plan): PlanVM => ({ id: plan.id, name: plan.name, generalConditions: plan.generalConditions })),
+      ),
+      catchError(() => {
+        this.snackBarService.error('Unable to load plans. Please try again.');
+        return of([] as PlanVM[]);
+      }),
+    ),
+    { initialValue: [] as PlanVM[] },
+  );
+
+  protected readonly showGeneralConditionsMsg = computed(() => this.plans().some(p => !!p.generalConditions));
+
+  protected onClose(): void {
+    this.dialogRef.close({ selectedPlanId: this.form.getRawValue().selectedPlanId });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.html
@@ -1,0 +1,284 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div id="subscription-edit" class="subscription">
+  <div class="subscription__nav">
+    <button mat-button aria-label="Go back to your subscriptions" [routerLink]="'../'">
+      <mat-icon svgIcon="gio:nav-arrow-left"></mat-icon> Go back to your subscriptions
+    </button>
+  </div>
+
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Subscription details</mat-card-title>
+    </mat-card-header>
+
+    @if (subscription(); as sub) {
+      <mat-card-content>
+        <dl class="gio-description-list">
+          <dt>ID</dt>
+          <dd gioClipboardCopyWrapper [contentToCopy]="sub.id" data-testid="subscription-id">
+            {{ sub.id || '-' }}
+          </dd>
+
+          <dt>Plan</dt>
+          <dd gioClipboardCopyWrapper [contentToCopy]="sub.plan.label" data-testid="subscription-plan">
+            {{ sub.plan.label || '-' }}
+          </dd>
+
+          <dt>Status</dt>
+          <dd gioClipboardCopyWrapper [contentToCopy]="sub.status" data-testid="subscription-status">
+            {{ sub.status || '-' }}
+          </dd>
+
+          @if (sub.consumerStatus) {
+            <dt>Consumer status</dt>
+            <dd gioClipboardCopyWrapper [contentToCopy]="sub.consumerStatus" data-testid="subscription-consumer-status">
+              {{ sub.consumerStatus }}
+            </dd>
+          }
+
+          @if (sub.failureCause) {
+            <dt>Failure Cause</dt>
+            <dd gioClipboardCopyWrapper [contentToCopy]="sub.failureCause" data-testid="subscription-failure-cause">
+              {{ sub.failureCause }}
+            </dd>
+          }
+
+          <dt>Subscribed by</dt>
+          <dd gioClipboardCopyWrapper [contentToCopy]="sub.subscribedBy" data-testid="subscription-subscribed-by">
+            {{ sub.subscribedBy || '-' }}
+          </dd>
+
+          <dt>Application</dt>
+          <dd data-testid="subscription-application">
+            <div class="subtitle-2">{{ sub.application?.label || '-' }}</div>
+            <div class="mat-body-2">{{ sub.application?.description }}</div>
+          </dd>
+
+          <dt>Publisher message to subscriber</dt>
+          <dd data-testid="subscription-publisher-message">
+            {{ sub.publisherMessage || '-' }}
+          </dd>
+
+          <dt>Subscriber message to publisher</dt>
+          <dd data-testid="subscription-subscriber-message">
+            {{ sub.subscriberMessage || '-' }}
+          </dd>
+
+          <dt>Created at</dt>
+          <dd data-testid="subscription-created-at">
+            {{ (sub.createdAt | date: 'medium') || '-' }}
+          </dd>
+
+          <dt>Updated at</dt>
+          <dd data-testid="subscription-updated-at">
+            {{ (sub.updatedAt | date: 'medium') || '-' }}
+          </dd>
+
+          <dt>Processed at</dt>
+          <dd data-testid="subscription-processed-at">
+            {{ (sub.processedAt | date: 'medium') || '-' }}
+          </dd>
+
+          @if (sub.status !== 'REJECTED') {
+            <dt>Starting at</dt>
+            <dd data-testid="subscription-starting-at">
+              {{ (sub.startingAt | date: 'medium') || '-' }}
+            </dd>
+            <dt>Paused at</dt>
+            <dd data-testid="subscription-paused-at">
+              {{ (sub.pausedAt | date: 'medium') || '-' }}
+            </dd>
+            <dt>Ending at</dt>
+            <dd data-testid="subscription-ending-at">
+              {{ (sub.endingAt | date: 'medium') || '-' }}
+            </dd>
+          }
+
+          <dt>Closed at</dt>
+          <dd data-testid="subscription-closed-at">
+            {{ (sub.closedAt | date: 'medium') || '-' }}
+          </dd>
+
+          <dt>Domain</dt>
+          <dd data-testid="subscription-domain">
+            {{ sub.domain || '-' }}
+          </dd>
+        </dl>
+      </mat-card-content>
+
+      <mat-card-actions>
+        @if (sub.status === 'PAUSED' || sub.status === 'ACCEPTED' || sub.status === 'PENDING') {
+          <div class="subscription__footer" *gioPermission="{ anyOf: ['api_product-subscription-u'] }">
+            @if (sub.status === 'PAUSED' || sub.status === 'ACCEPTED') {
+              <button mat-stroked-button (click)="transferSubscription()">
+                <mat-icon svgIcon="gio:data-transfer-both"></mat-icon>
+                Transfer
+              </button>
+              @if (sub.status === 'ACCEPTED') {
+                <button mat-stroked-button (click)="pauseSubscription()">
+                  <mat-icon svgIcon="gio:pause-circle"></mat-icon>
+                  Pause
+                </button>
+              }
+              @if (sub.status === 'PAUSED') {
+                <button mat-stroked-button (click)="resumeSubscription()">
+                  <mat-icon svgIcon="gio:play-circle"></mat-icon>
+                  Resume
+                </button>
+              }
+              <button mat-stroked-button (click)="changeEndDate()">
+                <mat-icon svgIcon="gio:calendar"></mat-icon>
+                Change end date
+              </button>
+              @if (sub.consumerStatus === 'FAILURE') {
+                <button mat-stroked-button (click)="resumeFailureSubscription()">
+                  <mat-icon svgIcon="gio:play-circle"></mat-icon>
+                  Resume from failure
+                </button>
+              }
+              <button mat-raised-button color="warn" (click)="closeSubscription()">
+                <mat-icon svgIcon="gio:x-circle"></mat-icon>
+                Close subscription
+              </button>
+            } @else {
+              <button mat-raised-button color="primary" (click)="validateSubscription()">Validate subscription</button>
+              <button mat-stroked-button (click)="rejectSubscription()">Reject subscription</button>
+            }
+          </div>
+        }
+      </mat-card-actions>
+    }
+  </mat-card>
+
+  @if (
+    apiKeys().length > 0 &&
+    (subscription()?.status === 'PENDING' || (subscription()?.status !== 'REJECTED' && subscription()?.plan?.securityType === 'API_KEY'))
+  ) {
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>{{ hasSharedApiKeyMode() ? 'Shared API Keys' : 'API Keys' }}</mat-card-title>
+        @if (hasSharedApiKeyMode()) {
+          <mat-card-subtitle>
+            This subscription uses a shared API Key. You can renew or revoke the shared API Key at the application level.
+          </mat-card-subtitle>
+        }
+      </mat-card-header>
+
+      <div class="subscription__api-keys__table-wrapper">
+        <gio-table-wrapper
+          [disableSearchInput]="true"
+          [length]="apiKeys().length"
+          [filters]="filters()"
+          (filtersChange)="onFiltersChanged($event)"
+          [paginationPageSizeOptions]="[25, 50, 100]"
+        >
+          <table
+            mat-table
+            [dataSource]="apiKeys()"
+            matSort
+            [matSortActive]="filters().sort?.active ?? ''"
+            [matSortDirection]="filters().sort?.direction ?? ''"
+            class="card__table"
+            aria-label="API Keys Table"
+          >
+            <ng-container matColumnDef="active-icon">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="isValid"></th>
+              <td mat-cell *matCellDef="let apiKey">
+                <mat-icon
+                  [matTooltip]="apiKey.isValid ? 'Valid' : 'Revoked or Expired'"
+                  [ngClass]="{
+                    activeIcon: apiKey.isValid,
+                    revokedIcon: !apiKey.isValid,
+                  }"
+                  [svgIcon]="apiKey.isValid ? 'gio:check-circled-outline' : 'gio:x-circle'"
+                ></mat-icon>
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="key">
+              <th mat-header-cell *matHeaderCellDef>Key</th>
+              <td mat-cell *matCellDef="let apiKey">
+                <mat-form-field class="apiKeyCell">
+                  <input matInput [value]="apiKey.key" readonly />
+                  <gio-clipboard-copy-icon matSuffix [contentToCopy]="apiKey.key"></gio-clipboard-copy-icon>
+                </mat-form-field>
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="createdAt">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="createdAt">Created at</th>
+              <td mat-cell *matCellDef="let apiKey">{{ apiKey.createdAt | date: 'medium' }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="endDate">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header="endDate">Revoked/Expired at</th>
+              <td mat-cell *matCellDef="let apiKey">{{ (apiKey.endDate | date: 'medium') || '-' }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef></th>
+              <td mat-cell *matCellDef="let apiKey">
+                @if (!hasSharedApiKeyMode() && (subscription()?.status === 'ACCEPTED' || subscription()?.status === 'PENDING')) {
+                  <div *gioPermission="{ anyOf: ['api_product-subscription-u'] }" class="subscription__api-keys__actions">
+                    @if (apiKey.isValid && subscription()?.status === 'ACCEPTED') {
+                      <button (click)="revokeApiKey(apiKey)" mat-button aria-label="Button to revoke an API Key" matTooltip="Revoke">
+                        <mat-icon svgIcon="gio:x-circle"></mat-icon>
+                      </button>
+                      <button (click)="expireApiKey(apiKey)" mat-button aria-label="Button to expire an API Key" matTooltip="Expire">
+                        <mat-icon svgIcon="gio:clock-outline"></mat-icon>
+                      </button>
+                    }
+                    @if (!apiKey.isValid) {
+                      <button
+                        (click)="reactivateApiKey(apiKey)"
+                        mat-button
+                        aria-label="Button to reactivate an API Key"
+                        matTooltip="Reactivate"
+                      >
+                        <mat-icon svgIcon="gio:rotate-cw"></mat-icon>
+                      </button>
+                    }
+                  </div>
+                }
+              </td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+            <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+              <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">No API keys!</td>
+            </tr>
+          </table>
+        </gio-table-wrapper>
+      </div>
+
+      @if (!hasSharedApiKeyMode() && subscription()?.status === 'ACCEPTED') {
+        <mat-card-actions>
+          <div class="subscription__api-keys__footer" *gioPermission="{ anyOf: ['api_product-subscription-u'] }">
+            <button mat-stroked-button (click)="renewApiKey()">
+              <mat-icon svgIcon="gio:refresh-cw"></mat-icon>
+              Renew
+            </button>
+          </div>
+        </mat-card-actions>
+      }
+    </mat-card>
+  }
+</div>

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.scss
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/gio-layout' as gio-layout;
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.subscription {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &__footer {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  &__api-keys {
+    &__actions {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    &__footer {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    &__table-wrapper {
+      .apiKeyCell {
+        width: 100%;
+      }
+
+      .activeIcon {
+        color: mat.m2-get-color-from-palette(gio.$mat-success-palette, darker20);
+      }
+
+      .revokedIcon {
+        color: mat.m2-get-color-from-palette(gio.$mat-error-palette, default);
+      }
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.spec.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { of } from 'rxjs';
+import { set } from 'lodash';
+
+import { ApiProductSubscriptionEditComponent } from './api-product-subscription-edit.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { Constants } from '../../../../entities/Constants';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { fakeBasePlan, fakeSubscription, Subscription } from '../../../../entities/management-api-v2';
+import { fakeApiKey } from '../../../../entities/management-api-v2/api-key';
+
+const API_PRODUCT_ID = 'product-1';
+const SUBSCRIPTION_ID = 'sub-1';
+const PLAN_ID = 'plan-1';
+const APP_ID = 'app-1';
+
+function buildSubscription(overrides: Partial<Subscription> = {}): Subscription {
+  return fakeSubscription({
+    id: SUBSCRIPTION_ID,
+    plan: fakeBasePlan({ id: PLAN_ID, security: { type: 'API_KEY' } }),
+    status: 'ACCEPTED',
+    application: {
+      id: APP_ID,
+      name: 'My App',
+      description: 'Test app',
+      domain: 'https://example.com',
+      type: 'SIMPLE',
+      primaryOwner: { id: 'owner-1', displayName: 'Owner One' },
+      apiKeyMode: 'UNSPECIFIED',
+    },
+    ...overrides,
+  });
+}
+
+describe('ApiProductSubscriptionEditComponent', () => {
+  let fixture: ComponentFixture<ApiProductSubscriptionEditComponent>;
+  let loader: HarnessLoader;
+  let rootLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  const snackBarService = { error: jest.fn(), success: jest.fn() };
+
+  async function init(permissions: string[] = ['api_product-subscription-r', 'api_product-subscription-u']) {
+    await TestBed.configureTestingModule({
+      imports: [ApiProductSubscriptionEditComponent, NoopAnimationsModule, GioTestingModule, MatIconTestingModule],
+      providers: [
+        { provide: GioTestingPermissionProvider, useValue: permissions },
+        { provide: SnackBarService, useValue: snackBarService },
+        {
+          provide: Constants,
+          useFactory: () => {
+            const constants = { ...CONSTANTS_TESTING };
+            set(constants, 'env.settings.plan.security.customApiKey.enabled', true);
+            return constants;
+          },
+        },
+        {
+          provide: InteractivityChecker,
+          useValue: { isFocusable: () => true, isTabbable: () => true },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ apiProductId: API_PRODUCT_ID, subscriptionId: SUBSCRIPTION_ID }),
+            paramMap: of(convertToParamMap({ apiProductId: API_PRODUCT_ID, subscriptionId: SUBSCRIPTION_ID })),
+            snapshot: { params: { apiProductId: API_PRODUCT_ID, subscriptionId: SUBSCRIPTION_ID } },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductSubscriptionEditComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+  }
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  function expectSubscriptionRequest(subscription = buildSubscription()) {
+    const req = httpTestingController.expectOne(r => {
+      if (!r.url.includes(`/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}`)) return false;
+      const expands = r.params.get('expands');
+      return expands === 'plan,application,subscribedBy';
+    });
+    req.flush(subscription);
+    return subscription;
+  }
+
+  function expectApiKeysRequest() {
+    const req = httpTestingController.expectOne(r =>
+      r.url.includes(`/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys`),
+    );
+    req.flush({ data: [fakeApiKey({ key: 'test-key-1', revoked: false, expired: false })], pagination: { totalCount: 1 } });
+  }
+
+  describe('subscription details display', () => {
+    beforeEach(async () => {
+      await init();
+    });
+
+    it('should display subscription details', async () => {
+      fixture.detectChanges();
+      expectSubscriptionRequest();
+      expectApiKeysRequest();
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('[data-testid="subscription-id"]')?.textContent).toContain(SUBSCRIPTION_ID);
+      expect(compiled.querySelector('[data-testid="subscription-status"]')?.textContent).toContain('ACCEPTED');
+    });
+
+    it('should display action buttons for accepted subscription', async () => {
+      fixture.detectChanges();
+      expectSubscriptionRequest();
+      expectApiKeysRequest();
+      fixture.detectChanges();
+
+      const closeButton = await loader.getHarness(MatButtonHarness.with({ text: /Close subscription/ }));
+      expect(closeButton).toBeTruthy();
+    });
+  });
+
+  describe('close subscription', () => {
+    beforeEach(async () => {
+      await init();
+    });
+
+    it('should close subscription on confirm', async () => {
+      fixture.detectChanges();
+      expectSubscriptionRequest();
+      expectApiKeysRequest();
+      fixture.detectChanges();
+
+      const closeButton = await loader.getHarness(MatButtonHarness.with({ text: /Close subscription/ }));
+      await closeButton.click();
+
+      const closeDialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#confirmCloseSubscriptionDialog' }));
+      const confirmBtn = await closeDialog.getHarness(MatButtonHarness.with({ text: /^Close$/ }));
+      await confirmBtn.click();
+
+      const closeReq = httpTestingController.expectOne(
+        r => r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_close`,
+      );
+      expect(closeReq.request.method).toBe('POST');
+      closeReq.flush(buildSubscription({ status: 'CLOSED' }));
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // After close, refreshSubscription triggers a reload: GET subscription then GET api-keys (plan is API_KEY)
+      expectSubscriptionRequest(buildSubscription({ status: 'CLOSED' }));
+      expectApiKeysRequest();
+
+      expect(snackBarService.success).toHaveBeenCalledWith('Subscription closed');
+    });
+  });
+
+  describe('pending subscription', () => {
+    beforeEach(async () => {
+      await init();
+    });
+
+    it('should show validate and reject buttons for pending subscription', async () => {
+      fixture.detectChanges();
+      expectSubscriptionRequest(buildSubscription({ status: 'PENDING' }));
+      expectApiKeysRequest();
+      fixture.detectChanges();
+
+      const validateButton = await loader.getHarness(MatButtonHarness.with({ text: /Validate subscription/ }));
+      const rejectButton = await loader.getHarness(MatButtonHarness.with({ text: /Reject subscription/ }));
+      expect(validateButton).toBeTruthy();
+      expect(rejectButton).toBeTruthy();
+    });
+  });
+
+  describe('read-only mode', () => {
+    beforeEach(async () => {
+      await init(['api_product-subscription-r']);
+    });
+
+    it('should not show action buttons without update permission', async () => {
+      fixture.detectChanges();
+      expectSubscriptionRequest();
+      expectApiKeysRequest();
+      fixture.detectChanges();
+
+      const closeButtons = await loader.getAllHarnesses(MatButtonHarness.with({ text: /Close subscription/ }));
+      expect(closeButtons.length).toBe(0);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(async () => {
+      await init();
+    });
+
+    it('should display error when subscription load fails', async () => {
+      fixture.detectChanges();
+      const req = httpTestingController.expectOne(r => r.url.includes(`/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}`));
+      req.flush({ message: 'Subscription not found' }, { status: 404, statusText: 'Not Found' });
+      fixture.detectChanges();
+
+      expect(snackBarService.error).toHaveBeenCalledWith('Subscription not found');
+    });
+
+    it('should display err.message when err.error.message is not available', async () => {
+      fixture.detectChanges();
+      const req = httpTestingController.expectOne(r => r.url.includes(`/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}`));
+      req.flush(null, { status: 500, statusText: 'Server Error' });
+      fixture.detectChanges();
+
+      // When error body is null, Angular's HttpErrorResponse sets err.message to the full HTTP error description
+      expect(snackBarService.error).toHaveBeenCalledWith(expect.stringMatching(/Http failure response for .*: 500 Server Error/));
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/edit/api-product-subscription-edit.component.ts
@@ -1,0 +1,627 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { catchError, EMPTY, map, Observable, of, switchMap, tap } from 'rxjs';
+import { DatePipe, NgClass } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import {
+  GIO_DIALOG_WIDTH,
+  GioClipboardModule,
+  GioConfirmDialogComponent,
+  GioConfirmDialogData,
+  GioIconsModule,
+} from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { filter } from 'rxjs/operators';
+
+import { ApiProductSubscriptionV2Service } from '../../../../services-ngx/api-product-subscription-v2.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { Constants } from '../../../../entities/Constants';
+import {
+  PlanMode,
+  PlanSecurityType,
+  Subscription as ApiSubscription,
+  SubscriptionConsumerConfiguration,
+  SubscriptionConsumerStatus,
+  SubscriptionStatus,
+} from '../../../../entities/management-api-v2';
+import { GioTableWrapperFilters } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
+import {
+  ApiPortalSubscriptionChangeEndDateDialogComponent,
+  ApiPortalSubscriptionChangeEndDateDialogData,
+  ApiPortalSubscriptionChangeEndDateDialogResult,
+} from '../../../api/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component';
+import {
+  ApiPortalSubscriptionAcceptDialogData,
+  ApiPortalSubscriptionAcceptDialogResult,
+  ApiPortalSubscriptionValidateDialogComponent,
+} from '../../../api/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component';
+import {
+  ApiPortalSubscriptionRejectDialogComponent,
+  ApiPortalSubscriptionRejectDialogResult,
+} from '../../../api/subscriptions/components/dialogs/reject/api-portal-subscription-reject-dialog.component';
+import {
+  ApiPortalSubscriptionRenewDialogComponent,
+  ApiPortalSubscriptionRenewDialogData,
+  ApiPortalSubscriptionRenewDialogResult,
+} from '../../../api/subscriptions/components/dialogs/renew/api-portal-subscription-renew-dialog.component';
+import {
+  ApiPortalSubscriptionExpireApiKeyDialogComponent,
+  ApiPortalSubscriptionExpireApiKeyDialogData,
+  ApiPortalSubscriptionExpireApiKeyDialogResult,
+} from '../../../api/subscriptions/components/dialogs/expire-api-key/api-portal-subscription-expire-api-key-dialog.component';
+import {
+  ApiProductSubscriptionTransferDialogComponent,
+  ApiProductSubscriptionTransferDialogData,
+  ApiProductSubscriptionTransferDialogResult,
+} from '../components/dialogs/api-product-subscription-transfer-dialog.component';
+import { ApiSubscriptionsModule } from '../../../api/subscriptions/api-subscriptions.module';
+
+interface SubscriptionDetailVM {
+  id: string;
+  plan: { id: string; label: string; securityType: PlanSecurityType; mode: PlanMode };
+  status: SubscriptionStatus;
+  consumerStatus: SubscriptionConsumerStatus;
+  subscribedBy: string;
+  application?: { id: string; label: string; name: string; description: string };
+  publisherMessage?: string;
+  subscriberMessage?: string;
+  failureCause?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  endingAt?: Date;
+  pausedAt?: Date;
+  processedAt?: Date;
+  startingAt?: Date;
+  closedAt?: Date;
+  domain?: string;
+  consumerConfiguration?: SubscriptionConsumerConfiguration;
+  metadata?: { [key: string]: string };
+}
+
+interface ApiKeyVM {
+  id: string;
+  key: string;
+  createdAt: Date;
+  endDate: Date;
+  isValid: boolean;
+}
+
+@Component({
+  selector: 'api-product-subscription-edit',
+  templateUrl: './api-product-subscription-edit.component.html',
+  styleUrls: ['./api-product-subscription-edit.component.scss'],
+  standalone: true,
+  imports: [
+    RouterModule,
+    DatePipe,
+    NgClass,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatSortModule,
+    MatTableModule,
+    MatTooltipModule,
+    GioClipboardModule,
+    GioIconsModule,
+    GioPermissionModule,
+    GioTableWrapperModule,
+    ApiSubscriptionsModule,
+  ],
+})
+export class ApiProductSubscriptionEditComponent {
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly subscriptionService = inject(ApiProductSubscriptionV2Service);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly constants = inject<Constants>(Constants);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly apiProductId = toSignal(this.activatedRoute.params.pipe(map(param => param['apiProductId'] ?? '')), {
+    initialValue: '',
+  });
+  private readonly subscriptionId = toSignal(this.activatedRoute.params.pipe(map(param => param['subscriptionId'] ?? '')), {
+    initialValue: '',
+  });
+  private readonly refreshSubscription = signal(0);
+
+  protected readonly displayedColumns = ['active-icon', 'key', 'createdAt', 'endDate', 'actions'];
+
+  protected readonly subscription = signal<SubscriptionDetailVM | null>(null);
+  protected readonly apiKeys = signal<ApiKeyVM[]>([]);
+  protected readonly apiKeysTotalCount = signal(0);
+  protected readonly hasSharedApiKeyMode = signal(false);
+  protected readonly filters = signal<GioTableWrapperFilters>({
+    searchTerm: '',
+    pagination: { index: 1, size: 25 },
+    sort: { active: 'isValid', direction: 'desc' },
+  });
+
+  private readonly canUseCustomApiKey = computed(() => {
+    const sub = this.subscription();
+    return sub?.plan?.securityType === 'API_KEY' && this.constants.env?.settings?.plan?.security?.customApiKey?.enabled === true;
+  });
+
+  private readonly loadTrigger = computed(() => ({
+    apiProductId: this.apiProductId(),
+    subscriptionId: this.subscriptionId(),
+    refresh: this.refreshSubscription(),
+  }));
+
+  protected readonly subscriptionData = toSignal(
+    toObservable(this.loadTrigger).pipe(
+      switchMap(({ apiProductId, subscriptionId }) =>
+        !apiProductId || !subscriptionId ? EMPTY : this.loadSubscriptionData(apiProductId, subscriptionId),
+      ),
+    ),
+    { initialValue: undefined },
+  );
+
+  protected validateSubscription(): void {
+    const subscription = this.subscription();
+    this.matDialog
+      .open<ApiPortalSubscriptionValidateDialogComponent, ApiPortalSubscriptionAcceptDialogData, ApiPortalSubscriptionAcceptDialogResult>(
+        ApiPortalSubscriptionValidateDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+          data: {
+            apiId: this.apiProductId(),
+            applicationId: subscription.application.id,
+            canUseCustomApiKey: this.canUseCustomApiKey(),
+            sharedApiKeyMode: this.hasSharedApiKeyMode(),
+            isFederated: false,
+          },
+          role: 'alertdialog',
+          id: 'validateSubscriptionDialog',
+        },
+      )
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => {
+          const acceptPayload = {
+            ...(result.customApiKey ? { customApiKey: result.customApiKey } : {}),
+            ...(result.message ? { reason: result.message } : {}),
+            ...(result.start ? { startingAt: result.start } : {}),
+            ...(result.end ? { endingAt: result.end } : {}),
+          };
+          return this.subscriptionService.accept(subscription.id, this.apiProductId(), acceptPayload);
+        }),
+        catchError(err => this.handleError(err, 'Failed to validate subscription')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(updated => {
+        if (updated.status === 'ACCEPTED') {
+          this.snackBarService.success('Subscription validated');
+        } else {
+          this.snackBarService.error(`Subscription ${updated.status.toLowerCase()}`);
+        }
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected rejectSubscription(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<ApiPortalSubscriptionRejectDialogComponent, unknown, ApiPortalSubscriptionRejectDialogResult>(
+        ApiPortalSubscriptionRejectDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+          data: {},
+          role: 'alertdialog',
+          id: 'rejectSubscriptionDialog',
+        },
+      )
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => this.subscriptionService.reject(sub.id, this.apiProductId(), result.reason)),
+        catchError(err => this.handleError(err, 'Failed to reject subscription')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription rejected');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected transferSubscription(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<
+        ApiProductSubscriptionTransferDialogComponent,
+        ApiProductSubscriptionTransferDialogData,
+        ApiProductSubscriptionTransferDialogResult
+      >(ApiProductSubscriptionTransferDialogComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        data: {
+          apiProductId: this.apiProductId(),
+          securityType: sub.plan.securityType,
+          currentPlanId: sub.plan.id,
+        },
+        role: 'alertdialog',
+        id: 'transferSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => this.subscriptionService.transfer(this.apiProductId(), sub.id, result.selectedPlanId)),
+        catchError(err => this.handleError(err, 'Failed to transfer subscription')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription successfully transferred');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected pauseSubscription(): void {
+    const sub = this.subscription();
+    let content = 'The application will not be able to consume this API product anymore.';
+    if (sub.plan.securityType === 'API_KEY' && !this.hasSharedApiKeyMode()) {
+      content += '<br/>All Api-keys associated to this subscription will be paused and unusable.';
+    }
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: { title: 'Pause your subscription', content, confirmButton: 'Pause' },
+        role: 'alertdialog',
+        id: 'confirmPauseSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.pause(sub.id, this.apiProductId())),
+        catchError(err => this.handleError(err, 'Failed to pause subscription')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription paused');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected resumeSubscription(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: {
+          title: 'Resume your subscription',
+          content: 'The application will be able to consume your API Product.',
+          confirmButton: 'Resume',
+        },
+        role: 'alertdialog',
+        id: 'confirmResumeSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.resume(sub.id, this.apiProductId())),
+        catchError(err => this.handleError(err, 'Failed to resume subscription')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription resumed');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected resumeFailureSubscription(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: {
+          title: 'Resume your failed subscription',
+          content: 'The application will be able to consume your API Product.',
+          confirmButton: 'Resume',
+        },
+        role: 'alertdialog',
+        id: 'confirmResumeFailureSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.resumeFailure(sub.id, this.apiProductId())),
+        catchError(err => this.handleError(err, 'Failed to resume subscription')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription resumed');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected changeEndDate(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<
+        ApiPortalSubscriptionChangeEndDateDialogComponent,
+        ApiPortalSubscriptionChangeEndDateDialogData,
+        ApiPortalSubscriptionChangeEndDateDialogResult
+      >(ApiPortalSubscriptionChangeEndDateDialogComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        data: {
+          currentEndDate: sub.endingAt,
+          applicationName: sub.application.name,
+          securityType: sub.plan.securityType,
+          isApiProduct: true,
+        },
+        role: 'alertdialog',
+        id: 'changeEndDateDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result =>
+          this.subscriptionService.update(this.apiProductId(), sub.id, {
+            startingAt: sub.startingAt,
+            endingAt: result.endDate,
+            consumerConfiguration: sub.consumerConfiguration,
+            metadata: sub.metadata,
+          }),
+        ),
+        catchError(err => this.handleError(err, 'Failed to change end date')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('End date successfully changed');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected closeSubscription(): void {
+    const sub = this.subscription();
+    let content = `${sub.application.name} will no longer be able to consume your API Product.`;
+    if (sub.plan.securityType === 'API_KEY' && !this.hasSharedApiKeyMode()) {
+      content += '<br/>All API keys associated to this subscription will be closed and unusable.';
+    }
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: { title: 'Close your subscription', content, confirmButton: 'Close' },
+        role: 'alertdialog',
+        id: 'confirmCloseSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.close(sub.id, this.apiProductId())),
+        catchError(err => this.handleError(err, 'Failed to close subscription')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('Subscription closed');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected renewApiKey(): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<ApiPortalSubscriptionRenewDialogComponent, ApiPortalSubscriptionRenewDialogData, ApiPortalSubscriptionRenewDialogResult>(
+        ApiPortalSubscriptionRenewDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+          data: {
+            apiId: this.apiProductId(),
+            applicationId: sub.application.id,
+            canUseCustomApiKey: this.canUseCustomApiKey(),
+          },
+          role: 'alertdialog',
+          id: 'renewApiKeysDialog',
+        },
+      )
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => this.subscriptionService.renewApiKey(this.apiProductId(), sub.id, result.customApiKey)),
+        catchError(err => this.handleError(err, 'Failed to renew API Key')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('API Key renewed');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected revokeApiKey(apiKey: ApiKeyVM): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: { title: 'Revoke your API Key', content: "Revoke your subscription's API Key", confirmButton: 'Revoke' },
+        role: 'alertdialog',
+        id: 'revokeApiKeyDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.revokeApiKey(this.apiProductId(), sub.id, apiKey.id)),
+        catchError(err => this.handleError(err, 'Failed to revoke API Key')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('API Key revoked');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected expireApiKey(apiKey: ApiKeyVM): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<
+        ApiPortalSubscriptionExpireApiKeyDialogComponent,
+        ApiPortalSubscriptionExpireApiKeyDialogData,
+        ApiPortalSubscriptionExpireApiKeyDialogResult
+      >(ApiPortalSubscriptionExpireApiKeyDialogComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        data: { expirationDate: apiKey.endDate },
+        role: 'alertdialog',
+        id: 'expireApiKeyDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => this.subscriptionService.expireApiKey(this.apiProductId(), sub.id, apiKey.id, result.expirationDate)),
+        catchError(err => this.handleError(err, 'Failed to expire API Key')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('API Key expiration validated');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected reactivateApiKey(apiKey: ApiKeyVM): void {
+    const sub = this.subscription();
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: {
+          title: 'Reactivate your API Key',
+          content: 'Reactivate your revoked or expired API Key',
+          confirmButton: 'Reactivate',
+        },
+        role: 'alertdialog',
+        id: 'reactivateApiKeyDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.subscriptionService.reactivateApiKey(this.apiProductId(), sub.id, apiKey.id)),
+        catchError(err => this.handleError(err, 'Failed to reactivate API Key')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.snackBarService.success('API Key reactivated');
+        this.refreshSubscription.update(r => r + 1);
+      });
+  }
+
+  protected onFiltersChanged(event: GioTableWrapperFilters): void {
+    if (this.apiKeys().length < this.apiKeysTotalCount() || event.pagination.size <= this.apiKeysTotalCount()) {
+      this.loadApiKeys(event.pagination.index, event.pagination.size);
+    }
+  }
+
+  private applySubscriptionToState(subscription: ApiSubscription): void {
+    const plan = subscription.plan;
+    const application = subscription.application;
+    if (!plan || !application) {
+      return;
+    }
+    const primaryOwnerDisplayName = application.primaryOwner?.displayName ?? '';
+    this.subscription.set({
+      id: subscription.id,
+      plan: {
+        id: plan.id,
+        label: plan.security?.type ? `${plan.name} (${plan.security.type})` : plan.name,
+        securityType: plan.security?.type,
+        mode: plan.security?.type ? 'STANDARD' : 'PUSH',
+      },
+      application: {
+        id: application.id,
+        label: `${application.name} (${primaryOwnerDisplayName}) - Type: ${application.type ?? ''}`,
+        name: application.name,
+        description: application.description,
+      },
+      status: subscription.status,
+      consumerStatus: subscription.consumerStatus,
+      failureCause: subscription.failureCause,
+      subscribedBy: subscription.subscribedBy?.displayName,
+      publisherMessage: subscription.publisherMessage,
+      subscriberMessage: subscription.consumerMessage,
+      createdAt: subscription.createdAt,
+      updatedAt: subscription.updatedAt,
+      pausedAt: subscription.pausedAt,
+      startingAt: subscription.startingAt,
+      endingAt: subscription.endingAt,
+      processedAt: subscription.processedAt,
+      closedAt: subscription.closedAt,
+      domain: application.domain || undefined,
+      consumerConfiguration: subscription.consumerConfiguration,
+      metadata: subscription.metadata,
+    });
+    if (plan.security?.type === 'API_KEY' && subscription.status !== 'REJECTED') {
+      this.hasSharedApiKeyMode.set(application.apiKeyMode === 'SHARED');
+    }
+  }
+
+  private loadApiKeys(page: number, perPage: number): void {
+    this.subscriptionService
+      .listApiKeys(this.apiProductId(), this.subscriptionId(), page, perPage)
+      .pipe(
+        catchError(err => this.handleError(err, 'Failed to load API keys')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(response => {
+        this.apiKeysTotalCount.set(response.pagination?.totalCount ?? 0);
+        this.apiKeys.set(
+          response.data.map(apiKey => ({
+            id: apiKey.id,
+            key: apiKey.key,
+            createdAt: apiKey.createdAt,
+            endDate: apiKey.revoked ? apiKey.revokedAt : apiKey.expireAt,
+            isValid: !apiKey.revoked && !apiKey.expired,
+          })),
+        );
+      });
+  }
+
+  private loadSubscriptionData(apiProductId: string, subscriptionId: string): Observable<unknown> {
+    return this.subscriptionService.getById(apiProductId, subscriptionId, ['plan', 'application', 'subscribedBy']).pipe(
+      tap(sub => this.applySubscriptionToState(sub)),
+      switchMap(sub => {
+        if (sub.plan?.security?.type !== 'API_KEY') return of(null);
+        const { index, size } = this.filters().pagination;
+        return this.subscriptionService.listApiKeys(apiProductId, subscriptionId, index, size);
+      }),
+      tap(apiKeysResponse => {
+        if (apiKeysResponse) {
+          this.apiKeysTotalCount.set(apiKeysResponse.pagination?.totalCount ?? 0);
+          this.apiKeys.set(
+            apiKeysResponse.data.map(apiKey => ({
+              id: apiKey.id,
+              key: apiKey.key,
+              createdAt: apiKey.createdAt,
+              endDate: apiKey.revoked ? apiKey.revokedAt : apiKey.expireAt,
+              isValid: !apiKey.revoked && !apiKey.expired,
+            })),
+          );
+        }
+      }),
+      catchError(err => this.handleError(err, 'Failed to load subscription')),
+    );
+  }
+
+  private handleError(err: unknown, defaultMessage = 'An error occurred.'): Observable<never> {
+    const message =
+      (err as { error?: { message?: string }; message?: string })?.error?.message ??
+      (err as { message?: string })?.message ??
+      defaultMessage;
+    this.snackBarService.error(message);
+    return EMPTY;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.html
@@ -1,0 +1,195 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="subscriptions__header">
+  <div class="subscriptions__header__title">
+    <h2>Manage your subscriptions</h2>
+  </div>
+
+  @if (!isLoadingData()) {
+    <div class="subscriptions__header__buttons">
+      <button
+        *gioPermission="{ anyOf: ['api_product-subscription-r'] }"
+        mat-raised-button
+        type="button"
+        [disabled]="true"
+        aria-label="Export as CSV"
+        (click)="exportAsCSV()"
+      >
+        <mat-icon svgIcon="gio:upload"></mat-icon>Export as CSV
+      </button>
+      <button
+        *gioPermission="{ anyOf: ['api_product-subscription-c'] }"
+        mat-raised-button
+        type="button"
+        color="primary"
+        aria-label="Create a subscription"
+        (click)="createSubscription()"
+      >
+        <mat-icon svgIcon="gio:plus"></mat-icon>Create a subscription
+      </button>
+    </div>
+  }
+</div>
+
+<mat-card class="subscriptions__filters" [formGroup]="filtersForm">
+  <mat-card-content>
+    <div class="subscriptions__filters__inputs">
+      <mat-form-field class="subscriptions__filters__inputs__field">
+        <mat-label>Plan</mat-label>
+        <mat-select formControlName="planIds" [multiple]="true">
+          @for (plan of plans(); track plan.id) {
+            <mat-option [value]="plan.id">{{ plan.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field class="subscriptions__filters__inputs__field">
+        <mat-label>Application</mat-label>
+        <gio-form-tags-input
+          [placeholder]="'Search for an application'"
+          formControlName="applicationIds"
+          [autocompleteOptions]="searchApplications$"
+          [displayValueWith]="displayApplication$"
+          [useAutocompleteOptionValueOnly]="true"
+        ></gio-form-tags-input>
+      </mat-form-field>
+
+      <mat-form-field class="subscriptions__filters__inputs__field">
+        <mat-label>Status</mat-label>
+        <mat-select formControlName="statuses" [multiple]="true">
+          @for (status of statuses; track status.id) {
+            <mat-option [value]="status.id">{{ status.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field class="subscriptions__filters__inputs__field">
+        <mat-label>API Key</mat-label>
+        <input matInput formControlName="apiKey" />
+      </mat-form-field>
+    </div>
+    <div class="subscriptions__filters__buttons">
+      <button mat-raised-button type="button" color="secondary" aria-label="Reset filters" (click)="resetFilters()">
+        <mat-icon svgIcon="gio:refresh-cw"></mat-icon>Reset filters
+      </button>
+    </div>
+  </mat-card-content>
+
+  <gio-table-wrapper
+    [disableSearchInput]="true"
+    [length]="totalSubscriptions()"
+    [filters]="filters()?.tableWrapper"
+    (filtersChange)="onFiltersChanged($event)"
+  >
+    <table
+      mat-table
+      [dataSource]="subscriptionsTableDS()"
+      class="subscriptions__table"
+      id="subscriptionsTable"
+      aria-label="Subscriptions table"
+    >
+      <ng-container matColumnDef="securityType">
+        <th mat-header-cell *matHeaderCellDef id="securityType">Security type</th>
+        <td mat-cell *matCellDef="let element">
+          {{ element.securityType }}
+          @if (element.isSharedApiKey) {
+            <span class="gio-badge-accent" matTooltip="Use shared API keys">Shared</span>
+          }
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="plan">
+        <th mat-header-cell *matHeaderCellDef id="plan">Plan</th>
+        <td mat-cell *matCellDef="let element">{{ element.plan }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="application">
+        <th mat-header-cell *matHeaderCellDef id="application">Application</th>
+        <td mat-cell *matCellDef="let element">{{ element.application }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="createdAt">
+        <th mat-header-cell *matHeaderCellDef id="createdAt">Created at</th>
+        <td mat-cell *matCellDef="let element">{{ element.createdAt | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="processedAt">
+        <th mat-header-cell *matHeaderCellDef id="processedAt">Processed at</th>
+        <td mat-cell *matCellDef="let element">{{ element.processedAt | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="startingAt">
+        <th mat-header-cell *matHeaderCellDef id="startingAt">Start at</th>
+        <td mat-cell *matCellDef="let element">{{ element.startingAt | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="endAt">
+        <th mat-header-cell *matHeaderCellDef id="endAt">End at</th>
+        <td mat-cell *matCellDef="let element">{{ element.endAt | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef id="status">Status</th>
+        <td mat-cell *matCellDef="let element">
+          <span [class]="'gio-badge-' + element.statusBadge">{{ element.status }}</span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef id="actions"></th>
+        <td mat-cell *matCellDef="let element">
+          <div class="subscriptions__table__actions">
+            @if (canUpdate()) {
+              <button
+                mat-icon-button
+                aria-label="Edit the subscription"
+                matTooltip="Edit the subscription"
+                [routerLink]="'./' + element.id"
+              >
+                <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+              </button>
+            } @else {
+              <button
+                *gioPermission="{ anyOf: ['api_product-subscription-r'] }"
+                mat-icon-button
+                aria-label="View the subscription details"
+                matTooltip="View the subscription details"
+                [routerLink]="'./' + element.id"
+              >
+                <mat-icon svgIcon="gio:eye-empty"></mat-icon>
+              </button>
+            }
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+      <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+        @if (isLoadingData()) {
+          <td class="mat-mdc-cell mdc-data-table__cell loader" [attr.colspan]="displayedColumns.length">
+            <gio-loader></gio-loader>
+          </td>
+        } @else {
+          <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">There is no subscription (yet).</td>
+        }
+      </tr>
+    </table>
+  </gio-table-wrapper>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.scss
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.subscriptions {
+  &__header {
+    display: flex;
+    align-items: center;
+
+    &__buttons {
+      flex: 1;
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      gap: 0.5rem;
+
+      & button {
+        margin: 0;
+      }
+    }
+  }
+
+  &__filters {
+    display: flex;
+    flex-direction: column;
+
+    &__inputs {
+      display: flex;
+      flex-direction: row;
+      gap: 0.5rem;
+
+      &__field {
+        flex: 1;
+      }
+    }
+  }
+
+  &__table {
+    width: 100%;
+    @include mat.elevation(3);
+
+    &__actions {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+    }
+
+    .mat-column-actions {
+      width: 0;
+    }
+
+    .mat-column-securityType {
+      white-space: nowrap;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.spec.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { BehaviorSubject, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { ApiProductSubscriptionListComponent } from './api-product-subscription-list.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { Constants } from '../../../../entities/Constants';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { ApiPlansResponse, ApiSubscriptionsResponse, fakePlanV4, fakeSubscription } from '../../../../entities/management-api-v2';
+
+describe('ApiProductSubscriptionListComponent', () => {
+  const API_PRODUCT_ID = 'product-abc';
+  const PLAN_ID = 'plan-1';
+  const APPLICATION_ID = 'app-1';
+
+  const aSubscription = fakeSubscription({
+    id: 'sub-1',
+    plan: fakePlanV4({ id: PLAN_ID, name: 'My API Key Plan', security: { type: 'API_KEY' } }),
+    status: 'ACCEPTED',
+    application: {
+      id: APPLICATION_ID,
+      name: 'Test App',
+      primaryOwner: { id: 'owner-1', displayName: 'App Owner' },
+      type: 'SIMPLE',
+      apiKeyMode: 'UNSPECIFIED',
+    },
+  });
+
+  const plansResponse: ApiPlansResponse = {
+    data: [fakePlanV4({ id: PLAN_ID, name: 'My API Key Plan', security: { type: 'API_KEY' }, status: 'PUBLISHED' })],
+  };
+
+  const subscriptionsResponse: ApiSubscriptionsResponse = {
+    data: [aSubscription],
+    pagination: { totalCount: 1 },
+  };
+
+  let fixture: ComponentFixture<ApiProductSubscriptionListComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  let queryParams$: BehaviorSubject<Record<string, string>>;
+
+  const snackBarService = { error: jest.fn(), success: jest.fn() };
+
+  async function init(
+    permissions: string[] = ['api_product-subscription-r', 'api_product-subscription-u', 'api_product-subscription-c'],
+    initialQueryParams: Record<string, string> = {},
+  ) {
+    queryParams$ = new BehaviorSubject<Record<string, string>>(initialQueryParams);
+    await TestBed.configureTestingModule({
+      imports: [ApiProductSubscriptionListComponent, NoopAnimationsModule, GioTestingModule, MatIconTestingModule],
+      providers: [
+        { provide: GioTestingPermissionProvider, useValue: permissions },
+        { provide: SnackBarService, useValue: snackBarService },
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        {
+          provide: InteractivityChecker,
+          useValue: { isFocusable: () => true, isTabbable: () => true },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ apiProductId: API_PRODUCT_ID })),
+            queryParams: queryParams$.asObservable(),
+            queryParamMap: queryParams$.pipe(map(p => convertToParamMap(p))),
+            snapshot: { params: { apiProductId: API_PRODUCT_ID }, queryParams: initialQueryParams },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductSubscriptionListComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+
+    // When the component calls router.navigate(..., { queryParams }), the real Router does not
+    // update our mock ActivatedRoute. Spy on navigate and push queryParams to queryParams$ so
+    // that filters (derived from queryParams) update and the component's flow runs as in production.
+    const router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate').mockImplementation(((...args: unknown[]) => {
+      const options = args[1] as { queryParams?: Record<string, unknown> } | undefined;
+      if (options?.queryParams) {
+        const strParams: Record<string, string> = {};
+        Object.entries(options.queryParams).forEach(([k, v]) => {
+          if (v !== undefined && v !== null) strParams[k] = String(v);
+        });
+        queryParams$.next(strParams);
+      }
+      return Promise.resolve(true);
+    }) as Router['navigate']);
+  }
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  function expectPlansRequest() {
+    const req = httpTestingController.expectOne(r =>
+      r.url.startsWith(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans`),
+    );
+    req.flush(plansResponse);
+  }
+
+  function expectSubscriptionsRequest(expectedPage?: string, emptyResponse = false) {
+    const baseUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions`;
+    const req = httpTestingController.expectOne(r => {
+      if (!r.url.startsWith(baseUrl) || r.url.includes('/_export')) return false;
+      if (r.params.get('expands') !== 'application,plan') return false;
+      if (expectedPage != null && r.params.get('page') !== expectedPage) return false;
+      return true;
+    });
+    req.flush(emptyResponse ? { data: [], pagination: { totalCount: 0 } } : subscriptionsResponse);
+  }
+
+  describe('list display', () => {
+    beforeEach(async () => {
+      await init();
+    });
+
+    it('should show subscriptions in table', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0); // Let toObservable(filters) effect emit
+      tick(400); // debounceTime(400) then subscriptions request is sent
+      fixture.detectChanges();
+      expectSubscriptionsRequest();
+      fixture.detectChanges();
+
+      const table = await loader.getHarness(MatTableHarness);
+      const rows = await table.getRows();
+      expect(rows.length).toBe(1);
+    }));
+
+    it('should show loading indicator initially', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.querySelector('gio-loader')).toBeTruthy();
+
+      expectSubscriptionsRequest();
+      fixture.detectChanges();
+    }));
+
+    it('should display empty table with no subscription message when no subscriptions', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest(undefined, true);
+      fixture.detectChanges();
+
+      const table = await loader.getHarness(MatTableHarness.with({ selector: '#subscriptionsTable' }));
+      const tableElement = await table.host();
+      expect(await tableElement.text()).toContain('There is no subscription (yet).');
+    }));
+  });
+
+  describe('with update permission', () => {
+    beforeEach(async () => {
+      await init(['api_product-subscription-r', 'api_product-subscription-u', 'api_product-subscription-c']);
+    });
+
+    it('should show edit button for subscriptions', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest();
+      fixture.detectChanges();
+
+      const table = await loader.getHarness(MatTableHarness);
+      const rows = await table.getRows();
+      expect(rows.length).toBe(1);
+    }));
+
+    it('should show create subscription button', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest();
+      fixture.detectChanges();
+
+      const createButton = await loader.getHarness(MatButtonHarness.with({ text: /Create a subscription/ }));
+      expect(createButton).toBeTruthy();
+    }));
+  });
+
+  describe('without update permission', () => {
+    beforeEach(async () => {
+      await init(['api_product-subscription-r']);
+    });
+
+    it('should not show create subscription button', fakeAsync(async () => {
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest();
+      fixture.detectChanges();
+
+      const buttons = await loader.getAllHarnesses(MatButtonHarness.with({ text: /Create a subscription/ }));
+      expect(buttons.length).toBe(0);
+    }));
+  });
+
+  describe('reset filters', () => {
+    it('should reset filters and reload subscriptions', fakeAsync(async () => {
+      // Start with page=2 so that after reset (page=1) the filters change and a second request is sent
+      await init(['api_product-subscription-r', 'api_product-subscription-u', 'api_product-subscription-c'], { page: '2' });
+      fixture.detectChanges();
+      expectPlansRequest();
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest('2');
+      fixture.detectChanges();
+
+      const resetButton = await loader.getHarness(MatButtonHarness.with({ text: /Reset filters/ }));
+      await resetButton.click();
+      // Router.navigate spy pushes queryParams to queryParams$ so filters update and subscriptions reload
+      tick(0);
+      tick(400);
+      fixture.detectChanges();
+      expectSubscriptionsRequest('1');
+      fixture.detectChanges();
+    }));
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.ts
@@ -1,0 +1,386 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, DestroyRef, effect, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Params, Router, RouterModule } from '@angular/router';
+import { catchError, debounceTime, distinctUntilChanged, EMPTY, filter, map, Observable, of, switchMap, tap } from 'rxjs';
+import { isEqual, now, omitBy, isNil } from 'lodash';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
+import { AutocompleteOptions, GioFormTagsInputModule, GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { DatePipe } from '@angular/common';
+
+import { ApiProductSubscriptionV2Service } from '../../../../services-ngx/api-product-subscription-v2.service';
+import { ApiProductPlanV2Service } from '../../../../services-ngx/api-product-plan-v2.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { ApplicationService } from '../../../../services-ngx/application.service';
+import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { GioTableWrapperFilters } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
+import {
+  DEFAULT_SUBSCRIPTION_FILTER_STATUSES,
+  SubscriptionsTableDS,
+  SUBSCRIPTION_STATUS_DISPLAY,
+  SubscriptionStatus,
+} from '../../../../entities/subscription/subscription';
+import { Plan } from '../../../../entities/management-api-v2';
+import {
+  ApiPortalSubscriptionCreationDialogComponent,
+  ApiPortalSubscriptionCreationDialogData,
+  ApiPortalSubscriptionCreationDialogResult,
+} from '../../../api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component';
+import { ApiSubscriptionsModule } from '../../../api/subscriptions/api-subscriptions.module';
+
+export type SubscriptionsFiltersValue = {
+  planIds: string[] | null;
+  applicationIds: string[] | null;
+  statuses: SubscriptionStatus[];
+  apiKey: string | undefined;
+};
+
+type SubscriptionsFiltersForm = {
+  planIds: FormControl<string[] | null>;
+  applicationIds: FormControl<string[] | null>;
+  statuses: FormControl<SubscriptionStatus[]>;
+  apiKey: FormControl<string | undefined>;
+};
+
+@Component({
+  selector: 'api-product-subscription-list',
+  templateUrl: './api-product-subscription-list.component.html',
+  styleUrls: ['./api-product-subscription-list.component.scss'],
+  standalone: true,
+  imports: [
+    RouterModule,
+    ReactiveFormsModule,
+    DatePipe,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatSelectModule,
+    MatTableModule,
+    MatTooltipModule,
+    GioFormTagsInputModule,
+    GioIconsModule,
+    GioLoaderModule,
+    GioPermissionModule,
+    GioTableWrapperModule,
+    ApiSubscriptionsModule,
+  ],
+})
+export class ApiProductSubscriptionListComponent {
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly subscriptionService = inject(ApiProductSubscriptionV2Service);
+  private readonly planService = inject(ApiProductPlanV2Service);
+  private readonly applicationService = inject(ApplicationService);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly permissionService = inject(GioPermissionService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly displayedColumns = [
+    'securityType',
+    'plan',
+    'application',
+    'createdAt',
+    'processedAt',
+    'startingAt',
+    'endAt',
+    'status',
+    'actions',
+  ];
+
+  protected readonly statuses = SUBSCRIPTION_STATUS_DISPLAY;
+
+  private readonly apiProductId = (this.activatedRoute.snapshot.params as { apiProductId: string }).apiProductId;
+
+  // Source of truth: The URL query parameters
+  protected readonly filters = toSignal(
+    this.activatedRoute.queryParams.pipe(
+      map(params => this.parseFiltersFromQueryParams(params)),
+      distinctUntilChanged(isEqual),
+    ),
+  );
+
+  protected readonly filtersForm: FormGroup<SubscriptionsFiltersForm> = this.buildFiltersForm();
+
+  protected readonly plans = toSignal(
+    this.planService.list(this.apiProductId, undefined, ['PUBLISHED'], undefined, undefined, 1, 9999).pipe(
+      map(response => response.data.filter(plan => plan.security?.type !== 'KEY_LESS')),
+      catchError(() => {
+        this.handleError('Unable to load plans. Please try again.');
+        return of([] as Plan[]);
+      }),
+    ),
+    { initialValue: [] as Plan[] },
+  );
+
+  protected readonly canUpdate = computed(() => this.permissionService.hasAnyMatching(['api_product-subscription-u']));
+
+  private readonly subscriptionsData = toSignal(
+    toObservable(this.filters).pipe(
+      debounceTime(400),
+      distinctUntilChanged(isEqual),
+      tap(() => this.isLoadingData.set(true)),
+      switchMap(filters =>
+        this.subscriptionService
+          .list(this.apiProductId, {
+            page: `${filters.tableWrapper.pagination.index}`,
+            perPage: `${filters.tableWrapper.pagination.size}`,
+            statuses: filters.subscriptionsFilters.statuses,
+            applicationIds: filters.subscriptionsFilters.applicationIds,
+            planIds: filters.subscriptionsFilters.planIds,
+            apiKey: filters.subscriptionsFilters.apiKey,
+            expands: ['application', 'plan'],
+          })
+          .pipe(
+            catchError(() => {
+              this.handleError('Unable to load subscriptions, please try again');
+              return of({ data: [], pagination: { totalCount: 0 } });
+            }),
+          ),
+      ),
+      tap(() => this.isLoadingData.set(false)),
+    ),
+  );
+
+  protected readonly subscriptionsTableDS = computed<SubscriptionsTableDS[]>(() => {
+    const data = this.subscriptionsData()?.data ?? [];
+    return data.map(subscription => {
+      const statusEntry = this.statuses.find(s => s.id === subscription.status);
+      return {
+        id: subscription.id,
+        application: `${subscription.application?.name} (${subscription.application?.primaryOwner?.displayName})`,
+        createdAt: subscription.createdAt,
+        endAt: subscription.endingAt,
+        securityType: subscription.plan?.security?.type ?? 'UNKNOWN',
+        isSharedApiKey: subscription.plan?.security?.type === 'API_KEY' && subscription.application?.apiKeyMode === 'SHARED',
+        plan: subscription.plan?.name,
+        processedAt: subscription.processedAt,
+        startingAt: subscription.startingAt,
+        status: statusEntry?.name,
+        statusBadge: statusEntry?.badge,
+      };
+    });
+  });
+
+  protected readonly totalSubscriptions = computed(() => this.subscriptionsData()?.pagination?.totalCount ?? 0);
+  protected readonly isLoadingData = signal(true);
+
+  protected readonly searchApplications$: (searchTerm: string) => Observable<AutocompleteOptions> = searchTerm =>
+    this.applicationService.list(undefined, searchTerm, 'name', 1, 20).pipe(
+      map(page =>
+        (page.data ?? []).map(app => ({
+          value: app.id,
+          label: `${app.name} (${app.owner?.displayName ?? ''})`,
+        })),
+      ),
+    );
+
+  protected readonly displayApplication$: (value: string) => Observable<string> = value =>
+    this.applicationService.getById(value).pipe(
+      map(application => `${application.name} (${application.owner?.displayName ?? ''})`),
+      catchError(() => of(value)),
+    );
+
+  // Keep URL in sync with form changes to enable browser back/forward navigation
+  private readonly syncFormToUrl = effect(() => {
+    const subscription = this.filtersForm.valueChanges.pipe(distinctUntilChanged(isEqual)).subscribe(formValues => {
+      this.navigateToFilters(
+        {
+          ...this.filters().subscriptionsFilters,
+          ...formValues,
+        },
+        {
+          ...this.filters().tableWrapper,
+          pagination: { ...this.filters().tableWrapper.pagination, index: 1 },
+        },
+      );
+    });
+    return () => subscription.unsubscribe();
+  });
+
+  // Sync URL -> Form (e.g. on back/forward) without triggering navigation (emitEvent: false)
+  private readonly syncUrlToForm = effect(() => {
+    const filters = this.filters();
+    if (filters) {
+      this.filtersForm.patchValue(filters.subscriptionsFilters, { emitEvent: false });
+    }
+  });
+
+  // Initial sync of planIds once plans are loaded
+  private readonly hasSyncedPlanIdsWhenPlansLoaded = signal(false);
+  private readonly syncPlanIdsWhenPlansLoaded = effect(() => {
+    const plans = this.plans();
+    if (plans.length === 0) return;
+    if (this.hasSyncedPlanIdsWhenPlansLoaded()) return;
+    this.hasSyncedPlanIdsWhenPlansLoaded.set(true);
+    const filters = this.filters();
+    this.filtersForm.get('planIds')?.setValue(filters?.subscriptionsFilters.planIds ?? null, { emitEvent: false });
+  });
+
+  protected exportAsCSV(): void {
+    const filters = this.filters();
+    this.subscriptionService
+      .exportAsCSV(
+        this.apiProductId,
+        '1',
+        `${this.totalSubscriptions()}`,
+        filters.subscriptionsFilters.statuses,
+        filters.subscriptionsFilters.applicationIds,
+        filters.subscriptionsFilters.planIds,
+        filters.subscriptionsFilters.apiKey,
+      )
+      .pipe(
+        tap(blob => {
+          let fileName = `subscriptions-api-product-${this.apiProductId}-${now()}.csv`;
+          fileName = fileName.replaceAll(/\s/gi, '-').replaceAll(/\W/gi, '-');
+          const anchor = document.createElement('a');
+          anchor.download = fileName;
+          anchor.href = (globalThis.webkitURL || globalThis.URL).createObjectURL(blob);
+          anchor.click();
+        }),
+        catchError(() => {
+          this.handleError('An error occurred while exporting the subscriptions.');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  protected createSubscription(): void {
+    this.matDialog
+      .open<
+        ApiPortalSubscriptionCreationDialogComponent,
+        ApiPortalSubscriptionCreationDialogData,
+        ApiPortalSubscriptionCreationDialogResult
+      >(ApiPortalSubscriptionCreationDialogComponent, {
+        role: 'alertdialog',
+        id: 'createSubscriptionDialog',
+        data: {
+          isFederatedApi: false,
+          availableSubscriptionEntrypoints: [],
+          plans: this.plans().filter(plan => plan.status === 'PUBLISHED'),
+        },
+      })
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => {
+          const toCreate = result.subscriptionToCreate;
+          if (result.apiKeyMode) {
+            toCreate.apiKeyMode = result.apiKeyMode;
+          }
+          return this.subscriptionService.create(this.apiProductId, toCreate);
+        }),
+        catchError(err => {
+          this.handleError(err?.error?.message ?? err?.message ?? 'Failed to create subscription');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(subscription => {
+        this.snackBarService.success('Subscription successfully created');
+        this.router.navigate(['.', subscription.id], { relativeTo: this.activatedRoute });
+      });
+  }
+
+  protected onFiltersChanged(filters: GioTableWrapperFilters): void {
+    this.navigateToFilters(this.filters().subscriptionsFilters, filters);
+  }
+
+  protected resetFilters(): void {
+    this.navigateToFilters(
+      {
+        planIds: null,
+        applicationIds: null,
+        statuses: DEFAULT_SUBSCRIPTION_FILTER_STATUSES,
+        apiKey: undefined,
+      },
+      { searchTerm: '', pagination: { index: 1, size: 10 } },
+    );
+  }
+
+  private navigateToFilters(subscriptionsFilters: SubscriptionsFiltersValue, tableWrapper: GioTableWrapperFilters) {
+    const params = omitBy(
+      {
+        page: tableWrapper.pagination.index,
+        size: tableWrapper.pagination.size,
+        status: subscriptionsFilters.statuses?.join(','),
+        plan: subscriptionsFilters.planIds?.join(','),
+        application: subscriptionsFilters.applicationIds?.join(','),
+        apiKey: subscriptionsFilters.apiKey,
+      },
+      isNil,
+    );
+
+    if (!isEqual(this.activatedRoute.snapshot.queryParams, params)) {
+      this.router.navigate(['.'], {
+        relativeTo: this.activatedRoute,
+        queryParams: params,
+      });
+    }
+  }
+
+  private parseFiltersFromQueryParams(queryParams: Params) {
+    const initialPageNumber = queryParams?.['page'] ? Number(queryParams['page']) : 1;
+    const initialPageSize = queryParams?.['size'] ? Number(queryParams['size']) : 10;
+    const initialPlanIds: string[] | null = queryParams?.['plan'] ? queryParams['plan'].split(',') : null;
+    const initialApplicationIds: string[] | null = queryParams?.['application'] ? queryParams['application'].split(',') : null;
+    const initialStatuses: SubscriptionStatus[] = queryParams?.['status']
+      ? queryParams['status'].split(',')
+      : DEFAULT_SUBSCRIPTION_FILTER_STATUSES;
+    const initialApiKey: string | undefined = queryParams?.['apiKey'] ?? undefined;
+
+    return {
+      tableWrapper: { searchTerm: '', pagination: { index: initialPageNumber, size: initialPageSize } },
+      subscriptionsFilters: {
+        planIds: initialPlanIds,
+        applicationIds: initialApplicationIds,
+        statuses: initialStatuses,
+        apiKey: initialApiKey,
+      },
+    };
+  }
+
+  private buildFiltersForm(): FormGroup<SubscriptionsFiltersForm> {
+    const initialFilters = this.parseFiltersFromQueryParams(this.activatedRoute.snapshot.queryParams);
+    const { subscriptionsFilters } = initialFilters;
+    return new FormGroup<SubscriptionsFiltersForm>({
+      planIds: new FormControl<string[] | null>(subscriptionsFilters.planIds),
+      applicationIds: new FormControl<string[] | null>(subscriptionsFilters.applicationIds),
+      statuses: new FormControl<SubscriptionStatus[]>(subscriptionsFilters.statuses),
+      apiKey: new FormControl<string | undefined>(subscriptionsFilters.apiKey),
+    });
+  }
+
+  private handleError(message: string): void {
+    this.snackBarService.error(message);
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component.html
@@ -21,7 +21,8 @@
   <mat-dialog-content class="change-end-date__dialog-content">
     <div class="change-end-date__content">
       <div class="change-end-date__warning">
-        Be careful, by changing the end date, {{ data.applicationName }} may no longer have access to this API.
+        Be careful, by changing the end date, {{ data.applicationName }} may no longer have access to this
+        {{ data.isApiProduct ? 'API product' : 'API' }}.
       </div>
       <div *ngIf="data.securityType === 'API_KEY'">All API Keys after the new end date will be revoked.</div>
       <mat-form-field>

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/change-end-date/api-portal-subscription-change-end-date-dialog.component.ts
@@ -23,6 +23,8 @@ export interface ApiPortalSubscriptionChangeEndDateDialogData {
   applicationName: string;
   securityType: PlanSecurityType;
   currentEndDate: Date;
+  /** When true, wording uses "API product" instead of "API". Used when opened from API Product context. */
+  isApiProduct?: boolean;
 }
 export interface ApiPortalSubscriptionChangeEndDateDialogResult {
   endDate: Date;

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/list/api-subscription-list.component.ts
@@ -22,7 +22,12 @@ import { MatDialog } from '@angular/material/dialog';
 import { AutocompleteOptions } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { SubscriptionStatus } from '../../../../entities/subscription/subscription';
+import {
+  DEFAULT_SUBSCRIPTION_FILTER_STATUSES,
+  SubscriptionsTableDS,
+  SUBSCRIPTION_STATUS_DISPLAY,
+  SubscriptionStatus,
+} from '../../../../entities/subscription/subscription';
 import { GioTableWrapperFilters } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { ApiSubscriptionV2Service } from '../../../../services-ngx/api-subscription-v2.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
@@ -36,20 +41,6 @@ import {
   ApiPortalSubscriptionCreationDialogResult,
 } from '../components/dialogs/creation/api-portal-subscription-creation-dialog.component';
 import { ApplicationService } from '../../../../services-ngx/application.service';
-
-type SubscriptionsTableDS = {
-  id: string;
-  securityType: string;
-  isSharedApiKey: boolean;
-  plan: string;
-  application: string;
-  createdAt: Date;
-  processedAt: Date;
-  startingAt: Date;
-  endAt: Date;
-  status: string;
-  statusBadge: string;
-};
 
 @Component({
   selector: 'api-subscription-list',
@@ -65,14 +56,7 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
   public filtersForm: UntypedFormGroup;
 
   public plans: Plan[] = [];
-  public statuses: { id: SubscriptionStatus; name: string; badge: string }[] = [
-    { id: 'ACCEPTED', name: 'Accepted', badge: 'success' },
-    { id: 'CLOSED', name: 'Closed', badge: 'neutral' },
-    { id: 'PAUSED', name: 'Paused', badge: 'accent' },
-    { id: 'PENDING', name: 'Pending', badge: 'warning' },
-    { id: 'REJECTED', name: 'Rejected', badge: 'warning' },
-    { id: 'RESUMED', name: 'Resumed', badge: 'neutral' },
-  ];
+  public statuses = SUBSCRIPTION_STATUS_DISPLAY;
 
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
@@ -93,7 +77,7 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
     subscriptionsFilters: {
       planIds: null,
       applicationIds: null,
-      statuses: ['ACCEPTED', 'PAUSED', 'PENDING'],
+      statuses: DEFAULT_SUBSCRIPTION_FILTER_STATUSES,
       apiKey: undefined,
     },
   });
@@ -315,7 +299,7 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
       : null;
     const initialStatuses = this.activatedRoute.snapshot.queryParams?.status
       ? this.activatedRoute.snapshot.queryParams.status.split(',')
-      : ['ACCEPTED', 'PAUSED', 'PENDING'];
+      : DEFAULT_SUBSCRIPTION_FILTER_STATUSES;
     const initialApiKey = this.activatedRoute.snapshot.queryParams?.apiKey ? this.activatedRoute.snapshot.queryParams.apiKey : undefined;
 
     this.filtersForm = new UntypedFormGroup({
@@ -348,7 +332,7 @@ export class ApiSubscriptionListComponent implements OnInit, OnDestroy {
       subscriptionsFilters: {
         planIds: null,
         applicationIds: null,
-        statuses: ['ACCEPTED', 'PAUSED', 'PENDING'],
+        statuses: DEFAULT_SUBSCRIPTION_FILTER_STATUSES,
         apiKey: undefined,
       },
     });

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.spec.ts
@@ -21,7 +21,9 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { of } from 'rxjs';
 import { MatTableHarness } from '@angular/material/table/testing';
 
 import { ApplicationSubscriptionListModule } from './application-subscription-list.module';
@@ -269,6 +271,56 @@ describe('ApplicationSubscriptionListComponent', () => {
       expect(rowCells[0][2]).toContain('Api Name - 1');
       expect(rowCells[0][2]).toContain('API Product');
       expect(rowCells[0][7]).toBe('Accepted');
+    }));
+
+    it('should show API product in close confirmation when subscription is API Product', fakeAsync(async () => {
+      const subscription = fakeSubscriptionPage({
+        referenceType: 'API_PRODUCT',
+        referenceId: 'product-id',
+        application: APPLICATION_ID,
+        plan: PLAN_ID,
+      });
+      await initComponent([subscription], undefined, [...DEFAULT_PERMISSIONS, 'application-subscription-d']);
+
+      const matDialog = fixture.debugElement.injector.get(MatDialog);
+      const openSpy = jest.spyOn(matDialog, 'open').mockReturnValue({ afterClosed: () => of(undefined) } as any);
+
+      const listComp = fixture.componentInstance.subscriptionListComponent;
+      const apiProductRow = listComp.subscriptionsTableDS[0];
+      listComp.closeSubscription(apiProductRow);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content: expect.stringContaining('API product'),
+          }),
+        }),
+      );
+      openSpy.mockRestore();
+    }));
+
+    it('should show API in close confirmation when subscription is API', fakeAsync(async () => {
+      const subscription = fakeSubscriptionPage({ api: API_ID, application: APPLICATION_ID, plan: PLAN_ID });
+      await initComponent([subscription], undefined, [...DEFAULT_PERMISSIONS, 'application-subscription-d']);
+
+      const matDialog = fixture.debugElement.injector.get(MatDialog);
+      const openSpy = jest.spyOn(matDialog, 'open').mockReturnValue({ afterClosed: () => of(undefined) } as any);
+
+      const listComp = fixture.componentInstance.subscriptionListComponent;
+      const apiRow = listComp.subscriptionsTableDS[0];
+      listComp.closeSubscription(apiRow);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            content: expect.stringContaining('consume this API anymore'),
+          }),
+        }),
+      );
+      expect((openSpy.mock.calls[0][1] as { data: { content: string } }).data.content).not.toContain('API product');
+      openSpy.mockRestore();
     }));
   });
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/list/application-subscription-list.component.ts
@@ -27,7 +27,11 @@ import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
 import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { GioTableWrapperFilters } from '../../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
-import { SubscriptionStatus } from '../../../../../entities/subscription/subscription';
+import {
+  DEFAULT_SUBSCRIPTION_FILTER_STATUSES,
+  SUBSCRIPTION_STATUS_DISPLAY,
+  SubscriptionStatus,
+} from '../../../../../entities/subscription/subscription';
 import { ApiPlanV2Service } from '../../../../../services-ngx/api-plan-v2.service';
 import { ApplicationSubscriptionCreationDialogComponent } from '../creation';
 import { NewSubscriptionEntity } from '../../../../../entities/application';
@@ -88,14 +92,7 @@ export class ApplicationSubscriptionListComponent implements OnInit, OnDestroy {
     status: new FormControl(),
     apiKey: new FormControl(),
   });
-  public statuses: { id: SubscriptionStatus; name: string; badge: string }[] = [
-    { id: 'ACCEPTED', name: 'Accepted', badge: 'success' },
-    { id: 'CLOSED', name: 'Closed', badge: 'neutral' },
-    { id: 'PAUSED', name: 'Paused', badge: 'accent' },
-    { id: 'PENDING', name: 'Pending', badge: 'warning' },
-    { id: 'REJECTED', name: 'Rejected', badge: 'warning' },
-    { id: 'RESUMED', name: 'Resumed', badge: 'neutral' },
-  ];
+  public statuses = SUBSCRIPTION_STATUS_DISPLAY;
 
   // Create filters stream
   public filtersStream = new BehaviorSubject<SubscriptionsFilters>({
@@ -105,7 +102,7 @@ export class ApplicationSubscriptionListComponent implements OnInit, OnDestroy {
     },
     subscriptionsFilters: {
       apis: null,
-      status: ['ACCEPTED', 'PAUSED', 'PENDING'],
+      status: DEFAULT_SUBSCRIPTION_FILTER_STATUSES,
       apiKey: undefined,
     },
   });
@@ -229,9 +226,9 @@ export class ApplicationSubscriptionListComponent implements OnInit, OnDestroy {
 
   public closeSubscription(subscription: SubscriptionsTableDS) {
     const applicationId = this.activatedRoute.snapshot.params.applicationId;
+    const referenceLabel = subscription.referenceTypeLabel === 'API Product' ? 'API product' : 'API';
 
-    let content =
-      'Are you sure you want to close this subscription? <br> <br> The application will not be able to consume this API anymore.';
+    let content = `Are you sure you want to close this subscription? <br> <br> The application will not be able to consume this ${referenceLabel} anymore.`;
     if (subscription.securityType === PlanSecurityType.API_KEY && subscription.isSharedApiKey) {
       content += '<br/>All Api-keys associated to this subscription will be closed and could not be used.';
     }
@@ -266,7 +263,7 @@ export class ApplicationSubscriptionListComponent implements OnInit, OnDestroy {
     const initialPageNumber = this.activatedRoute.snapshot.queryParams?.page ? Number(this.activatedRoute.snapshot.queryParams.page) : 1;
     const initialPageSize = this.activatedRoute.snapshot.queryParams?.size ? Number(this.activatedRoute.snapshot.queryParams.size) : 10;
     const initialApiIds = this.activatedRoute.snapshot.queryParams.apis?.split(',') ?? null;
-    const initialStatuses = this.activatedRoute.snapshot.queryParams.status?.split(',') ?? ['ACCEPTED', 'PAUSED', 'PENDING'];
+    const initialStatuses = this.activatedRoute.snapshot.queryParams.status?.split(',') ?? DEFAULT_SUBSCRIPTION_FILTER_STATUSES;
     const initialApiKey = this.activatedRoute.snapshot.queryParams.apiKey;
 
     this.filtersForm.patchValue({
@@ -296,7 +293,7 @@ export class ApplicationSubscriptionListComponent implements OnInit, OnDestroy {
       },
       subscriptionsFilters: {
         apis: null,
-        status: ['ACCEPTED', 'PAUSED', 'PENDING'],
+        status: DEFAULT_SUBSCRIPTION_FILTER_STATUSES,
         apiKey: null,
       },
     });

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.spec.ts
@@ -19,8 +19,10 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { ActivatedRoute } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HarnessLoader } from '@angular/cdk/testing';
+import { MatDialog } from '@angular/material/dialog';
 import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 import { InteractivityChecker } from '@angular/cdk/a11y';
+import { of } from 'rxjs';
 
 import { ApplicationSubscriptionComponent } from './application-subscription.component';
 import { ApplicationSubscriptionHarness } from './application-subscription.harness';
@@ -201,6 +203,57 @@ describe('ApplicationSubscriptionComponent', () => {
       url: `${CONSTANTS_TESTING.env.baseURL}/applications/${applicationId}/subscriptions/${subscriptionId}`,
       method: 'DELETE',
     });
+  });
+
+  it('should show API product in close confirmation when subscription is API Product', async () => {
+    const matDialog = fixture.debugElement.injector.get(MatDialog);
+    const openSpy = jest.spyOn(matDialog, 'open').mockReturnValue({ afterClosed: () => of(undefined) } as any);
+
+    const apiProductSubscription = fakeSubscription({
+      id: subscriptionId,
+      referenceType: 'API_PRODUCT',
+      apiProduct: {
+        id: 'product-id',
+        name: 'My API Product',
+        version: '1.0',
+        owner: { id: 'owner-id', displayName: 'Product Owner' },
+      },
+      plan: { id: 'planId', name: 'Free Plan', security: 'API_KEY' },
+    });
+    fixture.componentInstance.closeSubscription(fakeApplication({ id: applicationId }), apiProductSubscription);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          content: expect.stringContaining('API product'),
+        }),
+      }),
+    );
+    openSpy.mockRestore();
+  });
+
+  it('should show API in close confirmation when subscription is API', async () => {
+    const matDialog = fixture.debugElement.injector.get(MatDialog);
+    const openSpy = jest.spyOn(matDialog, 'open').mockReturnValue({ afterClosed: () => of(undefined) } as any);
+
+    const apiSubscription = fakeSubscription({
+      id: subscriptionId,
+      api: { id: 'api-1', name: 'Test API', version: '1.0', definitionVersion: 'V2', owner: { id: 'o1', displayName: 'Owner' } },
+      plan: { id: 'planId', name: 'Free Plan', security: 'API_KEY' },
+    });
+    fixture.componentInstance.closeSubscription(fakeApplication({ id: applicationId }), apiSubscription);
+
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          content: expect.stringContaining('consume this API anymore'),
+        }),
+      }),
+    );
+    expect((openSpy.mock.calls[0][1] as { data: { content: string } }).data.content).not.toContain('API product');
+    openSpy.mockRestore();
   });
 
   const expectApplicationGetRequest = (application: Application): void => {

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/subscription/application-subscription.component.ts
@@ -97,9 +97,9 @@ export class ApplicationSubscriptionComponent {
 
   public closeSubscription(application: Application, subscription: Subscription) {
     const applicationId = this.activatedRoute.snapshot.params.applicationId;
+    const referenceLabel = subscription.referenceType === 'API_PRODUCT' ? 'API product' : 'API';
 
-    let content =
-      'Are you sure you want to close this subscription? <br> <br> The application will not be able to consume this API anymore.';
+    let content = `Are you sure you want to close this subscription? <br> <br> The application will not be able to consume this ${referenceLabel} anymore.`;
     if (subscription.plan.security === PlanSecurityType.API_KEY && application.api_key_mode !== ApiKeyMode.SHARED) {
       content += '<br/>All Api-keys associated to this subscription will be closed and could not be used.';
     }

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-subscription-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-subscription-v2.service.spec.ts
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApiProductSubscriptionV2Service } from './api-product-subscription-v2.service';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
+import {
+  AcceptSubscription,
+  ApiSubscriptionsResponse,
+  CreateSubscription,
+  fakeSubscription,
+  VerifySubscription,
+} from '../entities/management-api-v2';
+import { fakeApiKey } from '../entities/management-api-v2/api-key';
+
+describe('ApiProductSubscriptionV2Service', () => {
+  let httpTestingController: HttpTestingController;
+  let service: ApiProductSubscriptionV2Service;
+  const API_PRODUCT_ID = 'api-product-id';
+  const SUBSCRIPTION_ID = 'subscription-id';
+  const PLAN_ID = 'plan-id';
+  const APPLICATION_ID = 'application-id';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(ApiProductSubscriptionV2Service);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('list', () => {
+    it('should call the API with defaults', done => {
+      const response: ApiSubscriptionsResponse = { data: [fakeSubscription()] };
+
+      service.list(API_PRODUCT_ID).subscribe(r => {
+        expect(r.data).toEqual([fakeSubscription()]);
+        done();
+      });
+
+      const baseUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions`;
+      const req = httpTestingController.expectOne(
+        r =>
+          r.method === 'GET' &&
+          r.url.startsWith(baseUrl) &&
+          !r.url.includes('_export') &&
+          r.params.get('page') === '1' &&
+          r.params.get('perPage') === '10',
+      );
+      req.flush(response);
+    });
+
+    it('should list with all query params', done => {
+      const response: ApiSubscriptionsResponse = { data: [fakeSubscription()] };
+
+      service
+        .list(API_PRODUCT_ID, {
+          page: '1',
+          perPage: '10',
+          statuses: ['ACCEPTED', 'CLOSED'],
+          applicationIds: ['app1', 'app2'],
+          planIds: ['plan1', 'plan2'],
+          apiKey: 'my-key',
+          expands: ['plan', 'application'],
+        })
+        .subscribe(r => {
+          expect(r).toEqual(response);
+          done();
+        });
+
+      const baseUrl = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions`;
+      const req = httpTestingController.expectOne(r => {
+        if (r.method !== 'GET' || !r.url.startsWith(baseUrl) || r.url.includes('_export')) return false;
+        const p = r.params;
+        return (
+          p.get('page') === '1' &&
+          p.get('perPage') === '10' &&
+          p.get('statuses') === 'ACCEPTED,CLOSED' &&
+          p.get('applicationIds') === 'app1,app2' &&
+          p.get('planIds') === 'plan1,plan2' &&
+          p.get('apiKey') === 'my-key' &&
+          p.get('expands') === 'plan,application'
+        );
+      });
+      req.flush(response);
+    });
+  });
+
+  describe('getById', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.getById(API_PRODUCT_ID, SUBSCRIPTION_ID, ['plan', 'application']).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      const url = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}`;
+      const req = httpTestingController.expectOne(
+        r => r.method === 'GET' && r.url.startsWith(url) && r.params.get('expands') === 'plan,application',
+      );
+      req.flush(subscription);
+    });
+  });
+
+  describe('create', () => {
+    it('should call the API', done => {
+      const createSubscription: CreateSubscription = { planId: PLAN_ID, applicationId: APPLICATION_ID };
+      const subscription = fakeSubscription();
+
+      service.create(API_PRODUCT_ID, createSubscription).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(createSubscription);
+      req.flush(subscription);
+    });
+  });
+
+  describe('close', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.close(SUBSCRIPTION_ID, API_PRODUCT_ID).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_close`,
+          method: 'POST',
+        })
+        .flush(subscription);
+    });
+  });
+
+  describe('accept', () => {
+    it('should call the API', done => {
+      const acceptSubscription: AcceptSubscription = { reason: 'ok' };
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.accept(SUBSCRIPTION_ID, API_PRODUCT_ID, acceptSubscription).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_accept`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(acceptSubscription);
+      req.flush(subscription);
+    });
+  });
+
+  describe('reject', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.reject(SUBSCRIPTION_ID, API_PRODUCT_ID, 'Not approved').subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_reject`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ reason: 'Not approved' });
+      req.flush(subscription);
+    });
+  });
+
+  describe('pause', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.pause(SUBSCRIPTION_ID, API_PRODUCT_ID).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_pause`,
+          method: 'POST',
+        })
+        .flush(subscription);
+    });
+  });
+
+  describe('resume', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+
+      service.resume(SUBSCRIPTION_ID, API_PRODUCT_ID).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_resume`,
+          method: 'POST',
+        })
+        .flush(subscription);
+    });
+  });
+
+  describe('transfer', () => {
+    it('should call the API', done => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+      const newPlanId = 'new-plan-id';
+
+      service.transfer(API_PRODUCT_ID, SUBSCRIPTION_ID, newPlanId).subscribe(r => {
+        expect(r).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/_transfer`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ planId: newPlanId });
+      req.flush(subscription);
+    });
+  });
+
+  describe('verify', () => {
+    it('should call the API', done => {
+      const verifySubscription: VerifySubscription = { applicationId: APPLICATION_ID, apiKey: 'my-api-key' };
+
+      service.verify(API_PRODUCT_ID, verifySubscription).subscribe(r => {
+        expect(r).toBeDefined();
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/_verify`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(verifySubscription);
+      req.flush({ ok: true });
+    });
+  });
+
+  describe('listApiKeys', () => {
+    it('should call the API', done => {
+      const apiKey = fakeApiKey();
+
+      service.listApiKeys(API_PRODUCT_ID, SUBSCRIPTION_ID).subscribe(r => {
+        expect(r.data).toContain(apiKey);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys?page=1&perPage=10`,
+          method: 'GET',
+        })
+        .flush({ data: [apiKey] });
+    });
+  });
+
+  describe('renewApiKey', () => {
+    it('should call the API', done => {
+      const apiKey = fakeApiKey();
+
+      service.renewApiKey(API_PRODUCT_ID, SUBSCRIPTION_ID, 'custom-key').subscribe(r => {
+        expect(r).toEqual(apiKey);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/_renew`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ customApiKey: 'custom-key' });
+      req.flush(apiKey);
+    });
+  });
+
+  describe('revokeApiKey', () => {
+    it('should call the API', done => {
+      const apiKey = fakeApiKey();
+
+      service.revokeApiKey(API_PRODUCT_ID, SUBSCRIPTION_ID, apiKey.id).subscribe(r => {
+        expect(r).toEqual(apiKey);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/${apiKey.id}/_revoke`,
+          method: 'POST',
+        })
+        .flush(apiKey);
+    });
+  });
+
+  describe('expireApiKey', () => {
+    it('should call the API', done => {
+      const apiKey = fakeApiKey();
+      const expireAt = new Date('2025-12-31');
+
+      service.expireApiKey(API_PRODUCT_ID, SUBSCRIPTION_ID, apiKey.id, expireAt).subscribe(r => {
+        expect(r).toEqual(apiKey);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/${apiKey.id}`,
+        method: 'PUT',
+      });
+      expect(req.request.body).toEqual({ expireAt });
+      req.flush(apiKey);
+    });
+  });
+
+  describe('reactivateApiKey', () => {
+    it('should call the API', done => {
+      const apiKey = fakeApiKey();
+
+      service.reactivateApiKey(API_PRODUCT_ID, SUBSCRIPTION_ID, apiKey.id).subscribe(r => {
+        expect(r).toEqual(apiKey);
+        done();
+      });
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/${apiKey.id}/_reactivate`,
+          method: 'POST',
+        })
+        .flush(apiKey);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-subscription-v2.service.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import {
+  AcceptSubscription,
+  ApiSubscriptionsResponse,
+  CreateSubscription,
+  Subscription,
+  UpdateSubscription,
+  VerifySubscription,
+  VerifySubscriptionResponse,
+} from '../entities/management-api-v2';
+import { ApiKey, SubscriptionApiKeysResponse } from '../entities/management-api-v2/api-key';
+
+export interface ListSubscriptionsParams {
+  page?: string;
+  perPage?: string;
+  statuses?: string[];
+  applicationIds?: string[];
+  planIds?: string[];
+  apiKey?: string;
+  expands?: ('plan' | 'application')[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiProductSubscriptionV2Service {
+  private readonly http = inject(HttpClient);
+  private readonly constants = inject<Constants>(Constants);
+
+  list(apiProductId: string, listParams: ListSubscriptionsParams = {}): Observable<ApiSubscriptionsResponse> {
+    const { page = '1', perPage = '10', statuses, applicationIds, planIds, apiKey, expands } = listParams;
+    return this.http.get<ApiSubscriptionsResponse>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions`, {
+      params: {
+        page,
+        perPage,
+        ...(statuses && statuses.length > 0 ? { statuses: statuses.join(',') } : {}),
+        ...(applicationIds && applicationIds.length > 0 ? { applicationIds: applicationIds.join(',') } : {}),
+        ...(planIds && planIds.length > 0 ? { planIds: planIds.join(',') } : {}),
+        ...(apiKey ? { apiKey } : {}),
+        ...(expands ? { expands: expands.join(',') } : {}),
+      },
+    });
+  }
+
+  exportAsCSV(
+    apiProductId: string,
+    page = '1',
+    perPage = '10',
+    statuses?: string[],
+    applicationIds?: string[],
+    planIds?: string[],
+    apiKey?: string,
+  ): Observable<Blob> {
+    return this.http.get(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/_export`, {
+      responseType: 'blob',
+      params: {
+        page,
+        perPage,
+        ...(statuses && statuses.length > 0 ? { statuses: statuses.join(',') } : {}),
+        ...(applicationIds && applicationIds.length > 0 ? { applicationIds: applicationIds.join(',') } : {}),
+        ...(planIds && planIds.length > 0 ? { planIds: planIds.join(',') } : {}),
+        ...(apiKey ? { apiKey } : {}),
+      },
+    });
+  }
+
+  getById(apiProductId: string, subscriptionId: string, expands: string[] = []): Observable<Subscription> {
+    return this.http.get<Subscription>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}`, {
+      params: { ...(expands.length > 0 ? { expands: expands.join(',') } : {}) },
+    });
+  }
+
+  create(apiProductId: string, createSubscription: CreateSubscription): Observable<Subscription> {
+    return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions`, createSubscription);
+  }
+
+  update(apiProductId: string, subscriptionId: string, updateSubscription: UpdateSubscription): Observable<Subscription> {
+    return this.http.put<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}`,
+      updateSubscription,
+    );
+  }
+
+  transfer(apiProductId: string, subscriptionId: string, planId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_transfer`,
+      { planId },
+    );
+  }
+
+  pause(subscriptionId: string, apiProductId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_pause`,
+      {},
+    );
+  }
+
+  resume(subscriptionId: string, apiProductId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_resume`,
+      {},
+    );
+  }
+
+  resumeFailure(subscriptionId: string, apiProductId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_resumeFailure`,
+      {},
+    );
+  }
+
+  close(subscriptionId: string, apiProductId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_close`,
+      {},
+    );
+  }
+
+  accept(subscriptionId: string, apiProductId: string, acceptSubscription: AcceptSubscription): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_accept`,
+      acceptSubscription,
+    );
+  }
+
+  reject(subscriptionId: string, apiProductId: string, reason: string): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/_reject`,
+      { reason },
+    );
+  }
+
+  verify(apiProductId: string, verifySubscription: VerifySubscription): Observable<VerifySubscriptionResponse> {
+    return this.http.post(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/_verify`, verifySubscription);
+  }
+
+  listApiKeys(apiProductId: string, subscriptionId: string, page = 1, perPage = 10): Observable<SubscriptionApiKeysResponse> {
+    return this.http.get<SubscriptionApiKeysResponse>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/api-keys`,
+      { params: { page, perPage } },
+    );
+  }
+
+  renewApiKey(apiProductId: string, subscriptionId: string, customApiKey: string): Observable<ApiKey> {
+    return this.http.post<ApiKey>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/api-keys/_renew`,
+      { customApiKey },
+    );
+  }
+
+  revokeApiKey(apiProductId: string, subscriptionId: string, apiKeyId: string): Observable<ApiKey> {
+    return this.http.post<ApiKey>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/api-keys/${apiKeyId}/_revoke`,
+      {},
+    );
+  }
+
+  expireApiKey(apiProductId: string, subscriptionId: string, apiKeyId: string, expireAt: Date): Observable<ApiKey> {
+    return this.http.put<ApiKey>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/api-keys/${apiKeyId}`,
+      { expireAt },
+    );
+  }
+
+  reactivateApiKey(apiProductId: string, subscriptionId: string, apiKeyId: string): Observable<ApiKey> {
+    return this.http.post<ApiKey>(
+      `${this.constants.env.v2BaseURL}/api-products/${apiProductId}/subscriptions/${subscriptionId}/api-keys/${apiKeyId}/_reactivate`,
+      {},
+    );
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12796

## Description
Introduces full subscription management for API Products: list, create, edit, validate, reject, pause, resume, transfer, close, and API key operations. Adds shared subscription entities and new components.

| Area | Change |
|------|--------|
| **Entities** | Added SUBSCRIPTION_STATUS_DISPLAY, DEFAULT_SUBSCRIPTION_FILTER_STATUSES, SubscriptionsTableDS in subscription.ts; new subscription.spec.ts |
| **API Product Subscription List** | New list component with filters (plan, application, status, API key), create subscription |
| **API Product Subscription Edit** | New edit component: validate, reject, pause, resume, close, transfer, renew API key, revoke, expire |
| **Transfer Dialog** | New dialog to transfer subscription to another plan |
| **API Product Navigation** | Consumers submenu with Plans + Subscriptions tabs |
| **API Product Plans** | Deprecate plan dialog text updated (removed Developer Portal reference) |
| **Routes** | Consumers routes added in api-products.routes.ts |
| **Shared Subscription Lists** | api-subscription-list, application-subscription-list updated to use shared constants |
| **Shared Dialogs** | Change end date dialog updated for reuse with API product subscriptions |
| **Services** | New ApiProductSubscriptionV2Service |
| **Application Subscriptions** | Application subscription views updated for API Product support |



https://github.com/user-attachments/assets/3de05de2-2f1a-48eb-95f1-a162ccba3bb5
