### PR TITLE
fix: don’t fail all token check in case of the match fail

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/websocket/auth/IntegrationWebsocketControllerAuthentication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-integration-controller/src/main/java/io/gravitee/integration/controller/websocket/auth/IntegrationWebsocketControllerAuthentication.java
@@ -17,7 +17,6 @@ package io.gravitee.integration.controller.websocket.auth;
 
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
-import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.exchange.controller.websocket.auth.WebSocketControllerAuthentication;
 import io.gravitee.integration.controller.command.IntegrationCommandContext;
 import io.gravitee.rest.api.service.TokenService;
@@ -27,7 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
 
 @CustomLog
@@ -61,7 +59,8 @@ public class IntegrationWebsocketControllerAuthentication implements WebSocketCo
                     .map(entry -> new IntegrationCommandContext(true, entry.getKey(), entry.getValue()))
                     .orElse(new IntegrationCommandContext(false));
             } catch (Exception e) {
-                log.warn("Unable to authenticate incoming websocket controller request");
+                log.warn("Token found, but unable to authenticate incoming websocket controller request");
+                log.debug("Token found, but unable to authenticate incoming websocket controller request", e);
             }
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -413,6 +413,11 @@
             <artifactId>vertx-junit5-rx-java3</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TokenServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TokenServiceImpl.java
@@ -145,7 +145,15 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
                 .findAll()
                 .stream()
                 .sorted(comparing(Token::getLastUseAt, nullsLast(reverseOrder())))
-                .filter(t -> passwordEncoder.matches(token, t.getToken()))
+                .filter(t -> {
+                    try {
+                        return passwordEncoder.matches(token, t.getToken());
+                    } catch (Exception e) {
+                        log.error("Failed to match token with password encoder (token id: {})", t.getId());
+                        log.debug("Failed to match token with password encoder (token id: {})", t.getId(), e);
+                        return false;
+                    }
+                })
                 .findFirst()
                 .orElseThrow(() -> new TokenNotFoundException(token));
 
@@ -153,7 +161,6 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
             return tokenRepository.update(matchingToken);
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to find token entity for a given token value";
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TokenServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TokenServiceTest.java
@@ -15,14 +15,12 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static com.google.common.collect.Sets.newHashSet;
 import static io.gravitee.repository.management.model.Token.AuditEvent.TOKEN_CREATED;
 import static io.gravitee.repository.management.model.Token.AuditEvent.TOKEN_DELETED;
 import static io.gravitee.rest.api.model.TokenReferenceType.USER;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static java.util.Optional.of;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -40,14 +38,16 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TokenNameAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.TokenNotFoundException;
 import java.util.*;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
