### PR TITLE
fix: improve exception logging across rest-api and gateway

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyContextFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyContextFactory.java
@@ -31,12 +31,7 @@ public class PolicyContextFactory {
             return null;
         }
 
-        try {
-            log.debug("Creating a new instance of policy context of type {}", policyContextClass.getName());
-            return policyContextClass.getDeclaredConstructor().newInstance();
-        } catch (Exception ex) {
-            log.error("Unable to create a policy context", ex);
-            throw ex;
-        }
+        log.debug("Creating a new instance of policy context of type {}", policyContextClass.getName());
+        return policyContextClass.getDeclaredConstructor().newInstance();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/vertx/DebugHttpProtocolVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/vertx/DebugHttpProtocolVerticle.java
@@ -124,13 +124,13 @@ public class DebugHttpProtocolVerticle extends AbstractVerticle {
                 // Try to end the response and complete normally in case of error.
                 return response
                     .rxEnd()
-                    .doOnError(throwable -> log.error("Failed to properly end response after error", throwable))
+                    .doOnError(throwable -> log.warn("Failed to properly end response after error", throwable))
                     .onErrorComplete();
             }
 
             return Completable.complete();
         } catch (Throwable throwable) {
-            log.error("Failed to properly end response after error", throwable);
+            log.warn("Failed to properly end response after error", throwable);
             return Completable.complete();
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/mapper/SubscriptionMapper.java
@@ -44,7 +44,7 @@ public class SubscriptionMapper {
             // Regular API subscription - return as single-item list
             return List.of(toSubscription(subscriptionModel));
         } catch (Exception e) {
-            log.error("Unable to map subscription from model [{}].", subscriptionModel.getId(), e);
+            log.warn("Unable to map subscription from model [{}].", subscriptionModel.getId(), e);
             return List.of(); // Return empty list on error
         }
     }
@@ -113,7 +113,7 @@ public class SubscriptionMapper {
                     objectMapper.readValue(subscriptionModel.getConfiguration(), SubscriptionConfiguration.class)
                 );
             } catch (Exception e) {
-                log.error("Unable to parse subscription configuration for [{}]", subscriptionModel.getId(), e);
+                log.warn("Unable to parse subscription configuration for [{}]", subscriptionModel.getId(), e);
             }
         }
         Map<String, String> metadata = subscriptionModel.getMetadata() != null

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/kubernetes/fetcher/ConfigMapEventFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/kubernetes/fetcher/ConfigMapEventFetcher.java
@@ -220,7 +220,12 @@ public class ConfigMapEventFetcher {
             }
         } catch (Exception ex) {
             // Log the error and ignore this event.
-            log.error("Unable to extract api definition from config map.", ex);
+            log.error(
+                "Unable to extract api definition from config map [{}/{}].",
+                configMap.getMetadata().getNamespace(),
+                configMap.getMetadata().getName(),
+                ex
+            );
         }
         return Maybe.empty();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/local/mapper/ApiMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/local/mapper/ApiMapper.java
@@ -85,7 +85,7 @@ public class ApiMapper {
             return reactableApi;
         } catch (Exception e) {
             // Log the error and ignore this event.
-            log.error("Unable to extract api definition from event [{}].", apiEvent.getId(), e);
+            log.warn("Unable to extract api definition from event [{}].", apiEvent.getId(), e);
             return null;
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapper.java
@@ -100,7 +100,7 @@ public class ApiMapper {
                 return reactableApi;
             } catch (Exception e) {
                 // Log the error and ignore this event.
-                log.error("Unable to extract api definition from event [{}].", apiEvent.getId(), e);
+                log.warn("Unable to extract api definition from event [{}].", apiEvent.getId(), e);
                 return null;
             }
         });

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/service/EnvironmentService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/service/EnvironmentService.java
@@ -126,6 +126,7 @@ public class EnvironmentService {
             try {
                 return organizationRepository.findById(orgId).orElse(null);
             } catch (Exception e) {
+                log.warn("An error occurred fetching the organization '{}'.", orgId, e);
                 return null;
             }
         });

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
@@ -156,13 +156,13 @@ public class HttpProtocolVerticle extends AbstractVerticle {
                 // Try to end the response and complete normally in case of error.
                 return response
                     .rxEnd()
-                    .doOnError(throwable -> log.error("Failed to properly end response after error", throwable))
+                    .doOnError(throwable -> log.warn("Failed to properly end response after error", throwable))
                     .onErrorComplete();
             }
 
             return Completable.complete();
         } catch (Throwable throwable) {
-            log.error("Failed to properly end response after error", throwable);
+            log.warn("Failed to properly end response after error", throwable);
             return Completable.complete();
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -323,7 +323,6 @@ public class ApiResource extends AbstractResource {
             ImageUtils.verify(apiToUpdate.getPicture());
             ImageUtils.verify(apiToUpdate.getBackground());
         } catch (InvalidImageException e) {
-            log.warn("Invalid image format", e);
             throw new BadRequestException("Invalid image format : " + e.getMessage());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -389,6 +389,7 @@ public class ApiResource extends AbstractResource {
                 .lastModified(apiEntity.getUpdatedAt())
                 .build();
         } catch (Exception e) {
+            log.error("Error deploying API [{}]", api, e);
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity("JsonProcessingException " + e).build();
         }
     }
@@ -459,6 +460,7 @@ public class ApiResource extends AbstractResource {
                 .lastModified(rollbackedApi.getUpdatedAt())
                 .build();
         } catch (Exception e) {
+            log.error("Error rolling back API [{}]", api, e);
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity(e).build();
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoryResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoryResource.java
@@ -190,7 +190,6 @@ public class CategoryResource extends AbstractCategoryResource {
             ImageUtils.verify(category.getPicture());
             ImageUtils.verify(category.getBackground());
         } catch (InvalidImageException e) {
-            log.warn("Invalid image format", e);
             throw new BadRequestException("Invalid image format : " + e.getMessage());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
@@ -303,7 +303,6 @@ public class CurrentUserResource extends AbstractResource {
                 user.setPicture(userEntity.getPicture());
             }
         } catch (InvalidImageException e) {
-            log.warn("Invalid image format", e);
             throw new BadRequestException("Invalid image format : " + e.getMessage());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AbstractPluginService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AbstractPluginService.java
@@ -57,7 +57,6 @@ public abstract class AbstractPluginService<T extends ConfigurablePlugin, E exte
 
             return new HashSet<>(plugins);
         } catch (Exception ex) {
-            log.error("An error occurs while trying to list all policies", ex);
             throw new TechnicalManagementException("An error occurs while trying to list all policies", ex);
         }
     }
@@ -79,7 +78,6 @@ public abstract class AbstractPluginService<T extends ConfigurablePlugin, E exte
             log.debug("Find plugin schema by ID: {}", pluginId);
             return pluginManager.getSchema(pluginId, true);
         } catch (IOException ioex) {
-            log.error("An error occurs while trying to get plugin schema for plugin {}", pluginId, ioex);
             throw new TechnicalManagementException("An error occurs while trying to get plugin schema for plugin " + pluginId, ioex);
         }
     }
@@ -90,7 +88,6 @@ public abstract class AbstractPluginService<T extends ConfigurablePlugin, E exte
             log.debug("Find plugin icon by ID: {}", pluginId);
             return pluginManager.getIcon(pluginId, true);
         } catch (IOException ioex) {
-            log.error("An error occurs while trying to get plugin icon for plugin {}", pluginId, ioex);
             throw new TechnicalManagementException("An error occurs while trying to get plugin icon for plugin " + pluginId, ioex);
         }
     }
@@ -101,7 +98,6 @@ public abstract class AbstractPluginService<T extends ConfigurablePlugin, E exte
             log.debug("Find plugin documentation by ID: {}", pluginId);
             return pluginManager.getDocumentation(pluginId, true);
         } catch (IOException ioex) {
-            log.error("An error occurs while trying to get plugin documentation for plugin {}", pluginId, ioex);
             throw new TechnicalManagementException("An error occurs while trying to get plugin documentation for plugin " + pluginId, ioex);
         }
     }
@@ -134,7 +130,6 @@ public abstract class AbstractPluginService<T extends ConfigurablePlugin, E exte
             log.debug("Find plugin more information by ID: {}", pluginId);
             return pluginManager.getMoreInformation(pluginId, true);
         } catch (IOException ioex) {
-            log.error("An error occurs while trying to get plugin more information for plugin {}", pluginId, ioex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to get plugin more information for plugin " + pluginId,
                 ioex

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AbstractReferenceMetadataService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AbstractReferenceMetadataService.java
@@ -101,7 +101,6 @@ public abstract class AbstractReferenceMetadataService extends AbstractService {
 
             return allMetadata;
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to find all metadata by REFERENCE", ex);
             throw new TechnicalManagementException("An error occurred while trying to find all metadata by REFERENCE", ex);
         }
     }
@@ -157,9 +156,7 @@ public abstract class AbstractReferenceMetadataService extends AbstractService {
                 }
             }
         } catch (TechnicalException ex) {
-            final String message = "An error occurs while trying to delete metadata " + metadataId;
-            log.error(message, ex);
-            throw new TechnicalManagementException(message, ex);
+            throw new TechnicalManagementException("An error occurs while trying to delete metadata " + metadataId, ex);
         }
     }
 
@@ -199,10 +196,10 @@ public abstract class AbstractReferenceMetadataService extends AbstractService {
             }
             return referenceMetadataEntity;
         } catch (TechnicalException ex) {
-            final String message =
-                "An error occurred while trying to create metadata " + metadataEntity.getName() + " on reference " + referenceId;
-            log.error(message, ex);
-            throw new TechnicalManagementException(message, ex);
+            throw new TechnicalManagementException(
+                "An error occurred while trying to create metadata " + metadataEntity.getName() + " on reference " + referenceId,
+                ex
+            );
         }
     }
 
@@ -298,7 +295,6 @@ public abstract class AbstractReferenceMetadataService extends AbstractService {
             }
             return referenceMetadataEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to update metadata {} on REFERENCE {}", metadataEntity.getName(), referenceId, ex);
             throw new TechnicalManagementException(
                 "An error occurred while trying to update metadata " + metadataEntity.getName() + " on REFERENCE " + referenceId,
                 ex

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertAnalyticsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertAnalyticsServiceImpl.java
@@ -121,7 +121,6 @@ public class AlertAnalyticsServiceImpl implements AlertAnalyticsService {
         } catch (TechnicalException ex) {
             final String message =
                 "An error occurs while trying to list alerts analytics by reference " + referenceType + '/' + referenceId;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
@@ -196,7 +196,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             return create(executionContext, alertTrigger);
         } catch (TechnicalException ex) {
             final String message = "An error occurs while trying to create an alert " + newAlertTrigger;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -260,7 +259,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             return alertTriggerEntity;
         } catch (TechnicalException ex) {
             final String message = "An error occurs while trying to update an alert " + updateAlertTrigger;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -273,7 +271,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
                 .map(alertTriggerConverter::toAlertTriggerEntity)
                 .orElseThrow(() -> new AlertNotFoundException(alertId));
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to find alert by id {}", alertId, e);
             throw new TechnicalManagementException("An error occurs while trying to find alert with id", e);
         }
     }
@@ -284,7 +281,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             return alertTriggerConverter.toAlertTriggerEntities(new ArrayList<>(alertTriggerRepository.findAll()));
         } catch (TechnicalException ex) {
             final String message = "An error occurs while trying to list all alerts";
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -297,7 +293,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             );
         } catch (TechnicalException ex) {
             final String message = "An error occurs while trying to list alerts by reference " + referenceType + '/' + referenceId;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -310,7 +305,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             );
         } catch (TechnicalException ex) {
             final String message = "An error occurs while trying to list alerts by references " + referenceType + '/' + referenceIds;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -359,7 +353,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
                 .collect(toList());
         } catch (TechnicalException ex) {
             final String message = "An error occurs while trying to list alerts by reference " + referenceType + '/' + referenceId;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -381,7 +374,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             disableTrigger(alert);
         } catch (TechnicalException te) {
             final String msg = "An error occurs while trying to delete the alert " + alertId;
-            log.error(msg, te);
             throw new TechnicalManagementException(msg, te);
         }
     }
@@ -425,7 +417,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             log.debug("findByEvent : {} - DONE", set);
             return set;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find alert triggers by event", ex);
             throw new TechnicalManagementException("An error occurs while trying to find alert triggers by event", ex);
         }
     }
@@ -508,7 +499,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             }
         } catch (TechnicalException te) {
             final String msg = "An error occurs while trying to apply template alert " + alertId;
-            log.error(msg, te);
             throw new TechnicalManagementException(msg, te);
         }
     }
@@ -699,7 +689,6 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             alertEventRepository.create(alertEvent);
         } catch (TechnicalException ex) {
             final String message = "An error occurs while trying to create an alert event from command {}" + command;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImpl.java
@@ -133,7 +133,6 @@ public class AnalyticsServiceImpl implements AnalyticsService {
 
             return response != null ? convert(response, query) : null;
         } catch (AnalyticsException ae) {
-            log.error("Unable to calculate analytics: ", ae);
             throw new AnalyticsCalculateException("Unable to calculate analytics");
         }
     }
@@ -153,7 +152,6 @@ public class AnalyticsServiceImpl implements AnalyticsService {
 
             return response != null ? convert(response) : null;
         } catch (AnalyticsException ae) {
-            log.error("Unable to calculate analytics: ", ae);
             throw new AnalyticsCalculateException("Unable to calculate analytics");
         }
     }
@@ -179,7 +177,6 @@ public class AnalyticsServiceImpl implements AnalyticsService {
             DateHistogramResponse response = analyticsRepository.query(executionContext.getQueryContext(), queryBuilder.build());
             return response != null ? convert(executionContext, response) : null;
         } catch (AnalyticsException ae) {
-            log.error("Unable to calculate analytics: ", ae);
             throw new AnalyticsCalculateException("Unable to calculate analytics");
         }
     }
@@ -212,7 +209,6 @@ public class AnalyticsServiceImpl implements AnalyticsService {
             GroupByResponse response = analyticsRepository.query(executionContext.getQueryContext(), queryBuilder.build());
             return response != null ? convert(executionContext, response) : null;
         } catch (AnalyticsException ae) {
-            log.error("Unable to calculate analytics: ", ae);
             throw new AnalyticsCalculateException("Unable to calculate analytics");
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiCRDServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiCRDServiceImpl.java
@@ -143,7 +143,6 @@ public class ApiCRDServiceImpl extends AbstractService implements ApiCRDService 
                 plansByCrossId
             );
         } catch (JsonProcessingException e) {
-            log.error("An error occurs while trying to JSON deserialize the API {}", api, e);
             throw new TechnicalManagementException("An error occurs while trying to JSON deserialize the API definition.");
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDefinitionContextServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDefinitionContextServiceImpl.java
@@ -50,7 +50,6 @@ public class ApiDefinitionContextServiceImpl implements ApiDefinitionContextServ
             api.setSyncFrom(definitionContext.getSyncFrom());
             apiRepository.update(api);
         } catch (TechnicalException e) {
-            log.error("An error has occurred while trying to set definition context on API " + apiId, e);
             throw new TechnicalManagementException(e);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -212,7 +212,6 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
             }
             return createdApiEntity;
         } catch (IOException e) {
-            log.error("An error occurs while trying to JSON deserialize the API {}", apiDefinition, e);
             throw new TechnicalManagementException("An error occurs while trying to JSON deserialize the API definition.");
         }
     }
@@ -251,7 +250,6 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
             createOrUpdateApiNestedEntities(executionContext, updatedApiEntity, apiJsonNode);
             return updatedApiEntity;
         } catch (IOException e) {
-            log.error("An error occurs while trying to JSON deserialize the API {}", apiDefinition, e);
             throw new TechnicalManagementException("An error occurs while trying to JSON deserialize the API definition.");
         }
     }
@@ -809,7 +807,6 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 apiMetadataService.update(executionContext, updateApiMetadataEntity);
             }
         } catch (Exception ex) {
-            log.error("An error occurs while creating API metadata", ex);
             throw new TechnicalManagementException("An error occurs while creating API Metadata", ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiExportServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiExportServiceImpl.java
@@ -155,7 +155,6 @@ public class ApiExportServiceImpl extends AbstractService implements ApiExportSe
 
             return customResourceDefinitionMapper.toCustomResourceDefinition(apiDefinitionResource);
         } catch (final Exception e) {
-            log.error(String.format("An error occurs while trying to convert API %s to CRD", apiId), e);
             throw new TechnicalManagementException(e);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiHeaderServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiHeaderServiceImpl.java
@@ -85,7 +85,6 @@ public class ApiHeaderServiceImpl extends TransactionalService implements ApiHea
 
             return convert(apiHeaderRepository.create(apiHeader));
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to create a header {}", newEntity, e);
             throw new TechnicalManagementException("An error occurs while trying to create a header " + newEntity, e);
         }
     }
@@ -123,7 +122,6 @@ public class ApiHeaderServiceImpl extends TransactionalService implements ApiHea
                 currentOrder++;
             }
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to delete a header {}", apiHeaderId, e);
             throw new TechnicalManagementException("An error occurs while trying to delete a header " + apiHeaderId, e);
         }
     }
