### PR TITLE
fix(analytics): display < 1 ms for sub-millisecond min response time

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.spec.ts
@@ -32,6 +32,7 @@ import {
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
 import { AnalyticsStatsResponse } from '../../../../entities/management-api-v2/analytics/analyticsStats';
 import { fakeAnalyticsStatsResponse } from '../../../../entities/management-api-v2/analytics/analyticsStats.fixture';
+import { SUB_MILLISECOND_LABEL } from '../../../../shared/components/analytics-stats/analytics-stats.component';
 
 describe('ApiAnalyticsWidgetService', () => {
   let service: ApiAnalyticsWidgetService;
@@ -155,6 +156,36 @@ describe('ApiAnalyticsWidgetService', () => {
             expect(result.tooltip).toBe('');
             expect(result.widgetType).toBe('stats');
             expect(result.widgetData).toEqual({ stats: 100, statsUnit: 'ms' });
+
+            service.clearStatsCache();
+            done();
+          });
+          expectStatsRequest('gateway-response-time-ms', mockedStatsResponse);
+        });
+
+        it('should display sub-millisecond label when min response time is 0', done => {
+          const fakeWidgetConfig: ApiAnalyticsDashboardWidgetConfig = {
+            type: 'stats',
+            apiId: API_ID,
+            title: 'Min Response Time',
+            statsKey: 'min',
+            statsUnit: 'ms',
+            tooltip: '',
+            shouldSortBuckets: false,
+            statsField: 'gateway-response-time-ms',
+            analyticsType: 'STATS',
+          };
+
+          const mockedStatsResponse: AnalyticsStatsResponse = fakeAnalyticsStatsResponse({ min: 0 });
+
+          service.getApiAnalyticsWidgetConfig$(fakeWidgetConfig).subscribe(result => {
+            if (result.state === 'loading') {
+              return;
+            }
+
+            expect(result.state).toBe('success');
+            expect(result.widgetType).toBe('stats');
+            expect(result.widgetData).toEqual({ stats: 0, statsUnit: 'ms', formattedOverride: SUB_MILLISECOND_LABEL });
 
             service.clearStatsCache();
             done();

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-widget.service.ts
@@ -32,6 +32,7 @@ import { TimeRangeParams } from '../../../../shared/utils/timeFrameRanges';
 import { AnalyticsStatsResponse } from '../../../../entities/management-api-v2/analytics/analyticsStats';
 import { EsFilter, toQuery } from '../../../../shared/utils/esQuery';
 import { MultiStatsWidgetData } from '../../../../shared/components/analytics-multi-stats/analytics-multi-stats.component';
+import { SUB_MILLISECOND_LABEL } from '../../../../shared/components/analytics-stats/analytics-stats.component';
 
 // Interface expected from component that transforms query params to UrlParamsData
 export interface ApiAnalyticsWidgetUrlParamsData {
@@ -168,16 +169,22 @@ export class ApiAnalyticsWidgetService {
     widgetConfig: ApiAnalyticsDashboardWidgetConfig,
   ): ApiAnalyticsWidgetConfig {
     const statsValue = widgetConfig.statsKey ? statsResponse[widgetConfig.statsKey] : undefined;
-    if (statsValue == null || statsValue === 0) {
+    if (statsValue == null) {
       return this.createEmptyConfig(widgetConfig);
     }
+
+    const isSubMillisecondMin = statsValue === 0 && widgetConfig.statsKey === 'min' && widgetConfig.statsUnit === 'ms';
 
     return {
       title: widgetConfig.title,
       tooltip: widgetConfig.tooltip,
       state: 'success',
       widgetType: 'stats' as const,
-      widgetData: { stats: statsValue, statsUnit: widgetConfig.statsUnit },
+      widgetData: {
+        stats: statsValue,
+        statsUnit: widgetConfig.statsUnit,
+        ...(isSubMillisecondMin && { formattedOverride: SUB_MILLISECOND_LABEL }),
+      },
     };
   }
 

--- a/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.html
+++ b/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.html
@@ -66,6 +66,8 @@
             <span class="stats__body__row__value">
               @if (data.responseMinTime) {
                 {{ data.responseMinTime | number: '.1-2' }} ms
+              } @else if (data.responseMinTime === 0 && data.requestsTotal) {
+                {{ subMillisecondLabel }}
               } @else {
                 -
               }

--- a/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+import { DashboardApiRequestStats, v4ApisRequestStats } from './dashboard-api-request-stats.component';
+import { DashboardApiRequestStatsHarness } from './dashboard-api-request-stats.harness';
+
+import { SUB_MILLISECOND_LABEL } from '../../../../shared/components/analytics-stats/analytics-stats.component';
+
+describe('DashboardApiRequestStats', () => {
+  let fixture: ComponentFixture<DashboardApiRequestStats>;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, MatIconTestingModule, DashboardApiRequestStats],
+    });
+
+    fixture = TestBed.createComponent(DashboardApiRequestStats);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should display response times when values are non-zero', async () => {
+    loadData({
+      requestsPerSecond: 1.5,
+      requestsTotal: 1000,
+      responseMinTime: 5,
+      responseMaxTime: 200,
+      responseAvgTime: 42.5,
+    });
+    const harness = await loader.getHarness(DashboardApiRequestStatsHarness);
+
+    expect(await harness.getMinResponseTime()).toContain('5.0 ms');
+    expect(await harness.getMaxResponseTime()).toContain('200.0 ms');
+    expect(await harness.getAverageResponseTime()).toContain('42.5 ms');
+  });
+
+  it('should display sub-millisecond label for zero min response time', async () => {
+    loadData({
+      requestsPerSecond: 10,
+      requestsTotal: 50000,
+      responseMinTime: 0,
+      responseMaxTime: 150,
+      responseAvgTime: 42,
+    });
+    const harness = await loader.getHarness(DashboardApiRequestStatsHarness);
+
+    expect(await harness.getMinResponseTime()).toContain(SUB_MILLISECOND_LABEL);
+  });
+
+  it('should display dash for min response time when there are no requests', async () => {
+    loadData({
+      requestsPerSecond: 0,
+      requestsTotal: 0,
+      responseMinTime: 0,
+      responseMaxTime: 0,
+      responseAvgTime: 0,
+    });
+    const harness = await loader.getHarness(DashboardApiRequestStatsHarness);
+
+    expect(await harness.getMinResponseTime()).toContain('-');
+  });
+
+  function loadData(data: v4ApisRequestStats) {
+    fixture.componentInstance.data = data;
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.ts
+++ b/gravitee-apim-console-webui/src/management/home/components/dashboard-api-request-stats/dashboard-api-request-stats.component.ts
@@ -21,6 +21,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatIcon } from '@angular/material/icon';
 
 import { GioShortNumberPipeModule } from '../../../../shared/utils/shortNumber.pipe.module';
+import { SUB_MILLISECOND_LABEL } from '../../../../shared/components/analytics-stats/analytics-stats.component';
 
 export type v4ApisRequestStats = {
   requestsPerSecond: number;
@@ -38,4 +39,5 @@ export type v4ApisRequestStats = {
 })
 export class DashboardApiRequestStats {
   @Input() public data?: v4ApisRequestStats;
+  protected readonly subMillisecondLabel = SUB_MILLISECOND_LABEL;
 }

--- a/gravitee-apim-console-webui/src/shared/components/analytics-stats/analytics-stats.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/analytics-stats/analytics-stats.component.ts
@@ -23,7 +23,9 @@ import { FormatNumberPipe } from '../../pipes/format-number.pipe';
 
 export type StatsUnitType = 'ms';
 
-export type StatsWidgetData = { stats: number; statsUnit: StatsUnitType };
+export const SUB_MILLISECOND_LABEL = '< 1 ms';
+
+export type StatsWidgetData = { stats: number; statsUnit: StatsUnitType; formattedOverride?: string };
 
 @Component({
   selector: 'analytics-stats',
@@ -39,13 +41,17 @@ export class AnalyticsStatsComponent {
   private readonly formatNumberPipe = inject(FormatNumberPipe);
 
   public statsFormatted = computed(() => {
-    const { stats, statsUnit } = this.input();
+    const data = this.input();
 
-    if (stats == null) {
+    if (data.formattedOverride) {
+      return data.formattedOverride;
+    }
+
+    if (data.stats == null) {
       return '-';
     }
 
-    return statsUnit === 'ms' ? this.formatDurationPipe.transform(stats) : this.formatNumberPipe.transform(stats);
+    return data.statsUnit === 'ms' ? this.formatDurationPipe.transform(data.stats) : this.formatNumberPipe.transform(data.stats);
   });
 
   public tooltipText = computed(() => {
@@ -61,7 +67,11 @@ export class AnalyticsStatsComponent {
   });
 
   public isTooltipShown = computed(() => {
-    const { stats } = this.input();
+    const { stats, formattedOverride } = this.input();
+
+    if (formattedOverride) {
+      return false;
+    }
 
     if (stats == null) {
       return false;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12338

## Description

Display < 1 ms for sub-millisecond min response time in api analytics and dashboard.

In the gateway we store min response time in milli seconds and not nano seconds. This is an immediate fix because the nanoseconds change is more of a breaking change across gateway, data, es and will be done later.

## Additional context

**Before:**

<img width="356" height="313" alt="image" src="https://github.com/user-attachments/assets/813c9164-9a5a-4188-b498-a6b743b5d4f2" />



<img width="1024" height="451" alt="image" src="https://github.com/user-attachments/assets/8e146608-2ee7-4639-af9a-4438df90f93a" />


**After:**

<img width="364" height="332" alt="image" src="https://github.com/user-attachments/assets/9df318df-5833-4e64-b48f-b1b256c2affb" />

<img width="1422" height="422" alt="image" src="https://github.com/user-attachments/assets/e7cfe6c2-0e60-43ff-bcd2-d74232d70545" />

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

