### PR TITLE
feat: grey out existing APIs in search dialog.

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.html
@@ -29,12 +29,15 @@
         <ng-container matColumnDef="select">
           <th mat-header-cell *matHeaderCellDef></th>
           <td mat-cell *matCellDef="let row">
-            <mat-checkbox
-              [disabled]="row.isDisabled"
-              [checked]="isChecked(row.id)"
-              (change)="toggleApiSelection(row.id, $event.checked, row.name)"
-              [attr.data-testid]="'api-picker-checkbox-' + row.id"
-            ></mat-checkbox>
+            @if (!row.isDisabled) {
+              <mat-checkbox
+                [checked]="isChecked(row.id)"
+                (change)="toggleApiSelection(row.id, $event.checked, row.name)"
+                [attr.data-testid]="'api-picker-checkbox-' + row.id"
+              ></mat-checkbox>
+            } @else {
+              <span class="already-added-label" [attr.data-testid]="'api-picker-already-added-' + row.id">Already added</span>
+            }
           </td>
         </ng-container>
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.scss
@@ -22,21 +22,26 @@ mat-dialog-content {
 }
 
 .selected-panel__title {
-  color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, darker80);
   @include mat.m2-typography-level($typography, subtitle-2);
+  color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, darker80);
 }
 
 .selected-panel__empty {
-  color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker80');
   @include mat.m2-typography-level($typography, body-2);
+  color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker80');
 }
 
 .api-search-description {
-  color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker80');
   @include mat.m2-typography-level($typography, caption);
+  color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker80');
 }
 
 .disabled {
+  color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker40');
+}
+
+.already-added-label {
+  @include mat.m2-typography-level($typography, caption);
   color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker40');
 }
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.spec.ts
@@ -40,8 +40,8 @@ class TestHostComponent {
   dialogValue: ApiSectionEditorDialogResult;
   private matDialog = inject(MatDialog);
 
-  public clicked(): void {
-    const data: ApiSectionEditorDialogData = { mode: 'create' };
+  public clicked(dialogData?: Partial<ApiSectionEditorDialogData>): void {
+    const data: ApiSectionEditorDialogData = { mode: 'create', ...dialogData };
     this.matDialog
       .open<ApiSectionEditorDialogComponent, ApiSectionEditorDialogData>(ApiSectionEditorDialogComponent, {
         width: '500px',
@@ -145,5 +145,47 @@ describe('ApiSectionEditorDialogComponent', () => {
     expect(Array.isArray(component.dialogValue?.apiIds)).toEqual(true);
     expect(component.dialogValue?.apiIds?.length).toBeGreaterThan(1);
     expect(component.dialogValue?.apiId).toEqual(component.dialogValue?.apiIds?.[0]);
+  }));
+
+  it('should hide checkbox, show "Already added" label and grey out row for already-added API', fakeAsync(async () => {
+    component.clicked({ existingApiIds: ['api-v2'] });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiSearchResponse();
+    tick();
+
+    const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    const checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+    expect(checkboxes.length).toBe(4);
+    const checkboxIds = await Promise.all(
+      checkboxes.map(async checkbox => {
+        const element = await checkbox.host();
+        const dataTestId = await element.getAttribute('data-testid');
+        return dataTestId?.replace('api-picker-checkbox-', '') ?? '';
+      }),
+    );
+    expect(checkboxIds).not.toContain('api-v2');
+    expect(checkboxIds).toContain('api-v4');
+
+    const alreadyAddedLabel = await dialog.getAlreadyAddedLabel('api-v2');
+    expect(alreadyAddedLabel).toBeTruthy();
+    expect(await alreadyAddedLabel.getText()).toBe('Already added');
+  }));
+
+  it('should show checkboxes for all APIs and no "Already added" label when existingApiIds is empty', fakeAsync(async () => {
+    component.clicked({ existingApiIds: [] });
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiSearchResponse();
+    tick();
+
+    const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+    const checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+    expect(checkboxes.length).toBe(5);
+
+    const alreadyAddedLabels = await dialog.getAlreadyAddedLabels();
+    expect(alreadyAddedLabels.length).toBe(0);
   }));
 });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
@@ -19,7 +19,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatChipsModule } from '@angular/material/chips';
-import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -37,6 +37,7 @@ import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrap
 
 export interface ApiSectionEditorDialogData {
   mode: 'create';
+  existingApiIds?: string[];
 }
 
 export interface ApiSectionEditorDialogResult {
@@ -89,6 +90,7 @@ type ApiSectionForm = FormGroup<ApiSectionFormControls>;
 })
 export class ApiSectionEditorDialogComponent implements OnInit {
   private readonly apiService = inject(ApiV2Service);
+  private readonly dialogData = inject<ApiSectionEditorDialogData>(MAT_DIALOG_DATA);
 
   form!: ApiSectionForm;
   public initialFormValues: ApiSectionFormValues;
@@ -144,7 +146,7 @@ export class ApiSectionEditorDialogComponent implements OnInit {
       this.selectedOrderedApis.set(current.filter(a => ids.includes(a.id)));
     });
 
