### PR TITLE
feat(kafka-explorer): UX improvements - sort, pagination and inline message detail

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
@@ -26,10 +26,18 @@ import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
 
 public interface KafkaClusterDomainService {
     KafkaClusterInfo describeCluster(KafkaClusterConfiguration config);
-    TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage);
+    TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage, String sortBy, String sortOrder);
     TopicDetail describeTopic(KafkaClusterConfiguration config, String topicName);
     BrokerInfo describeBroker(KafkaClusterConfiguration config, int brokerId);
-    ConsumerGroupsPage listConsumerGroups(KafkaClusterConfiguration config, String nameFilter, String topicFilter, int page, int perPage);
+    ConsumerGroupsPage listConsumerGroups(
+        KafkaClusterConfiguration config,
+        String nameFilter,
+        String topicFilter,
+        int page,
+        int perPage,
+        String sortBy,
+        String sortOrder
+    );
     ConsumerGroupDetail describeConsumerGroup(KafkaClusterConfiguration config, String groupId);
     BrowseMessagesResult browseMessages(
         KafkaClusterConfiguration config,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCase.java
@@ -46,12 +46,23 @@ public class ListConsumerGroupsUseCase {
             input.nameFilter(),
             input.topicFilter(),
             input.page(),
-            input.perPage()
+            input.perPage(),
+            input.sortBy(),
+            input.sortOrder()
         );
         return new Output(consumerGroupsPage);
     }
 
-    public record Input(String clusterId, String environmentId, String nameFilter, String topicFilter, int page, int perPage) {}
+    public record Input(
+        String clusterId,
+        String environmentId,
+        String nameFilter,
+        String topicFilter,
+        int page,
+        int perPage,
+        String sortBy,
+        String sortOrder
+    ) {}
 
     public record Output(ConsumerGroupsPage consumerGroupsPage) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListTopicsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListTopicsUseCase.java
@@ -41,11 +41,26 @@ public class ListTopicsUseCase {
     public Output execute(Input input) {
         var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
         var config = cluster.getKafkaClusterConfiguration(objectMapper);
-        var topicsPage = kafkaClusterDomainService.listTopics(config, input.nameFilter(), input.page(), input.perPage());
+        var topicsPage = kafkaClusterDomainService.listTopics(
+            config,
+            input.nameFilter(),
+            input.page(),
+            input.perPage(),
+            input.sortBy(),
+            input.sortOrder()
+        );
         return new Output(topicsPage);
     }
 
-    public record Input(String clusterId, String environmentId, String nameFilter, int page, int perPage) {}
+    public record Input(
+        String clusterId,
+        String environmentId,
+        String nameFilter,
+        int page,
+        int perPage,
+        String sortBy,
+        String sortOrder
+    ) {}
 
     public record Output(TopicsPage topicsPage) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
@@ -131,7 +131,14 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
     }
 
     @Override
-    public TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage) {
+    public TopicsPage listTopics(
+        KafkaClusterConfiguration config,
+        String nameFilter,
+        int page,
+        int perPage,
+        String sortBy,
+        String sortOrder
+    ) {
         return withAdminClient(config, adminClient -> {
             // Step 1: List all topics (cheap call)
             Collection<TopicListing> listings = adminClient
@@ -148,12 +155,15 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
                 return new TopicsPage(List.of(), 0, page, perPage);
             }
 
-            // Step 2: Filter by nameFilter (case-insensitive contains)
+            // Step 2: Filter by nameFilter (case-insensitive contains) and sort
+            Comparator<String> nameComparator = "desc".equalsIgnoreCase(sortOrder)
+                ? Comparator.<String>naturalOrder().reversed()
+                : Comparator.naturalOrder();
             List<String> filteredNames = internalFlags
                 .keySet()
                 .stream()
                 .filter(name -> nameFilter == null || nameFilter.isBlank() || name.toLowerCase().contains(nameFilter.toLowerCase()))
-                .sorted()
+                .sorted(nameComparator)
                 .toList();
 
             int totalCount = filteredNames.size();
@@ -348,7 +358,9 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
         String nameFilter,
         String topicFilter,
         int page,
-        int perPage
+        int perPage,
+        String sortBy,
+        String sortOrder
     ) {
         return withAdminClient(config, adminClient -> {
             boolean hasTopicFilter = topicFilter != null && !topicFilter.isBlank();
@@ -356,12 +368,15 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
             // Step 1: List all consumer groups
             Collection<ConsumerGroupListing> listings = adminClient.listConsumerGroups().all().get(GET_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-            // Step 2: Filter by name
+            // Step 2: Filter by name and sort
+            Comparator<String> groupIdComparator = "desc".equalsIgnoreCase(sortOrder)
+                ? Comparator.<String>naturalOrder().reversed()
+                : Comparator.naturalOrder();
             List<String> filteredGroupIds = listings
                 .stream()
                 .map(ConsumerGroupListing::groupId)
                 .filter(id -> nameFilter == null || nameFilter.isBlank() || id.toLowerCase().contains(nameFilter.toLowerCase()))
-                .sorted()
+                .sorted(groupIdComparator)
                 .toList();
 
             // Step 3: Filter by topic — fetch only the target topic's partition offsets, then filter in-memory

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResource.java
@@ -126,7 +126,9 @@ public class KafkaExplorerResource {
     public Response listTopics(
         ListTopicsRequest request,
         @QueryParam("page") @DefaultValue("1") int page,
-        @QueryParam("perPage") @DefaultValue("10") int perPage
+        @QueryParam("perPage") @DefaultValue("10") int perPage,
+        @QueryParam("sortBy") @DefaultValue("name") String sortBy,
+        @QueryParam("sortOrder") @DefaultValue("asc") String sortOrder
     ) {
         if (request == null || request.getClusterId() == null || request.getClusterId().isBlank()) {
             return Response.status(Response.Status.BAD_REQUEST)
@@ -154,7 +156,15 @@ public class KafkaExplorerResource {
             var environmentId = GraviteeContext.getExecutionContext().getEnvironmentId();
             int page0Based = page - 1;
             var result = listTopicsUseCase.execute(
-                new ListTopicsUseCase.Input(request.getClusterId(), environmentId, request.getNameFilter(), page0Based, perPage)
+                new ListTopicsUseCase.Input(
+                    request.getClusterId(),
+                    environmentId,
+                    request.getNameFilter(),
+                    page0Based,
+                    perPage,
+                    sortBy,
+                    sortOrder
+                )
             );
             return Response.ok(KafkaExplorerMapper.INSTANCE.map(result.topicsPage(), page, perPage)).build();
         } catch (KafkaExplorerException e) {
@@ -237,7 +247,9 @@ public class KafkaExplorerResource {
     public Response listConsumerGroups(
         ListConsumerGroupsRequest request,
         @QueryParam("page") @DefaultValue("1") int page,
-        @QueryParam("perPage") @DefaultValue("25") int perPage
+        @QueryParam("perPage") @DefaultValue("25") int perPage,
+        @QueryParam("sortBy") @DefaultValue("groupId") String sortBy,
+        @QueryParam("sortOrder") @DefaultValue("asc") String sortOrder
     ) {
         if (request == null || request.getClusterId() == null || request.getClusterId().isBlank()) {
             return Response.status(Response.Status.BAD_REQUEST)
@@ -271,7 +283,9 @@ public class KafkaExplorerResource {
                     request.getNameFilter(),
                     request.getTopicFilter(),
                     page0Based,
-                    perPage
+                    perPage,
+                    sortBy,
+                    sortOrder
                 )
             );
             return Response.ok(KafkaExplorerMapper.INSTANCE.map(result.consumerGroupsPage(), page, perPage)).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/resources/openapi/openapi-kafka-explorer.yaml
@@ -70,6 +70,21 @@ paths:
                       type: integer
                       default: 10
                   description: Number of topics per page
+                - name: sortBy
+                  in: query
+                  schema:
+                      type: string
+                      default: name
+                  description: Field to sort by (name)
+                - name: sortOrder
+                  in: query
+                  schema:
+                      type: string
+                      enum:
+                          - asc
+                          - desc
+                      default: asc
+                  description: Sort direction
             requestBody:
                 required: true
                 content:
@@ -185,6 +200,21 @@ paths:
                       type: integer
                       default: 10
                   description: Number of consumer groups per page
+                - name: sortBy
+                  in: query
+                  schema:
+                      type: string
+                      default: groupId
+                  description: Field to sort by (groupId)
+                - name: sortOrder
+                  in: query
+                  schema:
+                      type: string
+                      enum:
+                          - asc
+                          - desc
+                      default: asc
+                  description: Sort direction
             requestBody:
                 required: true
                 content:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCaseTest.java
@@ -63,7 +63,7 @@ class ListConsumerGroupsUseCaseTest {
         );
         clusterDomainService.givenConsumerGroups(allGroups);
 
-        var result = useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, null, 0, 25));
+        var result = useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, null, 0, 25, "groupId", "asc"));
 
         assertThat(result.consumerGroupsPage().data()).hasSize(2);
         assertThat(result.consumerGroupsPage().totalCount()).isEqualTo(2);
@@ -84,7 +84,7 @@ class ListConsumerGroupsUseCaseTest {
         );
         clusterDomainService.givenConsumerGroups(allGroups);
 
-        var result = useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my", null, 0, 25));
+        var result = useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my", null, 0, 25, "groupId", "asc"));
 
         assertThat(result.consumerGroupsPage().data()).hasSize(2);
         assertThat(result.consumerGroupsPage().data().get(0).groupId()).isEqualTo("my-group");
@@ -99,7 +99,9 @@ class ListConsumerGroupsUseCaseTest {
 
         clusterDomainService.givenException(new KafkaExplorerException("Connection failed", TechnicalCode.CONNECTION_FAILED));
 
-        assertThatThrownBy(() -> useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, null, 0, 25)))
+        assertThatThrownBy(() ->
+            useCase.execute(new ListConsumerGroupsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, null, 0, 25, "groupId", "asc"))
+        )
             .isInstanceOf(KafkaExplorerException.class)
             .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.CONNECTION_FAILED));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListTopicsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListTopicsUseCaseTest.java
@@ -61,7 +61,7 @@ class ListTopicsUseCaseTest {
         );
         clusterDomainService.givenTopics(allTopics);
 
-        var result = useCase.execute(new ListTopicsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, 0, 25));
+        var result = useCase.execute(new ListTopicsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, 0, 25, "name", "asc"));
 
         assertThat(result.topicsPage().data()).hasSize(2);
         assertThat(result.topicsPage().totalCount()).isEqualTo(2);
@@ -81,7 +81,7 @@ class ListTopicsUseCaseTest {
         );
         clusterDomainService.givenTopics(allTopics);
 
-        var result = useCase.execute(new ListTopicsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my", 0, 25));
+        var result = useCase.execute(new ListTopicsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, "my", 0, 25, "name", "asc"));
 
         assertThat(result.topicsPage().data()).hasSize(1);
         assertThat(result.topicsPage().data().get(0).name()).isEqualTo("my-topic");
@@ -95,7 +95,7 @@ class ListTopicsUseCaseTest {
 
         clusterDomainService.givenException(new KafkaExplorerException("Connection failed", TechnicalCode.CONNECTION_FAILED));
 
-        assertThatThrownBy(() -> useCase.execute(new ListTopicsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, 0, 25)))
+        assertThatThrownBy(() -> useCase.execute(new ListTopicsUseCase.Input(CLUSTER_ID, ENVIRONMENT_ID, null, 0, 25, "name", "asc")))
             .isInstanceOf(KafkaExplorerException.class)
             .satisfies(e -> assertThat(((KafkaExplorerException) e).getTechnicalCode()).isEqualTo(TechnicalCode.CONNECTION_FAILED));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
@@ -97,15 +97,26 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
     }
 
     @Override
-    public TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage) {
+    public TopicsPage listTopics(
+        KafkaClusterConfiguration config,
+        String nameFilter,
+        int page,
+        int perPage,
+        String sortBy,
+        String sortOrder
+    ) {
         if (exception != null) {
             throw exception;
         }
 
+        Comparator<KafkaTopic> comparator = Comparator.comparing(KafkaTopic::name);
+        if ("desc".equalsIgnoreCase(sortOrder)) {
+            comparator = comparator.reversed();
+        }
         List<KafkaTopic> filtered = topics
             .stream()
             .filter(t -> nameFilter == null || nameFilter.isBlank() || t.name().toLowerCase().contains(nameFilter.toLowerCase()))
-            .sorted(Comparator.comparing(KafkaTopic::name))
+            .sorted(comparator)
             .toList();
 
         int totalCount = filtered.size();
@@ -137,16 +148,22 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
         String nameFilter,
         String topicFilter,
         int page,
-        int perPage
+        int perPage,
+        String sortBy,
+        String sortOrder
     ) {
         if (exception != null) {
             throw exception;
         }
 
+        Comparator<ConsumerGroup> comparator = Comparator.comparing(ConsumerGroup::groupId);
+        if ("desc".equalsIgnoreCase(sortOrder)) {
+            comparator = comparator.reversed();
+        }
         List<ConsumerGroup> filtered = consumerGroups
             .stream()
             .filter(g -> nameFilter == null || nameFilter.isBlank() || g.groupId().toLowerCase().contains(nameFilter.toLowerCase()))
-            .sorted(Comparator.comparing(ConsumerGroup::groupId))
+            .sorted(comparator)
             .toList();
 
         int totalCount = filtered.size();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_ListConsumerGroups.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_ListConsumerGroups.java
@@ -58,7 +58,7 @@ class KafkaExplorerResourceIntegrationTest_ListConsumerGroups extends AbstractKa
 
         var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID);
 
-        var response = resource.listConsumerGroups(request, 1, 10);
+        var response = resource.listConsumerGroups(request, 1, 10, "groupId", "asc");
 
         assertThat(response.getStatus()).isEqualTo(200);
         var body = (ListConsumerGroupsResponse) response.getEntity();
@@ -76,7 +76,7 @@ class KafkaExplorerResourceIntegrationTest_ListConsumerGroups extends AbstractKa
 
         var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID).nameFilter(CONSUMER_GROUP_ID);
 
