### PR TITLE
feat(console): Cascading visibility - fix for non-private nested item

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -488,6 +488,63 @@ describe('PortalNavigationItemsComponent', () => {
 
       expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: createdItem.id } }));
     });
+
+    it('calls backend create with PRIVATE visibility when parent folder is private', async () => {
+      const fakeResponse = fakePortalNavigationItemsResponse({
+        items: [
+          fakePortalNavigationPage({
+            id: 'nav-item-1',
+            title: 'Nav Item 1',
+            portalPageContentId: 'nav-item-1-content',
+          }),
+          fakePortalNavigationFolder({ id: 'folder-1', title: 'Folder 1', visibility: 'PRIVATE' }),
+        ],
+      });
+
+      await expectGetNavigationItems(fakeResponse);
+      await expectGetPageContent('nav-item-1-content', 'This is the content of Nav Item 1');
+
+      const component = fixture.componentInstance;
+      const folderData = fakeResponse.items[1] as PortalNavigationItem;
+      const folderNode = { id: folderData.id, label: folderData.title, type: folderData.type, data: folderData } as any;
+
+      component.onNodeMenuAction({ action: 'create', itemType: 'PAGE', node: folderNode });
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      expect(dialog).toBeTruthy();
+
+      const authToggle = await dialog.getAuthenticationToggle();
+      expect(await authToggle.isChecked()).toBe(true);
+      expect(await authToggle.isDisabled()).toBe(true);
+
+      const title = 'New Private Child Page';
+      await dialog.setTitleInputValue(title);
+      await dialog.clickSubmitButton();
+
+      const createdItem = fakePortalNavigationPage({
+        id: 'child-page-1',
+        title,
+        area: 'TOP_NAVBAR',
+        type: 'PAGE',
+        parentId: folderData.id,
+        visibility: 'PRIVATE',
+        portalPageContentId: 'content-id',
+      });
+
+      expectCreateNavigationItem(
+        fakeNewPagePortalNavigationItem({
+          title,
+          area: 'TOP_NAVBAR',
+          type: 'PAGE',
+          parentId: folderData.id,
+          visibility: 'PRIVATE',
+          contentType: 'GRAVITEE_MARKDOWN',
+        }),
+        createdItem,
+      );
+      await expectGetNavigationItems(fakeResponse);
+    });
   });
 
   describe('creating a folder under a folder from tree node "More actions" menu', () => {
@@ -540,6 +597,61 @@ describe('PortalNavigationItemsComponent', () => {
       );
       await expectGetNavigationItems(fakeResponse);
     });
+
+    it('calls backend create with PRIVATE visibility when parent folder is private', async () => {
+      const fakeResponse = fakePortalNavigationItemsResponse({
+        items: [
+          fakePortalNavigationPage({
+            id: 'nav-item-1',
+            title: 'Nav Item 1',
+            portalPageContentId: 'nav-item-1-content',
+          }),
+          fakePortalNavigationFolder({ id: 'folder-1', title: 'Folder 1', visibility: 'PRIVATE' }),
+        ],
+      });
+
+      await expectGetNavigationItems(fakeResponse);
+      await expectGetPageContent('nav-item-1-content', 'This is the content of Nav Item 1');
+
+      const component = fixture.componentInstance;
+      const folderData = fakeResponse.items[1] as PortalNavigationItem;
+      const folderNode = { id: folderData.id, label: folderData.title, type: folderData.type, data: folderData } as any;
+
+      component.onNodeMenuAction({ action: 'create', itemType: 'FOLDER', node: folderNode });
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      expect(dialog).toBeTruthy();
+
+      const authToggle = await dialog.getAuthenticationToggle();
+      expect(await authToggle.isChecked()).toBe(true);
+      expect(await authToggle.isDisabled()).toBe(true);
+
+      const title = 'New Private Child Folder';
+      await dialog.setTitleInputValue(title);
+      await dialog.clickSubmitButton();
+
+      const createdItem = fakePortalNavigationFolder({
+        id: 'child-folder-1',
+        title,
+        area: 'TOP_NAVBAR',
+        type: 'FOLDER',
+        parentId: folderData.id,
+        visibility: 'PRIVATE',
+      });
+
+      expectCreateNavigationItem(
+        fakeNewFolderPortalNavigationItem({
+          title,
+          area: 'TOP_NAVBAR',
+          type: 'FOLDER',
+          parentId: folderData.id,
+          visibility: 'PRIVATE',
+        }),
+        createdItem,
+      );
+      await expectGetNavigationItems(fakeResponse);
+    });
   });
 
   describe('creating a link under a folder from tree node "More actions" menu', () => {
@@ -585,6 +697,65 @@ describe('PortalNavigationItemsComponent', () => {
 
       expectCreateNavigationItem(
         fakeNewLinkPortalNavigationItem({ title, url, area: 'TOP_NAVBAR', type: 'LINK', parentId: folderData.id }),
+        createdItem,
+      );
+      await expectGetNavigationItems(fakeResponse);
+    });
+
+    it('calls backend create with PRIVATE visibility when parent folder is private', async () => {
+      const fakeResponse = fakePortalNavigationItemsResponse({
+        items: [
+          fakePortalNavigationPage({
+            id: 'nav-item-1',
+            title: 'Nav Item 1',
+            portalPageContentId: 'nav-item-1-content',
+          }),
+          fakePortalNavigationFolder({ id: 'folder-1', title: 'Folder 1', visibility: 'PRIVATE' }),
+        ],
+      });
+
+      await expectGetNavigationItems(fakeResponse);
+      await expectGetPageContent('nav-item-1-content', 'This is the content of Nav Item 1');
+
+      const component = fixture.componentInstance;
+      const folderData = fakeResponse.items[1] as PortalNavigationItem;
+      const folderNode = { id: folderData.id, label: folderData.title, type: folderData.type, data: folderData } as any;
+
+      component.onNodeMenuAction({ action: 'create', itemType: 'LINK', node: folderNode });
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarness(SectionEditorDialogHarness);
+      expect(dialog).toBeTruthy();
+
+      const authToggle = await dialog.getAuthenticationToggle();
+      expect(await authToggle.isChecked()).toBe(true);
+      expect(await authToggle.isDisabled()).toBe(true);
+
+      const title = 'New Private Child Link';
+      const url = 'https://example.com/private';
+      await dialog.setTitleInputValue(title);
+      await dialog.setUrlInputValue(url);
+      await dialog.clickSubmitButton();
+
+      const createdItem = fakePortalNavigationLink({
+        id: 'child-link-1',
+        title,
+        url,
+        area: 'TOP_NAVBAR',
+        type: 'LINK',
+        parentId: folderData.id,
+        visibility: 'PRIVATE',
+      });
+
+      expectCreateNavigationItem(
+        fakeNewLinkPortalNavigationItem({
+          title,
+          url,
+          area: 'TOP_NAVBAR',
+          type: 'LINK',
+          parentId: folderData.id,
+          visibility: 'PRIVATE',
+        }),
         createdItem,
       );
       await expectGetNavigationItems(fakeResponse);

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -240,20 +240,20 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         case 'unpublish':
           this.handlePublishToggle(event.node.data);
           break;
-        default:
+        default: {
           if (event.itemType === 'API' && event.action !== 'edit') {
             this.createApiSection(event.node.data);
             return;
           }
 
-          this.manageSection(
-            event.itemType,
-            event.action,
-            'TOP_NAVBAR',
-            this.mapSelectedNavItemToNode(event.node.data.parentId, this.menuLinks())?.data || null,
-            event.node.data,
-          );
+          const parentItemForDialog =
+            event.action === 'create'
+              ? event.node.data
+              : this.mapSelectedNavItemToNode(event.node.data.parentId, this.menuLinks())?.data || null;
+
+          this.manageSection(event.itemType, event.action, 'TOP_NAVBAR', parentItemForDialog, event.node.data);
           break;
+        }
       }
     });
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12702

## Description

Fixed parent resolution in PortalNavigationItemsComponent for context-menu create actions.

Tests:
- PAGE created under a private folder -> request uses visibility: PRIVATE and toggle is checked + disabled.
- FOLDER created under a private folder -> same.
- LINK created under a private folder -> same.


example add page dialog  under private folder

<img width="709" height="639" alt="Zrzut ekranu 2026-03-9 o 19 42 27" src="https://github.com/user-attachments/assets/6aed180b-95a1-46b0-b154-6e147bafaf85" />


