### PR TITLE
[CJ-3646] - handle sharding tags key attribute for multi-tenant cloud control planes

### DIFF
--- a/gravitee-apim-console-webui/src/entities/tag/newTag.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/tag/newTag.fixture.ts
@@ -18,6 +18,7 @@ import { NewTag } from './newTag';
 export function fakeNewTag(attributes?: Partial<NewTag>): NewTag {
   const base: NewTag = {
     name: 'Internal',
+    key: 'internal',
     description: 'A tag for all internal stuff',
   };
 

--- a/gravitee-apim-console-webui/src/entities/tag/newTag.ts
+++ b/gravitee-apim-console-webui/src/entities/tag/newTag.ts
@@ -15,6 +15,7 @@
  */
 export interface NewTag {
   name: string;
+  key: string;
   description: string;
   restricted_groups?: string[];
 }

--- a/gravitee-apim-console-webui/src/entities/tag/tag.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/tag/tag.fixture.ts
@@ -17,8 +17,9 @@ import { Tag } from './tag';
 
 export function fakeTag(attributes?: Partial<Tag>): Tag {
   const base: Tag = {
-    id: 'external',
+    id: '875fb0a0-1ea2-3a1d-bfd6-f59f9a18bd5b',
     name: 'External',
+    key: 'external',
     description: 'A tag for all external stuff',
   };
 

--- a/gravitee-apim-console-webui/src/entities/tag/tag.ts
+++ b/gravitee-apim-console-webui/src/entities/tag/tag.ts
@@ -20,3 +20,9 @@ export interface Tag {
   description: string;
   restricted_groups?: string[];
 }
+
+export interface UpdateTagEntity {
+  name: string;
+  description: string;
+  restricted_groups?: string[];
+}

--- a/gravitee-apim-console-webui/src/entities/tag/tag.ts
+++ b/gravitee-apim-console-webui/src/entities/tag/tag.ts
@@ -16,6 +16,7 @@
 export interface Tag {
   id: string;
   name: string;
+  key: string;
   description: string;
   restricted_groups?: string[];
 }

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
@@ -15,97 +15,115 @@
     limitations under the License.
 
 -->
-<ng-container *ngIf="generalForm" [formGroup]="generalForm">
-  <mat-form-field class="name-field">
-    <mat-label>Name</mat-label>
-    <input matInput formControlName="name" data-testid="api_plans_name_field" required />
-    <mat-error *ngIf="generalForm.get('name').hasError('required')">Name is required.</mat-error>
-    <mat-error *ngIf="generalForm.get('name').hasError('maxlength')">The name has to be less than 50 characters long.</mat-error>
-    <mat-hint align="end">{{ generalForm.get('name').value?.length || 0 }}/50</mat-hint>
-  </mat-form-field>
-
-  <mat-form-field class="description-field">
-    <mat-label>Description</mat-label>
-    <textarea matInput formControlName="description" data-testid="api_plans_description_field"></textarea>
-  </mat-form-field>
-
-  <mat-form-field class="characteristics-field">
-    <mat-label>Characteristics</mat-label>
-    <gio-form-tags-input formControlName="characteristics" [addOnBlur]="true"></gio-form-tags-input>
-  </mat-form-field>
-
-  <ng-container *ngIf="api$ | async">
-    <h2>Conditions</h2>
-
-    <gio-banner-info *ngIf="mode === 'edit' && planStatus !== 'STAGING' && generalForm.get('generalConditions').enabled">
-      This plan is {{ planStatus | lowercase }}, if you change the general conditions please remember to notify your API subscribers.
-    </gio-banner-info>
-
-    <mat-form-field class="generalConditions-field">
-      <mat-label>Page of General Conditions</mat-label>
-      <mat-select formControlName="generalConditions">
-        <ng-container *ngIf="conditionPages$ | async; let conditionPages">
-          <mat-option *ngIf="conditionPages?.length === 0" disabled>No page available</mat-option>
-          <mat-option *ngIf="conditionPages?.length !== 0"></mat-option>
-          <mat-option *ngFor="let page of conditionPages" [value]="page.id">{{ page.name }}</mat-option>
-        </ng-container>
-      </mat-select>
+@if (generalForm) {
+  <ng-container [formGroup]="generalForm">
+    <mat-form-field class="name-field">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" data-testid="api_plans_name_field" required />
+      @if (generalForm.get('name').hasError('required')) {
+        <mat-error>Name is required.</mat-error>
+      }
+      @if (generalForm.get('name').hasError('maxlength')) {
+        <mat-error>The name has to be less than 50 characters long.</mat-error>
+      }
+      <mat-hint align="end">{{ generalForm.get('name').value?.length || 0 }}/50</mat-hint>
     </mat-form-field>
-  </ng-container>
 
-  <ng-container *ngIf="displaySubscriptionsSection">
-    <h2>Subscriptions</h2>
-
-    <gio-form-slide-toggle class="validation-field">
-      Auto validate subscription
-      <mat-slide-toggle
-        gioFormSlideToggle
-        formControlName="autoValidation"
-        aria-label="Auto validate subscription toggle"
-        name="validation"
-      ></mat-slide-toggle>
-    </gio-form-slide-toggle>
-
-    <gio-form-slide-toggle class="commentRequired-field">
-      Consumer must provide a comment when subscribing to the plan (Classic Portal only)
-      <mat-slide-toggle
-        gioFormSlideToggle
-        formControlName="commentRequired"
-        aria-label="Comment when subscribing to the plan toggle"
-        name="commentRequired"
-      ></mat-slide-toggle>
-    </gio-form-slide-toggle>
-
-    <mat-form-field class="commentMessage-field">
-      <mat-label>Custom message to display to consumer</mat-label>
-      <input matInput formControlName="commentMessage" />
-      <mat-error *ngIf="generalForm.get('commentMessage').hasError('maxlength')"
-        >The comment message has to be less than 64 characters long.</mat-error
-      >
+    <mat-form-field class="description-field">
+      <mat-label>Description</mat-label>
+      <textarea matInput formControlName="description" data-testid="api_plans_description_field"></textarea>
     </mat-form-field>
-  </ng-container>
 
-  <ng-container *ngIf="!isFederated && (api$ | async)">
-    <h2>Deployment</h2>
-
-    <mat-form-field>
-      <mat-label>Sharding tags</mat-label>
-      <mat-select formControlName="shardingTags" aria-label="Sharding tags selection" multiple>
-        <mat-option *ngFor="let tag of shardingTags$ | async" [value]="tag.id" [disabled]="tag.disabled"
-          >{{ tag.name }}{{ tag.description ? ' - ' + tag.description : '' }}</mat-option
-        >
-      </mat-select>
+    <mat-form-field class="characteristics-field">
+      <mat-label>Characteristics</mat-label>
+      <gio-form-tags-input formControlName="characteristics" [addOnBlur]="true"></gio-form-tags-input>
     </mat-form-field>
-  </ng-container>
 
-  <ng-container *ngIf="!hideAccessControl">
-    <h2>Access-Control</h2>
+    @if (api$ | async) {
+      <h2>Conditions</h2>
 
-    <mat-form-field>
-      <mat-label>Groups excluded</mat-label>
-      <mat-select formControlName="excludedGroups" aria-label="Groups excluded selection" multiple>
-        <mat-option *ngFor="let group of groups$ | async" [value]="group.id">{{ group.name }}</mat-option>
-      </mat-select>
-    </mat-form-field>
+      @if (mode === 'edit' && planStatus !== 'STAGING' && generalForm.get('generalConditions').enabled) {
+        <gio-banner-info>
+          This plan is {{ planStatus | lowercase }}, if you change the general conditions please remember to notify your API subscribers.
+        </gio-banner-info>
+      }
+
+      <mat-form-field class="generalConditions-field">
+        <mat-label>Page of General Conditions</mat-label>
+        <mat-select formControlName="generalConditions">
+          @if (conditionPages$ | async; as conditionPages) {
+            @if (conditionPages?.length === 0) {
+              <mat-option disabled>No page available</mat-option>
+            }
+            @if (conditionPages?.length !== 0) {
+              <mat-option></mat-option>
+            }
+            @for (page of conditionPages; track page.id) {
+              <mat-option [value]="page.id">{{ page.name }}</mat-option>
+            }
+          }
+        </mat-select>
+      </mat-form-field>
+    }
+
+    @if (displaySubscriptionsSection) {
+      <h2>Subscriptions</h2>
+
+      <gio-form-slide-toggle class="validation-field">
+        Auto validate subscription
+        <mat-slide-toggle
+          gioFormSlideToggle
+          formControlName="autoValidation"
+          aria-label="Auto validate subscription toggle"
+          name="validation"
+        ></mat-slide-toggle>
+      </gio-form-slide-toggle>
+
+      <gio-form-slide-toggle class="commentRequired-field">
+        Consumer must provide a comment when subscribing to the plan (Classic Portal only)
+        <mat-slide-toggle
+          gioFormSlideToggle
+          formControlName="commentRequired"
+          aria-label="Comment when subscribing to the plan toggle"
+          name="commentRequired"
+        ></mat-slide-toggle>
+      </gio-form-slide-toggle>
+
+      <mat-form-field class="commentMessage-field">
+        <mat-label>Custom message to display to consumer</mat-label>
+        <input matInput formControlName="commentMessage" />
+        @if (generalForm.get('commentMessage').hasError('maxlength')) {
+          <mat-error>The comment message has to be less than 64 characters long.</mat-error>
+        }
+      </mat-form-field>
+    }
+
+    @if (!isFederated && (api$ | async)) {
+      <h2>Deployment</h2>
+
+      <mat-form-field>
+        <mat-label>Sharding tags</mat-label>
+        <mat-select formControlName="shardingTags" aria-label="Sharding tags selection" multiple>
+          @for (tag of shardingTags$ | async; track tag.id) {
+            <mat-option [value]="tag.key" [disabled]="tag.disabled"
+              >{{ tag.name }}{{ tag.description ? ' - ' + tag.description : '' }}</mat-option
+            >
+          }
+        </mat-select>
+      </mat-form-field>
+    }
+
+    @if (!hideAccessControl) {
+      <h2>Access-Control</h2>
+
+      <mat-form-field>
+        <mat-label>Groups excluded</mat-label>
+        <mat-select formControlName="excludedGroups" aria-label="Groups excluded selection" multiple>
+          @for (group of groups$ | async; track group.id) {
+            <mat-option [value]="group.id">{{ group.name }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
   </ng-container>
-</ng-container>
+}

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Input, inject, OnInit, DestroyRef } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { includes } from 'lodash';
-import { combineLatest, of, ReplaySubject, Subject } from 'rxjs';
-import { map, startWith, switchMap, takeUntil } from 'rxjs/operators';
+import { combineLatest, of, ReplaySubject } from 'rxjs';
+import { map, startWith, switchMap } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { ApiFederated, ApiV2, ApiV4, PlanStatus } from '../../../../../entities/management-api-v2';
 import { CurrentUserService } from '../../../../../services-ngx/current-user.service';
@@ -31,8 +32,13 @@ import { TagService } from '../../../../../services-ngx/tag.service';
   styleUrls: ['./plan-edit-general-step.component.scss'],
   standalone: false,
 })
-export class PlanEditGeneralStepComponent implements OnInit, OnDestroy {
-  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+export class PlanEditGeneralStepComponent implements OnInit {
+  private readonly tagService = inject(TagService);
+  private readonly groupService = inject(GroupService);
+  private readonly documentationService = inject(DocumentationService);
+  private readonly currentUserService = inject(CurrentUserService);
+  private readonly destroyRef = inject(DestroyRef);
+
   public api$ = new ReplaySubject<ApiV2 | ApiV4 | ApiFederated>(1);
 
   public generalForm: UntypedFormGroup;
@@ -75,19 +81,12 @@ export class PlanEditGeneralStepComponent implements OnInit, OnDestroy {
     map(([tags, api, userTags]) => {
       return tags.map(tag => ({
         ...tag,
-        disabled: !includes(userTags, tag.id) || !includes(api.tags, tag.id),
+        disabled: !includes(userTags, tag.key) || !includes(api.tags, tag.key),
       }));
     }),
   );
 
   groups$ = this.groupService.list();
-
-  constructor(
-    private readonly tagService: TagService,
-    private readonly groupService: GroupService,
-    private readonly documentationService: DocumentationService,
-    private readonly currentUserService: CurrentUserService,
-  ) {}
 
   ngOnInit(): void {
     this.generalForm = new UntypedFormGroup({
@@ -105,14 +104,9 @@ export class PlanEditGeneralStepComponent implements OnInit, OnDestroy {
     // Enable comment message only if comment required is checked
     this.generalForm
       .get('commentRequired')
-      .valueChanges.pipe(startWith(this.generalForm.get('commentRequired').value), takeUntil(this.unsubscribe$))
+      .valueChanges.pipe(startWith(this.generalForm.get('commentRequired').value), takeUntilDestroyed(this.destroyRef))
       .subscribe(value => {
         value ? this.generalForm.get('commentMessage').enable() : this.generalForm.get('commentMessage').disable();
       });
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe$.next(true);
-    this.unsubscribe$.unsubscribe();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -134,9 +134,9 @@ describe('ApiPlanFormComponent', () => {
 
   describe('Create mode V2 with API', () => {
     describe('OAuth2 plan', () => {
-      const TAG_1_ID = 'tag-1';
+      const TAG_1_KEY = 'tag-1';
       const API = fakeApiV2({
-        tags: [TAG_1_ID],
+        tags: [TAG_1_KEY],
         resources: [
           {
             name: 'OAuth2 AM Resource',
@@ -207,9 +207,10 @@ describe('ApiPlanFormComponent', () => {
       });
     });
     describe('JWT plan', () => {
-      const TAG_1_ID = 'tag-1';
+      const TAG_1_ID = 'tag-1-id';
+      const TAG_1_KEY = 'tag-1';
       const API = fakeApiV2({
-        tags: [TAG_1_ID],
+        tags: [TAG_1_KEY],
         resources: [
           {
             name: 'OAuth2 AM Resource',
@@ -231,12 +232,15 @@ describe('ApiPlanFormComponent', () => {
 
         planForm
           .httpRequest(httpTestingController)
-          .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+          .expectTagsListRequest([
+            fakeTag({ id: TAG_1_ID, key: TAG_1_KEY, name: 'Tag 1' }),
+            fakeTag({ id: 'tag-2-id', key: 'tag-2', name: 'Tag 2' }),
+          ]);
         planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm
           .httpRequest(httpTestingController)
           .expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1', published: true }]);
-        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_KEY]);
         fixture.detectChanges();
 
         expect(testComponent.planControl.touched).toEqual(false);
@@ -320,7 +324,7 @@ describe('ApiPlanFormComponent', () => {
             configuration: {},
           },
           selectionRule: '{ #el ...}',
-          tags: [TAG_1_ID],
+          tags: [TAG_1_KEY],
           validation: 'AUTO',
           flows: [
             {
@@ -356,9 +360,10 @@ describe('ApiPlanFormComponent', () => {
       });
     });
     describe('API Key plan', () => {
-      const TAG_1_ID = 'tag-1';
+      const TAG_1_ID = 'tag-1-id';
+      const TAG_1_KEY = 'tag-1';
       const API = fakeApiV2({
-        tags: [TAG_1_ID],
+        tags: [TAG_1_KEY],
         resources: [
           {
             name: 'OAuth2 AM Resource',
@@ -380,12 +385,15 @@ describe('ApiPlanFormComponent', () => {
 
         planForm
           .httpRequest(httpTestingController)
-          .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+          .expectTagsListRequest([
+            fakeTag({ id: TAG_1_ID, key: TAG_1_KEY, name: 'Tag 1' }),
+            fakeTag({ id: 'tag-2-id', key: 'tag-2', name: 'Tag 2' }),
+          ]);
         planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm
           .httpRequest(httpTestingController)
           .expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1', published: true }]);
-        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_KEY]);
         fixture.detectChanges();
 
         expect(testComponent.planControl.touched).toEqual(false);
@@ -474,7 +482,7 @@ describe('ApiPlanFormComponent', () => {
             },
           },
           selectionRule: null,
-          tags: [TAG_1_ID],
+          tags: [TAG_1_KEY],
           validation: 'AUTO',
           flows: [
             {
@@ -510,9 +518,10 @@ describe('ApiPlanFormComponent', () => {
       });
     });
     describe('API Keyless plan', () => {
-      const TAG_1_ID = 'tag-1';
+      const TAG_1_ID = 'tag-1-id';
+      const TAG_1_KEY = 'tag-1';
       const API = fakeApiV2({
-        tags: [TAG_1_ID],
+        tags: [TAG_1_KEY],
         resources: [
           {
             name: 'OAuth2 AM Resource',
@@ -533,12 +542,15 @@ describe('ApiPlanFormComponent', () => {
 
         planForm
           .httpRequest(httpTestingController)
-          .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+          .expectTagsListRequest([
+            fakeTag({ id: TAG_1_ID, key: TAG_1_KEY, name: 'Tag 1' }),
+            fakeTag({ id: 'tag-2', key: 'tag-2', name: 'Tag 2' }),
+          ]);
         planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm
           .httpRequest(httpTestingController)
           .expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1', published: true }]);
-        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_KEY]);
         fixture.detectChanges();
 
         expect(testComponent.planControl.touched).toEqual(false);
@@ -609,7 +621,7 @@ describe('ApiPlanFormComponent', () => {
             configuration: {},
           },
           selectionRule: null,
-          tags: [TAG_1_ID],
+          tags: [TAG_1_KEY],
           validation: 'MANUAL',
           flows: [
             {
@@ -1113,9 +1125,10 @@ describe('ApiPlanFormComponent', () => {
   });
 
   describe('Edit mode V2', () => {
-    const TAG_1_ID = 'tag-1';
+    const TAG_1_ID = 'tag-1-id';
+    const TAG_1_KEY = 'tag-1';
     const API = fakeApiV2({
-      tags: [TAG_1_ID],
+      tags: [TAG_1_KEY],
     });
     const PLAN_ID = 'plan-1';
 
@@ -1124,7 +1137,7 @@ describe('ApiPlanFormComponent', () => {
     });
 
     it('should edit plan', async () => {
-      const planToUpdate = fakePlanV2({ id: PLAN_ID, name: 'Old 🗺', description: 'Old Description', tags: [TAG_1_ID] });
+      const planToUpdate = fakePlanV2({ id: PLAN_ID, name: 'Old 🗺', description: 'Old Description', tags: [TAG_1_KEY] });
       testComponent.planControl = new FormControl(planToUpdate);
       fixture.detectChanges();
 
@@ -1132,12 +1145,15 @@ describe('ApiPlanFormComponent', () => {
 
       planForm
         .httpRequest(httpTestingController)
-        .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+        .expectTagsListRequest([
+          fakeTag({ id: TAG_1_ID, key: TAG_1_KEY, name: 'Tag 1' }),
+          fakeTag({ id: 'tag-2', key: 'tag-2', name: 'Tag 2' }),
+        ]);
       planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       planForm
         .httpRequest(httpTestingController)
         .expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1', published: true }]);
-      planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+      planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_KEY]);
       fixture.detectChanges();
 
       expect(testComponent.planControl.touched).toEqual(false);
@@ -1196,9 +1212,10 @@ describe('ApiPlanFormComponent', () => {
   });
 
   describe('Edit mode V2 with disabled control', () => {
-    const TAG_1_ID = 'tag-1';
+    const TAG_1_ID = 'tag-1-id';
+    const TAG_1_KEY = 'tag-1';
     const API = fakeApiV2({
-      tags: [TAG_1_ID],
+      tags: [TAG_1_KEY],
       definitionContext: { origin: 'KUBERNETES' },
     });
     const PLAN_ID = 'plan-1';
@@ -1208,7 +1225,7 @@ describe('ApiPlanFormComponent', () => {
     });
 
     it('should access plan in read only ', async () => {
-      const planToUpdate = fakePlanV2({ id: PLAN_ID, name: 'Old 🗺', description: 'Old Description', tags: [TAG_1_ID] });
+      const planToUpdate = fakePlanV2({ id: PLAN_ID, name: 'Old 🗺', description: 'Old Description', tags: [TAG_1_KEY] });
       testComponent.planControl = new FormControl({
         value: planToUpdate,
         disabled: true,
@@ -1219,10 +1236,13 @@ describe('ApiPlanFormComponent', () => {
 
       planForm
         .httpRequest(httpTestingController)
-        .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+        .expectTagsListRequest([
+          fakeTag({ id: TAG_1_ID, key: TAG_1_KEY, name: 'Tag 1' }),
+          fakeTag({ id: 'tag-2', key: 'tag-2', name: 'Tag 2' }),
+        ]);
       planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
-      planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+      planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_KEY]);
       fixture.detectChanges();
 
       expect(testComponent.planControl.touched).toEqual(false);
@@ -1259,16 +1279,17 @@ describe('ApiPlanFormComponent', () => {
   });
 
   describe('Edit mode V4', () => {
-    const TAG_1_ID = 'tag-1';
+    const TAG_1_ID = 'tag-1-id';
+    const TAG_1_KEY = 'tag-1';
     const API = fakeApiV4({
-      tags: [TAG_1_ID],
+      tags: [TAG_1_KEY],
     });
     const PLAN_ID = 'plan-1';
 
     describe('Keyless plan', () => {
       it('should edit plan', async () => {
         configureTestingModule('edit', 'KEY_LESS', API);
-        const planToUpdate = fakePlanV4({ id: PLAN_ID, name: 'Old 🗺', description: 'Old Description', tags: [TAG_1_ID] });
+        const planToUpdate = fakePlanV4({ id: PLAN_ID, name: 'Old 🗺', description: 'Old Description', tags: [TAG_1_KEY] });
         testComponent.planControl = new FormControl(planToUpdate);
         fixture.detectChanges();
 
@@ -1276,12 +1297,15 @@ describe('ApiPlanFormComponent', () => {
 
         planForm
           .httpRequest(httpTestingController)
-          .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+          .expectTagsListRequest([
+            fakeTag({ id: TAG_1_ID, key: TAG_1_KEY, name: 'Tag 1' }),
+            fakeTag({ id: 'tag-2', key: 'tag-2', name: 'Tag 2' }),
+          ]);
         planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm
           .httpRequest(httpTestingController)
           .expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1', published: true }]);
-        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_KEY]);
         fixture.detectChanges();
 
         expect(testComponent.planControl.touched).toEqual(false);
@@ -1344,13 +1368,16 @@ describe('ApiPlanFormComponent', () => {
 
         planForm
           .httpRequest(httpTestingController)
-          .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+          .expectTagsListRequest([
+            fakeTag({ id: TAG_1_ID, key: TAG_1_KEY, name: 'Tag 1' }),
+            fakeTag({ id: 'tag-2', key: 'tag-2', name: 'Tag 2' }),
+          ]);
         planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [
           { id: 'doc-1', name: 'Doc 1', published: true },
           { id: 'doc-2', name: 'Doc 2', published: false },
         ]);
-        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_KEY]);
 
         const generalConditionsInput = await planForm.getGeneralConditionsInput();
         await generalConditionsInput.open();
@@ -1395,7 +1422,7 @@ describe('ApiPlanFormComponent', () => {
             type: 'API_KEY',
             configuration: { propagateApiKey: true },
           },
-          tags: [TAG_1_ID],
+          tags: [TAG_1_KEY],
         });
         testComponent.planControl = new FormControl(planToUpdate);
         fixture.detectChanges();
@@ -1404,10 +1431,13 @@ describe('ApiPlanFormComponent', () => {
 
         planForm
           .httpRequest(httpTestingController)
-          .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+          .expectTagsListRequest([
+            fakeTag({ id: TAG_1_ID, key: TAG_1_KEY, name: 'Tag 1' }),
+            fakeTag({ id: 'tag-2', key: 'tag-2', name: 'Tag 2' }),
+          ]);
         planForm.httpRequest(httpTestingController).expectGroupListRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
-        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_KEY]);
         planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', fakeApiKeySchema);
         fixture.detectChanges();
 

--- a/gravitee-apim-console-webui/src/management/api/deployment-configuration-v4/api-deployment-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/deployment-configuration-v4/api-deployment-configuration.component.html
@@ -23,23 +23,32 @@
     </div>
 
     <div class="deployment-configuration__content">
-      <form *ngIf="deploymentsForm" [formGroup]="deploymentsForm" autocomplete="off">
-        <div>
-          <div class="deployment-configuration__form-field__label">Sharding tags</div>
-          <div class="deployment-configuration__form-field__description">
-            Choose the sharding tag that you want to assign to the API. This will dictate where it is deployed. Sharding tags are configured
-            at the Organization level.
+      @if (deploymentsForm) {
+        <form [formGroup]="deploymentsForm" autocomplete="off">
+          <div>
+            <div class="deployment-configuration__form-field__label">Sharding tags</div>
+            <div class="deployment-configuration__form-field__description">
+              Choose the sharding tag that you want to assign to the API. This will dictate where it is deployed. Sharding tags are
+              configured at the Organization level.
+            </div>
+            <mat-form-field class="deployment-configuration__form-field">
+              <mat-label>Sharding tags</mat-label>
+              <mat-select formControlName="tags" multiple>
+                @for (tag of shardingTags; track tag.id) {
+                  <mat-option [value]="tag.key">
+                    {{ tag.name
+                    }}<span>
+                      @if (tag.description) {
+                        - {{ tag.description }}
+                      }
+                    </span>
+                  </mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
           </div>
-          <mat-form-field class="deployment-configuration__form-field">
-            <mat-label>Sharding tags</mat-label>
-            <mat-select formControlName="tags" multiple>
-              <mat-option *ngFor="let tag of shardingTags" [value]="tag.id"
-                >{{ tag.name }}<span *ngIf="tag.description"> - {{ tag.description }}</span></mat-option
-              >
-            </mat-select>
-          </mat-form-field>
-        </div>
-      </form>
+        </form>
+      }
     </div>
   </mat-card-content>
 </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/deployment-configuration-v4/api-deployment-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/deployment-configuration-v4/api-deployment-configuration.component.spec.ts
@@ -67,9 +67,9 @@ describe('ApiDeploymentConfigurationComponent', () => {
 
         expectApiGetRequest(api);
         expectTagGetRequest([
-          fakeTag({ id: 'tag1', name: 'tag1' }),
-          fakeTag({ id: 'tag2', name: 'tag2' }),
-          fakeTag({ id: 'tag3', name: 'tag3' }),
+          fakeTag({ id: 'tag-1-id', key: 'tag1', name: 'tag1' }),
+          fakeTag({ id: 'tag-2-id', key: 'tag2', name: 'tag2' }),
+          fakeTag({ id: 'tag-3-id', key: 'tag3', name: 'tag3' }),
         ]);
 
         const saveBar = await loader.getHarness(GioSaveBarHarness);
@@ -149,9 +149,9 @@ describe('ApiDeploymentConfigurationComponent', () => {
     it('should not be able to update deployment configuration', async () => {
       expectApiGetRequest(api);
       expectTagGetRequest([
-        fakeTag({ id: 'tag1', name: 'tag1' }),
-        fakeTag({ id: 'tag2', name: 'tag2' }),
-        fakeTag({ id: 'tag3', name: 'tag3' }),
+        fakeTag({ id: 'tag-1-id', key: 'tag1', name: 'tag1' }),
+        fakeTag({ id: 'tag-2-id', key: 'tag2', name: 'tag2' }),
+        fakeTag({ id: 'tag-3-id', key: 'tag3', name: 'tag3' }),
       ]);
 
       const saveBar = await loader.getHarness(GioSaveBarHarness);

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -359,7 +359,10 @@ describe('ApisListComponent', () => {
         tick();
 
         const reqTags = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/tags`);
-        reqTags.flush([{ id: 'tag-1' }, { id: 'tag-2' }]);
+        reqTags.flush([
+          { id: 'tag-1-id', key: 'tag-1' },
+          { id: 'tag-2-id', key: 'tag-2' },
+        ]);
       }
 
       function expectQualityRequest(apiId: string, score: number) {

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -191,7 +191,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
     this.tagService
       .list()
       .pipe(
-        map(tags => (this.tags = tags.map(tag => tag.id))),
+        map(tags => (this.tags = tags.map(tag => tag.key))),
         takeUntil(this.unsubscribe$),
       )
       .subscribe();

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-mapping-dialog.component.html
@@ -28,11 +28,13 @@
       <mat-form-field>
         <mat-label>Sharding tags</mat-label>
         <mat-select formControlName="tags" aria-label="Sharding tags selection" multiple required>
-          <mat-option *ngFor="let tag of tags$ | async" [value]="tag.id"
-            >{{ tag.name }}{{ tag.description ? ' - ' + tag.description : '' }}</mat-option
-          >
+          @for (tag of tags$ | async; track tag.id) {
+            <mat-option [value]="tag.key">{{ tag.name }}{{ tag.description ? ' - ' + tag.description : '' }}</mat-option>
+          }
         </mat-select>
-        <mat-error *ngIf="mappingForm.get('tags').hasError('required')">At least one tag must be selected.</mat-error>
+        @if (mappingForm.controls.tags.hasError('required')) {
+          <mat-error>At least one tag must be selected.</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field>
@@ -50,7 +52,9 @@
           <mat-form-field>
             <mat-label>Entrypoint url</mat-label>
             <input matInput formControlName="httpValue" type="url" placeholder="https://api.mycompany.com" required />
-            <mat-error *ngIf="mappingForm.get('httpValue').hasError('required')">Entrypoint Url is required.</mat-error>
+            @if (mappingForm.controls.httpValue.hasError('required')) {
+              <mat-error>Entrypoint Url is required.</mat-error>
+            }
           </mat-form-field>
         }
         @case ('KAFKA') {
@@ -59,21 +63,23 @@
               <mat-label>Default Kafka Bootstrap Domain Pattern</mat-label>
               <input matInput formControlName="kafkaDomain" />
 
-              <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('maxLength')"
-                >Kafka Domain must be less than 201 characters.</mat-error
-              >
-              <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('required')">Kafka Bootstrap Domain Pattern is required.</mat-error>
-              <mat-error *ngIf="mappingForm.get('kafkaDomain').hasError('apiHostMissing')">
-                Kafka Bootstrap Domain Pattern must contain {{ '{apiHost}' }}.
-              </mat-error>
+              @if (mappingForm.controls.kafkaDomain.hasError('maxLength')) {
+                <mat-error>Kafka Domain must be less than 201 characters.</mat-error>
+              }
+              @if (mappingForm.controls.kafkaDomain.hasError('required')) {
+                <mat-error>Kafka Bootstrap Domain Pattern is required.</mat-error>
+              }
+              @if (mappingForm.controls.kafkaDomain.hasError('apiHostMissing')) {
+                <mat-error>Kafka Bootstrap Domain Pattern must contain {{ '{apiHost}' }}.</mat-error>
+              }
               <mat-hint> To be configured according to the gateway configuration. e.g: {{ '{apiHost}.mycompany.org' }} </mat-hint>
             </mat-form-field>
             <mat-form-field class="kafka__port">
               <mat-label>Default Kafka port</mat-label>
               <input matInput formControlName="kafkaPort" type="number" />
-              <mat-error *ngIf="mappingForm.get('kafkaPort').hasError('invalidPort')"
-                >Port should be in range between 1025 and 65535</mat-error
-              >
+              @if (mappingForm.controls.kafkaPort.hasError('invalidPort')) {
+                <mat-error>Port should be in range between 1025 and 65535</mat-error>
+              }
             </mat-form-field>
           </div>
         }
@@ -81,7 +87,9 @@
           <mat-form-field class="tcp__port">
             <mat-label>Default TCP port</mat-label>
             <input matInput formControlName="tcpPort" type="number" />
-            <mat-error *ngIf="mappingForm.get('tcpPort').hasError('invalidPort')">Port should be in range between 1025 and 65535</mat-error>
+            @if (mappingForm.controls.tcpPort.hasError('invalidPort')) {
+              <mat-error>Port should be in range between 1025 and 65535</mat-error>
+            }
           </mat-form-field>
         }
       }

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.html
@@ -41,7 +41,7 @@
 
       <mat-form-field>
         <mat-label>Key</mat-label>
-        <input matInput formControlName="key" required />
+        <input matInput formControlName="key" required (blur)="onKeyBlur()" />
         <mat-hint align="end">{{ tagForm.controls.key.value?.length ?? 0 }}/64</mat-hint>
         @if (tagForm.controls.key.hasError('maxlength')) {
           <mat-error>Key has to be less than 64 characters long.</mat-error>

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.html
@@ -27,10 +27,31 @@
       <mat-form-field>
         <mat-label>Name</mat-label>
         <input matInput formControlName="name" required />
-        <mat-hint align="end">{{ tagForm.get('name').value?.length ?? 0 }}/64</mat-hint>
-        <mat-error *ngIf="tagForm.get('name').hasError('maxlength')">Name has to be less than 64 characters long.</mat-error>
-        <mat-error *ngIf="tagForm.get('name').hasError('minlength')">Name has to be more than 2 characters long.</mat-error>
-        <mat-error *ngIf="tagForm.get('name').hasError('required')">Name is required.</mat-error>
+        <mat-hint align="end">{{ tagForm.controls.name.value?.length ?? 0 }}/64</mat-hint>
+        @if (tagForm.controls.name.hasError('maxlength')) {
+          <mat-error>Name has to be less than 64 characters long.</mat-error>
+        }
+        @if (tagForm.controls.name.hasError('minlength')) {
+          <mat-error>Name has to be more than 2 characters long.</mat-error>
+        }
+        @if (tagForm.controls.name.hasError('required')) {
+          <mat-error>Name is required.</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>Key</mat-label>
+        <input matInput formControlName="key" required />
+        <mat-hint align="end">{{ tagForm.controls.key.value?.length ?? 0 }}/64</mat-hint>
+        @if (tagForm.controls.key.hasError('maxlength')) {
+          <mat-error>Key has to be less than 64 characters long.</mat-error>
+        }
+        @if (tagForm.controls.key.hasError('minlength')) {
+          <mat-error>Key has to be more than 1 characters long.</mat-error>
+        }
+        @if (tagForm.controls.key.hasError('required')) {
+          <mat-error>Key is required.</mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field>
@@ -41,7 +62,9 @@
       <mat-form-field>
         <mat-label>Restricted groups</mat-label>
         <mat-select formControlName="restrictedGroups" aria-label="Restricted groups selection" multiple>
-          <mat-option *ngFor="let group of groups$ | async" [value]="group.id">{{ group.name }}</mat-option>
+          @for (group of groups$ | async; track group.id) {
+            <mat-option [value]="group.id">{{ group.name }}</mat-option>
+          }
         </mat-select>
       </mat-form-field>
     </div>

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.spec.ts
@@ -21,7 +21,6 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { OrgSettingAddTagDialogComponent, OrgSettingAddTagDialogData } from './org-settings-add-tag-dialog.component';
 
@@ -41,27 +40,30 @@ describe('OrgSettingAddTagDialogComponent', () => {
     close: jest.fn(),
   };
 
+  const initComponent = (dialogData: OrgSettingAddTagDialogData) => {
+    TestBed.configureTestingModule({
+      imports: [OrganizationSettingsModule, GioTestingModule],
+      providers: [
+        {
+          provide: MAT_DIALOG_DATA,
+          useFactory: () => dialogData,
+        },
+        { provide: MatDialogRef, useValue: matDialogRefMock },
+      ],
+    });
+    fixture = TestBed.createComponent(OrgSettingAddTagDialogComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  };
+
   afterEach(() => {
     matDialogRefMock.close.mockClear();
   });
 
   describe('tag creation', () => {
     beforeEach(() => {
-      const dialogData: OrgSettingAddTagDialogData = {};
-      TestBed.configureTestingModule({
-        imports: [NoopAnimationsModule, OrganizationSettingsModule, GioTestingModule],
-        providers: [
-          {
-            provide: MAT_DIALOG_DATA,
-            useFactory: () => dialogData,
-          },
-          { provide: MatDialogRef, useValue: matDialogRefMock },
-        ],
-      });
-      fixture = TestBed.createComponent(OrgSettingAddTagDialogComponent);
-      component = fixture.componentInstance;
-      loader = TestbedHarnessEnvironment.loader(fixture);
-      httpTestingController = TestBed.inject(HttpTestingController);
+      initComponent({});
     });
 
     it('should fill and submit form', async () => {
@@ -74,6 +76,9 @@ describe('OrgSettingAddTagDialogComponent', () => {
       const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=name]' }));
       await nameInput.setValue('Tag name');
 
+      const keyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
+      await keyInput.setValue('tag-key');
+
       const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=description' }));
       await descriptionInput.setValue('Tag description');
 
@@ -84,6 +89,7 @@ describe('OrgSettingAddTagDialogComponent', () => {
 
       expect(matDialogRefMock.close).toHaveBeenCalledWith({
         name: 'Tag name',
+        key: 'tag-key',
         description: 'Tag description',
         restricted_groups: ['group-a'],
       });
@@ -92,28 +98,15 @@ describe('OrgSettingAddTagDialogComponent', () => {
 
   describe('tag edition', () => {
     beforeEach(() => {
-      const dialogData: OrgSettingAddTagDialogData = {
+      initComponent({
         tag: fakeTag({
-          id: 'tagId',
+          id: '875fb0a0-1ea2-3a1d-bfd6-f59f9a18bd5b',
           name: 'Tag name',
+          key: 'tag-key',
           description: 'Tag description',
           restricted_groups: ['group-a'],
         }),
-      };
-      TestBed.configureTestingModule({
-        imports: [NoopAnimationsModule, OrganizationSettingsModule, GioTestingModule],
-        providers: [
-          {
-            provide: MAT_DIALOG_DATA,
-            useFactory: () => dialogData,
-          },
-          { provide: MatDialogRef, useValue: matDialogRefMock },
-        ],
       });
-      fixture = TestBed.createComponent(OrgSettingAddTagDialogComponent);
-      component = fixture.componentInstance;
-      loader = TestbedHarnessEnvironment.loader(fixture);
-      httpTestingController = TestBed.inject(HttpTestingController);
     });
 
     it('should fill and submit form', async () => {
@@ -128,6 +121,9 @@ describe('OrgSettingAddTagDialogComponent', () => {
       expect(await submitButton.isDisabled()).toBeTruthy();
       await nameInput.setValue('Internal');
 
+      const keyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
+      await keyInput.setValue('internal-key');
+
       const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=description' }));
       await descriptionInput.setValue('Internal tenant');
 
@@ -137,8 +133,9 @@ describe('OrgSettingAddTagDialogComponent', () => {
       await submitButton.click();
 
       expect(matDialogRefMock.close).toHaveBeenCalledWith({
-        id: 'tagId',
+        id: '875fb0a0-1ea2-3a1d-bfd6-f59f9a18bd5b',
         name: 'Internal',
+        key: 'internal-key',
         description: 'Internal tenant',
         restricted_groups: [],
       });

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.spec.ts
@@ -148,7 +148,7 @@ describe('OrgSettingAddTagDialogComponent', () => {
       await nameInput.setValue('Internal');
 
       const keyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
-      await keyInput.setValue('internal-key');
+      expect(await keyInput.isDisabled()).toBeTruthy();
 
       const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=description' }));
       await descriptionInput.setValue('Internal tenant');
@@ -161,24 +161,10 @@ describe('OrgSettingAddTagDialogComponent', () => {
       expect(matDialogRefMock.close).toHaveBeenCalledWith({
         id: '875fb0a0-1ea2-3a1d-bfd6-f59f9a18bd5b',
         name: 'Internal',
-        key: 'internal-key',
+        key: 'tag-key',
         description: 'Internal tenant',
         restricted_groups: [],
       });
-    });
-
-    it('should sanitize key in real-time when editing', async () => {
-      fixture.detectChanges();
-      expectGroupListByOrganizationRequest([]);
-
-      component.tagForm.controls.key.setValue('New KEY With @#$ Special');
-      fixture.detectChanges();
-
-      const keyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
-      await keyInput.blur();
-      fixture.detectChanges();
-
-      expect(await keyInput.getValue()).toBe('new-key-with-special');
     });
   });
 

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HarnessLoader } from '@angular/cdk/testing';
@@ -94,6 +94,32 @@ describe('OrgSettingAddTagDialogComponent', () => {
         restricted_groups: ['group-a'],
       });
     });
+
+    it.each`
+      key                                  | sanitized
+      ${'My Tag Key'}                      | ${'my-tag-key'}
+      ${'Tâg Spécîal @#$ Nàme!'}           | ${'tag-special-name'}
+      ${'Tag   With    Multiple---Spaces'} | ${'tag-with-multiple-spaces'}
+      ${'Tag Key---'}                      | ${'tag-key'}
+      ${'UPPERCASE KEY'}                   | ${'uppercase-key'}
+      ${'Key 123 Value 456'}               | ${'key-123-value-456'}
+      ${'eu east 1! @#$%'}                 | ${'eu-east-1'}
+    `(
+      'should sanitize key "$key" to "$sanitized"',
+      fakeAsync(async ({ key, sanitized }) => {
+        fixture.detectChanges();
+        expectGroupListByOrganizationRequest([]);
+
+        component.tagForm.controls.key.setValue(key);
+        fixture.detectChanges();
+
+        const keyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
+        await keyInput.blur();
+        fixture.detectChanges();
+
+        expect(await keyInput.getValue()).toBe(sanitized);
+      }),
+    );
   });
 
   describe('tag edition', () => {
@@ -139,6 +165,20 @@ describe('OrgSettingAddTagDialogComponent', () => {
         description: 'Internal tenant',
         restricted_groups: [],
       });
+    });
+
+    it('should sanitize key in real-time when editing', async () => {
+      fixture.detectChanges();
+      expectGroupListByOrganizationRequest([]);
+
+      component.tagForm.controls.key.setValue('New KEY With @#$ Special');
+      fixture.detectChanges();
+
+      const keyInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
+      await keyInput.blur();
+      fixture.detectChanges();
+
+      expect(await keyInput.getValue()).toBe('new-key-with-special');
     });
   });
 

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.ts
@@ -42,7 +42,11 @@ export class OrgSettingAddTagDialogComponent {
   isUpdate = !!this.tag;
   tagForm = new FormGroup({
     name: new FormControl<string>(this.tag?.name, [Validators.required, Validators.minLength(1), Validators.maxLength(64)]),
-    key: new FormControl<string>(this.tag?.key, [Validators.required, Validators.minLength(1), Validators.maxLength(64)]),
+    key: new FormControl<string>({ value: this.tag?.key ?? '', disabled: this.isUpdate }, [
+      Validators.required,
+      Validators.minLength(1),
+      Validators.maxLength(64),
+    ]),
     description: new FormControl<string>(this.tag?.description),
     restrictedGroups: new FormControl<string[]>(this.tag?.restricted_groups ?? []),
   });

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.ts
@@ -21,6 +21,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { Tag } from '../../../../entities/tag/tag';
 import { GroupService } from '../../../../services-ngx/group.service';
+import { sanitizeKeyBase, sanitizeKeyFinal } from '../../../../shared/utils/key-sanitizer.util';
 
 export type OrgSettingAddTagDialogData = {
   tag?: Tag;
@@ -57,7 +58,7 @@ export class OrgSettingAddTagDialogComponent {
       .pipe(
         filter(key => key !== null),
         tap(key => {
-          const sanitized = this.sanitizeKeyBase(key);
+          const sanitized = sanitizeKeyBase(key);
           if (sanitized !== key) {
             this.tagForm.controls.key.setValue(sanitized, { emitEvent: false });
           }
@@ -77,37 +78,14 @@ export class OrgSettingAddTagDialogComponent {
     this.dialogRef.close(updatedTag);
   }
 
-  /**
-   * Finalizes `key` sanitization on blur.
-   *
-   * We intentionally keep trailing `-` while the user is typing (e.g. transient `eu-`),
-   * then apply the backend rule “no trailing hyphen” when the field loses focus.
-   */
   onKeyBlur(): void {
     const value = this.tagForm.controls.key.value;
-    if (value == null) return;
-
-    let sanitized = this.sanitizeKeyBase(value);
-    while (sanitized.endsWith('-')) {
-      sanitized = sanitized.slice(0, -1);
+    if (value == null) {
+      return;
     }
-
+    const sanitized = sanitizeKeyFinal(value);
     if (sanitized !== value) {
       this.tagForm.controls.key.setValue(sanitized, { emitEvent: false });
     }
-  }
-
-  /**
-   * Normalizes user input to produce a valid tag key that meets backend requirements
-   * (alphanumeric with hyphens only, no diacritics or special characters).
-   */
-  private sanitizeKeyBase(key: string): string {
-    return key
-      .normalize('NFD')
-      .replaceAll(/[\u0300-\u036f]+/g, '')
-      .toLowerCase()
-      .replaceAll(/[^a-z\d\s-]/g, '')
-      .trim()
-      .replaceAll(/[^a-z\d]+/g, '-');
   }
 }

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject } from '@angular/core';
-import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import { Component, inject } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { shareReplay } from 'rxjs/operators';
 
@@ -32,25 +32,19 @@ export type OrgSettingAddTagDialogData = {
   standalone: false,
 })
 export class OrgSettingAddTagDialogComponent {
-  tag?: Tag;
-  isUpdate = false;
-  tagForm: UntypedFormGroup;
-  groups$? = this.groupService.listByOrganization().pipe(shareReplay(1));
+  private readonly dialogRef = inject(MatDialogRef<OrgSettingAddTagDialogComponent>);
+  private readonly confirmDialogData = inject<OrgSettingAddTagDialogData>(MAT_DIALOG_DATA);
+  private readonly groupService = inject(GroupService);
 
-  constructor(
-    public dialogRef: MatDialogRef<OrgSettingAddTagDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) confirmDialogData: OrgSettingAddTagDialogData,
-    private readonly groupService: GroupService,
-  ) {
-    this.tag = confirmDialogData.tag;
-    this.isUpdate = !!this.tag;
-
-    this.tagForm = new UntypedFormGroup({
-      name: new UntypedFormControl(this.tag?.name, [Validators.required, Validators.minLength(1), Validators.maxLength(64)]),
-      description: new UntypedFormControl(this.tag?.description),
-      restrictedGroups: new UntypedFormControl(this.tag?.restricted_groups ?? []),
-    });
-  }
+  tag?: Tag = this.confirmDialogData.tag;
+  isUpdate = !!this.tag;
+  tagForm = new FormGroup({
+    name: new FormControl<string>(this.tag?.name, [Validators.required, Validators.minLength(1), Validators.maxLength(64)]),
+    key: new FormControl<string>(this.tag?.key, [Validators.required, Validators.minLength(1), Validators.maxLength(64)]),
+    description: new FormControl<string>(this.tag?.description),
+    restrictedGroups: new FormControl<string[]>(this.tag?.restricted_groups ?? []),
+  });
+  groups$ = this.groupService.listByOrganization().pipe(shareReplay(1));
 
   onSubmit() {
     const { restrictedGroups, ...formRawValue } = this.tagForm.getRawValue();

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/dialog/org-settings-add-tag-dialog.component.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { shareReplay } from 'rxjs/operators';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { filter, shareReplay, tap } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { Tag } from '../../../../entities/tag/tag';
 import { GroupService } from '../../../../services-ngx/group.service';
@@ -35,6 +36,7 @@ export class OrgSettingAddTagDialogComponent {
   private readonly dialogRef = inject(MatDialogRef<OrgSettingAddTagDialogComponent>);
   private readonly confirmDialogData = inject<OrgSettingAddTagDialogData>(MAT_DIALOG_DATA);
   private readonly groupService = inject(GroupService);
+  private readonly destroyRef = inject(DestroyRef);
 
   tag?: Tag = this.confirmDialogData.tag;
   isUpdate = !!this.tag;
@@ -46,6 +48,21 @@ export class OrgSettingAddTagDialogComponent {
   });
   groups$ = this.groupService.listByOrganization().pipe(shareReplay(1));
 
+  constructor() {
+    this.tagForm.controls.key.valueChanges
+      .pipe(
+        filter(key => key !== null),
+        tap(key => {
+          const sanitized = this.sanitizeKeyBase(key);
+          if (sanitized !== key) {
+            this.tagForm.controls.key.setValue(sanitized, { emitEvent: false });
+          }
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
   onSubmit() {
     const { restrictedGroups, ...formRawValue } = this.tagForm.getRawValue();
     const updatedTag = {
@@ -54,5 +71,39 @@ export class OrgSettingAddTagDialogComponent {
       restricted_groups: restrictedGroups,
     };
     this.dialogRef.close(updatedTag);
+  }
+
+  /**
+   * Finalizes `key` sanitization on blur.
+   *
+   * We intentionally keep trailing `-` while the user is typing (e.g. transient `eu-`),
+   * then apply the backend rule “no trailing hyphen” when the field loses focus.
+   */
+  onKeyBlur(): void {
+    const value = this.tagForm.controls.key.value;
+    if (value == null) return;
+
+    let sanitized = this.sanitizeKeyBase(value);
+    while (sanitized.endsWith('-')) {
+      sanitized = sanitized.slice(0, -1);
+    }
+
+    if (sanitized !== value) {
+      this.tagForm.controls.key.setValue(sanitized, { emitEvent: false });
+    }
+  }
+
+  /**
+   * Normalizes user input to produce a valid tag key that meets backend requirements
+   * (alphanumeric with hyphens only, no diacritics or special characters).
+   */
+  private sanitizeKeyBase(key: string): string {
+    return key
+      .normalize('NFD')
+      .replaceAll(/[\u0300-\u036f]+/g, '')
+      .toLowerCase()
+      .replaceAll(/[^a-z\d\s-]/g, '')
+      .trim()
+      .replaceAll(/[^a-z\d]+/g, '-');
   }
 }

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.html
@@ -16,310 +16,312 @@
 
 -->
 
-<form class="org-settings-tags" *ngIf="!isLoading" autocomplete="off" [formGroup]="defaultConfigForm">
-  <div>
-    <h1>Entrypoints & Sharding Tags</h1>
+@if (!isLoading) {
+  <form class="org-settings-tags" autocomplete="off" [formGroup]="defaultConfigForm">
+    <div>
+      <h1>Entrypoints & Sharding Tags</h1>
 
-    <h4>Manage sharding tags, entrypoints and mappings between them both for Console and the Developer Portal.</h4>
-  </div>
+      <h4>Manage sharding tags, entrypoints and mappings between them both for Console and the Developer Portal.</h4>
+    </div>
 
-  <gio-banner type="info"
-    >Include entrypoint and sharding tag configuration according to the values already used by the deployed API Gateway(s).</gio-banner
-  >
+    <gio-banner type="info"
+      >Include entrypoint and sharding tag configuration according to the values already used by the deployed API Gateway(s).</gio-banner
+    >
 
-  <mat-card>
-    <mat-card-header>
-      <mat-card-title>Entrypoint Configuration</mat-card-title>
-      <mat-card-subtitle>Default entrypoint values to be shown in the Developer Portal</mat-card-subtitle>
-    </mat-card-header>
-    <mat-card-content>
-      <div
-        *ngFor="let configForm of defaultConfigForm.controls | keyvalue"
-        [formGroupName]="configForm.key"
-        class="org-settings-tags__configuration"
-      >
-        <h4>
-          Default values for environment:
-          <div class="gio-badge-primary">{{ configForm.value.get('_environmentName').value }}</div>
-        </h4>
-        <div class="org-settings-tags__configuration__container">
-          <mat-form-field
-            [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonlySetting(configForm.key, 'entrypoint')"
-            class="org-settings-tags__configuration__entrypoint"
-          >
-            <mat-icon *ngIf="isReadonlySetting(configForm.key, 'entrypoint')" class="org-settings-tags__configuration__icon" matPrefix
-              >lock</mat-icon
-            >
-            <mat-label>Default HTTP entrypoint</mat-label>
-            <input #entrypointInput matInput formControlName="entrypoint" />
-            <gio-clipboard-copy-icon matSuffix [contentToCopy]="entrypointInput.value"></gio-clipboard-copy-icon>
-          </mat-form-field>
+    <mat-card>
+      <mat-card-header>
+        <mat-card-title>Entrypoint Configuration</mat-card-title>
+        <mat-card-subtitle>Default entrypoint values to be shown in the Developer Portal</mat-card-subtitle>
+      </mat-card-header>
+      <mat-card-content>
+        @for (configForm of defaultConfigForm.controls | keyvalue; track configForm.key) {
+          <div [formGroupName]="configForm.key" class="org-settings-tags__configuration">
+            <h4>
+              Default values for environment:
+              <div class="gio-badge-primary">{{ configForm.value.get('_environmentName').value }}</div>
+            </h4>
+            <div class="org-settings-tags__configuration__container">
+              <mat-form-field
+                [matTooltip]="providedConfigurationMessage"
+                [matTooltipDisabled]="!isReadonlySetting(configForm.key, 'entrypoint')"
+                class="org-settings-tags__configuration__entrypoint"
+              >
+                @if (isReadonlySetting(configForm.key, 'entrypoint')) {
+                  <mat-icon class="org-settings-tags__configuration__icon" matPrefix>lock</mat-icon>
+                }
+                <mat-label>Default HTTP entrypoint</mat-label>
+                <input #entrypointInput matInput formControlName="entrypoint" />
+                <gio-clipboard-copy-icon matSuffix [contentToCopy]="entrypointInput.value"></gio-clipboard-copy-icon>
+              </mat-form-field>
 
-          <mat-form-field
-            [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonlySetting(configForm.key, 'tcpPort')"
-            class="org-settings-tags__configuration__tcp"
-          >
-            <mat-icon *ngIf="isReadonlySetting(configForm.key, 'tcpPort')" class="org-settings-tags__configuration__icon" matPrefix
-              >lock</mat-icon
-            >
-            <mat-label>Default TCP port</mat-label>
-            <input #tcpPortInput matInput formControlName="tcpPort" type="number" />
-            <mat-error *ngIf="configForm.value.get('tcpPort').hasError('invalidPort')"
-              >TCP port should be in range between 1025 and 65535</mat-error
-            >
-            <gio-clipboard-copy-icon matSuffix [contentToCopy]="tcpPortInput.value"></gio-clipboard-copy-icon>
-          </mat-form-field>
+              <mat-form-field
+                [matTooltip]="providedConfigurationMessage"
+                [matTooltipDisabled]="!isReadonlySetting(configForm.key, 'tcpPort')"
+                class="org-settings-tags__configuration__tcp"
+              >
+                @if (isReadonlySetting(configForm.key, 'tcpPort')) {
+                  <mat-icon class="org-settings-tags__configuration__icon" matPrefix>lock</mat-icon>
+                }
+                <mat-label>Default TCP port</mat-label>
+                <input #tcpPortInput matInput formControlName="tcpPort" type="number" />
+                @if (configForm.value.get('tcpPort').hasError('invalidPort')) {
+                  <mat-error>TCP port should be in range between 1025 and 65535</mat-error>
+                }
+                <gio-clipboard-copy-icon matSuffix [contentToCopy]="tcpPortInput.value"></gio-clipboard-copy-icon>
+              </mat-form-field>
 
-          <div class="org-settings-tags__configuration__kafka">
-            <mat-form-field
-              [matTooltip]="providedConfigurationMessage"
-              [matTooltipDisabled]="!isReadonlySetting(configForm.key, 'kafkaDomain')"
-              class="org-settings-tags__configuration__kafka__domain"
-            >
-              <mat-icon *ngIf="isReadonlySetting(configForm.key, 'kafkaDomain')" class="org-settings-tags__configuration__icon" matPrefix
-                >lock</mat-icon
-              >
-              <mat-label>Default Kafka Bootstrap Domain Pattern</mat-label>
-              <input #kafkaDomainInput matInput formControlName="kafkaDomain" />
-              <gio-clipboard-copy-icon matSuffix [contentToCopy]="kafkaDomainInput.value"></gio-clipboard-copy-icon>
-              <mat-error *ngIf="configForm.value.get('kafkaDomain').hasError('maxLength')"
-                >Kafka Domain must be less than 201 characters.</mat-error
-              >
-              <mat-error *ngIf="configForm.value.get('kafkaDomain').hasError('required')"
-                >Kafka Bootstrap Domain Pattern is required.</mat-error
-              >
-              <mat-error *ngIf="configForm.value.get('kafkaDomain').hasError('apiHostMissing')">
-                Kafka Bootstrap Domain Pattern must contain {{ '{apiHost}' }}.
-              </mat-error>
-              <mat-hint> To be configured according to the gateway configuration. e.g: {{ '{apiHost}.mycompany.org' }} </mat-hint>
-            </mat-form-field>
-            <mat-form-field
-              [matTooltip]="providedConfigurationMessage"
-              [matTooltipDisabled]="!isReadonlySetting(configForm.key, 'kafkaPort')"
-              class="org-settings-tags__configuration__kafka__port"
-            >
-              <mat-icon *ngIf="isReadonlySetting(configForm.key, 'kafkaPort')" class="org-settings-tags__configuration__icon" matPrefix
-                >lock</mat-icon
-              >
-              <mat-label>Default Kafka port</mat-label>
-              <input #kafkaPortInput matInput formControlName="kafkaPort" type="number" />
-              <mat-error *ngIf="configForm.value.get('kafkaPort').hasError('invalidPort')"
-                >Port should be in range between 1025 and 65535</mat-error
-              >
-              <gio-clipboard-copy-icon matSuffix [contentToCopy]="kafkaPortInput.value"></gio-clipboard-copy-icon>
-            </mat-form-field>
+              <div class="org-settings-tags__configuration__kafka">
+                <mat-form-field
+                  [matTooltip]="providedConfigurationMessage"
+                  [matTooltipDisabled]="!isReadonlySetting(configForm.key, 'kafkaDomain')"
+                  class="org-settings-tags__configuration__kafka__domain"
+                >
+                  @if (isReadonlySetting(configForm.key, 'kafkaDomain')) {
+                    <mat-icon class="org-settings-tags__configuration__icon" matPrefix>lock</mat-icon>
+                  }
+                  <mat-label>Default Kafka Bootstrap Domain Pattern</mat-label>
+                  <input #kafkaDomainInput matInput formControlName="kafkaDomain" />
+                  <gio-clipboard-copy-icon matSuffix [contentToCopy]="kafkaDomainInput.value"></gio-clipboard-copy-icon>
+                  @if (configForm.value.get('kafkaDomain').hasError('maxLength')) {
+                    <mat-error>Kafka Domain must be less than 201 characters.</mat-error>
+                  }
+                  @if (configForm.value.get('kafkaDomain').hasError('required')) {
+                    <mat-error>Kafka Bootstrap Domain Pattern is required.</mat-error>
+                  }
+                  @if (configForm.value.get('kafkaDomain').hasError('apiHostMissing')) {
+                    <mat-error>Kafka Bootstrap Domain Pattern must contain {{ '{apiHost}' }}.</mat-error>
+                  }
+                  <mat-hint> To be configured according to the gateway configuration. e.g: {{ '{apiHost}.mycompany.org' }} </mat-hint>
+                </mat-form-field>
+                <mat-form-field
+                  [matTooltip]="providedConfigurationMessage"
+                  [matTooltipDisabled]="!isReadonlySetting(configForm.key, 'kafkaPort')"
+                  class="org-settings-tags__configuration__kafka__port"
+                >
+                  @if (isReadonlySetting(configForm.key, 'kafkaPort')) {
+                    <mat-icon class="org-settings-tags__configuration__icon" matPrefix>lock</mat-icon>
+                  }
+                  <mat-label>Default Kafka port</mat-label>
+                  <input #kafkaPortInput matInput formControlName="kafkaPort" type="number" />
+                  @if (configForm.value.get('kafkaPort').hasError('invalidPort')) {
+                    <mat-error>Port should be in range between 1025 and 65535</mat-error>
+                  }
+                  <gio-clipboard-copy-icon matSuffix [contentToCopy]="kafkaPortInput.value"></gio-clipboard-copy-icon>
+                </mat-form-field>
+              </div>
+            </div>
           </div>
+        }
+      </mat-card-content>
+    </mat-card>
+    <mat-card class="org-settings-tags__tags-card">
+      <mat-card-header>
+        <mat-card-title>Sharding Tags</mat-card-title>
+        <div class="org-settings-tags__tags-card__headerRightBtn" *gioPermission="{ anyOf: ['organization-tag-c'] }">
+          <button
+            [gioLicense]="shardingTagsLicenseOptions"
+            (click)="onAddTagClicked()"
+            mat-raised-button
+            color="primary"
+            aria-label="Button to add a tag"
+            type="button"
+          >
+            <mat-icon>add</mat-icon>Add a tag
+            @if (hasShardingTagsLock$ | async) {
+              <mat-icon iconPositionEnd svgIcon="gio:lock"></mat-icon>
+            }
+          </button>
         </div>
-      </div>
-    </mat-card-content>
-  </mat-card>
-  <mat-card class="org-settings-tags__tags-card">
-    <mat-card-header>
-      <mat-card-title>Sharding Tags</mat-card-title>
-      <div class="org-settings-tags__tags-card__headerRightBtn" *gioPermission="{ anyOf: ['organization-tag-c'] }">
-        <button
-          [gioLicense]="shardingTagsLicenseOptions"
-          (click)="onAddTagClicked()"
-          mat-raised-button
-          color="primary"
-          aria-label="Button to add a tag"
-          type="button"
+      </mat-card-header>
+      <mat-card-content>
+        <gio-banner type="info"
+          >Add the sharding tag's key to the API Gateway configuration file in order to manage API deployments.</gio-banner
         >
-          <mat-icon>add</mat-icon>Add a tag
-          <mat-icon *ngIf="hasShardingTagsLock$ | async" iconPositionEnd svgIcon="gio:lock"></mat-icon>
-        </button>
-      </div>
-    </mat-card-header>
-    <mat-card-content>
-      <gio-banner type="info"
-        >Add the sharding tag's ID to the API Gateway configuration file in order to manage API deployments.</gio-banner
-      >
-    </mat-card-content>
-    <gio-table-wrapper [length]="tagsTableUnpaginatedLength" (filtersChange)="onTagsFiltersChanged($event)">
-      <table
-        mat-table
-        [dataSource]="filteredTagsTableDS"
-        matSort
-        matSortActive="name"
-        matSortDirection="asc"
-        class="tags-table"
-        id="tagsTable"
-        aria-label="Tags table"
-      >
-        <!-- key Column -->
-        <ng-container matColumnDef="key">
-          <th mat-header-cell *matHeaderCellDef id="key" mat-sort-header>Key</th>
-          <td mat-cell *matCellDef="let tag">
-            <span gioClipboardCopyWrapper [contentToCopy]="tag.key">{{ tag.key }}</span>
-          </td>
-        </ng-container>
-
-        <!-- Name Column -->
-        <ng-container matColumnDef="name">
-          <th mat-header-cell *matHeaderCellDef id="name" mat-sort-header>Name</th>
-          <td mat-cell *matCellDef="let tag">{{ tag.name }}</td>
-        </ng-container>
-
-        <!-- Description Column -->
-        <ng-container matColumnDef="description">
-          <th mat-header-cell *matHeaderCellDef id="description" mat-sort-header>Description</th>
-          <td mat-cell *matCellDef="let tag">{{ tag.description }}</td>
-        </ng-container>
-
-        <!-- Restricted groups Column -->
-        <ng-container matColumnDef="restrictedGroupsName">
-          <th mat-header-cell *matHeaderCellDef id="restrictedGroupsName" mat-sort-header>Restricted groups</th>
-          <td mat-cell *matCellDef="let tag">{{ tag.restrictedGroupsName.join(', ') }}</td>
-        </ng-container>
-
-        <!-- Actions Column -->
-        <ng-container matColumnDef="actions">
-          <th mat-header-cell *matHeaderCellDef></th>
-          <td mat-cell *matCellDef="let tag">
-            <div class="centered-cell">
-              <ng-container *gioPermission="{ anyOf: ['organization-tag-u'] }">
-                <button
-                  (click)="onEditTagClicked(tag)"
-                  mat-icon-button
-                  type="button"
-                  aria-label="Button to edit a tag"
-                  matTooltip="Edit tag"
-                >
-                  <mat-icon>edit</mat-icon>
-                </button>
-              </ng-container>
-              <ng-container *gioPermission="{ anyOf: ['organization-tag-d'] }">
-                <button
-                  (click)="onDeleteTagClicked(tag)"
-                  mat-icon-button
-                  type="button"
-                  aria-label="Button to delete a tag"
-                  matTooltip="Delete tag"
-                >
-                  <mat-icon>delete</mat-icon>
-                </button>
-              </ng-container>
-            </div>
-          </td>
-        </ng-container>
-
-        <tr mat-header-row *matHeaderRowDef="tagsTableDisplayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: tagsTableDisplayedColumns"></tr>
-
-        <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-          <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="tagsTableDisplayedColumns.length">No tag</td>
-        </tr>
-      </table>
-    </gio-table-wrapper>
-  </mat-card>
-
-  <mat-card class="org-settings-tags__entrypoints-card">
-    <mat-card-header>
-      <mat-card-title>Entrypoint Mappings</mat-card-title>
-      <mat-card-subtitle>Entrypoint to be displayed in the Developer Portal if an API has a given tag</mat-card-subtitle>
-      <div class="org-settings-tags__entrypoints-card__headerRightBtn">
-        <button
-          *gioPermission="{ anyOf: ['organization-entrypoint-c'] }"
-          [matMenuTriggerFor]="addMappingMenu"
-          mat-raised-button
-          color="primary"
-          type="button"
-          aria-label="Button to add a mapping"
+      </mat-card-content>
+      <gio-table-wrapper [length]="tagsTableUnpaginatedLength" (filtersChange)="onTagsFiltersChanged($event)">
+        <table
+          mat-table
+          [dataSource]="filteredTagsTableDS"
+          matSort
+          matSortActive="name"
+          matSortDirection="asc"
+          class="tags-table"
+          id="tagsTable"
+          aria-label="Tags table"
         >
-          <mat-icon>add</mat-icon>Add a mapping
-        </button>
-        <mat-menu #addMappingMenu="matMenu">
-          <button mat-menu-item (click)="onAddEntrypointClicked('HTTP')">HTTP</button>
-          <button mat-menu-item (click)="onAddEntrypointClicked('TCP')">TCP</button>
-          <button mat-menu-item (click)="onAddEntrypointClicked('KAFKA')">Kafka</button>
-        </mat-menu>
-      </div>
-    </mat-card-header>
-    <gio-table-wrapper [length]="entrypointsTableUnpaginatedLength" (filtersChange)="onEntrypointsFiltersChanged($event)">
-      <table
-        mat-table
-        [dataSource]="filteredEntrypointsTableDS"
-        matSort
-        class="entrypoints-table"
-        id="entrypointsTable"
-        aria-label="Entrypoints table"
-      >
-        <!-- Entrypoint Column -->
-        <ng-container matColumnDef="entrypoint">
-          <th mat-header-cell *matHeaderCellDef id="entrypoint" mat-sort-header="url">Entrypoint</th>
-          <td mat-cell *matCellDef="let entrypoint">
-            <span gioClipboardCopyWrapper [contentToCopy]="entrypoint.url">{{ entrypoint.url }}</span>
-          </td>
-        </ng-container>
+          <!-- key Column -->
+          <ng-container matColumnDef="key">
+            <th mat-header-cell *matHeaderCellDef id="key" mat-sort-header>Key</th>
+            <td mat-cell *matCellDef="let tag">
+              <span gioClipboardCopyWrapper [contentToCopy]="tag.key">{{ tag.key }}</span>
+            </td>
+          </ng-container>
 
-        <!-- Target Column -->
-        <ng-container matColumnDef="target">
-          <th mat-header-cell *matHeaderCellDef id="target" mat-sort-header="target">Target</th>
-          <td mat-cell *matCellDef="let entrypoint">{{ entrypoint.target }}</td>
-        </ng-container>
+          <!-- Name Column -->
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef id="name" mat-sort-header>Name</th>
+            <td mat-cell *matCellDef="let tag">{{ tag.name }}</td>
+          </ng-container>
 
-        <!-- Tags Column -->
-        <ng-container matColumnDef="tags">
-          <th mat-header-cell *matHeaderCellDef id="tags" mat-sort-header="tags">Sharding Tags</th>
-          <td mat-cell *matCellDef="let entrypoint">{{ entrypoint.tagsName.join(', ') }}</td>
-        </ng-container>
+          <!-- Description Column -->
+          <ng-container matColumnDef="description">
+            <th mat-header-cell *matHeaderCellDef id="description" mat-sort-header>Description</th>
+            <td mat-cell *matCellDef="let tag">{{ tag.description }}</td>
+          </ng-container>
 
-        <!-- Environments Column -->
-        <ng-container matColumnDef="environments">
-          <th mat-header-cell *matHeaderCellDef id="environments">Environments</th>
-          <td mat-cell *matCellDef="let entrypoint">
-            {{ entrypoint.environmentNames.length > 0 ? entrypoint.environmentNames.join(', ') : 'All' }}
-          </td>
-        </ng-container>
+          <!-- Restricted groups Column -->
+          <ng-container matColumnDef="restrictedGroupsName">
+            <th mat-header-cell *matHeaderCellDef id="restrictedGroupsName" mat-sort-header>Restricted groups</th>
+            <td mat-cell *matCellDef="let tag">{{ tag.restrictedGroupsName.join(', ') }}</td>
+          </ng-container>
 
-        <!-- Actions Column -->
-        <ng-container matColumnDef="actions">
-          <th mat-header-cell *matHeaderCellDef></th>
-          <td mat-cell *matCellDef="let entrypoint">
-            <div class="centered-cell">
-              <ng-container *gioPermission="{ anyOf: ['organization-entrypoint-u'] }">
-                <button
-                  (click)="onEditEntrypointClicked(entrypoint)"
-                  mat-icon-button
-                  type="button"
-                  aria-label="Button to edit a mapping"
-                  matTooltip="Edit mapping"
-                >
-                  <mat-icon>edit</mat-icon>
-                </button>
-              </ng-container>
-              <ng-container *gioPermission="{ anyOf: ['organization-entrypoint-d'] }">
-                <button
-                  (click)="onDeleteEntrypointClicked(entrypoint)"
-                  mat-icon-button
-                  type="button"
-                  aria-label="Button to delete a mapping"
-                  matTooltip="Delete mapping"
-                >
-                  <mat-icon>delete</mat-icon>
-                </button>
-              </ng-container>
-            </div>
-          </td>
-        </ng-container>
+          <!-- Actions Column -->
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let tag">
+              <div class="centered-cell">
+                <ng-container *gioPermission="{ anyOf: ['organization-tag-u'] }">
+                  <button
+                    (click)="onEditTagClicked(tag)"
+                    mat-icon-button
+                    type="button"
+                    aria-label="Button to edit a tag"
+                    matTooltip="Edit tag"
+                  >
+                    <mat-icon>edit</mat-icon>
+                  </button>
+                </ng-container>
+                <ng-container *gioPermission="{ anyOf: ['organization-tag-d'] }">
+                  <button
+                    (click)="onDeleteTagClicked(tag)"
+                    mat-icon-button
+                    type="button"
+                    aria-label="Button to delete a tag"
+                    matTooltip="Delete tag"
+                  >
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                </ng-container>
+              </div>
+            </td>
+          </ng-container>
 
-        <tr mat-header-row *matHeaderRowDef="entrypointsTableDisplayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: entrypointsTableDisplayedColumns"></tr>
+          <tr mat-header-row *matHeaderRowDef="tagsTableDisplayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: tagsTableDisplayedColumns"></tr>
 
-        <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-          <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="entrypointsTableDisplayedColumns.length">No entrypoint</td>
-        </tr>
-      </table>
-    </gio-table-wrapper>
-  </mat-card>
+          <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+            <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="tagsTableDisplayedColumns.length">No tag</td>
+          </tr>
+        </table>
+      </gio-table-wrapper>
+    </mat-card>
 
-  <gio-save-bar
-    [creationMode]="false"
-    [form]="defaultConfigForm"
-    [formInitialValues]="initialDefaultConfigFormValues"
-    (submitted)="submitForm()"
-  >
-  </gio-save-bar>
-</form>
+    <mat-card class="org-settings-tags__entrypoints-card">
+      <mat-card-header>
+        <mat-card-title>Entrypoint Mappings</mat-card-title>
+        <mat-card-subtitle>Entrypoint to be displayed in the Developer Portal if an API has a given tag</mat-card-subtitle>
+        <div class="org-settings-tags__entrypoints-card__headerRightBtn">
+          <button
+            *gioPermission="{ anyOf: ['organization-entrypoint-c'] }"
+            [matMenuTriggerFor]="addMappingMenu"
+            mat-raised-button
+            color="primary"
+            type="button"
+            aria-label="Button to add a mapping"
+          >
+            <mat-icon>add</mat-icon>Add a mapping
+          </button>
+          <mat-menu #addMappingMenu="matMenu">
+            <button mat-menu-item (click)="onAddEntrypointClicked('HTTP')">HTTP</button>
+            <button mat-menu-item (click)="onAddEntrypointClicked('TCP')">TCP</button>
+            <button mat-menu-item (click)="onAddEntrypointClicked('KAFKA')">Kafka</button>
+          </mat-menu>
+        </div>
+      </mat-card-header>
+      <gio-table-wrapper [length]="entrypointsTableUnpaginatedLength" (filtersChange)="onEntrypointsFiltersChanged($event)">
+        <table
+          mat-table
+          [dataSource]="filteredEntrypointsTableDS"
+          matSort
+          class="entrypoints-table"
+          id="entrypointsTable"
+          aria-label="Entrypoints table"
+        >
+          <!-- Entrypoint Column -->
+          <ng-container matColumnDef="entrypoint">
+            <th mat-header-cell *matHeaderCellDef id="entrypoint" mat-sort-header="url">Entrypoint</th>
+            <td mat-cell *matCellDef="let entrypoint">
+              <span gioClipboardCopyWrapper [contentToCopy]="entrypoint.url">{{ entrypoint.url }}</span>
+            </td>
+          </ng-container>
+
+          <!-- Target Column -->
+          <ng-container matColumnDef="target">
+            <th mat-header-cell *matHeaderCellDef id="target" mat-sort-header="target">Target</th>
+            <td mat-cell *matCellDef="let entrypoint">{{ entrypoint.target }}</td>
+          </ng-container>
+
+          <!-- Tags Column -->
+          <ng-container matColumnDef="tags">
+            <th mat-header-cell *matHeaderCellDef id="tags" mat-sort-header="tags">Sharding Tags</th>
+            <td mat-cell *matCellDef="let entrypoint">{{ entrypoint.tagsName.join(', ') }}</td>
+          </ng-container>
+
+          <!-- Environments Column -->
+          <ng-container matColumnDef="environments">
+            <th mat-header-cell *matHeaderCellDef id="environments">Environments</th>
+            <td mat-cell *matCellDef="let entrypoint">
+              {{ entrypoint.environmentNames.length > 0 ? entrypoint.environmentNames.join(', ') : 'All' }}
+            </td>
+          </ng-container>
+
+          <!-- Actions Column -->
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let entrypoint">
+              <div class="centered-cell">
+                <ng-container *gioPermission="{ anyOf: ['organization-entrypoint-u'] }">
+                  <button
+                    (click)="onEditEntrypointClicked(entrypoint)"
+                    mat-icon-button
+                    type="button"
+                    aria-label="Button to edit a mapping"
+                    matTooltip="Edit mapping"
+                  >
+                    <mat-icon>edit</mat-icon>
+                  </button>
+                </ng-container>
+                <ng-container *gioPermission="{ anyOf: ['organization-entrypoint-d'] }">
+                  <button
+                    (click)="onDeleteEntrypointClicked(entrypoint)"
+                    mat-icon-button
+                    type="button"
+                    aria-label="Button to delete a mapping"
+                    matTooltip="Delete mapping"
+                  >
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                </ng-container>
+              </div>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="entrypointsTableDisplayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: entrypointsTableDisplayedColumns"></tr>
+
+          <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+            <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="entrypointsTableDisplayedColumns.length">No entrypoint</td>
+          </tr>
+        </table>
+      </gio-table-wrapper>
+    </mat-card>
+
+    <gio-save-bar
+      [creationMode]="false"
+      [form]="defaultConfigForm"
+      [formInitialValues]="initialDefaultConfigFormValues"
+      (submitted)="submitForm()"
+    >
+    </gio-save-bar>
+  </form>
+}

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.html
@@ -148,11 +148,11 @@
         id="tagsTable"
         aria-label="Tags table"
       >
-        <!-- Id Column -->
-        <ng-container matColumnDef="id">
-          <th mat-header-cell *matHeaderCellDef id="id" mat-sort-header>ID</th>
+        <!-- key Column -->
+        <ng-container matColumnDef="key">
+          <th mat-header-cell *matHeaderCellDef id="key" mat-sort-header>Key</th>
           <td mat-cell *matCellDef="let tag">
-            <span gioClipboardCopyWrapper [contentToCopy]="tag.id">{{ tag.id }}</span>
+            <span gioClipboardCopyWrapper [contentToCopy]="tag.key">{{ tag.key }}</span>
           </td>
         </ng-container>
 

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.spec.ts
@@ -443,7 +443,8 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
     });
 
     it('should create a new HTTP mapping', async () => {
-      expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' })]);
+      const tag1 = fakeTag({ id: 'tag-1-id', key: 'tag-1', name: 'Tag 1' });
+      expectTagsListRequest([tag1]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest();
@@ -451,7 +452,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       const addButtonMenu = await loader.getHarness(MatMenuHarness.with({ triggerText: /Add a mapping/ }));
       await addButtonMenu.clickItem({ text: 'HTTP' });
 
-      expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' })]);
+      expectTagsListRequest([tag1]);
       expectEnvironmentListRequest([fakeEnvironment({ id: 'DEFAULT', name: 'Environment DEFAULT' })]);
 
       const submitButton = await rootLoader.getHarness(MatButtonHarness.with({ selector: 'button[type=submit]' }));
@@ -475,7 +476,8 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
     });
 
     it('should create a new KAFKA mapping', async () => {
-      expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' })]);
+      const tag1 = fakeTag({ id: 'tag-1-id', key: 'tag-1', name: 'Tag 1' });
+      expectTagsListRequest([tag1]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest();
@@ -483,7 +485,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       const addButtonMenu = await loader.getHarness(MatMenuHarness.with({ triggerText: /Add a mapping/ }));
       await addButtonMenu.clickItem({ text: 'Kafka' });
 
-      expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' })]);
+      expectTagsListRequest([tag1]);
       expectEnvironmentListRequest([fakeEnvironment({ id: 'DEFAULT', name: 'Environment DEFAULT' })]);
 
       const addMappingDialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#addMappingDialog' }));
@@ -513,7 +515,9 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
     });
 
     it('should update a HTTP mapping', async () => {
-      expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+      const tag1 = fakeTag({ id: 'tag-1-id', key: 'tag-1', name: 'Tag 1' });
+      const tag2 = fakeTag({ id: 'tag-2-id', key: 'tag-2', name: 'Tag 2' });
+      expectTagsListRequest([tag1, tag2]);
       expectGroupListByOrganizationRequest([]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest([fakeEntrypoint({ id: 'entrypointIdA', tags: ['tag-1'] })]);
@@ -527,7 +531,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       );
       await editButton.click();
 
-      expectTagsListRequest([fakeTag({ id: 'tag-1', name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+      expectTagsListRequest([tag1, tag2]);
       expectEnvironmentListRequest([fakeEnvironment({ id: 'DEFAULT', name: 'Environment DEFAULT' })]);
 
       const submitButton = await rootLoader.getHarness(MatButtonHarness.with({ selector: 'button[type=submit]' }));

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.spec.ts
@@ -251,7 +251,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       expect(headerCells).toEqual([
         {
           description: 'Description',
-          id: 'ID',
+          key: 'Key',
           name: 'Name',
           restrictedGroupsName: 'Restricted groups',
           actions: '',
@@ -260,7 +260,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       expect(rowCells).toEqual([
         {
           description: 'A tag for all external stuff',
-          id: expect.stringContaining('external'),
+          key: expect.stringContaining('external'),
           name: 'External',
           restrictedGroupsName: 'Group A',
           actions: 'editdelete',
@@ -302,7 +302,10 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
     });
 
     it('should delete a tag', async () => {
-      expectTagsListRequest([fakeTag({ id: 'tag-1', restricted_groups: ['group-a'] }), fakeTag({ id: 'tag-2' })]);
+      expectTagsListRequest([
+        fakeTag({ id: 'tag-1-id', key: 'tag-1', restricted_groups: ['group-a'] }),
+        fakeTag({ id: 'tag-2-id', key: 'tag-2' }),
+      ]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest([fakeEntrypoint({ tags: ['tag-1', 'tag-2'] }), fakeEntrypoint({ id: 'epIdB', tags: ['tag-1'] })]);
@@ -339,7 +342,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
     });
 
     it('should delete a tag without entrypoint mapping', async () => {
-      expectTagsListRequest([fakeTag({ id: 'tag-1' })]);
+      expectTagsListRequest([fakeTag({ id: 'tag-1-id', key: 'tag-1' })]);
       expectGroupListByOrganizationRequest([]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest([]);
@@ -424,6 +427,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags/tag-1` });
       expect(req.request.body).toStrictEqual({
         id: 'tag-1',
+        key: 'external',
         name: 'New tag name',
         description: 'New tag description',
         restricted_groups: ['group-a', 'group-b'],
@@ -570,6 +574,9 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       const nameInput = await rootLoader.getHarness(MatInputHarness.with({ selector: '[formControlName=name]' }));
       await nameInput.setValue('Tag name');
 
+      const keyInput = await rootLoader.getHarness(MatInputHarness.with({ selector: '[formControlName=key]' }));
+      await keyInput.setValue('tag-key');
+
       const descriptionInput = await rootLoader.getHarness(MatInputHarness.with({ selector: '[formControlName=description' }));
       await descriptionInput.setValue('Tag description');
 
@@ -581,6 +588,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
       const req = httpTestingController.expectOne({ method: 'POST', url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags` });
       expect(req.request.body).toStrictEqual({
         name: 'Tag name',
+        key: 'tag-key',
         description: 'Tag description',
         restricted_groups: ['group-a'],
       });

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.spec.ts
@@ -397,7 +397,7 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
     });
 
     it('should update a tag', async () => {
-      expectTagsListRequest([fakeTag({ id: 'tag-1', restricted_groups: ['group-a'] })]);
+      expectTagsListRequest([fakeTag({ id: 'tag-1-id', key: 'tag-1', restricted_groups: ['group-a'] })]);
       expectGroupListByOrganizationRequest([fakeGroup({ id: 'group-a', name: 'Group A' }), fakeGroup({ id: 'group-b', name: 'Group B' })]);
       expectPortalSettingsGetRequest(fakePortalSettings());
       expectEntrypointsListRequest();
@@ -426,8 +426,6 @@ describe('OrgSettingsEntrypointsAndShardingTagsComponent', () => {
 
       const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags/tag-1` });
       expect(req.request.body).toStrictEqual({
-        id: 'tag-1',
-        key: 'external',
         name: 'New tag name',
         description: 'New tag description',
         restricted_groups: ['group-a', 'group-b'],

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
-import { combineLatest, EMPTY, Observable, of, Subject } from 'rxjs';
-import { catchError, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { combineLatest, EMPTY, Observable, of } from 'rxjs';
+import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
 import { GIO_DIALOG_WIDTH, GioConfirmDialogComponent, GioConfirmDialogData, GioLicenseService } from '@gravitee/ui-particles-angular';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { OrgSettingAddTagDialogComponent, OrgSettingAddTagDialogData } from './dialog/org-settings-add-tag-dialog.component';
 import { OrgSettingAddMappingDialogComponent, OrgSettingAddMappingDialogData } from './dialog/org-settings-add-mapping-dialog.component';
@@ -67,7 +68,17 @@ type EntrypointTableDS = {
   styleUrls: ['./org-settings-entrypoints-and-sharding-tags.component.scss'],
   standalone: false,
 })
-export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, OnDestroy {
+export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit {
+  private readonly tagService = inject(TagService);
+  private readonly groupService = inject(GroupService);
+  private readonly portalSettingsService = inject(PortalSettingsService);
+  private readonly environmentService = inject(EnvironmentService);
+  private readonly entrypointService = inject(EntrypointService);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly gioLicenseService = inject(GioLicenseService);
+  private readonly destroyRef = inject(DestroyRef);
+
   isLoading = true;
 
   providedConfigurationMessage = 'Configuration provided by the system';
@@ -90,19 +101,6 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
   shardingTagsLicenseOptions = { feature: ApimFeature.APIM_SHARDING_TAGS };
   hasShardingTagsLock$: Observable<boolean>;
 
-  private unsubscribe$ = new Subject<boolean>();
-
-  constructor(
-    private readonly tagService: TagService,
-    private readonly groupService: GroupService,
-    private readonly portalSettingsService: PortalSettingsService,
-    private readonly environmentService: EnvironmentService,
-    private readonly entrypointService: EntrypointService,
-    private readonly snackBarService: SnackBarService,
-    private readonly matDialog: MatDialog,
-    private readonly gioLicenseService: GioLicenseService,
-  ) {}
-
   ngOnInit(): void {
     this.hasShardingTagsLock$ = this.gioLicenseService.isMissingFeature$(this.shardingTagsLicenseOptions.feature);
 
@@ -122,7 +120,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
       environmentsPortalSettings$,
       this.entrypointService.list(),
     ])
-      .pipe(takeUntil(this.unsubscribe$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([tags, groups, environmentsPortalSettings, entrypoints]) => {
         this.tags = tags;
         this.tagsTableDS = tags.map(tag => ({
@@ -198,11 +196,6 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
       });
   }
 
-  ngOnDestroy() {
-    this.unsubscribe$.next(true);
-    this.unsubscribe$.unsubscribe();
-  }
-
   onTagsFiltersChanged(filters: GioTableWrapperFilters) {
     const filtered = gioTableFilterCollection(this.tagsTableDS, filters);
     this.filteredTagsTableDS = filtered.filteredCollection;
@@ -251,7 +244,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
           this.snackBarService.error(error.message);
           return EMPTY;
         }),
-        takeUntil(this.unsubscribe$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
@@ -275,7 +268,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
           this.snackBarService.error(error.message);
           return EMPTY;
         }),
-        takeUntil(this.unsubscribe$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => this.ngOnInit());
   }
@@ -301,7 +294,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
           this.snackBarService.error(error.message);
           return EMPTY;
         }),
-        takeUntil(this.unsubscribe$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => this.ngOnInit());
   }
@@ -371,7 +364,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
           this.snackBarService.error(error.message);
           return EMPTY;
         }),
-        takeUntil(this.unsubscribe$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => this.ngOnInit());
   }
@@ -403,7 +396,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
           this.snackBarService.error(error.message);
           return EMPTY;
         }),
-        takeUntil(this.unsubscribe$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => this.ngOnInit());
   }
@@ -432,7 +425,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
           this.snackBarService.error(error.message);
           return EMPTY;
         }),
-        takeUntil(this.unsubscribe$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => this.ngOnInit());
   }
@@ -458,7 +451,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
           this.snackBarService.error(error.message);
           return EMPTY;
         }),
-        takeUntil(this.unsubscribe$),
+        takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => this.ngOnInit());
   }

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.ts
@@ -46,7 +46,7 @@ const MAPPING_TARGET_DISPLAYABLE: Record<Entrypoint['target'], string> = {
 };
 
 type TagTableDS = {
-  id: string;
+  key: string;
   name?: string;
   description?: string;
   restrictedGroupsName?: string[];
@@ -76,7 +76,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
   tagsTableDS: TagTableDS;
   filteredTagsTableDS: TagTableDS;
   tagsTableUnpaginatedLength = 0;
-  tagsTableDisplayedColumns: string[] = ['id', 'name', 'description', 'restrictedGroupsName', 'actions'];
+  tagsTableDisplayedColumns: string[] = ['key', 'name', 'description', 'restrictedGroupsName', 'actions'];
 
   environmentsPortalSettings: { environment: Environment; portalSettings: PortalSettings }[];
   defaultConfigForm: UntypedFormGroup;
@@ -126,7 +126,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
       .subscribe(([tags, groups, environmentsPortalSettings, entrypoints]) => {
         this.tags = tags;
         this.tagsTableDS = tags.map(tag => ({
-          id: tag.id,
+          key: tag.key,
           name: tag.name,
           description: tag.description,
           restrictedGroupsName: (tag.restricted_groups ?? [])
@@ -176,15 +176,21 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
 
         this.entrypoints = entrypoints;
         const envNameById = new Map(environmentsPortalSettings.map(eps => [eps.environment.id, eps.environment.name]));
-        this.entrypointsTableDS = entrypoints.map(entrypoint => ({
-          id: entrypoint.id,
-          target: MAPPING_TARGET_DISPLAYABLE[entrypoint.target],
-          url: entrypoint.value,
-          tags: entrypoint.tags,
-          tagsName: (entrypoint.tags ?? []).map(tagId => tags.find(t => t.id === tagId)?.name ?? tagId),
-          environmentIds: entrypoint.environmentIds ?? [],
-          environmentNames: (entrypoint.environmentIds ?? []).map(envId => envNameById.get(envId) ?? envId),
-        }));
+        this.entrypointsTableDS = entrypoints.map(entrypoint => {
+          const tagsName = (entrypoint.tags ?? []).map(tagKey => {
+            const tag = tags.find(t => t.key === tagKey);
+            return tag?.name ?? tagKey;
+          });
+          return {
+            id: entrypoint.id,
+            target: MAPPING_TARGET_DISPLAYABLE[entrypoint.target],
+            url: entrypoint.value,
+            tags: entrypoint.tags,
+            environmentIds: entrypoint.environmentIds ?? [],
+            environmentNames: (entrypoint.environmentIds ?? []).map(envId => envNameById.get(envId) ?? envId),
+            tagsName,
+          };
+        });
         this.filteredEntrypointsTableDS = this.entrypointsTableDS;
         this.entrypointsTableUnpaginatedLength = this.entrypointsTableDS.length;
 
@@ -279,7 +285,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
       .open<OrgSettingAddTagDialogComponent, OrgSettingAddTagDialogData, Tag>(OrgSettingAddTagDialogComponent, {
         width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
-          tag: this.tags.find(t => t.id === tag.id),
+          tag: this.tags.find(t => t.key === tag.key),
         },
         role: 'dialog',
         id: 'addTagDialog',
@@ -301,7 +307,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
   }
 
   onDeleteTagClicked(tag: TagTableDS[number]) {
-    const entrypointsToUpdate = this.entrypoints.filter(entrypoint => entrypoint.tags.includes(tag.id));
+    const entrypointsToUpdate = this.entrypoints.filter(entrypoint => entrypoint.tags.includes(tag.key));
     const entrypointsToUpdateWithOneTag = entrypointsToUpdate.filter(e => e.tags.length === 1);
     const entrypointsToUpdateWithManyTags = entrypointsToUpdate.filter(e => e.tags.length > 1);
 
@@ -350,7 +356,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
           }
           const entrypointsUpdated = entrypointsToUpdateWithManyTags.map(entrypoint => ({
             ...entrypoint,
-            tags: entrypoint.tags.filter(t => t !== tag.id),
+            tags: entrypoint.tags.filter(t => t !== tag.key),
           }));
           const entrypointsToDelete = entrypointsToUpdateWithOneTag;
 
@@ -359,7 +365,7 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit, O
             ...entrypointsToDelete.map(entrypoint => this.entrypointService.delete(entrypoint.id)),
           ]);
         }),
-        switchMap(() => this.tagService.delete(tag.id)),
+        switchMap(() => this.tagService.delete(tag.key)),
         tap(() => this.snackBarService.success(`Tag "${tag.name}" has been deleted.`)),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);

--- a/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/entrypoints-and-sharding-tags/org-settings-entrypoints-and-sharding-tags.component.ts
@@ -286,7 +286,13 @@ export class OrgSettingsEntrypointsAndShardingTagsComponent implements OnInit {
       .afterClosed()
       .pipe(
         filter(result => !!result),
-        switchMap(updatedTag => this.tagService.update(updatedTag)),
+        switchMap((updatedTag: Tag) =>
+          this.tagService.update(updatedTag.key, {
+            name: updatedTag.name,
+            description: updatedTag.description,
+            restricted_groups: updatedTag.restricted_groups,
+          }),
+        ),
         tap(() => {
           this.snackBarService.success('Tag successfully updated!');
         }),

--- a/gravitee-apim-console-webui/src/services-ngx/tag.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/tag.service.spec.ts
@@ -21,6 +21,7 @@ import { TagService } from './tag.service';
 import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
 import { fakeTag } from '../entities/tag/tag.fixture';
 import { fakeNewTag } from '../entities/tag/newTag.fixture';
+import { UpdateTagEntity } from '../entities/tag/tag';
 
 describe('TagService', () => {
   let httpTestingController: HttpTestingController;
@@ -93,20 +94,25 @@ describe('TagService', () => {
 
   describe('update', () => {
     it('should call the API', done => {
-      const tag = fakeTag({ id: 'tag#1' });
+      const tagKey = 'external';
+      const updateTagEntity: UpdateTagEntity = {
+        name: 'External',
+        description: 'A tag for all external stuff',
+        restricted_groups: [],
+      };
 
-      tagService.update(tag).subscribe(response => {
-        expect(response).toStrictEqual(tag);
+      tagService.update(tagKey, updateTagEntity).subscribe(response => {
+        expect(response).toStrictEqual(updateTagEntity);
         done();
       });
 
       const req = httpTestingController.expectOne({
         method: 'PUT',
-        url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags/tag#1`,
+        url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags/${tagKey}`,
       });
-      expect(req.request.body).toEqual(tag);
+      expect(req.request.body).toEqual(updateTagEntity);
 
-      req.flush(tag);
+      req.flush(updateTagEntity);
     });
   });
 

--- a/gravitee-apim-console-webui/src/services-ngx/tag.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/tag.service.ts
@@ -18,7 +18,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { Tag } from '../entities/tag/tag';
+import { Tag, UpdateTagEntity } from '../entities/tag/tag';
 import { NewTag } from '../entities/tag/newTag';
 
 @Injectable({
@@ -42,8 +42,8 @@ export class TagService {
     return this.http.post<Tag>(`${this.constants.org.baseURL}/configuration/tags`, newTag);
   }
 
-  update(tag: Tag): Observable<Tag> {
-    return this.http.put<Tag>(`${this.constants.org.baseURL}/configuration/tags/${tag.id}`, tag);
+  update(tagKey: string, tag: UpdateTagEntity): Observable<Tag> {
+    return this.http.put<Tag>(`${this.constants.org.baseURL}/configuration/tags/${tagKey}`, tag);
   }
 
   delete(id: string): Observable<void> {

--- a/gravitee-apim-console-webui/src/shared/utils/key-sanitizer.util.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/key-sanitizer.util.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { sanitizeKeyBase, sanitizeKeyFinal } from './key-sanitizer.util';
+
+describe('Key Sanitizer Utils', () => {
+  describe('sanitizeKeyBase', () => {
+    it.each`
+      input                                | expected
+      ${'My Tag Key'}                      | ${'my-tag-key'}
+      ${'Tâg Spécîal @#$ Nàme!'}           | ${'tag-special-name'}
+      ${'Tag   With    Multiple---Spaces'} | ${'tag-with-multiple-spaces'}
+      ${'UPPERCASE KEY'}                   | ${'uppercase-key'}
+      ${'Key 123 Value 456'}               | ${'key-123-value-456'}
+      ${'eu east 1! @#$%'}                 | ${'eu-east-1'}
+      ${'café'}                            | ${'cafe'}
+      ${'  spaces-around  '}               | ${'spaces-around'}
+    `('should sanitize "$input" to "$expected"', ({ input, expected }) => {
+      expect(sanitizeKeyBase(input)).toBe(expected);
+    });
+  });
+
+  describe('sanitizeKeyFinal', () => {
+    it.each`
+      input                    | expected
+      ${'My Tag Key'}          | ${'my-tag-key'}
+      ${'Tag Key-'}            | ${'tag-key'}
+      ${'UPPERCASE KEY'}       | ${'uppercase-key'}
+      ${'Key 123 Value 456'}   | ${'key-123-value-456'}
+      ${'eu east 1! @#$%'}     | ${'eu-east-1'}
+      ${'trailing-hyphens---'} | ${'trailing-hyphens'}
+    `('should sanitize "$input" to "$expected"', ({ input, expected }) => {
+      expect(sanitizeKeyFinal(input)).toBe(expected);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/shared/utils/key-sanitizer.util.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/key-sanitizer.util.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Normalizes user input to produce a valid tag key that meets backend requirements
+ * (alphanumeric with hyphens only, no diacritics or special characters).
+ */
+export function sanitizeKeyBase(key: string): string {
+  return key
+    .normalize('NFD')
+    .replaceAll(/[\u0300-\u036f]+/g, '')
+    .toLowerCase()
+    .replaceAll(/[^a-z\d\s-]/g, '')
+    .trim()
+    .replaceAll(/[^a-z\d]+/g, '-');
+}
+
+/**
+ * Finalizes key sanitization by removing trailing hyphens.
+ * This should be called on blur to ensure the key requirements.
+ */
+export function sanitizeKeyFinal(key: string): string {
+  let sanitized = sanitizeKeyBase(key);
+  while (sanitized.endsWith('-')) {
+    sanitized = sanitized.slice(0, -1);
+  }
+  return sanitized;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/TagRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/TagRepository.java
@@ -29,9 +29,9 @@ import java.util.Set;
 public interface TagRepository extends CrudRepository<Tag, String> {
     Set<Tag> findByReference(String referenceId, TagReferenceType referenceType) throws TechnicalException;
 
-    Optional<Tag> findByIdAndReference(String tagId, String referenceId, TagReferenceType referenceType) throws TechnicalException;
+    Optional<Tag> findByKeyAndReference(String key, String referenceId, TagReferenceType referenceType) throws TechnicalException;
 
-    Set<Tag> findByIdsAndReference(Set<String> tagIds, String referenceId, TagReferenceType referenceType) throws TechnicalException;
+    Set<Tag> findByKeysAndReference(Set<String> keys, String referenceId, TagReferenceType referenceType) throws TechnicalException;
 
     /**
      * Delete tags by reference

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Tag.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Tag.java
@@ -41,6 +41,7 @@ public class Tag {
     }
 
     private String id;
+    private String key;
     private String name;
     private String description;
     private List<String> restrictedGroups;
@@ -54,6 +55,7 @@ public class Tag {
         Tag tag = (Tag) o;
         return (
             Objects.equals(id, tag.id) &&
+            Objects.equals(key, tag.key) &&
             Objects.equals(name, tag.name) &&
             Objects.equals(description, tag.description) &&
             Objects.equals(referenceId, tag.referenceId) &&
@@ -63,7 +65,7 @@ public class Tag {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, restrictedGroups);
+        return Objects.hash(id, key, name, description, restrictedGroups);
     }
 
     @Override
@@ -72,6 +74,9 @@ public class Tag {
             "Tag{" +
             "id='" +
             id +
+            '\'' +
+            ", key='" +
+            key +
             '\'' +
             ", name='" +
             name +

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcTagRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcTagRepository.java
@@ -50,6 +50,7 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
     protected JdbcObjectMapper<Tag> buildOrm() {
         return JdbcObjectMapper.builder(Tag.class, this.tableName, "id")
             .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("key", Types.NVARCHAR, String.class)
             .addColumn("name", Types.NVARCHAR, String.class)
             .addColumn("description", Types.NVARCHAR, String.class)
             .addColumn("reference_id", Types.NVARCHAR, String.class)
@@ -70,14 +71,14 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
     }
 
     @Override
-    public Optional<Tag> findByIdAndReference(final String id, String referenceId, TagReferenceType referenceType)
+    public Optional<Tag> findByKeyAndReference(final String key, String referenceId, TagReferenceType referenceType)
         throws TechnicalException {
         try {
             Optional<Tag> tag = jdbcTemplate
                 .query(
-                    getOrm().getSelectAllSql() + " t where id = ? and reference_id = ? and reference_type = ? ",
+                    getOrm().getSelectAllSql() + " t where key = ? and reference_id = ? and reference_type = ? ",
                     getOrm().getRowMapper(),
-                    id,
+                    key,
                     referenceId,
                     referenceType.name()
                 )
@@ -86,25 +87,24 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
             tag.ifPresent(this::addGroups);
             return tag;
         } catch (final Exception ex) {
-            log.error("Failed to find {} tags by id, referenceId and referenceType:", getOrm().getTableName(), ex);
-            throw new TechnicalException("Failed to find " + getOrm().getTableName() + " tags by id, referenceId and referenceType", ex);
+            log.error("Failed to find {} tags by key, referenceId and referenceType:", getOrm().getTableName(), ex);
+            throw new TechnicalException("Failed to find " + getOrm().getTableName() + " tags by key, referenceId and referenceType", ex);
         }
     }
 
     @Override
-    public Set<Tag> findByIdsAndReference(Set<String> tagIds, String referenceId, TagReferenceType referenceType)
-        throws TechnicalException {
+    public Set<Tag> findByKeysAndReference(Set<String> keys, String referenceId, TagReferenceType referenceType) throws TechnicalException {
         try {
             return jdbcTemplate
                 .query(
                     getOrm().getSelectAllSql() +
-                        " where reference_id = ? and reference_type = ? and id in ( " +
-                        getOrm().buildInClause(tagIds) +
+                        " where reference_id = ? and reference_type = ? and key in ( " +
+                        getOrm().buildInClause(keys) +
                         " )",
                     (PreparedStatement ps) -> {
                         ps.setString(1, referenceId);
                         ps.setString(2, referenceType.name());
-                        getOrm().setArguments(ps, tagIds, 3);
+                        getOrm().setArguments(ps, keys, 3);
                     },
                     getOrm().getRowMapper()
                 )
@@ -112,8 +112,8 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
                 .peek(this::addGroups)
                 .collect(toSet());
         } catch (final Exception ex) {
-            log.error("Failed to find {} tags by ids, referenceId and referenceType:", getOrm().getTableName(), ex);
-            throw new TechnicalException("Failed to find " + getOrm().getTableName() + " tags by ids, referenceId and referenceType", ex);
+            log.error("Failed to find {} tags by keys, referenceId and referenceType:", getOrm().getTableName(), ex);
+            throw new TechnicalException("Failed to find " + getOrm().getTableName() + " tags by keys, referenceId and referenceType", ex);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcTagRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcTagRepository.java
@@ -91,7 +91,6 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
             tag.ifPresent(this::addGroups);
             return tag;
         } catch (final Exception ex) {
-            log.error("Failed to find {} tags by key, referenceId and referenceType:", getOrm().getTableName(), ex);
             throw new TechnicalException("Failed to find " + getOrm().getTableName() + " tags by key, referenceId and referenceType", ex);
         }
     }
@@ -118,7 +117,6 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
                 .peek(this::addGroups)
                 .collect(toSet());
         } catch (final Exception ex) {
-            log.error("Failed to find {} tags by keys, referenceId and referenceType:", getOrm().getTableName(), ex);
             throw new TechnicalException("Failed to find " + getOrm().getTableName() + " tags by keys, referenceId and referenceType", ex);
         }
     }
@@ -149,7 +147,6 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
             log.debug("JdbcTagRepository.deleteByReferenceIdAndReferenceType({},{}) - Done", referenceId, referenceType);
             return rows;
         } catch (final Exception ex) {
-            log.error("Failed to delete tags by reference {}/{}", referenceId, referenceType, ex);
             throw new TechnicalException("Failed to delete tags by reference", ex);
         }
     }
@@ -168,7 +165,6 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
                 .peek(this::addGroups)
                 .collect(toSet());
         } catch (final Exception ex) {
-            log.error("Failed to find {} tags referenceId and referenceType:", getOrm().getTableName(), ex);
             throw new TechnicalException("Failed to find " + getOrm().getTableName() + " tags by referenceId and referenceType", ex);
         }
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcTagRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcTagRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -76,7 +77,10 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
         try {
             Optional<Tag> tag = jdbcTemplate
                 .query(
-                    getOrm().getSelectAllSql() + " t where key = ? and reference_id = ? and reference_type = ? ",
+                    getOrm().getSelectAllSql() +
+                        " t where " +
+                        escapeReservedWord("key") +
+                        "= ? and reference_id = ? and reference_type = ? ",
                     getOrm().getRowMapper(),
                     key,
                     referenceId,
@@ -98,7 +102,9 @@ public class JdbcTagRepository extends JdbcAbstractCrudRepository<Tag, String> i
             return jdbcTemplate
                 .query(
                     getOrm().getSelectAllSql() +
-                        " where reference_id = ? and reference_type = ? and key in ( " +
+                        " where reference_id = ? and reference_type = ? and " +
+                        escapeReservedWord("key") +
+                        " in ( " +
                         getOrm().buildInClause(keys) +
                         " )",
                     (PreparedStatement ps) -> {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/11_add_tags_key_column.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/11_add_tags_key_column.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.11.0_00_add_tags_key_columns
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}tags
+            columns:
+              - column:
+                  name: key
+                  type: nvarchar(64)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/00_add_tags_key_column.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/00_add_tags_key_column.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_00_add_tags_key_columns
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}tags
+            columns:
+              - column:
+                  name: key
+                  type: nvarchar(64)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -316,3 +316,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_11_0/09_add_root_id_to_portal_navigation_items.yml
     - include:
         - file: liquibase/changelogs/v4_11_0/10_make_root_id_not_null_portal_navigation_items.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/00_add_tags_key_column.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTagRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTagRepository.java
@@ -55,23 +55,22 @@ public class MongoTagRepository implements TagRepository {
     }
 
     @Override
-    public Optional<Tag> findByIdAndReference(String tagId, String referenceId, TagReferenceType referenceType) {
-        log.debug("Find tag by ID and reference [{}, {}, {}]", tagId, referenceId, referenceType);
+    public Optional<Tag> findByKeyAndReference(String key, String referenceId, TagReferenceType referenceType) {
+        log.debug("Find tag by key and reference [{}, {}, {}]", key, referenceId, referenceType);
 
-        final TagMongo tag = internalTagRepo.findByIdAndReferenceIdAndReferenceType(tagId, referenceId, referenceType).orElse(null);
+        final TagMongo tag = internalTagRepo.findByKeyAndReferenceIdAndReferenceType(key, referenceId, referenceType).orElse(null);
 
-        log.debug("Find tag by ID and reference[{}, {}, {}] - Done", tagId, referenceId, referenceType);
+        log.debug("Find tag by key and reference[{}, {}, {}] - Done", key, referenceId, referenceType);
         return Optional.ofNullable(mapper.map(tag));
     }
 
     @Override
-    public Set<Tag> findByIdsAndReference(Set<String> tagIds, String referenceId, TagReferenceType referenceType)
-        throws TechnicalException {
-        log.debug("Find tags by IDs and reference [{}, {}, {}]", tagIds, referenceId, referenceType);
+    public Set<Tag> findByKeysAndReference(Set<String> keys, String referenceId, TagReferenceType referenceType) throws TechnicalException {
+        log.debug("Find tags by keys and reference [{}, {}, {}]", keys, referenceId, referenceType);
 
-        final List<TagMongo> tags = internalTagRepo.findByIdInAndReferenceIdAndReferenceType(tagIds, referenceId, referenceType);
+        final List<TagMongo> tags = internalTagRepo.findByKeyInAndReferenceIdAndReferenceType(keys, referenceId, referenceType);
 
-        log.debug("Find tag by IDs and reference[{}, {}, {}] - Done", tagIds, referenceId, referenceType);
+        log.debug("Find tag by keys and reference[{}, {}, {}] - Done", keys, referenceId, referenceType);
         return tags
             .stream()
             .map(tagMongo -> mapper.map(tagMongo))
@@ -121,6 +120,7 @@ public class MongoTagRepository implements TagRepository {
         try {
             //Update
             tagMongo.setName(tag.getName());
+            tagMongo.setKey(tag.getKey());
             tagMongo.setDescription(tag.getDescription());
             tagMongo.setRestrictedGroups(tag.getRestrictedGroups());
             tagMongo.setReferenceId(tag.getReferenceId());

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/TagMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/TagMongoRepository.java
@@ -32,9 +32,9 @@ import org.springframework.stereotype.Repository;
 public interface TagMongoRepository extends MongoRepository<TagMongo, String> {
     List<TagMongo> findByReferenceIdAndReferenceType(String referenceId, TagReferenceType referenceType);
 
-    Optional<TagMongo> findByIdAndReferenceIdAndReferenceType(String tagId, String referenceId, TagReferenceType referenceType);
+    Optional<TagMongo> findByKeyAndReferenceIdAndReferenceType(String key, String referenceId, TagReferenceType referenceType);
 
-    List<TagMongo> findByIdInAndReferenceIdAndReferenceType(Set<String> ids, String referenceId, TagReferenceType referenceType);
+    List<TagMongo> findByKeyInAndReferenceIdAndReferenceType(Set<String> keys, String referenceId, TagReferenceType referenceType);
 
     @Query(value = "{ 'referenceId': ?0, 'referenceType': ?1 }", fields = "{ _id : 1 }", delete = true)
     List<TagMongo> deleteByReferenceIdAndReferenceType(String referenceId, String name);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/TagMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/TagMongo.java
@@ -39,6 +39,7 @@ public class TagMongo {
     @EqualsAndHashCode.Include
     private String id;
 
+    private String key;
     private String name;
     private String description;
     private List<String> restrictedGroups;

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/TagRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/TagRepositoryTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 
+import io.gravitee.common.utils.UUID;
 import io.gravitee.repository.management.model.Tag;
 import io.gravitee.repository.management.model.TagReferenceType;
 import java.util.Optional;
@@ -53,7 +54,8 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
     @Test
     public void shouldCreate() throws Exception {
         final Tag tag = new Tag();
-        tag.setId("new-tag");
+        tag.setId(UUID.random().toString());
+        tag.setKey("new-tag");
         tag.setName("Tag name");
         tag.setDescription("Description for the new tag");
         tag.setRestrictedGroups(asList("g1", "groupNew"));
@@ -66,11 +68,12 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
 
         Assert.assertEquals(nbTagsBeforeCreation + 1, nbTagsAfterCreation);
 
-        Optional<Tag> optional = tagRepository.findById("new-tag");
+        Optional<Tag> optional = tagRepository.findById(tag.getId());
         Assert.assertTrue("Tag saved not found", optional.isPresent());
 
         final Tag tagSaved = optional.get();
         Assert.assertEquals("Invalid saved tag name.", tag.getName(), tagSaved.getName());
+        Assert.assertEquals("Invalid saved tag key.", tag.getKey(), tagSaved.getKey());
         Assert.assertEquals("Invalid tag description.", tag.getDescription(), tagSaved.getDescription());
         Assert.assertEquals("Invalid tag groups.", tag.getRestrictedGroups(), tagSaved.getRestrictedGroups());
     }
@@ -130,6 +133,7 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertTrue(tag.isPresent());
         assertEquals("Other", tag.get().getName());
+        assertEquals("other", tag.get().getKey());
         assertEquals("Description for other tag", tag.get().getDescription());
     }
 
@@ -143,7 +147,12 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertThat(tags)
             .hasSize(2)
-            .anyMatch(tag -> tag.getId().equals("70237305-6f68-450e-a373-056f68750e50") && tag.getName().equals("International"));
+            .anyMatch(
+                tag ->
+                    tag.getId().equals("70237305-6f68-450e-a373-056f68750e50") &&
+                    tag.getName().equals("International") &&
+                    tag.getKey().equals("international")
+            );
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/TagRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/TagRepositoryTest.java
@@ -42,7 +42,7 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals(3, tags.size());
         final Tag tagProduct = tags
             .stream()
-            .filter(tag -> "products".equals(tag.getId()))
+            .filter(tag -> "1d114170-466d-4952-9141-70466de95213".equals(tag.getId()))
             .findAny()
             .get();
         assertEquals("Products", tagProduct.getName());
@@ -77,7 +77,7 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
 
     @Test
     public void shouldUpdate() throws Exception {
-        Optional<Tag> optional = tagRepository.findById("products");
+        Optional<Tag> optional = tagRepository.findById("1d114170-466d-4952-9141-70466de95213");
         Assert.assertTrue("Tag to update not found", optional.isPresent());
         Assert.assertEquals("Invalid saved tag name.", "Products", optional.get().getName());
 
@@ -92,7 +92,7 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
 
         Assert.assertEquals(nbTagsBeforeUpdate, nbTagsAfterUpdate);
 
-        Optional<Tag> optionalUpdated = tagRepository.findById("products");
+        Optional<Tag> optionalUpdated = tagRepository.findById("1d114170-466d-4952-9141-70466de95213");
         Assert.assertTrue("Tag to update not found", optionalUpdated.isPresent());
 
         final Tag tagUpdated = optionalUpdated.get();
@@ -104,7 +104,7 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
     @Test
     public void shouldDelete() throws Exception {
         int nbTagsBeforeDeletion = tagRepository.findByReference("DEFAULT", TagReferenceType.ORGANIZATION).size();
-        tagRepository.delete("international");
+        tagRepository.delete("70237305-6f68-450e-a373-056f68750e50");
         int nbTagsAfterDeletion = tagRepository.findByReference("DEFAULT", TagReferenceType.ORGANIZATION).size();
 
         Assert.assertEquals(nbTagsBeforeDeletion - 1, nbTagsAfterDeletion);
@@ -125,8 +125,8 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
-    public void shouldFindByIdAndReference() throws Exception {
-        final Optional<Tag> tag = tagRepository.findByIdAndReference("other", "OTHER", TagReferenceType.ORGANIZATION);
+    public void shouldFindByKeyAndReference() throws Exception {
+        final Optional<Tag> tag = tagRepository.findByKeyAndReference("other", "OTHER", TagReferenceType.ORGANIZATION);
 
         assertTrue(tag.isPresent());
         assertEquals("Other", tag.get().getName());
@@ -134,8 +134,8 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
-    public void should_find_by_ids_and_reference_id_and_reference_type() throws Exception {
-        final Set<Tag> tags = tagRepository.findByIdsAndReference(
+    public void should_find_by_keys_and_reference_id_and_reference_type() throws Exception {
+        final Set<Tag> tags = tagRepository.findByKeysAndReference(
             Set.of("international", "stores", "not-to-be-found"),
             "DEFAULT",
             TagReferenceType.ORGANIZATION
@@ -143,7 +143,7 @@ public class TagRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertThat(tags)
             .hasSize(2)
-            .anyMatch(tag -> tag.getId().equals("international") && tag.getName().equals("International"));
+            .anyMatch(tag -> tag.getId().equals("70237305-6f68-450e-a373-056f68750e50") && tag.getName().equals("International"));
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/tag-tests/tags.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/tag-tests/tags.json
@@ -1,13 +1,15 @@
 [
    {
-      "id":"international",
+      "id":"70237305-6f68-450e-a373-056f68750e50",
+      "key":"international",
       "name":"International",
       "description": "Description for international tag",
       "referenceId": "DEFAULT",
       "referenceType": "ORGANIZATION"
    },
    {
-      "id":"products",
+      "id":"1d114170-466d-4952-9141-70466de95213",
+      "key":"products",
       "name":"Products",
       "description": "Description for products tag",
       "restrictedGroups" : ["group1", "group2"],
@@ -15,28 +17,32 @@
       "referenceType": "ORGANIZATION"
    },
    {
-      "id":"stores",
+      "id":"69201f80-994b-4a55-a01f-80994b0a5509",
+      "key":"stores",
       "name":"Stores",
       "description": "Description for stores tag",
       "referenceId": "DEFAULT",
       "referenceType": "ORGANIZATION"
    },
    {
-      "id":"other",
+      "id":"1052671b-7a32-475a-9267-1b7a32875a5d",
+      "key":"other",
       "name":"Other",
       "description": "Description for other tag",
       "referenceId": "OTHER",
       "referenceType": "ORGANIZATION"
    },
    {
-     "id":"ro-be-deleted-1",
+     "id":"e90708f3-80f4-42b7-8708-f380f472b7f3",
+     "key":"ro-be-deleted-1",
      "name":"Other",
      "description": "Description for other tag",
      "referenceId": "ToBeDeleted",
      "referenceType": "ORGANIZATION"
    },
    {
-     "id":"ro-be-deleted-2",
+     "id":"4072895f-3652-4113-b289-5f3652711319",
+     "key":"ro-be-deleted-2",
      "name":"Other",
      "description": "Description for other tag",
      "referenceId": "ToBeDeleted",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TagsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TagsResource.java
@@ -85,7 +85,7 @@ public class TagsResource extends AbstractResource {
         }
     )
     public TagEntity getTag(@PathParam("tag") String tag) {
-        return tagService.findByIdAndReference(tag, GraviteeContext.getCurrentOrganization(), TagReferenceType.ORGANIZATION);
+        return tagService.findByKeyAndReference(tag, GraviteeContext.getCurrentOrganization(), TagReferenceType.ORGANIZATION);
     }
 
     @POST
@@ -135,9 +135,10 @@ public class TagsResource extends AbstractResource {
         }
     )
     @GraviteeLicenseFeature("apim-sharding-tags")
-    public TagEntity updateTag(@PathParam("tag") String tagId, @Valid @NotNull final UpdateTagEntity tag) {
+    public TagEntity updateTag(@PathParam("tag") String tagKey, @Valid @NotNull final UpdateTagEntity tag) {
         return tagService.update(
             GraviteeContext.getExecutionContext(),
+            tagKey,
             tag,
             GraviteeContext.getCurrentOrganization(),
             TagReferenceType.ORGANIZATION

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/TagsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/TagsResourceTest.java
@@ -17,7 +17,11 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static jakarta.ws.rs.client.Entity.json;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.node.api.license.License;
@@ -26,7 +30,6 @@ import io.gravitee.rest.api.model.NewTagEntity;
 import io.gravitee.rest.api.model.TagEntity;
 import io.gravitee.rest.api.model.UpdateTagEntity;
 import jakarta.ws.rs.core.Response;
-import java.util.List;
 import javax.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,6 +61,7 @@ public class TagsResourceTest extends AbstractResourceTest {
         when(license.isFeatureEnabled("apim-sharding-tags")).thenReturn(false);
         when(permissionService.hasPermission(any(), any(), any(), any(), any())).thenReturn(true);
         NewTagEntity newTag = new NewTagEntity();
+        newTag.setKey("tag-key");
         newTag.setName("tag-name");
         Response response = orgTarget().request().post(json(newTag));
         assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
@@ -68,9 +72,12 @@ public class TagsResourceTest extends AbstractResourceTest {
         when(license.isFeatureEnabled("apim-sharding-tags")).thenReturn(true);
         when(permissionService.hasPermission(any(), any(), any(), any(), any())).thenReturn(true);
         NewTagEntity newTag = new NewTagEntity();
+        newTag.setKey("tag-key");
         newTag.setName("tag-name");
         TagEntity tag = new TagEntity();
         tag.setId("tag-id");
+        tag.setKey("tag-key");
+        tag.setName("tag-name");
         when(tagService.create(any(), any(NewTagEntity.class), any(), any())).thenReturn(tag);
         Response response = orgTarget().request().post(json(newTag));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -84,7 +91,7 @@ public class TagsResourceTest extends AbstractResourceTest {
         when(permissionService.hasPermission(any(), any(), any(), any(), any())).thenReturn(true);
         UpdateTagEntity tag = new UpdateTagEntity();
         tag.setName("tag-name");
-        Response response = orgTarget("tag-id").request().put(json(tag));
+        Response response = orgTarget("tag-key").request().put(json(tag));
         assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
     }
 
@@ -92,15 +99,15 @@ public class TagsResourceTest extends AbstractResourceTest {
     public void should_allow_update_tag_with_sharding_tags_feature() {
         when(license.isFeatureEnabled("apim-sharding-tags")).thenReturn(true);
         when(permissionService.hasPermission(any(), any(), any(), any(), any())).thenReturn(true);
-        when(tagService.update(any(), any(UpdateTagEntity.class), anyString(), any())).thenAnswer(i -> {
+        when(tagService.update(any(), eq("tag-key"), any(UpdateTagEntity.class), anyString(), any())).thenAnswer(i -> {
             final TagEntity tagEntity = new TagEntity();
-            tagEntity.setName(i.<UpdateTagEntity>getArgument(1).getName());
+            tagEntity.setName(i.<UpdateTagEntity>getArgument(2).getName());
             return tagEntity;
         });
 
         UpdateTagEntity tag = new UpdateTagEntity();
-        tag.setName("tag-name");
-        Response response = orgTarget("tag-id").request().put(json(tag));
+        tag.setName("Tag");
+        Response response = orgTarget("tag-key").request().put(json(tag));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         TagEntity tagEntity = response.readEntity(TagEntity.class);
         assertEquals(tag.getName(), tagEntity.getName());
@@ -110,7 +117,7 @@ public class TagsResourceTest extends AbstractResourceTest {
     public void should_forbid_delete_tag_without_sharding_tags_feature() {
         when(license.isFeatureEnabled("apim-sharding-tags")).thenReturn(false);
         when(permissionService.hasPermission(any(), any(), any(), any(), any())).thenReturn(true);
-        Response response = orgTarget().path("tag-id").request().delete();
+        Response response = orgTarget().path("tag-key").request().delete();
         assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
     }
 
@@ -118,7 +125,7 @@ public class TagsResourceTest extends AbstractResourceTest {
     public void should_allow_delete_tag_with_sharding_tags_feature() {
         when(license.isFeatureEnabled("apim-sharding-tags")).thenReturn(true);
         when(permissionService.hasPermission(any(), any(), any(), any(), any())).thenReturn(true);
-        Response response = orgTarget().path("tag-id").request().delete();
+        Response response = orgTarget().path("tag-key").request().delete();
         assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewTagEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewTagEntity.java
@@ -31,6 +31,8 @@ public class NewTagEntity {
     @Size(min = 1)
     private String name;
 
+    private String key;
+
     private String description;
 
     @JsonProperty("restricted_groups")
@@ -42,6 +44,14 @@ public class NewTagEntity {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
     }
 
     public String getDescription() {
@@ -67,6 +77,7 @@ public class NewTagEntity {
         NewTagEntity that = (NewTagEntity) o;
         return (
             Objects.equals(name, that.name) &&
+            Objects.equals(key, that.key) &&
             Objects.equals(description, that.description) &&
             Objects.equals(restrictedGroups, that.restrictedGroups)
         );
@@ -74,7 +85,7 @@ public class NewTagEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, restrictedGroups);
+        return Objects.hash(name, key, description, restrictedGroups);
     }
 
     @Override
@@ -83,6 +94,9 @@ public class NewTagEntity {
             "NewTagEntity{" +
             "name='" +
             name +
+            '\'' +
+            ", key='" +
+            key +
             '\'' +
             ", description='" +
             description +

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewTagEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewTagEntity.java
@@ -28,9 +28,11 @@ import java.util.Objects;
 public class NewTagEntity {
 
     @NotNull
-    @Size(min = 1)
+    @Size(min = 1, max = 64)
     private String name;
 
+    @NotNull
+    @Size(min = 1, max = 64)
     private String key;
 
     private String description;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/TagEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/TagEntity.java
@@ -30,7 +30,11 @@ public class TagEntity {
     private String id;
 
     @NotNull
-    @Size(min = 1)
+    @Size(min = 1, max = 64)
+    private String key;
+
+    @NotNull
+    @Size(min = 1, max = 64)
     private String name;
 
     private String description;
@@ -44,6 +48,14 @@ public class TagEntity {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
     }
 
     public String getName() {
@@ -77,6 +89,7 @@ public class TagEntity {
         TagEntity tagEntity = (TagEntity) o;
         return (
             Objects.equals(id, tagEntity.id) &&
+            Objects.equals(key, tagEntity.key) &&
             Objects.equals(name, tagEntity.name) &&
             Objects.equals(description, tagEntity.description) &&
             Objects.equals(restrictedGroups, tagEntity.restrictedGroups)
@@ -85,7 +98,7 @@ public class TagEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, restrictedGroups);
+        return Objects.hash(id, key, name, description, restrictedGroups);
     }
 
     @Override
@@ -94,6 +107,9 @@ public class TagEntity {
             "TagEntity{" +
             "id='" +
             id +
+            '\'' +
+            ", key='" +
+            key +
             '\'' +
             ", name='" +
             name +

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateTagEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateTagEntity.java
@@ -27,24 +27,14 @@ import java.util.Objects;
  */
 public class UpdateTagEntity {
 
-    private String id;
-
     @NotNull
-    @Size(min = 1)
+    @Size(min = 1, max = 64)
     private String name;
 
     private String description;
 
     @JsonProperty("restricted_groups")
     private List<String> restrictedGroups;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
 
     public String getName() {
         return name;
@@ -76,7 +66,6 @@ public class UpdateTagEntity {
         if (!(o instanceof UpdateTagEntity)) return false;
         UpdateTagEntity that = (UpdateTagEntity) o;
         return (
-            Objects.equals(id, that.id) &&
             Objects.equals(name, that.name) &&
             Objects.equals(description, that.description) &&
             Objects.equals(restrictedGroups, that.restrictedGroups)
@@ -85,17 +74,14 @@ public class UpdateTagEntity {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, restrictedGroups);
+        return Objects.hash(name, description, restrictedGroups);
     }
 
     @Override
     public String toString() {
         return (
             "UpdateTagEntity{" +
-            "id='" +
-            id +
-            '\'' +
-            ", name='" +
+            "name='" +
             name +
             '\'' +
             ", description='" +

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/tag/model/Tag.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/tag/model/Tag.java
@@ -26,6 +26,7 @@ import lombok.With;
 public class Tag {
 
     private String id;
+    private String key;
     private String name;
     private String description;
     private List<String> restrictedGroups;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImpl.java
@@ -190,7 +190,7 @@ public class OAIDomainServiceImpl implements OAIDomainService {
                             .getTags()
                             .stream()
                             .flatMap(group -> tagsQueryService.findByName(organizationId, group).stream())
-                            .map(Tag::getId)
+                            .map(Tag::getKey)
                             .collect(Collectors.toSet())
                     )
                     .build()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/TagService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/TagService.java
@@ -30,22 +30,21 @@ import java.util.Set;
  */
 public interface TagService {
     List<TagEntity> findByReference(String referenceId, TagReferenceType referenceType);
-    TagEntity findByIdAndReference(String tagId, String referenceId, TagReferenceType referenceType);
-    void checkTagsExist(Set<String> tagIds, String referenceId, TagReferenceType referenceType) throws TechnicalException;
-    TagEntity create(final ExecutionContext executionContext, NewTagEntity tag, String referenceId, TagReferenceType referenceType);
-    TagEntity update(final ExecutionContext executionContext, UpdateTagEntity tag, String referenceId, TagReferenceType referenceType);
-    List<TagEntity> create(
+    TagEntity findByKeyAndReference(String key, String referenceId, TagReferenceType referenceType);
+    void checkTagsExist(Set<String> keys, String referenceId, TagReferenceType referenceType) throws TechnicalException;
+    TagEntity create(
         final ExecutionContext executionContext,
-        List<NewTagEntity> tags,
+        NewTagEntity newTagEntity,
         String referenceId,
         TagReferenceType referenceType
     );
-    List<TagEntity> update(
+    TagEntity update(
         final ExecutionContext executionContext,
-        List<UpdateTagEntity> tags,
+        String tagKey,
+        UpdateTagEntity updateTagEntity,
         String referenceId,
         TagReferenceType referenceType
     );
-    void delete(final ExecutionContext executionContext, String tagId, String referenceId, TagReferenceType referenceType);
+    void delete(final ExecutionContext executionContext, String key, String referenceId, TagReferenceType referenceType);
     Set<String> findByUser(String user, String referenceId, TagReferenceType referenceType);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/DuplicateTagKeyException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/DuplicateTagKeyException.java
@@ -24,12 +24,12 @@ import java.util.Map;
  * @author Azize ELAMRANI (azize at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class DuplicateTagNameException extends AbstractManagementException {
+public class DuplicateTagKeyException extends AbstractManagementException {
 
-    private final String tagName;
+    private final String tagKey;
 
-    public DuplicateTagNameException(String tagName) {
-        this.tagName = tagName;
+    public DuplicateTagKeyException(String tagKey) {
+        this.tagKey = tagKey;
     }
 
     @Override
@@ -39,7 +39,7 @@ public class DuplicateTagNameException extends AbstractManagementException {
 
     @Override
     public String getMessage() {
-        return "The tag '" + tagName + "' already exists.";
+        return "The tag '" + tagKey + "' already exists.";
     }
 
     @Override
@@ -49,6 +49,6 @@ public class DuplicateTagNameException extends AbstractManagementException {
 
     @Override
     public Map<String, String> getParameters() {
-        return singletonMap("tag", tagName);
+        return singletonMap("tag", tagKey);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
@@ -19,11 +19,11 @@ import static io.gravitee.repository.management.model.Audit.AuditProperties.TAG;
 import static io.gravitee.repository.management.model.Tag.AuditEvent.TAG_CREATED;
 import static io.gravitee.repository.management.model.Tag.AuditEvent.TAG_DELETED;
 import static io.gravitee.repository.management.model.Tag.AuditEvent.TAG_UPDATED;
-import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.common.utils.IdGenerator;
+import io.gravitee.common.utils.UUID;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.TagRepository;
 import io.gravitee.repository.management.model.Tag;
@@ -36,11 +36,10 @@ import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.TagService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.exceptions.DuplicateTagNameException;
+import io.gravitee.rest.api.service.exceptions.DuplicateTagKeyException;
 import io.gravitee.rest.api.service.exceptions.TagNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.v4.ApiTagService;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -88,138 +87,139 @@ public class TagServiceImpl extends AbstractService implements TagService {
     }
 
     @Override
-    public TagEntity findByIdAndReference(String tagId, String referenceId, TagReferenceType referenceType) {
+    public TagEntity findByKeyAndReference(String key, String referenceId, TagReferenceType referenceType) {
         try {
-            log.debug("Find tag by ID: {}", tagId);
-            Optional<Tag> optTag = tagRepository.findByIdAndReference(tagId, referenceId, repoTagReferenceType(referenceType));
+            log.debug("Find tag by key: {}", key);
+            Optional<Tag> optTag = tagRepository.findByKeyAndReference(key, referenceId, repoTagReferenceType(referenceType));
 
-            if (!optTag.isPresent()) {
-                throw new TagNotFoundException(tagId);
+            if (optTag.isEmpty()) {
+                throw new TagNotFoundException(key);
             }
 
             return convert(optTag.get());
         } catch (TechnicalException ex) {
-            throw new TechnicalManagementException("An error occurs while trying to find tag by ID", ex);
+            throw new TechnicalManagementException("An error occurs while trying to find tag by key", ex);
         }
     }
 
     @Override
-    public void checkTagsExist(Set<String> tagIds, String referenceId, TagReferenceType referenceType) throws TechnicalException {
-        Set<Tag> foundTags = tagRepository.findByIdsAndReference(tagIds, referenceId, repoTagReferenceType(referenceType));
-        if (foundTags.size() == tagIds.size()) {
+    public void checkTagsExist(Set<String> keys, String referenceId, TagReferenceType referenceType) throws TechnicalException {
+        if (keys == null || keys.isEmpty()) {
             return;
         }
-        foundTags.forEach(tag -> tagIds.remove(tag.getId()));
-        throw new TagNotFoundException(tagIds.toArray(String[]::new));
+
+        Set<Tag> foundTags = tagRepository.findByKeysAndReference(keys, referenceId, repoTagReferenceType(referenceType));
+
+        if (foundTags.size() == keys.size()) {
+            return;
+        }
+
+        Set<String> foundKeys = foundTags.stream().map(Tag::getKey).collect(toSet());
+
+        Set<String> notFoundKeys = keys
+            .stream()
+            .filter(key -> !foundKeys.contains(key))
+            .collect(toSet());
+
+        if (!notFoundKeys.isEmpty()) {
+            throw new TagNotFoundException(notFoundKeys.toArray(String[]::new));
+        }
     }
 
     @Override
-    public TagEntity create(final ExecutionContext executionContext, NewTagEntity tag, String referenceId, TagReferenceType referenceType) {
-        return create(executionContext, singletonList(tag), referenceId, referenceType).get(0);
+    public TagEntity create(
+        final ExecutionContext executionContext,
+        NewTagEntity tagEntity,
+        String referenceId,
+        TagReferenceType referenceType
+    ) {
+        final var optionalTag = findByReference(referenceId, referenceType)
+            .stream()
+            .filter(tag -> tag.getKey().equals(tagEntity.getKey()))
+            .findAny();
+
+        if (optionalTag.isPresent()) {
+            throw new DuplicateTagKeyException(optionalTag.get().getKey());
+        }
+
+        try {
+            var tagToSaved = convert(tagEntity, referenceId, referenceType);
+            var tagSaved = tagRepository.create(tagToSaved);
+            auditService.createOrganizationAuditLog(
+                executionContext,
+                AuditService.AuditLogData.builder()
+                    .properties(Collections.singletonMap(TAG, tagSaved.getKey()))
+                    .event(TAG_CREATED)
+                    .createdAt(new Date())
+                    .oldValue(null)
+                    .newValue(tagSaved)
+                    .build()
+            );
+
+            return convert(tagSaved);
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException("An error occurs while trying to create tag " + tagEntity.getName(), ex);
+        }
     }
 
     @Override
     public TagEntity update(
         final ExecutionContext executionContext,
-        UpdateTagEntity tag,
+        String tagKey,
+        UpdateTagEntity updateTagEntity,
         String referenceId,
         TagReferenceType referenceType
     ) {
-        return update(executionContext, singletonList(tag), referenceId, referenceType).get(0);
-    }
-
-    @Override
-    public List<TagEntity> create(
-        final ExecutionContext executionContext,
-        final List<NewTagEntity> tagEntities,
-        String referenceId,
-        TagReferenceType referenceType
-    ) {
-        // First we prevent the duplicate tag name
-        final List<String> tagNames = tagEntities.stream().map(NewTagEntity::getName).collect(toList());
-
-        final Optional<TagEntity> optionalTag = findByReference(referenceId, referenceType)
-            .stream()
-            .filter(tag -> tagNames.contains(tag.getName()))
-            .findAny();
-
-        if (optionalTag.isPresent()) {
-            throw new DuplicateTagNameException(optionalTag.get().getName());
-        }
-
-        final List<TagEntity> savedTags = new ArrayList<>(tagEntities.size());
-        tagEntities.forEach(tagEntity -> {
-            try {
-                Tag tag = convert(tagEntity, referenceId, referenceType);
-                savedTags.add(convert(tagRepository.create(tag)));
-                auditService.createOrganizationAuditLog(
-                    executionContext,
-                    AuditService.AuditLogData.builder()
-                        .properties(Collections.singletonMap(TAG, tag.getId()))
-                        .event(TAG_CREATED)
-                        .createdAt(new Date())
-                        .oldValue(null)
-                        .newValue(tag)
-                        .build()
-                );
-            } catch (TechnicalException ex) {
-                throw new TechnicalManagementException("An error occurs while trying to create tag " + tagEntity.getName(), ex);
-            }
-        });
-        return savedTags;
-    }
-
-    @Override
-    public List<TagEntity> update(
-        final ExecutionContext executionContext,
-        final List<UpdateTagEntity> tagEntities,
-        String referenceId,
-        TagReferenceType referenceType
-    ) {
-        final List<TagEntity> savedTags = new ArrayList<>(tagEntities.size());
-        tagEntities.forEach(tagEntity -> {
-            try {
-                Tag tag = convert(tagEntity);
-                Optional<Tag> tagOptional = tagRepository.findByIdAndReference(
-                    tag.getId(),
-                    referenceId,
-                    repoTagReferenceType(referenceType)
-                );
-                if (tagOptional.isPresent()) {
-                    Tag existingTag = tagOptional.get();
-                    tag.setReferenceId(existingTag.getReferenceId());
-                    tag.setReferenceType(existingTag.getReferenceType());
-                    savedTags.add(convert(tagRepository.update(tag)));
-                    auditService.createOrganizationAuditLog(
-                        executionContext,
-                        AuditService.AuditLogData.builder()
-                            .properties(Collections.singletonMap(TAG, tag.getId()))
-                            .event(TAG_UPDATED)
-                            .createdAt(new Date())
-                            .oldValue(tagOptional.get())
-                            .newValue(tag)
-                            .build()
-                    );
-                }
-            } catch (TechnicalException ex) {
-                throw new TechnicalManagementException("An error occurs while trying to update tag " + tagEntity.getName(), ex);
-            }
-        });
-        return savedTags;
-    }
-
-    @Override
-    public void delete(final ExecutionContext executionContext, final String tagId, String referenceId, TagReferenceType referenceType) {
         try {
-            Optional<Tag> tagOptional = tagRepository.findByIdAndReference(tagId, referenceId, repoTagReferenceType(referenceType));
+            var tagOptional = tagRepository.findByKeyAndReference(tagKey, referenceId, repoTagReferenceType(referenceType));
+
+            if (tagOptional.isEmpty()) {
+                throw new TagNotFoundException(tagKey);
+            }
+
+            var existingTag = tagOptional.get();
+            var tagToSave = Tag.builder()
+                .id(existingTag.getId())
+                .key(existingTag.getKey())
+                .name(updateTagEntity.getName())
+                .description(updateTagEntity.getDescription())
+                .restrictedGroups(updateTagEntity.getRestrictedGroups())
+                .referenceId(existingTag.getReferenceId())
+                .referenceType(existingTag.getReferenceType())
+                .build();
+
+            var tagSaved = tagRepository.update(tagToSave);
+            auditService.createOrganizationAuditLog(
+                executionContext,
+                AuditService.AuditLogData.builder()
+                    .properties(Collections.singletonMap(TAG, tagSaved.getKey()))
+                    .event(TAG_UPDATED)
+                    .createdAt(new Date())
+                    .oldValue(existingTag)
+                    .newValue(tagSaved)
+                    .build()
+            );
+
+            return convert(tagSaved);
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException("An error occurs while trying to update tag " + tagKey, ex);
+        }
+    }
+
+    @Override
+    public void delete(final ExecutionContext executionContext, final String key, String referenceId, TagReferenceType referenceType) {
+        try {
+            Optional<Tag> tagOptional = tagRepository.findByKeyAndReference(key, referenceId, repoTagReferenceType(referenceType));
+
             if (tagOptional.isPresent()) {
-                tagRepository.delete(tagId);
+                String actualTagId = tagOptional.get().getId();
+                tagRepository.delete(actualTagId);
                 // delete all reference on APIs
-                apiTagService.deleteTagFromAPIs(executionContext, tagId);
+                apiTagService.deleteTagFromAPIs(executionContext, actualTagId);
                 auditService.createOrganizationAuditLog(
                     executionContext,
                     AuditService.AuditLogData.builder()
-                        .properties(Collections.singletonMap(TAG, tagId))
+                        .properties(Collections.singletonMap(TAG, actualTagId))
                         .event(TAG_DELETED)
                         .createdAt(new Date())
                         .oldValue(null)
@@ -228,7 +228,7 @@ public class TagServiceImpl extends AbstractService implements TagService {
                 );
             }
         } catch (TechnicalException ex) {
-            throw new TechnicalManagementException("An error occurs while trying to delete tag " + tagId, ex);
+            throw new TechnicalManagementException("An error occurs while trying to delete tag " + key, ex);
         }
     }
 
@@ -236,12 +236,12 @@ public class TagServiceImpl extends AbstractService implements TagService {
     public Set<String> findByUser(final String user, String referenceId, TagReferenceType referenceType) {
         final List<TagEntity> tags = findByReference(referenceId, referenceType);
         if (isEnvironmentAdmin()) {
-            return tags.stream().map(TagEntity::getId).collect(toSet());
+            return tags.stream().map(TagEntity::getKey).collect(toSet());
         } else {
             final Set<String> restrictedTags = tags
                 .stream()
                 .filter(tag -> tag.getRestrictedGroups() != null && !tag.getRestrictedGroups().isEmpty())
-                .map(TagEntity::getId)
+                .map(TagEntity::getKey)
                 .collect(toSet());
 
             final Set<String> groups = groupService.findByUser(user).stream().map(GroupEntity::getId).collect(toSet());
@@ -250,10 +250,10 @@ public class TagServiceImpl extends AbstractService implements TagService {
                 .stream()
                 .filter(
                     tag ->
-                        !restrictedTags.contains(tag.getId()) ||
+                        !restrictedTags.contains(tag.getKey()) ||
                         (tag.getRestrictedGroups() != null && anyMatch(tag.getRestrictedGroups(), groups))
                 )
-                .map(TagEntity::getId)
+                .map(TagEntity::getKey)
                 .collect(toSet());
         }
     }
@@ -269,7 +269,8 @@ public class TagServiceImpl extends AbstractService implements TagService {
 
     private Tag convert(final NewTagEntity tagEntity, String referenceId, TagReferenceType referenceType) {
         final Tag tag = new Tag();
-        tag.setId(IdGenerator.generate(tagEntity.getName()));
+        tag.setId(UUID.random().toString());
+        tag.setKey(IdGenerator.generate(tagEntity.getKey()));
         tag.setName(tagEntity.getName());
         tag.setDescription(tagEntity.getDescription());
         tag.setRestrictedGroups(tagEntity.getRestrictedGroups());
@@ -278,18 +279,10 @@ public class TagServiceImpl extends AbstractService implements TagService {
         return tag;
     }
 
-    private Tag convert(final UpdateTagEntity tagEntity) {
-        final Tag tag = new Tag();
-        tag.setId(tagEntity.getId());
-        tag.setName(tagEntity.getName());
-        tag.setDescription(tagEntity.getDescription());
-        tag.setRestrictedGroups(tagEntity.getRestrictedGroups());
-        return tag;
-    }
-
     private TagEntity convert(final Tag tag) {
         final TagEntity tagEntity = new TagEntity();
         tagEntity.setId(tag.getId());
+        tagEntity.setKey(tag.getKey());
         tagEntity.setName(tag.getName());
         tagEntity.setDescription(tag.getDescription());
         tagEntity.setRestrictedGroups(tag.getRestrictedGroups());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
@@ -258,15 +258,15 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
                 final Map<String, String> tagMap = tagService
                     .findByReference(executionContext.getOrganizationId(), TagReferenceType.ORGANIZATION)
                     .stream()
-                    .collect(toMap(TagEntity::getId, TagEntity::getName));
-                final Set<String> tagIdToAdd = xGraviteeIODefinition
+                    .collect(toMap(TagEntity::getKey, TagEntity::getName));
+                final Set<String> tagKeyToAdd = xGraviteeIODefinition
                     .getTags()
                     .stream()
-                    .map(tag -> findTagIdByName(tagMap, tag))
+                    .map(tag -> findTagKeyByName(tagMap, tag))
                     .filter(Objects::nonNull)
                     .collect(Collectors.toSet());
-                if (tagIdToAdd != null && !tagIdToAdd.isEmpty()) {
-                    apiEntity.setTags(tagIdToAdd);
+                if (!tagKeyToAdd.isEmpty()) {
+                    apiEntity.setTags(tagKeyToAdd);
                 }
             }
 
@@ -348,7 +348,7 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
         return apiEntity;
     }
 
-    private String findTagIdByName(Map<String, String> tagMap, String tag) {
+    private String findTagKeyByName(Map<String, String> tagMap, String tag) {
         for (Map.Entry<String, String> entry : tagMap.entrySet()) {
             if (entry.getValue().equals(tag)) {
                 return entry.getKey();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/TagKeyUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/TagKeyUpgrader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import io.gravitee.common.utils.UUID;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.TagRepository;
+import io.gravitee.repository.management.model.Tag;
+import lombok.CustomLog;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Component
+public class TagKeyUpgrader implements Upgrader {
+
+    @Lazy
+    @Autowired
+    private TagRepository tagRepository;
+
+    @SneakyThrows
+    @Override
+    public boolean upgrade() {
+        try {
+            tagRepository
+                .findAll()
+                .forEach(tag -> {
+                    log.info("Migrating sharding tag {}", tag.getName());
+
+                    tag.setKey(tag.getId());
+
+                    try {
+                        tagRepository.update(tag);
+                    } catch (TechnicalException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            return true;
+        } catch (Exception ex) {
+            log.error("Failed to migrate sharding tags", ex);
+            return false;
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.TAG_KEY_UPGRADER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/TagKeyUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/TagKeyUpgrader.java
@@ -56,7 +56,7 @@ public class TagKeyUpgrader implements Upgrader {
                 });
             return true;
         } catch (Exception ex) {
-            log.error("Failed to migrate sharding tags", ex);
+            log.error("TagKeyUpgrader failed. Fail to upgrade tag key");
             return false;
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -62,6 +62,7 @@ public class UpgraderOrder {
     public static final int APPLICATION_CLIENT_CERTIFICATE_MIGRATION_UPGRADER = 713;
     public static final int ENVIRONMENTS_DEFAULT_SUBSCRIPTION_FORM_UPGRADER = 714;
     public static final int PORTAL_NAVIGATION_ITEM_ROOT_ID_UPGRADER = 715;
+    public static final int TAG_KEY_UPGRADER = 716;
     public static final int CLUSTER_ROLES_UPGRADER = 900;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;
     public static final int API_PRODUCT_ROLES_UPGRADER = 950;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
@@ -39,6 +39,7 @@ import io.gravitee.apim.core.plugin.model.PolicyPlugin;
 import io.gravitee.apim.core.tag.model.Tag;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.infra.domain_service.api.OAIDomainServiceImpl;
+import io.gravitee.common.utils.UUID;
 import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
@@ -82,7 +83,13 @@ class OAIToImportApiUseCaseTest {
         var tagQueryService = new TagQueryServiceInMemory();
         tagQueryService.initWith(
             List.of(
-                Tag.builder().id("1").name("tag1").referenceId(ORGANIZATION_ID).referenceType(Tag.TagReferenceType.ORGANIZATION).build()
+                Tag.builder()
+                    .id(UUID.random().toString())
+                    .key("tag1")
+                    .name("tag1")
+                    .referenceId(ORGANIZATION_ID)
+                    .referenceType(Tag.TagReferenceType.ORGANIZATION)
+                    .build()
             )
         );
 
@@ -144,7 +151,7 @@ class OAIToImportApiUseCaseTest {
 
     @Test
     @SneakyThrows
-    void should_map_tags_names_to_ids() {
+    void should_map_tags_names_to_keys() {
         // Given
         var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
         var resource = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
@@ -158,7 +165,7 @@ class OAIToImportApiUseCaseTest {
 
         var importDefinition = output.apiWithFlows();
         assertThat(importDefinition).isNotNull();
-        assertThat(importDefinition.getTags()).containsExactly("1");
+        assertThat(importDefinition.getTags()).containsExactly("tag1");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/cockpit/DeployModelToApiCreateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/cockpit/DeployModelToApiCreateUseCaseTest.java
@@ -163,7 +163,13 @@ public class DeployModelToApiCreateUseCaseTest {
         var tagQueryService = new TagQueryServiceInMemory();
         tagQueryService.initWith(
             List.of(
-                Tag.builder().id("1").name("tag1").referenceId(ORGANIZATION_ID).referenceType(Tag.TagReferenceType.ORGANIZATION).build()
+                Tag.builder()
+                    .id("1")
+                    .key("tag-1")
+                    .name("tag1")
+                    .referenceId(ORGANIZATION_ID)
+                    .referenceType(Tag.TagReferenceType.ORGANIZATION)
+                    .build()
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/tag/TagQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/tag/TagQueryServiceImplTest.java
@@ -52,8 +52,8 @@ class TagQueryServiceImplTest {
         void should_find_groups_matching_the_event_provided() {
             when(tagRepository.findByReference(any(String.class), eq(TagReferenceType.ORGANIZATION))).thenAnswer(invocation ->
                 Set.of(
-                    aTag("1").referenceId(invocation.getArgument(0)).name("tag-1").build(),
-                    aTag("2").referenceId(invocation.getArgument(0)).name("tag-2").build()
+                    aTag("1", "tag-1").referenceId(invocation.getArgument(0)).name("tag-1").build(),
+                    aTag("2", "tag-2").referenceId(invocation.getArgument(0)).name("tag-2").build()
                 )
             );
 
@@ -66,7 +66,7 @@ class TagQueryServiceImplTest {
         @SneakyThrows
         void should_adapt_groups() {
             when(tagRepository.findByReference(any(String.class), eq(TagReferenceType.ORGANIZATION))).thenAnswer(invocation ->
-                Set.of(aTag("1").referenceId(invocation.getArgument(0)).name("tag-1").build())
+                Set.of(aTag("1", "tag-1").referenceId(invocation.getArgument(0)).name("tag-1").build())
             );
 
             var tags = service.findByName(ORGANIZATION_ID, "tag-1");
@@ -76,6 +76,7 @@ class TagQueryServiceImplTest {
                 .containsExactly(
                     Tag.builder()
                         .id("1")
+                        .key("tag-1")
                         .name("tag-1")
                         .description("group-1-description")
                         .restrictedGroups(List.of("group-1-restricted-group"))
@@ -86,9 +87,10 @@ class TagQueryServiceImplTest {
         }
     }
 
-    private io.gravitee.repository.management.model.Tag.TagBuilder aTag(String id) {
+    private io.gravitee.repository.management.model.Tag.TagBuilder aTag(String id, String key) {
         return io.gravitee.repository.management.model.Tag.builder()
             .id(id)
+            .key(key)
             .name("group-1")
             .description("group-1-description")
             .restrictedGroups(List.of("group-1-restricted-group"))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SwaggerService_CreateAPITest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SwaggerService_CreateAPITest.java
@@ -104,10 +104,12 @@ public class SwaggerService_CreateAPITest {
         when(groupService.findByName(GraviteeContext.getCurrentEnvironment(), "group2")).thenReturn(Arrays.asList(grp2));
 
         TagEntity tag1 = new TagEntity();
-        tag1.setId("tagId1");
+        tag1.setId(UUID.randomUUID().toString());
+        tag1.setKey("tagId1");
         tag1.setName("tag1");
         TagEntity tag2 = new TagEntity();
-        tag2.setId("tagId2");
+        tag2.setId(UUID.randomUUID().toString());
+        tag2.setKey("tagId2");
         tag2.setName("tag2");
         when(tagService.findByReference(any(), any())).thenReturn(Arrays.asList(tag1, tag2));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TagServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TagServiceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.TagRepository;
+import io.gravitee.repository.management.model.Tag;
+import io.gravitee.rest.api.model.NewTagEntity;
+import io.gravitee.rest.api.model.TagReferenceType;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.DuplicateTagKeyException;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+public class TagServiceTest {
+
+    private static final String REFERENCE_ID = "DEFAULT";
+    private static final TagReferenceType REFERENCE_TYPE = TagReferenceType.ORGANIZATION;
+
+    @InjectMocks
+    private TagServiceImpl tagService = new TagServiceImpl();
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Mock
+    private AuditService auditService;
+
+    @Test
+    public void should_create_tag_when_key_does_not_exist() throws TechnicalException {
+        var newKey = "new-tag-key";
+        var newTag = new NewTagEntity();
+        newTag.setKey(newKey);
+        newTag.setName("New Tag Name");
+        newTag.setDescription("New Tag Description");
+
+        var executionContext = new ExecutionContext(REFERENCE_ID, null);
+
+        when(tagRepository.findByReference(REFERENCE_ID, io.gravitee.repository.management.model.TagReferenceType.ORGANIZATION)).thenReturn(
+            Collections.emptySet()
+        );
+
+        var savedTag = new Tag();
+        savedTag.setId("new-id");
+        savedTag.setKey(newKey);
+        savedTag.setName(newTag.getName());
+        savedTag.setReferenceId(REFERENCE_ID);
+        savedTag.setReferenceType(io.gravitee.repository.management.model.TagReferenceType.ORGANIZATION);
+
+        when(tagRepository.create(any())).thenReturn(savedTag);
+
+        var result = tagService.create(executionContext, newTag, REFERENCE_ID, REFERENCE_TYPE);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getKey()).isEqualTo(newKey);
+        assertThat(result.getName()).isEqualTo(newTag.getName());
+
+        var tagCaptor = ArgumentCaptor.forClass(Tag.class);
+        verify(tagRepository).create(tagCaptor.capture());
+        var tagToCreate = tagCaptor.getValue();
+        assertThat(tagToCreate.getKey()).isEqualTo(newKey);
+        assertThat(tagToCreate.getName()).isEqualTo(newTag.getName());
+        assertThat(tagToCreate.getReferenceId()).isEqualTo(REFERENCE_ID);
+        assertThat(tagToCreate.getReferenceType()).isEqualTo(io.gravitee.repository.management.model.TagReferenceType.ORGANIZATION);
+
+        verify(auditService).createOrganizationAuditLog(eq(executionContext), any());
+    }
+
+    @Test
+    public void should_throw_DuplicateTagKeyException_when_key_already_exists() throws TechnicalException {
+        var existingKey = "existing-tag-key";
+        var newTag = new NewTagEntity();
+        newTag.setKey(existingKey);
+        newTag.setName("New Tag Name");
+
+        var existingTag = new Tag();
+        existingTag.setId("existing-id");
+        existingTag.setKey(existingKey);
+        existingTag.setReferenceId(REFERENCE_ID);
+        existingTag.setReferenceType(io.gravitee.repository.management.model.TagReferenceType.ORGANIZATION);
+
+        when(tagRepository.findByReference(REFERENCE_ID, io.gravitee.repository.management.model.TagReferenceType.ORGANIZATION)).thenReturn(
+            Set.of(existingTag)
+        );
+
+        assertThatThrownBy(() ->
+            tagService.create(new ExecutionContext(REFERENCE_ID, null), newTag, REFERENCE_ID, REFERENCE_TYPE)
+        ).isInstanceOf(DuplicateTagKeyException.class);
+
+        verify(tagRepository, never()).create(any());
+        verifyNoInteractions(auditService);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TagService_CheckTagsExistTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TagService_CheckTagsExistTest.java
@@ -15,8 +15,13 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.TagRepository;
@@ -61,14 +66,14 @@ public class TagService_CheckTagsExistTest {
     }
 
     @Test
-    public void should_not_throw_exception_if_empty_tag_ids_parameter() throws TechnicalException {
-        when(tagRepository.findByIdsAndReference(new HashSet<>(), ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(Set.of());
+    public void should_not_throw_exception_if_empty_keys_parameter() throws TechnicalException {
         tagService.checkTagsExist(new HashSet<>(), ORG_ID, io.gravitee.rest.api.model.TagReferenceType.ORGANIZATION);
+        verifyNoInteractions(tagRepository);
     }
 
     @Test
     public void should_throw_error_if_no_tags_found() throws TechnicalException {
-        when(tagRepository.findByIdsAndReference(Set.of("tag-1", "tag-2"), ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(Set.of());
+        when(tagRepository.findByKeysAndReference(Set.of("tag-1", "tag-2"), ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(Set.of());
         assertThrows(TagNotFoundException.class, () ->
             tagService.checkTagsExist(Set.of("tag-1", "tag-2"), ORG_ID, io.gravitee.rest.api.model.TagReferenceType.ORGANIZATION)
         );
@@ -77,31 +82,44 @@ public class TagService_CheckTagsExistTest {
     @Test
     public void should_throw_error_if_only_one_tag_found() throws TechnicalException {
         Tag tag1 = getRepositoryTag("tag-1");
+        tag1.setKey("tag-1");
         Set<String> tags = new HashSet<>();
         tags.add("tag-1");
         tags.add("tag-2");
 
-        when(tagRepository.findByIdsAndReference(tags, ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(Set.of(tag1));
+        when(tagRepository.findByKeysAndReference(tags, ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(Set.of(tag1));
 
         assertThrows(TagNotFoundException.class, () ->
             tagService.checkTagsExist(tags, ORG_ID, io.gravitee.rest.api.model.TagReferenceType.ORGANIZATION)
         );
 
-        verify(tagRepository, times(1)).findByIdsAndReference(any(), any(), any());
+        verify(tagRepository, times(1)).findByKeysAndReference(any(), any(), any());
     }
 
     @Test
     public void should_return_tag_entities_when_all_tags_valid() throws TechnicalException {
         Tag tag1 = getRepositoryTag("tag-1");
+        tag1.setKey("tag-1");
         Tag tag2 = getRepositoryTag("tag-2");
+        tag2.setKey("tag-2");
 
-        when(tagRepository.findByIdsAndReference(Set.of("tag-1", "tag-2"), ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(
+        when(tagRepository.findByKeysAndReference(Set.of("tag-1", "tag-2"), ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(
             Set.of(tag1, tag2)
         );
 
         tagService.checkTagsExist(Set.of("tag-1", "tag-2"), ORG_ID, io.gravitee.rest.api.model.TagReferenceType.ORGANIZATION);
 
-        verify(tagRepository, times(1)).findByIdsAndReference(any(), any(), any());
+        verify(tagRepository, times(1)).findByKeysAndReference(any(), any(), any());
+    }
+
+    @Test
+    public void should_return_tag_entities_when_matching_on_key() throws TechnicalException {
+        Tag tag1 = getRepositoryTag("tag-1");
+        tag1.setKey("key-1");
+
+        when(tagRepository.findByKeysAndReference(Set.of("key-1"), ORG_ID, TagReferenceType.ORGANIZATION)).thenReturn(Set.of(tag1));
+
+        tagService.checkTagsExist(new HashSet<>(Set.of("key-1")), ORG_ID, io.gravitee.rest.api.model.TagReferenceType.ORGANIZATION);
     }
 
     private Tag getRepositoryTag(String id) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/TagKeyUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/TagKeyUpgraderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.management.api.TagRepository;
+import io.gravitee.repository.management.model.Tag;
+import io.gravitee.repository.management.model.TagReferenceType;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class TagKeyUpgraderTest {
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @InjectMocks
+    private TagKeyUpgrader upgrader;
+
+    @Test
+    void shouldMigrateTags() throws Exception {
+        var tag = Tag.builder()
+            .id("tag-key")
+            .key(null)
+            .name("Tag Name")
+            .description("description")
+            .restrictedGroups(List.of())
+            .referenceId("DEFAULT")
+            .referenceType(TagReferenceType.ORGANIZATION)
+            .build();
+
+        when(tagRepository.findAll()).thenReturn(Set.of(tag));
+        assertThat(upgrader.upgrade()).isTrue();
+
+        var tagCaptor = ArgumentCaptor.forClass(Tag.class);
+        verify(tagRepository).update(tagCaptor.capture());
+
+        var migratedTag = tagCaptor.getValue();
+        assertThat(migratedTag.getKey()).isEqualTo("tag-key");
+        assertThat(migratedTag.getId()).isEqualTo("tag-key");
+        assertThat(migratedTag.getName()).isEqualTo("Tag Name");
+    }
+
+    @Test
+    void shouldReturnFalseOnException() throws Exception {
+        when(tagRepository.findAll()).thenThrow(new RuntimeException("error"));
+        assertThat(upgrader.upgrade()).isFalse();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/CJ-3646

## Description

This PR implements comprehensive support for key-based sharding tag identification across the entire Gravitee API Management platform, enabling multi-tenant cloud control planes to use human-readable tag keys instead of UUIDs.

## 🔑 Migrate Sharding Tags from ID to Key-based Identification

### 📋 Overview
This PR introduces a `key` field for sharding tags, migrating away from using auto-generated `id` values as user-facing identifiers. This enables cloud users to define consistent, human-readable identifiers that can be reused across multiple tenants without conflicts, while the backend maintains unique UUID-based `id` values internally.

### 🎯 Context
In multi-tenant cloud environments, different organizations need to use the same logical tag names (e.g., "production", "staging") without conflicts. By introducing a `key` field separate from the internal `id`, we enable:
- Consistent tag naming across tenants
- Human-readable identifiers in configurations
- UUID-based internal tracking for uniqueness
- Simplified tag management in cloud control planes

### 🔄 Changes Summary

#### 1. **Backend Implementation**

**Database Schema**
- Added `key` column to `tags` table via Liquibase migration
- Updated JDBC and MongoDB tag repositories to handle the new field
- Implemented `TagKeyUpgrader` to migrate existing tags.

**Entity Models**
- Extended `Tag`, `NewTagEntity`, and `UpdateTagEntity` with `key` field
- Updated repository interfaces and implementations
- Modified service layer to enforce key uniqueness and immutability

**Migration Strategy**
- Automatic upgrader runs on deployment to populate keys for existing tags
- Keys are generated using sanitization rules (lowercase, alphanumeric + hyphens)
- Existing tag IDs are replaced with new UUIDs while preserving key-based references

#### 2. **Frontend Implementation**

**Tag Entity Model**
- Added `key` field to `Tag` and `NewTag` TypeScript interfaces
- Updated fixtures with distinct `id` and `key` values
- Created `UpdateTagEntity` interface to prevent key modification

**Tag Key Sanitization**
- Real-time sanitization during user input in tag creation dialog
- Normalization rules:
  - NFD Unicode normalization for diacritics (é → e)
  - Lowercase conversion
  - Non-alphanumeric characters removed (except hyphens/spaces)
  - Multiple separators collapsed to single hyphen
  - Trailing hyphens removed on blur
- Tag keys become immutable after creation

**Migration from `id` to `key` Across UI**
- ✅ **API List**: Tag filtering uses `tag.key`
- ✅ **Entrypoint Mappings**: Selection and associations use keys
- ✅ **API Deployment Configuration**: Sharding tag selection uses keys
- ✅ **API Plan Forms**: Plan sharding tags reference keys
- ✅ **Organization Settings**: Tag management and display uses keys

### ⚠️ Migration Notes
1. Database migration runs automatically via `TagKeyUpgrader`
2. Existing tags get keys generated from sanitized IDs/names
3. New UUIDs are generated for tag IDs
4. Frontend switches to key-based references
5. No user action required for existing deployments

### 🎯 Breaking Changes
- Tags are now referenced by `key` instead of `id` in:
  - API configurations (plans, deployment, entrypoints)
  - Sharding tag assignments
  - Organization settings
- Tag keys cannot be modified after creation

---

## Screenshot

<img width="1920" height="935" alt="Tag key field in organization settings dialog" src="https://github.com/user-attachments/assets/0eed9c7e-ba7b-4d05-ad25-a1d1f856bd7a" />