@@ -161,7 +159,6 @@ public class ApiHeaderServiceImpl extends TransactionalService implements ApiHea
                 return convert(header);
             }
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to update header {}", updateEntity, e);
             throw new TechnicalManagementException("An error occurs while trying to update header " + updateEntity, e);
         }
     }
@@ -176,7 +173,6 @@ public class ApiHeaderServiceImpl extends TransactionalService implements ApiHea
                 .map(this::convert)
                 .collect(toList());
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to find all header", e);
             throw new TechnicalManagementException("An error occurs while trying to find all header", e);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -173,7 +173,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
 
             return newApiKeyEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to renew an API Key for {}", subscription.getId(), ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to renew an API Key for %s", subscription.getId()),
                 ex
@@ -214,7 +213,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
 
             return newApiKeyEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to renew an API Key for application {}", application.getId(), ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to renew an API Key for application %s", application.getId()),
                 ex
@@ -263,7 +261,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 apiKeyRepository.addSubscription(apiKeyEntity.getId(), subscription.getId()).orElseThrow(ApiKeyNotFoundException::new)
             );
         } catch (TechnicalException e) {
-            log.error("An error occurred while trying to add subscription to API Key", e);
             throw new TechnicalManagementException("An error occurred while trying to a add subscription to API Key");
         }
     }
@@ -283,7 +280,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
 
             return apiKeyEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to generate an API Key for {}", subscription, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to generate an API Key for %s", subscription),
                 ex
@@ -380,7 +376,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
 
             return updatedEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to reactivate an api key", ex);
             throw new TechnicalManagementException("An error occurs while trying to reactivate an API Key", ex);
         }
     }
@@ -400,7 +395,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 .orElseThrow(ApiKeyNotFoundException::new);
         } catch (TechnicalException e) {
             String message = String.format("An error occurs while trying to find a key with id %s", keyId);
-            log.error(message, e);
             throw new TechnicalManagementException(message, e);
         }
     }
@@ -415,7 +409,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 .map(apiKey1 -> convert(executionContext, apiKey1))
                 .collect(toList());
         } catch (TechnicalException e) {
-            log.error("An error occurs while finding API Keys", e);
             throw new TechnicalManagementException("An error occurs while finding API Keys", e);
         }
     }
@@ -430,7 +423,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 .map(apiKey1 -> convert(executionContext, apiKey1))
                 .collect(toList());
         } catch (TechnicalException e) {
-            log.error("An error occurs while finding API Keys", e);
             throw new TechnicalManagementException("An error occurs while finding API Keys", e);
         }
     }
@@ -448,7 +440,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 .sorted((o1, o2) -> o2.getCreatedAt().compareTo(o1.getCreatedAt()))
                 .collect(toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while finding API Keys for subscription {}", subscription, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while finding API Keys for subscription %s", subscription),
                 ex
@@ -463,7 +454,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             ApiKey key = apiKeyRepository.findByKeyAndApi(apiKey, apiId).orElseThrow(ApiKeyNotFoundException::new);
             return convert(executionContext, key);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find an API Key for API {}", apiId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to find an API Key for API %s", apiId), ex);
         }
     }
@@ -477,7 +467,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 .map(apiKey -> convert(executionContext, apiKey))
                 .collect(toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find API Keys for application {}", applicationId, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to find API Keys for application %s", applicationId),
                 ex
@@ -500,7 +489,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
 
             return convert(executionContext, key);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while updating an API Key with id {}", apiKeyEntity.getId(), ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while updating an API Key with id %s", apiKeyEntity.getId()),
                 ex
@@ -522,7 +510,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                     try {
                         return apiKeyRepository.update(dbApiKey);
                     } catch (TechnicalException ex) {
-                        log.error("An error occurs while trying to update ApiKey with id {}", dbApiKey.getId(), ex);
                         throw new TechnicalManagementException(
                             String.format("An error occurs while trying to update ApiKey with id %s", dbApiKey.getId()),
                             ex
@@ -532,7 +519,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 .map(apiKey -> convert(executionContext, apiKey))
                 .orElseThrow(ApiKeyNotFoundException::new);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update apiKey", ex);
             throw new TechnicalManagementException("An error occurs while trying to update apiKey", ex);
         }
     }
@@ -593,7 +579,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 .map(apiKey -> convert(executionContext, apiKey))
                 .collect(toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to search API Keys: {}", query, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to search API Keys: {}", query), ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiQualityRuleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiQualityRuleServiceImpl.java
@@ -63,7 +63,6 @@ public class ApiQualityRuleServiceImpl extends AbstractService implements ApiQua
             return apiQualityRuleRepository.findByApi(api).stream().map(this::convert).collect(toList());
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to find quality rules by API";
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -92,7 +91,6 @@ public class ApiQualityRuleServiceImpl extends AbstractService implements ApiQua
             return convert(apiQualityRuleRepository.create(apiQualityRule));
         } catch (TechnicalException e) {
             final String error = "An error occurs while trying to create an API quality rule " + newEntity;
-            log.error(error, e);
             throw new TechnicalManagementException(error, e);
         }
     }
@@ -121,7 +119,6 @@ public class ApiQualityRuleServiceImpl extends AbstractService implements ApiQua
             return convert(apiQualityRule);
         } catch (TechnicalException e) {
             final String error = "An error occurs while trying to update API quality rule " + updateEntity;
-            log.error(error, e);
             throw new TechnicalManagementException(error, e);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -764,10 +764,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             searchEngineService.index(executionContext, apiWithMetadata, false);
             return apiEntity;
         } catch (InvalidPathsException ex) {
-            log.error("An error occurs while trying to create {} for user {}", api, userId, ex);
             throw new InvalidPathException("API paths are invalid", ex);
         } catch (TechnicalException | IllegalStateException ex) {
-            log.error("An error occurs while trying to create {} for user {}", api, userId, ex);
             throw new TechnicalManagementException("An error occurs while trying create " + api + " for user " + userId, ex);
         }
     }
@@ -971,7 +969,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             Set<String> apiIds = apiAuthorizationService.findIdsByUser(executionContext, userId, apiQuery, sortable, manageOnly);
             return loadPage(executionContext, apiIds, pageable);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find APIs for user {}", userId, ex);
             throw new TechnicalManagementException("An error occurs while trying to find APIs for user " + userId, ex);
         }
     }
@@ -988,7 +985,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             return optApi.orElseThrow(() -> new ApiNotFoundException(apiId));
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find an API using its ID: {}", apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to find an API using its ID: " + apiId, ex);
         }
     }
@@ -1446,10 +1442,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             return apiEntity;
         } catch (InvalidPathsException ex) {
-            log.error("An error occurs while trying to update API {}", apiId, ex);
             throw new InvalidPathException("API paths are invalid", ex);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update API {}", apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to update API " + apiId, ex);
         }
     }
@@ -1507,7 +1501,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             return objectMapper.writeValueAsString(updateApiDefinition);
         } catch (JsonProcessingException jse) {
-            log.error("Unexpected error while generating API definition", jse);
             throw new TechnicalManagementException("An error occurs while trying to parse API definition " + jse);
         }
     }
@@ -1638,7 +1631,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                     try {
                         Pattern.compile(path);
                     } catch (java.util.regex.PatternSyntaxException pse) {
-                        log.error("An error occurs while trying to parse the path {}", path, pse);
                         throw new TechnicalManagementException("An error occurs while trying to parse the path " + path, pse);
                     }
                 });
@@ -1652,7 +1644,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                     try {
                         Pattern.compile(pathMapping);
                     } catch (java.util.regex.PatternSyntaxException pse) {
-                        log.error("An error occurs while trying to parse the path mapping {}", pathMapping, pse);
                         throw new TechnicalManagementException("An error occurs while trying to parse the path mapping" + pathMapping, pse);
                     }
                 });
@@ -1786,7 +1777,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             apiMetadataService.deleteAllByApi(executionContext, apiId);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete API {}", apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete API " + apiId, ex);
         }
     }
@@ -1805,7 +1795,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             );
             return apiEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to start API {}", apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to start API " + apiId, ex);
         }
     }
@@ -1824,7 +1813,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             );
             return apiEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to stop API {}", apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to stop API " + apiId, ex);
         }
     }
@@ -1932,7 +1920,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             return deployCurrentAPI(executionContext, apiId, userId, eventType, apiDeploymentEntity);
         } catch (Exception ex) {
-            log.error("An error occurs while trying to deploy API: {}", apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to deploy API: " + apiId, ex);
         }
     }
@@ -1961,7 +1948,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 objectMapper.writeValueAsString(rollbackApiEntity)
             );
         } catch (Exception ex) {
-            log.error("An error occurs while trying to rollback API: {}", apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to rollback API: " + apiId, ex);
         }
     }
@@ -2105,7 +2091,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 return this.deploy(executionContext, apiId, userId, EventType.PUBLISH_API, new ApiDeploymentEntity());
             }
         } catch (Exception e) {
-            log.error("An error occurs while trying to deploy last published API {}", apiId, e);
             throw new TechnicalException("An error occurs while trying to deploy last published API " + apiId, e);
         }
     }
@@ -2232,7 +2217,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             );
         } catch (TechnicalException ex) {
             final String errorMessage = "An error occurs while trying to search for paginated APIs: " + query;
-            log.error(errorMessage, ex);
             throw new TechnicalManagementException(errorMessage, ex);
         }
     }
@@ -2293,7 +2277,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             return loadPage(executionContext, apiIds, pageable);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to search paged apis", ex);
             throw new TechnicalManagementException("An error occurs while trying to search paged apis", ex);
         }
     }
@@ -2729,7 +2712,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 apiUpdated.getId()
             );
         } catch (Exception ex) {
-            log.error("An error occurs while auditing API logging configuration for API: {}", apiUpdated.getId(), ex);
             throw new TechnicalManagementException(
                 "An error occurs while auditing API logging configuration for API: " + apiUpdated.getId(),
                 ex

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationAlertServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationAlertServiceImpl.java
@@ -150,7 +150,6 @@ public class ApplicationAlertServiceImpl implements ApplicationAlertService {
             notification.setConfiguration(mapper.writeValueAsString(configuration));
             return singletonList(notification);
         } catch (JsonProcessingException e) {
-            log.error("An error occurs while trying to create the Alert notification", e);
             throw new TechnicalManagementException("An error occurs while trying to create the Alert notification");
         }
     }
@@ -224,7 +223,6 @@ public class ApplicationAlertServiceImpl implements ApplicationAlertService {
                         configuration.put("body", emailNode.path("body").asText());
                         notification.setConfiguration(mapper.writeValueAsString(configuration));
                     } catch (JsonProcessingException e) {
-                        log.error("An error occurs while trying to add a recipient to the Alert notification", e);
                         throw new TechnicalManagementException("An error occurs while trying to add a recipient to the Alert notification");
                     }
                 } else {
@@ -280,7 +278,6 @@ public class ApplicationAlertServiceImpl implements ApplicationAlertService {
                         }
                         alertService.update(executionContext, convert(trigger));
                     } catch (JsonProcessingException e) {
-                        log.error("An error occurs while trying to add a recipient to the Alert notification", e);
                         throw new TechnicalManagementException("An error occurs while trying to add a recipient to the Alert notification");
                     }
                 }
@@ -462,7 +459,6 @@ public class ApplicationAlertServiceImpl implements ApplicationAlertService {
 
                     alertService.update(executionContext, convert(trigger));
                 } catch (JsonProcessingException e) {
-                    log.error("An error occurs while trying to update Alert notification", e);
                     throw new TechnicalManagementException("An error occurs while trying to update Alert notification");
                 }
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -246,7 +246,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
 
             throw new ApplicationNotFoundException(applicationId);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find an application using its ID {}", applicationId, ex);
             throw new TechnicalManagementException("An error occurs while trying to find an application using its ID " + applicationId, ex);
         }
     }
@@ -288,7 +287,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             }
             return this.convertToList(executionContext, applications.getContent());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find applications by ids {}", applicationIds, ex);
             throw new TechnicalManagementException("An error occurs while trying to find applications by ids {}" + applicationIds, ex);
         }
     }
@@ -391,7 +389,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 ? convertToList(executionContext, applications)
                 : convertToSimpleList(applications);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find applications for groups {}", groupIds, ex);
             throw new TechnicalManagementException("An error occurs while trying to find applications for groups " + groupIds, ex);
         }
     }
@@ -552,13 +549,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             }
             return convert(executionContext, createdApplication, userEntity);
         } catch (TechnicalException ex) {
-            log.error(
-                "An error occurs while trying to create {} for user {} in environment {}",
-                application,
-                userId,
-                executionContext.getEnvironmentId(),
-                ex
-            );
             throw new TechnicalManagementException(
                 "An error occurs while trying create " +
                     application +
@@ -836,7 +826,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 .filter(app -> clientId.equals(app.getMetadata().get(METADATA_CLIENT_ID)))
                 .findAny();
             if (byClientId.map(app -> !app.getId().equals(applicationToUpdate.getId())).orElse(false)) {
-                log.error("An application already exists with the same client_id");
                 throw new ClientIdAlreadyExistsException(clientId);
             }
         }
@@ -944,7 +933,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 applicationId,
                 apiKeyMode
             );
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -1047,7 +1035,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
 
             throw new ApplicationRenewClientSecretException(applicationToUpdate.getName());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to renew client secret {}", applicationId, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to renew client secret %s", applicationId),
                 ex
@@ -1113,7 +1100,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
 
             return convert(executionContext, restoredApplication, userEntity);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to restore {}", applicationId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to restore %s", applicationId), ex);
         }
     }
@@ -1193,7 +1179,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             // Audit
             createAuditLog(executionContext, APPLICATION_ARCHIVED, application.getUpdatedAt(), previousApplication, application);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete application {}", applicationId, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to delete application %s", applicationId),
                 ex
@@ -1519,7 +1504,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
 
             return applicationRepository.searchIds(searchCriteria, convert(sortable));
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to search applications for query {}", applicationQuery, ex);
             throw new TechnicalManagementException("An error occurs while trying to find applications for query " + applicationQuery, ex);
         }
     }
@@ -1546,7 +1530,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             }
             return this.convertToSimpleList(applications);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to search applications for query {}", applicationQuery, ex);
             throw new TechnicalManagementException("An error occurs while trying to find applications for query " + applicationQuery, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CategoryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CategoryServiceImpl.java
@@ -78,7 +78,6 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
             log.debug("Find all categories");
             return categoryRepository.findAllByEnvironment(environmentId).stream().map(this::convert).collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all categories", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all categories", ex);
         }
     }
@@ -92,7 +91,6 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to find categories by ids", e);
             throw new TechnicalManagementException("An error occurs while trying to find categories by ids", e);
         }
     }
@@ -103,7 +101,6 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
             log.debug("Find all categories by page");
             return categoryRepository.findByPage(page).stream().map(this::convert).collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all categories by page", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all categories by page", ex);
         }
     }
@@ -122,7 +119,6 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
             throw new CategoryNotFoundException(id);
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to find a category using its id: " + id;
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -174,7 +170,6 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
 
             return createdCategory;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create category {}", newCategory.getName(), ex);
             throw new TechnicalManagementException("An error occurs while trying to create category " + newCategory.getName(), ex);
         }
     }
@@ -216,7 +211,6 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
 
             return updatedCategory;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update category {}", categoryEntity.getName(), ex);
             throw new TechnicalManagementException("An error occurs while trying to update category " + categoryEntity.getName(), ex);
         }
     }
@@ -258,7 +252,6 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
                     );
                 }
             } catch (TechnicalException ex) {
-                log.error("An error occurs while trying to update category {}", categoryEntity.getName(), ex);
                 throw new TechnicalManagementException("An error occurs while trying to update category " + categoryEntity.getName(), ex);
             }
         });
@@ -289,7 +282,6 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
                 apiCategoryService.deleteCategoryFromAPIs(executionContext, categoryId);
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete category {}", categoryId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete category " + categoryId, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CommandServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CommandServiceImpl.java
@@ -67,7 +67,6 @@ public class CommandServiceImpl extends AbstractService implements CommandServic
         try {
             commandRepository.create(command);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create {}", command, ex);
             throw new TechnicalManagementException("An error occurs while trying create " + command, ex);
         }
     }
@@ -120,9 +119,7 @@ public class CommandServiceImpl extends AbstractService implements CommandServic
         try {
             commandRepository.delete(commandId);
         } catch (TechnicalException ex) {
-            final String error = "An error occurs while trying to delete command " + commandId;
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurs while trying to delete command " + commandId, ex);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CustomUserFieldsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CustomUserFieldsServiceImpl.java
@@ -101,7 +101,6 @@ public class CustomUserFieldsServiceImpl extends TransactionalService implements
                 return map(recorded);
             }
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to create CustomUserField", e);
             throw new TechnicalManagementException("An error occurs while trying to create CustomUserField", e);
         }
     }
@@ -134,7 +133,6 @@ public class CustomUserFieldsServiceImpl extends TransactionalService implements
                 throw new CustomUserFieldNotFoundException(updateFieldEntity.getKey());
             }
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to update CustomUserField", e);
             throw new TechnicalManagementException("An error occurs while trying to update CustomUserField", e);
         }
     }
