### PR TITLE
fix: 404 requests not visible in analytics

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
@@ -86,8 +86,9 @@ public class ReporterProcessor implements Processor {
                         reporterService.report(metrics);
                     }
                 } else {
-                    // No api found report only metrics
-                    reporterService.report(metrics);
+                    // No api found - report as V2 metrics so not-found requests appear in platform analytics
+                    io.gravitee.reporter.api.http.Metrics metricsV2 = metrics.toV2();
+                    reporterService.report(metricsV2);
                 }
             }
         })

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessorTest.java
@@ -219,9 +219,9 @@ class ReporterProcessorTest extends AbstractProcessorTest {
             reporterProcessor.execute(ctx).test().assertResult();
 
             // Then
-            verify(reporterService).report(ctx.metrics());
+            verify(reporterService, never()).report(any(Metrics.class));
+            verify(reporterService).report(any(io.gravitee.reporter.api.http.Metrics.class));
             assertNull(ctx.metrics().getLog());
-            verify(reporterService, never()).report(ctx.metrics().getLog());
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
@@ -75,6 +75,12 @@ public class EnvironmentAnalyticsResource extends AbstractResource {
     public static final String STATE_FIELD = "state";
     public static final String LIFECYCLE_STATE_FIELD = "lifecycle_state";
 
+    /**
+     * Sentinel API ID assigned by the gateway to requests that don't match any deployed API.
+     * Must stay in sync with NotFoundProcessor.UNKNOWN_SERVICE in the gateway module.
+     */
+    private static final String UNKNOWN_SERVICE = "1";
+
     @Inject
     ApiService apiService;
 
@@ -262,6 +268,12 @@ public class EnvironmentAnalyticsResource extends AbstractResource {
                     .filter(apiId -> permissionService.hasPermission(executionContext, API_ANALYTICS, apiId, READ))
                     .collect(Collectors.toSet());
             }
+        }
+        if (API_FIELD.equals(fieldName)) {
+            // Always include the not-found sentinel so that requests to non-existent APIs
+            // (stored with api="1" in gravitee-request-*) are counted in platform analytics.
+            ids = new HashSet<>(ids);
+            ids.add(UNKNOWN_SERVICE);
         }
         if (ids.isEmpty()) {
             throw new FieldFilterEmptyException();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
@@ -42,6 +42,7 @@ import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Response;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -56,6 +57,12 @@ import org.jetbrains.annotations.NotNull;
  */
 @Tag(name = "Platform Analytics")
 public class PlatformAnalyticsResource extends AbstractResource {
+
+    /**
+     * Sentinel API ID used by the gateway for requests that don't match any deployed API.
+     * Must stay in sync with NotFoundProcessor.UNKNOWN_SERVICE in the gateway module.
+     */
+    private static final String UNKNOWN_SERVICE = "1";
 
     @Inject
     PermissionService permissionService;
@@ -124,14 +131,20 @@ public class PlatformAnalyticsResource extends AbstractResource {
     @NotNull
     private Set<String> findApiIds() {
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        if (isAdmin()) {
-            return apiAuthorizationService.findIdsByEnvironment(executionContext.getEnvironmentId());
-        }
-        return apiAuthorizationService
-            .findIdsByUser(executionContext, getAuthenticatedUser(), true)
-            .stream()
-            .filter(appId -> permissionService.hasPermission(executionContext, API_ANALYTICS, appId, READ))
-            .collect(Collectors.toSet());
+
+        // Fetch and directly instantiate a mutable HashSet
+        Set<String> apiIds = isAdmin()
+            ? new HashSet<>(apiAuthorizationService.findIdsByEnvironment(executionContext.getEnvironmentId()))
+            : apiAuthorizationService
+                .findIdsByUser(executionContext, getAuthenticatedUser(), true)
+                .stream()
+                .filter(apiId -> permissionService.hasPermission(executionContext, API_ANALYTICS, apiId, READ))
+                .collect(Collectors.toCollection(HashSet::new));
+
+        // Include not-found sentinel so requests to non-existent APIs appear in platform analytics
+        apiIds.add(UNKNOWN_SERVICE);
+
+        return apiIds;
     }
 
     @NotNull

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResourceTest.java
@@ -34,7 +34,9 @@ import io.gravitee.rest.api.model.analytics.HitsAnalytics;
 import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
 import io.gravitee.rest.api.model.analytics.query.CountQuery;
 import io.gravitee.rest.api.model.analytics.query.DateHistogramQuery;
+import io.gravitee.rest.api.model.analytics.query.GroupByQuery;
 import io.gravitee.rest.api.model.analytics.query.StatsAnalytics;
+import io.gravitee.rest.api.model.analytics.query.StatsQuery;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -148,9 +150,10 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetEmptyHistoAnalyticsWhenNotAdminAndNoApi() {
-        when(apiAuthorizationService.findIdsByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), eq(true))).thenReturn(
+        when(apiAuthorizationService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), eq(true))).thenReturn(
             Collections.emptySet()
         );
+        when(analyticsService.execute(any(ExecutionContext.class), any(DateHistogramQuery.class))).thenReturn(new HistogramAnalytics());
 
         Response response = envTarget()
             .queryParam("type", "date_histo")
@@ -162,16 +165,20 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
-        HistogramAnalytics analytics = response.readEntity(HistogramAnalytics.class);
-        assertThat(analytics.getValues()).isNull();
-        assertThat(analytics.getTimestamp()).isNull();
+
+        // Even with no registered APIs the query must still fire with the not-found sentinel ("1")
+        // so that 404 requests to non-existent APIs are included in the histogram.
+        ArgumentCaptor<DateHistogramQuery> queryCaptor = ArgumentCaptor.forClass(DateHistogramQuery.class);
+        verify(analyticsService).execute(any(ExecutionContext.class), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().getTerms().get("api")).contains("1");
     }
 
     @Test
     public void shouldGetEmptyTopHitsAnalyticsWhenNotAdminAndNoApi() {
-        when(apiAuthorizationService.findIdsByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), eq(true))).thenReturn(
+        when(apiAuthorizationService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), eq(true))).thenReturn(
             Collections.emptySet()
         );
