### PR TITLE
fix: allow user attributes in mail templates

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -587,14 +587,15 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 if (subscription.getRequest() != null) {
                     paramSubscription.setRequest(Jsoup.clean(subscription.getRequest(), Safelist.none()));
                 }
-                final Map<String, Object> params = new NotificationParamsBuilder()
+                final NotificationParamsBuilder paramsBuilder = new NotificationParamsBuilder()
                     .api(api)
                     .plan(genericPlanEntity)
                     .application(applicationEntity)
                     .owner(apiOwner)
                     .subscription(paramSubscription)
-                    .subscriptionsUrl(subscriptionsUrl)
-                    .build();
+                    .subscriptionsUrl(subscriptionsUrl);
+                addSubscribedByUserIfPresent(executionContext, paramsBuilder, paramSubscription.getSubscribedBy());
+                final Map<String, Object> params = paramsBuilder.build();
 
                 notifierService.trigger(executionContext, ApiHook.SUBSCRIPTION_NEW, apiId, params);
                 notifierService.trigger(executionContext, ApplicationHook.SUBSCRIPTION_NEW, application, params);
@@ -613,6 +614,24 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         }
 
         return Optional.ofNullable(Base64.getEncoder().encodeToString(settings.getTls().getClientCertificate().getBytes()));