@@ -158,7 +156,6 @@ public class CustomUserFieldsServiceImpl extends TransactionalService implements
                 );
             }
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to create CustomUserField", e);
             throw new TechnicalManagementException("An error occurs while trying to create CustomUserField", e);
         }
     }
@@ -172,7 +169,6 @@ public class CustomUserFieldsServiceImpl extends TransactionalService implements
             List<CustomUserField> records = this.customUserFieldsRepository.findByReferenceIdAndReferenceType(refId, refType);
             return records.stream().map(this::map).collect(Collectors.toList());
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to list all CustomUserField", e);
             throw new TechnicalManagementException("An error occurs while trying to list all CustomUserField", e);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/DashboardServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/DashboardServiceImpl.java
@@ -91,9 +91,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
                 .sorted(comparing(DashboardEntity::getType))
                 .toList();
         } catch (TechnicalException ex) {
-            final String error = "An error occurs while trying to find all dashboards";
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurs while trying to find all dashboards", ex);
         }
     }
 
@@ -109,9 +107,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
                 .sorted(comparing(DashboardEntity::getType))
                 .toList();
         } catch (TechnicalException ex) {
-            final String error = "An error occurs while trying to find all dashboards";
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurs while trying to find all dashboards", ex);
         }
     }
 
@@ -138,9 +134,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
                     .toList();
             }
         } catch (TechnicalException ex) {
-            final String error = "An error occurs while trying to find all dashboards by reference type";
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurs while trying to find all dashboards by reference type", ex);
         }
     }
 
@@ -153,9 +147,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
                 .map(this::convert)
                 .orElseThrow(() -> new DashboardNotFoundException(dashboardId));
         } catch (TechnicalException ex) {
-            final String error = "An error occurs while trying to find dashboard by ID";
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurs while trying to find dashboard by ID", ex);
         }
     }
 
@@ -180,9 +172,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
             );
             return convert(dashboard);
         } catch (TechnicalException ex) {
-            final String error = "An error occurred while trying to create dashboard " + dashboardEntity;
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurred while trying to create dashboard " + dashboardEntity, ex);
         }
     }
 
@@ -257,9 +247,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
             );
             return savedDashboard;
         } catch (TechnicalException ex) {
-            final String error = "An error occurred while trying to update dashboard " + dashboardEntity;
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurred while trying to update dashboard " + dashboardEntity, ex);
         }
     }
 
@@ -275,9 +263,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
             JsonNode jsonNode = objectMapper.readValue(json, JsonNode.class);
             return jsonNode.toString();
         } catch (IOException ex) {
-            final String error = "Error while trying to load a dashboard from the definition path: " + path;
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("Error while trying to load a dashboard from the definition path: " + path, ex);
         }
     }
 
@@ -321,9 +307,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
             }
             return convert(dashboardRepository.update(dashboardToReorder));
         } catch (final TechnicalException ex) {
-            final String error = "An error occurs while trying to update dashboard " + dashboardToReorder.getId();
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurs while trying to update dashboard " + dashboardToReorder.getId(), ex);
         }
     }
 
@@ -355,9 +339,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
                 );
             }
         } catch (TechnicalException ex) {
-            final String error = "An error occurs while trying to delete dashboard " + dashboardId;
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurs while trying to delete dashboard " + dashboardId, ex);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EmailServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EmailServiceImpl.java
@@ -184,7 +184,6 @@ public class EmailServiceImpl extends TransactionalService implements EmailServi
 
                 mailSender.send(mailMessage.getMimeMessage());
             } catch (final Exception ex) {
-                log.error("Error while sending email notification", ex);
                 throw new TechnicalManagementException("Error while sending email notification", ex);
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EntrypointServiceImpl.java
@@ -74,7 +74,6 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
             }
             return convert(optionalEntryPoint.get());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all entrypoints", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all entrypoints", ex);
         }
     }
@@ -89,7 +88,6 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
                 .map(this::convert)
                 .collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all entrypoints", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all entrypoints", ex);
         }
     }
@@ -111,7 +109,6 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
             );
             return savedEntryPoint;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create entrypoint {}", entrypointEntity.getValue(), ex);
             throw new TechnicalManagementException("An error occurs while trying to create entrypoint " + entrypointEntity.getValue(), ex);
         }
     }
@@ -145,7 +142,6 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
                 throw new EntrypointNotFoundException(entrypointEntity.getId());
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update entrypoint {}", entrypointEntity.getValue(), ex);
             throw new TechnicalManagementException("An error occurs while trying to update entrypoint " + entrypointEntity.getValue(), ex);
         }
     }
@@ -174,7 +170,6 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
                 throw new EntrypointNotFoundException(entrypointId);
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete entrypoint {}", entrypointId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete entrypoint " + entrypointId, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EnvironmentServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EnvironmentServiceImpl.java
@@ -92,7 +92,6 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
 
             return convert(optEnvironment.get());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find environment by ID", ex);
             throw new TechnicalManagementException("An error occurs while trying to find environment by ID", ex);
         }
     }
@@ -115,7 +114,6 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
             }
             return envStream.map(this::convert).collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all environments", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all environments", ex);
         }
     }
@@ -142,7 +140,6 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
 
             return convert(byOrgAndIdOrHrid.iterator().next());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all environments", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all environments", ex);
         }
     }
@@ -190,7 +187,6 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
                 return createdEnvironment;
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update environment {}", environmentEntity.getName(), ex);
             throw new TechnicalManagementException("An error occurs while trying to update environment " + environmentEntity.getName(), ex);
         }
     }
@@ -205,7 +201,6 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
                 throw new EnvironmentNotFoundException(environmentId);
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete environment {}", environmentId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete environment " + environmentId, ex);
         }
     }
@@ -222,7 +217,6 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
             environmentRepository.create(defaultEnvironment);
             return convert(defaultEnvironment);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create default environment", ex);
             throw new TechnicalManagementException("An error occurs while trying to create default environment", ex);
         }
     }
@@ -236,7 +230,6 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
                 .map(this::convert)
                 .orElseThrow(() -> new EnvironmentNotFoundException(cockpitId));
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find environment by cockpit id {}", cockpitId, ex);
             throw new TechnicalManagementException("An error occurs while trying to find environment by cockpit id " + cockpitId, ex);
         }
     }
@@ -247,7 +240,6 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
             log.debug("Find all environments by organization");
             return environmentRepository.findByOrganization(organizationId).stream().map(this::convert).collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all environments by organization {}", organizationId, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to find all environments by organization " + organizationId,
                 ex
@@ -260,7 +252,6 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
         try {
             return environmentRepository.findById(GraviteeContext.getDefaultEnvironment()).map(this::convert).orElseGet(this::initialize);
         } catch (final Exception ex) {
-            log.error("Error while getting installation : {}", ex.getMessage());
             throw new TechnicalManagementException("Error while getting installation", ex);
         }
     }
@@ -274,7 +265,6 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
             }
             return environments;
         } catch (final Exception ex) {
-            log.error("Error while getting installation : {}", ex.getMessage());
             throw new TechnicalManagementException("Error while getting installation", ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EventServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EventServiceImpl.java
@@ -130,7 +130,6 @@ public class EventServiceImpl extends TransactionalService implements EventServi
 
             throw new EventNotFoundException(id);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find an event using its ID {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to find an event using its ID " + id, ex);
         }
     }
@@ -280,10 +279,8 @@ public class EventServiceImpl extends TransactionalService implements EventServi
 
             return convert(executionContext, createdEvent);
         } catch (UnknownHostException e) {
-            log.error("An error occurs while getting the server IP address", e);
             throw new TechnicalManagementException("An error occurs while getting the server IP address", e);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create {} for server {}", newEventEntity, hostAddress, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying create " + newEventEntity + " for server " + hostAddress,
                 ex
@@ -298,7 +295,6 @@ public class EventServiceImpl extends TransactionalService implements EventServi
             long deleteApiEvents = eventRepository.deleteApiEvents(apiId);
             log.debug("{} events deleted for API {}", deleteApiEvents, apiId);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete Events for API {}", apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete Events for API " + apiId, ex);
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/FetcherServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/FetcherServiceImpl.java
@@ -63,7 +63,6 @@ public class FetcherServiceImpl extends AbstractPluginService<FetcherPlugin<?>, 
                 .map(fetcherDefinition -> convert(fetcherDefinition, false))
                 .collect(Collectors.toSet());
         } catch (Exception ex) {
-            log.error("An error occurs while trying to list all fetchers", ex);
             throw new TechnicalManagementException("An error occurs while trying to list all fetchers", ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GenericNotificationConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GenericNotificationConfigServiceImpl.java
@@ -60,7 +60,6 @@ public class GenericNotificationConfigServiceImpl extends AbstractService implem
             notificationConfig.setUpdatedAt(notificationConfig.getCreatedAt());
             return convert(genericNotificationConfigRepository.create(notificationConfig));
         } catch (TechnicalException te) {
-            log.error("An error occurs while trying to save the generic notification settings {}", entity, te);
             throw new TechnicalManagementException("An error occurs while trying to save the generic notification settings " + entity, te);
         }
     }
@@ -85,7 +84,6 @@ public class GenericNotificationConfigServiceImpl extends AbstractService implem
             notificationConfig.setUpdatedAt(new Date());
             return convert(genericNotificationConfigRepository.update(notificationConfig));
         } catch (TechnicalException te) {
-            log.error("An error occurs while trying to save the generic notification settings {}", entity, te);
             throw new TechnicalManagementException("An error occurs while trying to save the generic notification settings " + entity, te);
         }
     }
@@ -95,7 +93,6 @@ public class GenericNotificationConfigServiceImpl extends AbstractService implem
         try {
             genericNotificationConfigRepository.delete(id);
         } catch (TechnicalException te) {
-            log.error("An error occurs while trying to delete the generic notification {}", id, te);
             throw new TechnicalManagementException("An error occurs while trying to delete the generic notification " + id, te);
         }
     }
@@ -105,7 +102,6 @@ public class GenericNotificationConfigServiceImpl extends AbstractService implem
         try {
             genericNotificationConfigRepository.deleteByReferenceIdAndReferenceType(referenceId, referenceType);
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to delete the generic notifications {} / {}", referenceType, referenceId, e);
             throw new TechnicalManagementException(
                 "An error occurs while trying to delete the generic notifications " + referenceType + " / " + referenceId,
                 e
@@ -122,7 +118,6 @@ public class GenericNotificationConfigServiceImpl extends AbstractService implem
             }
             throw new NotificationConfigNotFoundException();
         } catch (TechnicalException te) {
-            log.error("An error occurs while trying to get the notification config {}", id, te);
             throw new TechnicalManagementException("An error occurs while trying to get the notification config " + id, te);
         }
     }
@@ -136,7 +131,6 @@ public class GenericNotificationConfigServiceImpl extends AbstractService implem
                 .map(this::convert)
                 .collect(Collectors.toList());
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to get the notification config {}/{}", referenceType, referenceId);
             throw new TechnicalManagementException(
                 "An error occurs while trying to get the notification config " + referenceType + "/" + referenceId,
                 e
@@ -152,7 +146,6 @@ public class GenericNotificationConfigServiceImpl extends AbstractService implem
                 genericNotificationConfigRepository.deleteByConfig(user.getEmail());
             }
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to delete the notification config for user {}", user.getId(), e);
             throw new TechnicalManagementException(
                 "An error occurs while trying to delete the notification config for user " + user.getId(),
                 e

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -276,7 +276,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             }
             return groups;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all groups", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all groups", ex);
         }
     }
@@ -330,7 +329,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 .sorted(Comparator.comparing(GroupSimpleEntity::getName))
                 .collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all groups", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all groups", ex);
         }
     }
@@ -371,7 +369,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             log.debug("findByUsername : {} - DONE", name);
             return groupEntities;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find groups by name", ex);
             throw new TechnicalManagementException("An error occurs while trying to find groups by name", ex);
         }
     }
@@ -403,7 +400,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             log.debug("create {} - DONE", grp);
             return grp;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create a group", ex);
             throw new TechnicalManagementException("An error occurs while trying to create a group", ex);
         }
     }
@@ -445,7 +441,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             return findById(executionContext, groupId);
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to update a group";
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -532,7 +527,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             GroupEntity groupEntity = this.map(executionContext, group.get());
 
             if (groupEntity == null) {
-                log.error("An error occurs while trying to find a group {}", groupId);
                 throw new TechnicalManagementException("An error occurs while trying to find a group " + groupId);
             }
 
@@ -571,7 +565,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
             return groupEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find a group", ex);
             throw new TechnicalManagementException("An error occurs while trying to find a group", ex);
         }
     }
@@ -607,7 +600,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                     break;
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to associate group to all {}", associationType, ex);
             throw new TechnicalManagementException("An error occurs while trying to associate group to all " + associationType, ex);
         }
     }
@@ -640,7 +632,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 .sorted(Comparator.comparing(GroupEntity::getName))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find groups", ex);
             throw new TechnicalManagementException("An error occurs while trying to find groups", ex);
         }
     }
@@ -663,7 +654,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             log.debug("findByEvent : {} - DONE", set);
             return set;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find groups by event", ex);
             throw new TechnicalManagementException("An error occurs while trying to find groups by event", ex);
         }
     }
@@ -768,7 +758,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                         applicationRepository.update(application);
                         applicationIds.add(application.getId());
                     } catch (TechnicalException ex) {
-                        log.error("An error occurs while trying to delete a group", ex);
                         throw new TechnicalManagementException("An error occurs while trying to delete a group", ex);
                     }
                 });
@@ -802,7 +791,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
             log.debug("delete {} - DONE", groupId);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete a group", ex);
             throw new TechnicalManagementException("An error occurs while trying to delete a group", ex);
         }
     }
@@ -836,7 +824,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 }
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete a group", ex);
             throw new TechnicalManagementException("An error occurs while trying to delete a group", ex);
         }
     }
@@ -852,7 +839,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 }
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete a group", ex);
             throw new TechnicalManagementException("An error occurs while trying to delete a group", ex);
         }
     }
@@ -879,7 +865,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 }
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete a group", ex);
             throw new TechnicalManagementException("An error occurs while trying to delete a group", ex);
         }
     }
@@ -945,7 +930,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         try {
             return groupRepository.findByIds(userGroups).stream().map(this::map).collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all user groups", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all user groups", ex);
         }
     }
@@ -1008,7 +992,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 })
                 .collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all application of group {}", groupId, ex);
             throw new TechnicalManagementException("An error occurs while trying to find all application of group " + groupId, ex);
         }
     }
@@ -1284,7 +1267,6 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             group.setApiPrimaryOwner(newApiPrimaryOwner);
             groupRepository.update(group);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find or update a group", ex);
             throw new TechnicalManagementException("An error occurs while trying to find or update a group", ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/HealthCheckServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/HealthCheckServiceImpl.java
@@ -105,7 +105,6 @@ public class HealthCheckServiceImpl implements HealthCheckService {
             );
             return response != null ? convert(response) : null;
         } catch (AnalyticsException ae) {
-            log.error("Unable to calculate analytics: ", ae);
             throw new AnalyticsCalculateException("Unable to calculate analytics");
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstallationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstallationServiceImpl.java
@@ -57,7 +57,6 @@ public class InstallationServiceImpl implements InstallationService {
                 return convert(optInstallation.get());
             }
         } catch (final Exception ex) {
-            log.error("Error while getting installation : {}", ex.getMessage());
             throw new TechnicalManagementException("Error while getting installation", ex);
         }
         throw new InstallationNotFoundException("");
@@ -72,7 +71,6 @@ public class InstallationServiceImpl implements InstallationService {
             }
             return createInstallation();
         } catch (final Exception ex) {
-            log.error("Error while getting installation : {}", ex.getMessage());
             throw new TechnicalManagementException("Error while getting installation", ex);
         }
     }
@@ -88,7 +86,6 @@ public class InstallationServiceImpl implements InstallationService {
                 return convert(this.installationRepository.update(installation));
             }
         } catch (final Exception ex) {
-            log.error("Error while updating installation : {}", ex.getMessage());
             throw new TechnicalManagementException("Error while updating installation", ex);
         }
         throw new InstallationNotFoundException("");
@@ -116,7 +113,6 @@ public class InstallationServiceImpl implements InstallationService {
         try {
             return convert(this.installationRepository.create(installation));
         } catch (final Exception ex) {
-            log.error("Error while creating installation : {}", ex.getMessage());
             throw new TechnicalManagementException("Error while creating installation", ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InvitationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InvitationServiceImpl.java
@@ -147,9 +147,10 @@ public class InvitationServiceImpl extends TransactionalService implements Invit
                 return convert(createdInvitation);
             }
         } catch (TechnicalException ex) {
-            final String message = "An error occurs while trying to create invitation for email " + invitation.getEmail();
-            log.error(message, ex);
-            throw new TechnicalManagementException(message, ex);
+            throw new TechnicalManagementException(
+                "An error occurs while trying to create invitation for email " + invitation.getEmail(),
+                ex
+            );
         }
     }
 
