### PR TITLE
chore: bump up json-policy-validation version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <gravitee-policy-json-threat-protection.version>2.1.0</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>3.0.1</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-to-toon.version>1.0.0</gravitee-policy-json-to-toon.version>
-        <gravitee-policy-json-validation.version>2.1.0</gravitee-policy-json-validation.version>
+        <gravitee-policy-json-validation.version>2.1.1</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>2.0.0</gravitee-policy-jws.version>
         <gravitee-policy-jwt.version>7.0.1</gravitee-policy-jwt.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12738

## Description

If the JSON syntax is correct but the data type is incorrect, it should return JSON_INVALID_PAYLOAD.
If the JSON syntax itself is invalid, it should return JSON_INVALID_FORMAT.



