### PR TITLE
feat(console): Implement cascading visibility - disable publish contxt option

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.harness.ts
@@ -152,6 +152,12 @@ export class FlatTreeComponentHarness extends ComponentHarness {
     await unpublishButton.click();
   }
 
+  async openPublishMenuAndGetItem(id: string): Promise<MatMenuItemHarness | null> {
+    const moreActionsButton = await this.getMoreActionsButtonById(id)();
+    await moreActionsButton.click();
+    return this.getMenuItemByTestId('publish-node-button');
+  }
+
   async getMenuItemByText(text: string): Promise<MatMenuItemHarness | null> {
     return this._documentRootLocator.locatorForOptional(MatMenuItemHarness.with({ text }))();
   }

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -144,10 +144,20 @@
         </button>
 
         @if (isUnpublished(node)) {
-          <button mat-menu-item (click)="onPublish(node)" data-testid="publish-node-button">
-            <mat-icon svgIcon="gio:eye-empty"></mat-icon>
-            Publish
-          </button>
+          @let publishState = publishStateByNodeId().get(node.id) ?? publishActionEnabledState;
+          <span [matTooltip]="publishState.tooltip" [matTooltipDisabled]="!publishState.disabled" matTooltipPosition="right">
+            <button
+              mat-menu-item
+              [disabled]="publishState.disabled"
+              [attr.aria-disabled]="publishState.ariaDisabled"
+              [attr.tabindex]="publishState.tabIndex"
+              (click)="onPublish(node)"
+              data-testid="publish-node-button"
+            >
+              <mat-icon svgIcon="gio:eye-empty"></mat-icon>
+              Publish
+            </button>
+          </span>
         } @else {
           <button mat-menu-item (click)="onUnpublish(node)" data-testid="unpublish-node-button">
             <mat-icon svgIcon="gio:eye-off"></mat-icon>

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -288,7 +288,10 @@ describe('FlatTreeComponent', () => {
     const actionSpy = jest.fn();
     component.nodeMenuAction.subscribe(actionSpy);
 
-    const links = [makeItem('p1', 'PAGE', 'Page 1', 0, 'parent-id', false)];
+    const links = [
+      makeItem('parent-id', 'FOLDER', 'Parent Folder', 0, null, true),
+      makeItem('p1', 'PAGE', 'Page 1', 0, 'parent-id', false),
+    ];
 
     fixture.componentRef.setInput('links', links);
     fixture.detectChanges();
@@ -332,6 +335,150 @@ describe('FlatTreeComponent', () => {
         }),
       }),
     );