@@ -171,9 +172,10 @@ public class InvitationServiceImpl extends TransactionalService implements Invit
                 throw new InvitationNotFoundException(invitation.getId());
             }
         } catch (TechnicalException ex) {
-            final String message = "An error occurs while trying to update invitation with email " + invitation.getEmail();
-            log.error(message, ex);
-            throw new TechnicalManagementException(message, ex);
+            throw new TechnicalManagementException(
+                "An error occurs while trying to update invitation with email " + invitation.getEmail(),
+                ex
+            );
         }
     }
 
@@ -239,9 +241,7 @@ public class InvitationServiceImpl extends TransactionalService implements Invit
             final Set<Invitation> invitations = invitationRepository.findAll();
             return invitations.stream().map(this::convert).collect(toList());
         } catch (TechnicalException ex) {
-            final String message = "An error occurs while trying to list all invitations";
-            log.error(message, ex);
-            throw new TechnicalManagementException(message, ex);
+            throw new TechnicalManagementException("An error occurs while trying to list all invitations", ex);
         }
     }
 
@@ -254,9 +254,10 @@ public class InvitationServiceImpl extends TransactionalService implements Invit
             );
             return invitations.stream().map(this::convert).sorted(comparing(InvitationEntity::getEmail)).collect(toList());
         } catch (TechnicalException ex) {
-            final String message = "An error occurs while trying to list invitations by reference " + referenceType + '/' + referenceId;
-            log.error(message, ex);
-            throw new TechnicalManagementException(message, ex);
+            throw new TechnicalManagementException(
+                "An error occurs while trying to list invitations by reference " + referenceType + '/' + referenceId,
+                ex
+            );
         }
     }
 
@@ -269,9 +270,7 @@ public class InvitationServiceImpl extends TransactionalService implements Invit
             }
             invitationRepository.delete(invitationId);
         } catch (TechnicalException te) {
-            final String msg = "An error occurs while trying to delete the invitation " + invitationId;
-            log.error(msg, te);
-            throw new TechnicalManagementException(msg, te);
+            throw new TechnicalManagementException("An error occurs while trying to delete the invitation " + invitationId, te);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/JsonPatchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/JsonPatchServiceImpl.java
@@ -66,7 +66,6 @@ public class JsonPatchServiceImpl extends AbstractService implements JsonPatchSe
             Object apiDefinitionToUpdate = transform(jsonPatches, apiDefinitionParsed.json());
             return objectMapper.writeValueAsString(apiDefinitionToUpdate);
         } catch (JsonProcessingException | InvalidPathException ex) {
-            log.error("An error occurs while trying to execute json patches", ex);
             throw new TechnicalManagementException("An error occurs while trying to execute json patches", ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
@@ -186,7 +186,6 @@ public class LogsServiceImpl implements LogsService {
 
             return logResponse;
         } catch (AnalyticsException ae) {
-            log.error("Unable to retrieve logs: ", ae);
             throw new TechnicalManagementException("Unable to retrieve logs", ae);
         }
     }
@@ -217,10 +216,8 @@ public class LogsServiceImpl implements LogsService {
             }
             return toApiRequest(executionContext, log);
         } catch (AnalyticsException ae) {
-            log.error("Unable to retrieve log: " + id, ae);
             throw new TechnicalManagementException("Unable to retrieve log: " + id, ae);
         } catch (ApiNotFoundException anfe) {
-            log.warn("Requested log [" + id + "] is not attached to environment [" + executionContext.getEnvironmentId() + "]", anfe);
             throw new LogNotFoundException(id);
         }
     }
@@ -277,7 +274,6 @@ public class LogsServiceImpl implements LogsService {
 
             return logResponse;
         } catch (AnalyticsException ae) {
-            log.error("Unable to retrieve logs: ", ae);
             throw new TechnicalManagementException("Unable to retrieve logs", ae);
         }
     }
@@ -335,7 +331,6 @@ public class LogsServiceImpl implements LogsService {
 
             return logResponse;
         } catch (AnalyticsException ae) {
-            log.error("Unable to retrieve logs: ", ae);
             throw new TechnicalManagementException("Unable to retrieve logs", ae);
         }
     }
@@ -349,13 +344,11 @@ public class LogsServiceImpl implements LogsService {
             }
 
             if (!applicationId.equalsIgnoreCase(log.getApplication())) {
-                this.log.warn("Requested log [" + id + "] is not attached to application [" + applicationId + "]");
                 throw new LogNotFoundException(id);
             }
 
             return toApplicationRequest(executionContext, log);
         } catch (AnalyticsException ae) {
-            log.error("Unable to retrieve log: " + id, ae);
             if (ae.getMessage().equals("Request [" + id + "] does not exist")) {
                 throw new LogNotFoundException(id);
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaServiceImpl.java
@@ -115,7 +115,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
                 return hashString;
             }
         } catch (TechnicalException | NoSuchAlgorithmException ex) {
-            log.error("An error has occurred while trying to create media " + mediaEntity, ex);
             throw new TechnicalManagementException("An error occurs while trying create media", ex);
         }
     }
@@ -135,7 +134,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
                 .map(MediaServiceImpl::convert)
                 .orElse(null);
         } catch (TechnicalException e) {
-            log.error("An error has occurred trying to find media with hash " + hash, e);
             throw new TechnicalManagementException("An error has occurred trying to find media", e);
         }
     }
@@ -148,7 +146,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
                 .map(MediaServiceImpl::convert)
                 .orElse(null);
         } catch (TechnicalException e) {
-            log.error("An error as occurred trying to find media for API " + apiId + " with hash " + hash, e);
             throw new TechnicalManagementException("An error as occurred trying to find media", e);
         }
     }
@@ -168,7 +165,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
                 .map(MediaServiceImpl::convert)
                 .orElse(null);
         } catch (TechnicalException e) {
-            log.error("An error as occurred trying to find media with hash " + hash, e);
             throw new TechnicalManagementException("An error has occurred trying to find media", e);
         }
     }
@@ -181,7 +177,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
                 .map(MediaServiceImpl::convert)
                 .orElse(null);
         } catch (TechnicalException e) {
-            log.error("An error as occurred trying to find media for API " + api + " with hash " + hash, e);
             throw new TechnicalManagementException("An error as occurred trying to find media", e);
         }
     }
@@ -215,7 +210,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             }
             return result;
         } catch (TechnicalException e) {
-            log.error("An error as occurred trying to find medias with criteria " + mediaCriteria, e);
             throw new TechnicalManagementException("An error as occurred trying to find medias", e);
         }
     }
@@ -230,7 +224,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
         try {
             return mediaRepository.findAllByApi(apiId).stream().map(MediaServiceImpl::convert).toList();
         } catch (TechnicalException e) {
-            log.error("An error as occurred trying to find medias for API " + apiId, e);
             throw new TechnicalManagementException("An error as occurred trying to find medias", e);
         }
     }
@@ -241,7 +234,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             final MediaEntity media = convertToEntity(mediaDefinition);
             return saveApiMedia(executionContext, api, media);
         } catch (JsonProcessingException e) {
-            log.error("An error as occurred while trying to JSON deserialize the media " + mediaDefinition, e);
             throw new TechnicalManagementException("An error has occurred while trying to create media", e);
         }
     }
@@ -251,7 +243,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
         try {
             mediaRepository.deleteAllByApi(apiId);
         } catch (TechnicalException e) {
-            log.error("An error has occurred while trying delete medias for API " + apiId, e);
             throw new TechnicalManagementException("An error occurred trying to delete medias", e);
         }
     }
@@ -263,7 +254,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
             Media media = mediaRepository.findByHash(hash, mediaCriteria).orElseThrow(() -> new ApiMediaNotFoundException(hash, apiId));
             mediaRepository.deleteByHashAndApi(media.getHash(), apiId);
         } catch (TechnicalException e) {
-            log.error("An error has occurred trying to delete media for API " + apiId + " with hash " + hash, e);
             throw new TechnicalManagementException("An error has occurred trying to delete media", e);
         }
     }
@@ -280,7 +270,6 @@ public class MediaServiceImpl extends AbstractService implements MediaService {
 
             mediaRepository.deleteByHashAndEnvironment(media.getHash(), executionContext.getEnvironmentId());
         } catch (TechnicalException e) {
-            log.error("An error has occurred trying to delete media with hash " + hash, e);
             throw new TechnicalManagementException("An error has occurred trying to delete media", e);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaValidationServiceImpl.java
@@ -67,7 +67,6 @@ public class MediaValidationServiceImpl implements MediaValidationService {
         }
 
         if (mediaEntity.getType() == null || mediaEntity.getSubType() == null) {
-            log.warn("Validation failed for file '{}': missing media type", mediaEntity.getFileName());
             throw new UploadUnauthorized("The file should have media type.");
         }
 
@@ -77,7 +76,6 @@ public class MediaValidationServiceImpl implements MediaValidationService {
         try {
             detectedMediaType = TIKA.detect(mediaEntity.getData(), mediaEntity.getFileName());
         } catch (IllegalStateException e) {
-            log.error("Unable to determine file type for '{}'", mediaEntity.getFileName(), e);
             throw new UploadUnauthorized("Unable to determine file type.");
         }
 
@@ -87,7 +85,6 @@ public class MediaValidationServiceImpl implements MediaValidationService {
 
         (mediaType.equals(detectedMediaType) ? Set.of(mediaType) : Set.of(mediaType, detectedMediaType)).forEach(type -> {
             if (isForbidden(type)) {
-                log.warn("Forbidden file type '{}' detected for file '{}'", type, mediaEntity.getFileName());
                 throw new UploadUnauthorized("Unsupported file type: " + type + ". Uploading this type of file is not allowed.");
             }
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -428,7 +428,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
             }
             return userMember;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to add member for {} {}", reference.getType(), reference.getId(), ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to add member for " + reference.getType() + " " + reference.getId(),
                 ex
@@ -793,7 +792,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 );
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete membership {}", membershipId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete membership " + membershipId, ex);
         }
     }
@@ -821,7 +819,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 }
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete memberships for {} {}", referenceType, referenceId, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to delete memberships for " + referenceType + " " + referenceId,
                 ex
@@ -908,14 +905,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 }
             }
         } catch (TechnicalException ex) {
-            log.error(
-                "An error occurs while trying to delete memberships for {} {} {} {}",
-                referenceType,
-                referenceId,
-                memberType,
-                memberId,
-                ex
-            );
             throw new TechnicalManagementException(
                 "An error occurs while trying to delete memberships for " +
                     referenceType +
@@ -983,7 +972,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
 
             return new ArrayList<>(userMembershipMap.values());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to remove user {}", userId, ex);
             throw new TechnicalManagementException("An error occurs while trying to remove user " + userId, ex);
         }
     }
@@ -1066,7 +1054,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
 
             return new ArrayList<>(userMemberships);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to remove user {}", userId, ex);
             throw new TechnicalManagementException("An error occurs while trying to remove user " + userId, ex);
         }
     }
@@ -1106,7 +1093,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
             }
             return metadata;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get user membership metadata", ex);
             throw new TechnicalManagementException("An error occurs while trying to get user membership metadata", ex);
         }
     }
@@ -1217,7 +1203,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
             fillMemberUserInformation(executionContext, memberships, members);
             return paginate(results.values(), pageable);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get members for {} {}", referenceType, referenceIds, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to get members for " + referenceType + " " + referenceIds,
                 ex
@@ -1288,7 +1273,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get memberships for {} ", memberId, ex);
             throw new TechnicalManagementException("An error occurs while trying to get memberships for " + memberId, ex);
         }
     }
@@ -1304,7 +1288,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .findRefIdsByMemberIdAndMemberTypeAndReferenceType(memberId, convert(memberType), convert(referenceType))
                 .collect(toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get memberships for {} ", memberId, ex);
             throw new TechnicalManagementException("An error occurs while trying to get memberships for " + memberId, ex);
         }
     }
@@ -1322,7 +1305,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get memberships for {} ", memberId, ex);
             throw new TechnicalManagementException("An error occurs while trying to get memberships for " + memberId, ex);
         }
     }
@@ -1341,7 +1323,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get memberships for {} ", memberId, ex);
             throw new TechnicalManagementException("An error occurs while trying to get memberships for " + memberId, ex);
         }
     }
@@ -1360,7 +1341,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get memberships for {} ", memberId, ex);
             throw new TechnicalManagementException("An error occurs while trying to get memberships for " + memberId, ex);
         }
     }
@@ -1380,7 +1360,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 roleIds
             );
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get memberships for {} ", memberId, ex);
             throw new TechnicalManagementException("An error occurs while trying to get memberships for " + memberId, ex);
         }
     }
@@ -1398,7 +1377,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get memberships for {} ", memberIds, ex);
             throw new TechnicalManagementException("An error occurs while trying to get memberships for " + memberIds, ex);
         }
     }
@@ -1412,7 +1390,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get memberships for {} {} ", referenceType, referenceId, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to get memberships for " + referenceType + " " + referenceId,
                 ex
@@ -1429,7 +1406,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get memberships for {} {} {} and role", referenceType, referenceId, role, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to get memberships for " + referenceType + " " + referenceId + " and role " + role,
                 ex
@@ -1450,7 +1426,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get memberships for {} {} {} and role", referenceType, referenceIds, role, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to get memberships for " + referenceType + " " + referenceIds + " and role " + role,
                 ex
@@ -1471,7 +1446,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                     .map(this::convert)
                     .orElse(null);
             } catch (TechnicalException ex) {
-                log.error("An error occurs while trying to get primary owner for {} {} and role", referenceType, referenceId, ex);
                 throw new TechnicalManagementException(
                     "An error occurs while trying to get primary owner for " + referenceType + " " + referenceId,
                     ex
@@ -1525,7 +1499,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         } catch (Exception ex) {
             final String message =
                 "An error occurs while trying to get roles for " + referenceType + " " + referenceId + " " + memberType + " " + memberId;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -1663,7 +1636,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
 
             return memberEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get user member for {} {} {}", referenceType, referenceId, userId, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to get roles for " + referenceType + " " + referenceId + " " + userId,
                 ex
@@ -1794,15 +1766,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 );
             }
         } catch (TechnicalException ex) {
-            log.error(
-                "An error occurs while trying to remove role {} from member {} {} for {} {}",
-                roleId,
-                memberType,
-                memberId,
-                referenceType,
-                referenceId,
-                ex
-            );
             throw new TechnicalManagementException(
                 "An error occurs while trying to remove role " +
                     roleId +
@@ -1849,7 +1812,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 );
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to remove role {}", oldRoleId, ex);
             throw new TechnicalManagementException("An error occurs while trying to remove role " + oldRoleId, ex);
         }
     }
@@ -1885,7 +1847,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 new ApplicationAlertMembershipEvent(executionContext.getOrganizationId(), applicationIds, groupIds)
             );
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to remove member {} {}", memberType, memberId, ex);
             throw new TechnicalManagementException("An error occurs while trying to remove " + memberType + " " + memberId, ex);
         }
     }
@@ -2082,7 +2043,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 .map(role -> _addRoleToMemberOnReference(executionContext, reference, member, role, source, notify, false))
                 .collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update member for {} {}", reference.getType(), reference.getId(), ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to update member for " + reference.getType() + " " + reference.getId(),
                 ex

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MessageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MessageServiceImpl.java
@@ -189,7 +189,6 @@ public class MessageServiceImpl extends AbstractService implements MessageServic
             );
             return msgSize;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get create a message", ex);
             throw new TechnicalManagementException("An error occurs while trying to create a message", ex);
         }
     }
@@ -366,7 +365,6 @@ public class MessageServiceImpl extends AbstractService implements MessageServic
             }
             return recipientIds;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to get recipients", ex);
             throw new TechnicalManagementException("An error occurs while trying to get recipients", ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MetadataServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MetadataServiceImpl.java
@@ -84,7 +84,6 @@ public class MetadataServiceImpl extends TransactionalService implements Metadat
                 .map(this::convert)
                 .collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to find metadata by reference", ex);
             throw new TechnicalManagementException("An error occurred while trying to find metadata by reference", ex);
         }
     }
@@ -170,14 +169,12 @@ public class MetadataServiceImpl extends TransactionalService implements Metadat
             );
             return convert(metadata);
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to update metadata {}", metadataEntity.getName(), ex);
             throw new TechnicalManagementException("An error occurred while trying to update metadata " + metadataEntity.getName(), ex);
         }
     }
 
     private void checkMetadataValue(String value) {
         if (value == null || isBlank(value)) {
-            log.error("Error occurred while trying to validate null or empty value");
             throw new TechnicalManagementException("Metadata value is required");
         }
     }
@@ -224,7 +221,6 @@ public class MetadataServiceImpl extends TransactionalService implements Metadat
                 }
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete metadata {}", key, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete metadata " + key, ex);
         }
     }
@@ -240,7 +236,6 @@ public class MetadataServiceImpl extends TransactionalService implements Metadat
             final Optional<Metadata> optMetadata = metadataRepository.findById(key, referenceId, referenceType);
             return optMetadata.map(this::convert).orElse(null);
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to find default metadata by key", ex);
             throw new TechnicalManagementException("An error occurred while trying to find default metadata by key", ex);
         }
     }
