### PR TITLE
fix(elasticsearch): escape special characters in Lucene query_string

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
@@ -81,10 +81,11 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
         try {
             final String logQueryString = getQuery(query.query(), true);
             if (isEmpty(logQueryString)) {
+                String safeQuery = this.createSafeElasticsearchJsonQuery(query);
                 final Single<SearchResponse> result = this.client.search(
                     this.indexNameGenerator.getIndexName(queryContext.placeholder(), Type.REQUEST, from, to, clusters),
                     !info.getVersion().canUseTypeRequests() ? null : Type.REQUEST.getType(),
-                    this.createElasticsearchJsonQuery(query)
+                    safeQuery
                 );
 
                 return this.toTabularResponse(result.blockingGet());
@@ -95,7 +96,7 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
                     .size(MAX_RESULT_WINDOW)
                     .query(logQueryString)
                     .build();
-                final String sQuery = this.createElasticsearchJsonQuery(logQuery);
+                final String sQuery = this.createSafeElasticsearchJsonQuery(logQuery);
 
                 Single<SearchResponse> result = this.client.search(
                     this.indexNameGenerator.getIndexName(queryContext.placeholder(), Type.LOG, from, to, clusters),
@@ -126,7 +127,7 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
                     result = this.client.search(
                         this.indexNameGenerator.getIndexName(queryContext.placeholder(), Type.REQUEST, from, to, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : Type.REQUEST.getType(),
-                        this.createElasticsearchJsonQuery(requestQueryBuilder.build())
+                        this.createSafeElasticsearchJsonQuery(requestQueryBuilder.build())
                     );
                 }
 
@@ -248,5 +249,26 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
         tabularResponse.setLogs(logs);
 
         return tabularResponse;
+    }
+
+    /**
+     * Fix APIM-12955: Escapes Lucene special characters in the query string.
+     * Quadruple backslashes are required to survive both Java and JSON parsing levels
+     * so that Lucene finally receives the mandatory single backslash escape (e.g., \( ).
+     */
+    private String createSafeElasticsearchJsonQuery(final TabularQuery query) {
+        String json = this.createElasticsearchJsonQuery(query);
+
+        if (query != null && query.query() != null && query.query().filter() != null) {
+            String filter = query.query().filter();
+
+            if (!filter.isEmpty()) {
+                String escaped = filter.replace("\\", "\\\\\\\\").replace("/", "\\\\/").replace("(", "\\\\(").replace(")", "\\\\)");
+
+                // Targeted replacement within quotes to protect JSON structure
+                json = json.replace("\"" + filter + "\"", "\"" + escaped + "\"");
+            }
+        }
+        return json;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/LuceneEscapeTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/LuceneEscapeTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.lucene.queryparser.classic.QueryParser;
+import org.junit.jupiter.api.Test;
+
+public class LuceneEscapeTest {
+
+    @Test
+    public void compareImplementationWithStandardParser() {
+        String input = "status:200 AND custom.userAgent:RMel/1.0.0 (Ubuntu)";
+
+        String luceneStandard = QueryParser.escape(input);
+
+        String result = input.replace("\\", "\\\\\\\\").replace("/", "\\\\/").replace("(", "\\\\(").replace(")", "\\\\)");
+
+        assertThat(result).contains("RMel\\\\/1.0.0");
+        assertThat(result).contains("\\\\(Ubuntu\\\\)");
+
+        // NO REGRESSION Test
+        assertThat(result).contains("status:200");
+        assertThat(result).contains("custom.userAgent:");
+
+        assertThat(luceneStandard).contains("status\\:200");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12955

## Description

Fixed the 500 error occurring when log filters contain Lucene special characters (e.g., /, (, )), found in custom metric based on the User-Agent header

## Additional context

Why not used QueryParser (.escape()) or any other alternative? 
It is too aggressive; it escapes structural characters like : and *, which breaks standard field filters (e.g., status:200) and wildcard searches.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

