### PR TITLE
subscription form minor bugs fixes

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizer.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.rest.api.service.v4.validation;
 
-import io.gravitee.rest.api.service.sanitizer.HtmlSanitizer;
 import io.gravitee.rest.api.service.v4.exception.SubscriptionMetadataInvalidException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -24,7 +23,9 @@ import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
 /**
- * Validates and sanitizes subscription form metadata (keys, value length, HTML).
+ * Validates and sanitizes subscription form metadata (keys, value length).
+ * Values are plain text; HTML tags are stripped to prevent XSS when metadata is rendered.
+ * No HTML encoding is applied, so characters like {@code @}, {@code +}, {@code =} are stored as-is.
  *
  * @author GraviteeSource Team
  */
@@ -32,17 +33,13 @@ import org.springframework.stereotype.Component;
 public class SubscriptionMetadataSanitizer {
 
     private static final Pattern KEY_PATTERN = Pattern.compile("^[A-Za-z0-9_-]{1,100}$");
+    private static final Pattern HTML_TAG = Pattern.compile("<[^>]*>");
     private static final int MAX_VALUE_LENGTH = 1024;
     private static final int MAX_METADATA_COUNT = 25;
 
-    private final HtmlSanitizer htmlSanitizer;
-
-    public SubscriptionMetadataSanitizer(HtmlSanitizer htmlSanitizer) {
-        this.htmlSanitizer = htmlSanitizer;
-    }
-
     /**
-     * Validates metadata keys and value lengths, then sanitizes each value with HTML sanitizer.
+     * Validates metadata keys and value lengths, then strips HTML tags from each value.
+     * Any remaining characters (including {@code <}, {@code >}, non-Latin, etc.) are stored as-is.
      *
      * @param metadata raw metadata from the client
      * @return sanitized metadata, or empty map if input is null
@@ -78,7 +75,7 @@ public class SubscriptionMetadataSanitizer {
                 );
             }
 
-            String sanitizedValue = htmlSanitizer.sanitize(value);
+            String sanitizedValue = stripHtmlTags(value);
             if (sanitizedValue == null || sanitizedValue.isBlank()) {
                 continue;
             }
@@ -86,5 +83,16 @@ public class SubscriptionMetadataSanitizer {
         }
 
         return sanitizedMetadata;
+    }
+
+    /**
+     * Removes HTML tags from plain-text metadata. Used instead of OWASP HTML Sanitizer so that
+     * special characters (e.g. {@code @}, {@code +}, {@code =}) are not encoded.
+     */
+    private static String stripHtmlTags(String content) {
+        if (content == null) {
+            return null;
+        }
+        return HTML_TAG.matcher(content).replaceAll("").trim();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizerTest.java
@@ -17,11 +17,7 @@ package io.gravitee.rest.api.service.v4.validation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.when;
 
-import io.gravitee.rest.api.service.sanitizer.HtmlSanitizer;
 import io.gravitee.rest.api.service.v4.exception.SubscriptionMetadataInvalidException;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,22 +25,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class SubscriptionMetadataSanitizerTest {
-
-    @Mock
-    private HtmlSanitizer htmlSanitizer;
 
     private SubscriptionMetadataSanitizer cut;
 
     @BeforeEach
     void setUp() {
-        cut = new SubscriptionMetadataSanitizer(htmlSanitizer);
+        cut = new SubscriptionMetadataSanitizer();
     }
 
     @Test
@@ -87,7 +76,6 @@ class SubscriptionMetadataSanitizerTest {
 
     @Test
     void should_accept_metadata_at_maximum_count() {
-        when(htmlSanitizer.sanitize(anyString())).thenAnswer(inv -> inv.getArgument(0));
         Map<String, String> maxAllowed = new HashMap<>();
         for (int i = 0; i < 25; i++) {
             maxAllowed.put("key_" + i, "value");
@@ -99,10 +87,7 @@ class SubscriptionMetadataSanitizerTest {
     }
 
     @Test
-    void should_sanitize_values_and_omit_empty_values() {
-        when(htmlSanitizer.sanitize("<script>alert(1)</script>")).thenReturn("alert(1)");
-        when(htmlSanitizer.sanitize("   ")).thenReturn("   ");
-        when(htmlSanitizer.sanitize(isNull())).thenReturn(null);
+    void should_strip_html_tags_and_omit_empty_values() {
         Map<String, String> metadata = new HashMap<>();
         metadata.put("field_a", "<script>alert(1)</script>");
         metadata.put("field_b", null);
@@ -111,5 +96,43 @@ class SubscriptionMetadataSanitizerTest {
         var result = cut.sanitizeAndValidate(metadata);
 
         assertThat(result).containsEntry("field_a", "alert(1)").doesNotContainKeys("field_b", "field_c");
+    }
+
+    @Test
+    void should_preserve_special_chars_like_at_sign_in_email() {
+        var result = cut.sanitizeAndValidate(Map.of("email", "my@company.com"));
+
+        assertThat(result).containsEntry("email", "my@company.com");
+    }
+
+    @Test
+    void should_preserve_plain_text_special_chars_without_encoding() {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("field_a", "key=value+1");
+        metadata.put("field_b", "it's a \"test\"");
+        metadata.put("field_c", "code`snippet");
+
+        var result = cut.sanitizeAndValidate(metadata);
+
+        assertThat(result)
+            .containsEntry("field_a", "key=value+1")
+            .containsEntry("field_b", "it's a \"test\"")
+            .containsEntry("field_c", "code`snippet");
+    }
+
+    @Test
+    void should_accept_values_with_less_than_or_greater_than_after_strip() {
+        var result = cut.sanitizeAndValidate(Map.of("key", "x < 5"));
+        assertThat(result).containsEntry("key", "x < 5");
+
+        var result2 = cut.sanitizeAndValidate(Map.of("key", "y > 0"));
+        assertThat(result2).containsEntry("key", "y > 0");
+    }
+
+    @Test
+    void should_strip_html_tags_and_keep_text_content() {
+        var result = cut.sanitizeAndValidate(Map.of("content", "<b>bold</b>"));
+
+        assertThat(result).containsEntry("content", "bold");
     }
 }

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.html
@@ -28,7 +28,7 @@
     class="gmd-textarea__field"
     [id]="name()"
     [name]="name()"
-    [placeholder]="placeholder()"
+    [attr.placeholder]="placeholder() ?? null"
     [attr.minlength]="minLengthVM()"
     [attr.maxlength]="maxLengthVM()"
     [rows]="rowsVM()"

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/textarea/gmd-textarea.component.spec.ts
@@ -112,6 +112,14 @@ describe('GmdTextareaComponent', () => {
     expect(placeholder).toBe('Enter text here');
   });
 
+  it('should not render placeholder attribute when placeholder is undefined', async () => {
+    fixture.componentRef.setInput('placeholder', undefined);
+    fixture.detectChanges();
+
+    const placeholder = await harness.getPlaceholder();
+    expect(placeholder).toBeNull();
+  });
+
   it('should show required indicator when required is true', async () => {
     fixture.componentRef.setInput('label', 'Test Textarea');
     fixture.componentRef.setInput('required', true);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13077

## Description

**Placeholder fix:** GmdTextareaComponent rendered the literal string "undefined" as placeholder attribute when no value was passed. Fixed by binding via [attr.placeholder] with a ?? null fallback, which removes the attribute entirely when the input is not set.

**Subscription metadata encoding fix:** Special characters in subscription form metadata (e.g. @ in email addresses) were being stored in the database as HTML entities (&#64;, &#43;, etc.) due to OWASP HTML Sanitizer over-encoding plain-text values. Added an unescapeSafeChars post-processing step in SubscriptionMetadataSanitizer that restores these characters after sanitization. XSS-relevant entities (&lt;, &gt;, &amp;) are intentionally left encoded.

## Additional Context: 

### Placeholder fix
Before:
<img width="1231" height="477" alt="Zrzut ekranu 2026-03-10 o 19 12 11" src="https://github.com/user-attachments/assets/26602f1d-8bfb-46d1-af5f-fe3a92fa4585" />

After: 
<img width="1418" height="878" alt="image" src="https://github.com/user-attachments/assets/4ec455e5-2632-4fcf-bffd-7461f76e991a" />
 
**Subscription metadata encoding fix:**

Before:
<img width="3442" height="1892" alt="image" src="https://github.com/user-attachments/assets/e990e5c2-deae-46b1-b322-cbb53df0819b" />


After:
<img width="632" height="195" alt="image" src="https://github.com/user-attachments/assets/6868e054-5451-46c6-b8d9-fe6321aa63a2" />