@@ -320,7 +315,6 @@ public class MetadataServiceImpl extends TransactionalService implements Metadat
                     break;
             }
         } catch (final Exception e) {
-            log.error("Error occurred while trying to validate format '{}' of value '{}'", format, value, e);
             throw new TechnicalManagementException("Error occurred while trying to validate format " + format + " of value " + value, e);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotificationTemplateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotificationTemplateServiceImpl.java
@@ -290,7 +290,6 @@ public class NotificationTemplateServiceImpl extends AbstractService implements 
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to retrieve notificationTemplates", ex);
             throw new TechnicalManagementException("An error occurs while trying to retrieve notificationTemplates", ex);
         }
     }
@@ -406,7 +405,6 @@ public class NotificationTemplateServiceImpl extends AbstractService implements 
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to retrieve notificationTemplates by type", ex);
             throw new TechnicalManagementException("An error occurs while trying to retrieve notificationTemplates by type", ex);
         }
     }
@@ -451,7 +449,6 @@ public class NotificationTemplateServiceImpl extends AbstractService implements 
 
             return createdNotificationTemplateEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create or update notificationTemplate {}", newNotificationTemplate, ex);
             throw new TechnicalManagementException("An error occurs while trying to create or update " + newNotificationTemplate, ex);
         }
     }
@@ -494,7 +491,6 @@ public class NotificationTemplateServiceImpl extends AbstractService implements 
 
             return updatedNotificationTemplateEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create or update notificationTemplate {}", updatingNotificationTemplate, ex);
             throw new TechnicalManagementException("An error occurs while trying to create or update " + updatingNotificationTemplate, ex);
         }
     }
@@ -582,7 +578,6 @@ public class NotificationTemplateServiceImpl extends AbstractService implements 
             }
             throw new NotificationTemplateNotFoundException(id);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find a notificationTemplate using its ID {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to find a notificationTemplate using its ID " + id, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotifierServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotifierServiceImpl.java
@@ -343,7 +343,6 @@ public class NotifierServiceImpl extends AbstractService implements NotifierServ
 
             return notifiers;
         } catch (Exception ex) {
-            log.error("An error occurs while trying to list all notifiers", ex);
             throw new TechnicalManagementException("An error occurs while trying to list all notifiers", ex);
         }
     }
@@ -386,7 +385,6 @@ public class NotifierServiceImpl extends AbstractService implements NotifierServ
                 return notifierManager.getSchema(notifier);
             }
         } catch (IOException ioex) {
-            log.error("An error occurs while trying to get notifier schema for notifier {}", notifier, ioex);
             throw new TechnicalManagementException("An error occurs while trying to get notifier schema for notifier " + notifier, ioex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
@@ -85,7 +85,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
 
             return convert(optOrganization.get());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find organization by ID", ex);
             throw new TechnicalManagementException("An error occurs while trying to find organization by ID", ex);
         }
     }
@@ -104,7 +103,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
                 throw new OrganizationNotFoundException(organizationId);
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update organization {}", organizationEntity.getName(), ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to update organization " + organizationEntity.getName(),
                 ex
@@ -132,7 +130,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
                 return createdOrganization;
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update organization {}", organizationEntity.getName(), ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to update organization " + organizationEntity.getName(),
                 ex
@@ -155,7 +152,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
                 throw new OrganizationNotFoundException(organizationId);
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update organization {}", organizationEntity.getName(), ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to update organization " + organizationEntity.getName(),
                 ex
@@ -184,7 +180,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
         try {
             return organizationRepository.count();
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to count organizations", ex);
             throw new TechnicalManagementException("An error occurs while trying to count organizations ", ex);
         }
     }
@@ -197,7 +192,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
                 organizationRepository.delete(organizationId);
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete organization {}", organizationId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete organization " + organizationId, ex);
         }
     }
@@ -238,7 +232,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
             organizationRepository.create(defaultOrganization);
             return convert(defaultOrganization);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create default organization", ex);
             throw new TechnicalManagementException("An error occurs while trying to create default organization", ex);
         }
     }
@@ -248,7 +241,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
         try {
             return organizationRepository.findAll().stream().map(this::convert).collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to list all organizations", ex);
             throw new TechnicalManagementException("An error occurs while trying to list all organizations", ex);
         }
     }
@@ -258,7 +250,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
         try {
             return organizationRepository.findById(GraviteeContext.getDefaultOrganization()).map(this::convert).orElseGet(this::initialize);
         } catch (final Exception ex) {
-            log.error("Error while getting installation : {}", ex.getMessage());
             throw new TechnicalManagementException("Error while getting installation", ex);
         }
     }
@@ -272,7 +263,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
                 .map(this::convert)
                 .orElseThrow(() -> new OrganizationNotFoundException(cockpitId));
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find organization by cockpit id {}", cockpitId, ex);
             throw new TechnicalManagementException("An error occurs while trying to find organization by cockpit id " + cockpitId, ex);
         }
     }
@@ -282,7 +272,6 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
         try {
             return organizationRepository.findByHrids(hrids).stream().map(this::convert).collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to list all organizations", ex);
             throw new TechnicalManagementException("An error occurs while trying to list all organizations", ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageRevisionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageRevisionServiceImpl.java
@@ -56,7 +56,6 @@ public class PageRevisionServiceImpl extends TransactionalService implements Pag
         try {
             return pageRevisionRepository.findAll(pageable).map(this::convert);
         } catch (TechnicalException e) {
-            log.warn("An error occurs while trying to get the page revisions {}", pageable, e);
             throw new TechnicalManagementException("An error occurs while trying to get all page revisions", e);
         }
     }
@@ -67,7 +66,6 @@ public class PageRevisionServiceImpl extends TransactionalService implements Pag
         try {
             return pageRevisionRepository.findById(pageId, revision).map(this::convert);
         } catch (TechnicalException e) {
-            log.warn("An error occurs while trying to get the page revision {}-{}", pageId, revision, e);
             throw new TechnicalManagementException("An error occurs while trying to get a page revision", e);
         }
     }
@@ -78,7 +76,6 @@ public class PageRevisionServiceImpl extends TransactionalService implements Pag
         try {
             return pageRevisionRepository.findLastByPageId(pageId).map(this::convert);
         } catch (TechnicalException e) {
-            log.warn("An error occurs while trying to get the last revision for page {}", pageId, e);
             throw new TechnicalManagementException("An error occurs while trying to get the last page revision", e);
         }
     }
@@ -89,7 +86,6 @@ public class PageRevisionServiceImpl extends TransactionalService implements Pag
         try {
             return pageRevisionRepository.findAllByPageId(pageId).stream().map(this::convert).collect(Collectors.toList());
         } catch (TechnicalException e) {
-            log.warn("An error occurs while trying to get all the revisions for page {}", pageId, e);
             throw new TechnicalManagementException("An error occurs while trying to get all revisions", e);
         }
     }
@@ -108,7 +104,6 @@ public class PageRevisionServiceImpl extends TransactionalService implements Pag
 
             return convert(revision);
         } catch (TechnicalException e) {
-            log.warn("An error occurs while trying to create a revision for page {}", page.getId(), e);
             throw new TechnicalManagementException("An error occurs while trying to create a page revision", e);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -619,7 +619,6 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             try {
                 descriptor = swaggerService.parse(pageEntity.getContent());
             } catch (SwaggerDescriptorException sde) {
-                log.error("Parsing error for API id[{}]: {}", genericApiEntity.getId(), sde.getMessage());
                 throw sde;
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
@@ -331,9 +331,7 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
 
             return splitValue(this.getDefaultParameterValue(key), mapper, filter);
         } catch (final TechnicalException ex) {
-            final String message = "An error occurs while trying to find parameter values with key: " + key;
-            log.error(message, ex);
-            throw new TechnicalManagementException(message, ex);
+            throw new TechnicalManagementException("An error occurs while trying to find parameter values with key: " + key, ex);
         }
     }
 
@@ -395,9 +393,7 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
 
             return result;
         } catch (final TechnicalException ex) {
-            final String message = "An error occurs while trying to find parameter values with keys: " + keys;
-            log.error(message, ex);
-            throw new TechnicalManagementException(message, ex);
+            throw new TechnicalManagementException("An error occurs while trying to find parameter values with keys: " + keys, ex);
         }
     }
 
@@ -517,9 +513,10 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
                 return savedParameter;
             }
         } catch (final TechnicalException ex) {
-            final String message = "An error occurs while trying to create parameter for key/value: " + key + '/' + value;
-            log.error(message, ex);
-            throw new TechnicalManagementException(message, ex);
+            throw new TechnicalManagementException(
+                "An error occurs while trying to create parameter for key/value: " + key + '/' + value,
+                ex
+            );
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
@@ -205,13 +205,11 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             );
             return convert(plan);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create a plan {} for API {}", newPlan.getName(), newPlan.getReferenceId(), ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to create a plan %s for API %s", newPlan.getName(), newPlan.getReferenceId()),
                 ex
             );
         } catch (JsonProcessingException jse) {
-            log.error("Unexpected error while generating plan definition", jse);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to create a plan %s for API %s", newPlan.getName(), newPlan.getReferenceId()),
                 jse
@@ -338,13 +336,11 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
 
             return convert(newPlan);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update plan {}", updatePlan.getName(), ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to update plan %s", updatePlan.getName()),
                 ex
             );
         } catch (JsonProcessingException jse) {
-            log.error("Unexpected error while generating plan definition", jse);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to update a plan %s", updatePlan.getName()),
                 jse
@@ -437,7 +433,6 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
 
             return convert(plan);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to close plan: {}", planId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to close plan: %s", planId), ex);
         }
     }
@@ -483,7 +478,6 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             //reorder plan
             reorderedAndSavePlansAfterRemove(plan);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete plan: {}", planId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to delete plan: %s", planId), ex);
         }
     }
@@ -551,7 +545,6 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
 
             return convert(plan);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to publish plan: {}", planId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to publish plan: %s", planId), ex);
         }
     }
@@ -598,7 +591,6 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
 
             return convert(plan);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to deprecate plan: {}", planId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to deprecate plan: %s", planId), ex);
         }
     }
@@ -639,7 +631,6 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
             // update the modified plan
             return planRepository.update(planToReorder);
         } catch (final TechnicalException ex) {
-            log.error("An error occurs while trying to update plan {}", planToReorder.getId(), ex);
             throw new TechnicalManagementException("An error occurs while trying to update plan " + planToReorder.getId(), ex);
         }
     }
@@ -656,7 +647,6 @@ public class PlanServiceImpl extends AbstractService implements PlanService {
                         planRepository.updateOrder(plan.getId(), plan.getOrder() - 1);
                     }
                 } catch (final TechnicalException ex) {
-                    log.error("An error occurs while trying to reorder plan {}", plan.getId(), ex);
                     throw new TechnicalManagementException("An error occurs while trying to update plan " + plan.getId(), ex);
                 }
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PortalNotificationConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PortalNotificationConfigServiceImpl.java
@@ -93,7 +93,6 @@ public class PortalNotificationConfigServiceImpl extends AbstractService impleme
                 }
             }
         } catch (TechnicalException te) {
-            log.error("An error occurs while trying to save the notification settings {}", notificationEntity, te);
             throw new TechnicalManagementException(
                 "An error occurs while trying to save the notification settings " + notificationEntity,
                 te
@@ -121,7 +120,6 @@ public class PortalNotificationConfigServiceImpl extends AbstractService impleme
             notif.setGroupHooks(findGroupHooks(GraviteeContext.getExecutionContext(), user, referenceType, referenceId));
             return notif;
         } catch (TechnicalException te) {
-            log.error("An error occurs while trying to get the notification settings {}/{}/{}", user, referenceType, referenceId, te);
             throw new TechnicalManagementException(
                 "An error occurs while trying to get the notification settings " + user + "/" + referenceType + "/" + referenceId,
                 te
@@ -134,7 +132,6 @@ public class PortalNotificationConfigServiceImpl extends AbstractService impleme
         try {
             portalNotificationConfigRepository.deleteByUser(user);
         } catch (TechnicalException te) {
-            log.error("An error occurs while trying to delete notification settings for user {}", user, te);
             throw new TechnicalManagementException("An error occurs while trying to delete notification settings for user " + user, te);
         }
     }
@@ -144,7 +141,6 @@ public class PortalNotificationConfigServiceImpl extends AbstractService impleme
         try {
             portalNotificationConfigRepository.deleteByReferenceIdAndReferenceType(referenceId, referenceType);
         } catch (TechnicalException te) {
-            log.error("An error occurs while trying to delete notification settings for reference {} / {}", referenceType, referenceId, te);
             throw new TechnicalManagementException(
                 "An error occurs while trying to delete notification settings for reference " + referenceType + " / " + referenceId,
                 te

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PortalNotificationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PortalNotificationServiceImpl.java
@@ -57,7 +57,6 @@ public class PortalNotificationServiceImpl extends AbstractService implements Po
         try {
             return portalNotificationRepository.findByUser(user).stream().map(this::convert).collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find notifications by user {}", user, ex);
             throw new TechnicalManagementException("An error occurs while trying to find notifications by username " + user, ex);
         }
     }
@@ -71,7 +70,6 @@ public class PortalNotificationServiceImpl extends AbstractService implements Po
             }
             throw new PortalNotificationNotFoundException(notificationId);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find notification with id {}", notificationId, ex);
             throw new TechnicalManagementException("An error occurs while trying to find notification with id " + notificationId, ex);
         }
     }
@@ -101,7 +99,6 @@ public class PortalNotificationServiceImpl extends AbstractService implements Po
 
             create(notifications);
         } catch (final Exception ex) {
-            log.error("Error while sending notification", ex);
             throw new TechnicalManagementException("Error while sending notification", ex);
         }
     }
@@ -111,7 +108,6 @@ public class PortalNotificationServiceImpl extends AbstractService implements Po
         try {
             portalNotificationRepository.deleteAll(user);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete all notifications for user  {}", user, ex);
             throw new TechnicalManagementException("An error occurs while trying delete all notifications for user " + user, ex);
         }
     }
@@ -121,7 +117,6 @@ public class PortalNotificationServiceImpl extends AbstractService implements Po
         try {
             portalNotificationRepository.delete(notificationId);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete {}", notificationId, ex);
             throw new TechnicalManagementException("An error occurs while trying delete " + notificationId, ex);
         }
     }
@@ -136,7 +131,6 @@ public class PortalNotificationServiceImpl extends AbstractService implements Po
         try {
             portalNotificationRepository.create(notifications);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create {}", notifications, ex);
             throw new TechnicalManagementException("An error occurs while trying create " + notifications, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/QualityRuleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/QualityRuleServiceImpl.java
@@ -78,7 +78,6 @@ public class QualityRuleServiceImpl extends AbstractService implements QualityRu
                 .orElseThrow(() -> new QualityRuleNotFoundException(id));
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to find a quality rule using its ID: " + id;
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -89,7 +88,6 @@ public class QualityRuleServiceImpl extends AbstractService implements QualityRu
             log.debug("Find all quality rules");
             return qualityRuleRepository.findAll().stream().map(this::convert).collect(toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all quality rules", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all quality rules", ex);
         }
     }
@@ -104,7 +102,6 @@ public class QualityRuleServiceImpl extends AbstractService implements QualityRu
                 .map(this::convert)
                 .toList();
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find quality rules for {} [{}]", referenceType, referenceId, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to find quality rules for reference" + referenceType + " " + referenceId,
                 ex
@@ -134,7 +131,6 @@ public class QualityRuleServiceImpl extends AbstractService implements QualityRu
             );
             return convert(createdQualityRule);
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to create a quality rule {}", newEntity, e);
             throw new TechnicalManagementException("An error occurs while trying to create a quality rule " + newEntity, e);
         }
     }
@@ -163,7 +159,6 @@ public class QualityRuleServiceImpl extends AbstractService implements QualityRu
             );
             return convert(updatedQualityRule);
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to update quality rule {}", updateEntity, e);
             throw new TechnicalManagementException("An error occurs while trying to update quality rule " + updateEntity, e);
         }
     }
@@ -194,7 +189,6 @@ public class QualityRuleServiceImpl extends AbstractService implements QualityRu
                 );
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete quality rule {}", qualityRule, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete quality rule " + qualityRule, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RatingServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RatingServiceImpl.java
@@ -123,7 +123,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
 
             return convert(executionContext, rating);
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to create rating on api {}", ratingEntity.getApi(), ex);
             throw new TechnicalManagementException("An error occurred while trying to create rating on api " + ratingEntity.getApi(), ex);
         }
     }
@@ -165,7 +164,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
 
             return convert(executionContext, rating);
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to create a rating answer on rating {}", answerEntity.getRatingId(), ex);
             throw new TechnicalManagementException(
                 "An error occurred while trying to create a rating answer on rating" + answerEntity.getRatingId(),
                 ex
@@ -186,7 +184,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
                 .orElseThrow(() -> new RatingAnswerNotFoundException(answerId));
             return convert(executionContext, ratingAnswer);
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to find rating answer by answer id {}", answerId, ex);
             throw new TechnicalManagementException("An error occurred while trying to find rating answer by answer id " + answerId, ex);
         }
     }
@@ -219,7 +216,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
                 .findByReferenceIdAndReferenceTypePageable(api, RatingReferenceType.API, convert(pageable))
                 .map(rating -> convert(executionContext, rating));
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to find ratings for api {}", api, ex);
             throw new TechnicalManagementException("An error occurred while trying to find ratings for api " + api, ex);
         }
     }
