### PR TITLE
feat: add @CustomLog support via SLF4J for backport compatibility

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,1 +1,3 @@
 lombok.addLombokGeneratedAnnotation = true
+config.stopBubbling = true
+lombok.log.custom.declaration = org.slf4j.Logger org.slf4j.LoggerFactory.getLogger(TYPE)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12305

## Description

Adds `@CustomLog` Lombok support on 4.10.x using standard SLF4J `LoggerFactory` instead of `NodeLoggerFactory` (not available on this branch).

This allows commits using `@CustomLog` from `master` to be cherry-picked onto 4.10.x without modification — Lombok will resolve the annotation to `org.slf4j.LoggerFactory.getLogger(TYPE)`.

Also adds `config.stopBubbling = true` to prevent parent config interference.