### PR TITLE
fix: added shared api key changes for API product

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.spec.ts
@@ -66,6 +66,7 @@ class TestComponent {
   public plans?: Plan[];
   public isFederatedApi?: boolean;
   public availableSubscriptionEntrypoints?: Entrypoint[];
+  public apiProductId?: string;
   public subscriptionToCreate: CreateSubscription;
   public dialog: MatDialogRef<ApiPortalSubscriptionCreationDialogComponent>;
   constructor(private readonly matDialog: MatDialog) {}
@@ -80,6 +81,7 @@ class TestComponent {
         plans: this.plans,
         availableSubscriptionEntrypoints: this.availableSubscriptionEntrypoints,
         isFederatedApi: this.isFederatedApi,
+        apiProductId: this.apiProductId,
       },
       role: 'alertdialog',
       id: 'testDialog',
@@ -511,6 +513,45 @@ describe('Subscription creation dialog', () => {
         await harness.chooseApiKeyMode('Shared API Key');
 
         expect(await harness.isCustomApiKeyInputDisplayed()).toBeFalsy();
+      });
+
+      it('should display Shared API Key choice for API Product when app has existing API subscription', async () => {
+        const API_PRODUCT_ID = 'my-api-product';
+        const applicationWithClientId = fakeApplication({
+          id: 'my-app',
+          name: 'withClientId',
+          settings: { app: { client_id: 'clientId' } },
+          api_key_mode: ApiKeyMode.UNSPECIFIED,
+        });
+        const planV4 = fakePlanV4({
+          apiId: undefined,
+          apiProductId: API_PRODUCT_ID,
+          mode: 'STANDARD',
+          security: { type: 'API_KEY' },
+          generalConditions: undefined,
+        });
+        component.plans = [planV4];
+        component.availableSubscriptionEntrypoints = [];
+        component.apiProductId = API_PRODUCT_ID;
+
+        await componentTestingOpenDialog();
+
+        const harness = await loader.getHarness(ApiPortalSubscriptionCreationDialogHarness);
+        await harness.searchApplication('withClientId');
+        expectApplicationsSearch('withClientId', [applicationWithClientId]);
+        await harness.selectApplication(applicationWithClientId.name);
+
+        const apikeySubscription: Partial<SubscriptionPage> = {
+          security: PlanSecurityType.API_KEY,
+          api: 'another-api-id',
+          origin: 'MANAGEMENT',
+        };
+        expectSubscriptionsForApplication(applicationWithClientId.id, [apikeySubscription]);
+
+        await harness.choosePlan(planV4.name);
+
+        expectApiKeySubscriptionsGetRequest(applicationWithClientId.id, [apikeySubscription]);
+        expect(await harness.isApiKeyModeRadioGroupDisplayed()).toBeTruthy();
       });
     });
     describe('With custom API Key enabled and shared apiKey enabled and API is Federated', () => {

--- a/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/subscriptions/components/dialogs/creation/api-portal-subscription-creation-dialog.component.ts
@@ -259,7 +259,10 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
         }),
         switchMap(([subscriptions, plan]) => {
           if (this.canUseSharedApiKeys && this.form.get('selectedApplication').value.api_key_mode === ApiKeyMode.UNSPECIFIED) {
-            return of(subscriptions?.data?.filter(subscription => subscription?.api !== plan?.apiId).length >= 1);
+            const hasOtherApiKeySubscription = (subscriptions?.data ?? []).some(
+              subscription => !this.subscriptionMatchesPlan(subscription, plan),
+            );
+            return of(hasOtherApiKeySubscription);
           }
           return of(false);
         }),
@@ -303,6 +306,16 @@ export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnD
         takeUntil(this.unsubscribe$),
       )
       .subscribe();