-    const disabledSet = new Set<string>([]);
+    const disabledSet = new Set<string>(this.dialogData?.existingApiIds ?? []);
 
     this.rows$ = this.filters$.pipe(
       debounceTime(100),

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.harness.ts
@@ -15,7 +15,7 @@
  */
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { DivHarness } from '@gravitee/ui-particles-angular/testing';
+import { DivHarness, SpanHarness } from '@gravitee/ui-particles-angular/testing';
 
 export class ApiSectionEditorDialogHarness extends ComponentHarness {
   static hostSelector = 'api-section-editor-dialog';
@@ -23,6 +23,7 @@ export class ApiSectionEditorDialogHarness extends ComponentHarness {
   private locateCancelButton = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
   private locateSubmitButton = this.locatorFor(MatButtonHarness.with({ text: /Add|Save/ }));
   private locateFormTitle = this.locatorFor(DivHarness.with({ selector: '[mat-dialog-title]' }));
+  private locateAlreadyAddedLabels = this.locatorForAll(SpanHarness.with({ selector: '[data-testid^="api-picker-already-added-"]' }));
 
   async clickCancelButton(): Promise<void> {
     const cancelButton = await this.locateCancelButton();
@@ -42,5 +43,22 @@ export class ApiSectionEditorDialogHarness extends ComponentHarness {
   async getDialogTitle(): Promise<string> {
     const titleElement = await this.locateFormTitle();
     return titleElement.getText();
+  }
+
+  async getAlreadyAddedLabel(apiId: string): Promise<SpanHarness | null> {
+    const labels = await this.getAlreadyAddedLabels();
+    const expectedDataTestId = `api-picker-already-added-${apiId}`;
+    for (const label of labels) {
+      const host = await label.host();
+      const dataTestId = await host.getAttribute('data-testid');
+      if (dataTestId === expectedDataTestId) {
+        return label;
+      }
+    }
+    return null;
+  }
+
+  async getAlreadyAddedLabels(): Promise<SpanHarness[]> {
+    return this.locateAlreadyAddedLabels();
   }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -16,6 +16,7 @@
 import { ConfigureTestingGraviteeMarkdownEditor } from '@gravitee/gravitee-markdown';
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
@@ -2030,6 +2031,43 @@ describe('PortalNavigationItemsComponent', () => {
     await dialog.clickCancelButton();
 
     expect(component.hasUnsavedChanges()).toBeFalsy();
+  });
+
+  describe('API section dialog with already-added APIs', () => {
+    const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'API Folder' });
+    const existingApi = fakePortalNavigationApi({ id: 'nav-api-1', apiId: 'api-already-added', title: 'Existing API' });
+
+    beforeEach(async () => {
+      await expectGetNavigationItems(
+        fakePortalNavigationItemsResponse({
+          items: [folder, existingApi],
+        }),
+      );
+    });
+
+    it('should pass existingApiIds to dialog when menu contains API items', async () => {
+      const matDialog = TestBed.inject(MatDialog);
+      const openSpy = jest.spyOn(matDialog, 'open');
+      const component = fixture.componentInstance;
+      const folderNode = { id: folder.id, label: folder.title, type: folder.type, data: folder } as any;
+
+      await harness.selectNavigationItemByTitle(folder.title);
+      component.onNodeMenuAction({ action: 'create', itemType: 'API', node: folderNode });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await expectApiSearchResponse([]);
+
+      expect(openSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            mode: 'create',
+            existingApiIds: ['api-already-added'],
+          }),
+        }),
+      );
+    });
   });
 
   describe('calling onAddSection with API type', () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -261,7 +261,10 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     this.matDialog
       .open<ApiSectionEditorDialogComponent, ApiSectionEditorDialogData>(ApiSectionEditorDialogComponent, {
         width: GIO_DIALOG_WIDTH.LARGE,
-        data: { mode: 'create' },
+        data: {
+          mode: 'create',
+          existingApiIds: this.extractApiIdsFromNavigationItems(),
+        },
       })
       .afterClosed()
       .pipe(
@@ -692,6 +695,12 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         return EMPTY;
       }),
     );
+  }
+
+  private extractApiIdsFromNavigationItems(): string[] {
+    return this.menuLinks()
+      .filter(i => i.type === 'API')
+      .map(i => i.apiId);
   }
 }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11566

## Description

When adding APIs to the portal navigation, the API picker now clearly shows which APIs are already added and which can still be selected.

### Changes

- APIs already present in the portal navigation are shown greyed out and with an "Already added" label instead of a checkbox
- Added extractApiIdsFromNavigationItems() to collect API IDs from navigation items
- Dialog receives existingApiIds from the parent component when opened

https://github.com/user-attachments/assets/eac96b09-375a-492e-85ad-6853eadb85b5
