### PR TITLE
fix: Broken 'Open log settings' link in V4 Protocol Mediation API log…

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.ts
@@ -62,7 +62,7 @@ export class ApiRuntimeLogsMessagesComponent implements OnInit, OnDestroy {
   }
 
   public openLogsSettings() {
-    this.router.navigate(['../../runtime-logs-settings'], { relativeTo: this.activatedRoute });
+    this.router.navigate(['../../../reporter-settings'], { relativeTo: this.activatedRoute });
   }
 
   private loadConnectionLog(): Observable<ConnectionLogDetail> {


### PR DESCRIPTION
This PR fixes Broken 'Open log settings' link in V4 Protocol Mediation API log details.

https://gravitee.atlassian.net/browse/APIM-12810

https://github.com/user-attachments/assets/17a74234-be7c-40fd-a45e-aa6b0fc8a195

