### PR TITLE
fix(portal-next): JWT profile in API subscription advanced config

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.component.html
@@ -106,6 +106,190 @@
               <mat-hint i18n="@@subscriptionConfigurationAuthenticationScopesHint">The list of required scopes.</mat-hint>
             </mat-form-field>
           }
+
+          @case ('jwtProfileOauth2') {
+            <mat-form-field appearance="outline" class="form__field">
+              <mat-label i18n="@@subscriptionConfigurationAuthenticationIssuer">Issuer</mat-label>
+              <input matInput formControlName="issuer" name="issuer" required />
+              <mat-hint i18n="@@subscriptionConfigurationAuthenticationIssuerHint"
+                >Mandatory claim 'iss' identifies an entity that issued JWT at authorization server</mat-hint
+              >
+              @if (authForm.controls.issuer.hasError('required')) {
+                <mat-error i18n="@@subscriptionConfigurationAuthenticationIssuerRequired">Issuer is required</mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="form__field">
+              <mat-label i18n="@@subscriptionConfigurationAuthenticationSubject">Subject</mat-label>
+              <input matInput formControlName="subject" name="subject" required />
+              <mat-hint i18n="@@subscriptionConfigurationAuthenticationSubjectHint"
+                >Mandatory claim 'sub' identifies an entity accessing the resource via issuer</mat-hint
+              >
+              @if (authForm.controls.subject.hasError('required')) {
+                <mat-error i18n="@@subscriptionConfigurationAuthenticationSubjectRequired">Subject is required</mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="form__field">
+              <mat-label i18n="@@subscriptionConfigurationAuthenticationAudience">Audience</mat-label>
+              <input matInput formControlName="audience" name="audience" required />
+              <mat-hint i18n="@@subscriptionConfigurationAuthenticationAudienceHint"
+                >Mandatory claim 'aud' identifies an authorization server as intended audience</mat-hint
+              >
+              @if (authForm.controls.audience.hasError('required')) {
+                <mat-error i18n="@@subscriptionConfigurationAuthenticationAudienceRequired">Audience is required</mat-error>
+              }
+            </mat-form-field>
+
+            <div class="form__row">
+              <mat-form-field appearance="outline" class="form__field">
+                <mat-label i18n="@@subscriptionConfigurationAuthenticationExpirationTime">Expiration Time</mat-label>
+                <input matInput type="number" formControlName="expirationTime" name="expirationTime" required />
+                <mat-hint i18n="@@subscriptionConfigurationAuthenticationExpirationTimeHint"
+                  >Mandatory claim 'exp' identifies time duration after which JWT no longer remains valid</mat-hint
+                >
+                @if (authForm.controls.expirationTime.hasError('required')) {
+                  <mat-error i18n="@@subscriptionConfigurationAuthenticationExpirationTimeRequired">Expiration Time is required</mat-error>
+                }
+              </mat-form-field>
+
+              <mat-form-field appearance="outline" class="form__field">
+                <mat-label i18n="@@subscriptionConfigurationAuthenticationExpirationTimeUnit">Time Unit</mat-label>
+                <mat-select formControlName="expirationTimeUnit" name="expirationTimeUnit" required>
+                  <mat-option value="SECONDS">SECONDS</mat-option>
+                  <mat-option value="MINUTES">MINUTES</mat-option>
+                  <mat-option value="HOURS">HOURS</mat-option>
+                  <mat-option value="DAYS">DAYS</mat-option>
+                </mat-select>
+                @if (authForm.controls.expirationTimeUnit.hasError('required')) {
+                  <mat-error i18n="@@subscriptionConfigurationAuthenticationExpirationTimeUnitRequired">Time Unit is required</mat-error>
+                }
+              </mat-form-field>
+            </div>
+
+            <mat-form-field appearance="outline" class="form__field">
+              <mat-label i18n="@@subscriptionConfigurationAuthenticationSignatureAlgorithm">Signature algorithm</mat-label>
+              <mat-select formControlName="signatureAlgorithm" name="signatureAlgorithm" required>
+                <mat-option value="RSA_RS256">RSA_RS256</mat-option>
+                <mat-option value="HMAC_HS256">HMAC_HS256</mat-option>
+                <mat-option value="HMAC_HS384">HMAC_HS384</mat-option>
+                <mat-option value="HMAC_HS512">HMAC_HS512</mat-option>
+              </mat-select>
+              @if (authForm.controls.signatureAlgorithm.hasError('required')) {
+                <mat-error i18n="@@subscriptionConfigurationAuthenticationSignatureAlgorithmRequired"
+                  >Signature algorithm is required</mat-error
+                >
+              }
+            </mat-form-field>
+
+            @if (['RSA_RS256'].includes(authForm.controls.signatureAlgorithm.value)) {
+              <mat-form-field appearance="outline" class="form__field">
+                <mat-label i18n="@@subscriptionConfigurationAuthenticationKeySource">Key source</mat-label>
+                <mat-select formControlName="keySource" name="keySource" required>
+                  <mat-option value="INLINE">INLINE</mat-option>
+                  <mat-option value="PEM">PEM</mat-option>
+                  <mat-option value="JKS">JKS</mat-option>
+                  <mat-option value="PKCS12">PKCS12</mat-option>
+                </mat-select>
+                @if (authForm.controls.keySource.hasError('required')) {
+                  <mat-error i18n="@@subscriptionConfigurationAuthenticationKeySourceRequired">Key source is required</mat-error>
+                }
+              </mat-form-field>
+            }
+
+            <mat-form-field appearance="outline" class="form__field">
+              <mat-label i18n="@@subscriptionConfigurationAuthenticationJwtId">JWT ID</mat-label>
+              <input matInput formControlName="jwtId" name="jwtId" />
+              <mat-hint i18n="@@subscriptionConfigurationAuthenticationJwtIdHint"
+                >Optional claim 'jti' identifying a unique identifier for JWT</mat-hint
+              >
+            </mat-form-field>
+
+            @if (['HMAC_HS256', 'HMAC_HS384', 'HMAC_HS512'].includes(authForm.controls.signatureAlgorithm.value)) {
+              <div class="form__field">
+                <mat-checkbox formControlName="secretBase64Encoded" i18n="@@subscriptionConfigurationAuthenticationSecretBase64Encoded"
+                  >Key base64 encoded?</mat-checkbox
+                >
+              </div>
+            }
+
+            @if (
+              ['JKS', 'PKCS12'].includes(authForm.controls.keySource.value) && authForm.controls.signatureAlgorithm.value === 'RSA_RS256'
+            ) {
+              <mat-form-field appearance="outline" class="form__field">
+                <mat-label i18n="@@subscriptionConfigurationAuthenticationX509CertChain">X.509 certificate chain</mat-label>
+                <mat-select formControlName="x509CertChain" name="x509CertChain">
+                  <mat-option value="NONE">NONE</mat-option>
+                  <mat-option value="X5C">X5C</mat-option>
+                </mat-select>
+              </mat-form-field>
+
+              <mat-form-field appearance="outline" class="form__field">
+                <mat-label i18n="@@subscriptionConfigurationAuthenticationAlias">Private key alias</mat-label>
+                <input matInput formControlName="alias" name="alias" />
+              </mat-form-field>
+
+              <mat-form-field appearance="outline" class="form__field">
+                <mat-label i18n="@@subscriptionConfigurationAuthenticationStorePassword">Keystore password</mat-label>
+                <input matInput formControlName="storePassword" name="storePassword" type="password" />
+              </mat-form-field>
+
+              <mat-form-field appearance="outline" class="form__field">
+                <mat-label i18n="@@subscriptionConfigurationAuthenticationKeyPassword">Key password</mat-label>
+                <input matInput formControlName="keyPassword" name="keyPassword" type="password" />
+              </mat-form-field>
+            }
+
+            <mat-form-field appearance="outline" class="form__field">
+              <mat-label i18n="@@subscriptionConfigurationAuthenticationKeyId">Key ID</mat-label>
+              <input matInput formControlName="keyId" name="keyId" />
+              <mat-hint i18n="@@subscriptionConfigurationAuthenticationKeyIdHint"
+                >Optional header 'kid' identifies the specific public key used to sign the token</mat-hint
+              >
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="form__field">
+              <mat-label i18n="@@subscriptionConfigurationAuthenticationKeyContent">Private key as text or file path</mat-label>
+              <textarea matInput formControlName="keyContent" name="keyContent" required rows="5"></textarea>
+              <mat-hint i18n="@@subscriptionConfigurationAuthenticationKeyContentHint"
+                >Private key as text for INLINE source or absolute path to file storing private key for others</mat-hint
+              >
+              @if (authForm.controls.keyContent.hasError('required')) {
+                <mat-error i18n="@@subscriptionConfigurationAuthenticationKeyContentRequired">Key content is required</mat-error>
+              }
+            </mat-form-field>
+
+            <div class="form__field">
+              <mat-label i18n="@@subscriptionConfigurationAuthenticationAdditionalClaims">Additional claims</mat-label>
+              <mat-chip-grid #claimsChipGrid aria-label="Claims">
+                @for (claim of customClaims(); track claim.name) {
+                  <mat-chip-row (removed)="removeCustomClaim(claim)">
+                    {{ claim.name }}: {{ claim.value }}
+                    <button matChipRemove aria-label="'remove claim"><mat-icon>cancel</mat-icon></button>
+                  </mat-chip-row>
+                }
+              </mat-chip-grid>
+              <div class="form__row claim-inputs">
+                <mat-form-field appearance="outline" class="form__field">
+                  <mat-label i18n="@@subscriptionConfigurationAuthenticationClaimName">Name</mat-label>
+                  <input matInput #claimName placeholder="Name" />
+                </mat-form-field>
+                <mat-form-field appearance="outline" class="form__field">
+                  <mat-label i18n="@@subscriptionConfigurationAuthenticationClaimValue">Value</mat-label>
+                  <input matInput #claimValue placeholder="Value" />
+                </mat-form-field>
+                <button mat-icon-button type="button" (click)="addCustomClaim(claimName, claimValue)">
+                  <mat-icon>add</mat-icon>
+                </button>
+              </div>
+              @if (customClaimError()) {
+                <mat-error i18n="@@subscriptionConfigurationAuthenticationCustomClaimError">{{ customClaimError() }}</mat-error>
+              }
+              <mat-hint i18n="@@subscriptionConfigurationAuthenticationAdditionalClaimsHint"
+                >Add more claims required for successful client authentication</mat-hint
+              >
+            </div>
+          }
         }
       </div>
     }

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.component.spec.ts
@@ -1,0 +1,515 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatChipInputEvent } from '@angular/material/chips';
+
+import { ConsumerConfigurationAuthenticationComponent } from './consumer-configuration-authentication.component';
+import { WebhookSubscriptionConfigurationAuth } from '../../../../entities/subscription';
+import { AppTestingModule } from '../../../../testing/app-testing.module';
+
+@Component({
+  selector: 'app-test-wrapper',
+  template: `<app-consumer-configuration-authentication [formControl]="authControl" />`,
+  standalone: true,
+  imports: [ConsumerConfigurationAuthenticationComponent, ReactiveFormsModule],
+})
+class TestWrapperComponent {
+  authControl = new FormControl<WebhookSubscriptionConfigurationAuth>({ type: 'none' });
+}
+
+describe('ConsumerConfigurationAuthenticationComponent', () => {
+  let fixture: ComponentFixture<TestWrapperComponent>;
+  let wrapper: TestWrapperComponent;
+  let component: ConsumerConfigurationAuthenticationComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestWrapperComponent, AppTestingModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestWrapperComponent);
+    wrapper = fixture.componentInstance;
+    fixture.detectChanges();
+    component = fixture.debugElement.children[0].componentInstance;
+  });
+
+  describe('writeValue', () => {
+    it('should populate form for "none" auth type', () => {
+      wrapper.authControl.setValue({ type: 'none' });
+      fixture.detectChanges();
+
+      expect(component.authForm.controls.type.value).toBe('none');
+    });
+
+    it('should populate form for "basic" auth type', () => {
+      wrapper.authControl.setValue({ type: 'basic', basic: { username: 'user', password: 'pass' } });
+      fixture.detectChanges();
+
+      expect(component.authForm.controls.type.value).toBe('basic');
+      expect(component.authForm.controls.username.value).toBe('user');
+      expect(component.authForm.controls.password.value).toBe('pass');
+    });
+
+    it('should populate form for "token" auth type', () => {
+      wrapper.authControl.setValue({ type: 'token', token: { value: 'my-bearer-token' } });
+      fixture.detectChanges();
+
+      expect(component.authForm.controls.type.value).toBe('token');
+      expect(component.authForm.controls.token.value).toBe('my-bearer-token');
+    });
+
+    it('should populate form for "oauth2" auth type with scopes', () => {
+      wrapper.authControl.setValue({
+        type: 'oauth2',
+        oauth2: { endpoint: 'https://auth.example.com/token', clientId: 'client-id', clientSecret: 'secret', scopes: ['read', 'write'] },
+      });
+      fixture.detectChanges();
+
+      expect(component.authForm.controls.type.value).toBe('oauth2');
+      expect(component.authForm.controls.endpoint.value).toBe('https://auth.example.com/token');
+      expect(component.authForm.controls.clientId.value).toBe('client-id');
+      expect(component.authForm.controls.clientSecret.value).toBe('secret');
+      expect(component.authForm.controls.scopes.value).toEqual(['read', 'write']);
+      expect(component.scopes()).toEqual(['read', 'write']);
+    });
+
+    it('should populate form for "oauth2" auth type without scopes', () => {
+      wrapper.authControl.setValue({
+        type: 'oauth2',
+        oauth2: { endpoint: 'https://auth.example.com/token', clientId: 'client-id', clientSecret: 'secret' },
+      });
+      fixture.detectChanges();
+
+      expect(component.scopes()).toEqual([]);
+    });
+
+    it('should populate all fields for "jwtProfileOauth2" auth type', () => {
+      component.writeValue({
+        type: 'jwtProfileOauth2',
+        jwtProfileOauth2: {
+          issuer: 'https://issuer.example.com',
+          subject: 'service-account',
+          audience: 'https://api.example.com',
+          expirationTime: 60,
+          expirationTimeUnit: 'MINUTES',
+          signatureAlgorithm: 'RSA_RS256',
+          keySource: 'INLINE',
+          jwtId: 'jwt-id-123',
+          secretBase64Encoded: false,
+          x509CertChain: 'NONE',
+          keyId: 'key-id-456',
+          keyContent: '-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----',
+          customClaims: [{ name: 'tenant', value: 'acme' }],
+        },
+      });
+
+      expect(component.authForm.controls.type.value).toBe('jwtProfileOauth2');
+      expect(component.authForm.controls.issuer.value).toBe('https://issuer.example.com');
+      expect(component.authForm.controls.subject.value).toBe('service-account');
+      expect(component.authForm.controls.audience.value).toBe('https://api.example.com');
+      expect(component.authForm.controls.expirationTime.value).toBe(60);
+      expect(component.authForm.controls.expirationTimeUnit.value).toBe('MINUTES');
+      expect(component.authForm.controls.signatureAlgorithm.value).toBe('RSA_RS256');
+      expect(component.authForm.controls.keySource.value).toBe('INLINE');
+      expect(component.authForm.controls.jwtId.value).toBe('jwt-id-123');
+      expect(component.authForm.controls.secretBase64Encoded.value).toBe(false);
+      expect(component.authForm.controls.x509CertChain.value).toBe('NONE');
+      expect(component.authForm.controls.keyId.value).toBe('key-id-456');
+      expect(component.authForm.controls.keyContent.value).toBe('-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----');
+      expect(component.authForm.controls.customClaims.value).toEqual([{ name: 'tenant', value: 'acme' }]);
+      expect(component.customClaims()).toEqual([{ name: 'tenant', value: 'acme' }]);
+    });
+
+    it('should populate keystoreOptions for "jwtProfileOauth2" with JKS key source', () => {
+      component.writeValue({
+        type: 'jwtProfileOauth2',
+        jwtProfileOauth2: {
+          issuer: 'https://issuer.example.com',
+          subject: 'service-account',
+          audience: 'https://api.example.com',
+          expirationTime: 30,
+          expirationTimeUnit: 'SECONDS',
+          signatureAlgorithm: 'RSA_RS256',
+          keySource: 'JKS',
+          keyContent: '/path/to/keystore.jks',
+          keystoreOptions: { alias: 'my-alias', storePassword: 'store-pass', keyPassword: 'key-pass' },
+        },
+      });
+
+      expect(component.authForm.controls.keySource.value).toBe('JKS');
+      expect(component.authForm.controls.alias.value).toBe('my-alias');
+      expect(component.authForm.controls.storePassword.value).toBe('store-pass');
+      expect(component.authForm.controls.keyPassword.value).toBe('key-pass');
+    });
+
+    it('should apply jwtProfileOauth2 defaults when optional fields are absent', () => {
+      component.writeValue({
+        type: 'jwtProfileOauth2',
+        jwtProfileOauth2: {
+          issuer: 'https://issuer.example.com',
+          subject: 'service-account',
+          audience: 'https://api.example.com',
+          expirationTime: 30,
+          expirationTimeUnit: 'SECONDS',
+          signatureAlgorithm: 'RSA_RS256',
+          keySource: 'INLINE',
+          keyContent: 'key',
+        },
+      });
+
+      expect(component.authForm.controls.secretBase64Encoded.value).toBe(false);
+      expect(component.authForm.controls.x509CertChain.value).toBe('NONE');
+      expect(component.customClaims()).toEqual([]);
+    });
+
+    it('should not emit _onChange when writing a value with scopes (no duplicate events)', () => {
+      const emittedValues: WebhookSubscriptionConfigurationAuth[] = [];
+      wrapper.authControl.valueChanges.subscribe(v => emittedValues.push(v!));
+
+      wrapper.authControl.setValue({
+        type: 'oauth2',
+        oauth2: { endpoint: 'https://auth.example.com/token', clientId: 'id', clientSecret: 'secret', scopes: ['read'] },
+      });
+      fixture.detectChanges();
+
+      // writeValue should not trigger additional valueChanges on the parent FormControl
+      expect(emittedValues.length).toBe(1);
+    });
+
+    it('should not emit _onChange when writing a value with customClaims (no duplicate events)', () => {
+      const onChangeSpy = jest.fn();
+      component.registerOnChange(onChangeSpy);
+
+      component.writeValue({
+        type: 'jwtProfileOauth2',
+        jwtProfileOauth2: {
+          issuer: 'issuer',
+          subject: 'sub',
+          audience: 'aud',
+          expirationTime: 30,
+          expirationTimeUnit: 'SECONDS',
+          signatureAlgorithm: 'RSA_RS256',
+          keySource: 'INLINE',
+          keyContent: 'key',
+          customClaims: [{ name: 'k', value: 'v' }],
+        },
+      });
+
+      expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('_onChange output (toConfigurationAuthentication)', () => {
+    it('should emit "none" config', () => {
+      wrapper.authControl.setValue({ type: 'none' });
+      fixture.detectChanges();
+
+      component.authForm.controls.type.setValue('none');
+
+      expect(wrapper.authControl.value).toEqual({ type: 'none' });
+    });
+
+    it('should emit "basic" config when form values change', () => {
+      wrapper.authControl.setValue({ type: 'basic', basic: { username: 'u', password: 'p' } });
+      fixture.detectChanges();
+
+      component.authForm.controls.username.setValue('new-user');
+
+      expect(wrapper.authControl.value).toEqual({
+        type: 'basic',
+        basic: { username: 'new-user', password: 'p' },
+      });
+    });
+
+    it('should emit "token" config when form values change', () => {
+      wrapper.authControl.setValue({ type: 'token', token: { value: 'old' } });
+      fixture.detectChanges();
+
+      component.authForm.controls.token.setValue('new-token');
+
+      expect(wrapper.authControl.value).toEqual({ type: 'token', token: { value: 'new-token' } });
+    });
+
+    it('should emit "oauth2" config when form values change', () => {
+      wrapper.authControl.setValue({
+        type: 'oauth2',
+        oauth2: { endpoint: 'https://ep', clientId: 'id', clientSecret: 'sec', scopes: ['read'] },
+      });
+      fixture.detectChanges();
+
+      component.authForm.controls.clientId.setValue('new-id');
+
+      expect(wrapper.authControl.value).toEqual({
+        type: 'oauth2',
+        oauth2: { endpoint: 'https://ep', clientId: 'new-id', clientSecret: 'sec', scopes: ['read'] },
+      });
+    });
+
+    it('should emit full "jwtProfileOauth2" config when form values change', () => {
+      component.writeValue({
+        type: 'jwtProfileOauth2',
+        jwtProfileOauth2: {
+          issuer: 'issuer',
+          subject: 'sub',
+          audience: 'aud',
+          expirationTime: 30,
+          expirationTimeUnit: 'SECONDS',
+          signatureAlgorithm: 'RSA_RS256',
+          keySource: 'INLINE',
+          jwtId: 'jid',
+          secretBase64Encoded: false,
+          x509CertChain: 'NONE',
+          keyId: 'kid',
+          keyContent: 'key',
+          customClaims: [],
+        },
+      });
+
+      const onChangeSpy = jest.fn();
+      component.registerOnChange(onChangeSpy);
+
+      component.authForm.controls.issuer.setValue('https://new-issuer.example.com');
+
+      expect(onChangeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'jwtProfileOauth2',
+          jwtProfileOauth2: expect.objectContaining({ issuer: 'https://new-issuer.example.com' }),
+        }),
+      );
+    });
+  });
+
+  describe('validation', () => {
+    it('should be valid when type is "none"', () => {
+      wrapper.authControl.setValue({ type: 'none' });
+      fixture.detectChanges();
+
+      component.authForm.controls.type.setValue('none');
+
+      expect(component.authForm.valid).toBe(true);
+    });
+
+    it('should be invalid when type is "basic" and username/password are empty', () => {
+      component.authForm.controls.type.setValue('basic');
+
+      expect(component.authForm.valid).toBe(false);
+    });
+
+    it('should be valid when type is "basic" and username/password are provided', () => {
+      component.authForm.controls.type.setValue('basic');
+      component.authForm.controls.username.setValue('user');
+      component.authForm.controls.password.setValue('pass');
+
+      expect(component.authForm.valid).toBe(true);
+    });
+
+    it('should be invalid when type is "token" and token is empty', () => {
+      component.authForm.controls.type.setValue('token');
+
+      expect(component.authForm.valid).toBe(false);
+    });
+
+    it('should be valid when type is "token" and token is provided', () => {
+      component.authForm.controls.type.setValue('token');
+      component.authForm.controls.token.setValue('bearer-xyz');
+
+      expect(component.authForm.valid).toBe(true);
+    });
+
+    it('should be invalid when type is "oauth2" and required fields are empty', () => {
+      component.authForm.controls.type.setValue('oauth2');
+
+      expect(component.authForm.valid).toBe(false);
+    });
+
+    it('should be valid when type is "oauth2" and required fields are provided', () => {
+      component.authForm.controls.type.setValue('oauth2');
+      component.authForm.controls.endpoint.setValue('https://auth.example.com/token');
+      component.authForm.controls.clientId.setValue('client-id');
+      component.authForm.controls.clientSecret.setValue('secret');
+
+      expect(component.authForm.valid).toBe(true);
+    });
+
+    it('should be invalid when type is "jwtProfileOauth2" and required fields are empty', () => {
+      component.authForm.controls.type.setValue('jwtProfileOauth2');
+
+      expect(component.authForm.valid).toBe(false);
+    });
+
+    it('should be valid when type is "jwtProfileOauth2" and all required fields are provided', () => {
+      component.authForm.controls.type.setValue('jwtProfileOauth2');
+      component.authForm.controls.issuer.setValue('https://issuer.example.com');
+      component.authForm.controls.subject.setValue('service-account');
+      component.authForm.controls.audience.setValue('https://api.example.com');
+      component.authForm.controls.expirationTime.setValue(30);
+      component.authForm.controls.expirationTimeUnit.setValue('SECONDS');
+      component.authForm.controls.signatureAlgorithm.setValue('RSA_RS256');
+      component.authForm.controls.keySource.setValue('INLINE');
+      component.authForm.controls.keyContent.setValue('-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----');
+
+      expect(component.authForm.valid).toBe(true);
+    });
+
+    it('should clear validators when switching auth type', () => {
+      component.authForm.controls.type.setValue('basic');
+      component.authForm.controls.username.setValue('user');
+      component.authForm.controls.password.setValue('pass');
+      expect(component.authForm.valid).toBe(true);
+
+      component.authForm.controls.type.setValue('none');
+
+      expect(component.authForm.valid).toBe(true);
+    });
+  });
+
+  describe('oauth2 scopes', () => {
+    beforeEach(() => {
+      wrapper.authControl.setValue({
+        type: 'oauth2',
+        oauth2: { endpoint: 'https://ep', clientId: 'id', clientSecret: 'sec', scopes: ['read'] },
+      });
+      fixture.detectChanges();
+    });
+
+    it('should add a scope and emit updated config', () => {
+      const emittedValues: WebhookSubscriptionConfigurationAuth[] = [];
+      wrapper.authControl.valueChanges.subscribe(v => emittedValues.push(v!));
+
+      component.addScope({ value: 'write', chipInput: { clear: () => {} } } as MatChipInputEvent);
+
+      expect(component.scopes()).toEqual(['read', 'write']);
+      expect(component.authForm.controls.scopes.value).toEqual(['read', 'write']);
+      expect(emittedValues.length).toBeGreaterThanOrEqual(1);
+      expect(emittedValues[emittedValues.length - 1]).toMatchObject({
+        type: 'oauth2',
+        oauth2: expect.objectContaining({ scopes: ['read', 'write'] }),
+      });
+    });
+
+    it('should not add a scope when value is empty', () => {
+      component.addScope({ value: '  ', chipInput: { clear: () => {} } } as MatChipInputEvent);
+
+      expect(component.scopes()).toEqual(['read']);
+    });
+
+    it('should remove a scope and emit updated config', () => {
+      const emittedValues: WebhookSubscriptionConfigurationAuth[] = [];
+      wrapper.authControl.valueChanges.subscribe(v => emittedValues.push(v!));
+
+      component.removeScope('read');
+
+      expect(component.scopes()).toEqual([]);
+      expect(component.authForm.controls.scopes.value).toEqual([]);
+      expect(emittedValues.length).toBeGreaterThanOrEqual(1);
+      expect(emittedValues[emittedValues.length - 1]).toMatchObject({
+        type: 'oauth2',
+        oauth2: expect.objectContaining({ scopes: [] }),
+      });
+    });
+  });
+
+  describe('jwtProfileOauth2 custom claims', () => {
+    beforeEach(() => {
+      component.writeValue({
+        type: 'jwtProfileOauth2',
+        jwtProfileOauth2: {
+          issuer: 'issuer',
+          subject: 'sub',
+          audience: 'aud',
+          expirationTime: 30,
+          expirationTimeUnit: 'SECONDS',
+          signatureAlgorithm: 'RSA_RS256',
+          keySource: 'INLINE',
+          keyContent: 'key',
+          customClaims: [{ name: 'tenant', value: 'acme' }],
+        },
+      });
+    });
+
+    it('should add a custom claim and emit updated config', () => {
+      const onChangeSpy = jest.fn();
+      component.registerOnChange(onChangeSpy);
+
+      const nameInput = { value: 'env' } as HTMLInputElement;
+      const valueInput = { value: 'production' } as HTMLInputElement;
+      component.addCustomClaim(nameInput, valueInput);
+
+      expect(component.customClaims()).toEqual([
+        { name: 'tenant', value: 'acme' },
+        { name: 'env', value: 'production' },
+      ]);
+      expect(onChangeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'jwtProfileOauth2',
+          jwtProfileOauth2: expect.objectContaining({
+            customClaims: [
+              { name: 'tenant', value: 'acme' },
+              { name: 'env', value: 'production' },
+            ],
+          }),
+        }),
+      );
+    });
+
+    it('should clear input fields after adding a custom claim', () => {
+      const nameInput = { value: 'env' } as HTMLInputElement;
+      const valueInput = { value: 'production' } as HTMLInputElement;
+      component.addCustomClaim(nameInput, valueInput);
+
+      expect(nameInput.value).toBe('');
+      expect(valueInput.value).toBe('');
+    });
+
+    it('should not add a claim when name or value is empty', () => {
+      component.addCustomClaim({ value: '' } as HTMLInputElement, { value: 'v' } as HTMLInputElement);
+      expect(component.customClaims()).toEqual([{ name: 'tenant', value: 'acme' }]);
+
+      component.addCustomClaim({ value: 'n' } as HTMLInputElement, { value: '' } as HTMLInputElement);
+      expect(component.customClaims()).toEqual([{ name: 'tenant', value: 'acme' }]);
+    });
+
+    it('should remove a custom claim and emit updated config', () => {
+      const onChangeSpy = jest.fn();
+      component.registerOnChange(onChangeSpy);
+
+      component.removeCustomClaim({ name: 'tenant', value: 'acme' });
+
+      expect(component.customClaims()).toEqual([]);
+      expect(onChangeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'jwtProfileOauth2',
+          jwtProfileOauth2: expect.objectContaining({ customClaims: [] }),
+        }),
+      );
+    });
+  });
+
+  describe('setDisabledState', () => {
+    it('should disable the form when setDisabledState(true) is called', () => {
+      component.setDisabledState(true);
+      expect(component.authForm.disabled).toBe(true);
+    });
+
+    it('should enable the form when setDisabledState(false) is called', () => {
+      component.setDisabledState(true);
+      component.setDisabledState(false);
+      expect(component.authForm.enabled).toBe(true);
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.component.ts
@@ -28,6 +28,8 @@ import {
   Validator,
   Validators,
 } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
 import { MatError, MatFormFieldModule, MatHint } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
@@ -38,6 +40,7 @@ import { tap } from 'rxjs';
 import { AUTHENTICATION_TYPES, AuthFormValue } from './consumer-configuration-authentication.model';
 import {
   BasicAuthConfiguration,
+  JwtProfileOauth2AuthConfiguration,
   Oauth2AuthConfiguration,
   TokenAuthConfiguration,
   WebhookSubscriptionConfigurationAuth,
@@ -59,6 +62,8 @@ import { AccordionModule } from '../../../accordion/accordion.module';
     AccordionModule,
     MatChipsModule,
     MatIcon,
+    MatCheckboxModule,
+    MatButtonModule,
   ],
   templateUrl: './consumer-configuration-authentication.component.html',
   styleUrls: ['consumer-configuration-authentication.component.scss'],
@@ -77,6 +82,8 @@ import { AccordionModule } from '../../../accordion/accordion.module';
 })
 export class ConsumerConfigurationAuthenticationComponent implements AfterViewInit, ControlValueAccessor, Validator {
   scopes = signal<string[]>([]);
+  customClaims = signal<{ name: string; value: string }[]>([]);
+  customClaimError = signal<string | null>(null);
 
   authForm = new FormGroup({
     type: new FormControl<WebhookSubscriptionConfigurationAuthType>('none', { nonNullable: true }),
@@ -93,10 +100,27 @@ export class ConsumerConfigurationAuthenticationComponent implements AfterViewIn
     clientId: new FormControl(),
     clientSecret: new FormControl(),
     scopes: new FormControl(),
+
+    // for jwtProfileOauth2 authentication
+    issuer: new FormControl(),
+    subject: new FormControl(),
+    audience: new FormControl(),
+    expirationTime: new FormControl(),
+    expirationTimeUnit: new FormControl(),
+    signatureAlgorithm: new FormControl(),
+    keySource: new FormControl(),
+    jwtId: new FormControl(),
+    secretBase64Encoded: new FormControl(),
+    x509CertChain: new FormControl(),
+    alias: new FormControl(),
+    storePassword: new FormControl(),
+    keyPassword: new FormControl(),
+    keyId: new FormControl(),
+    keyContent: new FormControl(),
+    customClaims: new FormControl(),
   });
   readonly types = AUTHENTICATION_TYPES;
   private readonly destroyRef = inject(DestroyRef);
-  private isDisabled = false;
 
   constructor() {
     this.authForm.controls.type.valueChanges
@@ -104,6 +128,15 @@ export class ConsumerConfigurationAuthenticationComponent implements AfterViewIn
         tap(type => {
           this.updateValidators(type);
           this.updateValueAndValidity();
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+
+    this.authForm.controls.signatureAlgorithm.valueChanges
+      .pipe(
+        tap(algorithm => {
+          this.updateKeySourceValidators(algorithm);
         }),
         takeUntilDestroyed(this.destroyRef),
       )
@@ -123,6 +156,11 @@ export class ConsumerConfigurationAuthenticationComponent implements AfterViewIn
     this.authForm.patchValue({});
     if (this.authForm.controls.type.value === 'oauth2' && this.authForm.controls.scopes.getRawValue()) {
       this.scopes.set(this.authForm.controls.scopes.getRawValue());
+      this.authForm.controls.scopes.setValue(this.scopes(), { emitEvent: false });
+    }
+    if (this.authForm.controls.type.value === 'jwtProfileOauth2' && this.authForm.controls.customClaims.getRawValue()) {
+      this.customClaims.set(this.authForm.controls.customClaims.getRawValue());
+      this.authForm.controls.customClaims.setValue(this.customClaims(), { emitEvent: false });
     }
   }
 
@@ -139,6 +177,14 @@ export class ConsumerConfigurationAuthenticationComponent implements AfterViewIn
     } else {
       this.scopes.set([]);
     }
+    this.authForm.controls.scopes.setValue(this.scopes(), { emitEvent: false });
+
+    if (formValue.type === 'jwtProfileOauth2' && formValue.customClaims) {
+      this.customClaims.set([...formValue.customClaims]);
+    } else {
+      this.customClaims.set([]);
+    }
+    this.authForm.controls.customClaims.setValue(this.customClaims(), { emitEvent: false });
   }
 
   registerOnChange(fn: (value: WebhookSubscriptionConfigurationAuth) => void): void {
@@ -150,20 +196,47 @@ export class ConsumerConfigurationAuthenticationComponent implements AfterViewIn
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.isDisabled = isDisabled;
     isDisabled ? this.authForm.disable({ emitEvent: false }) : this.authForm.enable({ emitEvent: false });
   }
 
   removeScope(scopeToRemove: string) {
     this.scopes.set([...this.scopes().filter(scope => scope !== scopeToRemove)]);
+    this.authForm.controls.scopes.setValue(this.scopes());
   }
 
   addScope(event: MatChipInputEvent): void {
     const value = (event.value || '').trim();
     if (value) {
       this.scopes.set([...this.scopes(), value]);
+      this.authForm.controls.scopes.setValue(this.scopes());
     }
     event.chipInput.clear();
+  }
+
+  removeCustomClaim(claimToRemove: { name: string; value: string }) {
+    this.customClaims.set([
+      ...this.customClaims().filter(claim => !(claim.name === claimToRemove.name && claim.value === claimToRemove.value)),
+    ]);
+    this.authForm.controls.customClaims.setValue(this.customClaims());
+  }
+
+  addCustomClaim(nameInput: HTMLInputElement, valueInput: HTMLInputElement) {
+    const name = nameInput.value.trim();
+    const value = valueInput.value.trim();
+    if (name && value) {
+      // Check for duplicate claim name
+      const existingClaim = this.customClaims().find(claim => claim.name === name);
+      if (existingClaim) {
+        this.customClaimError.set('A claim with this name already exists');
+        return;
+      }
+
+      this.customClaims.set([...this.customClaims(), { name, value }]);
+      this.authForm.controls.customClaims.setValue(this.customClaims());
+      this.customClaimError.set(null);
+      nameInput.value = '';
+      valueInput.value = '';
+    }
   }
 
   private toFormValue(auth?: WebhookSubscriptionConfigurationAuth): AuthFormValue {
@@ -179,6 +252,26 @@ export class ConsumerConfigurationAuthenticationComponent implements AfterViewIn
           clientId: auth.oauth2?.clientId,
           clientSecret: auth.oauth2?.clientSecret,
           scopes: auth.oauth2?.scopes,
+        };
+      case 'jwtProfileOauth2':
+        return {
+          type: auth.type,
+          issuer: auth.jwtProfileOauth2?.issuer,
+          subject: auth.jwtProfileOauth2?.subject,
+          audience: auth.jwtProfileOauth2?.audience,
+          expirationTime: auth.jwtProfileOauth2?.expirationTime ?? 30,
+          expirationTimeUnit: auth.jwtProfileOauth2?.expirationTimeUnit ?? 'SECONDS',
+          signatureAlgorithm: auth.jwtProfileOauth2?.signatureAlgorithm ?? 'RSA_RS256',
+          keySource: auth.jwtProfileOauth2?.keySource ?? 'INLINE',
+          jwtId: auth.jwtProfileOauth2?.jwtId,
+          secretBase64Encoded: auth.jwtProfileOauth2?.secretBase64Encoded ?? false,
+          x509CertChain: auth.jwtProfileOauth2?.x509CertChain ?? 'NONE',
+          alias: auth.jwtProfileOauth2?.keystoreOptions?.alias,
+          storePassword: auth.jwtProfileOauth2?.keystoreOptions?.storePassword,
+          keyPassword: auth.jwtProfileOauth2?.keystoreOptions?.keyPassword,
+          keyId: auth.jwtProfileOauth2?.keyId,
+          keyContent: auth.jwtProfileOauth2?.keyContent,
+          customClaims: auth.jwtProfileOauth2?.customClaims,
         };
       default:
         return { type: 'none' };
@@ -204,6 +297,37 @@ export class ConsumerConfigurationAuthenticationComponent implements AfterViewIn
             scopes: authFormValue.scopes,
           } as Oauth2AuthConfiguration,
         };
+      case 'jwtProfileOauth2': {
+        const jwtConfig = {
+          issuer: authFormValue.issuer,
+          subject: authFormValue.subject,
+          audience: authFormValue.audience,
+          expirationTime: authFormValue.expirationTime,
+          expirationTimeUnit: authFormValue.expirationTimeUnit,
+          signatureAlgorithm: authFormValue.signatureAlgorithm,
+          keySource: authFormValue.keySource,
+          jwtId: authFormValue.jwtId,
+          secretBase64Encoded: authFormValue.secretBase64Encoded,
+          x509CertChain: authFormValue.x509CertChain,
+          keyId: authFormValue.keyId,
+          keyContent: authFormValue.keyContent,
+          customClaims: authFormValue.customClaims,
+        } as JwtProfileOauth2AuthConfiguration;
+
+        // Only add keystoreOptions for JKS and PKCS12 key sources
+        if (authFormValue.keySource === 'JKS' || authFormValue.keySource === 'PKCS12') {
+          jwtConfig.keystoreOptions = {
+            alias: authFormValue.alias,
+            storePassword: authFormValue.storePassword,
+            keyPassword: authFormValue.keyPassword,
+          };
+        }
+
+        return {
+          type: authFormValue.type,
+          jwtProfileOauth2: jwtConfig,
+        };
+      }
       default:
         return { type: 'none' };
     }
