### PR TITLE
[cj-4023] Add tenant key management with unique identifiers

### DIFF
--- a/gravitee-apim-console-webui/src/entities/tenant/newTenant.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/tenant/newTenant.fixture.ts
@@ -18,6 +18,7 @@ import { NewTenant } from './newTenant';
 export function fakeNewTenant(attributes?: Partial<NewTenant>): NewTenant {
   const base: NewTenant = {
     name: 'NewTenant 1',
+    key: 'new-tenant-1',
     description: 'NewTenant 1 description',
   };
 

--- a/gravitee-apim-console-webui/src/entities/tenant/newTenant.ts
+++ b/gravitee-apim-console-webui/src/entities/tenant/newTenant.ts
@@ -15,5 +15,6 @@
  */
 export interface NewTenant {
   name: string;
+  key: string;
   description: string;
 }

--- a/gravitee-apim-console-webui/src/entities/tenant/tenant.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/tenant/tenant.fixture.ts
@@ -13,11 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Tenant } from './tenant';
+import { Tenant, UpdateTenantEntity } from './tenant';
 
 export function fakeTenant(attributes?: Partial<Tenant>): Tenant {
   const base: Tenant = {
     id: 'tenant#1',
+    key: 'tenant-1',
+    name: 'Tenant 1',
+    description: 'Tenant 1 description',
+  };
+
+  return {
+    ...base,
+    ...attributes,
+  };
+}
+
+export function fakeUpdateTenantEntity(attributes?: Partial<UpdateTenantEntity>): UpdateTenantEntity {
+  const base: UpdateTenantEntity = {
+    key: 'tenant-1',
     name: 'Tenant 1',
     description: 'Tenant 1 description',
   };

--- a/gravitee-apim-console-webui/src/entities/tenant/tenant.ts
+++ b/gravitee-apim-console-webui/src/entities/tenant/tenant.ts
@@ -15,6 +15,13 @@
  */
 export interface Tenant {
   id: string;
+  key: string;
   name: string;
+  description: string;
+}
+
+export interface UpdateTenantEntity {
+  name: string;
+  key: string;
   description: string;
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.adapter.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.adapter.ts
@@ -83,7 +83,7 @@ const toEndpointsFromApiV4 = (api: ApiV4, tenants: Tenant[]): EndpointGroup[] =>
                 general: toGeneralInfo(api, endpoint),
                 nameBadge,
                 options,
-                tenants: endpoint.tenants?.map(tenantId => tenants.find(tenant => tenant.id === tenantId)?.name ?? tenantId),
+                tenants: endpoint.tenants?.map(tenantKey => getTenantNameByKey(tenants, tenantKey)),
                 weight: endpoint.weight,
                 configuration: endpoint.configuration,
               } satisfies Endpoint;
@@ -170,4 +170,8 @@ const toEndpointOptions = (api: ApiV4, endpointGroup: EndpointGroupV4, endpoint:
     }
   }
   return [];
+};
+
+const getTenantNameByKey = (tenants: Tenant[], tenantKey: string): string => {
+  return tenants.find(tenant => tenant.key === tenantKey)?.name ?? tenantKey;
 };

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
@@ -77,9 +77,11 @@
                 <mat-form-field class="endpoint-card__form__field">
                   <mat-label>Tenants</mat-label>
                   <mat-select aria-label="Endpoint tenants" formControlName="tenants" multiple>
-                    <mat-option *ngFor="let tenant of tenants" [value]="tenant.id">
-                      <span class="card__group-endpoint__row__tenant__name" [matTooltip]="tenant.description">{{ tenant.name }}</span>
-                    </mat-option>
+                    @for (tenant of tenants; track tenant.id) {
+                      <mat-option [value]="tenant.key">
+                        <span class="card__group-endpoint__row__tenant__name" [matTooltip]="tenant.description">{{ tenant.name }}</span>
+                      </mat-option>
+                    }
                   </mat-select>
                 </mat-form-field>
               </div>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.spec.ts
