### PR TITLE
feat(console): Cascading visibility - missing private toggle

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.harness.ts
@@ -152,6 +152,12 @@ export class FlatTreeComponentHarness extends ComponentHarness {
     await unpublishButton.click();
   }
 
+  async openPublishMenuAndGetItem(id: string): Promise<MatMenuItemHarness | null> {
+    const moreActionsButton = await this.getMoreActionsButtonById(id)();
+    await moreActionsButton.click();
+    return this.getMenuItemByTestId('publish-node-button');
+  }
+
   async getMenuItemByText(text: string): Promise<MatMenuItemHarness | null> {
     return this._documentRootLocator.locatorForOptional(MatMenuItemHarness.with({ text }))();
   }

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -144,10 +144,20 @@
         </button>
 
         @if (isUnpublished(node)) {
-          <button mat-menu-item (click)="onPublish(node)" data-testid="publish-node-button">
-            <mat-icon svgIcon="gio:eye-empty"></mat-icon>
-            Publish
-          </button>
+          @let publishState = publishStateByNodeId().get(node.id) ?? publishActionEnabledState;
+          <span [matTooltip]="publishState.tooltip" [matTooltipDisabled]="!publishState.disabled" matTooltipPosition="right">
+            <button
+              mat-menu-item
+              [disabled]="publishState.disabled"
+              [attr.aria-disabled]="publishState.ariaDisabled"
+              [attr.tabindex]="publishState.tabIndex"
+              (click)="onPublish(node)"
+              data-testid="publish-node-button"
+            >
+              <mat-icon svgIcon="gio:eye-empty"></mat-icon>
+              Publish
+            </button>
+          </span>
         } @else {
           <button mat-menu-item (click)="onUnpublish(node)" data-testid="unpublish-node-button">
             <mat-icon svgIcon="gio:eye-off"></mat-icon>

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -288,7 +288,10 @@ describe('FlatTreeComponent', () => {
     const actionSpy = jest.fn();
     component.nodeMenuAction.subscribe(actionSpy);
 
-    const links = [makeItem('p1', 'PAGE', 'Page 1', 0, 'parent-id', false)];
+    const links = [
+      makeItem('parent-id', 'FOLDER', 'Parent Folder', 0, null, true),
+      makeItem('p1', 'PAGE', 'Page 1', 0, 'parent-id', false),
+    ];
 
     fixture.componentRef.setInput('links', links);
     fixture.detectChanges();
@@ -332,6 +335,150 @@ describe('FlatTreeComponent', () => {
         }),
       }),
     );
