### PR TITLE
Clear stale cert from mTLS subscriptions when all certificates expire

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -270,6 +270,29 @@ class SubscriptionCacheServiceTest {
         }
 
         @Test
+        void should_update_trust_store_when_subscription_transitions_to_empty_certificate() {
+            // Register with a client certificate
+            Subscription subscription = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, PLAN_ID);
+            subscriptionService.register(subscription);
+
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent();
+            assertThat(subscriptionService.getByClientCertificate(subscription)).isPresent();
+
+            // Re-register with empty string — simulates all certs expired
+            Subscription updatedWithEmptyCert = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, "", PLAN_ID);
+            subscriptionService.register(updatedWithEmptyCert);
+
+            // Subscription should still be registered by ID with the new cert value
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent().get().isEqualTo(updatedWithEmptyCert);
+
+            // New cert entry is present
+            assertThat(subscriptionService.getByClientCertificate(updatedWithEmptyCert)).isPresent();
+
+            // Trust store loaders should have been re-registered with the new cert
+            verify(subscriptionTrustStoreLoaderManager).registerSubscription(eq(updatedWithEmptyCert), eq(Set.of()));
+        }
+
+        @Test
         void should_not_register_subscription_when_subscription_is_not_accepted() {
             Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscription.setStatus(io.gravitee.repository.management.model.Subscription.Status.CLOSED.name());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoader.java
@@ -23,6 +23,7 @@ import io.gravitee.gateway.security.core.exception.MalformedCertificateException
 import io.gravitee.node.api.certificate.AbstractStoreLoaderOptions;
 import io.gravitee.node.api.certificate.KeyStoreEvent;
 import io.gravitee.node.certificates.AbstractKeyStoreLoader;
+import io.micrometer.common.util.StringUtils;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.util.Base64;
@@ -57,8 +58,13 @@ public class SubscriptionTrustStoreLoader extends AbstractKeyStoreLoader<Subscri
     }
 
     public static Set<SubscriptionCertificate> readSubscriptionCertificate(Subscription subscription) throws MalformedCertificateException {
+        var clientCertificate = subscription.getClientCertificate();
+        if (StringUtils.isBlank(clientCertificate)) {
+            log.debug("Subscription {} has no client certificate, returning empty set", subscription.getId());
+            return Collections.emptySet();
+        }
         try {
-            final byte[] decodedData = Base64.getDecoder().decode(subscription.getClientCertificate());
+            final byte[] decodedData = Base64.getDecoder().decode(clientCertificate);
             var keystore = PKCS7Utils.pkcs7ToTruststore(decodedData, null, i -> "pkcs7-" + i, false).orElseGet(() ->
                 KeyStoreUtils.initFromPemCertificate(new String(decodedData), null, "solo")
             );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderManagerTest.java
@@ -395,6 +395,70 @@ class SubscriptionTrustStoreLoaderManagerTest {
         assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).isPresent();
     }
 
+    @Test
+    void should_remove_all_loaders_when_subscription_updated_with_empty_certificate() {
+        // Register subscription with 2 valid certs
+        final Subscription subscription = Subscription.builder()
+            .id("subscriptionId")
+            .api("apiId")
+            .plan("planId")
+            .clientCertificate(getPKCS7())
+            .build();
+        cut.registerSubscription(subscription, Set.of());
+
+        assertAllServers(2);
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_1_DIGEST)).isPresent();
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).isPresent();
+
+        // Re-register with empty string (all certs expired)
+        final Subscription updatedWithEmptyCert = Subscription.builder()
+            .id("subscriptionId")
+            .api("apiId")
+            .plan("planId")
+            .clientCertificate("")
+            .build();
+        cut.registerSubscription(updatedWithEmptyCert, Set.of());
+
+        // Both old loaders should be removed, no new loaders created
+        assertAllServers(0);
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_1_DIGEST)).isEmpty();
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).isEmpty();
+    }
+
+    @Test
+    void should_not_affect_other_subscription_when_clearing_one_subscription_loaders() {
+        // Register subscription A with cert 1
+        final Subscription subscriptionA = Subscription.builder()
+            .id("subA")
+            .api("apiId")
+            .plan("planId")
+            .clientCertificate(BASE_64_CERTIFICATE_1)
+            .build();
+        cut.registerSubscription(subscriptionA, Set.of());
+
+        // Register subscription B with cert 2
+        final Subscription subscriptionB = Subscription.builder()
+            .id("subB")
+            .api("apiId")
+            .plan("planId")
+            .clientCertificate(BASE_64_CERTIFICATE_2)
+            .build();
+        cut.registerSubscription(subscriptionB, Set.of());
+
+        assertAllServers(2);
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_1_DIGEST)).contains(subscriptionA);
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).contains(subscriptionB);
+
+        // Clear subscription A by re-registering with empty string
+        final Subscription updatedA = Subscription.builder().id("subA").api("apiId").plan("planId").clientCertificate("").build();
+        cut.registerSubscription(updatedA, Set.of());
+
+        // Subscription A's cert is gone, subscription B's cert is still there
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_1_DIGEST)).isEmpty();
+        assertThat(cut.getByCertificate("apiId", "planId", CERTIFICATE_2_DIGEST)).contains(subscriptionB);
+        assertAllServers(1);
+    }
+
     private void assertAllServers(int expected) {
         assertThat(truststoreAliases(trustStoreLoaderManager1)).hasSize(expected);
         assertThat(truststoreAliases(trustStoreLoaderManager2)).hasSize(expected);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/SubscriptionTrustStoreLoaderTest.java
@@ -18,12 +18,14 @@ package io.gravitee.gateway.security.core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.common.security.CertificateUtils;
+import io.gravitee.common.security.PKCS7Utils;
 import io.gravitee.common.util.KeyStoreUtils;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.node.api.certificate.KeyStoreEvent;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import lombok.SneakyThrows;
@@ -116,6 +118,39 @@ class SubscriptionTrustStoreLoaderTest {
                     assertThat(keyStore.getCertificate("cert")).isEqualTo(certificate);
                 });
             });
