### PR TITLE
fix(api-product): removed unwanted metadata

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -32,9 +32,6 @@ import lombok.RequiredArgsConstructor;
 @CustomLog
 public class SubscriptionMapper {
 
-    public static final String METADATA_REFERENCE_ID = "referenceId";
-    public static final String METADATA_REFERENCE_TYPE = "referenceType";
-
     private final ObjectMapper objectMapper;
     private final ApiProductRegistry apiProductRegistry;
 
@@ -83,15 +80,6 @@ public class SubscriptionMapper {
             .map(apiId -> {
                 Subscription sub = toSubscription(subscriptionModel);
                 sub.setApi(apiId); // Override with individual API
-
-                // Preserve product info in metadata for debugging/tracking
-                Map<String, String> metadata = sub.getMetadata();
-                if (metadata == null) {
-                    metadata = new HashMap<>();
-                    sub.setMetadata(metadata);
-                }
-                metadata.put("productId", productId);
-                metadata.put("exploded", "true");
                 sub.setApiProductId(productId);
 
                 return sub;
@@ -131,12 +119,6 @@ public class SubscriptionMapper {
         Map<String, String> metadata = subscriptionModel.getMetadata() != null
             ? new HashMap<>(subscriptionModel.getMetadata())
             : new HashMap<>();
-        if (subscriptionModel.getReferenceId() != null) {
-            metadata.put(METADATA_REFERENCE_ID, subscriptionModel.getReferenceId());
-        }
-        if (subscriptionModel.getReferenceType() != null) {
-            metadata.put(METADATA_REFERENCE_TYPE, subscriptionModel.getReferenceType().name());
-        }
         subscription.setMetadata(metadata);
         subscription.setEnvironmentId(subscriptionModel.getEnvironmentId());
         return subscription;
@@ -149,16 +131,9 @@ public class SubscriptionMapper {
     public Subscription toSubscriptionForApi(io.gravitee.repository.management.model.Subscription subscriptionModel, String apiId) {
         Subscription sub = toSubscription(subscriptionModel);
         sub.setApi(apiId);
-        Map<String, String> metadata = sub.getMetadata();
-        if (metadata == null) {
-            metadata = new HashMap<>();
-            sub.setMetadata(metadata);
-        }
         if (subscriptionModel.getReferenceId() != null) {
-            metadata.put("productId", subscriptionModel.getReferenceId());
             sub.setApiProductId(subscriptionModel.getReferenceId());
         }
-        metadata.put("exploded", "true");
         return sub;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SubscriptionMapperTest.java
@@ -90,7 +90,7 @@ class SubscriptionMapperTest {
         assertThat(subscriptionMapped.getConfiguration()).isEqualTo(
             objectMapper.readValue(subscription.getConfiguration(), SubscriptionConfiguration.class)
         );
-        assertThat(subscriptionMapped.getMetadata()).containsEntry("referenceId", "api").containsEntry("referenceType", "API");
+        assertThat(subscriptionMapped.getMetadata()).isEmpty();
     }
 
     @Test
@@ -114,7 +114,7 @@ class SubscriptionMapperTest {
         assertThat(subscriptionMapped.getConsumerStatus()).isEqualTo(io.gravitee.gateway.api.service.Subscription.ConsumerStatus.STARTED);
         assertThat(subscriptionMapped.getType()).isEqualTo(io.gravitee.gateway.api.service.Subscription.Type.STANDARD);
         assertThat(subscriptionMapped.getConfiguration()).isNull();
-        assertThat(subscriptionMapped.getMetadata()).containsEntry("referenceId", "api").containsEntry("referenceType", "API");
+        assertThat(subscriptionMapped.getMetadata()).isEmpty();
     }
 
     @Test
@@ -147,7 +147,7 @@ class SubscriptionMapperTest {
 
         assertThat(mapped).hasSize(2);
         assertThat(mapped).extracting(io.gravitee.gateway.api.service.Subscription::getApi).containsExactlyInAnyOrder("api1", "api2");
-        assertThat(mapped).allMatch(s -> "id".equals(s.getId()) && "product-1".equals(s.getMetadata().get("productId")));
+        assertThat(mapped).allMatch(s -> "id".equals(s.getId()) && "product-1".equals(s.getApiProductId()));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13073

## Description

Gateway subscription mapping is updated to stop injecting internal API Product metadata into subscription.metadata.

Previously, internal keys such as productId and exploded were added during API Product subscription mapping. Since subscription metadata can be user-provided (via mAPI, Terraform, or GKO), injecting internal keys could lead to collisions and ambiguity between system-generated and user-defined values.

Gateway now propagates only persisted subscription metadata as-is. Internal keys productId and exploded are no longer added during mapping. API Product linkage remains available through the dedicated apiProductId field.

# Additional data :
verified working : 

https://github.com/user-attachments/assets/bf84df4d-97e2-473d-9476-d225ec16093e