+  });
+
+  describe('publish disabled state', () => {
+    const findNode = (id: string, nodes: SectionNode[] = component.tree()): SectionNode | undefined => {
+      for (const node of nodes) {
+        if (node.id === id) {
+          return node;
+        }
+
+        if (node.children) {
+          const foundChild = findNode(id, node.children);
+          if (foundChild) {
+            return foundChild;
+          }
+        }
+      }
+
+      return undefined;
+    };
+
+    it('should not disable publish for root node', () => {
+      const links = [makeItem('root-page', 'PAGE', 'Root Page', 0)];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const rootNode = findNode('root-page');
+      expect(component.isPublishDisabled(rootNode)).toBe(false);
+      expect(component.getPublishDisabledTooltip(rootNode)).toBe('');
+    });
+
+    it('should disable publish when parent is unpublished', () => {
+      const links = [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, false),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const childNode = findNode('child-page-1');
+      expect(component.isPublishDisabled(childNode)).toBe(true);
+      expect(component.getPublishDisabledTooltip(childNode)).toBe('A navigation item cannot be published within an unpublished folder');
+    });
+
+    it('should not disable publish when parent is published', () => {
+      const links = [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, true),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const childNode = findNode('child-page-1');
+      expect(component.isPublishDisabled(childNode)).toBe(false);
+      expect(component.getPublishDisabledTooltip(childNode)).toBe('');
+    });
+
+    it('should refresh parent lookup cache when links signal changes', () => {
+      fixture.componentRef.setInput('links', [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, false),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ]);
+      fixture.detectChanges();
+
+      let childNode = findNode('child-page-1');
+      expect(component.isPublishDisabled(childNode)).toBe(true);
+
+      fixture.componentRef.setInput('links', [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, true),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ]);
+      fixture.detectChanges();
+
+      childNode = findNode('child-page-1');
+      expect(component.isPublishDisabled(childNode)).toBe(false);
+    });
+
+    it('should disable publish when parent cannot be resolved', () => {
+      const links = [makeItem('orphan-page', 'PAGE', 'Orphan Page', 0, 'missing-parent', false)];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const orphanNode = findNode('orphan-page');
+      expect(component.isPublishDisabled(orphanNode)).toBe(true);
+      expect(component.getPublishDisabledTooltip(orphanNode)).toBe(
+        'A navigation item cannot be published because its parent is unavailable',
+      );
+    });
+
+    it('should disable publish menu item when parent is unpublished', async () => {
+      const links = [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, false),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const publishButton = await harness.openPublishMenuAndGetItem('child-page-1');
+      expect(publishButton).toBeTruthy();
+      expect(await publishButton.isDisabled()).toBe(true);
+    });
+
+    it('should not emit publish action when clicking disabled publish menu item', async () => {
+      const actionSpy = jest.fn();
+      component.nodeMenuAction.subscribe(actionSpy);
+
+      const links = [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, false),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const publishButton = await harness.openPublishMenuAndGetItem('child-page-1');
+      expect(publishButton).toBeTruthy();
+      expect(await publishButton.isDisabled()).toBe(true);
+
+      const disabledPublishButton = document.querySelector('[data-testid="publish-node-button"]') as HTMLButtonElement;
+      expect(disabledPublishButton).toBeTruthy();
+
+      disabledPublishButton.click();
+      expect(actionSpy).not.toHaveBeenCalled();
+    });
+
+    it('should keep publish menu item enabled when parent is published', async () => {
+      const links = [
+        makeItem('folder-1', 'FOLDER', 'Folder 1', 0, null, true),
+        makeItem('child-page-1', 'PAGE', 'Child Page 1', 0, 'folder-1', false),
+      ];
+
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const publishButton = await harness.openPublishMenuAndGetItem('child-page-1');
+      expect(publishButton).toBeTruthy();
+      expect(await publishButton.isDisabled()).toBe(false);
+    });
   });
 
   it('should handle nested folder structure', async () => {

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -60,6 +60,13 @@ interface FlatTreeNode {
   children?: SectionNode[];
 }
 
+interface PublishActionState {
+  disabled: boolean;
+  tooltip: string;
+  ariaDisabled: boolean;
+  tabIndex: -1 | null;
+}
+
 type ProcessingNode = SectionNode & {
   __order: number;
   __parentId: string | null;
@@ -102,9 +109,82 @@ export class FlatTreeComponent {
     return links && Array.isArray(links) ? this.mapLinksToNodes(links) : [];
   });
 
+  readonly publishActionEnabledState: PublishActionState = {
+    disabled: false,
+    tooltip: '',
+    ariaDisabled: false,
+    tabIndex: null,
+  };
+
+  private parentNavigationItemByChildId = computed(() => {
+    const links = this.links();
+    const parentByChildId = new Map<string, PortalNavigationItem | undefined>();
+
+    if (!links || !Array.isArray(links)) {
+      return parentByChildId;
+    }
+
+    const itemsById = new Map<string, PortalNavigationItem>(links.map(item => [item.id, item]));
+
+    for (const link of links) {
+      parentByChildId.set(link.id, link.parentId ? itemsById.get(link.parentId) : undefined);
+    }
+
+    return parentByChildId;
+  });
+
+  publishStateByNodeId = computed(() => {
+    const links = this.links();
+    const publishStateByNodeId = new Map<string, PublishActionState>();
+
+    if (!links || !Array.isArray(links)) {
+      return publishStateByNodeId;
+    }
+
+    const parentByChildId = this.parentNavigationItemByChildId();
+
+    for (const link of links) {
+      if (!link.parentId) {
+        publishStateByNodeId.set(link.id, this.publishActionEnabledState);
+        continue;
+      }
+
+      const parentNavigationItem = parentByChildId.get(link.id);
+      if (!parentNavigationItem) {
+        publishStateByNodeId.set(
+          link.id,
+          this.toDisabledPublishActionState('A navigation item cannot be published because its parent is unavailable'),
+        );
+        continue;
+      }
+
+      if (!parentNavigationItem.published) {
+        publishStateByNodeId.set(
+          link.id,
+          this.toDisabledPublishActionState(
+            `A navigation item cannot be published within an unpublished ${parentNavigationItem.type.toLocaleLowerCase()}`,
+          ),
+        );
+        continue;
+      }
+
+      publishStateByNodeId.set(link.id, this.publishActionEnabledState);
+    }
+
+    return publishStateByNodeId;
+  });
+
   isSelected = (node: FlatTreeNode) => this.selectedId() === node.id;
 
   isUnpublished = (node: FlatTreeNode) => node.data?.published === false;
+
+  isPublishDisabled(node: SectionNode): boolean {
+    return this.getPublishActionState(node).disabled;
+  }
+
+  getPublishDisabledTooltip(node: SectionNode): string {
+    return this.getPublishActionState(node).tooltip;
+  }
 
   treeBase = viewChild(MatTree);
 
@@ -259,6 +339,19 @@ export class FlatTreeComponent {
 
   private mapFlatTreeNodeToSectionNode(flatTreeNode: FlatTreeNode): SectionNode {
     return flatTreeNode as SectionNode;
+  }
+
+  private getPublishActionState(node: SectionNode): PublishActionState {
+    return this.publishStateByNodeId().get(node.id) ?? this.publishActionEnabledState;
+  }
+
+  private toDisabledPublishActionState(tooltip: string): PublishActionState {
+    return {
+      disabled: true,
+      tooltip,
+      ariaDisabled: true,
+      tabIndex: -1,
+    };
   }
 
   private mapLinksToNodes(links: PortalNavigationItem[]): SectionNode[] {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.html
@@ -96,6 +96,13 @@
         }
       </div>
     </mat-expansion-panel>
+
+    <div class="selected-panel__title selected-panel__title--authentication">Authentication</div>
+    <span [matTooltip]="publicDisabledTooltip()" [matTooltipDisabled]="!publicDisabled()">
+      <mat-slide-toggle formControlName="isPrivate" aria-label="Require authentication to view selected APIs"
+        >Authentication is required to view selected APIs.</mat-slide-toggle
+      >
+    </span>
   </mat-dialog-content>
 
   <mat-dialog-actions align="end">

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.scss
@@ -24,6 +24,10 @@ mat-dialog-content {
 .selected-panel__title {
   @include mat.m2-typography-level($typography, subtitle-2);
   color: mat.m2-get-color-from-palette(gio.$mat-smoke-palette, darker80);
+
+  &--authentication {
+    margin-top: 10px;
+  }
 }
 
 .selected-panel__empty {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.spec.ts
@@ -30,7 +30,14 @@ import {
 import { ApiSectionEditorDialogHarness } from './api-section-editor-dialog.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
-import { fakeApiFederated, fakeApiFederatedAgent, fakeApiV1, fakeApiV2, fakeApiV4 } from '../../../entities/management-api-v2';
+import {
+  fakeApiFederated,
+  fakeApiFederatedAgent,
+  fakeApiV1,
+  fakeApiV2,
+  fakeApiV4,
+  fakePortalNavigationFolder,
+} from '../../../entities/management-api-v2';
 
 @Component({
   selector: 'test-host-component',
@@ -38,10 +45,11 @@ import { fakeApiFederated, fakeApiFederatedAgent, fakeApiV1, fakeApiV2, fakeApiV
 })
 class TestHostComponent {
   dialogValue: ApiSectionEditorDialogResult;
+  dialogData: ApiSectionEditorDialogData = { mode: 'create' };
   private matDialog = inject(MatDialog);
 
   public clicked(dialogData?: Partial<ApiSectionEditorDialogData>): void {
-    const data: ApiSectionEditorDialogData = { mode: 'create', ...dialogData };
+    const data: ApiSectionEditorDialogData = { mode: 'create', ...this.dialogData, ...dialogData };
     this.matDialog
       .open<ApiSectionEditorDialogComponent, ApiSectionEditorDialogData>(ApiSectionEditorDialogComponent, {
         width: '500px',
@@ -187,5 +195,68 @@ describe('ApiSectionEditorDialogComponent', () => {
 
     const alreadyAddedLabels = await dialog.getAlreadyAddedLabels();
     expect(alreadyAddedLabels.length).toBe(0);
+  }));
+
+  it('should allow selecting PRIVATE visibility when parent is public', fakeAsync(() => {
+    component.dialogData = { mode: 'create', parentItem: fakePortalNavigationFolder({ visibility: 'PUBLIC' }) };
+    component.clicked();
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiSearchResponse();
+
+    let dialog: ApiSectionEditorDialogHarness;
+    rootLoader.getHarness(ApiSectionEditorDialogHarness).then(h => (dialog = h));
+    tick();
+
+    dialog.isAuthenticationToggleDisabled().then(disabled => expect(disabled).toEqual(false));
+    dialog.isAuthenticationToggleChecked().then(checked => expect(checked).toEqual(false));
+    tick();
+
+    dialog.toggleAuthentication();
+    tick();
+    dialog.isAuthenticationToggleChecked().then(checked => expect(checked).toEqual(true));
+    tick();
+
+    let checkboxes: MatCheckboxHarness[] = [];
+    rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' })).then(c => (checkboxes = c));
+    tick();
+
+    checkboxes[0].check();
+    tick();
+
+    dialog.clickSubmitButton();
+    tick();
+
+    expect(component.dialogValue?.visibility).toEqual('PRIVATE');
+  }));
+
+  it('should force PRIVATE visibility when parent is private', fakeAsync(() => {
+    component.dialogData = { mode: 'create', parentItem: fakePortalNavigationFolder({ visibility: 'PRIVATE' }) };
+    component.clicked();
+    fixture.detectChanges();
+
+    tick(350);
+    expectApiSearchResponse();
+
+    let dialog: ApiSectionEditorDialogHarness;
+    rootLoader.getHarness(ApiSectionEditorDialogHarness).then(h => (dialog = h));
+    tick();
+
+    dialog.isAuthenticationToggleDisabled().then(disabled => expect(disabled).toEqual(true));
+    dialog.isAuthenticationToggleChecked().then(checked => expect(checked).toEqual(true));
+    tick();
+
+    let checkboxes: MatCheckboxHarness[] = [];
+    rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' })).then(c => (checkboxes = c));
+    tick();
+
+    checkboxes[0].check();
+    tick();
+
+    dialog.clickSubmitButton();
+    tick();
+
+    expect(component.dialogValue?.visibility).toEqual('PRIVATE');
   }));
 });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.component.ts
@@ -16,27 +16,31 @@
 import { AsyncPipe } from '@angular/common';
 import { Component, HostListener, inject, OnInit, computed, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatChipsModule } from '@angular/material/chips';
-import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTableModule } from '@angular/material/table';
 import { isEqual } from 'lodash';
 import { Observable, Subject, of, BehaviorSubject } from 'rxjs';
 import { catchError, debounceTime, distinctUntilChanged, map, startWith, switchMap, tap } from 'rxjs/operators';
 
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
-import { Api, ApiV2, ApiV4, PortalVisibility, ApisResponse } from '../../../entities/management-api-v2';
+import { Api, ApiV2, ApiV4, PortalNavigationItem, PortalVisibility, ApisResponse } from '../../../entities/management-api-v2';
 import { getApiAccess } from '../../../shared/utils';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { getPublicVisibilityDisabledTooltip, isPublicVisibilityDisabled } from '../visibility-toggle.util';
 
 export interface ApiSectionEditorDialogData {
   mode: 'create';
+  parentItem?: PortalNavigationItem;
   existingApiIds?: string[];
 }
 
@@ -61,10 +65,12 @@ type SelectedApi = {
 
 interface ApiSectionFormControls {
   apiIds: FormControl<string[]>;
+  isPrivate: FormControl<boolean>;
 }
 
 interface ApiSectionFormValues {
   apiIds: string[];
+  isPrivate: boolean;
 }
 
 type ApiSectionForm = FormGroup<ApiSectionFormControls>;
@@ -77,6 +83,8 @@ type ApiSectionForm = FormGroup<ApiSectionFormControls>;
     MatButtonModule,
     MatFormFieldModule,
     MatInputModule,
+    MatSlideToggleModule,
+    MatTooltipModule,
     MatIconModule,
     MatCheckboxModule,
     MatTableModule,
@@ -118,6 +126,11 @@ export class ApiSectionEditorDialogComponent implements OnInit {
 
   selectedPanelExpanded = signal(true);
 
+  readonly publicDisabled = computed(() => isPublicVisibilityDisabled(this.dialogData.parentItem));
+  readonly publicDisabledTooltip = computed(() => {
+    return getPublicVisibilityDisabledTooltip(this.dialogData.parentItem);
+  });
+
   private readonly dialogRef = inject(MatDialogRef<ApiSectionEditorDialogComponent, ApiSectionEditorDialogResult>);
 
   @HostListener('window:beforeunload', ['$event'])
@@ -133,6 +146,9 @@ export class ApiSectionEditorDialogComponent implements OnInit {
     this.form = new FormGroup<ApiSectionFormControls>({
       apiIds: new FormControl<string[]>([], {
         validators: [Validators.required],
+        nonNullable: true,
+      }),
+      isPrivate: new FormControl<boolean>(false, {
         nonNullable: true,
       }),
     });
@@ -184,7 +200,20 @@ export class ApiSectionEditorDialogComponent implements OnInit {
       ),
     );
 
+    this.syncVisibilityControlState();
     this.initialFormValues = this.form.getRawValue();
+  }
+
+  private syncVisibilityControlState(): void {
+    const isPrivateControl = this.form.controls.isPrivate;
+
+    if (this.publicDisabled()) {
+      isPrivateControl.setValue(true, { emitEvent: false });
+      isPrivateControl.disable({ emitEvent: false });
+      return;
+    }
+
+    isPrivateControl.enable({ emitEvent: false });
   }
 
   onFiltersChanged(filters: GioTableWrapperFilters): void {
@@ -241,7 +270,7 @@ export class ApiSectionEditorDialogComponent implements OnInit {
       const apiIds = formValues.apiIds ?? [];
 
       this.dialogRef.close({
-        visibility: 'PUBLIC',
+        visibility: formValues.isPrivate ? 'PRIVATE' : 'PUBLIC',
         apiIds,
         apiId: apiIds[0],
       });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/api-section-editor-dialog/api-section-editor-dialog.harness.ts
@@ -15,6 +15,7 @@
  */
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { DivHarness, SpanHarness } from '@gravitee/ui-particles-angular/testing';
 
 export class ApiSectionEditorDialogHarness extends ComponentHarness {
@@ -23,6 +24,7 @@ export class ApiSectionEditorDialogHarness extends ComponentHarness {
   private locateCancelButton = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
   private locateSubmitButton = this.locatorFor(MatButtonHarness.with({ text: /Add|Save/ }));
   private locateFormTitle = this.locatorFor(DivHarness.with({ selector: '[mat-dialog-title]' }));
+  private locateAuthenticationToggle = this.locatorFor(MatSlideToggleHarness);
   private locateAlreadyAddedLabels = this.locatorForAll(SpanHarness.with({ selector: '[data-testid^="api-picker-already-added-"]' }));
 
   async clickCancelButton(): Promise<void> {
@@ -43,6 +45,25 @@ export class ApiSectionEditorDialogHarness extends ComponentHarness {
   async getDialogTitle(): Promise<string> {
     const titleElement = await this.locateFormTitle();
     return titleElement.getText();
+  }
+
+  async getAuthenticationToggle(): Promise<MatSlideToggleHarness> {
+    return this.locateAuthenticationToggle();
+  }
+
+  async isAuthenticationToggleDisabled(): Promise<boolean> {
+    const toggle = await this.locateAuthenticationToggle();
+    return toggle.isDisabled();
+  }
+
+  async isAuthenticationToggleChecked(): Promise<boolean> {
+    const toggle = await this.locateAuthenticationToggle();
+    return toggle.isChecked();
+  }
+
+  async toggleAuthentication(): Promise<void> {
+    const toggle = await this.locateAuthenticationToggle();
+    return toggle.toggle();
   }
 
   async getAlreadyAddedLabel(apiId: string): Promise<SpanHarness | null> {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -1779,11 +1779,12 @@ describe('PortalNavigationItemsComponent', () => {
 
   describe('creating API navigation items in bulk', () => {
     const folder = fakePortalNavigationFolder({ id: 'folder-1', title: 'API Folder' });
+    const privateFolder = fakePortalNavigationFolder({ id: 'folder-private-1', title: 'Private API Folder', visibility: 'PRIVATE' });
 
     beforeEach(async () => {
       await expectGetNavigationItems(
         fakePortalNavigationItemsResponse({
-          items: [folder],
+          items: [folder, privateFolder],
         }),
       );
     });
@@ -1827,6 +1828,87 @@ describe('PortalNavigationItemsComponent', () => {
       );
 
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, ...createdApis] }));
+    });
+
+    it('should create API navigation items with PRIVATE visibility when toggle is selected for public parent', async () => {
+      const apiIds = ['api-1'];
+      const createdApis = [
+        fakePortalNavigationApi({ id: 'nav-api-1', apiId: 'api-1', title: '', parentId: folder.id, visibility: 'PRIVATE' }),
+      ];
+
+      await harness.selectNavigationItemByTitle(folder.title);
+
+      const component = fixture.componentInstance;
+      const folderNode = { id: folder.id, label: folder.title, type: folder.type, data: folder } as any;
+      component.onNodeMenuAction({ action: 'create', itemType: 'API', node: folderNode });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await expectApiSearchResponse(apiIds);
+
+      const checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+      await checkboxes[0].check();
+
+      const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+      expect(await dialog.isAuthenticationToggleDisabled()).toBe(false);
+      await dialog.toggleAuthentication();
+      expect(await dialog.isAuthenticationToggleChecked()).toBe(true);
+      await dialog.clickSubmitButton();
+
+      expectCreateNavigationItemsInBulk(
+        apiIds.map(apiId => ({
+          title: '',
+          type: 'API',
+          area: 'TOP_NAVBAR',
+          parentId: folder.id,
+          visibility: 'PRIVATE',
+          apiId,
+        })),
+        fakePortalNavigationItemsResponse({ items: createdApis }),
+      );
+
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, ...createdApis] }));
+    });
+
+    it('should force PRIVATE visibility when parent folder is private', async () => {
+      const apiIds = ['api-1', 'api-2'];
+      const createdApis = [
+        fakePortalNavigationApi({ id: 'nav-api-private-1', apiId: 'api-1', title: '', parentId: privateFolder.id, visibility: 'PRIVATE' }),
+        fakePortalNavigationApi({ id: 'nav-api-private-2', apiId: 'api-2', title: '', parentId: privateFolder.id, visibility: 'PRIVATE' }),
+      ];
+
+      await harness.selectNavigationItemByTitle(privateFolder.title);
+
+      const component = fixture.componentInstance;
+      const folderNode = { id: privateFolder.id, label: privateFolder.title, type: privateFolder.type, data: privateFolder } as any;
+      component.onNodeMenuAction({ action: 'create', itemType: 'API', node: folderNode });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await expectApiSearchResponse(apiIds);
+
+      const checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+      await checkboxes[0].check();
+      await checkboxes[1].check();
+
+      const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+      expect(await dialog.isAuthenticationToggleDisabled()).toBe(true);
+      expect(await dialog.isAuthenticationToggleChecked()).toBe(true);
+      await dialog.clickSubmitButton();
+
+      expectCreateNavigationItemsInBulk(
+        apiIds.map(apiId => ({
+          title: '',
+          type: 'API',
+          area: 'TOP_NAVBAR',
+          parentId: privateFolder.id,
+          visibility: 'PRIVATE',
+          apiId,
+        })),
+        fakePortalNavigationItemsResponse({ items: createdApis }),
+      );
+
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [privateFolder, ...createdApis] }));
     });
 
     it('should not call bulk endpoint when no folder is selected', async () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -60,6 +60,7 @@ import {
   PortalNavigationLink,
   PortalNavigationPage,
   PortalPageContentType,
+  PortalVisibility,
   UpdatePortalNavigationItem,
 } from '../../entities/management-api-v2';
 import { SnackBarService } from '../../services-ngx/snack-bar.service';
@@ -264,12 +265,13 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         data: {
           mode: 'create',
           existingApiIds: this.extractApiIdsFromNavigationItems(),
+          parentItem: existingItem,
         },
       })
       .afterClosed()
       .pipe(
         filter(result => !!result),
-        switchMap(result => this.createApisInOrder(existingItem?.id, result.apiIds ?? [])),
+        switchMap(result => this.createApisInOrder(existingItem?.id, result.apiIds ?? [], result.visibility ?? 'PUBLIC')),
         map(id => id ?? existingItem?.id ?? null),
         tap(id => {
           this.refreshMenuList.next(1);
@@ -391,7 +393,11 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       : null;
   }
 
-  private createApisInOrder(parentId: string | undefined, apiIds: string[]): Observable<string | null> {
+  private createApisInOrder(
+    parentId: string | undefined,
+    apiIds: string[],
+    visibility: PortalVisibility = 'PUBLIC',
+  ): Observable<string | null> {
     if (!parentId) {
       this.snackBarService.error('Select a folder before adding APIs');
       return of(null);
@@ -406,7 +412,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       type: 'API',
       area: 'TOP_NAVBAR',
       parentId,
-      visibility: 'PUBLIC',
+      visibility,
       apiId,
     }));
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/section-editor-dialog/section-editor-dialog.component.ts
@@ -33,6 +33,7 @@ import {
   PortalVisibility,
 } from '../../../entities/management-api-v2';
 import { urlValidator } from '../../../shared/validators/url.validator';
+import { getPublicVisibilityDisabledTooltip, isPublicVisibilityDisabled } from '../visibility-toggle.util';
 
 export type SectionEditorDialogMode = 'create' | 'edit';
 
@@ -125,14 +126,10 @@ export class SectionEditorDialogComponent implements OnInit {
   private readonly dialogRef = inject(MatDialogRef<SectionEditorDialogComponent, SectionEditorDialogResult>);
   private readonly data: SectionEditorDialogData = inject(MAT_DIALOG_DATA);
   readonly publicDisabled: Signal<boolean> = computed(() => {
-    return this.data.parentItem ? this.data.parentItem.visibility !== 'PUBLIC' : false;
+    return isPublicVisibilityDisabled(this.data.parentItem);
   });
   readonly publicDisabledTooltip: Signal<string> = computed(() => {
-    if (!this.publicDisabled()) {
-      return '';
-    }
-
-    return `This navigation item is in ${this.data.parentItem?.type?.toLocaleLowerCase()} requiring authentication`;
+    return getPublicVisibilityDisabledTooltip(this.data.parentItem);
   });
   public buttonTitle: string;
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/visibility-toggle.util.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/visibility-toggle.util.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getPublicVisibilityDisabledTooltip, isPublicVisibilityDisabled } from './visibility-toggle.util';
+
+import { fakePortalNavigationApi, fakePortalNavigationFolder } from '../../entities/management-api-v2';
+
+describe('visibility-toggle.util', () => {
+  describe('isPublicVisibilityDisabled', () => {
+    it('returns false when parent item is not provided', () => {
+      expect(isPublicVisibilityDisabled(undefined)).toBe(false);
+    });
+
+    it('returns false when parent item visibility is PUBLIC', () => {
+      const parent = fakePortalNavigationFolder({ visibility: 'PUBLIC' });
+      expect(isPublicVisibilityDisabled(parent)).toBe(false);
+    });
+
+    it('returns true when parent item visibility is PRIVATE', () => {
+      const parent = fakePortalNavigationFolder({ visibility: 'PRIVATE' });
+      expect(isPublicVisibilityDisabled(parent)).toBe(true);
+    });
+  });
+
+  describe('getPublicVisibilityDisabledTooltip', () => {
+    it('returns empty string when parent item is not provided', () => {
+      expect(getPublicVisibilityDisabledTooltip(undefined)).toBe('');
+    });
+
+    it('returns empty string when parent item visibility is PUBLIC', () => {
+      const parent = fakePortalNavigationFolder({ visibility: 'PUBLIC' });
+      expect(getPublicVisibilityDisabledTooltip(parent)).toBe('');
+    });
+
+    it('returns tooltip message with lower-cased parent type when parent is private', () => {
+      const parent = fakePortalNavigationApi({ visibility: 'PRIVATE' });
+      expect(getPublicVisibilityDisabledTooltip(parent)).toBe('This navigation item is in api requiring authentication');
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/portal/navigation-items/visibility-toggle.util.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/visibility-toggle.util.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PortalNavigationItem } from '../../entities/management-api-v2';
+
+export const isPublicVisibilityDisabled = (parentItem?: PortalNavigationItem): boolean => {
+  return parentItem ? parentItem.visibility !== 'PUBLIC' : false;
+};
+
+export const getPublicVisibilityDisabledTooltip = (parentItem?: PortalNavigationItem): string => {
+  if (!isPublicVisibilityDisabled(parentItem)) {
+    return '';
+  }
+
+  return `This navigation item is in ${parentItem.type.toLocaleLowerCase()} requiring authentication`;
+};


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12702

## Description

When adding an API inside a private folder, there is no privacy toggle switch available, unlike other item types (folder, page, link) where it is present but disabled with a clear message. This leads to a default attempt to create a public API, which results in an error. Looks like an unhandled edge case

### Add API in private folder 
<img width="1017" height="834" alt="Zrzut ekranu 2026-03-9 o 19 09 27" src="https://github.com/user-attachments/assets/b6d0b64e-9750-442f-83ae-4741057f92e0" />


### Add API in public folder 
<img width="1237" height="725" alt="Zrzut ekranu 2026-03-9 o 19 09 54" src="https://github.com/user-attachments/assets/f8229956-2dbc-448e-a121-c445d3a5dc32" />