+    }
+
+    @Test
+    void should_return_empty_set_when_client_certificate_is_null() {
+        var subscription = Subscription.builder().id("subscriptionId").clientCertificate(null).build();
+        var result = SubscriptionTrustStoreLoader.readSubscriptionCertificate(subscription);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_set_when_client_certificate_is_blank() {
+        var subscription = Subscription.builder().id("subscriptionId").clientCertificate("   ").build();
+        var result = SubscriptionTrustStoreLoader.readSubscriptionCertificate(subscription);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_set_when_client_certificate_is_empty_string() {
+        var subscription = Subscription.builder().id("subscriptionId").clientCertificate("").build();
+        var result = SubscriptionTrustStoreLoader.readSubscriptionCertificate(subscription);
+        assertThat(result).isEmpty();
+    }
+
+    @SneakyThrows
+    @Test
+    void should_return_certificates_from_valid_pkcs7_bundle() {
+        var pkcs7Bytes = PKCS7Utils.createBundle(List.of(CERTIFICATE));
+        var base64Bundle = Base64.getEncoder().encodeToString(pkcs7Bytes);
+
+        var subscription = Subscription.builder().id("subscriptionId").clientCertificate(base64Bundle).build();
+        var result = SubscriptionTrustStoreLoader.readSubscriptionCertificate(subscription);
+        assertThat(result).hasSize(1);
+        assertThat(result.iterator().next().certificate()).isEqualTo(certificate);
     }
 
     @SneakyThrows

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/ApplicationCertificatesUpdateDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/ApplicationCertificatesUpdateDomainServiceImpl.java
@@ -97,8 +97,7 @@ public class ApplicationCertificatesUpdateDomainServiceImpl implements Applicati
         );
 
         if (activeCertificates.isEmpty()) {
-            log.debug("No active certificates found for application: {}", applicationId);
-            return;
+            log.warn("No active certificates remain for application {}. mTLS subscriptions will be cleared.", applicationId);
         }
 
         String encodedCertificate = encodeCertificates(
@@ -108,13 +107,17 @@ public class ApplicationCertificatesUpdateDomainServiceImpl implements Applicati
     }
 
     private String encodeCertificates(List<ClientCertificate> certificates) {
+        if (certificates.isEmpty()) {
+            return "";
+        }
+
         if (certificates.size() == 1) {
             String pem = certificates.getFirst().certificate();
             return Base64.getEncoder().encodeToString(pem.getBytes(StandardCharsets.UTF_8));
-        } else {
-            byte[] pkcs7Bundle = PKCS7Utils.createBundle(certificates.stream().map(ClientCertificate::certificate).toList());
-            return Base64.getEncoder().encodeToString(pkcs7Bundle);
         }
+
+        byte[] pkcs7Bundle = PKCS7Utils.createBundle(certificates.stream().map(ClientCertificate::certificate).toList());
+        return Base64.getEncoder().encodeToString(pkcs7Bundle);
     }
 
     private void updateSubscriptionsWithCertificate(List<SubscriptionEntity> subscriptions, String encodedCertificate) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ApplicationCertificatesUpdateDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ApplicationCertificatesUpdateDomainServiceImplTest.java
@@ -223,7 +223,7 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
     }
 
     @Test