@@ -236,7 +232,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
                 .map(rating -> convert(executionContext, rating))
                 .collect(toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to find ratings for api {}", api, ex);
             throw new TechnicalManagementException("An error occurred while trying to find ratings for api " + api, ex);
         }
     }
@@ -258,7 +253,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
             ratingSummary.setNumberOfRatingsByRate(ratings.stream().collect(groupingBy(Rating::getRate, counting())));
             return ratingSummary;
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to find summary rating for api {}", api, ex);
             throw new TechnicalManagementException("An error occurred while trying to find summary rating for api " + api, ex);
         }
     }
@@ -271,7 +265,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
         try {
             return ratingRepository.findReferenceIdsOrderByRate(new RatingCriteria.Builder().referenceIds(apis).build());
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to compute ranking for apis {}", apis, ex);
             throw new TechnicalManagementException("An error occurred while trying to compute ranking for apis " + apis, ex);
         }
     }
@@ -294,7 +287,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
         } catch (final TechnicalException ex) {
             final String message =
                 "An error occurred while trying to find rating for api " + api + " and user " + getAuthenticatedUsername();
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -334,7 +326,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
             );
             return convert(executionContext, updatedRating);
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to update rating {}", ratingEntity.getId(), ex);
             throw new TechnicalManagementException("An error occurred while trying to update rating " + ratingEntity.getId(), ex);
         }
     }
@@ -353,7 +344,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
                 rating.getReferenceId()
             );
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete rating {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete rating " + id, ex);
         }
     }
@@ -377,7 +367,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
                 rating.getReferenceId()
             );
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete rating answer {}", answerId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete rating answer " + answerId, ex);
         }
     }
@@ -398,7 +387,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
             }
             return ratingOptional.get();
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to find a rating by id {}", id, ex);
             throw new TechnicalManagementException("An error occurred while trying to find a rating by id " + id, ex);
         }
     }
@@ -431,7 +419,6 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
                 );
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to find rating answers by rating id {}", rating.getId(), ex);
             throw new TechnicalManagementException(
                 "An error occurred while trying to find rating answers by rating id " + rating.getId(),
                 ex

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -150,7 +150,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                     .map(this::convert)
                     .orElseThrow(() -> new RoleNotFoundException(k));
             } catch (TechnicalException ex) {
-                log.error("An error occurs while trying to find a role : {}", k, ex);
                 throw new TechnicalManagementException("An error occurs while trying to find a role : " + k, ex);
             }
         });
@@ -177,7 +176,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
             try {
                 roleRepository.findAllByIdIn(missingRoleIds).forEach(role -> cache.put(role.getId(), convert(role)));
             } catch (TechnicalException ex) {
-                log.error("An error occurs while trying to find roles by ids: {}", missingRoleIds, ex);
                 throw new TechnicalManagementException("An error occurs while trying to find roles by ids", ex);
             }
         }
@@ -193,7 +191,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 .findByIdAndReferenceIdAndReferenceType(roleId, organizationId, RoleReferenceType.ORGANIZATION)
                 .map(this::convert);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find roles by id and organizationId", ex);
             throw new TechnicalManagementException("An error occurs while trying to find roles by id and organizationId", ex);
         }
     }
@@ -208,7 +205,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 .map(this::convert)
                 .collect(toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all roles", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all roles", ex);
         }
     }
@@ -251,7 +247,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
             }
             return entity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create role {}", roleEntity.getName(), ex);
             throw new TechnicalManagementException("An error occurs while trying to create role " + roleEntity.getName(), ex);
         }
     }
@@ -295,7 +290,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
             }
             return entity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update role {}", roleEntity.getName(), ex);
             throw new TechnicalManagementException("An error occurs while trying to update role " + roleEntity.getName(), ex);
         }
     }
@@ -328,7 +322,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                     .build()
             );
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete role {}", roleId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete role " + roleId, ex);
         }
     }
@@ -344,7 +337,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 .sorted(comparing(RoleEntity::getName))
                 .collect(toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find roles by scope", ex);
             throw new TechnicalManagementException("An error occurs while trying to find roles by scope", ex);
         }
     }
@@ -358,7 +350,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 .findByScopeAndNameAndReferenceIdAndReferenceType(convert(scope), name, organizationId, RoleReferenceType.ORGANIZATION)
                 .map(this::convert);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find roles by scope", ex);
             throw new TechnicalManagementException("An error occurs while trying to find roles by scope", ex);
         }
     }
@@ -380,7 +371,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
             }
             return roles;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find default roles by scope", ex);
             throw new TechnicalManagementException("An error occurs while trying to find default roles by scope", ex);
         }
     }
@@ -616,7 +606,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 organizationId
             );
         } catch (TechnicalManagementException ex) {
-            log.error("An error occurs while trying to create admin roles", ex);
             throw new TechnicalManagementException("An error occurs while trying to create admin roles ", ex);
         }
     }
@@ -687,7 +676,6 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 );
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create {} {} roles", roleName.name(), roleScope.name(), ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to create " + roleName.name() + " " + roleScope.name() + " roles ",
                 ex

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -261,7 +261,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 .map(this::convert)
                 .orElseThrow(() -> new SubscriptionNotFoundException(subscriptionId));
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find a subscription using its ID: {}", subscriptionId, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to find a subscription using its ID: %s", subscriptionId),
                 ex
@@ -274,7 +273,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         try {
             return subscriptionRepository.findByIdIn(subscriptionIds).stream().map(this::convert).collect(toSet());
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to find subscriptions using IDs [{}]", subscriptionIds, e);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to find subscriptions using IDs [%s]", subscriptionIds),
                 e
@@ -819,7 +817,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 return convert(subscription);
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to subscribe to the plan {}", plan, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to subscribe to the plan %s", plan), ex);
         }
     }
@@ -1094,11 +1091,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             return convert(subscription);
         } catch (TechnicalException ex) {
-            log.error(
-                "An error occurs while trying to update subscription {} configuration",
-                subscriptionConfigEntity.getSubscriptionId(),
-                ex
-            );
             throw new TechnicalManagementException(
                 String.format(
                     "An error occurs while trying to update subscription %s configuration",
@@ -1129,7 +1121,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                     try {
                         return subscriptionRepository.update(subscription);
                     } catch (TechnicalException ex) {
-                        log.error("An error occurs while trying to update subscription {}", subscriptionId, ex);
                         throw new TechnicalManagementException(
                             String.format("An error occurs while trying to update subscription %s", subscriptionId),
                             ex
@@ -1139,7 +1130,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 .map(this::convert)
                 .orElseThrow(() -> new SubscriptionNotFoundException(subscriptionId));
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update subscription {}", subscriptionId, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to update subscription %s", subscriptionId),
                 ex
@@ -1212,7 +1202,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             throw new SubscriptionNotUpdatableException(updateSubscription.getId());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update subscription {}", updateSubscription.getId(), ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to update subscription %s", updateSubscription.getId()),
                 ex
@@ -1726,7 +1715,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             throw new SubscriptionNotPausedException(subscription);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to resume subscription {}", subscriptionId, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to resume subscription %s", subscriptionId),
                 ex
@@ -1777,7 +1765,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             throw new SubscriptionNotClosedException(subscriptionId);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to restore subscription {}", subscriptionId, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to restore subscription %s", subscriptionId),
                 ex
@@ -1810,7 +1797,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 null
             );
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete subscription: {}", subscriptionId, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to delete subscription: %s", subscriptionId),
                 ex
@@ -1855,7 +1841,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             return subscriptionsStream.collect(toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to search for subscriptions: {}", query, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to search for subscriptions: %s", query),
                 ex
@@ -1922,7 +1907,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 );
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to search for pageable subscriptions: {}", query, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to search for pageable subscriptions: %s", query),
                 ex
@@ -2101,7 +2085,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             }
             return subscriptionEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to transfer subscription {} by {}", transferSubscription.getId(), userId, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to transfer subscription %s by %s", transferSubscription.getId(), userId),
                 ex
@@ -2172,7 +2155,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         try {
             return subscriptionRepository.findReferenceIdsOrderByNumberOfSubscriptions(toSubscriptionCriteriaBuilder(query).build(), order);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to findReferenceIdsOrderByNumberOfSubscriptions for subscriptions: {}", query, ex);
             throw new TechnicalManagementException(
                 String.format("An error occurs while trying to findReferenceIdsOrderByNumberOfSubscriptions for subscriptions: %s", query),
                 ex

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
@@ -83,7 +83,6 @@ public class TagServiceImpl extends AbstractService implements TagService {
                 .map(this::convert)
                 .collect(toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all tags", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all tags", ex);
         }
     }
@@ -100,7 +99,6 @@ public class TagServiceImpl extends AbstractService implements TagService {
 
             return convert(optTag.get());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find tag by ID", ex);
             throw new TechnicalManagementException("An error occurs while trying to find tag by ID", ex);
         }
     }
@@ -165,7 +163,6 @@ public class TagServiceImpl extends AbstractService implements TagService {
                         .build()
                 );
             } catch (TechnicalException ex) {
-                log.error("An error occurs while trying to create tag {}", tagEntity.getName(), ex);
                 throw new TechnicalManagementException("An error occurs while trying to create tag " + tagEntity.getName(), ex);
             }
         });
@@ -205,7 +202,6 @@ public class TagServiceImpl extends AbstractService implements TagService {
                     );
                 }
             } catch (TechnicalException ex) {
-                log.error("An error occurs while trying to update tag {}", tagEntity.getName(), ex);
                 throw new TechnicalManagementException("An error occurs while trying to update tag " + tagEntity.getName(), ex);
             }
         });
@@ -232,7 +228,6 @@ public class TagServiceImpl extends AbstractService implements TagService {
                 );
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete tag {}", tagId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete tag " + tagId, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TaskServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TaskServiceImpl.java
@@ -212,7 +212,6 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
 
             return tasks;
         } catch (TechnicalException e) {
-            log.error("Error retrieving user tasks {}", e.getMessage());
             throw new TechnicalManagementException("Error retreiving user tasks", e);
         }
     }
@@ -363,7 +362,7 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
                         .getContent()
                 );
             } catch (TechnicalException e) {
-                log.error("Error retrieving API Product IDs for environment admin tasks: {}", e.getMessage());
+                log.error("Error retrieving API Product IDs for environment admin tasks", e);
             }
         }
 
@@ -402,7 +401,7 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
                     metadata.put(workflow.getReferenceId(), "environmentId", api.getEnvironmentId());
                 });
             } catch (TechnicalException e) {
-                log.error("Error retrieving api task metadata {}", e.getMessage());
+                log.error("Error retrieving api task metadata for workflow [{}]", workflow.getReferenceId(), e);
             }
         }
     }
@@ -416,7 +415,7 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
                 metadata.put(subscription.getApplication(), "environmentId", value.getEnvironmentId());
             });
         } catch (TechnicalException e) {
-            log.error("Error retrieving application task metadata {}", e.getMessage());
+            log.error("Error retrieving application task metadata for application [{}]", subscription.getApplication(), e);
         }
     }
 
@@ -441,7 +440,7 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
                 }
             }
         } catch (TechnicalException e) {
-            log.error("Error retrieving plan task metadata {}", e.getMessage());
+            log.error("Error retrieving plan task metadata for plan [{}]", subscription.getPlan(), e);
         }
     }
 
@@ -452,7 +451,6 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
             taskEntity.setCreatedAt(user.getCreatedAt());
             taskEntity.setData(user);
         } catch (Exception e) {
-            log.error("Error converting user {} to a Task", user.getId());
             throw new TechnicalManagementException("Error converting user " + user.getId() + " to a Task", e);
         }
         return taskEntity;
@@ -465,7 +463,6 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
             taskEntity.setCreatedAt(subscription.getCreatedAt());
             taskEntity.setData(subscription);
         } catch (Exception e) {
-            log.error("Error converting subscription {} to a Task", subscription.getId());
             throw new TechnicalManagementException("Error converting subscription " + subscription.getId() + " to a Task", e);
         }
         return taskEntity;
@@ -478,9 +475,7 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
             taskEntity.setCreatedAt(workflow.getCreatedAt());
             taskEntity.setData(workflow);
         } catch (Exception e) {
-            final String error = "Error converting workflow " + workflow.getId() + " to a Task";
-            log.error(error);
-            throw new TechnicalManagementException(error, e);
+            throw new TechnicalManagementException("Error converting workflow " + workflow.getId() + " to a Task", e);
         }
         return taskEntity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TenantServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TenantServiceImpl.java
@@ -76,7 +76,6 @@ public class TenantServiceImpl extends TransactionalService implements TenantSer
 
             return convert(optTenant.get());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find tenant by ID", ex);
             throw new TechnicalManagementException("An error occurs while trying to find tenant by ID", ex);
         }
     }
@@ -91,7 +90,6 @@ public class TenantServiceImpl extends TransactionalService implements TenantSer
                 .map(this::convert)
                 .collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all tenants", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all tenants", ex);
         }
     }
@@ -131,7 +129,6 @@ public class TenantServiceImpl extends TransactionalService implements TenantSer
                         .build()
                 );
             } catch (TechnicalException ex) {
-                log.error("An error occurs while trying to create tenant {}", tenantEntity.getName(), ex);
                 throw new TechnicalManagementException("An error occurs while trying to create tenant " + tenantEntity.getName(), ex);
             }
         });
@@ -171,7 +168,6 @@ public class TenantServiceImpl extends TransactionalService implements TenantSer
                     );
                 }
             } catch (TechnicalException ex) {
-                log.error("An error occurs while trying to update tenant {}", tenantEntity.getName(), ex);
                 throw new TechnicalManagementException("An error occurs while trying to update tenant " + tenantEntity.getName(), ex);
             }
         });
@@ -201,7 +197,6 @@ public class TenantServiceImpl extends TransactionalService implements TenantSer
                 tenantRepository.delete(tenantId);
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete tenant {}", tenantId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete tenant " + tenantId, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ThemeServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ThemeServiceImpl.java
@@ -103,7 +103,6 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all themes", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all themes", ex);
         }
     }
@@ -124,14 +123,10 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
 
             Theme theme = optTheme.get();
             if (!theme.getReferenceId().equals(executionContext.getEnvironmentId())) {
-                log.warn(
-                    "Theme is not in current environment " + executionContext.getEnvironmentId() + " actual:" + theme.getReferenceId()
-                );
                 throw new ThemeNotFoundException(themeId);
             }
             return theme;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find theme by ID", ex);
             throw new TechnicalManagementException("An error occurs while trying to find theme by ID", ex);
         }
     }
@@ -167,7 +162,6 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             return convertToPortalThemeEntity(theme);
         } catch (TechnicalException ex) {
             final String error = "An error occurred while trying to create theme " + themeEntity;
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -194,9 +188,6 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
                 final Theme theme = new Theme(themeOptional.get());
 
                 if (!theme.getReferenceId().equals(executionContext.getEnvironmentId())) {
-                    log.warn(
-                        "Theme is not in current environment " + executionContext.getEnvironmentId() + " actual:" + theme.getReferenceId()
-                    );
                     throw new ThemeNotFoundException(theme.getId());
                 }
 
@@ -261,7 +252,6 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             }
         } catch (TechnicalException | JsonProcessingException ex) {
             final String error = "An error occurred while trying to update theme " + updateThemeEntity;
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -291,7 +281,6 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             }
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to delete theme " + themeId;
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -302,7 +291,6 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             return findEnvironmentPortalThemes(executionContext).filter(ThemeEntity::isEnabled).orElseGet(this::buildDefaultPortalTheme);
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to find enabled theme";
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -313,7 +301,6 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             return findEnvironmentPortalThemes(executionContext).orElseGet(() -> createDefaultPortalTheme(executionContext));
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to find theme or create default";
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -426,7 +413,6 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             return jsonNode.toString();
         } catch (IOException ex) {
             final String error = "Error while trying to load a theme from the definition path: " + path;
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -486,7 +472,6 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             return null;
         } catch (Exception ex) {
             final String error = "Error while trying to reset a default theme";
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TicketServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TicketServiceImpl.java
@@ -202,7 +202,6 @@ public class TicketServiceImpl extends AbstractService implements TicketService 
 
             return convert(createdTicket);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create a ticket {}", ticketEntity, ex);
             throw new TechnicalManagementException("An error occurs while trying to create a ticket " + ticketEntity, ex);
         }
     }
@@ -232,7 +231,6 @@ public class TicketServiceImpl extends AbstractService implements TicketService 
                 tickets.getTotalElements()
             );
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to search tickets", ex);
             throw new TechnicalManagementException("An error occurs while trying to search tickets", ex);
         }
     }
@@ -247,7 +245,6 @@ public class TicketServiceImpl extends AbstractService implements TicketService 
                 .map(this::convert)
                 .orElseThrow(() -> new TicketNotFoundException(ticketId));
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to search ticket {}", ticketId, ex);
             throw new TechnicalManagementException("An error occurs while trying to search ticket " + ticketId, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TokenServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TokenServiceImpl.java
@@ -71,7 +71,6 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
             return tokenRepository.findByReference(TokenReferenceType.USER.name(), userId).stream().map(this::convert).collect(toList());
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to find all tokens";
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -101,7 +100,6 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
             return convert(tokenRepository.create(token), decodedToken);
         } catch (TechnicalException e) {
             final String error = "An error occurs while trying to create a token " + newToken;
-            log.error(error, e);
             throw new TechnicalManagementException(error, e);
         }
     }
