### PR TITLE
fix(gateway): add error/debug logs to improve traceability

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/lifecycle/impl/EndpointGroupLifecycleManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/lifecycle/impl/EndpointGroupLifecycleManager.java
@@ -270,7 +270,14 @@ public class EndpointGroupLifecycleManager
                 endpointNode.putPOJO("headers", group.getHeaders());
                 return endpointNode.toString();
             }
-        } catch (IOException ioe) {}
+        } catch (IOException ioe) {
+            log.warn(
+                "Unable to parse endpoint configuration for endpoint [{}] in group [{}], falling back to raw configuration",
+                endpoint.getName(),
+                group.getName(),
+                ioe
+            );
+        }
 
         return endpoint.getConfiguration();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/resolver/ProxyEndpointResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/resolver/ProxyEndpointResolver.java
@@ -25,6 +25,7 @@ import io.gravitee.gateway.core.endpoint.ref.Reference;
 import io.gravitee.gateway.core.endpoint.ref.ReferenceRegister;
 import java.util.Collection;
 import java.util.regex.Pattern;
+import lombok.CustomLog;
 import org.springframework.util.StringUtils;
 
 /**
@@ -32,6 +33,7 @@ import org.springframework.util.StringUtils;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class ProxyEndpointResolver implements EndpointResolver {
 
     private static final String URI_PATH_SEPARATOR = "/";
@@ -51,7 +53,13 @@ public class ProxyEndpointResolver implements EndpointResolver {
 
     @Override
     public ProxyEndpoint resolve(String reference) {
-        return (reference != null) ? selectUserDefinedEndpoint(reference) : selectLoadBalancedEndpoint();
+        ProxyEndpoint result = (reference != null) ? selectUserDefinedEndpoint(reference) : selectLoadBalancedEndpoint();
+        if (result == null) {
+            log.debug("No endpoint resolved for reference [{}]", reference);
+        } else {
+            log.debug("Endpoint resolved: [{}] for reference [{}]", result.name(), reference);
+        }
+        return result;
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/endpoint/loadbalancer/AbstractLoadBalancerStrategy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/endpoint/loadbalancer/AbstractLoadBalancerStrategy.java
@@ -17,11 +17,13 @@ package io.gravitee.gateway.reactive.core.v4.endpoint.loadbalancer;
 
 import io.gravitee.gateway.reactive.core.v4.endpoint.ManagedEndpoint;
 import java.util.List;
+import lombok.CustomLog;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public abstract class AbstractLoadBalancerStrategy implements LoadBalancerStrategy {
 
     protected final List<ManagedEndpoint> endpoints;
@@ -44,9 +46,11 @@ public abstract class AbstractLoadBalancerStrategy implements LoadBalancerStrate
         } catch (IndexOutOfBoundsException exception) {
             // This has been implemented to avoid putting the method in synchronized and avoid TooManyException
             if (attempt < 2) {
+                log.debug("Load balancer encountered IndexOutOfBoundsException (attempt {}/3), retrying", attempt + 1);
                 attempt++;
                 return next(attempt);
             }
+            log.debug("Load balancer failed to select endpoint after 3 attempts, endpoints size: {}", endpoints.size());
             return null;
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/reactive/v4/flow/BestMatchFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/reactive/v4/flow/BestMatchFlowResolver.java
@@ -21,6 +21,7 @@ import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpBaseExecutionContext;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
+import lombok.CustomLog;
 
 /**
  * This flow resolver resolves only the {@link Flow} which best matches according to the incoming request.
@@ -30,6 +31,7 @@ import io.reactivex.rxjava3.core.Maybe;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class BestMatchFlowResolver implements FlowResolver<HttpBaseExecutionContext> {
 
     private final FlowResolver flowResolver;
@@ -44,7 +46,13 @@ public class BestMatchFlowResolver implements FlowResolver<HttpBaseExecutionCont
     public Flowable<Flow> resolve(final HttpBaseExecutionContext ctx) {
         return provideFlows(ctx)
             .toList()
-            .flatMapMaybe(flows -> Maybe.fromCallable(() -> bestMatchFlowSelector.forPath(flows, ctx.request().pathInfo())))
+            .flatMapMaybe(flows -> {
+                ctx
+                    .withLogger(log)
+                    .debug("Resolving best match flow for path [{}] among {} candidate flow(s)", ctx.request().pathInfo(), flows.size());
+                return Maybe.fromCallable(() -> bestMatchFlowSelector.forPath(flows, ctx.request().pathInfo()));
+            })
+            .doOnSuccess(flow -> ctx.withLogger(log).debug("Best match flow resolved: [{}]", flow.getName()))
             .toFlowable();
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/reactive/v4/flow/BestMatchFlowResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/reactive/v4/flow/BestMatchFlowResolverTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.v4.flow;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.v4.Api;
@@ -31,10 +32,12 @@ import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import java.util.Optional;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mock;
+import org.slf4j.helpers.NOPLogger;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -53,6 +56,11 @@ public class BestMatchFlowResolverTest extends BestMatchFlowBaseTest {
     public ReactableApi reactableApi;
 
     public AbstractBestMatchFlowSelector<Flow> bestMatchFlowSelector = new BestMatchFlowSelector();
+
+    @Before
+    public void prepareLogger() {
+        when(executionContext.withLogger(any())).thenReturn(NOPLogger.NOP_LOGGER);
+    }
 
     @Test
     public void should_resolve_bestMatchFlow_with_api_sync() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/path/impl/AbstractPathResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/path/impl/AbstractPathResolver.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
+import lombok.CustomLog;
 
 /**
  * A simple path resolver based on context paths definition.
@@ -33,6 +34,7 @@ import java.util.regex.Pattern;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public abstract class AbstractPathResolver implements PathResolver {
 
     private static final String URL_PATH_SEPARATOR = "/";
@@ -63,7 +65,9 @@ public abstract class AbstractPathResolver implements PathResolver {
 
         try {
             path = QueryStringDecoder.decodeComponent(path, Charset.defaultCharset());
-        } catch (IllegalArgumentException iae) {}
+        } catch (IllegalArgumentException iae) {
+            log.warn("Unable to decode request path [{}], using raw path for resolution", request.pathInfo(), iae);
+        }
 
         int pieces = -1;
         Path bestPath = null;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -96,13 +96,27 @@ public class SubscriptionCacheService implements SubscriptionService {
         // take all fields (including "updatedAt" in metadata) into account
         if (ACCEPTED.name().equals(subscription.getStatus())) {
             if (subscription.getClientCertificate() != null) {
+                log.debug("Registering subscription [{}] for API [{}] by client certificate", subscription.getId(), subscription.getApi());
                 registerFromClientCertificate(subscription);
             } else if (subscription.getClientId() != null) {
+                log.debug(
+                    "Registering subscription [{}] for API [{}] by clientId [{}]",
+                    subscription.getId(),
+                    subscription.getApi(),
+                    subscription.getClientId()
+                );
                 registerFromClientId(subscription);
             } else {
+                log.debug("Registering subscription [{}] for API [{}] by ID", subscription.getId(), subscription.getApi());
                 registerFromId(subscription);
             }
         } else {
+            log.debug(
+                "Unregistering subscription [{}] for API [{}] with status [{}]",
+                subscription.getId(),
+                subscription.getApi(),
+                subscription.getStatus()
+            );
             unregister(subscription);
         }
     }
@@ -138,6 +152,7 @@ public class SubscriptionCacheService implements SubscriptionService {
 
     @Override
     public void unregisterByApiId(final String apiId) {
+        log.debug("Unregistering all subscriptions for API [{}]", apiId);
         cacheKeysByApiId.computeIfPresent(apiId, (k, subscriptionsByApi) -> {
             subscriptionsByApi.forEach(cacheKey -> {
                 Set<Subscription> all = cacheBySubscriptionIdAll.get(cacheKey);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/ConnectionHandlerAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/ConnectionHandlerAdapter.java
@@ -26,6 +26,7 @@ import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
 import io.reactivex.rxjava3.core.CompletableEmitter;
 import io.reactivex.rxjava3.core.Flowable;
+import lombok.CustomLog;
 
 /**
  * The {@link ConnectionHandlerAdapter} allows to manage the response chunks coming from the upstream.
@@ -37,6 +38,7 @@ import io.reactivex.rxjava3.core.Flowable;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class ConnectionHandlerAdapter implements Handler<ProxyConnection> {
 
     private final HttpPlainExecutionContext ctx;
@@ -143,6 +145,8 @@ public class ConnectionHandlerAdapter implements Handler<ProxyConnection> {
     private void tryCancel(ProxyResponse proxyResponse) {
         try {
             proxyResponse.cancel();
-        } catch (Throwable ignored) {}
+        } catch (Throwable t) {
+            ctx.withLogger(log).warn("Unable to cancel proxy response", t);
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
@@ -34,6 +34,7 @@ import io.reactivex.rxjava3.core.Completable;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Objects;
+import lombok.CustomLog;
 import org.bouncycastle.util.encoders.Hex;
 
 /**
@@ -41,6 +42,7 @@ import org.bouncycastle.util.encoders.Hex;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class SubscriptionProcessor implements Processor {
 
     public static final String ID = "processor-subscription";
@@ -125,6 +127,13 @@ public class SubscriptionProcessor implements Processor {
 
             Subscription subscription = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SUBSCRIPTION);
             if (subscription == null) {
+                ctx
+                    .withLogger(log)
+                    .debug(
+                        "No subscription resolved for request, creating anonymous subscription for API [{}] with plan [{}]",
+                        ctx.getAttribute(ATTR_API),
+                        planId
+                    );
                 subscription = new Subscription();
                 subscription.setId(subscriptionId);
                 subscription.setApi(ctx.getAttribute(ATTR_API));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/flow/FlowChain.java
@@ -127,6 +127,7 @@ public class FlowChain implements Hookable<ChainHook> {
                         flowsMatch = previousChainFlowsMatch;
                     }
                     if (interruptIfNoMatch && !flowsMatch) {
+                        ctx.withLogger(log).debug("No flow matched for chain [{}], interrupting with 404", id);
                         return ctx
                             .interruptWith(new ExecutionFailure(HttpStatusCode.NOT_FOUND_404).key(EXECUTION_FAILURE_KEY_FAILURE))
                             .toFlowable();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/AbstractPolicyChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/AbstractPolicyChain.java
@@ -81,6 +81,7 @@ public abstract class AbstractPolicyChain<T extends BasePolicy> implements Polic
      */
     @Override
     public Completable execute(BaseExecutionContext ctx) {
+        ctx.withLogger(log).debug("Executing policy chain [{}] with {} policy(ies) for phase [{}]", id, originalPolicies.size(), phase);
         return policies.concatMapCompletable(policy -> {
             ComponentScope.push(ctx, ComponentType.POLICY, policy.id());
             return executePolicy(ctx, policy).doFinally(() -> ComponentScope.remove(ctx, ComponentType.POLICY, policy.id()));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -146,6 +146,11 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         final HttpAcceptor httpAcceptor = httpAcceptorResolver.resolve(httpServerRequest.host(), httpServerRequest.path(), serverId);
         Context vertxContext = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
         if (httpAcceptor == null || httpAcceptor.reactor() == null) {
+            log.debug(
+                "No acceptor found for host {} and path {}, handling as not found",
+                httpServerRequest.host(),
+                httpServerRequest.path()
+            );
             MutableExecutionContext mutableCtx = prepareExecutionContext(httpServerRequest, serverId);
             mutableCtx.tracer(
                 new io.gravitee.gateway.reactive.api.tracing.Tracer(vertxContext, gatewayTracingContext.opentelemetryTracer())
@@ -183,6 +188,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
                 return handleNotFoundCompletable;
             }
         } else if (httpAcceptor.reactor() instanceof ApiReactor<?> apiReactor) {
+            log.debug("Request routed to API reactor on path [{}]", httpAcceptor.path());
             MutableExecutionContext mutableCtx = prepareExecutionContext(httpServerRequest, serverId);
             mutableCtx.request().contextPath(httpAcceptor.path());
             TracingContext tracingContext = apiReactor.tracingContext();
@@ -241,6 +247,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
             });
         }
         // V3 execution mode.
+        log.debug("Request routed to V3 handler on path [{}]", httpAcceptor.path());
         return handleV3Request(httpServerRequest, httpAcceptor, vertxContext);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -234,7 +234,10 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
                                 );
                         });
                 }