@@ -58,7 +58,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
  * @author Azize ELAMRANI (azize at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
 public class TokenServiceTest {
 
     private static final String USER_ID = "user123";
@@ -75,13 +76,20 @@ public class TokenServiceTest {
     @Mock
     private AuditService auditService;
 
-    @Mock
-    private Token token;
+    Token token = Token.builder()
+        .id(TOKEN_ID)
+        .name("name")
+        .token("token")
+        .createdAt(new Date(1486771200000L))
+        .expiresAt(new Date(1486772200000L))
+        .lastUseAt(new Date(1486773200000L))
+        .referenceId(USER_ID)
+        .build();
 
     @Mock
     private PasswordEncoder passwordEncoder;
 
-    @AfterClass
+    @AfterAll
     public static void cleanSecurityContextHolder() {
         // reset authentication to avoid side effect during test executions.
         SecurityContextHolder.setContext(
@@ -98,19 +106,12 @@ public class TokenServiceTest {
         GraviteeContext.cleanContext();
     }
 
-    @Before
+    @BeforeEach
     public void init() throws TechnicalException {
         setField(tokenService, "passwordEncoder", passwordEncoder);
-        when(passwordEncoder.matches(any(), any())).thenReturn(true);
+        lenient().when(passwordEncoder.matches(any(), any())).thenReturn(true);
 
-        when(token.getId()).thenReturn(TOKEN_ID);
-        when(token.getName()).thenReturn("name");
-        when(token.getToken()).thenReturn("token");
-        when(token.getCreatedAt()).thenReturn(new Date(1486771200000L));
-        when(token.getExpiresAt()).thenReturn(new Date(1486772200000L));
-        when(token.getLastUseAt()).thenReturn(new Date(1486773200000L));
-        when(token.getReferenceId()).thenReturn(USER_ID);
-        when(tokenRepository.findById(TOKEN_ID)).thenReturn(of(token));
+        lenient().when(tokenRepository.findById(TOKEN_ID)).thenReturn(of(token));
 
         SecurityContextHolder.setContext(
             new SecurityContext() {
@@ -161,40 +162,34 @@ public class TokenServiceTest {
     }
 
     @Test
-    public void shouldFindByUser() throws TechnicalException {
-        final Token token2 = new Token();
-        token2.setId("2");
+    public void should_find_by_user() throws TechnicalException {
+        final Token token2 = Token.builder().id("2").build();
 
-        when(tokenRepository.findByReference(eq(USER.name()), eq(USER_ID))).thenReturn(asList(token, token2));
+        when(tokenRepository.findByReference(eq(USER.name()), eq(USER_ID))).thenReturn(List.of(token, token2));
 
         final List<TokenEntity> tokens = tokenService.findByUser(USER_ID);
 
-        assertEquals(TOKEN_ID, tokens.get(0).getId());
-        assertEquals("name", tokens.get(0).getName());
-        assertNull("Token cannot be read after creation", tokens.get(0).getToken());
-        assertEquals(new Date(1486771200000L), tokens.get(0).getCreatedAt());
-        assertEquals(new Date(1486772200000L), tokens.get(0).getExpiresAt());
-        assertEquals(new Date(1486773200000L), tokens.get(0).getLastUseAt());
-        assertEquals("2", tokens.get(1).getId());
+        assertThat(tokens.getFirst().getId()).isEqualTo(TOKEN_ID);
+        assertThat(tokens.getFirst().getName()).isEqualTo("name");
+        assertThat(tokens.getFirst().getToken()).as("Token cannot be read after creation").isNull();
+        assertThat(tokens.getFirst().getCreatedAt()).isEqualTo(new Date(1486771200000L));
+        assertThat(tokens.getFirst().getExpiresAt()).isEqualTo(new Date(1486772200000L));
+        assertThat(tokens.getFirst().getLastUseAt()).isEqualTo(new Date(1486773200000L));
+        assertThat(tokens.get(1).getId()).isEqualTo("2");
     }
 
     @Test
-    public void shouldFindByToken() throws TechnicalException {
-        when(tokenRepository.findAll()).thenReturn(newHashSet(token));
+    public void should_find_by_token() throws TechnicalException {
+        when(tokenRepository.findAll()).thenReturn(Set.of(token));
         when(tokenRepository.update(token)).thenReturn(token);
 
         final Token t = tokenService.findByToken("token");
 
-        assertEquals(TOKEN_ID, t.getId());
-        assertEquals("name", t.getName());
-        assertEquals("token", t.getToken());
-        assertEquals(new Date(1486771200000L), t.getCreatedAt());
-        assertEquals(new Date(1486772200000L), t.getExpiresAt());
-        assertEquals(new Date(1486773200000L), t.getLastUseAt());
+        assertThat(t.getId()).isEqualTo(TOKEN_ID);
     }
 
     @Test
-    public void shouldCreate() throws TechnicalException {
+    public void should_create() throws TechnicalException {
         final NewTokenEntity newToken = new NewTokenEntity();
         newToken.setName("name");
 
@@ -210,18 +205,20 @@ public class TokenServiceTest {
         verify(tokenRepository).findByReference(eq(USER.name()), eq(USER_ID));
     }
 
-    @Test(expected = TokenNameAlreadyExistsException.class)
-    public void shouldNotCreateNameExists() throws TechnicalException {
+    @Test
+    public void should_not_create_if_name_already_exists() throws TechnicalException {
         final NewTokenEntity newToken = new NewTokenEntity();
         newToken.setName("name");
 
-        when(tokenRepository.findByReference(eq(USER.name()), eq(USER_ID))).thenReturn(singletonList(token));
+        when(tokenRepository.findByReference(eq(USER.name()), eq(USER_ID))).thenReturn(List.of(token));
 
-        tokenService.create(GraviteeContext.getExecutionContext(), newToken, USER_ID);
+        Throwable throwable = catchThrowable(() -> tokenService.create(GraviteeContext.getExecutionContext(), newToken, USER_ID));
+
+        assertThat(throwable).isInstanceOf(TokenNameAlreadyExistsException.class);
     }
 
     @Test
-    public void shouldRevoke() throws TechnicalException {
+    public void should_revoke() throws TechnicalException {
         tokenService.revoke(GraviteeContext.getExecutionContext(), TOKEN_ID);
 
         verify(auditService).createOrganizationAuditLog(
@@ -237,8 +234,8 @@ public class TokenServiceTest {
     }
 
     @Test
-    public void shouldRevokeByUser() throws TechnicalException {
-        when(tokenRepository.findByReference(eq(USER.name()), eq(USER_ID))).thenReturn(singletonList(token));
+    public void should_revoke_by_user() throws TechnicalException {
+        when(tokenRepository.findByReference(eq(USER.name()), eq(USER_ID))).thenReturn(List.of(token));
 
         tokenService.revokeByUser(GraviteeContext.getExecutionContext(), USER_ID);
 
@@ -256,19 +253,14 @@ public class TokenServiceTest {
 
     @Test
     public void findByToken_should_prioritize_last_used_token() throws TechnicalException {
-        Token tokens[] = { mock(Token.class), mock(Token.class), mock(Token.class), mock(Token.class) };
+        List<Token> tokens = List.of(
+            Token.builder().lastUseAt(null).build(),
+            Token.builder().lastUseAt(new Date(1486772200000L)).token("encodedToken1").build(),
+            Token.builder().lastUseAt(new Date(1486772200999L)).token("encodedToken2").build(),
+            Token.builder().lastUseAt(null).build()
+        );
 
-        when(tokens[0].getLastUseAt()).thenReturn(null);
-
-        when(tokens[1].getLastUseAt()).thenReturn(new Date(1486772200000L));
-        when(tokens[1].getToken()).thenReturn("encodedToken1");
-
-        when(tokens[2].getLastUseAt()).thenReturn(new Date(1486772200999L));
-        when(tokens[2].getToken()).thenReturn("encodedToken2");
-
-        when(tokens[3].getLastUseAt()).thenReturn(null);
-
-        when(tokenRepository.findAll()).thenReturn(newHashSet(tokens));
+        when(tokenRepository.findAll()).thenReturn(new HashSet<>(tokens));
         doAnswer(returnsFirstArg()).when(tokenRepository).update(any());
 
         when(passwordEncoder.matches("inputToken", "encodedToken2")).thenReturn(false);
@@ -277,7 +269,7 @@ public class TokenServiceTest {
         Token resultToken = tokenService.findByToken("inputToken");
 
         // Assert that token1 has been returned cause it's the one matching input token
-        assertSame(resultToken, tokens[1]);
+        assertThat(resultToken).isEqualTo(tokens.get(1));
 
         // Assert that there was only 2 interactions with the passwordEncoder check, in this order :
         //   - first, token2 cause it's the most recently used
@@ -289,40 +281,60 @@ public class TokenServiceTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    @Test(expected = TokenNotFoundException.class)
+    @Test
+    public void findByToken_should_not_failed_if_matcher_failed() throws TechnicalException {
+        // Given
+        when(tokenRepository.findAll()).thenReturn(
+            Set.of(Token.builder().id("failed").lastUseAt(new Date()).token("a").build(), Token.builder().token("b").build())
+        );
+        doAnswer(returnsFirstArg()).when(tokenRepository).update(any());
+
+        when(passwordEncoder.matches(anyString(), eq("a"))).thenThrow(new RuntimeException("Mocked exception"));
+        when(passwordEncoder.matches(anyString(), eq("b"))).thenReturn(true);
+
+        // When
+        Token resultToken = tokenService.findByToken("inputToken");
+
+        // Then
+        assertThat(resultToken.getToken()).isEqualTo("b");
+    }
+
+    @Test
     public void findByToken_should_throw_TokenNotFound_when_no_token_matches() throws TechnicalException {
-        Token tokens[] = { mock(Token.class), mock(Token.class), mock(Token.class), mock(Token.class) };
-        when(tokenRepository.findAll()).thenReturn(newHashSet(tokens));
+        var tokens = Set.of(
+            Token.builder().id(UUID.randomUUID().toString()).build(),
+            Token.builder().id(UUID.randomUUID().toString()).build(),
+            Token.builder().id(UUID.randomUUID().toString()).build(),
+            Token.builder().id(UUID.randomUUID().toString()).build()
+        );
+        when(tokenRepository.findAll()).thenReturn(tokens);
         when(passwordEncoder.matches(any(), any())).thenReturn(false);
 
-        try {
-            tokenService.findByToken("inputToken");
-        } catch (Exception e) {
-            // Assert that all 4 tokens have been checked using passwordEncoder
-            // And none of them have been updated
-            verify(passwordEncoder, times(4)).matches(any(), any());
-            verify(tokenRepository, never()).update(any());
-            throw e;
-        }
+        Throwable throwable = catchThrowable(() -> tokenService.findByToken("inputToken"));
+        // Assert that all 4 tokens have been checked using passwordEncoder
+        // And none of them have been updated
+        verify(passwordEncoder, times(4)).matches(any(), any());
+        verify(tokenRepository, never()).update(any());
+        assertThat(throwable).isInstanceOf(TokenNotFoundException.class);
     }
 
     @Test
     public void should_return_token_does_not_exist() throws TechnicalException {
         when(tokenRepository.findById(TOKEN_ID)).thenReturn(Optional.empty());
         boolean tokenExistsForUser = tokenService.tokenExistsForUser(TOKEN_ID, USER_ID);
-        assertFalse(tokenExistsForUser);
+        assertThat(tokenExistsForUser).isFalse();
     }
 
     @Test
-    public void should_return_token_does_not_exist_because_does_not_belong_to_user() throws TechnicalException {
-        when(token.getReferenceId()).thenReturn("another_user_id");
+    public void should_return_token_does_not_exist_because_does_not_belong_to_user() {
+        token.setReferenceId("another_user_id");
         boolean tokenExistsForUser = tokenService.tokenExistsForUser(TOKEN_ID, USER_ID);
-        assertFalse(tokenExistsForUser);
+        assertThat(tokenExistsForUser).isFalse();
     }
 
     @Test
-    public void should_return_token_exists() throws TechnicalException {
+    public void should_return_token_exists() {
         boolean tokenExistsForUser = tokenService.tokenExistsForUser(TOKEN_ID, USER_ID);
-        assertTrue(tokenExistsForUser);
+        assertThat(tokenExistsForUser).isTrue();
     }
 }


### PR DESCRIPTION
## Description

We meet an issue, when one token fail. We don’t have enought log and all tokens usages are broken.
