### PR TITLE
fix: remove mdcList conversionRule from default logback.xml and enable pattern override

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -525,7 +525,7 @@ node:
     # Configure the patterns for the most common appenders
     # Nothing prevents the user from modifying logback.xml
     pattern:
-      overrideLogbackXml: false # when enabled, use the following patterns instead of those from logback.xml
+      overrideLogbackXml: true # when enabled, use the following patterns instead of those from logback.xml
       # Use a custom keyword to use MDC formatting and filtering: %mdcList. This list is built from the previous 'mdc.include' list
       console: "%d{HH:mm:ss} %-5level %logger{36} [%mdcList] - %msg%n" # Override default STDOUT appender pattern
       file: "%d %-5p [%t] %c [%mdcList] : %m%n" # Override default FILE appender pattern

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/logback.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/logback.xml
@@ -18,14 +18,10 @@
 
 <configuration>
 
-<!--   Declare the 'mdcList' conversion word used by filtering mechanism in gravitee.yml node.logging options -->
-    <conversionRule conversionWord="mdcList"
-                    converterClass="io.gravitee.node.container.logback.MdcListConverter" />
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- Classical STDOUT logger -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] [%mdcList] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
 
 <!--       Uncomment to enable Json Encoder -->
@@ -56,7 +52,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] [%mdcList] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -343,7 +343,7 @@ node:
     # Configure the patterns for the most common appenders
     # Nothing prevents the user from modifying logback.xml
     pattern:
-      overrideLogbackXml: false # when enabled, use the following patterns instead of those from logback.xml
+      overrideLogbackXml: true # when enabled, use the following patterns instead of those from logback.xml
       # Use a custom keyword to use MDC formatting and filtering: %mdcList. This list is built from the previous 'mdc.include' list
       console: "%d{HH:mm:ss} %-5level %logger{36} [%mdcList] - %msg%n" # Override default STDOUT appender pattern
       file: "%d %-5p [%t] %c [%mdcList] : %m%n" # Override default FILE appender pattern

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/logback.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/logback.xml
@@ -16,15 +16,11 @@
   -->
 <configuration>
 
-    <!--   Declare the 'mdcList' conversion word used by filtering mechanism in gravitee.yml node.logging options -->
-    <conversionRule conversionWord="mdcList"
-                    converterClass="io.gravitee.node.container.logback.MdcListConverter" />
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] [%mdcList] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
 
         <!--       Uncomment to enable Json Encoder -->
@@ -55,7 +51,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] [%mdcList] %-5level %logger{36} - %msg%n%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12307

## Description

Fix `PARSER_ERROR[mdcList]` in Docker deployments caused by the bootstrap classloader hierarchy: Logback (loaded from `lib/ext/`) cannot resolve `io.gravitee.node.container.logback.MdcListConverter` (in `lib/`) at parse time.

**Changes:**
- Remove `<conversionRule conversionWord="mdcList" converterClass="io.gravitee.node.container.logback.MdcListConverter"/>` and `%mdcList` usage from default `logback.xml` files (gateway + rest-api)
- Enable `overrideLogbackXml: true` by default in `gravitee.yml` so that `LogbackPatternOverrider` registers the converter programmatically with the correct classloader and applies the patterns containing `%mdcList`

Companion PR on gravitee-node: https://github.com/gravitee-io/gravitee-node/pull/529