### PR TITLE
Refractor/gko 2443 renderer improve dashboard section title and change analytics icon in sidenav

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -238,7 +238,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       category: 'Analytics',
       permissions: ['environment-platform-r'],
       routerBasePath: `/${this.currentEnv.hrids}/analytics`,
-      iconRight$: of('info'),
+      iconRight$: of('gio:info'),
       iconRightTooltip: 'This feature is deprecated, please use Observability > Dashboards instead.',
       items: [
         {

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/dashboard-detail/dashboard-detail.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/dashboard-detail/dashboard-detail.component.html
@@ -16,27 +16,28 @@
 
 -->
 @if (dashboard(); as dashboard) {
-  <div class="title">
-    <h1>{{ dashboard.name }}</h1>
-    <gio-action-menu [icon]="'more_vert'">
-      <gio-action-menu-item
-        *gioPermission="{ anyOf: ['environment-dashboard-u'] }"
-        icon="gio:edit-pencil"
-        label="Edit"
-        [disabled]="true"
-        [matTooltip]="'Coming soon!'"
-        [matTooltipPosition]="'before'"
-      ></gio-action-menu-item>
-      <mat-divider></mat-divider>
-      <gio-action-menu-item
-        *gioPermission="{ anyOf: ['environment-dashboard-d'] }"
-        class="delete-action"
-        icon="gio:trash"
-        label="Delete"
-        (click)="deleteDashboard(dashboard)"
-      ></gio-action-menu-item>
-    </gio-action-menu>
-  </div>
+  <gio-header [title]="dashboard.name" [showActions]="true">
+    <ng-container additionalActions>
+      <gio-action-menu [icon]="'more_vert'">
+        <gio-action-menu-item
+          *gioPermission="{ anyOf: ['environment-dashboard-u'] }"
+          icon="gio:edit-pencil"
+          label="Edit"
+          [disabled]="true"
+          [matTooltip]="'Coming soon!'"
+          [matTooltipPosition]="'before'"
+        ></gio-action-menu-item>
+        <mat-divider></mat-divider>
+        <gio-action-menu-item
+          *gioPermission="{ anyOf: ['environment-dashboard-d'] }"
+          class="delete-action"
+          icon="gio:trash"
+          label="Delete"
+          (click)="deleteDashboard(dashboard)"
+        ></gio-action-menu-item>
+      </gio-action-menu>
+    </ng-container>
+  </gio-header>
   <dashboard-viewer [widgets]="dashboard.widgets"></dashboard-viewer>
 } @else {
   <p>Loading dashboard...</p>

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/dashboard-detail/dashboard-detail.component.scss
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/dashboard-detail/dashboard-detail.component.scss
@@ -5,20 +5,9 @@
 $error-color: mat.m2-get-color-from-palette(gio.$mat-error-palette, default);
 
 :host {
-  @include gio-layout.gio-responsive-content-container;
   display: flex;
   flex-direction: column;
-}
-
-.title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 16px;
-
-  h1 {
-    margin: 0;
-  }
+  @include gio-layout.gio-responsive-content-container;
 }
 
 ::ng-deep .delete-action {

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/dashboard-detail/dashboard-detail.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/dashboard-detail/dashboard-detail.component.ts
@@ -26,10 +26,19 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
 import { DashboardService } from '../../data-access/dashboard.service';
 import { DashboardViewerComponent } from '../ui/dashboard-viewer/dashboard-viewer.component';
+import { GioHeaderComponent } from '../../../../shared/components/gio-header/gio-header.component';
 
 @Component({
   selector: 'dashboard-detail',
-  imports: [DashboardViewerComponent, GioActionMenuComponent, GioActionMenuItemComponent, MatDivider, MatTooltip, GioPermissionModule],
+  imports: [
+    DashboardViewerComponent,
+    GioActionMenuComponent,
+    GioActionMenuItemComponent,
+    MatDivider,
+    MatTooltip,
+    GioPermissionModule,
+    GioHeaderComponent,
+  ],
   templateUrl: './dashboard-detail.component.html',
   styleUrls: ['./dashboard-detail.component.scss'],
 })

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/dashboards-list/dashboards-list.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/dashboards-list/dashboards-list.component.html
@@ -15,17 +15,18 @@
     limitations under the License.
 
 -->
-<div class="title">
-  <h1>Analytics dashboards</h1>
-  <button *gioPermission="{ anyOf: ['environment-dashboard-c'] }" mat-raised-button color="primary" [matMenuTriggerFor]="createMenu">
-    Create dashboard
-    <mat-icon>keyboard_arrow_down</mat-icon>
-  </button>
-  <mat-menu #createMenu="matMenu">
-    <button mat-menu-item (click)="openTemplateDialog()">Create from template</button>
-    <button mat-menu-item [disabled]="true" [matTooltip]="'Coming soon!'" [matTooltipPosition]="'before'">Create from scratch</button>
-  </mat-menu>
-</div>
+<gio-header title="Dashboards" subtitle="Monitor and visualize your API analytics with custom dashboards." [showActions]="true">
+  <ng-container additionalActions>
+    <button *gioPermission="{ anyOf: ['environment-dashboard-c'] }" mat-raised-button color="primary" [matMenuTriggerFor]="createMenu">
+      Create dashboard
+      <mat-icon>keyboard_arrow_down</mat-icon>
+    </button>
+    <mat-menu #createMenu="matMenu">
+      <button mat-menu-item (click)="openTemplateDialog()">Create from template</button>
+      <button mat-menu-item [disabled]="true" [matTooltip]="'Coming soon!'" [matTooltipPosition]="'before'">Create from scratch</button>
+    </mat-menu>
+  </ng-container>
+</gio-header>
 
 <gio-table-wrapper [filters]="filters()" [length]="totalCount()" [disableSearchInput]="true" (filtersChange)="onFiltersChanged($event)">
   <table mat-table [dataSource]="dashboardItems()">

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/dashboards-list/dashboards-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/dashboards-list/dashboards-list.component.scss
@@ -1,4 +1,4 @@
-//@use 'index.d.ts' as gio;
+@use 'sass:map';
 @use '@angular/material' as mat;
 @use '@gravitee/ui-particles-angular' as gio;
 @use '../../../../scss/gio-layout' as gio-layout;
@@ -6,26 +6,9 @@
 $error-color: mat.m2-get-color-from-palette(gio.$mat-error-palette, default);
 
 :host {
-  @include gio-layout.gio-responsive-content-container;
   display: flex;
   flex-direction: column;
-}
-
-.title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 16px;
-
-  h1 {
-    margin: 0;
-  }
-
-  button mat-icon {
-    order: 1;
-    margin-left: 8px;
-    margin-right: 0 !important;
-  }
+  @include gio-layout.gio-responsive-content-container;
 }
 
 .actions-buttons {

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/dashboards-list/dashboards-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/dashboards-list/dashboards-list.component.ts
@@ -53,6 +53,7 @@ import { DashboardService } from '../../data-access/dashboard.service';
 import { PagedResult } from '../../../../entities/management-api-v2';
 import { UsersService } from '../../../../services-ngx/users.service';
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
+import { GioHeaderComponent } from '../../../../shared/components/gio-header/gio-header.component';
 
 @Component({
   selector: 'dashboards-list',
@@ -82,6 +83,7 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     MatTooltip,
     RouterLink,
     GioPermissionModule,
+    GioHeaderComponent,
   ],
   templateUrl: './dashboards-list.component.html',
   styleUrls: ['./dashboards-list.component.scss'],

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.html
@@ -19,12 +19,10 @@
 <div class="logs-details">
   @if (log(); as log) {
     <div class="logs-details__container">
-      <div class="logs-details__header">
-        <a class="back-button" mat-flat-button [routerLink]="['..']" aria-label="Back to logs"
-          ><mat-icon svgIcon="gio:arrow-left"></mat-icon>Back to logs</a
-        >
-        <h1>Log</h1>
-      </div>
+      <a class="back-button" mat-flat-button [routerLink]="['..']" aria-label="Back to logs"
+        ><mat-icon svgIcon="gio:arrow-left"></mat-icon>Back to logs</a
+      >
+      <gio-header title="Log" />
 
       <div class="logs-details__form">
         <div class="logs-details__content">

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.scss
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.scss
@@ -18,10 +18,10 @@
 @use '../../../../../scss/gio-layout' as gio-layout;
 
 :host {
-  @include gio-layout.gio-full-width-content-container;
   display: flex;
   flex-direction: column;
   gap: 16px;
+  @include gio-layout.gio-full-width-content-container;
 
   .back-button {
     margin-bottom: 24px;
@@ -33,14 +33,6 @@
     display: flex;
     flex-direction: column;
     padding: 24px 32px 0 32px;
-  }
-
-  &__header {
-    margin-bottom: 16px;
-
-    h1 {
-      margin: 0;
-    }
   }
 
   &__form {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.ts
@@ -26,6 +26,7 @@ import { GioBannerModule, GioClipboardModule, GioMonacoEditorModule } from '@gra
 import { fakeEnvLogs } from '../../models/env-log.fixture';
 import { EnvLog } from '../../models/env-log.model';
 import { EnvLogsDetailsRowComponent } from '../env-logs-details-row/env-logs-details-row.component';
+import { GioHeaderComponent } from '../../../../../shared/components/gio-header/gio-header.component';
 
 @Component({
   selector: 'env-logs-details',
@@ -42,6 +43,7 @@ import { EnvLogsDetailsRowComponent } from '../env-logs-details-row/env-logs-det
     GioClipboardModule,
     GioMonacoEditorModule,
     EnvLogsDetailsRowComponent,
+    GioHeaderComponent,
   ],
   standalone: true,
 })

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.html
@@ -16,26 +16,24 @@
 
 -->
 
-<div class="env-runtime-logs-v4">
-  <h1>Logs</h1>
-  <gio-banner-info class="banner-warning">
-    <div class="banner-warning__content">
-      Currently, only HTTP Proxy is supported.
-      <span class="mat-body">Message APIs, SSEs, and webhook support are coming soon.</span>
-    </div>
-  </gio-banner-info>
+<gio-header title="Logs" subtitle="Inspect and analyze API runtime logs." />
+<gio-banner-info class="banner-warning">
+  <div class="banner-warning__content">
+    Currently, only HTTP Proxy is supported.
+    <span class="mat-body">Message APIs, SSEs, and webhook support are coming soon.</span>
+  </div>
+</gio-banner-info>
 
-  @if (error()) {
-    <gio-banner-error>{{ error() }}</gio-banner-error>
-  }
+@if (error()) {
+  <gio-banner-error>{{ error() }}</gio-banner-error>
+}
 
-  <mat-card class="logs-section">
-    <env-logs-filter-bar [loading]="loading()" (refresh)="onRefresh()"></env-logs-filter-bar>
-    <env-logs-table
-      class="env-runtime-logs__table"
-      [logs]="logs()"
-      [pagination]="paginationWithTotal()"
-      (paginationUpdated)="onPaginationUpdated($event)"
-    ></env-logs-table>
-  </mat-card>
-</div>
+<mat-card class="logs-section">
+  <env-logs-filter-bar [loading]="loading()" (refresh)="onRefresh()"></env-logs-filter-bar>
+  <env-logs-table
+    class="env-runtime-logs__table"
+    [logs]="logs()"
+    [pagination]="paginationWithTotal()"
+    (paginationUpdated)="onPaginationUpdated($event)"
+  ></env-logs-table>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.scss
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.scss
@@ -1,23 +1,22 @@
 @use '@angular/material' as mat;
 @use '@gravitee/ui-particles-angular' as gio;
+@use '../../../scss/gio-layout' as gio-layout;
 
-.env-runtime-logs-v4 {
-  padding: 24px;
+:host {
+  display: flex;
+  flex-direction: column;
+  @include gio-layout.gio-responsive-content-container;
+}
 
-  h1 {
-    margin-bottom: 24px;
+.banner-warning {
+  margin-bottom: 24px;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
   }
+}
 
-  .banner-warning {
-    margin-bottom: 24px;
-
-    &__content {
-      display: flex;
-      flex-direction: column;
-    }
-  }
-
-  .logs-section {
-    border: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20');
-  }
+.logs-section {
+  border: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20');
 }

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
@@ -32,6 +32,7 @@ import { EnvironmentLogsService, EnvironmentApiLog } from '../../../services-ngx
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { GioTableWrapperPagination } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { Pagination } from '../../../entities/management-api-v2';
+import { GioHeaderComponent } from '../../../shared/components/gio-header/gio-header.component';
 
 /** Gravitee's built-in sentinel ID for unauthenticated / Keyless traffic. */
 const UNKNOWN_APPLICATION_ID = '1';
@@ -41,7 +42,7 @@ const UNKNOWN_APPLICATION_LABEL = 'Default application';
   selector: 'env-logs',
   templateUrl: './env-logs.component.html',
   styleUrl: './env-logs.component.scss',
-  imports: [EnvLogsTableComponent, EnvLogsFilterBarComponent, MatCardModule, GioBannerModule, DatePipe],
+  imports: [EnvLogsTableComponent, EnvLogsFilterBarComponent, MatCardModule, GioBannerModule, DatePipe, GioHeaderComponent],
   providers: [DatePipe],
   standalone: true,
 })

--- a/gravitee-apim-console-webui/src/management/observability/overview/overview.component.scss
+++ b/gravitee-apim-console-webui/src/management/observability/overview/overview.component.scss
@@ -1,18 +1,7 @@
-.overview-header {
+@use '../../../scss/gio-layout' as gio-layout;
+
+:host {
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  margin-bottom: 24px;
-
-  &__link a {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-
-    .mat-icon {
-      height: 16px;
-      width: 16px;
-      font-size: 16px;
-    }
-  }
+  flex-direction: column;
+  @include gio-layout.gio-responsive-content-container;
 }

--- a/gravitee-apim-console-webui/src/management/observability/overview/overview.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/overview/overview.component.ts
@@ -16,16 +16,14 @@
 import { Widget } from '@gravitee/gravitee-dashboard';
 
 import { Component, inject } from '@angular/core';
-import { RouterModule } from '@angular/router';
-import { MatIconModule } from '@angular/material/icon';
-import { GioIconsModule } from '@gravitee/ui-particles-angular';
 
 import { DashboardService } from '../data-access/dashboard.service';
 import { DashboardViewerComponent } from '../dashboards/ui/dashboard-viewer/dashboard-viewer.component';
+import { GioHeaderComponent } from '../../../shared/components/gio-header/gio-header.component';
 
 @Component({
   selector: 'overview',
-  imports: [DashboardViewerComponent, RouterModule, MatIconModule, GioIconsModule],
+  imports: [DashboardViewerComponent, GioHeaderComponent],
   templateUrl: './overview.component.html',
   styleUrl: './overview.component.scss',
 })

--- a/gravitee-apim-console-webui/src/shared/components/gio-header/gio-header.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-header/gio-header.component.html
@@ -15,6 +15,16 @@
     limitations under the License.
 
 -->
-
-<gio-header title="Overview" subtitle="Get a quick overview of what's happening across your platform." />
-<dashboard-viewer [widgets]="widgets"></dashboard-viewer>
+<div class="gio-header">
+  <div class="gio-header__content">
+    <div>
+      <h1>{{ title() }}</h1>
+      @if (subtitle()) {
+        <div class="gio-header__subtitle mat-body-2">{{ subtitle() }}</div>
+      }
+    </div>
+    @if (showActions()) {
+      <ng-content select="[additionalActions]" />
+    }
+  </div>
+</div>

--- a/gravitee-apim-console-webui/src/shared/components/gio-header/gio-header.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-header/gio-header.component.scss
@@ -1,0 +1,15 @@
+@use '@angular/material/index' as mat;
+@use '@gravitee/ui-particles-angular/index' as gio;
+
+.gio-header {
+  margin-bottom: 28px;
+
+  &__subtitle {
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+  }
+
+  &__content {
+    display: flex;
+    justify-content: space-between;
+  }
+}

--- a/gravitee-apim-console-webui/src/shared/components/gio-header/gio-header.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-header/gio-header.component.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input, InputSignal } from '@angular/core';
+
+@Component({
+  selector: 'gio-header',
+  imports: [],
+  templateUrl: './gio-header.component.html',
+  styleUrl: './gio-header.component.scss',
+})
+export class GioHeaderComponent {
+  title: InputSignal<string> = input.required();
+  subtitle: InputSignal<string> = input();
+  showActions: InputSignal<boolean> = input(false);
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2443

## Description

Change icon in sidenav for Analytics.
Add a new component for title and subtitle consistency.
Refractor html/css to remove unused css class.
Add subtitles for overview and Dashboards UI.
Change Dashboards list title (from 'Analytics dashboards' to 'Dashboard').

## Additional context
<img width="1679" height="133" alt="Screenshot 2026-03-06 at 12 12 22" src="https://github.com/user-attachments/assets/973f1182-de8b-40db-927d-eb6f8f1d9ae9" />
<img width="1681" height="131" alt="Screenshot 2026-03-06 at 12 12 48" src="https://github.com/user-attachments/assets/7f16d078-8b41-411a-a264-529f0c138aeb" />
<img width="1694" height="129" alt="Screenshot 2026-03-06 at 12 12 36" src="https://github.com/user-attachments/assets/3c32c60a-91ff-486c-a9cc-844373690ce2" />



