### PR TITLE
feat: add server-side pagination and search for APIs list in api-product

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
@@ -135,14 +135,14 @@ describe('ApiProductApisComponent', () => {
   });
 
   it('should display empty state when no APIs in product', async () => {
-    await initComponent({ ...fakeApiProduct, apiIds: [] });
+    await initComponent([]);
 
     const emptyState = await loader.getHarness(DivHarness.with({ selector: '.api-product-apis-empty-state' }));
     expect(await emptyState.getText()).toContain('There are no APIs in this API Product (yet).');
   });
 
   it('should display table with API rows when product has APIs', async () => {
-    await initComponent(fakeApiProduct, [fakeApi1, fakeApi2]);
+    await initComponent([fakeApi1, fakeApi2]);
 
     const table = await loader.getHarness(MatTableHarness.with({ selector: 'table' }));
     const rows = await table.getRows();
@@ -164,13 +164,8 @@ describe('ApiProductApisComponent', () => {
     const emptyState = await loader.getHarness(DivHarness.with({ selector: '.api-product-apis-empty-state' }));
     expect(await emptyState.getText()).toContain('Loading...');
 
-    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    productReq.flush(fakeApiProduct);
-
-    const api1Req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-1`);
-    api1Req.flush(fakeApi1);
-    const api2Req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-2`);
-    api2Req.flush(fakeApi2);
+    const apisReq = expectApisRequest();
+    apisReq.flush({ data: [fakeApi1, fakeApi2], pagination: { totalCount: 2 } });
 
     fixture.detectChanges();
     await fixture.whenStable();
@@ -184,7 +179,7 @@ describe('ApiProductApisComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    const req = expectApisRequest();
     req.flush({ message: 'Error' }, { status: 500, statusText: 'Server Error' });
     fixture.detectChanges();
     await fixture.whenStable();
@@ -192,8 +187,21 @@ describe('ApiProductApisComponent', () => {
     expect(fakeSnackBarService.error).toHaveBeenCalled();
   });
 
+  it('should show error and navigate to list when API Product not found (404)', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const req = expectApisRequest();
+    req.flush({ message: 'API Product not found' }, { status: 404, statusText: 'Not Found' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.error).toHaveBeenCalledWith('API Product not found');
+    expect(_router.navigate).toHaveBeenCalledWith(['../..'], { relativeTo: expect.anything() });
+  });
+
   it('should have Add API button', async () => {
-    await initComponent({ ...fakeApiProduct, apiIds: ['api-1'] }, [fakeApi1]);
+    await initComponent([fakeApi1]);
 
     const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="add-api-button"]' }));
     expect(await addButton.getText()).toContain('Add API');
@@ -202,7 +210,7 @@ describe('ApiProductApisComponent', () => {
   it('should open Add API dialog when Add API clicked', async () => {
     const matDialog = TestBed.inject(MatDialog);
     const dialogOpenSpy = jest.spyOn(matDialog, 'open');
-    await initComponent({ ...fakeApiProduct, apiIds: ['api-1'] }, [fakeApi1]);
+    await initComponent([fakeApi1]);
 
     const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="add-api-button"]' }));
     await addButton.click();
@@ -224,16 +232,14 @@ describe('ApiProductApisComponent', () => {
   });
 
   it('should filter APIs by search term', async () => {
-    await initComponent(fakeApiProduct, [fakeApi1, fakeApi2]);
+    await initComponent([fakeApi1, fakeApi2]);
 
     const tableWrapper = await loader.getHarness(GioTableWrapperHarness);
     await tableWrapper.setSearchValue('Orders');
     await fixture.whenStable();
 
-    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    productReq.flush(fakeApiProduct);
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-1`).flush(fakeApi1);
-    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-2`).flush(fakeApi2);
+    const filterReq = expectApisRequest('Orders');
+    filterReq.flush({ data: [fakeApi2], pagination: { totalCount: 1 } });
 
     fixture.detectChanges();
     await fixture.whenStable();
@@ -245,17 +251,22 @@ describe('ApiProductApisComponent', () => {
     expect(rowCells[1]).toContain('Orders API');
   });
 
-  async function initComponent(apiProduct: ApiProduct, apis: Api[] = []) {
+  function expectApisRequest(query?: string) {
+    return httpTestingController.expectOne(req => {
+      if (req.url !== `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/apis`) return false;
+      if (req.params.get('page') !== '1' || req.params.get('perPage') !== '10') return false;
+      if (query !== undefined && req.params.get('query') !== query) return false;
+      if (query === undefined && req.params.has('query')) return false;
+      return true;
+    });
+  }
+
+  async function initComponent(apis: Api[] = []) {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const productReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
-    productReq.flush(apiProduct);
-
-    for (const api of apis) {
-      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`);
-      req.flush(api);
-    }
+    const apisReq = expectApisRequest();
+    apisReq.flush({ data: apis, pagination: { totalCount: apis.length } });
 
     fixture.detectChanges();
     await fixture.whenStable();

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
@@ -22,8 +22,9 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog } from '@angular/material/dialog';
-import { combineLatest, EMPTY, Observable, forkJoin, of } from 'rxjs';
-import { catchError, debounceTime, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
+import { HttpErrorResponse } from '@angular/common/http';
+import { BehaviorSubject, combineLatest, EMPTY, merge, Observable, of, Subject } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, filter, map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 import { isEqual } from 'lodash';
 import {
   GIO_DIALOG_WIDTH,
@@ -43,9 +44,7 @@ import { Api } from '../../../entities/management-api-v2';
 import { getApiContextPath } from '../../../shared/utils/api-access.util';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
-import { filtersToQueryParams } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
 import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
-import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 
 export type ApiProductApiTableDS = {
@@ -60,20 +59,15 @@ export type ApiProductApiTableDS = {
 
 interface ApiProductApisTableWrapperFilters extends GioTableWrapperFilters {}
 
-const DEFAULT_FILTERS: ApiProductApisTableWrapperFilters = {
-  pagination: { index: 1, size: 10 },
-  searchTerm: '',
+export const DEFAULT_PAGINATION = {
+  page: 1,
+  perPage: 10,
 };
 
-function queryParamsToFilters(queryParams: Record<string, string>): ApiProductApisTableWrapperFilters {
-  const searchTerm = queryParams['q'] ?? DEFAULT_FILTERS.searchTerm;
-  const index = queryParams['page'] ? Number(queryParams['page']) : DEFAULT_FILTERS.pagination.index;
-  const size = queryParams['size'] ? Number(queryParams['size']) : DEFAULT_FILTERS.pagination.size;
-  return {
-    searchTerm,
-    pagination: { index, size },
-  };
-}
+const DEFAULT_FILTERS: ApiProductApisTableWrapperFilters = {
+  pagination: { index: DEFAULT_PAGINATION.page, size: DEFAULT_PAGINATION.perPage },
+  searchTerm: '',
+};
 
 @Component({
   selector: 'api-product-apis',
@@ -88,7 +82,6 @@ export class ApiProductApisComponent implements OnInit {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly apiProductV2Service = inject(ApiProductV2Service);
-  private readonly apiV2Service = inject(ApiV2Service);
   private readonly snackBarService = inject(SnackBarService);
   private readonly matDialog = inject(MatDialog);
 
@@ -101,10 +94,12 @@ export class ApiProductApisComponent implements OnInit {
     initialValue: '',
   });
 
-  /** Filters derived from router query params (single source of truth) */
-  readonly filters = toSignal(this.activatedRoute.queryParams.pipe(map(params => queryParamsToFilters(params as Record<string, string>))), {
-    initialValue: queryParamsToFilters(this.activatedRoute.snapshot.queryParams as Record<string, string>),
-  });
+  /** Filters kept in component state (no query params in URL); backend still receives page, perPage, q */
+  private readonly filtersSubject = new BehaviorSubject<ApiProductApisTableWrapperFilters>(DEFAULT_FILTERS);
+  readonly filters = toSignal(this.filtersSubject.asObservable(), { initialValue: DEFAULT_FILTERS });
+
+  /** Triggers a reload (e.g. after add/remove API) through the same switchMap as filter changes to avoid race conditions. */
+  private readonly reloadTrigger$ = new Subject<void>();
 
   private static readonly LOAD_API_PRODUCT_ERROR = 'An error occurred while loading the API Product';
 
@@ -129,62 +124,69 @@ export class ApiProductApisComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.clearQueryParamsFromUrl();
     this.initApisTableSubscription();
   }
 
+  /** Keep router URL clean: /api-products/:id/apis */
+  private clearQueryParamsFromUrl(): void {
+    this.router.navigate([], {
+      relativeTo: this.activatedRoute,
+      queryParams: {},
+      replaceUrl: true,
+    });
+  }
+
   private initApisTableSubscription(): void {
-    combineLatest([
-      this.activatedRoute.queryParams.pipe(
-        map(params => queryParamsToFilters(params as Record<string, string>)),
-        debounceTime(100),
-        distinctUntilChanged(isEqual),
-      ),
-      toObservable(this.apiProductId, { injector: this.injector }).pipe(filter(id => !!id)),
-    ])
+    const filters$ = this.filtersSubject.pipe(debounceTime(100), distinctUntilChanged(isEqual));
+    const apiProductId$ = toObservable(this.apiProductId, { injector: this.injector }).pipe(filter((id): id is string => !!id));
+
+    const onFilterOrIdChange$ = combineLatest([filters$, apiProductId$]).pipe(
+      map(([filters, apiProductId]) => ({ filters, apiProductId })),
+    );
+    const onReload$ = this.reloadTrigger$.pipe(
+      withLatestFrom(this.filtersSubject, apiProductId$),
+      map(([, filters, apiProductId]) => ({ filters, apiProductId })),
+    );
+
+    merge(onFilterOrIdChange$, onReload$)
       .pipe(
-        map(([filters, apiProductId]) => ({ filters, apiProductId })),
-        switchMap(({ filters, apiProductId }) => this.loadApisForProduct(apiProductId).pipe(map(apis => ({ filters, apis })))),
-        tap(({ filters, apis }) => this.processAndDisplayApis(filters, apis)),
+        switchMap(({ filters, apiProductId }) => this.loadApisForProduct(apiProductId, filters)),
+        tap(response => this.displayApis(response)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
 
-  private loadApisForProduct(apiProductId: string): Observable<(Api | null)[]> {
+  private loadApisForProduct(
+    apiProductId: string,
+    filters: ApiProductApisTableWrapperFilters,
+  ): Observable<{ data: Api[]; totalCount: number }> {
     this.isLoadingData = true;
-    return this.apiProductV2Service.get(apiProductId).pipe(
-      catchError(this.handleError(ApiProductApisComponent.LOAD_API_PRODUCT_ERROR, of(null))),
-      switchMap(apiProduct => {
-        if (!apiProduct?.apiIds?.length) {
-          return of([]);
+    const page = filters.pagination?.index ?? DEFAULT_PAGINATION.page;
+    const perPage = filters.pagination?.size ?? DEFAULT_PAGINATION.perPage;
+    const query = filters.searchTerm?.trim() ?? '';
+    return this.apiProductV2Service.getApis(apiProductId, page, perPage, query).pipe(
+      catchError((err: unknown) => {
+        // 404 can occur when the product was deleted elsewhere, user opened a bookmark with a removed id, or the id in the URL is invalid.
+        if (err instanceof HttpErrorResponse && err.status === 404) {
+          this.snackBarService.error((err.error as { message?: string })?.message ?? 'API Product not found.');
+          this.isLoadingData = false;
+          this.router.navigate(['../..'], { relativeTo: this.activatedRoute });
+          return EMPTY;
         }
-        const apiObservables = apiProduct.apiIds.map(apiId => this.apiV2Service.get(apiId).pipe(catchError(() => of(null))));
-        return forkJoin(apiObservables).pipe(catchError(this.handleError('An error occurred while loading APIs', of([]))));
+        return this.handleError('An error occurred while loading APIs', of({ data: [], pagination: { totalCount: 0 } }))(err);
       }),
+      map(res => ({
+        data: res.data ?? [],
+        totalCount: res.pagination?.totalCount ?? 0,
+      })),
     );
   }
 
-  private processAndDisplayApis(filters: ApiProductApisTableWrapperFilters, apis: (Api | null)[]): void {
-    let filteredApis = apis.filter((api): api is Api => api !== null);
-    const searchTerm = filters.searchTerm?.toLowerCase() || '';
-
-    if (searchTerm) {
-      filteredApis = filteredApis.filter(
-        api =>
-          api.name?.toLowerCase().includes(searchTerm) ||
-          getApiContextPath(api)?.toLowerCase().includes(searchTerm) ||
-          api.apiVersion?.toLowerCase().includes(searchTerm),
-      );
-    }
-
-    const page = filters.pagination?.index || 1;
-    const perPage = filters.pagination?.size || 10;
-    const startIndex = (page - 1) * perPage;
-    const endIndex = startIndex + perPage;
-    const paginatedApis = filteredApis.slice(startIndex, endIndex);
-
-    this.apisTableDS = this.toApisTableDS(paginatedApis);
-    this.apisTableDSUnpaginatedLength = filteredApis.length;
+  private displayApis(response: { data: Api[]; totalCount: number }): void {
+    this.apisTableDS = this.toApisTableDS(response.data);
+    this.apisTableDSUnpaginatedLength = response.totalCount;
     this.isLoadingData = false;
   }
 
@@ -205,20 +207,11 @@ export class ApiProductApisComponent implements OnInit {
       ...this.filters(),
       ...filters,
     };
-    this.router.navigate([], {
-      relativeTo: this.activatedRoute,
-      queryParams: filtersToQueryParams(mergedFilters),
-      queryParamsHandling: 'merge',
-    });
+    this.filtersSubject.next(mergedFilters);
   }
 
   private reloadTable(): void {
-    this.loadApisForProduct(this.apiProductId())
-      .pipe(
-        tap(apis => this.processAndDisplayApis(this.filters(), apis)),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
+    this.reloadTrigger$.next();
   }
 
   onAddApi(): void {

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.spec.ts
@@ -213,6 +213,36 @@ describe('ApiProductV2Service', () => {
     });
   });
 
+  describe('getApis', () => {
+    it('should call the API with default page and perPage', done => {
+      const response = { data: [], pagination: { totalCount: 0, page: 1, perPage: 10 }, links: {} };
+
+      apiProductV2Service.getApis('product-123').subscribe(result => {
+        expect(result.data).toEqual([]);
+        expect(result.pagination?.totalCount).toBe(0);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/product-123/apis?page=1&perPage=10`,
+        method: 'GET',
+      });
+      req.flush(response);
+    });
+
+    it('should call the API with custom page, perPage and query', done => {
+      const response = { data: [], pagination: { totalCount: 0, page: 2, perPage: 20 }, links: {} };
+
+      apiProductV2Service.getApis('product-123', 2, 20, 'search-term').subscribe(() => done());
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/product-123/apis?page=2&perPage=20&query=search-term`,
+        method: 'GET',
+      });
+      req.flush(response);
+    });
+  });
+
   describe('update', () => {
     it('should call the API', done => {
       const apiProductId = 'product-123';

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
@@ -20,6 +20,7 @@ import { distinctUntilChanged, filter, shareReplay, switchMap, tap } from 'rxjs/
 import { isEqual } from 'lodash';
 
 import { Constants } from '../entities/Constants';
+import { ApisResponse } from '../entities/management-api-v2/apisResponse';
 import {
   ApiProduct,
   ApiProductSearchQuery,
@@ -91,6 +92,25 @@ export class ApiProductV2Service {
       params = params.set('sortBy', validSortBy);
     }
     return this.http.post<ApiProductsResponse>(`${this.constants.env.v2BaseURL}/api-products/_search`, searchQuery, {
+      params,
+    });
+  }
+
+  /**
+   * Get paginated list of APIs in an API Product with optional search (Lucene-backed).
+   * Calls GET /environments/{envId}/api-products/{apiProductId}/apis
+   * @param apiProductId - The API Product ID
+   * @param page - Page number (1-based)
+   * @param perPage - Page size
+   * @param query - Optional search query (searches name, context path, version, etc.)
+   * @returns Observable of ApisResponse (data, pagination, links)
+   */
+  getApis(apiProductId: string, page = 1, perPage = 10, query = ''): Observable<ApisResponse> {
+    let params = new HttpParams().set('page', page.toString()).set('perPage', perPage.toString());
+    if (query?.trim()) {
+      params = params.set('query', query.trim());
+    }
+    return this.http.get<ApisResponse>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/apis`, {
       params,
     });
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductApisResource.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api_product;
+
+import io.gravitee.apim.core.api_product.use_case.GetApiProductApisUseCase;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.ApiMapper;
+import io.gravitee.rest.api.management.v2.rest.model.Api;
+import io.gravitee.rest.api.management.v2.rest.model.ApisResponse;
+import io.gravitee.rest.api.management.v2.rest.model.Links;
+import io.gravitee.rest.api.management.v2.rest.model.Pagination;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.management.v2.rest.resource.param.ApiSortByParam;
+import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import lombok.CustomLog;
+
+/**
+ * APIs sub-resource for an API Product: list/search APIs that belong to the product with Lucene-backed search and pagination.
+ */
+@CustomLog
+public class ApiProductApisResource extends AbstractResource {
+
+    @PathParam("apiProductId")
+    private String apiProductId;
+
+    @Inject
+    private GetApiProductApisUseCase getApiProductApisUseCase;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_DEFINITION, acls = { RolePermissionAction.READ }) })
+    public Response getApiProductApis(
+        @BeanParam @Valid PaginationParam paginationParam,
+        @BeanParam ApiSortByParam apiSortByParam,
+        @QueryParam("query") String query
+    ) {
+        apiSortByParam.validate();
+
+        var executionContext = GraviteeContext.getExecutionContext();
+        var input = new GetApiProductApisUseCase.Input(
+            executionContext,
+            apiProductId,
+            query,
+            paginationParam.toPageable(),
+            apiSortByParam.toSortable(),
+            getAuthenticatedUser(),
+            isAdmin()
+        );
+
+        var output = getApiProductApisUseCase.execute(input);
+
+        if (output.apiProduct().isEmpty()) {
+            log.debug("API Product not found: {}", apiProductId);
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        Page<io.gravitee.apim.core.api.model.Api> apisPage = output.apisPage();
+        if (apisPage == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        return Response.ok(toApisResponse(apisPage, paginationParam)).build();
+    }
+
+    private ApisResponse toApisResponse(Page<io.gravitee.apim.core.api.model.Api> apisPage, PaginationParam paginationParam) {
+        long totalCount = apisPage.getTotalElements();
+        int pageItemsCount = Math.toIntExact(apisPage.getPageElements());
+        List<Api> data = apisPage
+            .getContent()
+            .stream()
+            .map(coreApi -> ApiMapper.INSTANCE.map(coreApi, uriInfo, null))
+            .toList();
+        Pagination pagination = totalCount == 0
+            ? new Pagination()
+                .page(paginationParam.getPage())
+                .perPage(paginationParam.getPerPage())
+                .pageItemsCount(0)
+                .pageCount(0)
+                .totalCount(0L)
+            : PaginationInfo.computePaginationInfo(totalCount, pageItemsCount, paginationParam);
+        Links links = computePaginationLinks(totalCount, paginationParam);
+        return new ApisResponse().data(data).pagination(pagination).links(links != null ? links : new Links().self(""));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResource.java
@@ -133,6 +133,11 @@ public class ApiProductResource extends AbstractResource {
         return Response.ok(output.apiProduct()).build();
     }
 
+    @Path("/apis")
+    public ApiProductApisResource getApiProductApisResource() {
+        return resourceContext.getResource(ApiProductApisResource.class);
+    }
+
     @Path("/members")
     public ApiProductMembersResource getApiProductMembersResource() {
         return resourceContext.getResource(ApiProductMembersResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -451,6 +451,49 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /environments/{envId}/api-products/{apiProductId}/apis:
+    parameters:
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/apiProductIdParam"
+    get:
+      tags:
+        - API Product
+      summary: List APIs of the API Product
+      description: |-
+        List APIs that belong to the API Product with server-side pagination and optional full-text search.
+        User must have API_PRODUCT_DEFINITION[READ] permission.
+      operationId: getApiProductApis
+      parameters:
+        - $ref: "#/components/parameters/pageParam"
+        - $ref: "#/components/parameters/perPageParam"
+        - name: query
+          in: query
+          required: false
+          description: Optional search query (full-text on name, context path, version, etc.).
+          schema:
+            type: string
+        - name: sortBy
+          in: query
+          required: false
+          description: Sort by field; prefix with '-' for descending (e.g. name, -name).
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: "./openapi-apis.yaml#/components/responses/ApisResponse"
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /environments/{envId}/api-products/{apiProductId}/members/permissions:
     parameters:
       - $ref: "#/components/parameters/envIdParam"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductApisResourceTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api_product;
+
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.use_case.GetApiProductApisUseCase;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.management.v2.rest.model.ApisResponse;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApiProductApisResourceTest extends AbstractResourceTest {
+
+    private static final String ENV_ID = "my-env";
+    private static final String API_PRODUCT_ID = "c45b8e66-4d2a-47ad-9b8e-664d2a97ad88";
+
+    @Inject
+    private GetApiProductApisUseCase getApiProductApisUseCase;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENV_ID + "/api-products/" + API_PRODUCT_ID + "/apis";
+    }
+
+    @BeforeEach
+    void init() {
+        super.setUp();
+        GraviteeContext.cleanContext();
+
+        EnvironmentEntity environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENV_ID);
+        environmentEntity.setOrganizationId(ORGANIZATION);
+        when(environmentService.findById(ENV_ID)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENV_ID)).thenReturn(environmentEntity);
+
+        GraviteeContext.setCurrentEnvironment(ENV_ID);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        GraviteeContext.cleanContext();
+        reset(getApiProductApisUseCase);
+    }
+
+    @Nested
+    class GetApiProductApisTest {
+
+        @Test
+        void should_return_empty_list_when_product_has_no_apis() {
+            var apiProduct = ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENV_ID).name("My Product").apiIds(Set.of()).build();
+            when(getApiProductApisUseCase.execute(any())).thenReturn(
+                new GetApiProductApisUseCase.Output(Optional.of(apiProduct), new Page<Api>(List.of(), 0, 0, 0))
+            );
+
+            Response response = rootTarget().queryParam("page", 1).queryParam("perPage", 10).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+            ApisResponse result = response.readEntity(ApisResponse.class);
+            assertAll(
+                () -> assertThat(result.getData()).isEmpty(),
+                () -> assertThat(result.getPagination()).isNotNull(),
+                () -> assertThat(result.getPagination().getTotalCount()).isEqualTo(0),
+                () -> assertThat(result.getLinks()).isNotNull()
+            );
+        }
+
+        @Test
+        void should_return_apis_page_when_product_has_apis() {
+            var apiProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .environmentId(ENV_ID)
+                .name("My Product")
+                .apiIds(Set.of("api-1", "api-2"))
+                .build();
+
+            var coreApi = Api.builder().id("api-1").name("My API").definitionVersion(DefinitionVersion.V4).build();
+            when(getApiProductApisUseCase.execute(any())).thenReturn(
+                new GetApiProductApisUseCase.Output(Optional.of(apiProduct), new Page<>(List.of(coreApi), 1, 10, 2))
+            );
+
+            Response response = rootTarget().queryParam("page", 1).queryParam("perPage", 10).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+            ApisResponse result = response.readEntity(ApisResponse.class);
+            assertAll(
+                () -> assertThat(result.getData()).hasSize(1),
+                () -> assertThat(result.getData().get(0).getApiV4().getId()).isEqualTo("api-1"),
+                () -> assertThat(result.getData().get(0).getApiV4().getName()).isEqualTo("My API"),
+                () -> assertThat(result.getPagination()).isNotNull(),
+                () -> assertThat(result.getPagination().getTotalCount()).isEqualTo(2),
+                () -> assertThat(result.getLinks()).isNotNull()
+            );
+        }
+
+        @Test
+        void should_pass_pagination_and_search_to_use_case() {
+            var apiProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .environmentId(ENV_ID)
+                .name("My Product")
+                .apiIds(Set.of("api-1"))
+                .build();
+            when(getApiProductApisUseCase.execute(any())).thenReturn(
+                new GetApiProductApisUseCase.Output(Optional.of(apiProduct), new Page<Api>(List.of(), 2, 20, 0))
+            );
+
+            rootTarget().queryParam("page", 2).queryParam("perPage", 20).queryParam("query", "search-term").request().get();
+
+            verify(getApiProductApisUseCase).execute(
+                argThat(
+                    input ->
+                        input.pageable().getPageNumber() == 2 && input.pageable().getPageSize() == 20 && "search-term".equals(input.query())
+                )
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -73,6 +73,7 @@ import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeployApiProductUseCase;
+import io.gravitee.apim.core.api_product.use_case.GetApiProductApisUseCase;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.SearchApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.UpdateApiProductUseCase;
@@ -923,6 +924,12 @@ public class ResourceContextConfiguration {
     @Primary
     public CreateApiProductUseCase createApiProductUseCase() {
         return mock(CreateApiProductUseCase.class);
+    }
+
+    @Bean
+    @Primary
+    public GetApiProductApisUseCase getApiProductApisUseCase() {
+        return mock(GetApiProductApisUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductApisUseCase.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.ApiAuthorizationDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.model.Sortable;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetApiProductApisUseCase {
+
+    private final ApiProductQueryService apiProductQueryService;
+    private final ApiQueryService apiQueryService;
+    private final ApiAuthorizationDomainService apiAuthorizationDomainService;
+
+    public Output execute(Input input) {
+        Optional<ApiProduct> apiProduct = apiProductQueryService.findById(input.apiProductId());
+
+        if (apiProduct.isEmpty()) {
+            return new Output(Optional.empty(), null);
+        }
+
+        List<String> apiIds = Optional.ofNullable(apiProduct.get().getApiIds())
+            .map(ids -> ids.stream().toList())
+            .orElse(List.of());
+
+        if (apiIds.isEmpty()) {
+            return new Output(apiProduct, new Page<>(List.of(), 0, 0, 0));
+        }
+
+        List<String> searchIds = apiIds;
+        if (!input.isAdmin()) {
+            Set<String> manageableIds = apiAuthorizationDomainService.findIdsByUser(
+                input.executionContext(),
+                input.userId(),
+                io.gravitee.apim.core.api.model.ApiQueryCriteria.builder().ids(apiIds).build(),
+                input.sortable(),
+                true // manageOnly
+            );
+            if (manageableIds == null || manageableIds.isEmpty()) {
+                return new Output(apiProduct, new Page<>(List.of(), 0, 0, 0));
+            }
+            searchIds = new ArrayList<>(manageableIds);
+        }
+
+        var criteriaBuilder = ApiSearchCriteria.builder().ids(searchIds).environmentId(input.executionContext().getEnvironmentId());
+        if (input.query() != null && !input.query().isBlank()) {
+            criteriaBuilder.name(input.query().strip());
+        }
+        ApiSearchCriteria criteria = criteriaBuilder.build();
+
+        Sortable coreSortable = toCoreSortable(input.sortable());
+        Page<Api> apisPage = apiQueryService.search(
+            criteria,
+            coreSortable,
+            input.pageable(),
+            ApiFieldFilter.builder().pictureExcluded(true).build()
+        );
+
+        return new Output(apiProduct, apisPage);
+    }
+
+    private static Sortable toCoreSortable(io.gravitee.rest.api.model.common.Sortable restSortable) {
+        if (restSortable == null || restSortable.getField() == null) {
+            return null;
+        }
+        return Sortable.builder()
+            .field(restSortable.getField())
+            .order(restSortable.isAscOrder() ? Sortable.Order.ASC : Sortable.Order.DESC)
+            .build();
+    }
+
+    public record Input(
+        ExecutionContext executionContext,
+        String apiProductId,
+        String query,
+        Pageable pageable,
+        io.gravitee.rest.api.model.common.Sortable sortable,
+        String userId,
+        boolean isAdmin
+    ) {}
+
+    public record Output(Optional<ApiProduct> apiProduct, Page<Api> apisPage) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductApisUseCaseTest.java
@@ -142,12 +142,10 @@ class GetApiProductApisUseCaseTest {
             assertThat(page.getContent()).extracting(Api::getId).containsExactlyInAnyOrder("api-1", "api-2");
             assertThat(page.getTotalElements()).isEqualTo(2);
         }
-
     }
 
     @Nested
     class AdminUser {
-
 
         @Test
         void should_respect_pagination_when_admin() {
@@ -207,5 +205,4 @@ class GetApiProductApisUseCaseTest {
             assertThat(output.apisPage().getContent()).hasSize(1);
         }
     }
-
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductApisUseCaseTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApiAuthorizationDomainServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.model.common.SortableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GetApiProductApisUseCaseTest {
+
+    private static final String ORG_ID = "org-id";
+    private static final String ENV_ID = "env-id";
+    private static final String USER_ID = "user-id";
+    private static final String API_PRODUCT_ID = "api-product-1";
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext(ORG_ID, ENV_ID);
+
+    private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
+    private final ApiAuthorizationDomainServiceInMemory apiAuthorizationDomainService = new ApiAuthorizationDomainServiceInMemory();
+
+    private GetApiProductApisUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetApiProductApisUseCase(apiProductQueryService, apiQueryService, apiAuthorizationDomainService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(apiProductQueryService, apiQueryService, apiAuthorizationDomainService).forEach(InMemoryAlternative::reset);
+    }
+
+    private GetApiProductApisUseCase.Input input(
+        String apiProductId,
+        String query,
+        Pageable pageable,
+        Sortable sortable,
+        String userId,
+        boolean isAdmin
+    ) {
+        return new GetApiProductApisUseCase.Input(EXECUTION_CONTEXT, apiProductId, query, pageable, sortable, userId, isAdmin);
+    }
+
+    @Nested
+    class ProductNotFound {
+
+        @Test
+        void should_return_empty_output_when_product_not_found() {
+            var input = input(API_PRODUCT_ID, null, new PageableImpl(1, 10), null, USER_ID, true);
+            var output = useCase.execute(input);
+
+            assertThat(output.apiProduct()).isEmpty();
+            assertThat(output.apisPage()).isNull();
+        }
+    }
+
+    @Nested
+    class ProductWithNoApis {
+
+        @Test
+        void should_return_empty_page_when_product_has_no_api_ids() {
+            ApiProduct product = ApiProduct.builder().id(API_PRODUCT_ID).name("Product").environmentId(ENV_ID).apiIds(Set.of()).build();
+            apiProductQueryService.initWith(List.of(product));
+
+            var input = input(API_PRODUCT_ID, null, new PageableImpl(1, 10), null, USER_ID, true);
+            var output = useCase.execute(input);
+
+            assertThat(output.apiProduct()).isPresent();
+            assertThat(output.apiProduct().get().getId()).isEqualTo(API_PRODUCT_ID);
+            assertThat(output.apisPage()).isNotNull();
+            assertThat(output.apisPage().getContent()).isEmpty();
+            assertThat(output.apisPage().getTotalElements()).isZero();
+        }
+
+        @Test
+        void should_return_empty_page_when_product_has_null_api_ids() {
+            ApiProduct product = ApiProduct.builder().id(API_PRODUCT_ID).name("Product").environmentId(ENV_ID).apiIds(null).build();
+            apiProductQueryService.initWith(List.of(product));
+
+            var input = input(API_PRODUCT_ID, null, new PageableImpl(1, 10), null, USER_ID, true);
+            var output = useCase.execute(input);
+
+            assertThat(output.apiProduct()).isPresent();
+            assertThat(output.apisPage()).isNotNull();
+            assertThat(output.apisPage().getContent()).isEmpty();
+            assertThat(output.apisPage().getTotalElements()).isZero();
+        }
+
+        @Test
+        void should_return_paginated_apis_when_admin_and_product_has_apis() {
+            ApiProduct product = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1", "api-2"))
+                .build();
+            apiProductQueryService.initWith(List.of(product));
+
+            Api api1 = Api.builder().id("api-1").name("API 1").environmentId(ENV_ID).build();
+            Api api2 = Api.builder().id("api-2").name("API 2").environmentId(ENV_ID).build();
+            apiQueryService.initWith(List.of(api1, api2));
+
+            var input = input(API_PRODUCT_ID, null, new PageableImpl(1, 10), null, USER_ID, true);
+            var output = useCase.execute(input);
+
+            assertThat(output.apiProduct()).isPresent();
+            assertThat(output.apiProduct().get().getId()).isEqualTo(API_PRODUCT_ID);
+            Page<Api> page = output.apisPage();
+            assertThat(page).isNotNull();
+            assertThat(page.getContent()).hasSize(2);
+            assertThat(page.getContent()).extracting(Api::getId).containsExactlyInAnyOrder("api-1", "api-2");
+            assertThat(page.getTotalElements()).isEqualTo(2);
+        }
+
+    }
+
+    @Nested
+    class AdminUser {
+
+
+        @Test
+        void should_respect_pagination_when_admin() {
+            ApiProduct product = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1", "api-2", "api-3"))
+                .build();
+            apiProductQueryService.initWith(List.of(product));
+
+            Api api1 = Api.builder().id("api-1").name("API 1").environmentId(ENV_ID).build();
+            Api api2 = Api.builder().id("api-2").name("API 2").environmentId(ENV_ID).build();
+            Api api3 = Api.builder().id("api-3").name("API 3").environmentId(ENV_ID).build();
+            apiQueryService.initWith(List.of(api1, api2, api3));
+
+            var input = input(API_PRODUCT_ID, null, new PageableImpl(1, 2), null, USER_ID, true);
+            var output = useCase.execute(input);
+
+            assertThat(output.apisPage().getContent()).hasSize(2);
+            assertThat(output.apisPage().getTotalElements()).isEqualTo(3);
+        }
+
+        @Test
+        void should_accept_query_without_error_when_admin() {
+            ApiProduct product = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            apiProductQueryService.initWith(List.of(product));
+            apiQueryService.initWith(List.of(Api.builder().id("api-1").name("My API").environmentId(ENV_ID).build()));
+
+            var input = input(API_PRODUCT_ID, "My API", new PageableImpl(1, 10), null, USER_ID, true);
+            var output = useCase.execute(input);
+
+            assertThat(output.apiProduct()).isPresent();
+            assertThat(output.apisPage()).isNotNull();
+        }
+
+        @Test
+        void should_accept_sortable_without_error_when_admin() {
+            ApiProduct product = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .build();
+            apiProductQueryService.initWith(List.of(product));
+            apiQueryService.initWith(List.of(Api.builder().id("api-1").name("API 1").environmentId(ENV_ID).build()));
+
+            var input = input(API_PRODUCT_ID, null, new PageableImpl(1, 10), new SortableImpl("name", true), USER_ID, true);
+            var output = useCase.execute(input);
+
+            assertThat(output.apiProduct()).isPresent();
+            assertThat(output.apisPage().getContent()).hasSize(1);
+        }
+    }
+
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12975

## Description

**Backend**

- New endpoint: GET /management/v2/environments/{envId}/api-products/{apiProductId}/apis
- Query parameters: page, perPage, q (optional search), sortBy (optional)
- Behaviour: Resolves the API product, restricts Lucene API search to the product’s apiIds, optionally applies full-text search q, then paginates and returns one page of APIs. Same permission as product definition read.

**Frontend**
Pagination and search are kept in component state; the router URL stays without query params (e.g. .../api-products/{id}/apis only). Backend still receives page, perPage, and q on each request.

**Curl examples**

List first page (no search)
```
curl -s -X GET \
  "https://apim-master-api.team-apim.gravitee.dev/management/v2/environments/DEFAULT/api-products/83a73199-c2d8-4d59-a731-99c2d8cd597f/apis?page=1&perPage=10" \
  -H "Authorization: Bearer <TOKEN>"
```

With search
```
curl -s -X GET \
  "https://apim-master-api.team-apim.gravitee.dev/management/v2/environments/DEFAULT/api-products/83a73199-c2d8-4d59-a731-99c2d8cd597f/apis?page=1&perPage=10&q=apim-12809" \
  -H "Authorization: Bearer <TOKEN>"

```


