### PR TITLE
Fix e2e

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl;
 
 import static java.util.Map.entry;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -284,6 +285,18 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
         }
     }
 
+    private ObjectNode toObjectNode(Object value) {
+        if (value == null) {
+            return mapper.createObjectNode();
+        }
+        try {
+            return (ObjectNode) mapper.readTree(mapper.writeValueAsString(value));
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize value for audit log diff, using empty node", e);
+            return mapper.createObjectNode();
+        }
+    }
+
     @Override
     @Async
     public void createAuditLog(ExecutionContext executionContext, AuditLogData auditLogData) {
@@ -328,12 +341,8 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
         audit.setReferenceId(auditLogData.getReferenceId());
         audit.setEvent(auditLogData.getEvent().name());
 
-        ObjectNode oldNode = auditLogData.getOldValue() == null
-            ? mapper.createObjectNode()
-            : mapper.convertValue(auditLogData.getOldValue(), ObjectNode.class).remove(Arrays.asList("updatedAt", "createdAt"));
-        ObjectNode newNode = auditLogData.getNewValue() == null
-            ? mapper.createObjectNode()
-            : mapper.convertValue(auditLogData.getNewValue(), ObjectNode.class).remove(Arrays.asList("updatedAt", "createdAt"));
+        ObjectNode oldNode = toObjectNode(auditLogData.getOldValue()).remove(Arrays.asList("updatedAt", "createdAt"));
+        ObjectNode newNode = toObjectNode(auditLogData.getNewValue()).remove(Arrays.asList("updatedAt", "createdAt"));
 
         JsonNode diff = JsonDiff.asJson(oldNode, newNode);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
@@ -158,8 +158,8 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
                         .properties(Collections.emptyMap())
                         .event(Organization.AuditEvent.ORGANIZATION_FLOWS_UPDATED)
                         .createdAt(new Date())
-                        .oldValue(previousFlows)
-                        .newValue(newFlows)
+                        .oldValue(Collections.singletonMap("flows", previousFlows))
+                        .newValue(Collections.singletonMap("flows", newFlows))
                         .build()
                 );
                 Organization organization = convert(organizationEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/OrganizationService_UpdateOrganizationAndFlowsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/OrganizationService_UpdateOrganizationAndFlowsTest.java
@@ -117,8 +117,8 @@ public class OrganizationService_UpdateOrganizationAndFlowsTest {
             eq(GraviteeContext.getExecutionContext()),
             argThat(auditLogData -> {
                 assertEquals(Organization.AuditEvent.ORGANIZATION_FLOWS_UPDATED, auditLogData.getEvent());
-                assertEquals(previousFlows, auditLogData.getOldValue());
-                assertEquals(newFlows, auditLogData.getNewValue());
+                assertEquals(Collections.singletonMap("flows", previousFlows), auditLogData.getOldValue());
+                assertEquals(Collections.singletonMap("flows", newFlows), auditLogData.getNewValue());
                 return true;
             })
         );


### PR DESCRIPTION
## Issue

Fix e2e failures after the commit: https://github.com/gravitee-io/gravitee-api-management/pull/15080

## Description

e2e: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/75162/workflows/d15a1158-822e-4dd1-885c-ef7c5d7ba77d

## Additional context

1. Wrap flow lists in map for organisation audit log serialisation.
2. Replace convertValue with writeValueAsString + readTree so @JsonRawValue fields are fully serialised to JSON text before diffing, avoiding VALUE_EMBEDDED_OBJECT nodes that the json-patch library cannot handle.

☝️ Above bug (2nd) was already there, the commit that introduced the audit trace on organisation flows, called createAuditLog with a Flow object. The Flow model contains Step objects which have @JsonRawValue on configuration. Jackson tried to build a node tree from a Flow, hit the @JsonRawValue field, and produced the VALUE_EMBEDDED_OBJECT token that crashed JsonDiff.

