### PR TITLE
feat(portal): add support for rootId in navigation item hierarchy map…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.UUID;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -41,21 +42,25 @@ public interface PortalNavigationItemsMapper {
 
     @Mapping(target = "type", constant = "PAGE")
     @Mapping(target = "portalPageContentId", expression = "java(page.getPortalPageContentId().id())")
+    @Mapping(target = "rootId", source = "rootId", qualifiedByName = "portalNavigationItemIdToUuid")
     io.gravitee.rest.api.management.v2.rest.model.PortalNavigationPage map(
         io.gravitee.apim.core.portal_page.model.PortalNavigationPage page
     );
 
     @Mapping(target = "type", constant = "FOLDER")
+    @Mapping(target = "rootId", source = "rootId", qualifiedByName = "portalNavigationItemIdToUuid")
     io.gravitee.rest.api.management.v2.rest.model.PortalNavigationFolder map(
         io.gravitee.apim.core.portal_page.model.PortalNavigationFolder folder
     );
 
     @Mapping(target = "type", constant = "LINK")
+    @Mapping(target = "rootId", source = "rootId", qualifiedByName = "portalNavigationItemIdToUuid")
     io.gravitee.rest.api.management.v2.rest.model.PortalNavigationLink map(
         io.gravitee.apim.core.portal_page.model.PortalNavigationLink link
     );
 
     @Mapping(target = "type", constant = "API")
+    @Mapping(target = "rootId", source = "rootId", qualifiedByName = "portalNavigationItemIdToUuid")
     io.gravitee.rest.api.management.v2.rest.model.PortalNavigationApi map(io.gravitee.apim.core.portal_page.model.PortalNavigationApi api);
 
     default List<PortalNavigationItem> map(List<io.gravitee.apim.core.portal_page.model.PortalNavigationItem> items) {
@@ -120,6 +125,11 @@ public interface PortalNavigationItemsMapper {
 
     default PortalNavigationItemId map(UUID id) {
         return id == null ? null : PortalNavigationItemId.of(id.toString());
+    }
+
+    @Named("portalNavigationItemIdToUuid")
+    default UUID mapToUuid(io.gravitee.apim.core.portal_page.model.PortalNavigationItemId id) {
+        return id != null ? id.id() : null;
     }
 
     default String map(io.gravitee.apim.core.portal_page.model.PortalNavigationItemId id) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -2002,6 +2002,11 @@ components:
           format: uuid
           description: The parent ID of the navigation item
           example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
+        rootId:
+          type: string
+          format: uuid
+          description: The root parent ID of the navigation item hierarchy
+          example: 00f8c9e7-78fc-4907-b8c9-e778fc790750
         order:
           type: integer
           description: The order of the navigation item (zero-based)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapperTest.java
@@ -66,6 +66,7 @@ class PortalNavigationItemsMapperTest {
             assertThat(result.getOrder()).isEqualTo(1);
             assertThat(result.getParentId()).isNull();
             assertThat(result.getPortalPageContentId()).isEqualTo(page.getPortalPageContentId().id());
+            assertThat(result.getRootId()).isEqualTo(page.getRootId().id());
         }
 
         @Test
@@ -84,6 +85,7 @@ class PortalNavigationItemsMapperTest {
             assertThat(result.getArea()).isEqualTo(io.gravitee.rest.api.management.v2.rest.model.PortalArea.TOP_NAVBAR);
             assertThat(result.getOrder()).isEqualTo(2);
             assertThat(result.getParentId()).isNull();
+            assertThat(result.getRootId()).isEqualTo(folder.getRootId().id());
         }
 
         @Test
@@ -102,6 +104,7 @@ class PortalNavigationItemsMapperTest {
             assertThat(result.getOrder()).isEqualTo(3);
             assertThat(result.getParentId()).isNull();
             assertThat(result.getUrl()).isEqualTo("https://example.com");
+            assertThat(result.getRootId()).isEqualTo(link.getRootId().id());
         }
 
         @Test
@@ -120,6 +123,7 @@ class PortalNavigationItemsMapperTest {
             assertThat(result.getOrder()).isEqualTo(3);
             assertThat(result.getParentId()).isNull();
             assertThat(result.getApiId()).isEqualTo("apiId");
+            assertThat(result.getRootId()).isEqualTo(api.getRootId().id());
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -6445,6 +6445,9 @@ components:
                 parentId:
                     type: string
                     description: The parent ID of the navigation item
+                rootId:
+                    type: string
+                    description: The root parent ID of the navigation item hierarchy
                 order:
                     type: integer
                     description: The order of the navigation item

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapperTest.java
@@ -47,6 +47,7 @@ class PortalNavigationItemMapperTest {
         assertThat(item0.getActualInstance()).isInstanceOf(PortalNavigationFolder.class);
         var folder = (PortalNavigationFolder) item0.getActualInstance();
         assertThat(folder.getTitle()).isEqualTo("Folder 1");
+        assertThat(folder.getRootId()).isEqualTo(domain.getFirst().getRootId().json());
 
         var item1 = restItems.get(1);
         assertThat(item1.getActualInstance()).isInstanceOf(PortalNavigationLink.class);


### PR DESCRIPTION
…ping and API schemas

## Issue

https://gravitee.atlassian.net/browse/APIM-12823

## Description

This PR exposes rootId on portal navigation item API responses and documents it in the management v2 and portal OpenAPI schemas. It also extends mapper tests to ensure the field is serialized for the supported navigation item types.

The goal is to let clients identify the root ancestor of a navigation item directly from the payload, which simplifies hierarchy rendering and grouping.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

