### PR TITLE
fix: added duplicate custom api key validation for API product & consumers icon change

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/basePlan.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/basePlan.ts
@@ -27,6 +27,11 @@ export interface BasePlan {
    * @example 6c530064-0b2c-4004-9300-640b2ce0047b
    */
   apiId?: string;
+  /**
+   * @description Id of the API Product owning the plan. Present when the plan belongs to an API Product.
+   * @example 6c530064-0b2c-4004-9300-640b2ce0047b
+   */
+  apiProductId?: string;
   characteristics?: string[];
   /**
    * Format: date-time

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.html
@@ -28,7 +28,11 @@
             <gio-submenu-item tabIndex="1" [active]="menuItem.active">
               <div class="api-product-navigation__submenu__item">
                 @if (menuItem.icon) {
-                  <mat-icon class="api-product-navigation__submenu__item__icon" [svgIcon]="menuItem.icon"></mat-icon>
+                  <mat-icon
+                    class="api-product-navigation__submenu__item__icon"
+                    [matTooltip]="menuItem.displayName"
+                    [svgIcon]="menuItem.icon"
+                  ></mat-icon>
                 }
                 {{ menuItem.displayName }}
               </div>

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -264,7 +264,7 @@ export class ApiProductNavigationComponent {
     items.push({
       displayName: 'Consumers',
       routerLink: 'consumers',
-      icon: 'gio:users',
+      icon: 'gio:cloud-consumers',
       header: { title: 'Consumers', subtitle: 'Manage how your API Product is consumed' },
       tabs,
     });

--- a/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/subscriptions/list/api-product-subscription-list.component.ts
@@ -285,6 +285,7 @@ export class ApiProductSubscriptionListComponent {
         id: 'createSubscriptionDialog',
         data: {
           isFederatedApi: false,
+          apiProductId: this.apiProductId,
           availableSubscriptionEntrypoints: [],
           plans: this.plans().filter(plan => plan.status === 'PUBLISHED'),
         },

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/api-key-validation/api-key-validation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/api-key-validation/api-key-validation.component.spec.ts
@@ -30,15 +30,22 @@ import { ApiSubscriptionsModule } from '../../api-subscriptions.module';
 import { VerifySubscription } from '../../../../../entities/management-api-v2';
 
 const API_ID = 'my-api-id';
+const API_PRODUCT_ID = 'my-api-product-id';
 const APP_ID = 'my-app-id';
 
 @Component({
   selector: 'test-component',
-  template: `<api-key-validation [formControl]="apiKey" [apiId]="apiId" [applicationId]="applicationId"></api-key-validation>`,
+  template: `<api-key-validation
+    [formControl]="apiKey"
+    [apiId]="apiId"
+    [apiProductId]="apiProductId"
+    [applicationId]="applicationId"
+  ></api-key-validation>`,
   standalone: false,
 })
 class TestComponent {
-  apiId: string = API_ID;
+  apiId: string | undefined = API_ID;
+  apiProductId: string | undefined = undefined;
   applicationId: string = APP_ID;
   apiKey: FormControl = new FormControl('');
 }
@@ -150,5 +157,50 @@ describe('ApiKeyValidationComponent', () => {
 
     expect(await harness.isValid()).toEqual(true);
     expect(fixture.componentInstance.apiKey.touched).toEqual(true);
+  });
+
+  it('should call API Product verify endpoint when apiProductId is set', async () => {
+    fixture.componentInstance.apiId = undefined;
+    fixture.componentInstance.apiProductId = API_PRODUCT_ID;
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(ApiKeyValidationHarness);
+    await harness.setInputValue('custom_key_12345');
+
+    const httpMatches = httpTestingController.match({
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/_verify`,
+      method: 'POST',
+    });
+    expect(httpMatches.length).toBeGreaterThanOrEqual(1);
+    const verifySubscription: VerifySubscription = {
+      applicationId: APP_ID,
+      apiKey: 'custom_key_12345',
+    };
+    // Flush only non-cancelled requests (cancelled = prior requests replaced by new validation)
+    const lastReq = httpMatches[httpMatches.length - 1];
+    expect(lastReq.request.body).toEqual(verifySubscription);
+    httpMatches.filter(req => !req.cancelled).forEach(req => req.flush({ ok: true }));
+
+    expect(await harness.isValid()).toEqual(true);
+  });
+
+  it('should be invalid when API Product verify returns duplicate key', async () => {
+    fixture.componentInstance.apiId = undefined;
+    fixture.componentInstance.apiProductId = API_PRODUCT_ID;
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(ApiKeyValidationHarness);
+    await harness.setInputValue('duplicate_key_12345');
+
+    const httpMatches = httpTestingController.match({
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/subscriptions/_verify`,
+      method: 'POST',
+    });
+    expect(httpMatches.length).toBeGreaterThanOrEqual(1);
+    const lastReq = httpMatches[httpMatches.length - 1];
+    expect(lastReq.request.body).toEqual({ applicationId: APP_ID, apiKey: 'duplicate_key_12345' });
+    lastReq.flush({ ok: false });
+
+    expect(await harness.isValid()).toEqual(false);
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/api-key-validation/api-key-validation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/api-key-validation/api-key-validation.component.ts
@@ -28,6 +28,8 @@ import { filter, map, startWith, take, takeUntil, tap } from 'rxjs/operators';
 import { Observable, of, Subject } from 'rxjs';
 import { FocusMonitor } from '@angular/cdk/a11y';
 
+import { VerifySubscriptionResponse } from '../../../../../entities/management-api-v2';
+import { ApiProductSubscriptionV2Service } from '../../../../../services-ngx/api-product-subscription-v2.service';
 import { ApiSubscriptionV2Service } from '../../../../../services-ngx/api-subscription-v2.service';
 
 @Component({
@@ -50,7 +52,10 @@ import { ApiSubscriptionV2Service } from '../../../../../services-ngx/api-subscr
 })
 export class ApiKeyValidationComponent implements OnInit, ControlValueAccessor, Validator {
   @Input()
-  apiId: string;
+  apiId: string | undefined;
+
+  @Input()
+  apiProductId: string | undefined;
 
   @Input()
   applicationId: string;
@@ -63,6 +68,7 @@ export class ApiKeyValidationComponent implements OnInit, ControlValueAccessor, 
 
   constructor(
     private readonly apiSubscriptionService: ApiSubscriptionV2Service,
+    private readonly apiProductSubscriptionService: ApiProductSubscriptionV2Service,
     private readonly fm: FocusMonitor,
     private readonly elRef: ElementRef,
   ) {}
@@ -121,9 +127,14 @@ export class ApiKeyValidationComponent implements OnInit, ControlValueAccessor, 
         return of(control.errors);
       }
 
-      return this.apiSubscriptionService
-        .verify(this.apiId, { applicationId: this.applicationId, apiKey: control.value })
-        .pipe(map(isUnique => (!isUnique.ok ? { unique: true } : null)));
+      const verifyPayload = { applicationId: this.applicationId, apiKey: control.value };
+
+      const verify$ =
+        this.apiId != null
+          ? this.apiSubscriptionService.verify(this.apiId, verifyPayload)
+          : this.apiProductSubscriptionService.verify(this.apiProductId, verifyPayload);
+
+      return verify$.pipe(map((isUnique: VerifySubscriptionResponse) => (isUnique.ok ? null : { unique: true })));
     };
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.html
@@ -97,7 +97,8 @@
         <api-key-validation
           formControlName="customApiKey"
           [applicationId]="form.get('selectedApplication').value.id"
-          [apiId]="form.get('selectedPlan').value.apiId"
+          [apiId]="form.get('selectedPlan').value?.apiId"
+          [apiProductId]="form.get('selectedPlan').value?.apiProductId ?? apiProductId"
         ></api-key-validation>
       </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
@@ -37,6 +37,8 @@ export type ApiPortalSubscriptionCreationDialogData = {
   availableSubscriptionEntrypoints?: Entrypoint[];
   plans: Plan[];
   isFederatedApi?: boolean;
+  /** API Product ID when creating subscription for an API Product **/
+  apiProductId?: string;
 };
 
 export type ApiPortalSubscriptionCreationDialogResult = {
@@ -59,6 +61,7 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
   public showGeneralConditionsMsg: boolean;
   public canUseCustomApiKey: boolean;
   public canUseSharedApiKeys: boolean;
+  public apiProductId: string | undefined;
 
   public form: UntypedFormGroup = new UntypedFormGroup({
     selectedPlan: new UntypedFormControl(undefined, [Validators.required]),
@@ -82,6 +85,7 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
     this.availableSubscriptionEntrypoints = dialogData.availableSubscriptionEntrypoints.map(entrypoint => ({ type: entrypoint.type }));
     this.canUseCustomApiKey = !dialogData.isFederatedApi && this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
     this.canUseSharedApiKeys = !dialogData.isFederatedApi && this.constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
+    this.apiProductId = dialogData.apiProductId;
   }
 
   ngOnInit(): void {

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/renew/api-portal-subscription-renew-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/renew/api-portal-subscription-renew-dialog.component.html
@@ -21,7 +21,12 @@
     <div class="mat-body-2">Your previous API Key will be no longer valid in 2 hours!</div>
     <div *ngIf="data.canUseCustomApiKey" class="renew__content__custom-api-key">
       <div class="mat-body-2">You can provide a custom API Key here</div>
-      <api-key-validation formControlName="apiKey" [applicationId]="data.applicationId" [apiId]="data.apiId"></api-key-validation>
+      <api-key-validation
+        formControlName="apiKey"
+        [applicationId]="data.applicationId"
+        [apiId]="data.apiId"
+        [apiProductId]="data.apiProductId"
+      ></api-key-validation>
     </div>
   </mat-dialog-content>
   <mat-dialog-actions class="actions">

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/renew/api-portal-subscription-renew-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/renew/api-portal-subscription-renew-dialog.component.ts
@@ -20,7 +20,8 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 export interface ApiPortalSubscriptionRenewDialogData {
   canUseCustomApiKey: boolean;
   applicationId: string;
-  apiId: string;
+  apiId?: string;
+  apiProductId?: string;
 }
 
 export interface ApiPortalSubscriptionRenewDialogResult {

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component.html
@@ -45,7 +45,12 @@
       </div>
       <div class="validate-subscription__content__row" *ngIf="!data.isFederated && data.canUseCustomApiKey && !data.sharedApiKeyMode">
         <div class="mat-body-2">This plan allows custom API Keys. You can provide it here.</div>
-        <api-key-validation formControlName="apiKey" [applicationId]="data.applicationId" [apiId]="data.apiId"></api-key-validation>
+        <api-key-validation
+          formControlName="apiKey"
+          [applicationId]="data.applicationId"
+          [apiId]="data.apiId"
+          [apiProductId]="data.apiProductId"
+        ></api-key-validation>
       </div>
     </div>
   </mat-dialog-content>

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/validate/api-portal-subscription-validate-dialog.component.ts
@@ -18,7 +18,8 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 
 export interface ApiPortalSubscriptionAcceptDialogData {
-  apiId: string;
+  apiId?: string;
+  apiProductId?: string;
   applicationId: string;
   canUseCustomApiKey: boolean;
   sharedApiKeyMode: boolean;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13043

## Description

| Area | File(s) | Description |
|------|---------|-------------|
| Core validation | api-key-validation.component.ts | Routes to ApiProductSubscriptionV2Service.verify() when apiProductId is set; keeps API flow when apiId is set |
| Unit tests | api-key-validation.component.spec.ts | Adds tests for API Product validation path |
| Entity | basePlan.ts | Adds apiProductId to BasePlan for plans owned by API Products |
| Console - API Product navigation | api-product-navigation.component.ts, .html | Updates Consumers icon to gio:cloud-consumers; adds entrypoint tooltips |
| Console - subscription list | api-product-subscription-list.component.ts | Passes apiProductId into subscription creation flow |
| Portal - creation dialog | api-portal-subscription-creation-dialog | Supports apiProductId for custom API key input |
| Portal - renew dialog | api-portal-subscription-renew-dialog | Supports apiProductId for custom API key input |
| Portal - validate dialog | api-portal-subscription-validate-dialog | Supports apiProductId for custom API key input |

Existing custom api Key: 
<img width="1502" height="738" alt="image" src="https://github.com/user-attachments/assets/482912e5-352f-4bc9-b366-77b5874dd36f" />
Post fix api key validation: Now save button disabled when using existing API key
<img width="1502" height="738" alt="image" src="https://github.com/user-attachments/assets/f5fd65e5-ef36-4126-a5d9-b2feace405fe" />

Post fix consumers icon & tooltip: 
<img width="1502" height="738" alt="image" src="https://github.com/user-attachments/assets/ac7a4c59-f73a-418f-9e6b-0ecf2add610e" />
