### PR TITLE
feat(gateway): support secrets in SharedPolicyGroup

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/manager/impl/SharedPolicyGroupManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/manager/impl/SharedPolicyGroupManagerImpl.java
@@ -23,6 +23,10 @@ import io.gravitee.gateway.handlers.sharedpolicygroup.manager.SharedPolicyGroupM
 import io.gravitee.node.api.license.ForbiddenFeatureException;
 import io.gravitee.node.api.license.InvalidLicenseException;
 import io.gravitee.node.api.license.LicenseManager;
+import io.gravitee.secrets.api.discovery.Definition;
+import io.gravitee.secrets.api.discovery.DefinitionMetadata;
+import io.gravitee.secrets.api.event.SecretDiscoveryEvent;
+import io.gravitee.secrets.api.event.SecretDiscoveryEventType;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +47,7 @@ import lombok.CustomLog;
 public class SharedPolicyGroupManagerImpl implements SharedPolicyGroupManager {
 
     private static final int PARALLELISM = Runtime.getRuntime().availableProcessors() * 2;
+    private static final String SHARED_POLICY_GROUP_DEFINITION_KIND = "shared-policy-group";
     private final Map<String, ReactableSharedPolicyGroup> sharedPolicyGroups = new ConcurrentHashMap<>();
 
     private final EventManager eventManager;
@@ -51,6 +56,28 @@ public class SharedPolicyGroupManagerImpl implements SharedPolicyGroupManager {
     public SharedPolicyGroupManagerImpl(EventManager eventManager, LicenseManager licenseManager) {
         this.eventManager = eventManager;
         this.licenseManager = licenseManager;
+
+        eventManager.subscribeForEvents(
+            event -> {
+                if (!(event.content() instanceof SecretDiscoveryEvent secretDiscoveryEvent)) {
+                    return;
+                }
+                if (!(secretDiscoveryEvent.definition() instanceof Definition definition)) {
+                    return;
+                }
+                if (!SHARED_POLICY_GROUP_DEFINITION_KIND.equals(definition.kind())) {
+                    return;
+                }
+                ReactableSharedPolicyGroup spg = sharedPolicyGroups.get(definition.id());
+                if (spg == null) {
+                    log.trace("Received SecretDiscoveryEvent for Shared Policy Group {}, but not found in manager", definition.id());
+                    return;
+                }
+                log.info("Secret value changed for Shared Policy Group {}, updating it", definition.id());
+                eventManager.publishEvent(SharedPolicyGroupEvent.UPDATE, spg);
+            },
+            SecretDiscoveryEventType.VALUE_CHANGED
+        );
     }
 
     @Override
@@ -151,6 +178,14 @@ public class SharedPolicyGroupManagerImpl implements SharedPolicyGroupManager {
     private void deploy(ReactableSharedPolicyGroup sharedPolicyGroup) {
         log.debug("Deployment of {}", sharedPolicyGroup);
 
+        eventManager.publishEvent(
+            SecretDiscoveryEventType.DISCOVER,
+            new SecretDiscoveryEvent(
+                sharedPolicyGroup.getEnvironmentId(),
+                sharedPolicyGroup.getDefinition(),
+                new DefinitionMetadata(sharedPolicyGroup.getDefinition().getVersion())
+            )
+        );
         sharedPolicyGroups.put(sharedPolicyGroup.getId(), sharedPolicyGroup);
         eventManager.publishEvent(SharedPolicyGroupEvent.DEPLOY, sharedPolicyGroup);
         log.info("Shared Policy Group [{}] has been deployed", sharedPolicyGroup.getId());
@@ -159,8 +194,27 @@ public class SharedPolicyGroupManagerImpl implements SharedPolicyGroupManager {
     private void update(ReactableSharedPolicyGroup sharedPolicyGroup) {
         log.debug("Updating {}", sharedPolicyGroup);
 
+        eventManager.publishEvent(
+            SecretDiscoveryEventType.DISCOVER,
+            new SecretDiscoveryEvent(
+                sharedPolicyGroup.getEnvironmentId(),
+                sharedPolicyGroup.getDefinition(),
+                new DefinitionMetadata(sharedPolicyGroup.getDefinition().getVersion())
+            )
+        );
+        ReactableSharedPolicyGroup previousSharedPolicyGroup = sharedPolicyGroups.get(sharedPolicyGroup.getId());
         sharedPolicyGroups.put(sharedPolicyGroup.getId(), sharedPolicyGroup);
         eventManager.publishEvent(SharedPolicyGroupEvent.UPDATE, sharedPolicyGroup);
+        if (previousSharedPolicyGroup != null) {
+            eventManager.publishEvent(
+                SecretDiscoveryEventType.REVOKE,
+                new SecretDiscoveryEvent(
+                    previousSharedPolicyGroup.getEnvironmentId(),
+                    previousSharedPolicyGroup.getDefinition(),
+                    new DefinitionMetadata(previousSharedPolicyGroup.getDefinition().getVersion())
+                )
+            );
+        }
         log.info("Shared Policy Group [{}] has been updated", sharedPolicyGroup.getId());
     }
 
@@ -170,6 +224,14 @@ public class SharedPolicyGroupManagerImpl implements SharedPolicyGroupManager {
             log.debug("Undeployment of Shared Policy Group [{}]", currentSharedPolicyGroup.getEnvironmentId());
 
             eventManager.publishEvent(SharedPolicyGroupEvent.UNDEPLOY, currentSharedPolicyGroup);
+            eventManager.publishEvent(
+                SecretDiscoveryEventType.REVOKE,
+                new SecretDiscoveryEvent(
+                    currentSharedPolicyGroup.getEnvironmentId(),
+                    currentSharedPolicyGroup.getDefinition(),
+                    new DefinitionMetadata(currentSharedPolicyGroup.getDefinition().getVersion())
+                )
+            );
             log.info("[{}] has been undeployed", currentSharedPolicyGroup.getId());
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/manager/impl/SharedPolicyGroupManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/manager/impl/SharedPolicyGroupManagerImplTest.java
@@ -16,6 +16,8 @@
 package io.gravitee.gateway.handlers.sharedpolicygroup.manager.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -24,6 +26,8 @@ import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
 import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
 import io.gravitee.gateway.handlers.sharedpolicygroup.event.SharedPolicyGroupEvent;
 import io.gravitee.node.api.license.LicenseManager;
+import io.gravitee.secrets.api.event.SecretDiscoveryEvent;
+import io.gravitee.secrets.api.event.SecretDiscoveryEventType;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
@@ -61,6 +65,7 @@ class SharedPolicyGroupManagerImplTest {
     void should_deploy_shared_policy_group() {
         final ReactableSharedPolicyGroup sharedPolicyGroup = new SharedPolicyGroupBuilder().id(SHARED_POLICY_GROUP_ID).build();
         cut.register(sharedPolicyGroup);
+        verify(eventManager).publishEvent(eq(SecretDiscoveryEventType.DISCOVER), any(SecretDiscoveryEvent.class));
         verify(eventManager).publishEvent(SharedPolicyGroupEvent.DEPLOY, sharedPolicyGroup);
         assertThat(cut.sharedPolicyGroups()).hasSize(1);
     }
@@ -79,6 +84,7 @@ class SharedPolicyGroupManagerImplTest {
 
         cut.register(sharedPolicyGroup2);
         verify(eventManager).publishEvent(SharedPolicyGroupEvent.UPDATE, sharedPolicyGroup2);
+        verify(eventManager).publishEvent(eq(SecretDiscoveryEventType.REVOKE), any(SecretDiscoveryEvent.class));
         assertThat(cut.sharedPolicyGroups()).hasSize(1);
     }
 
@@ -109,6 +115,7 @@ class SharedPolicyGroupManagerImplTest {
 
         cut.unregister(sharedPolicyGroup.getId());
         verify(eventManager).publishEvent(SharedPolicyGroupEvent.UNDEPLOY, sharedPolicyGroup);
+        verify(eventManager).publishEvent(eq(SecretDiscoveryEventType.REVOKE), any(SecretDiscoveryEvent.class));
         assertThat(cut.sharedPolicyGroups()).isEmpty();
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/v4/secrets/SharedPolicyGroupDefinitionSecretRefsFinder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/v4/secrets/SharedPolicyGroupDefinitionSecretRefsFinder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.v4.secrets;
+
+import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
+import io.gravitee.secrets.api.discovery.Definition;
+import io.gravitee.secrets.api.discovery.DefinitionDescriptor;
+import io.gravitee.secrets.api.discovery.DefinitionMetadata;
+import io.gravitee.secrets.api.discovery.DefinitionSecretRefsListener;
+import java.util.Optional;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class SharedPolicyGroupDefinitionSecretRefsFinder extends AbstractV4APISecretRefFinder<SharedPolicyGroup> {
+
+    public static final String SHARED_POLICY_GROUP_DEFINITION_KIND = "shared-policy-group";
+
+    @Override
+    public boolean canHandle(Object definition) {
+        return canHandle(definition, SharedPolicyGroup.class);
+    }
+
+    @Override
+    public DefinitionDescriptor toDefinitionDescriptor(SharedPolicyGroup definition, DefinitionMetadata metadata) {
+        return new DefinitionDescriptor(
+            new Definition(SHARED_POLICY_GROUP_DEFINITION_KIND, definition.getId()),
+            Optional.ofNullable(metadata.revision())
+        );
+    }
+
+    @Override
+    public void findSecretRefs(SharedPolicyGroup definition, DefinitionSecretRefsListener listener) {
+        safeList(definition.getPolicies()).forEach(step -> processStep(listener, step));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -44,6 +44,7 @@ import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactoryManager;
 import io.gravitee.gateway.reactive.reactor.v4.secrets.ApiV4DefinitionSecretRefsFinder;
 import io.gravitee.gateway.reactive.reactor.v4.secrets.NativeApiV4DefinitionSecretRefsFinder;
+import io.gravitee.gateway.reactive.reactor.v4.secrets.SharedPolicyGroupDefinitionSecretRefsFinder;
 import io.gravitee.gateway.reactor.Reactor;
 import io.gravitee.gateway.reactor.handler.AcceptorResolver;
 import io.gravitee.gateway.reactor.handler.HttpAcceptor;
@@ -275,6 +276,11 @@ public class ReactorConfiguration {
     @Bean
     public DefinitionSecretRefsFinder<?> nativeV4ApiDefinitionSecretRefsFinder() {
         return new NativeApiV4DefinitionSecretRefsFinder();
+    }
+
+    @Bean
+    public DefinitionSecretRefsFinder<?> sharedPolicyGroupDefinitionSecretRefsFinder() {
+        return new SharedPolicyGroupDefinitionSecretRefsFinder();
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/v4/secrets/SharedPolicyGroupDefinitionSecretRefsFinderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/v4/secrets/SharedPolicyGroupDefinitionSecretRefsFinderTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.v4.secrets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.flow.step.Step;
+import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
+import io.gravitee.secrets.api.discovery.Definition;
+import io.gravitee.secrets.api.discovery.DefinitionDescriptor;
+import io.gravitee.secrets.api.discovery.DefinitionMetadata;
+import io.gravitee.secrets.api.discovery.DefinitionSecretRefsFinder;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SharedPolicyGroupDefinitionSecretRefsFinderTest {
+
+    DefinitionSecretRefsFinder<SharedPolicyGroup> underTest = new SharedPolicyGroupDefinitionSecretRefsFinder();
+
+    @Test
+    void should_can_handle() {
+        assertThat(underTest.canHandle(null)).isFalse();
+        assertThat(underTest.canHandle(new Api())).isFalse();
+        assertThat(underTest.canHandle(new SharedPolicyGroup())).isTrue();
+    }
+
+    @Test
+    void should_get_definition_descriptor() {
+        SharedPolicyGroup spg = new SharedPolicyGroup();
+        spg.setId("spg-123");
+        assertThat(underTest.toDefinitionDescriptor(spg, new DefinitionMetadata(null))).isEqualTo(
+            new DefinitionDescriptor(new Definition("shared-policy-group", "spg-123"), Optional.empty())
+        );
+        assertThat(underTest.toDefinitionDescriptor(spg, new DefinitionMetadata("v2"))).isEqualTo(
+            new DefinitionDescriptor(new Definition("shared-policy-group", "spg-123"), Optional.of("v2"))
+        );
+    }
+
+    @Test
+    void should_not_fail_with_null_or_empty_policies() {
+        SharedPolicyGroup withNull = new SharedPolicyGroup();
+        withNull.setPolicies(null);
+        assertThatCode(() ->
+            underTest.findSecretRefs(withNull, (config, location, setter) -> setter.accept(config))
+        ).doesNotThrowAnyException();
+
+        SharedPolicyGroup withEmpty = new SharedPolicyGroup();
+        withEmpty.setPolicies(List.of());
+        assertThatCode(() ->
+            underTest.findSecretRefs(withEmpty, (config, location, setter) -> setter.accept(config))
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_find_secrets_in_policies() {
+        String config1 = "policy1-config";
+        String policy1 = "policy1-type";
+        String config2 = "policy2-config";
+        String policy2 = "policy2-type";
+
+        SharedPolicyGroup spg = new SharedPolicyGroup();
+        spg.setPolicies(List.of(newStep(config1, policy1), newStep(config2, policy2)));
+
+        Set<String> actualConfigs = new HashSet<>();
+        Set<String> actualLocations = new HashSet<>();
+
+        underTest.findSecretRefs(spg, (config, location, setter) -> {
+            actualConfigs.add(config);
+            actualLocations.add(location.id());
+            setter.accept(processed(config));
+        });
+
+        assertThat(actualConfigs).containsExactlyInAnyOrder(config1, config2);
+        assertThat(actualLocations).containsExactlyInAnyOrder(policy1, policy2);
+
+        // Verify setter worked
+        assertThat(spg.getPolicies().get(0).getConfiguration()).isEqualTo(processed(config1));
+        assertThat(spg.getPolicies().get(1).getConfiguration()).isEqualTo(processed(config2));
+    }
+
+    private static Step newStep(String configuration, String policy) {
+        Step step = new Step();
+        step.setConfiguration(configuration);
+        step.setPolicy(policy);
+        return step;
+    }
+
+    private String processed(String original) {
+        return original.concat(" - updated!");
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/secrets/api/v4/VaultSharedPolicyGroupSecretTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/secrets/api/v4/VaultSharedPolicyGroupSecretTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.secrets.api.v4;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.graviteesource.secretprovider.hcvault.HCVaultSecretProvider;
+import com.graviteesource.secretprovider.hcvault.HCVaultSecretProviderFactory;
+import com.graviteesource.secretprovider.hcvault.config.manager.VaultConfig;
+import com.graviteesource.service.secrets.SecretsService;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.VaultException;
+import io.github.jopenlibs.vault.response.LogicalResponse;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeploySharedPolicyGroups;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.secrets.SecretProviderBuilder;
+import io.gravitee.apim.integration.tests.secrets.SecuredVaultContainer;
+import io.gravitee.apim.integration.tests.secrets.conf.SSLUtils;
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.node.secrets.plugins.SecretProviderPlugin;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.transformheaders.TransformHeadersPolicy;
+import io.gravitee.policy.transformheaders.configuration.TransformHeadersPolicyConfiguration;
+import io.gravitee.secrets.api.plugin.SecretManagerConfiguration;
+import io.gravitee.secrets.api.plugin.SecretProviderFactory;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test verifying that secrets ({@code {#secrets.get(...)}}) are correctly resolved
+ * inside SharedPolicyGroup policy configurations.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class VaultSharedPolicyGroupSecretTest {
+
+    static SecuredVaultContainer vaultContainer;
+    static Vault rootVault;
+
+    @AfterAll
+    static void cleanup() {
+        vaultContainer.close();
+    }
+
+    @BeforeAll
+    static void createVaultContainer() throws IOException, InterruptedException, VaultException {
+        vaultContainer = new SecuredVaultContainer();
+        vaultContainer.start();
+        vaultContainer.initAndUnsealVault();
+        vaultContainer.loginAndLoadTestPolicy();
+        vaultContainer.setEngineVersions();
+        vaultContainer.setupUserPassAuth();
+        SSLUtils.SSLPairs clientCertAndKey = SSLUtils.createPairs();
+        vaultContainer.setupCertAuth(clientCertAndKey.cert());
+        rootVault = vaultContainer.getRootVault();
+    }
+
+    @Nested
+    @GatewayTest
+    @DeploySharedPolicyGroups("/sharedpolicygroups/spg-secret-header-on-request.json")
+    class SharedPolicyGroupWithStaticSecretRef extends AbstractGatewayTest {
+
+        final String apiKey = UUID.randomUUID().toString();
+
+        @Override
+        public void configureGateway(GatewayConfigurationBuilder configurationBuilder) {
+            configurationBuilder.setYamlProperty("api.secrets.providers[0].plugin", "vault");
+            configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.enabled", true);
+            configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.host", vaultContainer.getHost());
+            configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.port", vaultContainer.getPort());
+            configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.ssl.enabled", true);
+            configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.ssl.format", "pemfile");
+            configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.ssl.file", SecuredVaultContainer.CERT_PEMFILE);
+            configurationBuilder.setYamlProperty("api.secrets.providers[0].configuration.auth.method", "userpass");
+            configurationBuilder.setYamlProperty(
+                "api.secrets.providers[0].configuration.auth.config.username",
+                SecuredVaultContainer.USER_ID
+            );
+            configurationBuilder.setYamlProperty(
+                "api.secrets.providers[0].configuration.auth.config.password",
+                SecuredVaultContainer.PASSWORD
+            );
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.putIfAbsent(
+                "transform-headers",
+                PolicyBuilder.build("transform-headers", TransformHeadersPolicy.class, TransformHeadersPolicyConfiguration.class)
+            );
+        }
+
+        @Override
+        public void configureSecretProviders(
+            Set<SecretProviderPlugin<? extends SecretProviderFactory<?>, ? extends SecretManagerConfiguration>> secretProviderPlugins
+        ) throws Exception {
+            secretProviderPlugins.add(
+                SecretProviderBuilder.build(HCVaultSecretProvider.PLUGIN_ID, HCVaultSecretProviderFactory.class, VaultConfig.class)
+            );
+            LogicalResponse write = rootVault.logical().write("secret/test", Map.of("api-key", apiKey));
+            assertThat(write.getRestResponse().getStatus()).isLessThan(300);
+        }
+
+        @Override
+        public void configureServices(Set<Class<? extends AbstractService<?>>> services) {
+            super.configureServices(services);
+            services.add(SecretsService.class);
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/secrets/vault/api-spg-secret.json")
+        void should_resolve_secret_in_shared_policy_group(HttpClient httpClient) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(10, TimeUnit.SECONDS)
+                .assertComplete();
+
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")).withHeader("Authorization", equalTo("ApiKey ".concat(apiKey))));
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/secrets/vault/api-spg-secret.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/secrets/vault/api-spg-secret.json
@@ -1,0 +1,72 @@
+{
+  "id": "spg-secret-api-v4",
+  "name": "my-spg-secret-api-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": ["GET"]
+        }
+      ],
+      "request": [
+        {
+          "name": "my-shared-policy-group-policy",
+          "description": "",
+          "enabled": true,
+          "policy": "shared-policy-group-policy",
+          "configuration": {
+            "sharedPolicyGroupId": "spg-secret-header-on-request"
+          }
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/sharedpolicygroups/spg-secret-header-on-request.json
+++ b/gravitee-apim-integration-tests/src/test/resources/sharedpolicygroups/spg-secret-header-on-request.json
@@ -1,0 +1,24 @@
+{
+  "id": "spg-secret-header-on-request",
+  "name": "spg-secret-header-on-request",
+  "environmentId": "DEFAULT",
+  "version": "1",
+  "phase": "REQUEST",
+  "policies": [
+    {
+      "name": "Transform headers with secret",
+      "description": "",
+      "enabled": true,
+      "policy": "transform-headers",
+      "configuration": {
+        "scope": "REQUEST",
+        "addHeaders": [
+          {
+            "name": "Authorization",
+            "value": "ApiKey {#secrets.get('/vault/secret/test:api-key')}"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add secret discovery support for SharedPolicyGroup so that `{#secrets.get(...)}` expressions are resolved at runtime
- Publish `DISCOVER`/`REVOKE` `SecretDiscoveryEvent` during SPG deploy/update/undeploy lifecycle
- Subscribe to `VALUE_CHANGED` events to trigger SPG update when a secret value changes

https://gravitee.atlassian.net/browse/APIM-12348

## Changes
- **`SharedPolicyGroupDefinitionSecretRefsFinder`** (new): scans SPG policies for secret references, following the same pattern as `ApiV4DefinitionSecretRefsFinder`
- **`ReactorConfiguration`**: register the new finder as a Spring bean
- **`SharedPolicyGroupManagerImpl`**: publish `SecretDiscoveryEvent` on deploy/update/undeploy and subscribe to `VALUE_CHANGED`
- Unit tests for finder and manager
- Vault integration test verifying end-to-end secret resolution in a SharedPolicyGroup