-        var response = resource.listConsumerGroups(request, 1, 10);
+        var response = resource.listConsumerGroups(request, 1, 10, "groupId", "asc");
 
         assertThat(response.getStatus()).isEqualTo(200);
         var body = (ListConsumerGroupsResponse) response.getEntity();
@@ -90,7 +90,7 @@ class KafkaExplorerResourceIntegrationTest_ListConsumerGroups extends AbstractKa
 
         var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID).topicFilter("__consumer_offsets");
 
-        var response = resource.listConsumerGroups(request, 1, 10);
+        var response = resource.listConsumerGroups(request, 1, 10, "groupId", "asc");
 
         assertThat(response.getStatus()).isEqualTo(200);
         var body = (ListConsumerGroupsResponse) response.getEntity();
@@ -104,7 +104,7 @@ class KafkaExplorerResourceIntegrationTest_ListConsumerGroups extends AbstractKa
 
         var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID).topicFilter("non-existent-topic-xyz");
 
-        var response = resource.listConsumerGroups(request, 1, 10);
+        var response = resource.listConsumerGroups(request, 1, 10, "groupId", "asc");
 
         assertThat(response.getStatus()).isEqualTo(200);
         var body = (ListConsumerGroupsResponse) response.getEntity();
@@ -113,7 +113,7 @@ class KafkaExplorerResourceIntegrationTest_ListConsumerGroups extends AbstractKa
 
     @Test
     void should_return_400_when_request_is_null() {
-        var response = resource.listConsumerGroups(null, 1, 10);
+        var response = resource.listConsumerGroups(null, 1, 10, "groupId", "asc");
 
         assertThat(response.getStatus()).isEqualTo(400);
         var error = (KafkaExplorerError) response.getEntity();
@@ -126,7 +126,7 @@ class KafkaExplorerResourceIntegrationTest_ListConsumerGroups extends AbstractKa
 
         var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID);
 
-        var response = resource.listConsumerGroups(request, 0, 10);
+        var response = resource.listConsumerGroups(request, 0, 10, "groupId", "asc");
 
         assertThat(response.getStatus()).isEqualTo(400);
         var error = (KafkaExplorerError) response.getEntity();
@@ -139,7 +139,7 @@ class KafkaExplorerResourceIntegrationTest_ListConsumerGroups extends AbstractKa
 
         var request = new ListConsumerGroupsRequest().clusterId(CLUSTER_ID);
 
-        var response = resource.listConsumerGroups(request, 1, 10);
+        var response = resource.listConsumerGroups(request, 1, 10, "groupId", "asc");
 
         assertThat(response.getStatus()).isEqualTo(502);
         var error = (KafkaExplorerError) response.getEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_ListTopics.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/KafkaExplorerResourceIntegrationTest_ListTopics.java
@@ -67,7 +67,7 @@ class KafkaExplorerResourceIntegrationTest_ListTopics extends AbstractKafkaExplo
 
         var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
 
-        var response = resource.listTopics(request, 1, 10);
+        var response = resource.listTopics(request, 1, 10, "name", "asc");
 
         assertThat(response.getStatus()).isEqualTo(200);
         var body = (ListTopicsResponse) response.getEntity();
@@ -88,7 +88,7 @@ class KafkaExplorerResourceIntegrationTest_ListTopics extends AbstractKafkaExplo
 
         var request = new ListTopicsRequest().clusterId(CLUSTER_ID).nameFilter(TEST_TOPIC);
 
-        var response = resource.listTopics(request, 1, 10);
+        var response = resource.listTopics(request, 1, 10, "name", "asc");
 
         assertThat(response.getStatus()).isEqualTo(200);
         var body = (ListTopicsResponse) response.getEntity();