+  }
+
+  private subscriptionMatchesPlan(
+    subscription: SubscriptionPage | null | undefined,
+    { apiId, apiProductId }: { apiId?: string; apiProductId?: string },
+  ): boolean {
+    if (!subscription) return false;
+    if (apiId) return subscription.api === apiId;
+    if (apiProductId) return subscription.referenceType === 'API_PRODUCT' && subscription.referenceId === apiProductId;
+    return false;
   }
 
   private onJwtOrOauth2PlanChange() {

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.spec.ts
@@ -419,6 +419,32 @@ describe('ApplicationSubscriptionCreationDialogComponent', () => {
         generalConditions: null,
       });
 
+      it('should display Shared API Key choice and create subscription when app has existing API Key subscription', fakeAsync(async () => {
+        await init(APP, {
+          plan: {
+            security: {
+              ...DEFAULT_ENV_SETTINGS.plan.security,
+              sharedApiKey: { enabled: true },
+            },
+          },
+        });
+
+        await dialogHarness.searchApi(API_PRODUCT_NAME);
+        tick(100);
+        expectApiSearchPost(API_PRODUCT_NAME, [], [API_PRODUCT]);
+
+        await dialogHarness.selectApi(API_PRODUCT_NAME);
+        expectSubscribableApiProductPlansGet(API_PRODUCT_ID, [{ ...API_PRODUCT_PLAN, apiId: undefined, apiProductId: API_PRODUCT_ID }]);
+
+        await dialogHarness.selectPlan(API_PRODUCT_PLAN.name);
+        await dialogHarness.selectApiKeyMode('Shared API Key');
+        await dialogHarness.createSubscription();
+
+        const subscription = fakeNewSubscriptionEntity({ apiKeyMode: ApiKeyMode.SHARED });
+        expectApiSubscriptionsPostRequest(subscription, API_PRODUCT_PLAN.id, ApiKeyMode.SHARED);
+        expect(routerNavigateSpy).toHaveBeenCalledWith(['.', expect.anything()], expect.anything());
+      }));
+
       it('should create a subscription for an API Product', fakeAsync(async () => {
         await init();
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/creation/application-subscription-creation-dialog.component.ts
@@ -224,6 +224,16 @@ export class ApplicationSubscriptionCreationDialogComponent {
       .subscribe();
   }
 
+  private subscriptionMatchesPlan(
+    subscription: SubscriptionPage | null | undefined,
+    { apiId, apiProductId }: { apiId?: string; apiProductId?: string },
+  ): boolean {
+    if (!subscription) return false;
+    if (apiId) return subscription.api === apiId;
+    if (apiProductId) return subscription.referenceType === 'API_PRODUCT' && subscription.referenceId === apiProductId;
+    return false;
+  }
+
   private onApiKeyPlanChange() {
     this.form.controls.selectedPlan.valueChanges
       .pipe(
@@ -234,8 +244,8 @@ export class ApplicationSubscriptionCreationDialogComponent {
             !this.isFederatedApi &&
               this.canUseSharedApiKeys &&
               this.application.api_key_mode === ApiKeyMode.UNSPECIFIED &&
-              plan.apiId != null &&
-              this.apiKeySubscriptions.some(subscription => subscription?.api !== plan.apiId),
+              (plan.apiId != null || plan.apiProductId != null) &&
+              this.apiKeySubscriptions.some(subscription => !this.subscriptionMatchesPlan(subscription, plan)),
           ),
         ),
         tap(shouldDisplayKeyModeChoice => {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResource.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.management.v2.rest.utils.SubscriptionExpandHelper;
+import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.SubscriptionConfigurationEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.parameters.Key;
@@ -226,6 +227,7 @@ public class ApiProductSubscriptionsResource extends AbstractResource {
             .customApiKey(createSubscription.getCustomApiKey())
             .configuration(coreConfig)
             .metadata(createSubscription.getMetadata())
+            .apiKeyMode(getApiKeyMode(createSubscription))
             .generalConditionsAccepted(null)
             .generalConditionsContentRevision(null)
             .auditInfo(getAuditInfo())
@@ -310,5 +312,9 @@ public class ApiProductSubscriptionsResource extends AbstractResource {
 
     private Error subscriptionInvalid(String message) {
         return new Error().httpStatus(Response.Status.BAD_REQUEST.getStatusCode()).message(message).technicalCode("subscription.invalid");
+    }
+
+    private ApiKeyMode getApiKeyMode(CreateSubscription createSubscription) {
+        return createSubscription.getApiKeyMode() != null ? ApiKeyMode.valueOf(createSubscription.getApiKeyMode().name()) : null;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -2280,9 +2280,22 @@ components:
           type: object
           additionalProperties:
             type: string
+        apiKeyMode:
+          $ref: "#/components/schemas/ApiKeyMode"
       required:
         - applicationId
         - planId
+    ApiKeyMode:
+      type: string
+      description: |
+        The mode of an application regarding ApiKey plans.
+        * UNSPECIFIED: no selected mode yet
+        * EXCLUSIVE: an API Key is generated for each new subscription
+        * SHARED: the same API Key is reused for all subscriptions of the application
+      enum:
+        - UNSPECIFIED
+        - EXCLUSIVE
+        - SHARED
     UpdateSubscription:
       type: object
       description: Request to update a subscription

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResourceTest.java
@@ -39,6 +39,7 @@ import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.core.subscription.use_case.AcceptSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.management.v2.rest.model.ApiKeyMode;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.VerifySubscription;
 import io.gravitee.rest.api.management.v2.rest.model.VerifySubscriptionResponse;
@@ -63,6 +64,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 
 class ApiProductSubscriptionsResourceTest extends AbstractResourceTest {
@@ -458,8 +461,40 @@ class ApiProductSubscriptionsResourceTest extends AbstractResourceTest {
                 soft.assertThat(captor.getValue().referenceType()).isEqualTo(SubscriptionReferenceType.API_PRODUCT);
                 soft.assertThat(captor.getValue().planId()).isEqualTo("plan-1");
                 soft.assertThat(captor.getValue().applicationId()).isEqualTo("app-1");
+                soft.assertThat(captor.getValue().apiKeyMode()).isNull();
             });
             verify(acceptSubscriptionUseCase).execute(any());
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = ApiKeyMode.class, names = { "SHARED", "EXCLUSIVE" })
+        void should_create_subscription_with_api_key_mode(ApiKeyMode apiKeyMode) {
+            io.gravitee.apim.core.subscription.model.SubscriptionEntity created =
+                io.gravitee.apim.core.subscription.model.SubscriptionEntity.builder()
+                    .id("new-sub-id")
+                    .apiId(null)
+                    .referenceId(API_PRODUCT_ID)
+                    .referenceType(SubscriptionReferenceType.API_PRODUCT)
+                    .planId("plan-1")
+                    .applicationId("app-1")
+                    .status(io.gravitee.apim.core.subscription.model.SubscriptionEntity.Status.ACCEPTED)
+                    .createdAt(ZonedDateTime.now())
+                    .updatedAt(ZonedDateTime.now())
+                    .build();
+            when(createSubscriptionUseCase.execute(any())).thenReturn(new CreateSubscriptionUseCase.Output(created));
+
+            var createPayload = new io.gravitee.rest.api.management.v2.rest.model.CreateSubscription();
+            createPayload.setPlanId("plan-1");
+            createPayload.setApplicationId("app-1");
+            createPayload.setApiKeyMode(apiKeyMode);
+
+            Response response = rootTarget().request().post(json(createPayload));
+
+            MAPIAssertions.assertThat(response).hasStatus(CREATED_201);
+
+            var captor = ArgumentCaptor.forClass(CreateSubscriptionUseCase.Input.class);
+            verify(createSubscriptionUseCase).execute(captor.capture());
+            assertThat(captor.getValue().apiKeyMode()).isEqualTo(io.gravitee.rest.api.model.ApiKeyMode.valueOf(apiKeyMode.name()));
         }
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13063

## Description


Area | Change
-- | --
Shared API Key visibility | Add subscriptionMatchesPlan() and use it so the shared API key choice appears for API Product plans(UI).
Shared API Key reuse | Pass apiKeyMode into CreateSubscriptionUseCase when creating API Product subscriptions(Backend).



https://github.com/user-attachments/assets/18e838a4-b3eb-41ff-b0c9-bb4e0f1e4598