@@ -131,7 +129,6 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
             }
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to delete token " + tokenId;
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }
@@ -175,7 +172,6 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
                 .isPresent();
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to check if token exists";
-            log.error(error, ex);
             throw new TechnicalManagementException(error, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserMetadataServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserMetadataServiceImpl.java
@@ -132,7 +132,6 @@ public class UserMetadataServiceImpl extends AbstractReferenceMetadataService im
                 pageNumber++;
             } while (pageOfUser.getPageElements() > 0);
         } catch (TechnicalException ex) {
-            log.error("An error occurred while trying to all metadata with key {}", key, ex);
             throw new TechnicalManagementException("An error occurred while trying to all metadata with key " + key, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -380,7 +380,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             searchEngineService.index(executionContext, userEntity, false);
             return userEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to connect {}", userId, ex);
             throw new TechnicalManagementException("An error occurs while trying to connect " + userId, ex);
         }
     }
@@ -408,7 +407,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 //should never happen
                 throw new UserNotFoundException(k);
             } catch (TechnicalException ex) {
-                log.error("An error occurs while trying to find user using its ID {}", k, ex);
                 throw new TechnicalManagementException("An error occurs while trying to find user using its ID " + k, ex);
             }
         });
@@ -424,7 +422,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 .map(user -> convert(user, false))
                 .toList();
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find user using its email", ex);
             throw new TechnicalManagementException("An error occurs while trying to find user using its email", ex);
         }
     }
@@ -439,7 +436,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 .map(user -> convertWithFlags(executionContext, user))
                 .orElseThrow(() -> new UserNotFoundException(userId)); // should never happen
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find user using its ID {}", userId, ex);
             throw new TechnicalManagementException("An error occurs while trying to find user using its ID " + userId, ex);
         }
     }
@@ -454,7 +450,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 .map(user -> convert(user, loadRoles, emptyList(), false))
                 .orElseThrow(() -> new UserNotFoundException(sourceId));
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find user using source[{}], user[{}]", source, sourceId, ex);
             throw new TechnicalManagementException("An error occurs while trying to find user using source " + source + ':' + sourceId, ex);
         }
     }
@@ -486,7 +481,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             }
         } catch (TechnicalException ex) {
             Optional<String> idsAsString = ids.stream().reduce((a, b) -> a + '/' + b);
-            log.error("An error occurs while trying to find users using their ID {}", idsAsString, ex);
             throw new TechnicalManagementException("An error occurs while trying to find users using their ID " + idsAsString, ex);
         }
     }
@@ -624,7 +618,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         } catch (AbstractManagementException ex) {
             throw ex;
         } catch (Exception ex) {
-            log.error("An error occurs while trying to create an internal user with the token {}", registerUserEntity.getToken(), ex);
             throw new TechnicalManagementException(ex.getMessage(), ex);
         }
     }
@@ -678,11 +671,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         } catch (AbstractManagementException ex) {
             throw ex;
         } catch (Exception ex) {
-            log.error(
-                "An error occurs while trying to change password of an internal user with the token {}",
-                registerUserEntity.getToken(),
-                ex
-            );
             throw new TechnicalManagementException(ex.getMessage(), ex);
         }
     }
@@ -818,7 +806,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             searchEngineService.index(executionContext, userEntity, false);
             return userEntity;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create an external user {}", newExternalUserEntity, ex);
             throw new TechnicalManagementException("An error occurs while trying to create an external user" + newExternalUserEntity, ex);
         }
     }
@@ -975,19 +962,12 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 );
             }
         } catch (final TechnicalException e) {
-            log.error(
-                "An error occurs while trying to create user {} / {}",
-                newExternalUserEntity.getSource(),
-                newExternalUserEntity.getSourceId(),
-                e
-            );
             throw new TechnicalManagementException(e.getMessage(), e);
         }
 
         final UserEntity userEntity = create(executionContext, newExternalUserEntity, true, autoRegistrationEnabled);
 
         if (userEntity == null) {
-            log.error("An error occurs while trying to create user");
             throw new TechnicalManagementException("An error occurs while trying to create user");
         }
 
@@ -1077,7 +1057,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             }
             throw new UserNotFoundException(userId);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to validate user registration {}", userId, ex);
             throw new TechnicalManagementException("An error occurs while trying to create an external user" + userId, ex);
         }
     }
@@ -1265,7 +1244,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
             return convert(updatedUser, true, updatedMetadata, true);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update {}", updateUserEntity, ex);
             throw new TechnicalManagementException("An error occurs while trying update " + updateUserEntity, ex);
         }
     }
@@ -1356,7 +1334,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
             return new Page<>(entities, users.getPageNumber() + 1, (int) users.getPageElements(), users.getTotalElements());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to search users", ex);
             throw new TechnicalManagementException("An error occurs while trying to search users", ex);
         }
     }
@@ -1431,7 +1408,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             final UserEntity userEntity = convert(user, false);
             searchEngineService.delete(executionContext, userEntity);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete user", ex);
             throw new TechnicalManagementException("An error occurs while trying to delete user", ex);
         }
     }
@@ -1511,7 +1487,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                         .filter(evt -> user.getId().equals(evt.getProperties().get(USER.name())))
                         .findFirst();
                     if (optReset.isPresent()) {
-                        log.warn("Multiple reset password received for user '{}' in less than 1 hour", user.getId());
                         throw new PasswordAlreadyResetException();
                     }
                 }
@@ -1547,7 +1522,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             );
         } catch (TechnicalException ex) {
             final String message = "An error occurs while trying to reset password for user " + id;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -2176,7 +2150,6 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 );
             } catch (TechnicalException e) {
                 final String msg = "An error occurs while finding memberships for user " + userId;
-                log.error(msg, e);
                 throw new TechnicalManagementException(msg, e);
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/WorkflowServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/WorkflowServiceImpl.java
@@ -66,7 +66,6 @@ public class WorkflowServiceImpl extends TransactionalService implements Workflo
             return workflowRepository.create(workflow);
         } catch (TechnicalException ex) {
             final String message = "An error occurs while trying to create workflow of type " + workflow.getType();
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -82,7 +81,6 @@ public class WorkflowServiceImpl extends TransactionalService implements Workflo
         } catch (TechnicalException ex) {
             final String message =
                 "An error occurs while trying to find workflow by ref " + referenceType + "/" + referenceId + " and type " + type;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }
@@ -101,7 +99,6 @@ public class WorkflowServiceImpl extends TransactionalService implements Workflo
         } catch (TechnicalException ex) {
             final String message =
                 "An error occurs while trying to find workflows by refs " + referenceType + "/" + referenceIds + " and type " + type;
-            log.error(message, ex);
             throw new TechnicalManagementException(message, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
@@ -94,7 +94,6 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to retrieve client registration providers", ex);
             throw new TechnicalManagementException("An error occurs while trying to retrieve client registration providers", ex);
         }
     }
@@ -162,7 +161,6 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
 
             return convert(createdClientRegistrationProvider);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create client registration provider {}", newClientRegistrationProvider, ex);
             throw new TechnicalManagementException("An error occurs while trying to create " + newClientRegistrationProvider, ex);
         }
     }
@@ -230,7 +228,6 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
 
             return convert(updatedClientRegistrationProvider);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update client registration provider {}", updateClientRegistrationProvider, ex);
             throw new TechnicalManagementException("An error occurs while trying to update " + updateClientRegistrationProvider, ex);
         }
     }
@@ -267,7 +264,6 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
 
             throw new ClientRegistrationProviderNotFoundException(id);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find a client registration provider using its ID {}", id, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to delete a client registration provider using its ID " + id,
                 ex
@@ -301,7 +297,6 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
                     .build()
             );
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete a client registration provider using its ID {}", id, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to delete a client registration provider using its ID " + id,
                 ex

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/DiscoveryBasedDynamicClientRegistrationProviderClient.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/DiscoveryBasedDynamicClientRegistrationProviderClient.java
@@ -66,11 +66,6 @@ public class DiscoveryBasedDynamicClientRegistrationProviderClient extends Dynam
                         throw new DynamicClientRegistrationException("OIDC Discovery response is not well-formed");
                     }
                 } else {
-                    log.error(
-                        "Unexpected response status from OIDC Discovery endpoint: status[{}] message[{}]",
-                        status,
-                        EntityUtils.toString(response.getEntity())
-                    );
                     throw new DynamicClientRegistrationException("Unexpected response status from OIDC Discovery endpoint");
                 }
             });
@@ -80,7 +75,6 @@ public class DiscoveryBasedDynamicClientRegistrationProviderClient extends Dynam
             metadata.put("registration_endpoint", discovery.getRegistrationEndpoint());
             metadata.put("token_endpoint", discovery.getTokenEndpoint());
         } catch (Exception ex) {
-            log.error("Unexpected error while getting OIDC metadata from Discovery endpoint: " + ex.getMessage(), ex);
             throw new DynamicClientRegistrationException(
                 "Unexpected error while getting OIDC metadata from Discovery endpoint: " + ex.getMessage(),
                 ex

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/DynamicClientRegistrationProviderClient.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/DynamicClientRegistrationProviderClient.java
@@ -92,16 +92,10 @@ public abstract class DynamicClientRegistrationProviderClient {
                             JsonNode node = mapper.readTree(responsePayload);
                             String error = node.path("error").asText();
                             String description = node.path("error_description").asText();
-                            log.error("Unexpected response from OIDC Registration endpoint: error[{}] description[{}]", error, description);
                             throw new DynamicClientRegistrationException(
                                 "Unexpected response from OIDC Registration endpoint: error[" + error + "] description[" + description + "]"
                             );
                         } catch (JsonProcessingException ex) {
-                            log.error(
-                                "Unexpected response from OIDC Registration endpoint: status[{}] message[{}]",
-                                status,
-                                responsePayload
-                            );
                             throw new DynamicClientRegistrationException(
                                 "Unexpected response from OIDC Registration endpoint: status[" +
                                     status +
@@ -111,7 +105,6 @@ public abstract class DynamicClientRegistrationProviderClient {
                             );
                         }
                     } else {
-                        log.error("Unexpected response from OIDC Registration endpoint: status[{}]", status);
                         throw new DynamicClientRegistrationException(
                             "Unexpected response from OIDC Registration endpoint: status[" + status + "]"
                         );
@@ -119,7 +112,6 @@ public abstract class DynamicClientRegistrationProviderClient {
                 }
             });
         } catch (Exception ex) {
-            log.error("Unexpected error while registering client: " + ex.getMessage(), ex);
             throw new DynamicClientRegistrationException("Unexpected error while registering client: " + ex.getMessage(), ex);
         }
     }
@@ -167,16 +159,10 @@ public abstract class DynamicClientRegistrationProviderClient {
                             JsonNode node = mapper.readTree(responsePayload);
                             String error = node.path("error").asText();
                             String description = node.path("error_description").asText();
-                            log.error("Unexpected response from OIDC Registration endpoint: error[{}] description[{}]", error, description);
                             throw new DynamicClientRegistrationException(
                                 "Unexpected response from OIDC Registration endpoint: error[" + error + "] description[" + description + "]"
                             );
                         } catch (JsonProcessingException ex) {
-                            log.error(
-                                "Unexpected response from OIDC Registration endpoint: status[{}] message[{}]",
-                                status,
-                                responsePayload
-                            );
                             throw new DynamicClientRegistrationException(
                                 "Unexpected response from OIDC Registration endpoint: status[" +
                                     status +
@@ -186,7 +172,6 @@ public abstract class DynamicClientRegistrationProviderClient {
                             );
                         }
                     } else {
-                        log.error("Unexpected response from OIDC Registration endpoint: status[{}]", status);
                         throw new DynamicClientRegistrationException(
                             "Unexpected response from OIDC Registration endpoint: status[" + status + "]"
                         );
@@ -194,7 +179,6 @@ public abstract class DynamicClientRegistrationProviderClient {
                 }
             });
         } catch (Exception ex) {
-            log.error("Unexpected error while registering client: " + ex.getMessage(), ex);
             throw new DynamicClientRegistrationException("Unexpected error while registering client: " + ex.getMessage(), ex);
         }
     }
@@ -234,11 +218,6 @@ public abstract class DynamicClientRegistrationProviderClient {
                             JsonNode node = mapper.readTree(responsePayload);
                             String error = node.path("error").asText();
                             String description = node.path("error_description").asText();
-                            log.error(
-                                "Unexpected response from renew client secret endpoint: error[{}] description[{}]",
-                                error,
-                                description
-                            );
                             throw new DynamicClientRegistrationException(
                                 "Unexpected response from renew client secret endpoint: error[" +
                                     error +
@@ -247,11 +226,6 @@ public abstract class DynamicClientRegistrationProviderClient {
                                     "]"
                             );
                         } catch (JsonProcessingException ex) {
-                            log.error(
-                                "Unexpected response from renew client secret endpoint: status[{}] message[{}]",
-                                status,
-                                responsePayload
-                            );
                             throw new DynamicClientRegistrationException(
                                 "Unexpected response from new client secret endpoint: status[" +
                                     status +
@@ -261,7 +235,6 @@ public abstract class DynamicClientRegistrationProviderClient {
                             );
                         }
                     } else {
-                        log.error("Unexpected response from renew client secret endpoint: status[{}]", status);
                         throw new DynamicClientRegistrationException(
                             "Unexpected response from renew client secret endpoint: status[" + status + "]"
                         );
@@ -269,7 +242,6 @@ public abstract class DynamicClientRegistrationProviderClient {
                 }
             });
         } catch (Exception ex) {
-            log.error("Unexpected error while renewing client secret: " + ex.getMessage(), ex);
             throw new DynamicClientRegistrationException("Unexpected error while renewing client secret: " + ex.getMessage(), ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/token/ClientCredentialsInitialAccessTokenProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/client/token/ClientCredentialsInitialAccessTokenProvider.java
@@ -109,18 +109,15 @@ public class ClientCredentialsInitialAccessTokenProvider implements InitialAcces
                             JsonNode node = mapper.readTree(responsePayload);
                             String error = node.path("error").asText();
                             String description = node.path("error_description").asText();
-                            log.error("Unexpected response from OIDC Token endpoint: error[{}] description[{}]", error, description);
                             throw new DynamicClientRegistrationException(
                                 "Unexpected response from OIDC Token endpoint: error[" + error + "] description[" + description + "]"
                             );
                         } catch (JsonProcessingException ex) {
-                            log.error("Unexpected response from OIDC Token endpoint: status[{}] message[{}]", status, responsePayload);
                             throw new DynamicClientRegistrationException(
                                 "Unexpected response from OIDC Token endpoint: status[" + status + "] message[" + responsePayload + "]"
                             );
                         }
                     } else {
-                        log.error("Unexpected response from OIDC Token endpoint: status[{}]", status);
                         throw new DynamicClientRegistrationException(
                             "Unexpected response from OIDC Token endpoint: status[" + status + "]"
                         );
@@ -128,7 +125,6 @@ public class ClientCredentialsInitialAccessTokenProvider implements InitialAcces
                 }
             });
         } catch (Exception ex) {
-            log.error("Unexpected error while generating an access_token: " + ex.getMessage(), ex);
             throw new DynamicClientRegistrationException("Unexpected error while generating an access_token: " + ex.getMessage(), ex);
         } finally {
             try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
@@ -83,7 +83,6 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to retrieve dictionaries", ex);
             throw new TechnicalManagementException("An error occurs while trying to retrieve dictionaries", ex);
         }
     }
@@ -114,7 +113,6 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             );
             return convert(dictionary);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to deploy dictionary {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to deploy " + id, ex);
         }
     }
@@ -145,7 +143,6 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             );
             return convert(dictionary);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to undeploy dictionary {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to undeploy " + id, ex);
         }
     }
@@ -186,7 +183,6 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
 
             return convert(updatedDictionary);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to undeploy dictionary {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to undeploy " + id, ex);
         }
     }
@@ -227,7 +223,6 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
 
             return convert(updatedDictionary);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to undeploy dictionary {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to undeploy " + id, ex);
         }
     }
@@ -262,7 +257,6 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             createAuditLog(executionContext, Dictionary.AuditEvent.DICTIONARY_CREATED, dictionary.getCreatedAt(), null, dictionary);
             return convert(createdDictionary);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create dictionary {}", newDictionaryEntity, ex);
             throw new TechnicalManagementException("An error occurs while trying to create " + newDictionaryEntity, ex);
         }
     }
@@ -310,7 +304,6 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
 
             return convert(updatedDictionary);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update dictionary {}", updateDictionaryEntity, ex);
             throw new TechnicalManagementException("An error occurs while trying to update " + updateDictionaryEntity, ex);
         }
     }
@@ -364,7 +357,6 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             }
             return byId.map(this::convert).orElseThrow(() -> new DictionaryNotFoundException(id));
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete a dictionary using its ID {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete a dictionary using its ID " + id, ex);
         }
     }