@@ -232,7 +356,29 @@ export class ConsumerConfigurationAuthenticationComponent implements AfterViewIn
         this.authForm.controls.scopes.setValidators([]);
         break;
       }
+      case 'jwtProfileOauth2': {
+        this.authForm.controls.issuer.setValidators([Validators.required]);
+        this.authForm.controls.subject.setValidators([Validators.required]);
+        this.authForm.controls.audience.setValidators([Validators.required]);
+        this.authForm.controls.expirationTime.setValidators([Validators.required]);
+        this.authForm.controls.expirationTimeUnit.setValidators([Validators.required]);
+        this.authForm.controls.signatureAlgorithm.setValidators([Validators.required]);
+        this.authForm.controls.keyContent.setValidators([Validators.required]);
+        // keySource validation is handled dynamically by updateKeySourceValidators
+        this.updateKeySourceValidators(this.authForm.controls.signatureAlgorithm.value);
+        break;
+      }
     }
+  }
+
+  private updateKeySourceValidators(algorithm: string | null | undefined) {
+    // Only require keySource for RSA_RS256 algorithm
+    if (algorithm === 'RSA_RS256') {
+      this.authForm.controls.keySource.setValidators([Validators.required]);
+    } else {
+      this.authForm.controls.keySource.clearValidators();
+    }
+    this.authForm.controls.keySource.updateValueAndValidity({ emitEvent: false });
   }
 
   private updateValueAndValidity() {

--- a/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.model.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription/webhook/consumer-configuration-authentification/consumer-configuration-authentication.model.ts
@@ -24,6 +24,22 @@ export type AuthFormValue = {
   clientId?: string;
   clientSecret?: string;
   scopes?: string[];
+  issuer?: string;
+  subject?: string;
+  audience?: string;
+  expirationTime?: number;
+  expirationTimeUnit?: string;
+  signatureAlgorithm?: string;
+  keySource?: string;
+  jwtId?: string;
+  secretBase64Encoded?: boolean;
+  x509CertChain?: string;
+  alias?: string;
+  storePassword?: string;
+  keyPassword?: string;
+  keyId?: string;
+  keyContent?: string;
+  customClaims?: { name: string; value: string }[];
 };
 
 export const AUTHENTICATION_TYPES: { label: string; value: WebhookSubscriptionConfigurationAuthType }[] = [
@@ -42,5 +58,9 @@ export const AUTHENTICATION_TYPES: { label: string; value: WebhookSubscriptionCo
   {
     label: 'Oauth2 security',
     value: 'oauth2',
+  },
+  {
+    label: 'JWT Profile for OAuth2',
+    value: 'jwtProfileOauth2',
   },
 ];

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription-consumer-configuration.ts
@@ -34,13 +34,14 @@ export interface Header {
   value: string;
 }
 
-export type WebhookSubscriptionConfigurationAuthType = 'none' | 'basic' | 'token' | 'oauth2';
+export type WebhookSubscriptionConfigurationAuthType = 'none' | 'basic' | 'token' | 'oauth2' | 'jwtProfileOauth2';
 
 export interface WebhookSubscriptionConfigurationAuth {
   type: WebhookSubscriptionConfigurationAuthType;
   basic?: BasicAuthConfiguration;
   token?: TokenAuthConfiguration;
   oauth2?: Oauth2AuthConfiguration;
+  jwtProfileOauth2?: JwtProfileOauth2AuthConfiguration;
 }
 
 export interface BasicAuthConfiguration {
@@ -57,6 +58,34 @@ export interface Oauth2AuthConfiguration {
   clientId: string;
   clientSecret: string;
   scopes?: string[];
+}
+
+export interface JwtProfileOauth2AuthConfiguration {
+  issuer: string;
+  subject: string;
+  audience: string;
+  expirationTime: number;
+  expirationTimeUnit: string;
+  signatureAlgorithm: string;
+  keySource: string;
+  jwtId?: string;
+  secretBase64Encoded?: boolean;
+  x509CertChain?: string;
+  keystoreOptions?: JwtProfileOauth2KeystoreOptions;
+  keyId?: string;
+  keyContent: string;
+  customClaims?: JwtProfileOauth2CustomClaim[];
+}
+
+export interface JwtProfileOauth2KeystoreOptions {
+  alias?: string;
+  storePassword?: string;
+  keyPassword?: string;
+}
+
+export interface JwtProfileOauth2CustomClaim {
+  name: string;
+  value: string;
 }
 
 export interface SslOptions {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12981

## Summary

This Pull Request introduces a new authentication mechanism, "JWT Profile for OAuth2", to the webhook subscription configuration module. It adds support for configuring authentication parameters required for JWT-based OAuth2 flows.

## Main Changes 
- Template Updates: Added new UI elements in the HTML template to configure JWT settings (issuer, subject, audience, signature algorithm, key source, etc.).
- Support for optional fields like custom claims, jwtId, x509CertChain, and other cryptographic keys and algorithms.
Component Updates
- Defined new interfaces for JwtProfileOauth2AuthConfiguration, including claims, keystore options, cryptography, and other related attributes.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