+        when(analyticsService.execute(any(ExecutionContext.class), any(GroupByQuery.class))).thenReturn(new TopHitsAnalytics());
 
         Response response = envTarget()
             .queryParam("type", "group_by")
@@ -183,9 +190,10 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
-        TopHitsAnalytics analytics = response.readEntity(TopHitsAnalytics.class);
-        assertThat(analytics.getValues()).isNull();
-        assertThat(analytics.getMetadata()).isNull();
+
+        ArgumentCaptor<GroupByQuery> queryCaptor = ArgumentCaptor.forClass(GroupByQuery.class);
+        verify(analyticsService).execute(any(ExecutionContext.class), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().getTerms().get("api")).contains("1");
     }
 
     @Test
@@ -210,9 +218,10 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetEmptyStatsAnalyticsWhenNotAdminAndNoApi() {
-        when(apiAuthorizationService.findIdsByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), eq(true))).thenReturn(
+        when(apiAuthorizationService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), eq(true))).thenReturn(
             Collections.emptySet()
         );
+        when(analyticsService.execute(any(ExecutionContext.class), any(StatsQuery.class))).thenReturn(new StatsAnalytics());
 
         Response response = envTarget()
             .queryParam("type", "stats")
@@ -224,9 +233,10 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
-        StatsAnalytics analytics = response.readEntity(StatsAnalytics.class);
-        assertThat(analytics.getAvg()).isNull();
-        assertThat(analytics.getCount()).isNull();
+
+        ArgumentCaptor<StatsQuery> queryCaptor = ArgumentCaptor.forClass(StatsQuery.class);
+        verify(analyticsService).execute(any(ExecutionContext.class), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().getTerms().get("api")).contains("1");
     }
 
     @Test
@@ -350,7 +360,7 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
                 Objects.equals(query.getQuery(), "foo:bar") &&
                 query.getTerms().size() == 1 &&
                 query.getTerms().containsKey("api") &&
-                query.getTerms().get("api").equals(Set.of("api1")) &&
+                query.getTerms().get("api").containsAll(Set.of("api1", "1")) &&
                 query.getFrom() == 0 &&
                 query.getTo() == 1000
         );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12831

## Description

| File | Change |
|------|--------|
| `gravitee-apim-gateway/.../reporter/ReporterProcessor.java` | When no API is found, convert v4 metrics to v2 and report them (`metrics.toV2()` + `reporterService.report()`), so not-found requests are stored in `gravitee-request-*` with `api="1"`. |
| `gravitee-apim-rest-api/.../EnvironmentAnalyticsResource.java` | Introduce `UNKNOWN_SERVICE = "1"`. In `buildTerms()`, when the filter is on the API field, add `"1"` to the API IDs set so environment analytics (v1 `.../analytics`) includes not-found requests. |
| `gravitee-apim-rest-api/.../PlatformAnalyticsResource.java` | Introduce `UNKNOWN_SERVICE = "1"`. In `findApiIds()`, add `"1"` to the returned set so platform analytics (v1 `.../platform/analytics`) includes not-found requests in the Status widget and related queries. |

