### PR TITLE
fix: implement viewport scrolling on homepage navigation

### DIFF
--- a/gravitee-apim-portal-webui/src/app/app.component.ts
+++ b/gravitee-apim-portal-webui/src/app/app.component.ts
@@ -31,6 +31,7 @@ import {
 } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Title } from '@angular/platform-browser';
+import { ViewportScroller } from '@angular/common';
 import {
   ActivatedRoute,
   NavigationEnd,
@@ -108,6 +109,7 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
     private ref: ChangeDetectorRef,
     private googleAnalyticsService: GoogleAnalyticsService,
     private previewService: PreviewService,
+    private viewportScroller: ViewportScroller,
   ) {
     this.activatedRoute.queryParamMap.subscribe(params => {
       if (params.has('preview') && params.get('preview') === 'on') {
@@ -343,6 +345,11 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
 
   private _onNavigationEnd(event: NavigationEnd) {
     this.isHomepage = this.isHomepageUrl(event.url);
+    if (this.isHomepage) {
+      this.viewportScroller.scrollToPosition([0, 0]);
+      this.isSticky = false;
+      this.isStickyHomepage = false;
+    }
     this.portalService.getPortalLinks().subscribe(portalLinks => {
       if (portalLinks.slots) {
         // deepcode ignore reDOS: <please specify a reason of ignoring this>

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.ts
@@ -54,6 +54,11 @@ export class GvPageSwaggerUIComponent implements OnInit, OnDestroy {
 
     // Clean up global side effects leakage from SwaggerUI / React
     document.getElementById('preact-border-shadow-host')?.remove();
+
+    // Restore body overflow - Swagger UI sets overflow:hidden when opening schema modals,
+    // which can persist and break the layout when navigating back to homepage
+    document.body.style.overflow = '';
+    document.body.style.paddingRight = '';
   }
 
   private refresh(page: Page) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12985

## Description

**Two things were causing the issue:**

1. Scroll position not reset on navigation – With scrollPositionRestoration: 'disabled', the scroll position stayed at the value from the documentation page (e.g. after viewing schema fields). When navigating to the homepage, the scroll position was still high.

1. Incorrect sticky state – computeMenuMode() uses pageYOffset to set isStickyHomepage. Because the scroll position was not reset, isStickyHomepage stayed true, so the header used the collapsed sticky layout (height: 70px, overflow: hidden). The homepage title (e.g. "Custom Title") was clipped and appeared broken.

## Additional context

### Pre fix behaviour: 
https://github.com/user-attachments/assets/9b736c73-0b45-446f-93eb-0406422b7a19


### Post fix behaviour: 
https://github.com/user-attachments/assets/cd938587-6944-4e72-88a5-e06bbe3243fb

