### PR TITLE
feat: remove restriction step from API Product plan creation flow

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
@@ -34,6 +34,7 @@
         [isFederated]="false"
         [isNative]="false"
         [hideAccessControl]="true"
+        [showRestrictionStep]="false"
         [planMenuItem]="planMenuItem()!"
         [planStatus]="currentPlanStatus()"
       ></api-plan-form>

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -153,6 +153,12 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
 
   @Input({ required: true }) isTcpApi!: boolean;
 
+  /**
+   * When set, overrides the default restriction step visibility (e.g. use false to hide for API Product).
+   * When undefined, restriction step is shown in create mode for non-TCP, non-native APIs.
+   */
+  @Input() showRestrictionStep?: boolean;
+
   public isInit = false;
 
   public planForm = new UntypedFormGroup({});
@@ -215,7 +221,8 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
     this.ngControl.control.setValidators(this.validate.bind(this));
     this.ngControl.control.updateValueAndValidity();
 
-    this.displayRestrictionStep = this.mode === 'create' && !this.isTcpApi && !this.isNative;
+    this.displayRestrictionStep =
+      this.showRestrictionStep !== undefined ? this.showRestrictionStep : this.mode === 'create' && !this.isTcpApi && !this.isNative;
     this.displaySecurityStep =
       !this.isFederated &&
       !['KEY_LESS', 'PUSH'].includes(this.planMenuItem.planFormType) &&


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13060

## Description

**Summary of changes:**

**1. api-plan-form.component.ts**

- Added optional input:
   @Input() showRestrictionStep?: boolean
- Restriction step visibility:
   - If showRestrictionStep is set (true/false), that value is used.
   - If it’s not set, existing behavior is kept: step is shown in create mode when not TCP and not native.

**2. api-product-plan-edit.component.html**
Set [showRestrictionStep]="false" on <api-plan-form> so the Restriction step is hidden for API Product plans.


https://github.com/user-attachments/assets/dd7dc605-ae5b-46f1-9407-cdeb43158efc