@@ -394,7 +386,6 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
                 dictionary
             );
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete a dictionary using its ID {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete a dictionary using its ID " + id, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/flow/FlowServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/flow/FlowServiceImpl.java
@@ -115,9 +115,7 @@ public class FlowServiceImpl extends AbstractService implements FlowService {
 
                 return jsonSchema.toPrettyString();
             } catch (JsonProcessingException ex) {
-                final String error = "An error occurs while append tags to platform flow schema form";
-                log.error(error, ex);
-                throw new TechnicalManagementException(error, ex);
+                throw new TechnicalManagementException("An error occurs while append tags to platform flow schema form", ex);
             }
         }
 
@@ -135,9 +133,7 @@ public class FlowServiceImpl extends AbstractService implements FlowService {
                 .map(flowConverter::toDefinition)
                 .collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            final String error = "An error occurs while find flows by reference";
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurs while find flows by reference", ex);
         }
     }
 
@@ -188,9 +184,7 @@ public class FlowServiceImpl extends AbstractService implements FlowService {
                 .map(flowConverter::toDefinition)
                 .collect(Collectors.toList());
         } catch (TechnicalException ex) {
-            final String error = "An error occurs while save flows";
-            log.error(error, ex);
-            throw new TechnicalManagementException(error, ex);
+            throw new TechnicalManagementException("An error occurs while save flows", ex);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderActivationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderActivationServiceImpl.java
@@ -78,7 +78,6 @@ public class IdentityProviderActivationServiceImpl extends AbstractService imple
             }
             return createdActivations;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to Activate identity provider {} on targets {}", identityProviderId, targetsToAdd, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to Activate identity provider " +
                     identityProviderId +
@@ -109,7 +108,6 @@ public class IdentityProviderActivationServiceImpl extends AbstractService imple
             }
             return createdActivations;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to add identity providers {} on target {}", identityProviderIdsToAdd, target, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to add identity providers " +
                     Arrays.toString(identityProviderIdsToAdd) +
@@ -131,7 +129,6 @@ public class IdentityProviderActivationServiceImpl extends AbstractService imple
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all activations for identity provider {}", identityProviderId, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to find all activations for identity provider " + identityProviderId,
                 ex
@@ -150,7 +147,6 @@ public class IdentityProviderActivationServiceImpl extends AbstractService imple
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find all activations for target {}", target, ex);
             throw new TechnicalManagementException("An error occurs while trying to find all activations for target " + target, ex);
         }
     }
@@ -164,12 +160,6 @@ public class IdentityProviderActivationServiceImpl extends AbstractService imple
                 deleteIdentityProviderActivation(executionContext, identityProviderId, target);
             }
         } catch (TechnicalException ex) {
-            log.error(
-                "An error occurs while trying to deactivate identity provider {} on targets {}",
-                identityProviderId,
-                targetsToRemove,
-                ex
-            );
             throw new TechnicalManagementException(
                 "An error occurs while trying to deactivate identity provider " +
                     identityProviderId +
@@ -189,12 +179,6 @@ public class IdentityProviderActivationServiceImpl extends AbstractService imple
                 deleteIdentityProviderActivation(executionContext, identityProviderId, target);
             }
         } catch (TechnicalException ex) {
-            log.error(
-                "An error occurs while trying to remove identity providers {} from target {}",
-                identityProviderIdsToRemove,
-                target,
-                ex
-            );
             throw new TechnicalManagementException(
                 "An error occurs while trying to remove identity providers " +
                     Arrays.toString(identityProviderIdsToRemove) +
@@ -231,7 +215,6 @@ public class IdentityProviderActivationServiceImpl extends AbstractService imple
                 );
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to deactivate identity provider {} on all targets", identityProviderId, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to deactivate identity provider " + identityProviderId + " on all targets",
                 ex
@@ -269,7 +252,6 @@ public class IdentityProviderActivationServiceImpl extends AbstractService imple
                 );
             }
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to remove all identity providers from target {}", target, ex);
             throw new TechnicalManagementException(
                 "An error occurs while trying to remove all identity providers from target " + target,
                 ex

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderServiceImpl.java
@@ -128,7 +128,6 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
 
             return convert(createdIdentityProvider);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to create identity provider {}", newIdentityProviderEntity, ex);
             throw new TechnicalManagementException("An error occurs while trying to create " + newIdentityProviderEntity, ex);
         }
     }
@@ -171,7 +170,6 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
 
             return convert(updatedIdentityProvider);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to update identity provider {}", updateIdentityProvider, ex);
             throw new TechnicalManagementException("An error occurs while trying to update " + updateIdentityProvider, ex);
         }
     }
@@ -189,7 +187,6 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
 
             throw new IdentityProviderNotFoundException(id);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to find an identity provider using its ID {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete an identity provider using its ID " + id, ex);
         }
     }
@@ -219,7 +216,6 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
 
             identityProviderActivationService.deactivateIdpOnAllTargets(executionContext, id);
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to delete an identity provider using its ID {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete an identity provider using its ID " + id, ex);
         }
     }
@@ -248,7 +244,6 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to retrieve identity providers", ex);
             throw new TechnicalManagementException("An error occurs while trying to retrieve identity providers", ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/SocialIdentityProviderImpl.java
@@ -88,7 +88,6 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
                 .map(this::convert)
                 .collect(Collectors.toSet());
         } catch (Exception ex) {
-            log.error("An error occurs while trying to retrieve identity providers", ex);
             throw new TechnicalManagementException("An error occurs while trying to retrieve identity providers", ex);
         }
     }
@@ -118,7 +117,6 @@ public class SocialIdentityProviderImpl extends AbstractService implements Socia
         } catch (IdentityProviderNotFoundException ex) {
             throw ex;
         } catch (Exception ex) {
-            log.error("An error occurs while trying to find an identity provider using its ID {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete an identity provider using its ID " + id, ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -242,7 +242,6 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
 
             return convert(createdOrUpdatedPromotion);
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to create or update a promotion using its id {}", promotionEntity.getId(), e);
             throw new TechnicalManagementException(
                 "An error occurs while trying to create or update a promotion using its id {}" + promotionEntity.getId(),
                 e
@@ -265,7 +264,6 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
 
             return promotions;
         } catch (TechnicalException ex) {
-            log.error("An error occurs while trying to search promotions", ex);
             throw new TechnicalManagementException("An error occurs while trying to search promotions", ex);
         }
     }
@@ -323,7 +321,6 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
 
             return convert(updated);
         } catch (TechnicalException | IOException ex) {
-            log.error("An error occurs while trying to process promotion", ex);
             throw new TechnicalManagementException("An error occurs while trying to process promotion", ex);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/SearchEngineServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/SearchEngineServiceImpl.java
@@ -284,7 +284,6 @@ public class SearchEngineServiceImpl implements SearchEngineService {
             Assert.isAssignable(Indexable.class, clazz);
             return (Indexable) clazz.newInstance();
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException ex) {
-            log.error("Unable to instantiate class: {}", className, ex);
             throw ex;
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/SearchEngineIndexer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/SearchEngineIndexer.java
@@ -49,7 +49,6 @@ public class SearchEngineIndexer {
             }
             return seq;
         } catch (IOException ioe) {
-            log.error("Fail to index document with ID: {}", id, ioe);
             throw new TechnicalException("Fail to index document with ID: " + id, ioe);
         }
     }
@@ -67,7 +66,6 @@ public class SearchEngineIndexer {
         try {
             writer.deleteDocuments(bq.build());
         } catch (IOException ioe) {
-            log.error("Fail to index document with ID: {}", id, ioe);
             throw new TechnicalException("Fail to index document with ID: " + id, ioe);
         }
     }
@@ -76,7 +74,6 @@ public class SearchEngineIndexer {
         try {
             writer.commit();
         } catch (IOException ioe) {
-            log.error("Unexpected IO errors while committing Lucene index", ioe);
             throw new TechnicalException("Unexpected IO errors while committing Lucene index", ioe);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
@@ -119,7 +119,6 @@ public abstract class AbstractDocumentSearcher implements DocumentSearcher {
 
             return new SearchResult(results, topDocs.totalHits.value());
         } catch (IOException ioe) {
-            log.error("An error occurs while getting documents from search result", ioe);
             throw new TechnicalException("An error occurs while getting documents from search result", ioe);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -211,7 +211,6 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
             buildWildcardQuery(executionContext, query, baseFilterQuery).ifPresent(q -> apiQuery.add(q, BooleanClause.Occur.SHOULD));
             buildIdsQuery(executionContext, query).ifPresent(q -> apiQuery.add(q, BooleanClause.Occur.SHOULD));
         } catch (ParseException pe) {
-            log.error("Invalid query to search for API documents", pe);
             throw new TechnicalException("Invalid query to search for API documents", pe);
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiProductDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiProductDocumentSearcher.java
@@ -153,7 +153,6 @@ public class ApiProductDocumentSearcher extends AbstractDocumentSearcher {
                 mainQuery.add(buildApiProductQuery(executionContext, baseFilterQuery).build(), BooleanClause.Occur.MUST);
             }
         } catch (ParseException pe) {
-            log.error("Invalid query to search for API Product documents", pe);
             throw new TechnicalException("Invalid query to search for API Product documents", pe);
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/PageDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/PageDocumentSearcher.java
@@ -53,7 +53,6 @@ public class PageDocumentSearcher extends AbstractDocumentSearcher {
             // Note: Page search does not seem to be used so for now we don't implement any filtering for organization or environment.
             return searchReference(pageQuery.build());
         } catch (ParseException pe) {
-            log.error("Invalid query to search for page documents", pe);
             throw new TechnicalException("Invalid query to search for page documents", pe);
         }
     }
@@ -66,7 +65,6 @@ public class PageDocumentSearcher extends AbstractDocumentSearcher {
             // Note: Page search does not seem to be used so for now we don't implement any filtering for organization or environment.
             return search(pageQuery.build());
         } catch (ParseException pe) {
-            log.error("Invalid query to search for page documents", pe);
             throw new TechnicalException("Invalid query to search for page documents", pe);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/UserDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/UserDocumentSearcher.java
@@ -120,7 +120,6 @@ public class UserDocumentSearcher extends AbstractDocumentSearcher {
 
             return search(userQuery.build(), query.getSort(), query.getPage());
         } catch (ParseException pe) {
-            log.error("Invalid query to search for user documents", pe);
             throw new TechnicalException("Invalid query to search for user documents", pe);
         }
     }
@@ -163,7 +162,6 @@ public class UserDocumentSearcher extends AbstractDocumentSearcher {
 
             return new SearchResult(results, topDocs.totalHits.value());
         } catch (IOException ioe) {
-            log.error("An error occurs while getting documents from search result", ioe);
             throw new TechnicalException("An error occurs while getting documents from search result", ioe);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/parser/WsdlParser.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/parser/WsdlParser.java
@@ -36,7 +36,7 @@ public class WsdlParser extends AbstractDescriptorParser<OpenAPI> {
                 return new WSDLToOpenAPIConverter().toOpenAPI(content);
             }
         } catch (Exception e) {
-            log.info("Wsdl parsing failed : {}", e.getMessage());
+            log.warn("Wsdl parsing failed : {}", e.getMessage());
             return null;
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/policy/PolicyPluginHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/policy/PolicyPluginHandler.java
@@ -71,7 +71,6 @@ public class PolicyPluginHandler extends io.gravitee.plugin.policy.internal.Poli
         try {
             return clazz.newInstance();
         } catch (InstantiationException | IllegalAccessException ex) {
-            log.error("Unable to instantiate class: {}", clazz, ex);
             throw ex;
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/IntegrationControllerInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/IntegrationControllerInitializer.java
@@ -48,7 +48,6 @@ public class IntegrationControllerInitializer implements Initializer {
                 integrationExchangeController.start();
                 log.info("Integrations started.");
             } catch (Exception e) {
-                log.error("Fail to start Integration Controller", e);
                 throw new RuntimeException(e);
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiCategoryOrderUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiCategoryOrderUpgrader.java
@@ -75,7 +75,6 @@ public class ApiCategoryOrderUpgrader implements Upgrader {
                                 .build()
                         );
                     } catch (TechnicalException e) {
-                        log.error("Unable to create api category order for API [{}] and Category [{}]", api.getId(), category.getId(), e);
                         throw new RuntimeException(e);
                     }
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiHRIDUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiHRIDUpgrader.java
@@ -73,7 +73,6 @@ public class ApiHRIDUpgrader implements Upgrader {
                 try {
                     apiRepository.update(api);
                 } catch (TechnicalException e) {
-                    log.error("Unable to set HRID for API {}", api.getId(), e);
                     throw new RuntimeException(e);
                 }
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiLoggingConditionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiLoggingConditionUpgrader.java
@@ -125,7 +125,6 @@ public class ApiLoggingConditionUpgrader implements Upgrader {
                         }
                     }
                 } catch (Exception e) {
-                    log.error("Unable to fix logging condition for API {}", api.getId(), e);
                     throw new RuntimeException(e);
                 }
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiV4CategoriesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiV4CategoriesUpgrader.java
@@ -73,7 +73,6 @@ public class ApiV4CategoriesUpgrader implements Upgrader {
         try {
             categories = categoryRepository.findAll();
         } catch (TechnicalException e) {
-            log.error("An error occurred when finding all categories", e);
             throw new TechnicalException(e);
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationHRIDUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationHRIDUpgrader.java
@@ -68,7 +68,6 @@ public class ApplicationHRIDUpgrader implements Upgrader {
                 try {
                     applicationRepository.update(application);
                 } catch (TechnicalException e) {
-                    log.error("Unable to set HRID for Application {}", application.getId(), e);
                     throw new RuntimeException(e);
                 }
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ExecutionModeUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ExecutionModeUpgrader.java
@@ -86,7 +86,6 @@ public class ExecutionModeUpgrader implements Upgrader {
                     }
                 }
             } catch (JsonProcessingException | TechnicalException e) {
-                log.error("Error processing API {}: {}", api.getId(), e.getMessage());
                 throw new UpgraderException(e);
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/MetadataDefaultReferenceUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/MetadataDefaultReferenceUpgrader.java
@@ -77,14 +77,12 @@ public class MetadataDefaultReferenceUpgrader implements Upgrader {
                     log.warn("Failed to duplicate metadata {} to {}", metadata, environment, e);
                     return metadataToCreate;
                 } catch (TechnicalException e) {
-                    log.error("Failed to duplicate metadata {} to {}", metadata, environment, e);
                     throw new TechnicalManagementException(e);
                 }
             });
         try {
             metadataRepository.delete(metadata.getKey(), metadata.getReferenceId(), metadata.getReferenceType());
         } catch (TechnicalException e) {
-            log.error("Failed to delete metadata {}", metadata, e);
             throw new TechnicalManagementException(e);
         }
         return metadataStream;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlanHRIDUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/PlanHRIDUpgrader.java
@@ -56,7 +56,6 @@ public class PlanHRIDUpgrader implements Upgrader {
                     try {
                         planRepository.update(plan);
                     } catch (TechnicalException e) {
-                        log.error("Unable to set HRID for Plan {}", plan.getId(), e);
                         throw new RuntimeException(e);
                     }
                 });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SharedPolicyGroupHRIDUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SharedPolicyGroupHRIDUpgrader.java
@@ -73,7 +73,6 @@ public class SharedPolicyGroupHRIDUpgrader implements Upgrader {
                     sharedPolicyGroup.setHrid(sharedPolicyGroup.getCrossId());
                     sharedPolicyGroupRepository.update(sharedPolicyGroup);
                 } catch (TechnicalException e) {
-                    log.error("Unable to set HRID for Shared Policy Group {}", sharedPolicyGroup.getId(), e);
                     throw new RuntimeException(e);
                 }
             });


### PR DESCRIPTION
**Issue**

  https://gravitee.atlassian.net/browse/APIM-10139 (epic)
  https://gravitee.atlassian.net/browse/APIM-10140
  https://gravitee.atlassian.net/browse/APIM-10141
  https://gravitee.atlassian.net/browse/APIM-10142
  https://gravitee.atlassian.net/browse/APIM-10143

  **Description**

  Improve exception logging quality across `rest-api` and `gateway` modules, addressing 4 categories of issues:

  ### 1. Remove redundant exception logging (88 rest-api files + 1 gateway)
  Remove `log.error()` / `log.warn()` calls systematically followed by `throw new TechnicalManagementException(...)` with
  the same message. The exception is already logged at the upper level (REST layer / exception mapper), making the
  service-layer log redundant and a source of duplicate entries in production logs.

  ### 2. Fix mishandled exceptions
  - **ApiResource**: add `log.error` before `return Response.status(500)` calls that were silently swallowing exceptions
  (deploy + rollback endpoints)
  - **EnvironmentService (gateway)**: add `log.warn` when organization fetch fails (was `return null` with no log at all)
  - **HttpProtocolVerticle / DebugHttpProtocolVerticle**: downgrade ERROR → WARN for graceful response cleanup
  (intentional `onErrorComplete()` pattern)

  ### 3. Add context to exception log messages
  - **TaskServiceImpl**: replace `e.getMessage()` with full exception + add entity IDs (workflow, application, plan)
  - **ConfigMapEventFetcher**: add ConfigMap namespace/name to error message

  ### 4. Fix inappropriate log levels
  - **Gateway sync mappers** (ApiMapper, SubscriptionMapper): ERROR → WARN for resilient patterns (intentional return
  null/empty)
  - **WsdlParser**: INFO → WARN for parsing failures