+    }
+
+    private void addSubscribedByUserIfPresent(
+        ExecutionContext executionContext,
+        NotificationParamsBuilder paramsBuilder,
+        String subscribedBy
+    ) {
+        if (subscribedBy == null || subscribedBy.isEmpty()) {
+            return;
+        }
+        try {
+            UserEntity subscribedByUser = userService.findById(executionContext, subscribedBy);
+            if (subscribedByUser != null) {
+                paramsBuilder.user(subscribedByUser);
+            }
+        } catch (Exception e) {
+            logger.debug("Could not resolve subscribed-by user {} for subscription notification params", subscribedBy, e);
+        }
     }
 
     private long countSubscriptionMatchingPredicate(
@@ -903,13 +922,14 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             String apiId = genericPlanEntity.getApiId();
             final GenericApiModel genericApiModel = apiTemplateService.findByIdForTemplates(executionContext, apiId);
             final PrimaryOwnerEntity owner = application.getPrimaryOwner();
-            final Map<String, Object> params = new NotificationParamsBuilder()
+            final NotificationParamsBuilder paramsBuilder = new NotificationParamsBuilder()
                 .owner(owner)
                 .api(genericApiModel)
                 .plan(genericPlanEntity)
                 .application(application)
-                .subscription(result)
-                .build();
+                .subscription(result);
+            addSubscribedByUserIfPresent(executionContext, paramsBuilder, result.getSubscribedBy());
+            final Map<String, Object> params = paramsBuilder.build();
             notifierService.trigger(executionContext, ApiHook.SUBSCRIPTION_FAILED, apiId, params);
             notifierService.trigger(executionContext, ApplicationHook.SUBSCRIPTION_FAILED, application.getId(), params);
 
@@ -943,13 +963,14 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             String apiId = genericPlanEntity.getApiId();
             final GenericApiModel genericApiModel = apiTemplateService.findByIdForTemplates(executionContext, apiId);
             final PrimaryOwnerEntity owner = application.getPrimaryOwner();
-            final Map<String, Object> params = new NotificationParamsBuilder()
+            final NotificationParamsBuilder paramsBuilder = new NotificationParamsBuilder()
                 .owner(owner)
                 .api(genericApiModel)
                 .plan(genericPlanEntity)
                 .application(application)
-                .subscription(result)
-                .build();
+                .subscription(result);
+            addSubscribedByUserIfPresent(executionContext, paramsBuilder, result.getSubscribedBy());
+            final Map<String, Object> params = paramsBuilder.build();
             notifierService.trigger(executionContext, ApiHook.SUBSCRIPTION_FAILED, apiId, params);
             notifierService.trigger(executionContext, ApplicationHook.SUBSCRIPTION_FAILED, application.getId(), params);
 
@@ -1045,12 +1066,13 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 String apiId = genericPlanEntity.getApiId();
                 final GenericApiModel genericApiModel = apiTemplateService.findByIdForTemplates(executionContext, apiId);
                 final PrimaryOwnerEntity owner = application.getPrimaryOwner();
-                final Map<String, Object> params = new NotificationParamsBuilder()
+                final NotificationParamsBuilder paramsBuilder = new NotificationParamsBuilder()
                     .owner(owner)
                     .api(genericApiModel)
                     .plan(genericPlanEntity)
-                    .application(application)
-                    .build();
+                    .application(application);
+                addSubscribedByUserIfPresent(executionContext, paramsBuilder, subscription.getSubscribedBy());
+                final Map<String, Object> params = paramsBuilder.build();
 
                 notifierService.trigger(executionContext, ApiHook.SUBSCRIPTION_PAUSED, apiId, params);
                 notifierService.trigger(executionContext, ApplicationHook.SUBSCRIPTION_PAUSED, application.getId(), params);
@@ -1222,12 +1244,13 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 String apiId = genericPlanEntity.getApiId();
                 final GenericApiModel genericApiModel = apiTemplateService.findByIdForTemplates(executionContext, apiId);
                 final PrimaryOwnerEntity owner = application.getPrimaryOwner();
-                final Map<String, Object> params = new NotificationParamsBuilder()
+                final NotificationParamsBuilder paramsBuilder = new NotificationParamsBuilder()
                     .owner(owner)
                     .api(genericApiModel)
                     .plan(genericPlanEntity)
-                    .application(application)
-                    .build();
+                    .application(application);
+                addSubscribedByUserIfPresent(executionContext, paramsBuilder, subscription.getSubscribedBy());
+                final Map<String, Object> params = paramsBuilder.build();
 
                 notifierService.trigger(executionContext, ApiHook.SUBSCRIPTION_RESUMED, apiId, params);
                 notifierService.trigger(executionContext, ApplicationHook.SUBSCRIPTION_RESUMED, application.getId(), params);
@@ -1568,13 +1591,14 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             SubscriptionEntity subscriptionEntity = convert(subscription);
 
-            final Map<String, Object> params = new NotificationParamsBuilder()
+            final NotificationParamsBuilder paramsBuilder = new NotificationParamsBuilder()
                 .owner(owner)
                 .application(application)
                 .api(genericApiModel)
                 .plan(subscriptionGenericPlanEntity)
-                .subscription(subscriptionEntity)
-                .build();
+                .subscription(subscriptionEntity);
+            addSubscribedByUserIfPresent(executionContext, paramsBuilder, subscriptionEntity.getSubscribedBy());
+            final Map<String, Object> params = paramsBuilder.build();
             notifierService.trigger(executionContext, ApiHook.SUBSCRIPTION_TRANSFERRED, apiId, params);
             notifierService.trigger(executionContext, ApplicationHook.SUBSCRIPTION_TRANSFERRED, application.getId(), params);
             return subscriptionEntity;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -87,6 +87,7 @@ import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.TransferSubscriptionEntity;
 import io.gravitee.rest.api.model.UpdateSubscriptionConfigurationEntity;
 import io.gravitee.rest.api.model.UpdateSubscriptionEntity;
+import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.SimpleApplicationSettings;
@@ -125,6 +126,7 @@ import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.TransferNotAllowedException;
 import io.gravitee.rest.api.service.notification.ApiHook;
 import io.gravitee.rest.api.service.notification.ApplicationHook;
+import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.v4.ApiEntrypointService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.ApiTemplateService;
@@ -1384,6 +1386,59 @@ public class SubscriptionServiceTest {
             anyMap()
         );
         verify(subscription).setUpdatedAt(any());
+    }
+
+    @Test
+    public void shouldIncludeSubscribedByUserInApiSubscriptionNotificationParams() throws Exception {
+        final TransferSubscriptionEntity transferSubscription = new TransferSubscriptionEntity();
+        transferSubscription.setId(SUBSCRIPTION_ID);
+        transferSubscription.setPlan(PLAN_ID);
+
+        String subscribedByDisplayName = "Subscriber Display Name";
+        UserEntity subscribedByUser = new UserEntity();
+        subscribedByUser.setFirstname("Subscriber");
+        subscribedByUser.setLastname("Display Name");
+
+        when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
+        when(subscription.getApplication()).thenReturn(APPLICATION_ID);
+        when(subscription.getPlan()).thenReturn(PLAN_ID);
+        when(subscription.getStatus()).thenReturn(ACCEPTED);
+        when(subscription.getApi()).thenReturn(API_ID);
+        when(subscription.getSubscribedBy()).thenReturn(SUBSCRIBER_ID);
+
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.update(any())).thenReturn(subscription);
+        planEntity.setStatus(PlanStatus.PUBLISHED);
+        planEntity.setSecurity(PlanSecurityType.API_KEY);
+        planEntity.setApi(API_ID);
+        when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntity);
+        when(applicationService.findById(GraviteeContext.getExecutionContext(), APPLICATION_ID)).thenReturn(application);
+        application.setPrimaryOwner(new PrimaryOwnerEntity());
+        when(apiTemplateService.findByIdForTemplates(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(apiModelEntity);
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), eq(SUBSCRIBER_ID))).thenReturn(subscribedByUser);
+
+        subscriptionService.transfer(GraviteeContext.getExecutionContext(), transferSubscription, USER_ID);
+
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApiHook.SUBSCRIPTION_TRANSFERRED),
+            anyString(),
+            argThat(
+                params ->
+                    params.containsKey(NotificationParamsBuilder.PARAM_USER) &&
+                    subscribedByDisplayName.equals(((UserEntity) params.get(NotificationParamsBuilder.PARAM_USER)).getDisplayName())
+            )
+        );
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApplicationHook.SUBSCRIPTION_TRANSFERRED),
+            nullable(String.class),
+            argThat(
+                params ->
+                    params.containsKey(NotificationParamsBuilder.PARAM_USER) &&
+                    subscribedByDisplayName.equals(((UserEntity) params.get(NotificationParamsBuilder.PARAM_USER)).getDisplayName())
+            )
+        );
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12958