+  });
+
+  describe('publish disabled state', () => {
+    const findNode = (id: string, nodes: SectionNode[] = component.tree()): SectionNode | undefined => {
+      for (const node of nodes) {
+        if (node.id === id) {
+          return node;
+        }
+
+        if (node.children) {
+          const foundChild = findNode(id, node.children);
+          if (foundChild) {
+            return foundChild;
+          }
+        }
+      }
+
+      return undefined;
+    };
+
+    it('should not disable publish for root node', () => {
+      const links = [makeItem('root-page', 'PAGE', 'Root Page', 0)];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const rootNode = findNode('root-page');
+      expect(component.isPublishDisabled(rootNode)).toBe(false);
+      expect(component.getPublishDisabledTooltip(rootNode)).toBe('');
+    });
+
+    it('should disable publish when parent is unpublished', () => {
+      const links = [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, false),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const childNode = findNode('child-page-1');
+      expect(component.isPublishDisabled(childNode)).toBe(true);
+      expect(component.getPublishDisabledTooltip(childNode)).toBe('A navigation item cannot be published within an unpublished folder');
+    });
+
+    it('should not disable publish when parent is published', () => {
+      const links = [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, true),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const childNode = findNode('child-page-1');
+      expect(component.isPublishDisabled(childNode)).toBe(false);
+      expect(component.getPublishDisabledTooltip(childNode)).toBe('');
+    });
+
+    it('should refresh parent lookup cache when links signal changes', () => {
+      fixture.componentRef.setInput('links', [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, false),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ]);
+      fixture.detectChanges();
+
+      let childNode = findNode('child-page-1');
+      expect(component.isPublishDisabled(childNode)).toBe(true);
+
+      fixture.componentRef.setInput('links', [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, true),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ]);
+      fixture.detectChanges();
+
+      childNode = findNode('child-page-1');
+      expect(component.isPublishDisabled(childNode)).toBe(false);
+    });
+
+    it('should disable publish when parent cannot be resolved', () => {
+      const links = [makeItem('orphan-page', 'PAGE', 'Orphan Page', 0, 'missing-parent', false)];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const orphanNode = findNode('orphan-page');
+      expect(component.isPublishDisabled(orphanNode)).toBe(true);
+      expect(component.getPublishDisabledTooltip(orphanNode)).toBe(
+        'A navigation item cannot be published because its parent is unavailable',
+      );
+    });
+
+    it('should disable publish menu item when parent is unpublished', async () => {
+      const links = [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, false),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const publishButton = await harness.openPublishMenuAndGetItem('child-page-1');
+      expect(publishButton).toBeTruthy();
+      expect(await publishButton.isDisabled()).toBe(true);
+    });
+
+    it('should not emit publish action when clicking disabled publish menu item', async () => {
+      const actionSpy = jest.fn();
+      component.nodeMenuAction.subscribe(actionSpy);
+
+      const links = [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, false),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const publishButton = await harness.openPublishMenuAndGetItem('child-page-1');
+      expect(publishButton).toBeTruthy();
+      expect(await publishButton.isDisabled()).toBe(true);
+
+      const disabledPublishButton = document.querySelector('[data-testid="publish-node-button"]') as HTMLButtonElement;
+      expect(disabledPublishButton).toBeTruthy();
+
+      disabledPublishButton.click();
+      expect(actionSpy).not.toHaveBeenCalled();
+    });
+
+    it('should keep publish menu item enabled when parent is published', async () => {
+      const links = [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, true),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const publishButton = await harness.openPublishMenuAndGetItem('child-page-1');
+      expect(publishButton).toBeTruthy();
+      expect(await publishButton.isDisabled()).toBe(false);
+    });
   });
 
   it('should handle nested folder structure', async () => {

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -60,6 +60,13 @@ interface FlatTreeNode {
   children?: SectionNode[];
 }
 
+interface PublishActionState {
+  disabled: boolean;
+  tooltip: string;
+  ariaDisabled: boolean;
+  tabIndex: -1 | null;
+}
+
 type ProcessingNode = SectionNode & {
   __order: number;
   __parentId: string | null;
@@ -102,9 +109,82 @@ export class FlatTreeComponent {
     return links && Array.isArray(links) ? this.mapLinksToNodes(links) : [];
   });
 
+  readonly publishActionEnabledState: PublishActionState = {
+    disabled: false,
+    tooltip: '',
+    ariaDisabled: false,
+    tabIndex: null,
+  };
+
+  private parentNavigationItemByChildId = computed(() => {
+    const links = this.links();
+    const parentByChildId = new Map<string, PortalNavigationItem | undefined>();
+
+    if (!links || !Array.isArray(links)) {
+      return parentByChildId;
+    }
+
+    const itemsById = new Map<string, PortalNavigationItem>(links.map(item => [item.id, item]));
+
+    for (const link of links) {
+      parentByChildId.set(link.id, link.parentId ? itemsById.get(link.parentId) : undefined);
+    }
+
+    return parentByChildId;
+  });
+
+  publishStateByNodeId = computed(() => {
+    const links = this.links();
+    const publishStateByNodeId = new Map<string, PublishActionState>();
+
+    if (!links || !Array.isArray(links)) {
+      return publishStateByNodeId;
+    }
+
+    const parentByChildId = this.parentNavigationItemByChildId();
+
+    for (const link of links) {
+      if (!link.parentId) {
+        publishStateByNodeId.set(link.id, this.publishActionEnabledState);
+        continue;
+      }
+
+      const parentNavigationItem = parentByChildId.get(link.id);
+      if (!parentNavigationItem) {
+        publishStateByNodeId.set(
+          link.id,
+          this.toDisabledPublishActionState('A navigation item cannot be published because its parent is unavailable'),
+        );
+        continue;
+      }
+
+      if (!parentNavigationItem.published) {
+        publishStateByNodeId.set(
+          link.id,
+          this.toDisabledPublishActionState(
+            `A navigation item cannot be published within an unpublished ${parentNavigationItem.type.toLocaleLowerCase()}`,
+          ),
+        );
+        continue;
+      }
+
+      publishStateByNodeId.set(link.id, this.publishActionEnabledState);
+    }
+
+    return publishStateByNodeId;
+  });
+
   isSelected = (node: FlatTreeNode) => this.selectedId() === node.id;
 
   isUnpublished = (node: FlatTreeNode) => node.data?.published === false;
+
+  isPublishDisabled(node: SectionNode): boolean {
+    return this.getPublishActionState(node).disabled;
+  }
+
+  getPublishDisabledTooltip(node: SectionNode): string {
+    return this.getPublishActionState(node).tooltip;
+  }
 
   treeBase = viewChild(MatTree);
 
@@ -259,6 +339,19 @@ export class FlatTreeComponent {
 
   private mapFlatTreeNodeToSectionNode(flatTreeNode: FlatTreeNode): SectionNode {
     return flatTreeNode as SectionNode;
+  }
+
+  private getPublishActionState(node: SectionNode): PublishActionState {
+    return this.publishStateByNodeId().get(node.id) ?? this.publishActionEnabledState;
+  }
+
+  private toDisabledPublishActionState(tooltip: string): PublishActionState {
+    return {
+      disabled: true,
+      tooltip,
+      ariaDisabled: true,
+      tabIndex: -1,
+    };
   }
 
   private mapLinksToNodes(links: PortalNavigationItem[]): SectionNode[] {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12702

## Description

"Publish" context menu option disabled for unpublished containers


<img width="787" height="607" alt="Zrzut ekranu 2026-03-9 o 17 34 39" src="https://github.com/user-attachments/assets/76981955-36a3-4261-96ef-375ee416aae0" />