-                postProcessCompletable.onErrorComplete().subscribe();
+                postProcessCompletable
+                    .doOnError(error -> log.warn("Unexpected error while executing post-processor chain", error))
+                    .onErrorComplete()
+                    .subscribe();
             });
         }
         // V3 execution mode.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultTcpSocketDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultTcpSocketDispatcher.java
@@ -57,6 +57,7 @@ public class DefaultTcpSocketDispatcher implements TcpSocketDispatcher {
                 return Completable.error(new IllegalStateException("No TCP acceptor found for SNI: %s".formatted(sni)));
             }
 
+            log.debug("TCP request matched acceptor for SNI [{}] on serverId [{}]", sni, serverId);
             if (acceptor.reactor() instanceof ApiReactor<?> tcpReactor) {
                 // pause the socket as soon as possible
                 proxySocket.pause();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceManagerImpl.java
@@ -75,6 +75,13 @@ public class ResourceManagerImpl extends LegacyResourceManagerImpl {
 
                     if (resourceInstance != null) {
                         resources.put(resource.getName(), resourceInstance);
+                    } else {
+                        log.debug(
+                            "Resource [{}] of type [{}] could not be loaded for {}",
+                            resource.getName(),
+                            resource.getType(),
+                            reactable
+                        );
                     }
                 });
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/v4/DefaultResourceManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/v4/DefaultResourceManager.java
@@ -71,6 +71,8 @@ public class DefaultResourceManager extends LegacyResourceManagerImpl {
 
                 if (resourceInstance != null) {
                     resources.put(resource.getName(), resourceInstance);
+                } else {
+                    log.debug("Resource [{}] of type [{}] could not be loaded for {}", resource.getName(), resource.getType(), reactable);
                 }
             });
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-10134
https://gravitee.atlassian.net/browse/APIM-10135
https://gravitee.atlassian.net/browse/APIM-10136
https://gravitee.atlassian.net/browse/APIM-10137

## Description

Add missing ERROR/WARN/DEBUG logs across the gateway to improve traceability and incident resolution.

**Silent failures fixed (ERROR/WARN):**
- `EndpointGroupLifecycleManager`: empty catch on endpoint config JSON parsing
- `DefaultHttpRequestDispatcher`: post-processor chain errors silently swallowed
- `AbstractPathResolver`: empty catch on URL path decoding failure
- `ConnectionHandlerAdapter`: proxy response cancellation failure silently ignored

**DEBUG logs added for:**
- HTTP/TCP request routing (which API matched, V3 vs V4 path, not-found cases)
- Subscription cache operations (register/unregister by clientId, certificate, ID)
- Subscription resolution (anonymous subscription creation)
- Flow resolution (best match selection, no-match interruption)
- Policy chain execution (chain entry with policy count)
- Endpoint selection and load balancer retries
- Certificate subscription registration
- Resource loading failures

## Additional context

This PR targets `master` (4.11+). A separate backport PR for `4.10.x` will follow with adapted logging (without `@CustomLog`).