### PR TITLE
feat(upgrader): add PortalNavigationItemRootIdUpgrader

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemRootIdUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemRootIdUpgrader.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.PORTAL_NAVIGATION_ITEM_ROOT_ID_UPGRADER;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.PortalNavigationItemRepository;
+import io.gravitee.repository.management.model.PortalNavigationItem;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * One-time backfill of {@code rootId} on existing portal navigation items so the front end can
+ * resolve the root of a navigation hierarchy without traversing parent chains at query time (e.g.
+ * redirect from Catalog to a specific API doc page using only the API nav item id). Root-level
+ * items get {@code rootId = id}; nested items get the top-level ancestor's id.
+ */
+@Component
+@CustomLog
+public class PortalNavigationItemRootIdUpgrader implements Upgrader {
+
+    private static final int MAX_PARENT_CHAIN_DEPTH = 50;
+
+    /**
+     * Sentinel value for "no root" in the domain; repository may store null/empty or this UUID string.
+     */
+    private static final String ZERO_ROOT_ID = "00000000-0000-0000-0000-000000000000";
+
+    private final EnvironmentRepository environmentRepository;
+    private final PortalNavigationItemRepository portalNavigationItemRepository;
+
+    public PortalNavigationItemRootIdUpgrader(
+        @Lazy EnvironmentRepository environmentRepository,
+        @Lazy PortalNavigationItemRepository portalNavigationItemRepository
+    ) {
+        this.environmentRepository = environmentRepository;
+        this.portalNavigationItemRepository = portalNavigationItemRepository;
+    }
+
+    @Override
+    public int getOrder() {
+        return PORTAL_NAVIGATION_ITEM_ROOT_ID_UPGRADER;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::applyUpgrade);
+    }
+
+    private boolean applyUpgrade() throws TechnicalException {
+        for (final var environment : environmentRepository.findAll()) {
+            migrateEnvironment(environment.getOrganizationId(), environment.getId());
+        }
+        return true;
+    }
+
+    private void migrateEnvironment(String organizationId, String environmentId) throws TechnicalException {
+        List<PortalNavigationItem> items = portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId(
+            organizationId,
+            environmentId
+        );
+
+        Map<String, PortalNavigationItem> itemsById = items
+            .stream()
+            .collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
+        Map<String, String> rootIdsByItemId = new HashMap<>();
+        int updatedCount = 0;
+
+        for (PortalNavigationItem item : items) {
+            if (!needsRootIdMigration(item)) {
+                rootIdsByItemId.put(item.getId(), item.getRootId());
+                continue;
+            }
+
+            item.setRootId(findRootId(item, itemsById, rootIdsByItemId));
+            portalNavigationItemRepository.update(item);
+            rootIdsByItemId.put(item.getId(), item.getRootId());
+            updatedCount++;
+        }
+
+        log.debug("Updated {} portal navigation items for environment {}", updatedCount, environmentId);
+    }
+
+    private static boolean needsRootIdMigration(PortalNavigationItem item) {
+        String rootId = item.getRootId();
+        return rootId == null || rootId.isBlank() || ZERO_ROOT_ID.equals(rootId);
+    }
+
+    private static void cacheRootId(List<String> visitedItemIds, String rootId, Map<String, String> rootIdsByItemId) {
+        for (String itemId : visitedItemIds) {
+            rootIdsByItemId.put(itemId, rootId);
+        }
+    }
+
+    private static String findRootId(
+        PortalNavigationItem item,
+        Map<String, PortalNavigationItem> itemsById,
+        Map<String, String> rootIdsByItemId
+    ) {
+        String cached = rootIdsByItemId.get(item.getId());
+        if (cached != null) {
+            return cached;
+        }
+
+        List<String> visitedItemIds = new ArrayList<>();
+        Set<String> visitedItemIdSet = new HashSet<>();
+        PortalNavigationItem current = item;
+        int depth = 0;
+
+        while (depth < MAX_PARENT_CHAIN_DEPTH) {
+            String currentId = current.getId();
+
+            String cachedRootId = rootIdsByItemId.get(currentId);
+            if (cachedRootId != null) {
+                cacheRootId(visitedItemIds, cachedRootId, rootIdsByItemId);
+                return cachedRootId;
+            }
+
+            if (!visitedItemIdSet.add(currentId)) {
+                cacheRootId(visitedItemIds, currentId, rootIdsByItemId);
+                rootIdsByItemId.put(currentId, currentId);
+                return currentId;
+            }
+
+            visitedItemIds.add(currentId);
+
+            if (current.getParentId() == null) {
+                cacheRootId(visitedItemIds, currentId, rootIdsByItemId);
+                return currentId;
+            }
+
+            PortalNavigationItem parent = itemsById.get(current.getParentId());
+            if (parent == null) {
+                cacheRootId(visitedItemIds, currentId, rootIdsByItemId);
+                return currentId;
+            }
+
+            current = parent;
+            depth++;
+        }
+
+        String fallbackRootId = visitedItemIds.isEmpty() ? item.getId() : visitedItemIds.get(visitedItemIds.size() - 1);
+        cacheRootId(visitedItemIds, fallbackRootId, rootIdsByItemId);
+        return fallbackRootId;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemRootIdUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemRootIdUpgrader.java
@@ -23,14 +23,12 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.PortalNavigationItemRepository;
 import io.gravitee.repository.management.model.PortalNavigationItem;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -45,11 +43,6 @@ import org.springframework.stereotype.Component;
 @CustomLog
 public class PortalNavigationItemRootIdUpgrader implements Upgrader {
 
-    private static final int MAX_PARENT_CHAIN_DEPTH = 50;
-
-    /**
-     * Sentinel value for "no root" in the domain; repository may store null/empty or this UUID string.
-     */
     private static final String ZERO_ROOT_ID = "00000000-0000-0000-0000-000000000000";
 
     private final EnvironmentRepository environmentRepository;
@@ -70,10 +63,10 @@ public class PortalNavigationItemRootIdUpgrader implements Upgrader {
 
     @Override
     public boolean upgrade() throws UpgraderException {
-        return this.wrapException(this::applyUpgrade);
+        return this.wrapException(this::migrateAllEnvironments);
     }
 
-    private boolean applyUpgrade() throws TechnicalException {
+    private boolean migrateAllEnvironments() throws TechnicalException {
         for (final var environment : environmentRepository.findAll()) {
             migrateEnvironment(environment.getOrganizationId(), environment.getId());
         }
@@ -81,27 +74,51 @@ public class PortalNavigationItemRootIdUpgrader implements Upgrader {
     }
 
     private void migrateEnvironment(String organizationId, String environmentId) throws TechnicalException {
-        List<PortalNavigationItem> items = portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId(
-            organizationId,
-            environmentId
+        List<PortalNavigationItem> items = new ArrayList<>(
+            portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId(organizationId, environmentId)
         );
+        if (items.isEmpty()) {
+            return;
+        }
 
-        Map<String, PortalNavigationItem> itemsById = items
+        List<PortalNavigationItem> roots = items
             .stream()
-            .collect(Collectors.toMap(PortalNavigationItem::getId, Function.identity()));
-        Map<String, String> rootIdsByItemId = new HashMap<>();
+            .filter(item -> item.getParentId() == null)
+            .toList();
+        Deque<PortalNavigationItem> queue = new ArrayDeque<>(roots);
+        items.removeAll(roots);
+
+        Map<String, String> resolved = new HashMap<>();
         int updatedCount = 0;
 
-        for (PortalNavigationItem item : items) {
-            if (!needsRootIdMigration(item)) {
-                rootIdsByItemId.put(item.getId(), item.getRootId());
-                continue;
+        while (!queue.isEmpty()) {
+            PortalNavigationItem item = queue.removeFirst();
+
+            String rootId = item.getParentId() == null ? item.getId() : resolved.get(item.getParentId());
+            resolved.put(item.getId(), rootId);
+
+            if (needsRootIdMigration(item)) {
+                item.setRootId(rootId);
+                portalNavigationItemRepository.update(item);
+                updatedCount++;
             }
 
-            item.setRootId(findRootId(item, itemsById, rootIdsByItemId));
-            portalNavigationItemRepository.update(item);
-            rootIdsByItemId.put(item.getId(), item.getRootId());
-            updatedCount++;
+            List<PortalNavigationItem> children = items
+                .stream()
+                .filter(child -> item.getId().equals(child.getParentId()))
+                .toList();
+            queue.addAll(children);
+            items.removeAll(children);
+        }
+
+        if (!items.isEmpty()) {
+            List<String> unresolvedIds = items.stream().map(PortalNavigationItem::getId).toList();
+            throw new TechnicalException(
+                "Unable to resolve rootId for portal navigation items in environment " +
+                    environmentId +
+                    ". Unresolved item ids: " +
+                    String.join(", ", unresolvedIds)
+            );
         }
 
         log.debug("Updated {} portal navigation items for environment {}", updatedCount, environmentId);
@@ -110,63 +127,5 @@ public class PortalNavigationItemRootIdUpgrader implements Upgrader {
     private static boolean needsRootIdMigration(PortalNavigationItem item) {
         String rootId = item.getRootId();
         return rootId == null || rootId.isBlank() || ZERO_ROOT_ID.equals(rootId);
-    }
-
-    private static void cacheRootId(List<String> visitedItemIds, String rootId, Map<String, String> rootIdsByItemId) {
-        for (String itemId : visitedItemIds) {
-            rootIdsByItemId.put(itemId, rootId);
-        }
-    }
-
-    private static String findRootId(
-        PortalNavigationItem item,
-        Map<String, PortalNavigationItem> itemsById,
-        Map<String, String> rootIdsByItemId
-    ) {
-        String cached = rootIdsByItemId.get(item.getId());
-        if (cached != null) {
-            return cached;
-        }
-
-        List<String> visitedItemIds = new ArrayList<>();
-        Set<String> visitedItemIdSet = new HashSet<>();
-        PortalNavigationItem current = item;
-        int depth = 0;
-
-        while (depth < MAX_PARENT_CHAIN_DEPTH) {
-            String currentId = current.getId();
-
-            String cachedRootId = rootIdsByItemId.get(currentId);
-            if (cachedRootId != null) {
-                cacheRootId(visitedItemIds, cachedRootId, rootIdsByItemId);
-                return cachedRootId;
-            }
-
-            if (!visitedItemIdSet.add(currentId)) {
-                cacheRootId(visitedItemIds, currentId, rootIdsByItemId);
-                rootIdsByItemId.put(currentId, currentId);
-                return currentId;
-            }
-
-            visitedItemIds.add(currentId);
-
-            if (current.getParentId() == null) {
-                cacheRootId(visitedItemIds, currentId, rootIdsByItemId);
-                return currentId;
-            }
-
-            PortalNavigationItem parent = itemsById.get(current.getParentId());
-            if (parent == null) {
-                cacheRootId(visitedItemIds, currentId, rootIdsByItemId);
-                return currentId;
-            }
-
-            current = parent;
-            depth++;
-        }
-
-        String fallbackRootId = visitedItemIds.isEmpty() ? item.getId() : visitedItemIds.get(visitedItemIds.size() - 1);
-        cacheRootId(visitedItemIds, fallbackRootId, rootIdsByItemId);
-        return fallbackRootId;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -61,6 +61,7 @@ public class UpgraderOrder {
     public static final int ENVIRONMENTS_DEFAULT_PORTAL_NAVIGATION_ITEMS_UPGRADER = 712;
     public static final int APPLICATION_CLIENT_CERTIFICATE_MIGRATION_UPGRADER = 713;
     public static final int ENVIRONMENTS_DEFAULT_SUBSCRIPTION_FORM_UPGRADER = 714;
+    public static final int PORTAL_NAVIGATION_ITEM_ROOT_ID_UPGRADER = 715;
     public static final int CLUSTER_ROLES_UPGRADER = 900;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;
     public static final int API_PRODUCT_ROLES_UPGRADER = 950;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemRootIdUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemRootIdUpgraderTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.PortalNavigationItemRepository;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.repository.management.model.PortalNavigationItem;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PortalNavigationItemRootIdUpgraderTest {
+
+    private static final Environment ANOTHER_ENVIRONMENT = Environment.builder()
+        .id("ANOTHER_ENVIRONMENT")
+        .hrids(List.of("another environment"))
+        .name("another environment")
+        .organizationId("ANOTHER_ORG")
+        .build();
+
+    @Mock
+    EnvironmentRepository environmentRepository;
+
+    @Mock
+    PortalNavigationItemRepository portalNavigationItemRepository;
+
+    private PortalNavigationItemRootIdUpgrader upgrader;
+
+    @BeforeEach
+    public void setUp() {
+        upgrader = new PortalNavigationItemRootIdUpgrader(environmentRepository, portalNavigationItemRepository);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_true_when_no_environments() {
+        when(environmentRepository.findAll()).thenReturn(Collections.emptySet());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verifyNoInteractions(portalNavigationItemRepository);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_true_when_no_nav_items_in_environment() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+        when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("DEFAULT", "DEFAULT")).thenReturn(
+            Collections.emptyList()
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(portalNavigationItemRepository, never()).update(any());
+    }
+
+    @Test
+    @SneakyThrows
+    void should_throw_upgrader_exception_on_repository_error() {
+        when(environmentRepository.findAll()).thenThrow(new TechnicalException("connection failed"));
+
+        final ThrowingRunnable throwing = () -> upgrader.upgrade();
+
+        Exception exception = assertThrows(UpgraderException.class, throwing);
+        assertThat(exception.getMessage()).contains("connection failed");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_set_root_id_to_self_for_root_items() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+
+        PortalNavigationItem rootFolder = navItem("folder-1", null, null);
+        PortalNavigationItem rootPage = navItem("page-1", null, null);
+
+        when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("DEFAULT", "DEFAULT")).thenReturn(
+            List.of(rootFolder, rootPage)
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<PortalNavigationItem> captor = ArgumentCaptor.forClass(PortalNavigationItem.class);
+        verify(portalNavigationItemRepository, times(2)).update(captor.capture());
+
+        List<PortalNavigationItem> updated = captor.getAllValues();
+        assertThat(updated).extracting(PortalNavigationItem::getId).containsExactlyInAnyOrder("folder-1", "page-1");
+        assertThat(updated).allSatisfy(item -> assertThat(item.getRootId()).isEqualTo(item.getId()));
+    }
+
+    @Test
+    @SneakyThrows
+    void should_resolve_root_id_for_nested_items() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+
+        PortalNavigationItem root = navItem("root", null, null);
+        PortalNavigationItem child = navItem("child", "root", null);
+
+        when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("DEFAULT", "DEFAULT")).thenReturn(List.of(root, child));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<PortalNavigationItem> captor = ArgumentCaptor.forClass(PortalNavigationItem.class);
+        verify(portalNavigationItemRepository, times(2)).update(captor.capture());
+
+        PortalNavigationItem updatedChild = captor
+            .getAllValues()
+            .stream()
+            .filter(i -> "child".equals(i.getId()))
+            .findFirst()
+            .orElseThrow();
+        assertThat(updatedChild.getRootId()).isEqualTo("root");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_resolve_root_id_for_deeply_nested_hierarchy() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+
+        PortalNavigationItem root = navItem("root", null, null);
+        PortalNavigationItem level1 = navItem("level1", "root", null);
+        PortalNavigationItem level2 = navItem("level2", "level1", null);
+        PortalNavigationItem level3 = navItem("level3", "level2", null);
+
+        when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("DEFAULT", "DEFAULT")).thenReturn(
+            List.of(root, level1, level2, level3)
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<PortalNavigationItem> captor = ArgumentCaptor.forClass(PortalNavigationItem.class);
+        verify(portalNavigationItemRepository, times(4)).update(captor.capture());
+
+        for (PortalNavigationItem updated : captor.getAllValues()) {
+            assertThat(updated.getRootId()).isEqualTo("root");
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void should_skip_items_that_already_have_valid_root_id() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+
+        PortalNavigationItem alreadyMigrated = navItem("item-1", null, "item-1");
+        PortalNavigationItem needsMigration = navItem("item-2", null, null);
+
+        when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("DEFAULT", "DEFAULT")).thenReturn(
+            List.of(alreadyMigrated, needsMigration)
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<PortalNavigationItem> captor = ArgumentCaptor.forClass(PortalNavigationItem.class);
+        verify(portalNavigationItemRepository, times(1)).update(captor.capture());
+
+        assertThat(captor.getValue().getId()).isEqualTo("item-2");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_migrate_items_with_zero_root_id_sentinel() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+
+        String zeroRootId = "00000000-0000-0000-0000-000000000000";
+        PortalNavigationItem itemWithZeroRoot = navItem("item-zero", null, zeroRootId);
+
+        when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("DEFAULT", "DEFAULT")).thenReturn(
+            List.of(itemWithZeroRoot)
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<PortalNavigationItem> captor = ArgumentCaptor.forClass(PortalNavigationItem.class);
+        verify(portalNavigationItemRepository, times(1)).update(captor.capture());
+
+        assertThat(captor.getValue().getId()).isEqualTo("item-zero");
+        assertThat(captor.getValue().getRootId()).isEqualTo("item-zero");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_process_multiple_environments() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT, ANOTHER_ENVIRONMENT));
+
+        PortalNavigationItem itemEnv1 = navItem("item-env1", null, null);
+        PortalNavigationItem itemEnv2 = navItem("item-env2", null, null);
+
+        when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("DEFAULT", "DEFAULT")).thenReturn(List.of(itemEnv1));
+        when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("ANOTHER_ORG", "ANOTHER_ENVIRONMENT")).thenReturn(
+            List.of(itemEnv2)
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(portalNavigationItemRepository, times(2)).update(any());
+    }
+
+    @Test
+    @SneakyThrows
+    void should_handle_orphaned_child_gracefully() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+
+        PortalNavigationItem orphan = navItem("orphan", "missing-parent", null);
+
+        when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("DEFAULT", "DEFAULT")).thenReturn(List.of(orphan));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<PortalNavigationItem> captor = ArgumentCaptor.forClass(PortalNavigationItem.class);
+        verify(portalNavigationItemRepository, times(1)).update(captor.capture());
+
+        assertThat(captor.getValue().getRootId()).isEqualTo("orphan");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_handle_cyclic_parent_reference_gracefully() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
+
+        PortalNavigationItem nodeA = navItem("A", "B", null);
+        PortalNavigationItem nodeB = navItem("B", "A", null);
+
+        when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("DEFAULT", "DEFAULT")).thenReturn(
+            List.of(nodeA, nodeB)
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<PortalNavigationItem> captor = ArgumentCaptor.forClass(PortalNavigationItem.class);
+        verify(portalNavigationItemRepository, times(2)).update(captor.capture());
+
+        for (PortalNavigationItem updated : captor.getAllValues()) {
+            assertThat(updated.getRootId()).isNotNull().isNotBlank();
+        }
+    }
+
+    @Test
+    void should_have_correct_order() {
+        assertThat(upgrader.getOrder()).isEqualTo(UpgraderOrder.PORTAL_NAVIGATION_ITEM_ROOT_ID_UPGRADER);
+    }
+
+    private static PortalNavigationItem navItem(String id, String parentId, String rootId) {
+        return PortalNavigationItem.builder()
+            .id(id)
+            .organizationId("DEFAULT")
+            .environmentId("DEFAULT")
+            .title("Nav Item " + id)
+            .type(PortalNavigationItem.Type.FOLDER)
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .parentId(parentId)
+            .rootId(rootId)
+            .order(0)
+            .published(true)
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemRootIdUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PortalNavigationItemRootIdUpgraderTest.java
@@ -229,24 +229,23 @@ public class PortalNavigationItemRootIdUpgraderTest {
 
     @Test
     @SneakyThrows
-    void should_handle_orphaned_child_gracefully() {
+    void should_throw_when_orphaned_items_cannot_be_resolved() {
         when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
 
         PortalNavigationItem orphan = navItem("orphan", "missing-parent", null);
 
         when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("DEFAULT", "DEFAULT")).thenReturn(List.of(orphan));
 
-        assertThat(upgrader.upgrade()).isTrue();
+        final ThrowingRunnable throwing = () -> upgrader.upgrade();
 
-        ArgumentCaptor<PortalNavigationItem> captor = ArgumentCaptor.forClass(PortalNavigationItem.class);
-        verify(portalNavigationItemRepository, times(1)).update(captor.capture());
-
-        assertThat(captor.getValue().getRootId()).isEqualTo("orphan");
+        Exception exception = assertThrows(UpgraderException.class, throwing);
+        assertThat(exception.getMessage()).contains("Unable to resolve rootId");
+        verify(portalNavigationItemRepository, never()).update(any());
     }
 
     @Test
     @SneakyThrows
-    void should_handle_cyclic_parent_reference_gracefully() {
+    void should_throw_when_cycle_prevents_root_resolution() {
         when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT));
 
         PortalNavigationItem nodeA = navItem("A", "B", null);
@@ -256,14 +255,11 @@ public class PortalNavigationItemRootIdUpgraderTest {
             List.of(nodeA, nodeB)
         );
 
-        assertThat(upgrader.upgrade()).isTrue();
+        final ThrowingRunnable throwing = () -> upgrader.upgrade();
 
-        ArgumentCaptor<PortalNavigationItem> captor = ArgumentCaptor.forClass(PortalNavigationItem.class);
-        verify(portalNavigationItemRepository, times(2)).update(captor.capture());
-
-        for (PortalNavigationItem updated : captor.getAllValues()) {
-            assertThat(updated.getRootId()).isNotNull().isNotBlank();
-        }
+        Exception exception = assertThrows(UpgraderException.class, throwing);
+        assertThat(exception.getMessage()).contains("Unable to resolve rootId");
+        verify(portalNavigationItemRepository, never()).update(any());
     }
 
     @Test


### PR DESCRIPTION
Introduces `PortalNavigationItemRootIdUpgrader` to populate `rootId` for portal navigation items. Includes functionality for resolving root IDs, handling nested hierarchies, and extensive test coverage.

## Issue

https://gravitee.atlassian.net/browse/APIM-12818

## Description

Implements the service-level upgrader for portal navigation item rootId data migration

Context: All portal navigation items must have a rootId so the hierarchy can be resolved easily (e.g. redirect from Catalog to a specific API doc page). Existing items created before rootId was added have rootId = null and need a one-time backfill.

Changes:

 - New service-level upgrader (PortalNavigationItemRootIdUpgrader): Runs once at startup, iterates all environments, loads all portal navigation items per environment, and backfills rootId:
      - Root items (parentId == null): set rootId = id
      - Nested items: walk up the parentId chain to the top-level ancestor and set rootId to that ancestor’s id
      - Items that already have a valid rootId are skipped (idempotent)
      - Uses repository-level read/update only (no domain side effects like reordering)

Execution order: Registered in UpgraderOrder with value 715, after default portal navigation items (712) and subscription form (714).

Tests: 
   - Unit tests for no environments, no nav items, repository errors, root vs nested items, deep hierarchies, already-migrated items, multiple environments, and orphaned children.

Note: Schema (Liquibase for JDBC, MongoDB model), domain/repository models, creation logic (markAsRoot() / updateParent()), and update/parent-change logic (including propagateRootIdToDescendants()) were already in place; this PR adds only the one-time migration upgrader and its tests.

**Before**


https://github.com/user-attachments/assets/1a0e03c4-7be5-4a59-ad3b-4f266aa47c00

**After Upgrader Run**

 - DB
 

https://github.com/user-attachments/assets/220079fa-ac29-4493-962f-4990d1fb2cb6


 - API calls

https://github.com/user-attachments/assets/991bd86f-ffb4-4e72-924f-c2200668a0f4



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