@@ -69,7 +69,7 @@ class TestComponent {
 
 describe('ApiEndpointComponent', () => {
   const API_ID = 'apiId';
-  const TENANT: Tenant = { id: 'tenant-id', name: 'tenant-name', description: '' };
+  const TENANT: Tenant = { id: 'tenant-id', key: 'tenant-key', name: 'tenant-name', description: '' };
 
   let fixture: ComponentFixture<TestComponent>;
   let httpTestingController: HttpTestingController;
@@ -162,7 +162,7 @@ describe('ApiEndpointComponent', () => {
                   inheritConfiguration: true,
                   sharedConfigurationOverride: {},
                   name: 'endpoint-name',
-                  tenants: [TENANT.id],
+                  tenants: [TENANT.key],
                   type: 'kafka',
                   weight: 10,
                 },
@@ -259,7 +259,7 @@ describe('ApiEndpointComponent', () => {
                 {
                   ...apiV4.endpointGroups[0].endpoints[0],
                   name: 'endpoint-name updated',
-                  tenants: [TENANT.id],
+                  tenants: [TENANT.key],
                   sharedConfigurationOverride: {
                     test: undefined,
                   },

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
@@ -175,7 +175,7 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
                   backup: false,
                   type: 'HTTP',
                   inherit: true,
-                  tenants: [tenants[0].id],
+                  tenants: [tenants[0].key],
                   healthCheck: {
                     inherit: true,
                   },

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/general/api-proxy-group-endpoint-edit-general.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/general/api-proxy-group-endpoint-edit-general.component.html
@@ -73,9 +73,11 @@
         <mat-form-field class="card__group-endpoint__row__tenant__form-field">
           <mat-label>Tenants</mat-label>
           <mat-select aria-label="Endpoint tenants" formControlName="tenants" multiple>
-            <mat-option *ngFor="let tenant of tenants" [value]="tenant.id">
-              <span class="card__group-endpoint__row__tenant__name" [matTooltip]="tenant.description">{{ tenant.name }}</span>
-            </mat-option>
+            @for (tenant of tenants; track tenant.id) {
+              <mat-option [value]="tenant.key">
+                <span class="card__group-endpoint__row__tenant__name" [matTooltip]="tenant.description">{{ tenant.name }}</span>
+              </mat-option>
+            }
           </mat-select>
         </mat-form-field>
       </div>

--- a/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.html
@@ -20,25 +20,41 @@
 <form autocomplete="off" [formGroup]="tenantForm" (ngSubmit)="onSubmit()">
   <mat-dialog-content>
     <div class="form">
-      <mat-form-field *ngIf="isUpdate">
-        <mat-label>Id</mat-label>
-        <input matInput formControlName="id" data-testid="tenant-id" />
-      </mat-form-field>
       <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput formControlName="name" required data-testid="tenant-name" />
         <mat-hint align="end">{{ tenantForm.get('name').value?.length ?? 0 }}/40</mat-hint>
-        <mat-error *ngIf="tenantForm.get('name').hasError('maxlength')">Name has to be less than 40 characters long.</mat-error>
-        <mat-error *ngIf="tenantForm.get('name').hasError('minlength')">Name has to be more than 2 characters long.</mat-error>
-        <mat-error *ngIf="tenantForm.get('name').hasError('required')">Name is required.</mat-error>
+        @if (tenantForm.controls.name.hasError('maxlength')) {
+          <mat-error>Name has to be less than 40 characters long.</mat-error>
+        }
+        @if (tenantForm.controls.name.hasError('minlength')) {
+          <mat-error>Name has to be more than 2 characters long.</mat-error>
+        }
+        @if (tenantForm.controls.name.hasError('required')) {
+          <mat-error>Name is required.</mat-error>
+        }
+      </mat-form-field>
+      <mat-form-field>
+        <mat-label>Key</mat-label>
+        <input matInput formControlName="key" required data-testid="tenant-key" (blur)="onKeyBlur()" />
+        <mat-hint align="end">{{ tenantForm.get('key').value?.length ?? 0 }}/64</mat-hint>
+        @if (tenantForm.controls.key.hasError('maxlength')) {
+          <mat-error>Key has to be less than 64 characters long.</mat-error>
+        }
+        @if (tenantForm.controls.key.hasError('minlength')) {
+          <mat-error>Key has to be at least 1 character long.</mat-error>
+        }
+        @if (tenantForm.controls.key.hasError('required')) {
+          <mat-error>Key is required.</mat-error>
+        }
       </mat-form-field>
       <mat-form-field>
         <mat-label>Description</mat-label>
         <input matInput formControlName="description" data-testid="tenant-description" />
         <mat-hint align="end">{{ tenantForm.get('description').value?.length ?? 0 }}/160</mat-hint>
-        <mat-error *ngIf="tenantForm.get('description').hasError('maxlength')"
-          >Description has to be less than 160 characters long.</mat-error
-        >
+        @if (tenantForm.controls.description.hasError('maxlength')) {
+          <mat-error>Description has to be less than 160 characters long.</mat-error>
+        }
       </mat-form-field>
     </div>
   </mat-dialog-content>

--- a/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.spec.ts
@@ -26,7 +26,7 @@ import { OrgSettingAddTenantComponent, OrgSettingAddTenantDialogData } from './o
 import { OrganizationSettingsModule } from '../organization-settings.module';
 import { fakeTenant } from '../../../entities/tenant/tenant.fixture';
 
-describe('GioConfirmDialogComponent', () => {
+describe('OrgSettingAddTenantComponent', () => {
   let component: OrgSettingAddTenantComponent;
   let fixture: ComponentFixture<OrgSettingAddTenantComponent>;
   let loader: HarnessLoader;
@@ -67,6 +67,9 @@ describe('GioConfirmDialogComponent', () => {
       const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=name]' }));
       await nameInput.setValue('External');
 
+      const keyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
+      await keyInput.setValue('external');
+
       const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=description' }));
       await descriptionInput.setValue('External tenant');
 
@@ -74,6 +77,7 @@ describe('GioConfirmDialogComponent', () => {
 
       expect(matDialogRefMock.close).toHaveBeenCalledWith({
         name: 'External',
+        key: 'external',
         description: 'External tenant',
       });
     });
@@ -83,7 +87,8 @@ describe('GioConfirmDialogComponent', () => {
     beforeEach(() => {
       const dialogData: OrgSettingAddTenantDialogData = {
         tenant: fakeTenant({
-          id: 'external',
+          id: '875fb0a0-1ea2-3a1d-bfd6-f59f9a18bd5b',
+          key: 'external',
           name: 'External',
           description: 'External tenant',
         }),
@@ -109,9 +114,9 @@ describe('GioConfirmDialogComponent', () => {
 
       const submitButton = await loader.getHarness(MatButtonHarness.with({ selector: 'button[type=submit]' }));
 
-      const idInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=id]' }));
-      expect(await idInput.isDisabled()).toBeTruthy();
-      expect(await idInput.getValue()).toEqual('external');
+      const keyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
+      expect(await keyInput.isDisabled()).toBeTruthy();
+      expect(await keyInput.getValue()).toEqual('external');
 
       const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=name]' }));
       await nameInput.setValue('');
@@ -124,7 +129,7 @@ describe('GioConfirmDialogComponent', () => {
       await submitButton.click();
 
       expect(matDialogRefMock.close).toHaveBeenCalledWith({
-        id: 'external',
+        key: 'external',
         name: 'Internal',
         description: 'Internal tenant',
       });
@@ -139,6 +144,28 @@ describe('GioConfirmDialogComponent', () => {
       expect(await submitButton.isDisabled()).toBeTruthy();
       expect(component.tenantForm.controls['name'].valid).toBeFalsy();
       expect(component.tenantForm.controls['name'].errors?.['maxlength']).toBeTruthy();
+    });
+
+    it.each`
+      key                                 | sanitized
+      ${'My Tenant Key'}                  | ${'my-tenant-key'}
+      ${'Tênant Spécîal @#$ Nàme!'}       | ${'tenant-special-name'}
+      ${'Tenant   With    Multiple---Sp'} | ${'tenant-with-multiple-sp'}
+      ${'Tenant Key---'}                  | ${'tenant-key'}
+      ${'UPPERCASE KEY'}                  | ${'uppercase-key'}
+      ${'Key 123 Value 456'}              | ${'key-123-value-456'}
+      ${'eu east 1! @#$%'}                | ${'eu-east-1'}
+    `('should sanitize key "$key" to "$sanitized"', async ({ key, sanitized }) => {
+      fixture.detectChanges();
+
+      component.tenantForm.controls.key.setValue(key);
+      fixture.detectChanges();
+
+      const keyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
+      await keyInput.blur();
+      fixture.detectChanges();
+
+      expect(await keyInput.getValue()).toBe(sanitized);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-add-tenant.component.ts
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject } from '@angular/core';
-import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import { Component, DestroyRef, Inject, inject } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { filter, tap } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { Tenant } from '../../../entities/tenant/tenant';
+import { sanitizeKeyBase, sanitizeKeyFinal } from '../../../shared/utils/key-sanitizer.util';
 
 export type OrgSettingAddTenantDialogData = {
   tenant?: Tenant;
@@ -30,9 +33,11 @@ export type OrgSettingAddTenantDialogData = {
   standalone: false,
 })
 export class OrgSettingAddTenantComponent {
+  private readonly destroyRef = inject(DestroyRef);
+
   tenant?: Tenant;
   isUpdate = false;
-  tenantForm: UntypedFormGroup;
+  tenantForm: FormGroup;
 
   constructor(
     public dialogRef: MatDialogRef<OrgSettingAddTenantComponent>,
@@ -41,18 +46,43 @@ export class OrgSettingAddTenantComponent {
     this.tenant = confirmDialogData.tenant;
     this.isUpdate = !!this.tenant;
 
-    this.tenantForm = new UntypedFormGroup({
-      name: new UntypedFormControl(this.tenant?.name, [Validators.required, Validators.minLength(1), Validators.maxLength(40)]),
-      description: new UntypedFormControl(this.tenant?.description, [Validators.maxLength(160)]),
+    this.tenantForm = new FormGroup({
+      name: new FormControl<string>(this.tenant?.name, [Validators.required, Validators.minLength(1), Validators.maxLength(40)]),
+      key: new FormControl<string>({ value: this.tenant?.key ?? '', disabled: this.isUpdate }, [
+        Validators.required,
+        Validators.minLength(1),
+        Validators.maxLength(64),
+      ]),
+      description: new FormControl<string>(this.tenant?.description, [Validators.maxLength(160)]),
     });
 
-    if (this.isUpdate) {
-      this.tenantForm.addControl('id', new UntypedFormControl({ value: this.tenant.id, disabled: true }, [Validators.required]));
-    }
+    this.tenantForm.controls.key.valueChanges
+      .pipe(
+        filter(value => value !== null),
+        tap(value => {
+          const sanitized = sanitizeKeyBase(value);
+          if (sanitized !== value) {
+            this.tenantForm.controls.key.setValue(sanitized, { emitEvent: false });
+          }
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 
   onSubmit() {
     const updatedTenant = this.tenantForm.getRawValue();
     this.dialogRef.close(updatedTenant);
+  }
+
+  onKeyBlur(): void {
+    const value = this.tenantForm.controls.key.value;
+    if (value == null) {
+      return;
+    }
+    const sanitized = sanitizeKeyFinal(value);
+    if (sanitized !== value) {
+      this.tenantForm.controls.key.setValue(sanitized, { emitEvent: false });
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-tenants.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-tenants.component.html
@@ -18,7 +18,7 @@
 <h1>Tenants</h1>
 
 <h4>
-  Copy/paste the tenant's id to the API gateway configuration file in order to resolve API endpoints according to the configured tenant.
+  Copy/paste the tenant's key to the API gateway configuration file in order to resolve API endpoints according to the configured tenant.
 </h4>
 
 <div class="add-button-container" *gioPermission="{ anyOf: ['organization-tenant-c'] }">
@@ -30,9 +30,9 @@
 <gio-table-wrapper [length]="tenantsTableUnpaginatedLength" (filtersChange)="onFiltersChanged($event)">
   <table mat-table [dataSource]="tenantsDataSource" class="tenants-table" id="tenantsTable" aria-label="Tenant table">
     <!-- Id Column -->
-    <ng-container matColumnDef="id">
-      <th mat-header-cell *matHeaderCellDef id="id">Id</th>
-      <td mat-cell *matCellDef="let element">{{ element.id }}</td>
+    <ng-container matColumnDef="key">
+      <th mat-header-cell *matHeaderCellDef id="key">Key</th>
+      <td mat-cell *matCellDef="let element">{{ element.key }}</td>
     </ng-container>
 
     <!-- Name Column -->

--- a/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-tenants.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-tenants.component.spec.ts
@@ -60,8 +60,8 @@ describe('OrgSettingsTenantsComponent', () => {
     fixture.detectChanges();
 
     const tenants = [
-      fakeTenant({ id: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' }),
-      fakeTenant({ id: 'tenant-2', name: 'Tenant 2', description: 'Tenant 2 description' }),
+      fakeTenant({ id: 'tenant-1-id', key: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' }),
+      fakeTenant({ id: 'tenant-2-id', key: 'tenant-2', name: 'Tenant 2', description: 'Tenant 2 description' }),
     ];
 
     respondToGetTenants(tenants);
@@ -79,8 +79,8 @@ describe('OrgSettingsTenantsComponent', () => {
     fixture.detectChanges();
 
     const tenants = [
-      fakeTenant({ id: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' }),
-      fakeTenant({ id: 'tenant-2', name: 'Tenant 2', description: 'Tenant 2 description' }),
+      fakeTenant({ id: 'tenant-1-id', key: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' }),
+      fakeTenant({ id: 'tenant-2-id', key: 'tenant-2', name: 'Tenant 2', description: 'Tenant 2 description' }),
     ];
 
     respondToGetTenants(tenants);
@@ -107,6 +107,9 @@ describe('OrgSettingsTenantsComponent', () => {
     const nameInput = await rootLoader.getHarness(MatInputHarness.with({ selector: '[formControlName=name]' }));
     await nameInput.setValue('External');
 
+    const keyInput = await rootLoader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
+    await keyInput.setValue('external');
+
     const descriptionInput = await rootLoader.getHarness(MatInputHarness.with({ selector: '[formControlName=description' }));
     await descriptionInput.setValue('External tenant');
 
@@ -120,13 +123,15 @@ describe('OrgSettingsTenantsComponent', () => {
     expect(req.request.body).toEqual([
       {
         name: 'External',
+        key: 'external',
         description: 'External tenant',
       },
     ]);
 
     const serverResponse = [
       {
-        id: 'external',
+        id: 'external-tenant-id',
+        key: 'external',
         name: 'External',
         description: 'External tenant',
       },
@@ -139,7 +144,7 @@ describe('OrgSettingsTenantsComponent', () => {
     permissionsService._setPermissions(['organization-tenant-u']);
     fixture.detectChanges();
 
-    respondToGetTenants([fakeTenant({ id: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' })]);
+    respondToGetTenants([fakeTenant({ id: 'tenant-1-id', key: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' })]);
 
     fixture.detectChanges();
 
@@ -161,7 +166,7 @@ describe('OrgSettingsTenantsComponent', () => {
     });
     expect(req.request.body).toEqual([
       {
-        id: 'tenant-1',
+        key: 'tenant-1',
         name: 'External',
         description: 'External tenant',
       },
@@ -169,7 +174,8 @@ describe('OrgSettingsTenantsComponent', () => {
 
     const serverResponse = [
       {
-        id: 'external',
+        id: 'external-tenant-id',
+        key: 'external',
         name: 'External',
         description: 'External tenant',
       },
@@ -182,7 +188,7 @@ describe('OrgSettingsTenantsComponent', () => {
     permissionsService._setPermissions(['organization-tenant-d']);
     fixture.detectChanges();
 
-    respondToGetTenants([fakeTenant({ id: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' })]);
+    respondToGetTenants([fakeTenant({ id: 'tenant-1-id', key: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' })]);
 
     fixture.detectChanges();
 
@@ -218,7 +224,7 @@ describe('OrgSettingsTenantsComponent', () => {
   it('should not submit tenant form if name is too long', async () => {
     permissionsService._setPermissions(['organization-tenant-c']);
     fixture.detectChanges();
-    respondToGetTenants([fakeTenant({ id: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' })]);
+    respondToGetTenants([fakeTenant({ id: 'tenant-1-id', key: 'tenant-1', name: 'Tenant 1', description: 'Tenant 1 description' })]);
     fixture.detectChanges();
     const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to add a tenant"]' }));
     await addButton.click();

--- a/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-tenants.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tenants/org-settings-tenants.component.ts
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { EMPTY, Subject } from 'rxjs';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { EMPTY } from 'rxjs';
 import { MatTableDataSource } from '@angular/material/table';
-import { catchError, filter, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { catchError, filter, switchMap, tap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { OrgSettingAddTenantComponent, OrgSettingAddTenantDialogData } from './org-settings-add-tenant.component';
 
 import { TenantService } from '../../../services-ngx/tenant.service';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
-import { Tenant } from '../../../entities/tenant/tenant';
+import { Tenant, UpdateTenantEntity } from '../../../entities/tenant/tenant';
 import { gioTableFilterCollection } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 
@@ -35,31 +36,30 @@ import { SnackBarService } from '../../../services-ngx/snack-bar.service';
   styleUrls: ['./org-settings-tenants.component.scss'],
   standalone: false,
 })
-export class OrgSettingsTenantsComponent implements OnInit, OnDestroy {
-  displayedColumns: string[] = ['id', 'name', 'description', 'actions'];
+export class OrgSettingsTenantsComponent {
+  private readonly tenantService = inject(TenantService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly destroyRef = inject(DestroyRef);
+  private tenants: Tenant[] = [];
+
+  displayedColumns: string[] = ['key', 'name', 'description', 'actions'];
   tenantsDataSource: MatTableDataSource<Tenant> = new MatTableDataSource([]);
   tenantsTableUnpaginatedLength = 0;
 
-  private unsubscribe$ = new Subject<boolean>();
-  private tenants: Tenant[] = [];
-
-  constructor(
-    private readonly tenantService: TenantService,
-    private readonly matDialog: MatDialog,
-    private readonly snackBarService: SnackBarService,
-  ) {}
-
-  ngOnInit(): void {
-    this.tenantService.list().subscribe(tenants => {
-      this.tenants = tenants;
-      this.tenantsDataSource.data = tenants;
-      this.tenantsTableUnpaginatedLength = tenants.length;
-    });
+  constructor() {
+    this.loadTenants();
   }
 
-  ngOnDestroy() {
-    this.unsubscribe$.next(true);
-    this.unsubscribe$.unsubscribe();
+  private loadTenants(): void {
+    this.tenantService
+      .list()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(tenants => {
+        this.tenants = tenants;
+        this.tenantsDataSource.data = tenants;
+        this.tenantsTableUnpaginatedLength = tenants.length;
+      });
   }
 
   onAddTenantClicked(): void {
@@ -81,9 +81,9 @@ export class OrgSettingsTenantsComponent implements OnInit, OnDestroy {
           this.snackBarService.error(error.message);
           return EMPTY;
         }),
-        takeUntil(this.unsubscribe$),
+        takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe(() => this.ngOnInit());
+      .subscribe(() => this.loadTenants());
   }
 
   onDeleteTenantClicked(tenant: Tenant) {
@@ -101,11 +101,11 @@ export class OrgSettingsTenantsComponent implements OnInit, OnDestroy {
       .afterClosed()
       .pipe(
         filter(confirm => confirm === true),
-        switchMap(() => this.tenantService.delete(tenant.id)),
+        switchMap(() => this.tenantService.delete(tenant.key)),
         tap(() => this.snackBarService.success(`Tenant successfully deleted!`)),
-        takeUntil(this.unsubscribe$),
+        takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe(() => this.ngOnInit());
+      .subscribe(() => this.loadTenants());
   }
 
   onEditTenantClicked(tenant: Tenant) {
@@ -121,7 +121,7 @@ export class OrgSettingsTenantsComponent implements OnInit, OnDestroy {
       .afterClosed()
       .pipe(
         filter(result => !!result),
-        switchMap(updatedTenant => this.tenantService.update([updatedTenant])),
+        switchMap(tenant => this.tenantService.update([this.toUpdateTenantEntity(tenant)])),
         tap(() => {
           this.snackBarService.success('Tenant successfully updated!');
         }),
@@ -129,14 +129,22 @@ export class OrgSettingsTenantsComponent implements OnInit, OnDestroy {
           this.snackBarService.error(error.message);
           return EMPTY;
         }),
-        takeUntil(this.unsubscribe$),
+        takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe(() => this.ngOnInit());
+      .subscribe(() => this.loadTenants());
   }
 
   onFiltersChanged(filters: GioTableWrapperFilters) {
     const filtered = gioTableFilterCollection(this.tenants, filters);
     this.tenantsDataSource.data = filtered.filteredCollection;
     this.tenantsTableUnpaginatedLength = filtered.unpaginatedLength;
+  }
+
+  private toUpdateTenantEntity(tenant: Tenant): UpdateTenantEntity {
+    return {
+      name: tenant.name,
+      key: tenant.key,
+      description: tenant.description,
+    };
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/tenant.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/tenant.service.spec.ts
@@ -19,7 +19,7 @@ import { TestBed } from '@angular/core/testing';
 import { TenantService } from './tenant.service';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
-import { fakeTenant } from '../entities/tenant/tenant.fixture';
+import { fakeTenant, fakeUpdateTenantEntity } from '../entities/tenant/tenant.fixture';
 import { fakeNewTenant } from '../entities/tenant/newTenant.fixture';
 
 describe('TenantService', () => {
@@ -66,7 +66,7 @@ describe('TenantService', () => {
 
   describe('update', () => {
     it('should call the API', done => {
-      const tenants = [fakeTenant()];
+      const tenants = [fakeUpdateTenantEntity()];
 
       tenantService.update(tenants).subscribe(response => {
         expect(response).toStrictEqual(tenants);

--- a/gravitee-apim-console-webui/src/services-ngx/tenant.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/tenant.service.ts
@@ -18,7 +18,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { Tenant } from '../entities/tenant/tenant';
+import { Tenant, UpdateTenantEntity } from '../entities/tenant/tenant';
 import { NewTenant } from '../entities/tenant/newTenant';
 
 @Injectable({
@@ -38,7 +38,7 @@ export class TenantService {
     return this.http.post<Tenant[]>(`${this.constants.org.baseURL}/configuration/tenants`, tenants);
   }
 
-  update(tenants: Tenant[]): Observable<Tenant[]> {
+  update(tenants: UpdateTenantEntity[]): Observable<Tenant[]> {
     return this.http.put<Tenant[]>(`${this.constants.org.baseURL}/configuration/tenants`, tenants);
   }
 

--- a/gravitee-apim-console-webui/src/shared/utils/key-sanitizer.util.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/key-sanitizer.util.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { sanitizeKeyBase, sanitizeKeyFinal } from './key-sanitizer.util';
+
+describe('Key Sanitizer Utils', () => {
+  describe('sanitizeKeyBase', () => {
+    it.each`
+      input                                | expected
+      ${'My Tag Key'}                      | ${'my-tag-key'}
+      ${'Tâg Spécîal @#$ Nàme!'}           | ${'tag-special-name'}
+      ${'Tag   With    Multiple---Spaces'} | ${'tag-with-multiple-spaces'}
+      ${'UPPERCASE KEY'}                   | ${'uppercase-key'}
+      ${'Key 123 Value 456'}               | ${'key-123-value-456'}
+      ${'eu east 1! @#$%'}                 | ${'eu-east-1'}
+      ${'café'}                            | ${'cafe'}
+      ${'  spaces-around  '}               | ${'spaces-around'}
+    `('should sanitize "$input" to "$expected"', ({ input, expected }) => {
+      expect(sanitizeKeyBase(input)).toBe(expected);
+    });
+  });
+
+  describe('sanitizeKeyFinal', () => {
+    it.each`
+      input                    | expected
+      ${'My Tag Key'}          | ${'my-tag-key'}
+      ${'Tag Key-'}            | ${'tag-key'}
+      ${'UPPERCASE KEY'}       | ${'uppercase-key'}
+      ${'Key 123 Value 456'}   | ${'key-123-value-456'}
+      ${'eu east 1! @#$%'}     | ${'eu-east-1'}
+      ${'trailing-hyphens---'} | ${'trailing-hyphens'}
+    `('should sanitize "$input" to "$expected"', ({ input, expected }) => {
+      expect(sanitizeKeyFinal(input)).toBe(expected);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/shared/utils/key-sanitizer.util.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/key-sanitizer.util.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Normalizes user input to produce a valid tag key that meets backend requirements
+ * (alphanumeric with hyphens only, no diacritics or special characters).
+ */
+export function sanitizeKeyBase(key: string): string {
+  return key
+    .normalize('NFD')
+    .replaceAll(/[\u0300-\u036f]+/g, '')
+    .toLowerCase()
+    .replaceAll(/[^a-z\d\s-]/g, '')
+    .trim()
+    .replaceAll(/[^a-z\d]+/g, '-');
+}
+
+/**
+ * Finalizes key sanitization by removing trailing hyphens.
+ * This should be called on blur to ensure the key meets backend requirements.
+ */
+export function sanitizeKeyFinal(key: string): string {
+  let sanitized = sanitizeKeyBase(key);
+  while (sanitized.endsWith('-')) {
+    sanitized = sanitized.slice(0, -1);
+  }
+  return sanitized;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-4023

## Description

## 🎯 Feature: Add tenant key management with unique identifiers

### 📝 Summary

This PR implements the ability to define both a **name** and a **key** for tenant tags in the API Management Console. Previously, tenant names were used as IDs, which caused conflicts when multiple tenants wanted to use the same key. Now, each tenant has a unique UUID-based ID, allowing different tenants to safely use the same key without conflicts.

This PR contains only the frontend part and as the backend is already handled in the target branch.

### 🔄 Changes

#### 1. Tenant Entity & Service Updates
- **Added `key` attribute** to `Tenant` entity alongside existing `id`, `name`, and `description`
- Updated `TenantService` to handle the new key attribute

#### 2. Organization Settings - Tenant Management
- **Enhanced tenant creation/edit form** with a new `key` input field
- **Key field is disabled** when editing existing tenants (immutable after creation)
- Updated tenant list to display keys

#### 3. API Endpoints Configuration (V4 & V2)
  - Updated `api-endpoint.component.html` and `api-proxy-group-endpoint-edit-general.component.html`  to use `tenant.key` instead of `tenant.id` in dropdown selection
  - Updated `api-endpoint-groups-standard.adapter.ts` to map tenant keys to names for display
  - Migrated to **Angular control flow syntax** (`@for` instead of `*ngFor`)

---

## Additional context

https://github.com/user-attachments/assets/42773da3-c009-4542-aa9b-6fe643a61bea

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