-    void should_not_update_subscriptions_when_no_active_certificates() {
+    void should_clear_certificate_when_no_active_certificates() {
         // Given: an mTLS plan
         Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
         planCrudService.initWith(List.of(mtlsPlan));
@@ -239,10 +239,10 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
         // When
         service.updateActiveMTLSSubscriptions(APPLICATION_ID);
 
-        // Then: subscription should remain unchanged
+        // Then: subscription should be updated with empty string
         SubscriptionEntity result = subscriptionCrudService.get(SUBSCRIPTION_ID);
-        assertThat(result.getClientCertificate()).isEqualTo(existingEncodedCert);
-        assertThat(result.getCreatedAt()).isSameAs(result.getUpdatedAt());
+        assertThat(result.getClientCertificate()).isEmpty();
+        assertThat(result.getCreatedAt()).isNotEqualTo(result.getUpdatedAt());
     }
 
     @Test
@@ -302,6 +302,31 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
         KeyStore ks = keyStore.get();
         assertThat(ks.getCertificate("0")).isEqualTo(KeyStoreUtils.loadPemCertificates(PEM_CERTIFICATE_1)[0]);
         assertThat(ks.getCertificate("1")).isEqualTo(KeyStoreUtils.loadPemCertificates(PEM_CERTIFICATE_2)[0]);
+    }
+
+    @Test
+    void should_clear_certificate_on_all_mtls_subscriptions_when_no_active_certificates() {
+        // Given: an mTLS plan with 2 subscriptions and all certificates revoked
+        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
+        planCrudService.initWith(List.of(mtlsPlan));
+
+        SubscriptionEntity subscription1 = buildSubscription("sub-1", APPLICATION_ID, PLAN_ID, null);
+        SubscriptionEntity subscription2 = buildSubscription("sub-2", APPLICATION_ID, PLAN_ID, null);
+        subscriptionCrudService.initWith(List.of(subscription1, subscription2));
+
+        ClientCertificate revokedCert = buildClientCertificate("cert-1", ClientCertificateStatus.REVOKED, PEM_CERTIFICATE_1);
+        clientCertificateCrudService.initWith(List.of(revokedCert));
+
+        // When
+        service.updateActiveMTLSSubscriptions(APPLICATION_ID);
+
+        // Then: both subscriptions should be updated with empty string
+        SubscriptionEntity result1 = subscriptionCrudService.get("sub-1");
+        SubscriptionEntity result2 = subscriptionCrudService.get("sub-2");
+        assertThat(result1.getClientCertificate()).isEmpty();
+        assertThat(result2.getClientCertificate()).isEmpty();
+        assertThat(result1.getCreatedAt()).isNotEqualTo(result1.getUpdatedAt());
+        assertThat(result2.getCreatedAt()).isNotEqualTo(result2.getUpdatedAt());
     }
 
     @Test


### PR DESCRIPTION
## Issue

[GKO-2450](https://gravitee.atlassian.net/browse/GKO-2450)

## Description

When all client certificates for an application expire or are revoked, mTLS subscriptions were left holding the stale certificate bundle. The gateway kept old trust store loaders active with the expired cert, creating inconsistent state.

**Root cause:** `ApplicationCertificatesUpdateDomainServiceImpl.updateActiveMTLSSubscriptions()` threw `ClientCertificateLastRemovalException` when no active certs remained, so the subscription was never updated.

**Changes:**

- **ApplicationCertificatesUpdateDomainServiceImpl** — Remove the exception when no active certificates remain. Instead, update mTLS subscriptions with an empty PKCS7 bundle, clearing the stale cert from the DB and triggering gateway sync.
- **SubscriptionTrustStoreLoader.readSubscriptionCertificate** — Return an empty set when the client certificate is null/blank, and pass `allowEmpty=true` to `PKCS7Utils.pkcs7ToTruststore` so empty bundles are handled gracefully.
- **SubscriptionCacheService** — Added test covering the transition to an empty certificate bundle.

## Additional context

- The empty PKCS7 bundle flows through `SubscriptionTrustStoreLoaderManager.registerSubscription()`: the update path removes all existing loaders via diff, and the new subscription path registers no loaders.
- Tests cover null cert, blank cert, empty PKCS7 bundle, and valid PKCS7 bundle scenarios.

## Manual test scenarios

I ran the following tests:

- Happy path: mTLS request with a valid client certificate succeeds (200).
- Main bug scenario: after all certs expire and the cron job runs, the gateway rejects the old certificate.
- Partial expiry: the remaining valid cert still allows mTLS access after one cert expires.
- Partial expiry: the expired cert is rejected after another cert on the same app has expired.
- Recovery: adding a new cert after full expiry restores mTLS access.
- Manual revocation: gateway rejects mTLS after certs are manually revoked and the gateway syncs.
- API Key subscription on the same API is unaffected when the mTLS app's certs expire.
- OAuth2/JWT subscription on the same API is unaffected when the mTLS app's certs expire.
- mTLS subscription on a different application is unaffected when another app's certs expire.
- Same app subscribed to mTLS plans on two different APIs: both subscriptions are cleared after full expiry.
- New clientId-based (OAuth2/JWT) subscription on the same application works normally after its mTLS certs have been cleared.

[GKO-2450]: https://gravitee.atlassian.net/browse/GKO-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