### PR TITLE
fix: avoid requests being cancelled on dashboard component mount

### DIFF
--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/gravitee-dashboard.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/gravitee-dashboard.component.spec.ts
@@ -458,7 +458,8 @@ describe('GraviteeDashboardComponent', () => {
     const component = newFixture.componentInstance;
     const selectedFilters = component.currentSelectedFilters();
 
-    expect(selectedFilters.length).toBe(0);
+    expect(selectedFilters.length).toBe(1);
+    expect(selectedFilters[0]).toEqual({ parentKey: 'period', value: '5m' });
   });
 
   it('should apply filters to widget requests', fakeAsync(() => {

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/gravitee-dashboard.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/gravitee-dashboard.component.ts
@@ -57,10 +57,20 @@ export class GraviteeDashboardComponent {
   baseURL = input.required<string>();
   filters = input.required<Filter[]>();
   widgetConfigs = input.required<Widget[]>();
+  defaultPeriod = input<string>('5m');
 
-  currentSelectedFilters = toSignal(this.activatedRoute.queryParams.pipe(map(params => this.getSelectedFiltersFromQueryParams(params))), {
-    initialValue: [] as SelectedFilter[],
-  });
+  currentSelectedFilters = toSignal(
+    this.activatedRoute.queryParams.pipe(
+      map(params => {
+        const filters = this.getSelectedFiltersFromQueryParams(params);
+        if (!filters.some(f => f.parentKey === 'period')) {
+          return [{ parentKey: 'period', value: this.defaultPeriod() }, ...filters];
+        }
+        return filters;
+      }),
+    ),
+    { initialValue: [{ parentKey: 'period', value: '5m' }] as SelectedFilter[] },
+  );
 
   readonly widgetsWithFilters = computed(() => {
     this.refreshTrigger();


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-2449

The fix is to have currentSelectedFilters apply the default period when query params are empty, so the filter bar never sees length === 0 and never triggers the redundant router navigation.

Now currentSelectedFilters always has at least the default period. This means GenericFilterBarComponent.ngOnInit() will see length > 0 and skip the emit that triggers the router navigation and the double-fire.

That was leading to this error being logged many times in MAPI
```
Caused by: java.io.IOException: Broken pipe
	at java.base/sun.nio.ch.SocketDispatcher.writev0(Native Method)
	at java.base/sun.nio.ch.SocketDispatcher.writev(SocketDispatcher.java:66)
	at java.base/sun.nio.ch.IOUtil.write(IOUtil.java:227)
	at java.base/sun.nio.ch.IOUtil.write(IOUtil.java:158)
	at java.base/sun.nio.ch.SocketChannelImpl.write(SocketChannelImpl.java:574)
	at java.base/java.nio.channels.SocketChannel.write(SocketChannel.java:660)
	at org.eclipse.jetty.io.SocketChannelEndPoint.flush(SocketChannelEndPoint.java:112)
	... 171 common frames omitted
```