@@ -105,7 +105,7 @@ class KafkaExplorerResourceIntegrationTest_ListTopics extends AbstractKafkaExplo
 
     @Test
     void should_return_400_when_request_is_null() {
-        var response = resource.listTopics(null, 1, 10);
+        var response = resource.listTopics(null, 1, 10, "name", "asc");
 
         assertThat(response.getStatus()).isEqualTo(400);
         var error = (KafkaExplorerError) response.getEntity();
@@ -118,7 +118,7 @@ class KafkaExplorerResourceIntegrationTest_ListTopics extends AbstractKafkaExplo
 
         var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
 
-        var response = resource.listTopics(request, 0, 10);
+        var response = resource.listTopics(request, 0, 10, "name", "asc");
 
         assertThat(response.getStatus()).isEqualTo(400);
         var error = (KafkaExplorerError) response.getEntity();
@@ -131,7 +131,7 @@ class KafkaExplorerResourceIntegrationTest_ListTopics extends AbstractKafkaExplo
 
         var request = new ListTopicsRequest().clusterId(CLUSTER_ID);
 
-        var response = resource.listTopics(request, 1, 10);
+        var response = resource.listTopics(request, 1, 10, "name", "asc");
 
         assertThat(response.getStatus()).isEqualTo(502);
         var error = (KafkaExplorerError) response.getEntity();

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/components/data-table/data-table.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/components/data-table/data-table.component.html
@@ -1,0 +1,45 @@
+<!--
+
+    Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="data-table">
+  @if (filterable()) {
+    <mat-form-field appearance="outline" class="data-table__filter">
+      <mat-icon matPrefix>search</mat-icon>
+      <input matInput (input)="onFilterChange($event)" [placeholder]="filterPlaceholder()" />
+    </mat-form-field>
+  }
+
+  @if (loading()) {
+    <mat-progress-bar mode="indeterminate" />
+  }
+
+  <ng-content />
+
+  @if (empty() && !loading()) {
+    <div class="data-table__empty">{{ emptyMessage() }}</div>
+  }
+
+  @if (paginated()) {
+    <mat-paginator
+      [length]="totalElements()"
+      [pageIndex]="page()"
+      [pageSize]="pageSize()"
+      [pageSizeOptions]="pageSizeOptions()"
+      (page)="pageChange.emit({ page: $event.pageIndex, pageSize: $event.pageSize })"
+    />
+  }
+</div>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/components/data-table/data-table.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/components/data-table/data-table.component.scss
@@ -14,40 +14,18 @@
  * limitations under the License.
  */
 
-.topic-detail {
+.data-table {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 8px;
 
-  &__header {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  &__title {
-    margin: 0;
-  }
-
-  &__spacer {
-    flex: 1;
-  }
-
-  &__browse-btn {
-    mat-icon {
-      margin-right: 4px;
-    }
-  }
-
-  mat-card-content {
-    overflow-x: auto;
-  }
-
-  &__link {
-    cursor: pointer;
-  }
-
-  table {
+  &__filter {
     width: 100%;
+  }
+
+  &__empty {
+    text-align: center;
+    padding: 32px;
+    color: var(--mat-sys-on-surface-variant);
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/components/data-table/data-table.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/components/data-table/data-table.component.spec.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { DataTableComponent } from './data-table.component';
+import { DataTableHarness } from './data-table.harness';
+
+@Component({
+  selector: 'gke-test-host',
+  standalone: true,
+  imports: [DataTableComponent],
+  template: `
+    <gke-data-table
+      [filterable]="filterable()"
+      [filterPlaceholder]="filterPlaceholder()"
+      [loading]="loading()"
+      [empty]="empty()"
+      [emptyMessage]="emptyMessage()"
+      [paginated]="paginated()"
+      [totalElements]="totalElements()"
+      [page]="page()"
+      [pageSize]="pageSize()"
+      (filterChange)="lastFilter = $event"
+      (pageChange)="lastPage = $event"
+    >
+      <p class="projected-content">Table goes here</p>
+    </gke-data-table>
+  `,
+})
+class TestHostComponent {
+  filterable = input(false);
+  filterPlaceholder = input('Filter...');
+  loading = input(false);
+  empty = input(false);
+  emptyMessage = input('No data available');
+  paginated = input(false);
+  totalElements = input(0);
+  page = input(0);
+  pageSize = input(25);
+
+  lastFilter = '';
+  lastPage: { page: number; pageSize: number } | null = null;
+}
+
+describe('DataTableComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  it('should project content via ng-content', () => {
+    const el = fixture.nativeElement.querySelector('.projected-content');
+    expect(el.textContent).toContain('Table goes here');
+  });
+
+  it('should not show filter by default', async () => {
+    const harness = await loader.getHarness(DataTableHarness);
+    expect(await harness.hasFilter()).toBe(false);
+  });
+
+  it('should show filter when filterable is true', async () => {
+    fixture.componentRef.setInput('filterable', true);
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(DataTableHarness);
+    expect(await harness.hasFilter()).toBe(true);
+  });
+
+  it('should emit filterChange on input', async () => {
+    fixture.componentRef.setInput('filterable', true);
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(DataTableHarness);
+    await harness.setFilter('test');
+
+    expect(fixture.componentInstance.lastFilter).toBe('test');
+  });
+
+  it('should not show progress bar when not loading', async () => {
+    const harness = await loader.getHarness(DataTableHarness);
+    expect(await harness.isLoading()).toBe(false);
+  });
+
+  it('should show progress bar when loading', async () => {
+    fixture.componentRef.setInput('loading', true);
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(DataTableHarness);
+    expect(await harness.isLoading()).toBe(true);
+  });
+
+  it('should show empty message when empty and not loading', async () => {
+    fixture.componentRef.setInput('empty', true);
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(DataTableHarness);
+    expect(await harness.getEmptyText()).toBe('No data available');
+  });
+
+  it('should not show empty message when loading', async () => {
+    fixture.componentRef.setInput('empty', true);
+    fixture.componentRef.setInput('loading', true);
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(DataTableHarness);
+    expect(await harness.getEmptyText()).toBeNull();
+  });
+
+  it('should show custom empty message', async () => {
+    fixture.componentRef.setInput('empty', true);
+    fixture.componentRef.setInput('emptyMessage', 'Nothing here');
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(DataTableHarness);
+    expect(await harness.getEmptyText()).toBe('Nothing here');
+  });
+
+  it('should not show paginator by default', async () => {
+    const harness = await loader.getHarness(DataTableHarness);
+    expect(await harness.hasPaginator()).toBe(false);
+  });
+
+  it('should show paginator when paginated is true', async () => {
+    fixture.componentRef.setInput('paginated', true);
+    fixture.componentRef.setInput('totalElements', 100);
+    fixture.detectChanges();
+
+    const harness = await loader.getHarness(DataTableHarness);
+    expect(await harness.hasPaginator()).toBe(true);
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/components/data-table/data-table.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/components/data-table/data-table.component.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+
+@Component({
+  selector: 'gke-data-table',
+  standalone: true,
+  imports: [MatFormFieldModule, MatIconModule, MatInputModule, MatPaginatorModule, MatProgressBarModule],
+  templateUrl: './data-table.component.html',
+  styleUrls: ['./data-table.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DataTableComponent {
+  filterable = input(false);
+  filterPlaceholder = input('Filter...');
+  filterChange = output<string>();
+
+  loading = input(false);
+
+  empty = input(false);
+  emptyMessage = input('No data available');
+
+  paginated = input(false);
+  totalElements = input(0);
+  page = input(0);
+  pageSize = input(25);
+  pageSizeOptions = input([10, 25, 50, 100]);
+  pageChange = output<{ page: number; pageSize: number }>();
+
+  onFilterChange(event: Event) {
+    this.filterChange.emit((event.target as HTMLInputElement).value);
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/components/data-table/data-table.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/components/data-table/data-table.harness.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BaseHarnessFilters, ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatPaginatorHarness } from '@angular/material/paginator/testing';
+import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
+
+export class DataTableHarness extends ComponentHarness {
+  static hostSelector = 'gke-data-table';
+
+  private readonly getFilterInput = this.locatorForOptional(MatInputHarness);
+  private readonly getPaginator = this.locatorForOptional(MatPaginatorHarness);
+  private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
+  private readonly getEmptyMessage = this.locatorForOptional('.data-table__empty');
+
+  static with(options: BaseHarnessFilters = {}): HarnessPredicate<DataTableHarness> {
+    return new HarnessPredicate(DataTableHarness, options);
+  }
+
+  async isLoading() {
+    return (await this.getProgressBar()) !== null;
+  }
+
+  async getEmptyText() {
+    const el = await this.getEmptyMessage();
+    return el ? el.text() : null;
+  }
+
+  async hasFilter() {
+    return (await this.getFilterInput()) !== null;
+  }
+
+  async setFilter(value: string) {
+    const input = await this.getFilterInput();
+    if (!input) throw new Error('Filter input not found');
+    await input.setValue(value);
+  }
+
+  async hasPaginator() {
+    return (await this.getPaginator()) !== null;
+  }
+
+  async getPaginatorHarness() {
+    return this.getPaginator();
+  }
+
+  async getRangeLabel() {
+    const paginator = await this.getPaginator();
+    if (!paginator) throw new Error('Paginator not found');
+    return paginator.getRangeLabel();
+  }
+
+  async goToNextPage() {
+    const paginator = await this.getPaginator();
+    if (!paginator) throw new Error('Paginator not found');
+    await paginator.goToNextPage();
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/broker-detail/broker-detail.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/broker-detail/broker-detail.component.html
@@ -42,39 +42,53 @@
         <mat-card-title>Log Directories</mat-card-title>
       </mat-card-header>
       <mat-card-content>
-        @if (detail.logDirEntries.length === 0) {
-          <p class="broker-detail__empty-message">Log dir data not available</p>
-        } @else {
-          <table id="log-dir-table" mat-table [dataSource]="detail.logDirEntries">
+        <gke-data-table
+          [empty]="detail.logDirEntries.length === 0"
+          emptyMessage="Log dir data not available"
+          [paginated]="true"
+          [totalElements]="logDirSortedData().length"
+          [page]="logDirPage()"
+          [pageSize]="logDirPageSize()"
+          (pageChange)="logDirPage.set($event.page); logDirPageSize.set($event.pageSize)"
+        >
+          <table
+            id="log-dir-table"
+            mat-table
+            [dataSource]="logDirPaginatedData()"
+            matSort
+            [matSortActive]="logDirSortActive()"
+            [matSortDirection]="logDirSortDirection()"
+            (matSortChange)="onLogDirSortChange($event)"
+          >
             <ng-container matColumnDef="path">
-              <th mat-header-cell *matHeaderCellDef>Path</th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Path</th>
               <td mat-cell *matCellDef="let e">{{ e.path }}</td>
             </ng-container>
 
             <ng-container matColumnDef="error">
-              <th mat-header-cell *matHeaderCellDef>Error</th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Error</th>
               <td mat-cell *matCellDef="let e">{{ e.error ?? '—' }}</td>
             </ng-container>
 
             <ng-container matColumnDef="topics">
-              <th mat-header-cell *matHeaderCellDef>Topics</th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Topics</th>
               <td mat-cell *matCellDef="let e">{{ e.topics }}</td>
             </ng-container>
 
             <ng-container matColumnDef="partitions">
-              <th mat-header-cell *matHeaderCellDef>Partitions</th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Partitions</th>
               <td mat-cell *matCellDef="let e">{{ e.partitions }}</td>
             </ng-container>
 
             <ng-container matColumnDef="size">
-              <th mat-header-cell *matHeaderCellDef>Size</th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Size</th>
               <td mat-cell *matCellDef="let e">{{ e.size | gkeFileSize }}</td>
             </ng-container>
 
             <tr mat-header-row *matHeaderRowDef="logDirColumns"></tr>
             <tr mat-row *matRowDef="let row; columns: logDirColumns"></tr>
           </table>
-        }
+        </gke-data-table>
       </mat-card-content>
     </mat-card>
 
@@ -83,35 +97,56 @@
         <mat-card-title>Configuration</mat-card-title>
       </mat-card-header>
       <mat-card-content>
-        <table id="config-table" mat-table [dataSource]="detail.configs">
-          <ng-container matColumnDef="name">
-            <th mat-header-cell *matHeaderCellDef>Name</th>
-            <td mat-cell *matCellDef="let c">{{ c.name }}</td>
-          </ng-container>
+        <gke-data-table
+          [filterable]="true"
+          filterPlaceholder="Search configuration..."
+          [empty]="configsEmpty()"
+          emptyMessage="No configuration found"
+          (filterChange)="onConfigFilter($event)"
+          [paginated]="true"
+          [totalElements]="configSortedData().length"
+          [page]="configPage()"
+          [pageSize]="configPageSize()"
+          (pageChange)="configPage.set($event.page); configPageSize.set($event.pageSize)"
+        >
+          <table
+            id="config-table"
+            mat-table
+            [dataSource]="configPaginatedData()"
+            matSort
+            [matSortActive]="configSortActive()"
+            [matSortDirection]="configSortDirection()"
+            (matSortChange)="onConfigSortChange($event)"
+          >
+            <ng-container matColumnDef="name">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
+              <td mat-cell *matCellDef="let c">{{ c.name }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="value">
-            <th mat-header-cell *matHeaderCellDef>Value</th>
-            <td mat-cell *matCellDef="let c">{{ c.sensitive ? '******' : c.value }}</td>
-          </ng-container>
+            <ng-container matColumnDef="value">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Value</th>
+              <td mat-cell *matCellDef="let c">{{ c.sensitive ? '******' : c.value }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="source">
-            <th mat-header-cell *matHeaderCellDef>Source</th>
-            <td mat-cell *matCellDef="let c">{{ c.source }}</td>
-          </ng-container>
+            <ng-container matColumnDef="source">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Source</th>
+              <td mat-cell *matCellDef="let c">{{ c.source }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="readOnly">
-            <th mat-header-cell *matHeaderCellDef>Read Only</th>
-            <td mat-cell *matCellDef="let c">{{ c.readOnly ? 'Yes' : 'No' }}</td>
-          </ng-container>
+            <ng-container matColumnDef="readOnly">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Read Only</th>
+              <td mat-cell *matCellDef="let c">{{ c.readOnly ? 'Yes' : 'No' }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="sensitive">
-            <th mat-header-cell *matHeaderCellDef>Sensitive</th>
-            <td mat-cell *matCellDef="let c">{{ c.sensitive ? 'Yes' : 'No' }}</td>
-          </ng-container>
+            <ng-container matColumnDef="sensitive">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Sensitive</th>
+              <td mat-cell *matCellDef="let c">{{ c.sensitive ? 'Yes' : 'No' }}</td>
+            </ng-container>
 
-          <tr mat-header-row *matHeaderRowDef="configColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: configColumns"></tr>
-        </table>
+            <tr mat-header-row *matHeaderRowDef="configColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: configColumns"></tr>
+          </table>
+        </gke-data-table>
       </mat-card-content>
     </mat-card>
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/broker-detail/broker-detail.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/broker-detail/broker-detail.component.scss
@@ -34,12 +34,6 @@
     font-size: 14px;
   }
 
-  &__empty-message {
-    color: var(--mat-sys-on-surface-variant, #49454f);
-    font-style: italic;
-    margin: 8px 0;
-  }
-
   mat-card-content {
     overflow-x: auto;
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/broker-detail/broker-detail.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/broker-detail/broker-detail.component.ts
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { Sort, MatSortModule, SortDirection } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 
 import { BadgeComponent } from '../../../components/badge/badge.component';
-import { DescribeBrokerResponse } from '../../../models/kafka-cluster.model';
+import { DataTableComponent } from '../../../components/data-table/data-table.component';
+import { BrokerLogDirEntry, DescribeBrokerResponse, TopicConfig } from '../../../models/kafka-cluster.model';
 import { FileSizePipe } from '../../../pipes/file-size.pipe';
+import { SortComparators, sortData } from '../../../utils/sort-data';
 
 @Component({
   selector: 'gke-broker-detail',
@@ -32,11 +35,13 @@ import { FileSizePipe } from '../../../pipes/file-size.pipe';
     CommonModule,
     MatCardModule,
     MatTableModule,
+    MatSortModule,
     MatIconModule,
     MatButtonModule,
     MatProgressBarModule,
     FileSizePipe,
     BadgeComponent,
+    DataTableComponent,
   ],
   templateUrl: './broker-detail.component.html',
   styleUrls: ['./broker-detail.component.scss'],
@@ -49,4 +54,82 @@ export class BrokerDetailComponent {
 
   logDirColumns = ['path', 'error', 'topics', 'partitions', 'size'];
   configColumns = ['name', 'value', 'source', 'readOnly', 'sensitive'];
+
+  // Log Directories sort + pagination
+  logDirSortActive = signal('');
+  logDirSortDirection = signal<SortDirection>('');
+  logDirPage = signal(0);
+  logDirPageSize = signal(25);
+
+  private logDirComparators: SortComparators<BrokerLogDirEntry> = {
+    path: (a, b) => a.path.localeCompare(b.path),
+    error: (a, b) => (a.error ?? '').localeCompare(b.error ?? ''),
+    topics: (a, b) => a.topics - b.topics,
+    partitions: (a, b) => a.partitions - b.partitions,
+    size: (a, b) => a.size - b.size,
+  };
+
+  logDirSortedData = computed(() =>
+    sortData(this.brokerDetail()?.logDirEntries ?? [], this.logDirSortActive(), this.logDirSortDirection(), this.logDirComparators),
+  );
+
+  logDirPaginatedData = computed(() => {
+    const data = this.logDirSortedData();
+    const start = this.logDirPage() * this.logDirPageSize();
+    return data.slice(start, start + this.logDirPageSize());
+  });
+
+  // Configuration filter + sort + pagination
+  configFilter = signal('');
+  configSortActive = signal('');
+  configSortDirection = signal<SortDirection>('');
+  configPage = signal(0);
+  configPageSize = signal(25);
+
+  configsEmpty = computed(() => (this.brokerDetail()?.configs?.length ?? 0) === 0);
+
+  configFilteredData = computed(() => {
+    const data = this.brokerDetail()?.configs ?? [];
+    const filter = this.configFilter();
+    if (!filter) return data;
+    return data.filter(
+      (c: TopicConfig) =>
+        c.name.toLowerCase().includes(filter) || c.value.toLowerCase().includes(filter) || c.source.toLowerCase().includes(filter),
+    );
+  });
+
+  private configComparators: SortComparators<TopicConfig> = {
+    name: (a, b) => a.name.localeCompare(b.name),
+    value: (a, b) => a.value.localeCompare(b.value),
+    source: (a, b) => a.source.localeCompare(b.source),
+    readOnly: (a, b) => Number(a.readOnly) - Number(b.readOnly),
+    sensitive: (a, b) => Number(a.sensitive) - Number(b.sensitive),
+  };
+
+  configSortedData = computed(() =>
+    sortData(this.configFilteredData(), this.configSortActive(), this.configSortDirection(), this.configComparators),
+  );
+
+  configPaginatedData = computed(() => {
+    const data = this.configSortedData();
+    const start = this.configPage() * this.configPageSize();
+    return data.slice(start, start + this.configPageSize());
+  });
+
+  onLogDirSortChange(sort: Sort) {
+    this.logDirSortActive.set(sort.active);
+    this.logDirSortDirection.set(sort.direction);
+    this.logDirPage.set(0);
+  }
+
+  onConfigSortChange(sort: Sort) {
+    this.configSortActive.set(sort.active);
+    this.configSortDirection.set(sort.direction);
+    this.configPage.set(0);
+  }
+
+  onConfigFilter(value: string) {
+    this.configFilter.set(value.trim().toLowerCase());
+    this.configPage.set(0);
+  }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/broker-detail/broker-detail.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/broker-detail/broker-detail.harness.ts
@@ -19,6 +19,7 @@ import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
 
 import { BadgeHarness } from '../../../components/badge/badge.harness';
+import { DataTableHarness } from '../../../components/data-table/data-table.harness';
 
 export class BrokerDetailHarness extends ComponentHarness {
   static hostSelector = 'gke-broker-detail';
@@ -29,7 +30,7 @@ export class BrokerDetailHarness extends ComponentHarness {
   private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
   private readonly getTitle = this.locatorFor('.broker-detail__title');
   private readonly getControllerBadge = this.locatorForOptional(BadgeHarness.with({ selector: '.broker-detail__controller-badge' }));
-  private readonly getEmptyMessage = this.locatorForOptional('.broker-detail__empty-message');
+  private readonly getDataTables = this.locatorForAll(DataTableHarness);
 
   async getBrokerTitle() {
     const title = await this.getTitle();
@@ -50,8 +51,9 @@ export class BrokerDetailHarness extends ComponentHarness {
   }
 
   async getLogDirEmptyMessage() {
-    const el = await this.getEmptyMessage();
-    return el ? el.text() : null;
+    const dataTables = await this.getDataTables();
+    if (dataTables.length < 1) return null;
+    return dataTables[0].getEmptyText();
   }
 
   async getLogDirRows() {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/brokers/brokers.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/brokers/brokers.component.html
@@ -53,52 +53,61 @@
       <mat-card-title>Broker Nodes</mat-card-title>
     </mat-card-header>
     <mat-card-content>
-      <table mat-table [dataSource]="nodes()">
-        <ng-container matColumnDef="id">
-          <th mat-header-cell *matHeaderCellDef>Node ID</th>
-          <td mat-cell *matCellDef="let node">
-            <span class="brokers__node-id">
-              {{ node.id }}
-              @if (node.id === controllerId()) {
-                <gke-badge class="brokers__controller-badge" color="primary">Controller</gke-badge>
-              }
-            </span>
-          </td>
-        </ng-container>
+      <gke-data-table [empty]="nodes().length === 0">
+        <table
+          mat-table
+          [dataSource]="sortedNodes()"
+          matSort
+          [matSortActive]="sortActive()"
+          [matSortDirection]="sortDirection()"
+          (matSortChange)="onSortChange($event)"
+        >
+          <ng-container matColumnDef="id">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Node ID</th>
+            <td mat-cell *matCellDef="let node">
+              <span class="brokers__node-id">
+                {{ node.id }}
+                @if (node.id === controllerId()) {
+                  <gke-badge class="brokers__controller-badge" color="primary">Controller</gke-badge>
+                }
+              </span>
+            </td>
+          </ng-container>
 
-        <ng-container matColumnDef="host">
-          <th mat-header-cell *matHeaderCellDef>Host</th>
-          <td mat-cell *matCellDef="let node">{{ node.host }}</td>
-        </ng-container>
+          <ng-container matColumnDef="host">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Host</th>
+            <td mat-cell *matCellDef="let node">{{ node.host }}</td>
+          </ng-container>
 
-        <ng-container matColumnDef="port">
-          <th mat-header-cell *matHeaderCellDef>Port</th>
-          <td mat-cell *matCellDef="let node">{{ node.port }}</td>
-        </ng-container>
+          <ng-container matColumnDef="port">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Port</th>
+            <td mat-cell *matCellDef="let node">{{ node.port }}</td>
+          </ng-container>
 
-        <ng-container matColumnDef="rack">
-          <th mat-header-cell *matHeaderCellDef>Rack</th>
-          <td mat-cell *matCellDef="let node">{{ node.rack || '-' }}</td>
-        </ng-container>
+          <ng-container matColumnDef="rack">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Rack</th>
+            <td mat-cell *matCellDef="let node">{{ node.rack || '-' }}</td>
+          </ng-container>
 
-        <ng-container matColumnDef="leaderPartitions">
-          <th mat-header-cell *matHeaderCellDef>Leader Partitions</th>
-          <td mat-cell *matCellDef="let node">{{ node.leaderPartitions }}</td>
-        </ng-container>
+          <ng-container matColumnDef="leaderPartitions">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Leader Partitions</th>
+            <td mat-cell *matCellDef="let node">{{ node.leaderPartitions }}</td>
+          </ng-container>
 
-        <ng-container matColumnDef="replicaPartitions">
-          <th mat-header-cell *matHeaderCellDef>Replica Partitions</th>
-          <td mat-cell *matCellDef="let node">{{ node.replicaPartitions }}</td>
-        </ng-container>
+          <ng-container matColumnDef="replicaPartitions">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Replica Partitions</th>
+            <td mat-cell *matCellDef="let node">{{ node.replicaPartitions }}</td>
+          </ng-container>
 
-        <ng-container matColumnDef="logDirSize">
-          <th mat-header-cell *matHeaderCellDef>Disk Usage</th>
-          <td mat-cell *matCellDef="let node">{{ node.logDirSize | gkeFileSize }}</td>
-        </ng-container>
+          <ng-container matColumnDef="logDirSize">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header>Disk Usage</th>
+            <td mat-cell *matCellDef="let node">{{ node.logDirSize | gkeFileSize }}</td>
+          </ng-container>
 
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns" class="brokers__row" (click)="brokerSelect.emit(row.id)"></tr>
-      </table>
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns" class="brokers__row" (click)="brokerSelect.emit(row.id)"></tr>
+        </table>
+      </gke-data-table>
     </mat-card-content>
   </mat-card>
 </div>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/brokers/brokers.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/brokers/brokers/brokers.component.ts
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output, signal } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
+import { Sort, MatSortModule, SortDirection } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 
 import { BadgeComponent } from '../../../components/badge/badge.component';
+import { DataTableComponent } from '../../../components/data-table/data-table.component';
 import { BrokerDetail, KafkaNode } from '../../../models/kafka-cluster.model';
 import { FileSizePipe } from '../../../pipes/file-size.pipe';
 
 @Component({
   selector: 'gke-brokers',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatTableModule, FileSizePipe, BadgeComponent],
+  imports: [CommonModule, MatCardModule, MatTableModule, MatSortModule, FileSizePipe, BadgeComponent, DataTableComponent],
   templateUrl: './brokers.component.html',
   styleUrls: ['./brokers.component.scss'],
 })
@@ -40,4 +42,41 @@ export class BrokersComponent {
   brokerSelect = output<number>();
 
   displayedColumns = ['id', 'host', 'port', 'rack', 'leaderPartitions', 'replicaPartitions', 'logDirSize'];
+
+  sortActive = signal('');
+  sortDirection = signal<SortDirection>('');
+
+  sortedNodes = computed(() => {
+    const data = this.nodes();
+    const active = this.sortActive();
+    const direction = this.sortDirection();
+    if (!active || direction === '') return data;
+
+    const factor = direction === 'asc' ? 1 : -1;
+    return [...data].sort((a, b) => {
+      switch (active) {
+        case 'id':
+          return (a.id - b.id) * factor;
+        case 'host':
+          return a.host.localeCompare(b.host) * factor;
+        case 'port':
+          return (a.port - b.port) * factor;
+        case 'rack':
+          return (a.rack ?? '').localeCompare(b.rack ?? '') * factor;
+        case 'leaderPartitions':
+          return ((a.leaderPartitions ?? 0) - (b.leaderPartitions ?? 0)) * factor;
+        case 'replicaPartitions':
+          return ((a.replicaPartitions ?? 0) - (b.replicaPartitions ?? 0)) * factor;
+        case 'logDirSize':
+          return ((a.logDirSize ?? 0) - (b.logDirSize ?? 0)) * factor;
+        default:
+          return 0;
+      }
+    });
+  });
+
+  onSortChange(sort: Sort) {
+    this.sortActive.set(sort.active);
+    this.sortDirection.set(sort.direction);
+  }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-group-detail/consumer-group-detail.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-group-detail/consumer-group-detail.component.html
@@ -59,42 +59,59 @@
         <mat-card-title>Members</mat-card-title>
       </mat-card-header>
       <mat-card-content>
-        <table mat-table [dataSource]="detail.members">
-          <ng-container matColumnDef="memberId">
-            <th mat-header-cell *matHeaderCellDef>Member ID</th>
-            <td mat-cell *matCellDef="let m">{{ m.memberId }}</td>
-          </ng-container>
+        <gke-data-table
+          [empty]="detail.members.length === 0"
+          emptyMessage="No members found"
+          [paginated]="true"
+          [totalElements]="memberSortedData().length"
+          [page]="memberPage()"
+          [pageSize]="memberPageSize()"
+          (pageChange)="memberPage.set($event.page); memberPageSize.set($event.pageSize)"
+        >
+          <table
+            mat-table
+            [dataSource]="memberPaginatedData()"
+            matSort
+            [matSortActive]="memberSortActive()"
+            [matSortDirection]="memberSortDirection()"
+            (matSortChange)="onMemberSortChange($event)"
+          >
+            <ng-container matColumnDef="memberId">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Member ID</th>
+              <td mat-cell *matCellDef="let m">{{ m.memberId }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="clientId">
-            <th mat-header-cell *matHeaderCellDef>Client ID</th>
-            <td mat-cell *matCellDef="let m">{{ m.clientId }}</td>
-          </ng-container>
+            <ng-container matColumnDef="clientId">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Client ID</th>
+              <td mat-cell *matCellDef="let m">{{ m.clientId }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="host">
-            <th mat-header-cell *matHeaderCellDef>Host</th>
-            <td mat-cell *matCellDef="let m">{{ m.host }}</td>
-          </ng-container>
+            <ng-container matColumnDef="host">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Host</th>
+              <td mat-cell *matCellDef="let m">{{ m.host }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="assignments">
-            <th mat-header-cell *matHeaderCellDef>Assignments</th>
-            <td mat-cell *matCellDef="let m">
-              @for (a of m.assignments; track a.topicName) {
-                <span
-                  ><a
-                    class="consumer-group-detail__topic-link"
-                    tabindex="0"
-                    (click)="topicSelect.emit(a.topicName); $event.stopPropagation()"
-                    (keydown.enter)="topicSelect.emit(a.topicName); $event.stopPropagation()"
-                    >{{ a.topicName }}</a
-                  >[{{ a.partitions.join(', ') }}]</span
-                >
-              }
-            </td>
-          </ng-container>
+            <ng-container matColumnDef="assignments">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Assignments</th>
+              <td mat-cell *matCellDef="let m">
+                @for (a of m.assignments; track a.topicName) {
+                  <span
+                    ><a
+                      class="consumer-group-detail__topic-link"
+                      tabindex="0"
+                      (click)="topicSelect.emit(a.topicName); $event.stopPropagation()"
+                      (keydown.enter)="topicSelect.emit(a.topicName); $event.stopPropagation()"
+                      >{{ a.topicName }}</a
+                    >[{{ a.partitions.join(', ') }}]</span
+                  >
+                }
+              </td>
+            </ng-container>
 
-          <tr mat-header-row *matHeaderRowDef="memberColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: memberColumns"></tr>
-        </table>
+            <tr mat-header-row *matHeaderRowDef="memberColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: memberColumns"></tr>
+          </table>
+        </gke-data-table>
       </mat-card-content>
     </mat-card>
 
@@ -103,48 +120,65 @@
         <mat-card-title>Offsets</mat-card-title>
       </mat-card-header>
       <mat-card-content>
-        <table mat-table [dataSource]="detail.offsets">
-          <ng-container matColumnDef="topic">
-            <th mat-header-cell *matHeaderCellDef>Topic</th>
-            <td mat-cell *matCellDef="let o">
-              <a
-                class="consumer-group-detail__topic-link"
-                tabindex="0"
-                (click)="topicSelect.emit(o.topic); $event.stopPropagation()"
-                (keydown.enter)="topicSelect.emit(o.topic); $event.stopPropagation()"
-                >{{ o.topic }}</a
-              >
-            </td>
-          </ng-container>
+        <gke-data-table
+          [empty]="detail.offsets.length === 0"
+          emptyMessage="No offsets found"
+          [paginated]="true"
+          [totalElements]="offsetSortedData().length"
+          [page]="offsetPage()"
+          [pageSize]="offsetPageSize()"
+          (pageChange)="offsetPage.set($event.page); offsetPageSize.set($event.pageSize)"
+        >
+          <table
+            mat-table
+            [dataSource]="offsetPaginatedData()"
+            matSort
+            [matSortActive]="offsetSortActive()"
+            [matSortDirection]="offsetSortDirection()"
+            (matSortChange)="onOffsetSortChange($event)"
+          >
+            <ng-container matColumnDef="topic">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Topic</th>
+              <td mat-cell *matCellDef="let o">
+                <a
+                  class="consumer-group-detail__topic-link"
+                  tabindex="0"
+                  (click)="topicSelect.emit(o.topic); $event.stopPropagation()"
+                  (keydown.enter)="topicSelect.emit(o.topic); $event.stopPropagation()"
+                  >{{ o.topic }}</a
+                >
+              </td>
+            </ng-container>
 
-          <ng-container matColumnDef="partition">
-            <th mat-header-cell *matHeaderCellDef>Partition</th>
-            <td mat-cell *matCellDef="let o">{{ o.partition }}</td>
-          </ng-container>
+            <ng-container matColumnDef="partition">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Partition</th>
+              <td mat-cell *matCellDef="let o">{{ o.partition }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="committedOffset">
-            <th mat-header-cell *matHeaderCellDef>Committed Offset</th>
-            <td mat-cell *matCellDef="let o">{{ o.committedOffset }}</td>
-          </ng-container>
+            <ng-container matColumnDef="committedOffset">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Committed Offset</th>
+              <td mat-cell *matCellDef="let o">{{ o.committedOffset }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="endOffset">
-            <th mat-header-cell *matHeaderCellDef>End Offset</th>
-            <td mat-cell *matCellDef="let o">{{ o.endOffset }}</td>
-          </ng-container>
+            <ng-container matColumnDef="endOffset">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>End Offset</th>
+              <td mat-cell *matCellDef="let o">{{ o.endOffset }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="lag">
-            <th mat-header-cell *matHeaderCellDef>Lag</th>
-            <td mat-cell *matCellDef="let o">
-              {{ o.lag }}
-              @if (o.lag > 0) {
-                <gke-badge class="consumer-group-detail__lag-warning" color="warning">behind</gke-badge>
-              }
-            </td>
-          </ng-container>
+            <ng-container matColumnDef="lag">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Lag</th>
+              <td mat-cell *matCellDef="let o">
+                {{ o.lag }}
+                @if (o.lag > 0) {
+                  <gke-badge class="consumer-group-detail__lag-warning" color="warning">behind</gke-badge>
+                }
+              </td>
+            </ng-container>
 
-          <tr mat-header-row *matHeaderRowDef="offsetColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: offsetColumns"></tr>
-        </table>
+            <tr mat-header-row *matHeaderRowDef="offsetColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: offsetColumns"></tr>
+          </table>
+        </gke-data-table>
       </mat-card-content>
     </mat-card>
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-group-detail/consumer-group-detail.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-group-detail/consumer-group-detail.component.ts
@@ -14,21 +14,34 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { Sort, MatSortModule, SortDirection } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 
 import { BadgeComponent } from '../../../components/badge/badge.component';
-import { ConsumerGroupOffset, DescribeConsumerGroupResponse } from '../../../models/kafka-cluster.model';
+import { DataTableComponent } from '../../../components/data-table/data-table.component';
+import { ConsumerGroupMember, ConsumerGroupOffset, DescribeConsumerGroupResponse } from '../../../models/kafka-cluster.model';
+import { SortComparators, sortData } from '../../../utils/sort-data';
 import { consumerGroupStateColor } from '../consumer-group-state';
 
 @Component({
   selector: 'gke-consumer-group-detail',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatTableModule, MatIconModule, MatButtonModule, MatProgressBarModule, BadgeComponent],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatTableModule,
+    MatSortModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressBarModule,
+    BadgeComponent,
+    DataTableComponent,
+  ],
   templateUrl: './consumer-group-detail.component.html',
   styleUrls: ['./consumer-group-detail.component.scss'],
 })
@@ -42,6 +55,65 @@ export class ConsumerGroupDetailComponent {
   memberColumns = ['memberId', 'clientId', 'host', 'assignments'];
   offsetColumns = ['topic', 'partition', 'committedOffset', 'endOffset', 'lag'];
   stateColor = consumerGroupStateColor;
+
+  // Members sort + pagination
+  memberSortActive = signal('');
+  memberSortDirection = signal<SortDirection>('');
+  memberPage = signal(0);
+  memberPageSize = signal(25);
+
+  private memberComparators: SortComparators<ConsumerGroupMember> = {
+    memberId: (a, b) => a.memberId.localeCompare(b.memberId),
+    clientId: (a, b) => a.clientId.localeCompare(b.clientId),
+    host: (a, b) => a.host.localeCompare(b.host),
+    assignments: (a, b) => (a.assignments?.length ?? 0) - (b.assignments?.length ?? 0),
+  };
+
+  memberSortedData = computed(() =>
+    sortData(this.groupDetail()?.members ?? [], this.memberSortActive(), this.memberSortDirection(), this.memberComparators),
+  );
+
+  memberPaginatedData = computed(() => {
+    const data = this.memberSortedData();
+    const start = this.memberPage() * this.memberPageSize();
+    return data.slice(start, start + this.memberPageSize());
+  });
+
+  // Offsets sort + pagination
+  offsetSortActive = signal('');
+  offsetSortDirection = signal<SortDirection>('');
+  offsetPage = signal(0);
+  offsetPageSize = signal(25);
+
+  private offsetComparators: SortComparators<ConsumerGroupOffset> = {
+    topic: (a, b) => a.topic.localeCompare(b.topic),
+    partition: (a, b) => a.partition - b.partition,
+    committedOffset: (a, b) => a.committedOffset - b.committedOffset,
+    endOffset: (a, b) => a.endOffset - b.endOffset,
+    lag: (a, b) => a.lag - b.lag,
+  };
+
+  offsetSortedData = computed(() =>
+    sortData(this.groupDetail()?.offsets ?? [], this.offsetSortActive(), this.offsetSortDirection(), this.offsetComparators),
+  );
+
+  offsetPaginatedData = computed(() => {
+    const data = this.offsetSortedData();
+    const start = this.offsetPage() * this.offsetPageSize();
+    return data.slice(start, start + this.offsetPageSize());
+  });
+
+  onMemberSortChange(sort: Sort) {
+    this.memberSortActive.set(sort.active);
+    this.memberSortDirection.set(sort.direction);
+    this.memberPage.set(0);
+  }
+
+  onOffsetSortChange(sort: Sort) {
+    this.offsetSortActive.set(sort.active);
+    this.offsetSortDirection.set(sort.direction);
+    this.offsetPage.set(0);
+  }
 
   countDistinctTopics(offsets: ConsumerGroupOffset[]): number {
     return new Set(offsets.map(o => o.topic)).size;

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups-page.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups-page.component.html
@@ -23,5 +23,6 @@
   [loading]="consumerGroupsLoading()"
   (filterChange)="onFilterChange($event)"
   (pageChange)="onPageChange($event)"
+  (sortChange)="onSortChange($event)"
   (groupSelect)="onGroupSelect($event)"
 />

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups-page.component.ts
@@ -42,6 +42,8 @@ export class ConsumerGroupsPageComponent implements OnInit {
   private currentFilter = '';
   private currentPage = 0;
   private currentPageSize = 25;
+  private currentSortBy = '';
+  private currentSortOrder = '';
   private readonly filterSubject = new Subject<string>();
 
   ngOnInit() {
@@ -68,10 +70,26 @@ export class ConsumerGroupsPageComponent implements OnInit {
     this.loadConsumerGroups(this.currentFilter, event.page, event.pageSize);
   }
 
+  onSortChange(event: { active: string; direction: string }) {
+    this.currentSortBy = event.active;
+    this.currentSortOrder = event.direction;
+    this.currentPage = 0;
+    this.loadConsumerGroups(this.currentFilter, 0, this.currentPageSize);
+  }
+
   private loadConsumerGroups(nameFilter: string, page: number, pageSize: number) {
     this.consumerGroupsLoading.set(true);
     this.service
-      .listConsumerGroups(this.store.baseURL(), this.store.clusterId(), nameFilter || undefined, page + 1, pageSize)
+      .listConsumerGroups(
+        this.store.baseURL(),
+        this.store.clusterId(),
+        nameFilter || undefined,
+        page + 1,
+        pageSize,
+        undefined,
+        this.currentSortBy || undefined,
+        this.currentSortOrder || undefined,
+      )
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: response => {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.component.html
@@ -33,43 +33,36 @@
       (filterChange)="filterChange.emit($event)"
       (pageChange)="pageChange.emit($event)"
     >
-      <table
-        mat-table
-        [dataSource]="sortedConsumerGroups()"
-        matSort
-        [matSortActive]="sortActive()"
-        [matSortDirection]="sortDirection()"
-        (matSortChange)="onSortChange($event)"
-      >
+      <table mat-table [dataSource]="consumerGroups()" matSort (matSortChange)="onSortChange($event)">
         <ng-container matColumnDef="groupId">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Group ID</th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Group ID</th>
           <td mat-cell *matCellDef="let group">{{ group.groupId }}</td>
         </ng-container>
 
         <ng-container matColumnDef="state">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">State</th>
+          <th mat-header-cell *matHeaderCellDef>State</th>
           <td mat-cell *matCellDef="let group">
             <gke-badge [color]="stateColor(group.state)">{{ group.state }}</gke-badge>
           </td>
         </ng-container>
 
         <ng-container matColumnDef="membersCount">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Members</th>
+          <th mat-header-cell *matHeaderCellDef>Members</th>
           <td mat-cell *matCellDef="let group">{{ group.membersCount }}</td>
         </ng-container>
 
         <ng-container matColumnDef="numTopics">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Topics</th>
+          <th mat-header-cell *matHeaderCellDef>Topics</th>
           <td mat-cell *matCellDef="let group">{{ group.numTopics }}</td>
         </ng-container>
 
         <ng-container matColumnDef="coordinator">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Coordinator</th>
+          <th mat-header-cell *matHeaderCellDef>Coordinator</th>
           <td mat-cell *matCellDef="let group">{{ group.coordinator?.id }}</td>
         </ng-container>
 
         <ng-container matColumnDef="totalLag">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Total Lag</th>
+          <th mat-header-cell *matHeaderCellDef>Total Lag</th>
           <td mat-cell *matCellDef="let group">
             @if (group.totalLag > 0) {
               <gke-badge color="warning">{{ group.totalLag | number }}</gke-badge>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.component.html
@@ -20,64 +20,73 @@
     <mat-card-title>Consumer Groups</mat-card-title>
   </mat-card-header>
   <mat-card-content>
-    <mat-form-field class="consumer-groups__filter" appearance="outline">
-      <mat-label>Filter by group ID</mat-label>
-      <input matInput (input)="onFilterInput($event)" placeholder="Search consumer groups..." />
-    </mat-form-field>
-
-    @if (loading()) {
-      <mat-progress-bar mode="indeterminate" />
-    }
-
-    <table mat-table [dataSource]="consumerGroups()">
-      <ng-container matColumnDef="groupId">
-        <th mat-header-cell *matHeaderCellDef>Group ID</th>
-        <td mat-cell *matCellDef="let group">{{ group.groupId }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="state">
-        <th mat-header-cell *matHeaderCellDef>State</th>
-        <td mat-cell *matCellDef="let group">
-          <gke-badge [color]="stateColor(group.state)">{{ group.state }}</gke-badge>
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="membersCount">
-        <th mat-header-cell *matHeaderCellDef>Members</th>
-        <td mat-cell *matCellDef="let group">{{ group.membersCount }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="numTopics">
-        <th mat-header-cell *matHeaderCellDef>Topics</th>
-        <td mat-cell *matCellDef="let group">{{ group.numTopics }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="coordinator">
-        <th mat-header-cell *matHeaderCellDef>Coordinator</th>
-        <td mat-cell *matCellDef="let group">{{ group.coordinator?.id }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="totalLag">
-        <th mat-header-cell *matHeaderCellDef>Total Lag</th>
-        <td mat-cell *matCellDef="let group">
-          @if (group.totalLag > 0) {
-            <gke-badge color="warning">{{ group.totalLag | number }}</gke-badge>
-          } @else {
-            {{ group.totalLag | number }}
-          }
-        </td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="consumer-groups__row" (click)="groupSelect.emit(row.groupId)"></tr>
-    </table>
-
-    <mat-paginator
-      [length]="totalElements()"
-      [pageIndex]="page()"
+    <gke-data-table
+      [filterable]="true"
+      filterPlaceholder="Search consumer groups..."
+      [loading]="loading()"
+      [empty]="consumerGroups().length === 0"
+      [paginated]="true"
+      [totalElements]="totalElements()"
+      [page]="page()"
       [pageSize]="pageSize()"
       [pageSizeOptions]="[25, 50, 100]"
-      (page)="onPageEvent($event)"
-    />
+      (filterChange)="filterChange.emit($event)"
+      (pageChange)="pageChange.emit($event)"
+    >
+      <table
+        mat-table
+        [dataSource]="sortedConsumerGroups()"
+        matSort
+        [matSortActive]="sortActive()"
+        [matSortDirection]="sortDirection()"
+        (matSortChange)="onSortChange($event)"
+      >
+        <ng-container matColumnDef="groupId">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Group ID</th>
+          <td mat-cell *matCellDef="let group">{{ group.groupId }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="state">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">State</th>
+          <td mat-cell *matCellDef="let group">
+            <gke-badge [color]="stateColor(group.state)">{{ group.state }}</gke-badge>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="membersCount">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Members</th>
+          <td mat-cell *matCellDef="let group">{{ group.membersCount }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="numTopics">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Topics</th>
+          <td mat-cell *matCellDef="let group">{{ group.numTopics }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="coordinator">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Coordinator</th>
+          <td mat-cell *matCellDef="let group">{{ group.coordinator?.id }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="totalLag">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Total Lag</th>
+          <td mat-cell *matCellDef="let group">
+            @if (group.totalLag > 0) {
+              <gke-badge color="warning">{{ group.totalLag | number }}</gke-badge>
+            } @else {
+              {{ group.totalLag | number }}
+            }
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: displayedColumns"
+          class="consumer-groups__row"
+          (click)="groupSelect.emit(row.groupId)"
+        ></tr>
+      </table>
+    </gke-data-table>
   </mat-card-content>
 </mat-card>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.component.scss
@@ -23,11 +23,6 @@
     width: 100%;
   }
 
-  &__filter {
-    width: 100%;
-    margin-bottom: 8px;
-  }
-
   &__row {
     cursor: pointer;
 

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.component.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 import { CommonModule, DecimalPipe } from '@angular/common';
-import { Component, computed, input, output, signal } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
-import { Sort, MatSortModule, SortDirection } from '@angular/material/sort';
+import { Sort, MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
-import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { BadgeComponent } from '../../../components/badge/badge.component';
 import { DataTableComponent } from '../../../components/data-table/data-table.component';
@@ -28,7 +27,7 @@ import { consumerGroupStateColor } from '../consumer-group-state';
 @Component({
   selector: 'gke-consumer-groups',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatTableModule, MatSortModule, MatTooltipModule, DecimalPipe, BadgeComponent, DataTableComponent],
+  imports: [CommonModule, MatCardModule, MatTableModule, MatSortModule, DecimalPipe, BadgeComponent, DataTableComponent],
   templateUrl: './consumer-groups.component.html',
   styleUrls: ['./consumer-groups.component.scss'],
 })
@@ -41,44 +40,14 @@ export class ConsumerGroupsComponent {
 
   filterChange = output<string>();
   pageChange = output<{ page: number; pageSize: number }>();
+  sortChange = output<{ active: string; direction: string }>();
   groupSelect = output<string>();
 
   displayedColumns = ['groupId', 'state', 'membersCount', 'numTopics', 'coordinator', 'totalLag'];
 
   stateColor = consumerGroupStateColor;
 
-  sortActive = signal('');
-  sortDirection = signal<SortDirection>('');
-
-  sortedConsumerGroups = computed(() => {
-    const data = this.consumerGroups();
-    const active = this.sortActive();
-    const direction = this.sortDirection();
-    if (!active || direction === '') return data;
-
-    const factor = direction === 'asc' ? 1 : -1;
-    return [...data].sort((a, b) => {
-      switch (active) {
-        case 'groupId':
-          return a.groupId.localeCompare(b.groupId) * factor;
-        case 'state':
-          return (a.state ?? '').localeCompare(b.state ?? '') * factor;
-        case 'membersCount':
-          return (a.membersCount - b.membersCount) * factor;
-        case 'numTopics':
-          return (a.numTopics - b.numTopics) * factor;
-        case 'coordinator':
-          return ((a.coordinator?.id ?? 0) - (b.coordinator?.id ?? 0)) * factor;
-        case 'totalLag':
-          return (a.totalLag - b.totalLag) * factor;
-        default:
-          return 0;
-      }
-    });
-  });
-
   onSortChange(sort: Sort) {
-    this.sortActive.set(sort.active);
-    this.sortDirection.set(sort.direction);
+    this.sortChange.emit({ active: sort.active, direction: sort.direction });
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.component.ts
@@ -14,32 +14,21 @@
  * limitations under the License.
  */
 import { CommonModule, DecimalPipe } from '@angular/common';
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output, signal } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { Sort, MatSortModule, SortDirection } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { BadgeComponent } from '../../../components/badge/badge.component';
+import { DataTableComponent } from '../../../components/data-table/data-table.component';
 import { ConsumerGroupSummary } from '../../../models/kafka-cluster.model';
 import { consumerGroupStateColor } from '../consumer-group-state';
 
 @Component({
   selector: 'gke-consumer-groups',
   standalone: true,
-  imports: [
-    CommonModule,
-    MatCardModule,
-    MatTableModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatPaginatorModule,
-    MatProgressBarModule,
-    DecimalPipe,
-    BadgeComponent,
-  ],
+  imports: [CommonModule, MatCardModule, MatTableModule, MatSortModule, MatTooltipModule, DecimalPipe, BadgeComponent, DataTableComponent],
   templateUrl: './consumer-groups.component.html',
   styleUrls: ['./consumer-groups.component.scss'],
 })
@@ -58,12 +47,38 @@ export class ConsumerGroupsComponent {
 
   stateColor = consumerGroupStateColor;
 
-  onFilterInput(event: Event) {
-    const value = (event.target as HTMLInputElement).value;
-    this.filterChange.emit(value);
-  }
+  sortActive = signal('');
+  sortDirection = signal<SortDirection>('');
 
-  onPageEvent(event: PageEvent) {
-    this.pageChange.emit({ page: event.pageIndex, pageSize: event.pageSize });
+  sortedConsumerGroups = computed(() => {
+    const data = this.consumerGroups();
+    const active = this.sortActive();
+    const direction = this.sortDirection();
+    if (!active || direction === '') return data;
+
+    const factor = direction === 'asc' ? 1 : -1;
+    return [...data].sort((a, b) => {
+      switch (active) {
+        case 'groupId':
+          return a.groupId.localeCompare(b.groupId) * factor;
+        case 'state':
+          return (a.state ?? '').localeCompare(b.state ?? '') * factor;
+        case 'membersCount':
+          return (a.membersCount - b.membersCount) * factor;
+        case 'numTopics':
+          return (a.numTopics - b.numTopics) * factor;
+        case 'coordinator':
+          return ((a.coordinator?.id ?? 0) - (b.coordinator?.id ?? 0)) * factor;
+        case 'totalLag':
+          return (a.totalLag - b.totalLag) * factor;
+        default:
+          return 0;
+      }
+    });
+  });
+
+  onSortChange(sort: Sort) {
+    this.sortActive.set(sort.active);
+    this.sortDirection.set(sort.direction);
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/consumer-groups/consumer-groups/consumer-groups.harness.ts
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 import { ComponentHarness, parallel } from '@angular/cdk/testing';
-import { MatInputHarness } from '@angular/material/input/testing';
-import { MatPaginatorHarness } from '@angular/material/paginator/testing';
-import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
+
+import { DataTableHarness } from '../../../components/data-table/data-table.harness';
 
 export class ConsumerGroupsHarness extends ComponentHarness {
   static hostSelector = 'gke-consumer-groups';
 
   private readonly getTable = this.locatorFor(MatTableHarness);
-  private readonly getFilterInput = this.locatorFor(MatInputHarness);
-  private readonly getPaginator = this.locatorFor(MatPaginatorHarness);
-  private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
+  private readonly getDataTable = this.locatorFor(DataTableHarness);
 
   async getRows() {
     const table = await this.getTable();
@@ -43,22 +40,22 @@ export class ConsumerGroupsHarness extends ComponentHarness {
   }
 
   async setFilter(value: string) {
-    const input = await this.getFilterInput();
-    await input.setValue(value);
+    const dataTable = await this.getDataTable();
+    await dataTable.setFilter(value);
   }
 
   async getRangeLabel() {
-    const paginator = await this.getPaginator();
-    return paginator.getRangeLabel();
+    const dataTable = await this.getDataTable();
+    return dataTable.getRangeLabel();
   }
 
   async goToNextPage() {
-    const paginator = await this.getPaginator();
-    await paginator.goToNextPage();
+    const dataTable = await this.getDataTable();
+    await dataTable.goToNextPage();
   }
 
   async isLoading() {
-    const progressBar = await this.getProgressBar();
-    return progressBar !== null;
+    const dataTable = await this.getDataTable();
+    return dataTable.isLoading();
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.html
@@ -130,6 +130,7 @@
           [matSortActive]="sortActive()"
           [matSortDirection]="sortDirection()"
           class="messages-browser__table"
+          multiTemplateDataRows
         >
           <ng-container matColumnDef="partition">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>Partition</th>
@@ -156,8 +157,49 @@
             <td mat-cell *matCellDef="let m">{{ truncate(m.value) }}</td>
           </ng-container>
 
+          <ng-container matColumnDef="expandedDetail">
+            <td mat-cell *matCellDef="let msg" [attr.colspan]="displayedColumns.length">
+              @if (expandedMessage() === msg) {
+                <div class="messages-browser__detail">
+                  <div class="messages-browser__detail-section">
+                    <strong>Key:</strong>
+                    <pre class="messages-browser__pre">{{ msg.key }}</pre>
+                  </div>
+                  <div class="messages-browser__detail-section">
+                    <strong>Value:</strong>
+                    <pre class="messages-browser__pre">{{ isJson(msg.value) ? formatJson(msg.value) : msg.value }}</pre>
+                  </div>
+                  @if (msg.headers && msg.headers.length > 0) {
+                    <div class="messages-browser__detail-section">
+                      <strong>Headers:</strong>
+                      <table mat-table [dataSource]="msg.headers" class="messages-browser__headers-table">
+                        <ng-container matColumnDef="key">
+                          <th mat-header-cell *matHeaderCellDef>Key</th>
+                          <td mat-cell *matCellDef="let h">{{ h.key }}</td>
+                        </ng-container>
+                        <ng-container matColumnDef="value">
+                          <th mat-header-cell *matHeaderCellDef>Value</th>
+                          <td mat-cell *matCellDef="let h">{{ h.value }}</td>
+                        </ng-container>
+                        <tr mat-header-row *matHeaderRowDef="['key', 'value']"></tr>
+                        <tr mat-row *matRowDef="let row; columns: ['key', 'value']"></tr>
+                      </table>
+                    </div>
+                  }
+                </div>
+              }
+            </td>
+          </ng-container>
+
           <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: displayedColumns" class="messages-browser__row" (click)="onRowClick(row)"></tr>
+          <tr
+            mat-row
+            *matRowDef="let row; columns: displayedColumns"
+            class="messages-browser__row"
+            [class.messages-browser__row--expanded]="expandedMessage() === row"
+            (click)="onRowClick(row)"
+          ></tr>
+          <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="messages-browser__detail-row"></tr>
         </table>
       </mat-card-content>
     </mat-card>
@@ -167,41 +209,6 @@
     <mat-card>
       <mat-card-content>
         <p class="messages-browser__empty">No messages found.</p>
-      </mat-card-content>
-    </mat-card>
-  }
-
-  @if (expandedMessage(); as msg) {
-    <mat-card class="messages-browser__detail">
-      <mat-card-header>
-        <mat-card-title>Message Detail - Partition {{ msg.partition }}, Offset {{ msg.offset }}</mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <div class="messages-browser__detail-section">
-          <strong>Key:</strong>
-          <pre class="messages-browser__pre">{{ msg.key }}</pre>
-        </div>
-        <div class="messages-browser__detail-section">
-          <strong>Value:</strong>
-          <pre class="messages-browser__pre">{{ isJson(msg.value) ? formatJson(msg.value) : msg.value }}</pre>
-        </div>
-        @if (msg.headers && msg.headers.length > 0) {
-          <div class="messages-browser__detail-section">
-            <strong>Headers:</strong>
-            <table mat-table [dataSource]="msg.headers" class="messages-browser__headers-table">
-              <ng-container matColumnDef="key">
-                <th mat-header-cell *matHeaderCellDef>Key</th>
-                <td mat-cell *matCellDef="let h">{{ h.key }}</td>
-              </ng-container>
-              <ng-container matColumnDef="value">
-                <th mat-header-cell *matHeaderCellDef>Value</th>
-                <td mat-cell *matCellDef="let h">{{ h.value }}</td>
-              </ng-container>
-              <tr mat-header-row *matHeaderRowDef="['key', 'value']"></tr>
-              <tr mat-row *matRowDef="let row; columns: ['key', 'value']"></tr>
-            </table>
-          </div>
-        }
       </mat-card-content>
     </mat-card>
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.component.scss
@@ -68,6 +68,32 @@
     &:hover {
       background-color: var(--mat-sys-surface-variant, rgba(0, 0, 0, 0.04));
     }
+
+    &--expanded {
+      background-color: var(--mat-sys-surface-variant, rgba(0, 0, 0, 0.04));
+    }
+  }
+
+  &__detail-row {
+    height: 0;
+
+    > td {
+      padding: 0;
+      border-bottom-width: 0;
+    }
+
+    &:has(.messages-browser__detail) {
+      height: auto;
+
+      > td {
+        border-bottom-width: 1px;
+      }
+    }
+  }
+
+  &__detail {
+    padding: 16px 24px;
+    overflow: hidden;
   }
 
   &__empty {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/messages/messages-browser.harness.ts
@@ -54,7 +54,8 @@ export class MessagesBrowserHarness extends ComponentHarness {
     const tables = await this.getTables();
     if (tables.length < 1) return [];
     const rows = await tables[0].getRows();
-    return parallel(() => rows.map(row => row.getCellTextByColumnName()));
+    const allCells = await parallel(() => rows.map(row => row.getCellTextByColumnName()));
+    return allCells.filter(cells => 'partition' in cells);
   }
 
   async clickMessageRow(index: number) {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.html
@@ -43,35 +43,52 @@
         <mat-card-title>Partitions</mat-card-title>
       </mat-card-header>
       <mat-card-content>
-        <table mat-table [dataSource]="detail.partitions">
-          <ng-container matColumnDef="id">
-            <th mat-header-cell *matHeaderCellDef>ID</th>
-            <td mat-cell *matCellDef="let p">{{ p.id }}</td>
-          </ng-container>
+        <gke-data-table
+          [empty]="detail.partitions.length === 0"
+          emptyMessage="No partitions found"
+          [paginated]="true"
+          [totalElements]="partitionSortedData().length"
+          [page]="partitionPage()"
+          [pageSize]="partitionPageSize()"
+          (pageChange)="partitionPage.set($event.page); partitionPageSize.set($event.pageSize)"
+        >
+          <table
+            mat-table
+            [dataSource]="partitionPaginatedData()"
+            matSort
+            [matSortActive]="partitionSortActive()"
+            [matSortDirection]="partitionSortDirection()"
+            (matSortChange)="onPartitionSortChange($event)"
+          >
+            <ng-container matColumnDef="id">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>ID</th>
+              <td mat-cell *matCellDef="let p">{{ p.id }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="leader">
-            <th mat-header-cell *matHeaderCellDef>Leader</th>
-            <td mat-cell *matCellDef="let p">{{ p.leader?.host }}:{{ p.leader?.port }}</td>
-          </ng-container>
+            <ng-container matColumnDef="leader">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Leader</th>
+              <td mat-cell *matCellDef="let p">{{ p.leader?.host }}:{{ p.leader?.port }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="replicas">
-            <th mat-header-cell *matHeaderCellDef>Replicas</th>
-            <td mat-cell *matCellDef="let p">{{ p.replicas?.length }}</td>
-          </ng-container>
+            <ng-container matColumnDef="replicas">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Replicas</th>
+              <td mat-cell *matCellDef="let p">{{ p.replicas?.length }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="isr">
-            <th mat-header-cell *matHeaderCellDef>ISR</th>
-            <td mat-cell *matCellDef="let p">{{ p.isr?.length }}</td>
-          </ng-container>
+            <ng-container matColumnDef="isr">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>ISR</th>
+              <td mat-cell *matCellDef="let p">{{ p.isr?.length }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="offline">
-            <th mat-header-cell *matHeaderCellDef>Offline</th>
-            <td mat-cell *matCellDef="let p">{{ p.offline?.length }}</td>
-          </ng-container>
+            <ng-container matColumnDef="offline">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Offline</th>
+              <td mat-cell *matCellDef="let p">{{ p.offline?.length }}</td>
+            </ng-container>
 
-          <tr mat-header-row *matHeaderRowDef="partitionColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: partitionColumns"></tr>
-        </table>
+            <tr mat-header-row *matHeaderRowDef="partitionColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: partitionColumns"></tr>
+          </table>
+        </gke-data-table>
       </mat-card-content>
     </mat-card>
 
@@ -80,35 +97,55 @@
         <mat-card-title>Configuration</mat-card-title>
       </mat-card-header>
       <mat-card-content>
-        <table mat-table [dataSource]="detail.configs">
-          <ng-container matColumnDef="name">
-            <th mat-header-cell *matHeaderCellDef>Name</th>
-            <td mat-cell *matCellDef="let c">{{ c.name }}</td>
-          </ng-container>
+        <gke-data-table
+          [filterable]="true"
+          filterPlaceholder="Search configuration..."
+          [empty]="configsEmpty()"
+          emptyMessage="No configuration found"
+          (filterChange)="onConfigFilter($event)"
+          [paginated]="true"
+          [totalElements]="configSortedData().length"
+          [page]="configPage()"
+          [pageSize]="configPageSize()"
+          (pageChange)="configPage.set($event.page); configPageSize.set($event.pageSize)"
+        >
+          <table
+            mat-table
+            [dataSource]="configPaginatedData()"
+            matSort
+            [matSortActive]="configSortActive()"
+            [matSortDirection]="configSortDirection()"
+            (matSortChange)="onConfigSortChange($event)"
+          >
+            <ng-container matColumnDef="name">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
+              <td mat-cell *matCellDef="let c">{{ c.name }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="value">
-            <th mat-header-cell *matHeaderCellDef>Value</th>
-            <td mat-cell *matCellDef="let c">{{ c.sensitive ? '******' : c.value }}</td>
-          </ng-container>
+            <ng-container matColumnDef="value">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Value</th>
+              <td mat-cell *matCellDef="let c">{{ c.sensitive ? '******' : c.value }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="source">
-            <th mat-header-cell *matHeaderCellDef>Source</th>
-            <td mat-cell *matCellDef="let c">{{ c.source }}</td>
-          </ng-container>
+            <ng-container matColumnDef="source">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Source</th>
+              <td mat-cell *matCellDef="let c">{{ c.source }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="readOnly">
-            <th mat-header-cell *matHeaderCellDef>Read Only</th>
-            <td mat-cell *matCellDef="let c">{{ c.readOnly ? 'Yes' : 'No' }}</td>
-          </ng-container>
+            <ng-container matColumnDef="readOnly">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Read Only</th>
+              <td mat-cell *matCellDef="let c">{{ c.readOnly ? 'Yes' : 'No' }}</td>
+            </ng-container>
 
-          <ng-container matColumnDef="sensitive">
-            <th mat-header-cell *matHeaderCellDef>Sensitive</th>
-            <td mat-cell *matCellDef="let c">{{ c.sensitive ? 'Yes' : 'No' }}</td>
-          </ng-container>
+            <ng-container matColumnDef="sensitive">
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Sensitive</th>
+              <td mat-cell *matCellDef="let c">{{ c.sensitive ? 'Yes' : 'No' }}</td>
+            </ng-container>
 
-          <tr mat-header-row *matHeaderRowDef="configColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: configColumns"></tr>
-        </table>
+            <tr mat-header-row *matHeaderRowDef="configColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: configColumns"></tr>
+          </table>
+        </gke-data-table>
       </mat-card-content>
     </mat-card>
 
@@ -117,12 +154,25 @@
         <mat-card-title>Consumer Groups</mat-card-title>
       </mat-card-header>
       <mat-card-content>
-        @if (consumerGroups().length === 0) {
-          <p class="topic-detail__empty">No consumer groups found</p>
-        } @else {
-          <table mat-table [dataSource]="consumerGroups()">
+        <gke-data-table
+          [empty]="consumerGroups().length === 0"
+          emptyMessage="No consumer groups found"
+          [paginated]="true"
+          [totalElements]="cgSortedData().length"
+          [page]="cgPage()"
+          [pageSize]="cgPageSize()"
+          (pageChange)="cgPage.set($event.page); cgPageSize.set($event.pageSize)"
+        >
+          <table
+            mat-table
+            [dataSource]="cgPaginatedData()"
+            matSort
+            [matSortActive]="cgSortActive()"
+            [matSortDirection]="cgSortDirection()"
+            (matSortChange)="onCgSortChange($event)"
+          >
             <ng-container matColumnDef="groupId">
-              <th mat-header-cell *matHeaderCellDef>Group ID</th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Group ID</th>
               <td mat-cell *matCellDef="let g">
                 <a
                   class="topic-detail__link"
@@ -135,12 +185,12 @@
             </ng-container>
 
             <ng-container matColumnDef="membersCount">
-              <th mat-header-cell *matHeaderCellDef>Active Consumers</th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Active Consumers</th>
               <td mat-cell *matCellDef="let g">{{ g.membersCount }}</td>
             </ng-container>
 
             <ng-container matColumnDef="totalLag">
-              <th mat-header-cell *matHeaderCellDef>Messages Behind</th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Messages Behind</th>
               <td mat-cell *matCellDef="let g">
                 {{ g.totalLag }}
                 @if (g.totalLag > 0) {
@@ -150,12 +200,12 @@
             </ng-container>
 
             <ng-container matColumnDef="coordinator">
-              <th mat-header-cell *matHeaderCellDef>Coordinator</th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>Coordinator</th>
               <td mat-cell *matCellDef="let g">{{ g.coordinator?.host }}:{{ g.coordinator?.port }}</td>
             </ng-container>
 
             <ng-container matColumnDef="state">
-              <th mat-header-cell *matHeaderCellDef>State</th>
+              <th mat-header-cell *matHeaderCellDef mat-sort-header>State</th>
               <td mat-cell *matCellDef="let g">
                 <gke-badge [color]="stateColor(g.state)">{{ g.state }}</gke-badge>
               </td>
@@ -164,7 +214,7 @@
             <tr mat-header-row *matHeaderRowDef="consumerGroupColumns"></tr>
             <tr mat-row *matRowDef="let row; columns: consumerGroupColumns"></tr>
           </table>
-        }
+        </gke-data-table>
       </mat-card-content>
     </mat-card>
   }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topic-detail/topic-detail.component.ts
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { Sort, MatSortModule, SortDirection } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 
 import { BadgeColor, BadgeComponent } from '../../../components/badge/badge.component';
-import { ConsumerGroupSummary, DescribeTopicResponse } from '../../../models/kafka-cluster.model';
+import { DataTableComponent } from '../../../components/data-table/data-table.component';
+import { ConsumerGroupSummary, DescribeTopicResponse, TopicConfig, TopicPartitionDetail } from '../../../models/kafka-cluster.model';
+import { SortComparators, sortData } from '../../../utils/sort-data';
 
 const STATE_COLORS: Record<string, BadgeColor> = {
   stable: 'success',
@@ -34,7 +37,17 @@ const STATE_COLORS: Record<string, BadgeColor> = {
 @Component({
   selector: 'gke-topic-detail',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatTableModule, MatIconModule, MatButtonModule, MatProgressBarModule, BadgeComponent],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatTableModule,
+    MatSortModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressBarModule,
+    BadgeComponent,
+    DataTableComponent,
+  ],
   templateUrl: './topic-detail.component.html',
   styleUrls: ['./topic-detail.component.scss'],
 })
@@ -50,6 +63,112 @@ export class TopicDetailComponent {
   partitionColumns = ['id', 'leader', 'replicas', 'isr', 'offline'];
   configColumns = ['name', 'value', 'source', 'readOnly', 'sensitive'];
   consumerGroupColumns = ['groupId', 'membersCount', 'totalLag', 'coordinator', 'state'];
+
+  // Partitions sort + pagination
+  partitionSortActive = signal('');
+  partitionSortDirection = signal<SortDirection>('');
+  partitionPage = signal(0);
+  partitionPageSize = signal(25);
+
+  private partitionComparators: SortComparators<TopicPartitionDetail> = {
+    id: (a, b) => a.id - b.id,
+    leader: (a, b) => (a.leader?.host ?? '').localeCompare(b.leader?.host ?? ''),
+    replicas: (a, b) => (a.replicas?.length ?? 0) - (b.replicas?.length ?? 0),
+    isr: (a, b) => (a.isr?.length ?? 0) - (b.isr?.length ?? 0),
+    offline: (a, b) => (a.offline?.length ?? 0) - (b.offline?.length ?? 0),
+  };
+
+  partitionSortedData = computed(() =>
+    sortData(this.topicDetail()?.partitions ?? [], this.partitionSortActive(), this.partitionSortDirection(), this.partitionComparators),
+  );
+
+  partitionPaginatedData = computed(() => {
+    const data = this.partitionSortedData();
+    const start = this.partitionPage() * this.partitionPageSize();
+    return data.slice(start, start + this.partitionPageSize());
+  });
+
+  // Configuration filter + sort + pagination
+  configFilter = signal('');
+  configSortActive = signal('');
+  configSortDirection = signal<SortDirection>('');
+  configPage = signal(0);
+  configPageSize = signal(25);
+
+  configsEmpty = computed(() => (this.topicDetail()?.configs?.length ?? 0) === 0);
+
+  configFilteredData = computed(() => {
+    const data = this.topicDetail()?.configs ?? [];
+    const filter = this.configFilter();
+    if (!filter) return data;
+    return data.filter(
+      (c: TopicConfig) =>
+        c.name.toLowerCase().includes(filter) || c.value.toLowerCase().includes(filter) || c.source.toLowerCase().includes(filter),
+    );
+  });
+
+  private configComparators: SortComparators<TopicConfig> = {
+    name: (a, b) => a.name.localeCompare(b.name),
+    value: (a, b) => a.value.localeCompare(b.value),
+    source: (a, b) => a.source.localeCompare(b.source),
+    readOnly: (a, b) => Number(a.readOnly) - Number(b.readOnly),
+    sensitive: (a, b) => Number(a.sensitive) - Number(b.sensitive),
+  };
+
+  configSortedData = computed(() =>
+    sortData(this.configFilteredData(), this.configSortActive(), this.configSortDirection(), this.configComparators),
+  );
+
+  configPaginatedData = computed(() => {
+    const data = this.configSortedData();
+    const start = this.configPage() * this.configPageSize();
+    return data.slice(start, start + this.configPageSize());
+  });
+
+  // Consumer Groups sort + pagination
+  cgSortActive = signal('');
+  cgSortDirection = signal<SortDirection>('');
+  cgPage = signal(0);
+  cgPageSize = signal(25);
+
+  private cgComparators: SortComparators<ConsumerGroupSummary> = {
+    groupId: (a, b) => a.groupId.localeCompare(b.groupId),
+    membersCount: (a, b) => a.membersCount - b.membersCount,
+    totalLag: (a, b) => a.totalLag - b.totalLag,
+    coordinator: (a, b) => (a.coordinator?.id ?? 0) - (b.coordinator?.id ?? 0),
+    state: (a, b) => (a.state ?? '').localeCompare(b.state ?? ''),
+  };
+
+  cgSortedData = computed(() => sortData(this.consumerGroups(), this.cgSortActive(), this.cgSortDirection(), this.cgComparators));
+
+  cgPaginatedData = computed(() => {
+    const data = this.cgSortedData();
+    const start = this.cgPage() * this.cgPageSize();
+    return data.slice(start, start + this.cgPageSize());
+  });
+
+  onPartitionSortChange(sort: Sort) {
+    this.partitionSortActive.set(sort.active);
+    this.partitionSortDirection.set(sort.direction);
+    this.partitionPage.set(0);
+  }
+
+  onConfigSortChange(sort: Sort) {
+    this.configSortActive.set(sort.active);
+    this.configSortDirection.set(sort.direction);
+    this.configPage.set(0);
+  }
+
+  onCgSortChange(sort: Sort) {
+    this.cgSortActive.set(sort.active);
+    this.cgSortDirection.set(sort.direction);
+    this.cgPage.set(0);
+  }
+
+  onConfigFilter(value: string) {
+    this.configFilter.set(value.trim().toLowerCase());
+    this.configPage.set(0);
+  }
 
   stateColor(state: string | undefined): BadgeColor {
     return STATE_COLORS[state?.toLowerCase() ?? ''] ?? 'default';

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics-page.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics-page.component.html
@@ -23,5 +23,6 @@
   [loading]="topicsLoading()"
   (filterChange)="onTopicsFilterChange($event)"
   (pageChange)="onTopicsPageChange($event)"
+  (sortChange)="onTopicsSortChange($event)"
   (topicSelect)="onTopicSelect($event)"
 />

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics-page.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics-page.component.ts
@@ -42,6 +42,8 @@ export class TopicsPageComponent implements OnInit {
   private currentFilter = '';
   private currentPage = 0;
   private currentPageSize = 25;
+  private currentSortBy = '';
+  private currentSortOrder = '';
   private readonly filterSubject = new Subject<string>();
 
   ngOnInit() {
@@ -68,10 +70,25 @@ export class TopicsPageComponent implements OnInit {
     this.loadTopics(this.currentFilter, event.page, event.pageSize);
   }
 
+  onTopicsSortChange(event: { active: string; direction: string }) {
+    this.currentSortBy = event.active;
+    this.currentSortOrder = event.direction;
+    this.currentPage = 0;
+    this.loadTopics(this.currentFilter, 0, this.currentPageSize);
+  }
+
   private loadTopics(nameFilter: string, page: number, pageSize: number) {
     this.topicsLoading.set(true);
     this.service
-      .listTopics(this.store.baseURL(), this.store.clusterId(), nameFilter || undefined, page + 1, pageSize)
+      .listTopics(
+        this.store.baseURL(),
+        this.store.clusterId(),
+        nameFilter || undefined,
+        page + 1,
+        pageSize,
+        this.currentSortBy || undefined,
+        this.currentSortOrder || undefined,
+      )
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: response => {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.component.html
@@ -33,16 +33,9 @@
       (filterChange)="filterChange.emit($event)"
       (pageChange)="pageChange.emit($event)"
     >
-      <table
-        mat-table
-        [dataSource]="sortedTopics()"
-        matSort
-        [matSortActive]="sortActive()"
-        [matSortDirection]="sortDirection()"
-        (matSortChange)="onSortChange($event)"
-      >
+      <table mat-table [dataSource]="topics()" matSort (matSortChange)="onSortChange($event)">
         <ng-container matColumnDef="name">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Name</th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>Name</th>
           <td mat-cell *matCellDef="let topic">
             <span class="topics__topic-name">
               {{ topic.name }}
@@ -54,17 +47,17 @@
         </ng-container>
 
         <ng-container matColumnDef="partitionCount">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Partitions</th>
+          <th mat-header-cell *matHeaderCellDef>Partitions</th>
           <td mat-cell *matCellDef="let topic">{{ topic.partitionCount }}</td>
         </ng-container>
 
         <ng-container matColumnDef="replicationFactor">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Replication Factor</th>
+          <th mat-header-cell *matHeaderCellDef>Replication Factor</th>
           <td mat-cell *matCellDef="let topic">{{ topic.replicationFactor }}</td>
         </ng-container>
 
         <ng-container matColumnDef="underReplicatedCount">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Under-Replicated</th>
+          <th mat-header-cell *matHeaderCellDef>Under-Replicated</th>
           <td mat-cell *matCellDef="let topic">
             @if (topic.underReplicatedCount > 0) {
               <gke-badge color="warning">{{ topic.underReplicatedCount }}</gke-badge>
@@ -75,12 +68,12 @@
         </ng-container>
 
         <ng-container matColumnDef="messageCount">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Number of messages</th>
+          <th mat-header-cell *matHeaderCellDef>Number of messages</th>
           <td mat-cell *matCellDef="let topic">{{ topic.messageCount !== undefined ? (topic.messageCount | number) : '-' }}</td>
         </ng-container>
 
         <ng-container matColumnDef="size">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Size</th>
+          <th mat-header-cell *matHeaderCellDef>Size</th>
           <td mat-cell *matCellDef="let topic">{{ topic.size | gkeFileSize }}</td>
         </ng-container>
 

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.component.html
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.component.html
@@ -20,69 +20,73 @@
     <mat-card-title>Topics</mat-card-title>
   </mat-card-header>
   <mat-card-content>
-    <mat-form-field class="topics__filter" appearance="outline">
-      <mat-label>Filter by name</mat-label>
-      <input matInput (input)="onFilterInput($event)" placeholder="Search topics..." />
-    </mat-form-field>
-
-    @if (loading()) {
-      <mat-progress-bar mode="indeterminate" />
-    }
-
-    <table mat-table [dataSource]="topics()">
-      <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef>Name</th>
-        <td mat-cell *matCellDef="let topic">
-          <span class="topics__topic-name">
-            {{ topic.name }}
-            @if (topic.internal) {
-              <gke-badge class="topics__internal-badge">Internal</gke-badge>
-            }
-          </span>
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="partitionCount">
-        <th mat-header-cell *matHeaderCellDef>Partitions</th>
-        <td mat-cell *matCellDef="let topic">{{ topic.partitionCount }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="replicationFactor">
-        <th mat-header-cell *matHeaderCellDef>Replication Factor</th>
-        <td mat-cell *matCellDef="let topic">{{ topic.replicationFactor }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="underReplicatedCount">
-        <th mat-header-cell *matHeaderCellDef>Under-Replicated</th>
-        <td mat-cell *matCellDef="let topic">
-          @if (topic.underReplicatedCount > 0) {
-            <gke-badge color="warning">{{ topic.underReplicatedCount }}</gke-badge>
-          } @else {
-            {{ topic.underReplicatedCount }}
-          }
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="messageCount">
-        <th mat-header-cell *matHeaderCellDef>Number of messages</th>
-        <td mat-cell *matCellDef="let topic">{{ topic.messageCount !== undefined ? (topic.messageCount | number) : '-' }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="size">
-        <th mat-header-cell *matHeaderCellDef>Size</th>
-        <td mat-cell *matCellDef="let topic">{{ topic.size | gkeFileSize }}</td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="topics__row" (click)="topicSelect.emit(row.name)"></tr>
-    </table>
-
-    <mat-paginator
-      [length]="totalElements()"
-      [pageIndex]="page()"
+    <gke-data-table
+      [filterable]="true"
+      filterPlaceholder="Search topics..."
+      [loading]="loading()"
+      [empty]="topics().length === 0"
+      [paginated]="true"
+      [totalElements]="totalElements()"
+      [page]="page()"
       [pageSize]="pageSize()"
       [pageSizeOptions]="[25, 50, 100]"
-      (page)="onPageEvent($event)"
-    />
+      (filterChange)="filterChange.emit($event)"
+      (pageChange)="pageChange.emit($event)"
+    >
+      <table
+        mat-table
+        [dataSource]="sortedTopics()"
+        matSort
+        [matSortActive]="sortActive()"
+        [matSortDirection]="sortDirection()"
+        (matSortChange)="onSortChange($event)"
+      >
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Name</th>
+          <td mat-cell *matCellDef="let topic">
+            <span class="topics__topic-name">
+              {{ topic.name }}
+              @if (topic.internal) {
+                <gke-badge class="topics__internal-badge">Internal</gke-badge>
+              }
+            </span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="partitionCount">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Partitions</th>
+          <td mat-cell *matCellDef="let topic">{{ topic.partitionCount }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="replicationFactor">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Replication Factor</th>
+          <td mat-cell *matCellDef="let topic">{{ topic.replicationFactor }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="underReplicatedCount">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Under-Replicated</th>
+          <td mat-cell *matCellDef="let topic">
+            @if (topic.underReplicatedCount > 0) {
+              <gke-badge color="warning">{{ topic.underReplicatedCount }}</gke-badge>
+            } @else {
+              {{ topic.underReplicatedCount }}
+            }
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="messageCount">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Number of messages</th>
+          <td mat-cell *matCellDef="let topic">{{ topic.messageCount !== undefined ? (topic.messageCount | number) : '-' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="size">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header matTooltip="Sort current page only">Size</th>
+          <td mat-cell *matCellDef="let topic">{{ topic.size | gkeFileSize }}</td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns" class="topics__row" (click)="topicSelect.emit(row.name)"></tr>
+      </table>
+    </gke-data-table>
   </mat-card-content>
 </mat-card>

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.component.scss
@@ -23,11 +23,6 @@
     width: 100%;
   }
 
-  &__filter {
-    width: 100%;
-    margin-bottom: 8px;
-  }
-
   &__row {
     cursor: pointer;
 

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.component.ts
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 import { CommonModule, DecimalPipe } from '@angular/common';
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output, signal } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { Sort, MatSortModule, SortDirection } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { BadgeComponent } from '../../../components/badge/badge.component';
+import { DataTableComponent } from '../../../components/data-table/data-table.component';
 import { KafkaTopic } from '../../../models/kafka-cluster.model';
 import { FileSizePipe } from '../../../pipes/file-size.pipe';
 
@@ -33,13 +32,12 @@ import { FileSizePipe } from '../../../pipes/file-size.pipe';
     CommonModule,
     MatCardModule,
     MatTableModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatPaginatorModule,
-    MatProgressBarModule,
+    MatSortModule,
+    MatTooltipModule,
     FileSizePipe,
     DecimalPipe,
     BadgeComponent,
+    DataTableComponent,
   ],
   templateUrl: './topics.component.html',
   styleUrls: ['./topics.component.scss'],
@@ -57,12 +55,38 @@ export class TopicsComponent {
 
   displayedColumns = ['name', 'partitionCount', 'replicationFactor', 'underReplicatedCount', 'messageCount', 'size'];
 
-  onFilterInput(event: Event) {
-    const value = (event.target as HTMLInputElement).value;
-    this.filterChange.emit(value);
-  }
+  sortActive = signal('');
+  sortDirection = signal<SortDirection>('');
 
-  onPageEvent(event: PageEvent) {
-    this.pageChange.emit({ page: event.pageIndex, pageSize: event.pageSize });
+  sortedTopics = computed(() => {
+    const data = this.topics();
+    const active = this.sortActive();
+    const direction = this.sortDirection();
+    if (!active || direction === '') return data;
+
+    const factor = direction === 'asc' ? 1 : -1;
+    return [...data].sort((a, b) => {
+      switch (active) {
+        case 'name':
+          return a.name.localeCompare(b.name) * factor;
+        case 'partitionCount':
+          return (a.partitionCount - b.partitionCount) * factor;
+        case 'replicationFactor':
+          return (a.replicationFactor - b.replicationFactor) * factor;
+        case 'underReplicatedCount':
+          return ((a.underReplicatedCount ?? 0) - (b.underReplicatedCount ?? 0)) * factor;
+        case 'messageCount':
+          return ((a.messageCount ?? 0) - (b.messageCount ?? 0)) * factor;
+        case 'size':
+          return ((a.size ?? 0) - (b.size ?? 0)) * factor;
+        default:
+          return 0;
+      }
+    });
+  });
+
+  onSortChange(sort: Sort) {
+    this.sortActive.set(sort.active);
+    this.sortDirection.set(sort.direction);
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.component.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 import { CommonModule, DecimalPipe } from '@angular/common';
-import { Component, computed, input, output, signal } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
-import { Sort, MatSortModule, SortDirection } from '@angular/material/sort';
+import { Sort, MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
-import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { BadgeComponent } from '../../../components/badge/badge.component';
 import { DataTableComponent } from '../../../components/data-table/data-table.component';
@@ -28,17 +27,7 @@ import { FileSizePipe } from '../../../pipes/file-size.pipe';
 @Component({
   selector: 'gke-topics',
   standalone: true,
-  imports: [
-    CommonModule,
-    MatCardModule,
-    MatTableModule,
-    MatSortModule,
-    MatTooltipModule,
-    FileSizePipe,
-    DecimalPipe,
-    BadgeComponent,
-    DataTableComponent,
-  ],
+  imports: [CommonModule, MatCardModule, MatTableModule, MatSortModule, FileSizePipe, DecimalPipe, BadgeComponent, DataTableComponent],
   templateUrl: './topics.component.html',
   styleUrls: ['./topics.component.scss'],
 })
@@ -51,42 +40,12 @@ export class TopicsComponent {
 
   filterChange = output<string>();
   pageChange = output<{ page: number; pageSize: number }>();
+  sortChange = output<{ active: string; direction: string }>();
   topicSelect = output<string>();
 
   displayedColumns = ['name', 'partitionCount', 'replicationFactor', 'underReplicatedCount', 'messageCount', 'size'];
 
-  sortActive = signal('');
-  sortDirection = signal<SortDirection>('');
-
-  sortedTopics = computed(() => {
-    const data = this.topics();
-    const active = this.sortActive();
-    const direction = this.sortDirection();
-    if (!active || direction === '') return data;
-
-    const factor = direction === 'asc' ? 1 : -1;
-    return [...data].sort((a, b) => {
-      switch (active) {
-        case 'name':
-          return a.name.localeCompare(b.name) * factor;
-        case 'partitionCount':
-          return (a.partitionCount - b.partitionCount) * factor;
-        case 'replicationFactor':
-          return (a.replicationFactor - b.replicationFactor) * factor;
-        case 'underReplicatedCount':
-          return ((a.underReplicatedCount ?? 0) - (b.underReplicatedCount ?? 0)) * factor;
-        case 'messageCount':
-          return ((a.messageCount ?? 0) - (b.messageCount ?? 0)) * factor;
-        case 'size':
-          return ((a.size ?? 0) - (b.size ?? 0)) * factor;
-        default:
-          return 0;
-      }
-    });
-  });
-
   onSortChange(sort: Sort) {
-    this.sortActive.set(sort.active);
-    this.sortDirection.set(sort.direction);
+    this.sortChange.emit({ active: sort.active, direction: sort.direction });
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/features/topics/topics/topics.harness.ts
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 import { ComponentHarness, parallel } from '@angular/cdk/testing';
-import { MatInputHarness } from '@angular/material/input/testing';
-import { MatPaginatorHarness } from '@angular/material/paginator/testing';
-import { MatProgressBarHarness } from '@angular/material/progress-bar/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
+
+import { DataTableHarness } from '../../../components/data-table/data-table.harness';
 
 export class TopicsHarness extends ComponentHarness {
   static hostSelector = 'gke-topics';
 
   private readonly getTable = this.locatorFor(MatTableHarness);
-  private readonly getFilterInput = this.locatorFor(MatInputHarness);
-  private readonly getPaginator = this.locatorFor(MatPaginatorHarness);
-  private readonly getProgressBar = this.locatorForOptional(MatProgressBarHarness);
+  private readonly getDataTable = this.locatorFor(DataTableHarness);
 
   async getRows() {
     const table = await this.getTable();
@@ -43,26 +40,27 @@ export class TopicsHarness extends ComponentHarness {
   }
 
   async setFilter(value: string) {
-    const input = await this.getFilterInput();
-    await input.setValue(value);
+    const dataTable = await this.getDataTable();
+    await dataTable.setFilter(value);
   }
 
   async getPaginatorHarness() {
-    return this.getPaginator();
+    const dataTable = await this.getDataTable();
+    return dataTable.getPaginatorHarness();
   }
 
   async getRangeLabel() {
-    const paginator = await this.getPaginator();
-    return paginator.getRangeLabel();
+    const dataTable = await this.getDataTable();
+    return dataTable.getRangeLabel();
   }
 
   async goToNextPage() {
-    const paginator = await this.getPaginator();
-    await paginator.goToNextPage();
+    const dataTable = await this.getDataTable();
+    await dataTable.goToNextPage();
   }
 
   async isLoading() {
-    const progressBar = await this.getProgressBar();
-    return progressBar !== null;
+    const dataTable = await this.getDataTable();
+    return dataTable.isLoading();
   }
 }

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/services/kafka-explorer.service.ts
@@ -39,14 +39,19 @@ export class KafkaExplorerService {
     return this.http.post<DescribeClusterResponse>(`${baseURL}/kafka-explorer/describe-cluster`, { clusterId });
   }
 
-  listTopics(baseURL: string, clusterId: string, nameFilter?: string, page = 1, perPage = 25): Observable<ListTopicsResponse> {
-    return this.http.post<ListTopicsResponse>(
-      `${baseURL}/kafka-explorer/list-topics`,
-      { clusterId, nameFilter },
-      {
-        params: { page: page.toString(), perPage: perPage.toString() },
-      },
-    );
+  listTopics(
+    baseURL: string,
+    clusterId: string,
+    nameFilter?: string,
+    page = 1,
+    perPage = 25,
+    sortBy?: string,
+    sortOrder?: string,
+  ): Observable<ListTopicsResponse> {
+    const params: Record<string, string> = { page: page.toString(), perPage: perPage.toString() };
+    if (sortBy) params['sortBy'] = sortBy;
+    if (sortOrder) params['sortOrder'] = sortOrder;
+    return this.http.post<ListTopicsResponse>(`${baseURL}/kafka-explorer/list-topics`, { clusterId, nameFilter }, { params });
   }
 
   describeTopic(baseURL: string, clusterId: string, topicName: string): Observable<DescribeTopicResponse> {
@@ -64,12 +69,15 @@ export class KafkaExplorerService {
     page = 1,
     perPage = 25,
     topicFilter?: string,
+    sortBy?: string,
+    sortOrder?: string,
   ): Observable<ListConsumerGroupsResponse> {
     const body: Record<string, unknown> = { clusterId, nameFilter };
     if (topicFilter) body['topicFilter'] = topicFilter;
-    return this.http.post<ListConsumerGroupsResponse>(`${baseURL}/kafka-explorer/list-consumer-groups`, body, {
-      params: { page: page.toString(), perPage: perPage.toString() },
-    });
+    const params: Record<string, string> = { page: page.toString(), perPage: perPage.toString() };
+    if (sortBy) params['sortBy'] = sortBy;
+    if (sortOrder) params['sortOrder'] = sortOrder;
+    return this.http.post<ListConsumerGroupsResponse>(`${baseURL}/kafka-explorer/list-consumer-groups`, body, { params });
   }
 
   describeConsumerGroup(baseURL: string, clusterId: string, groupId: string): Observable<DescribeConsumerGroupResponse> {

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/utils/sort-data.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/lib/utils/sort-data.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SortDirection } from '@angular/material/sort';
+
+export type SortComparators<T> = Record<string, (a: T, b: T) => number>;
+
+export function sortData<T>(data: T[], active: string, direction: SortDirection, comparators: SortComparators<T>): T[] {
+  if (!active || direction === '') {
+    return data;
+  }
+
+  const comparator = comparators[active];
+  if (!comparator) {
+    return data;
+  }
+
+  const factor = direction === 'asc' ? 1 : -1;
+  return [...data].sort((a, b) => comparator(a, b) * factor);
+}

--- a/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/testing-public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-kafka-explorer/src/testing-public-api.ts
@@ -17,6 +17,7 @@
  * Public API Surface of gravitee-kafka-explorer/testing
  */
 
+export * from './lib/components/data-table/data-table.harness';
 export * from './lib/kafka-explorer/kafka-explorer.harness';
 export * from './lib/features/brokers/brokers/brokers.harness';
 export * from './lib/features/brokers/broker-detail/broker-detail.harness';


### PR DESCRIPTION
## Summary

- Add reusable `gke-data-table` wrapper component with filter, pagination and empty state support
- Add client-side **sort** and **pagination** on all detail tables (broker-detail, topic-detail, consumer-group-detail) using a shared `sortData` utility
- Add **server-side sorting** (by name/groupId) on topics and consumer groups list pages with `sortBy`/`sortOrder` query params
- Show **message detail as expandable row** under the selected message instead of at the bottom of the page
- Replace `$any()` template cast with typed `onFilterChange` method in data-table component

### PR review feedback addressed
- **Type safety**: removed `$any()` from data-table template, added `onFilterChange(event: Event)` method
- **Sort deduplication**: extracted generic `sortData<T>()` utility with `SortComparators<T>` type, used across all detail components
- **Server-side sort**: added `sortBy`/`sortOrder` params to list-topics and list-consumer-groups endpoints (backend + frontend), removed client-side sort from list pages

<img width="1967" height="1235" alt="image" src="https://github.com/user-attachments/assets/1ecba903-b2ad-4c3a-aae1-89110e928864" />
<img width="1440" height="989" alt="image" src="https://github.com/user-attachments/assets/77bf7290-a2e0-4fa6-bc5a-6c586c3c0a6a" />