## Description

User attributes such as ${user.displayName} were not resolved in email templates during subscription notifications. Owner attributes were working correctly.

This change ensures user attributes are properly evaluated in both placeholders and conditional expressions within templates.

Additional context
When a user creates a subscription, notification emails are sent to the API owner and the application owner. These email templates support variable interpolation (e.g. ${owner.displayName}, ${api.name}) via Gravitee's NotificationParamsBuilder.

However, user-specific attributes such as ${user.displayName} were not being resolved in these templates. The user object was never added to the notification parameters during subscription creation, causing the placeholders to silently render as empty strings or fail conditional expressions in templates.

API owner attributes (${owner.*}) worked correctly because they were already mapped separately. The missing piece was the subscribing user's UserEntity.

Documentation : https://documentation.gravitee.io/apim/configure-and-manage-the-platform/gravitee-gateway/notifications

Approach:

Retrieve the current UserDetails from the SecurityContext.
Prefer UserDetails#getId() as the lookup key; fall back to UserDetails#getUsername() for token/JWT-based auth flows where id may be null.
Call userService.findById(executionContext, identifier) to load the full UserEntity.
If resolution succeeds, add the user to the params builder via paramsBuilder.user(subscribedByUser).
If the authenticated user is null, blank, or the lookup throws (e.g. user not found), the notification is still triggered — the user param is simply absent. No exception is propagated.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

