### PR TITLE
Expose logs OpenAPI spec under /management/v2/#/

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index-logs.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index-logs.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Management API v2 - Logs</title>
+    <!-- Embed elements Elements via Web Component -->
+    <script src="https://unpkg.com/@stoplight/elements@7.7.17/web-components.min.js" integrity="sha512-er7CDLsLJUSwP4m6VU9pNH4bdjIrs3J/2DHLsbA3zCrWfGgvfSvftqmBQcqp4nHMafykJdMd4GbETNEIi34S+g==" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@7.7.17/styles.min.css" integrity="sha512-R0lX4nTGMLQSM9/IWxQD5cY/8e2VIcpcZNPaRuXdHjpCkxYxvmXF4uveEJk5NKqAGOximNajPCZIA5JwmE731w==" crossorigin="anonymous">
+</head>
+<body>
+
+<elements-api
+        apiDescriptionUrl="openapi-logs.yaml"
+        router="hash"
+        layout="sidebar"
+/>
+
+</body>
+</html>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/index.html
@@ -1,26 +1,27 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <title>Management API v2 - API Docs</title>
+    <meta charset="utf-8">
+    <title>Management API v2 - API Docs</title>
 </head>
 <body>
-  <h1>Gravitee.io APIM - Management API V2 - OpenAPI Specifications:</h1>
+<h1>Gravitee.io APIM - Management API V2 - OpenAPI Specifications:</h1>
 
-  <ul>
+<ul>
     <li><a href="index-apis.html">Gravitee.io APIM - APIs</a>
     <li><a href="index-environments.html">Gravitee.io APIM - Environments</a>
     <li><a href="index-plugins.html">Gravitee.io APIM - Plugins</a>
     <li><a href="index-ui.html">Gravitee.io APIM - UI</a>
     <li><a href="index-installation.html">Gravitee.io APIM - Installation</a>
-      <li><a href="index-analytics.html">Gravitee.io APIM - Analytics Engine</a>
-  </ul>
+    <li><a href="index-analytics.html">Gravitee.io APIM - Analytics Engine</a>
+    <li><a href="index-logs.html">Gravitee.io APIM - Logs Engine</a>
+</ul>
 
-  <h2>Deprecated OpenAPI Specifications:</h2>
+<h2>Deprecated OpenAPI Specifications:</h2>
 
-  <ul>
+<ul>
     <li><a href="index-plugins-deprecated.html">Gravitee.io APIM - Plugins - Deprecated</a>
     <li><a href="index-installation-deprecated.html">Gravitee.io APIM - Installation - Deprecated</a>
-  </ul>
+</ul>
 </body>
 </html>


### PR DESCRIPTION
## Issue

[GKO-2514](https://gravitee.atlassian.net/browse/GKO-2514)

## Description

- Added `index-logs.html` Stoplight Elements page to render the Logs OpenAPI spec (`openapi-logs.yaml`) as interactive API docs
- Added link to the Logs spec in the main `index.html` landing page at `/management/v2/#/`
- Minor indentation cleanup in `index.html`

## Additional context

Follows the same pattern as the existing `index-analytics.html` — a static HTML wrapper that loads the YAML spec client-side via Stoplight Elements web component.


[GKO-2514]: https://gravitee.atlassian.net/browse/GKO-2514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