### PR TITLE
Apim 12952 papi scope get api

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PortalNavigationItemCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PortalNavigationItemCriteria.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.management.api.search;
 
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -32,5 +33,6 @@ public class PortalNavigationItemCriteria {
     private Boolean published;
     private Boolean root;
     private String visibility;
+    private Set<String> apiIds;
     private String type;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.model.PortalNavigationItem;
 import java.sql.PreparedStatement;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Value;
@@ -179,7 +180,10 @@ public class JdbcPortalNavigationItemRepository
                 clauses.add("visibility = ?");
                 params.add(criteria.getVisibility());
             }
-
+            if (criteria.getApiIds() != null && !criteria.getApiIds().isEmpty()) {
+                clauses.add("api_id IN (" + String.join(",", Collections.nCopies(criteria.getApiIds().size(), "?")) + ")");
+                params.addAll(criteria.getApiIds());
+            }
             if (hasText(criteria.getType())) {
                 try {
                     PortalNavigationItem.Type type = PortalNavigationItem.Type.valueOf(criteria.getType());

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNavigationItemRepository.java
@@ -125,7 +125,9 @@ public class MongoPortalNavigationItemRepository implements PortalNavigationItem
             if (criteria.getVisibility() != null) {
                 query.addCriteria(where("visibility").is(criteria.getVisibility()));
             }
-
+            if (criteria.getApiIds() != null && !criteria.getApiIds().isEmpty()) {
+                query.addCriteria(where("apiId").in(criteria.getApiIds()));
+            }
             if (hasText(criteria.getType())) {
                 try {
                     PortalNavigationItem.Type type = PortalNavigationItem.Type.valueOf(criteria.getType());

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
@@ -38,13 +38,15 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         List<PortalNavigationItem> items = portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId("org-1", "env-1");
 
         assertThat(items).isNotNull();
-        assertThat(items).hasSize(6);
+        assertThat(items).hasSize(8);
         assertThat(items).anyMatch(i -> "2d7b9f6c-1a2b-4c3d-8e9f-0a1b2c3d4e5f".equals(i.getId()));
         assertThat(items).anyMatch(i -> "3e8c0d7f-2b3c-4d5e-9f0a-1b2c3d4e5f6a".equals(i.getId()));
         assertThat(items).anyMatch(i -> "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c".equals(i.getId()));
         assertThat(items).anyMatch(i -> "6b1c2d3e-4e5f-6a7b-8c9d-0e1f2a3b4c5d".equals(i.getId()));
         assertThat(items).anyMatch(i -> "7c2d3e4f-5f6a-7b8c-9d0e-1f2a3b4c5d6e".equals(i.getId()));
         assertThat(items).anyMatch(i -> "8d3e4f5a-6a7b-8c9d-0e1f-2a3b4c5d6e7f".equals(i.getId()));
+        assertThat(items).anyMatch(i -> "9e4f5a6b-7b8c-9d0e-1f2a-3b4c5d6e7f8a".equals(i.getId()));
+        assertThat(items).anyMatch(i -> "af5a6b7c-8c9d-0e1f-2a3b-4c5d6e7f8a9b".equals(i.getId()));
     }
 
     @Test
@@ -55,7 +57,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         );
 
         assertThat(items).isNotNull();
-        assertThat(items).hasSize(5);
+        assertThat(items).hasSize(7);
         assertThat(items).anyMatch(i -> "3e8c0d7f-2b3c-4d5e-9f0a-1b2c3d4e5f6a".equals(i.getId()));
     }
 
@@ -219,7 +221,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
 
         assertThat(items).isNotNull();
-        assertThat(items).hasSize(6);
+        assertThat(items).hasSize(8);
         assertThat(items).extracting("environmentId").containsOnly("env-1");
     }
 
@@ -254,13 +256,15 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
 
         assertThat(items).isNotNull();
-        assertThat(items).hasSize(3);
+        assertThat(items).hasSize(5);
         assertThat(items)
             .extracting("id")
             .containsExactlyInAnyOrder(
                 "2d7b9f6c-1a2b-4c3d-8e9f-0a1b2c3d4e5f",
                 "3e8c0d7f-2b3c-4d5e-9f0a-1b2c3d4e5f6a",
-                "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c"
+                "5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c",
+                "9e4f5a6b-7b8c-9d0e-1f2a-3b4c5d6e7f8a",
+                "af5a6b7c-8c9d-0e1f-2a3b-4c5d6e7f8a9b"
             );
     }
 
@@ -274,7 +278,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
 
         assertThat(items).isNotNull();
-        assertThat(items).hasSize(5);
+        assertThat(items).hasSize(7);
         assertThat(items).extracting("area").containsOnly(PortalNavigationItem.Area.TOP_NAVBAR);
     }
 
@@ -285,7 +289,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
 
         assertThat(items).isNotNull();
-        assertThat(items).hasSize(6);
+        assertThat(items).hasSize(8);
         assertThat(items).extracting("published").containsOnly(true);
     }
 
@@ -371,7 +375,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
             List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
 
             assertThat(items).isNotNull();
-            assertThat(items).hasSize(7); // 6 original + 1 unpublished
+            assertThat(items).hasSize(9); // 8 original + 1 unpublished
             assertThat(items).extracting("id").contains("unpublished-item-2");
         } finally {
             portalNavigationItemRepository.delete("unpublished-item-2");
@@ -528,5 +532,73 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         } finally {
             portalNavigationItemRepository.delete("public-item");
         }
+    }
+
+    //////////////////////////////////////
+    ////   SEARCH BY TYPE / API IDS
+    //////////////////////////////////////
+
+    @Test
+    public void should_search_by_type() throws Exception {
+        PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder().environmentId("env-1").type("API").build();
+
+        List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+        assertThat(items).hasSize(2);
+        assertThat(items).extracting("type").containsOnly(PortalNavigationItem.Type.API);
+        assertThat(items).extracting("apiId").containsExactlyInAnyOrder("api-public-1", "api-private-1");
+    }
+
+    @Test
+    public void should_search_by_api_ids() throws Exception {
+        PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+            .environmentId("env-1")
+            .apiIds(Set.of("api-public-1"))
+            .build();
+
+        List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+        assertThat(items).hasSize(1);
+        assertThat(items.getFirst().getApiId()).isEqualTo("api-public-1");
+    }
+
+    @Test
+    public void should_search_by_api_ids_multiple() throws Exception {
+        PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+            .environmentId("env-1")
+            .apiIds(Set.of("api-public-1", "api-private-1"))
+            .build();
+
+        List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+        assertThat(items).hasSize(2);
+        assertThat(items).extracting("apiId").containsExactlyInAnyOrder("api-public-1", "api-private-1");
+    }
+
+    @Test
+    public void should_search_by_type_and_api_ids() throws Exception {
+        PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+            .environmentId("env-1")
+            .type("API")
+            .apiIds(Set.of("api-public-1"))
+            .build();
+
+        List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+        assertThat(items).hasSize(1);
+        assertThat(items.getFirst().getType()).isEqualTo(PortalNavigationItem.Type.API);
+        assertThat(items.getFirst().getApiId()).isEqualTo("api-public-1");
+    }
+
+    @Test
+    public void should_return_empty_when_api_ids_do_not_match() throws Exception {
+        PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+            .environmentId("env-1")
+            .apiIds(Set.of("non-existent-api"))
+            .build();
+
+        List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+        assertThat(items).isEmpty();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
@@ -440,7 +440,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         PortalNavigationItem apiItem = PortalNavigationItem.builder()
             .id("type-api-item")
             .organizationId("org-1")
-            .environmentId("env-1")
+            .environmentId("env-type-api-test")
             .title("My API")
             .type(PortalNavigationItem.Type.API)
             .apiId("some-api-id")
@@ -456,7 +456,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
 
         try {
             PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
-                .environmentId("env-1")
+                .environmentId("env-type-api-test")
                 .type(PortalNavigationItem.Type.API.name())
                 .build();
 
@@ -474,7 +474,7 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
     @Test
     public void should_search_by_type_returns_empty_when_no_match() throws Exception {
         PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
-            .environmentId("env-1")
+            .environmentId("env-no-api-items")
             .type(PortalNavigationItem.Type.API.name())
             .build();
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portalnavigationitem-tests/portalNavigationItems.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portalnavigationitem-tests/portalNavigationItems.json
@@ -82,5 +82,35 @@
     "published": true,
     "configuration": "{ \"portalPageContentId\": \"880e8400-e29b-41d4-a716-446655440003\" }",
     "visibility": "PUBLIC"
+  },
+  {
+    "id": "9e4f5a6b-7b8c-9d0e-1f2a-3b4c5d6e7f8a",
+    "organizationId": "org-1",
+    "environmentId": "env-1",
+    "title": "My Public API",
+    "type": "API",
+    "apiId": "api-public-1",
+    "area": "TOP_NAVBAR",
+    "parentId": null,
+    "rootId": "9e4f5a6b-7b8c-9d0e-1f2a-3b4c5d6e7f8a",
+    "order": 4,
+    "published": true,
+    "configuration": "{}",
+    "visibility": "PUBLIC"
+  },
+  {
+    "id": "af5a6b7c-8c9d-0e1f-2a3b-4c5d6e7f8a9b",
+    "organizationId": "org-1",
+    "environmentId": "env-1",
+    "title": "My Private API",
+    "type": "API",
+    "apiId": "api-private-1",
+    "area": "TOP_NAVBAR",
+    "parentId": null,
+    "rootId": "af5a6b7c-8c9d-0e1f-2a3b-4c5d6e7f8a9b",
+    "order": 5,
+    "published": true,
+    "configuration": "{}",
+    "visibility": "PRIVATE"
   }
 ]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.apim.core.api.use_case.GetApiForPortalUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.InlinePictureEntity;
@@ -60,6 +61,7 @@ public class ApiResource extends AbstractResource {
 
     private static final String INCLUDE_PAGES = "pages";
     private static final String INCLUDE_PLANS = "plans";
+    private static final String VIEW_DOCUMENTATION = "documentation";
 
     @Context
     private ResourceContext resourceContext;
@@ -88,65 +90,75 @@ public class ApiResource extends AbstractResource {
     @Inject
     private ApiAuthorizationService apiAuthorizationService;
 
+    @Inject
+    private GetApiForPortalUseCase getApiForPortalUseCase;
+
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
     @RequirePortalAuth
-    public Response getApiByApiId(@PathParam("apiId") String apiId, @QueryParam("include") List<String> include) {
+    public Response getApiByApiId(
+        @PathParam("apiId") String apiId,
+        @QueryParam("include") List<String> include,
+        @QueryParam("view") String view
+    ) {
         String username = getAuthenticatedUserOrNull();
 
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, apiId, false, false, true);
-        if (accessControlService.canAccessApiFromPortal(executionContext, genericApiEntity)) {
-            Api api = apiMapper.convert(executionContext, genericApiEntity);
 
-            if (include.contains(INCLUDE_PAGES)) {
-                List<Page> pages = pageService
-                    .search(GraviteeContext.getCurrentEnvironment(), new PageQuery.Builder().api(apiId).published(true).build())
-                    .stream()
-                    .filter(page -> accessControlService.canAccessPageFromPortal(executionContext, page))
-                    .map(pageMapper::convert)
-                    .collect(Collectors.toList());
-                api.setPages(pages);
-            }
-            if (include.contains(INCLUDE_PLANS)) {
-                List<Plan> plans = planSearchService
-                    .findByApi(executionContext, genericApiEntity, true)
-                    .stream()
-                    .filter(plan -> PlanStatus.PUBLISHED.equals(plan.getPlanStatus()))
-                    .filter(plan -> groupService.isUserAuthorizedToAccessApiData(genericApiEntity, plan.getExcludedGroups(), username))
-                    .sorted(Comparator.comparingInt(GenericPlanEntity::getOrder))
-                    .map(p -> planMapper.convert(p, genericApiEntity))
-                    .collect(Collectors.toList());
-                api.setPlans(plans);
-            }
-
-            api.links(
-                apiMapper.computeApiLinks(
-                    PortalApiLinkHelper.apisURL(uriInfo.getBaseUriBuilder(), api.getId()),
-                    genericApiEntity.getUpdatedAt()
-                )
+        if (VIEW_DOCUMENTATION.equalsIgnoreCase(view)) {
+            var output = getApiForPortalUseCase.execute(
+                new GetApiForPortalUseCase.Input(executionContext.getEnvironmentId(), apiId, username)
             );
-            if (
-                !parameterService.findAsBoolean(
-                    executionContext,
-                    Key.PORTAL_APIS_SHOW_TAGS_IN_APIHEADER,
-                    ParameterReferenceType.ENVIRONMENT
-                )
-            ) {
-                api.setLabels(new ArrayList<>());
+            if (!output.visible()) {
+                throw new ApiNotFoundException(apiId);
             }
-            if (
-                !parameterService.findAsBoolean(
-                    executionContext,
-                    Key.PORTAL_APIS_SHOW_CATEGORIES_IN_APIHEADER,
-                    ParameterReferenceType.ENVIRONMENT
-                )
-            ) {
-                api.setCategories(new ArrayList<>());
-            }
-            return Response.ok(api).build();
+        } else if (!accessControlService.canAccessApiFromPortal(executionContext, genericApiEntity)) {
+            throw new ApiNotFoundException(apiId);
         }
-        throw new ApiNotFoundException(apiId);
+
+        Api api = apiMapper.convert(executionContext, genericApiEntity);
+
+        if (include.contains(INCLUDE_PAGES)) {
+            List<Page> pages = pageService
+                .search(GraviteeContext.getCurrentEnvironment(), new PageQuery.Builder().api(apiId).published(true).build())
+                .stream()
+                .filter(page -> accessControlService.canAccessPageFromPortal(executionContext, page))
+                .map(pageMapper::convert)
+                .collect(Collectors.toList());
+            api.setPages(pages);
+        }
+        if (include.contains(INCLUDE_PLANS)) {
+            List<Plan> plans = planSearchService
+                .findByApi(executionContext, genericApiEntity, true)
+                .stream()
+                .filter(plan -> PlanStatus.PUBLISHED.equals(plan.getPlanStatus()))
+                .filter(plan -> groupService.isUserAuthorizedToAccessApiData(genericApiEntity, plan.getExcludedGroups(), username))
+                .sorted(Comparator.comparingInt(GenericPlanEntity::getOrder))
+                .map(p -> planMapper.convert(p, genericApiEntity))
+                .collect(Collectors.toList());
+            api.setPlans(plans);
+        }
+
+        api.links(
+            apiMapper.computeApiLinks(
+                PortalApiLinkHelper.apisURL(uriInfo.getBaseUriBuilder(), api.getId()),
+                genericApiEntity.getUpdatedAt()
+            )
+        );
+        if (!parameterService.findAsBoolean(executionContext, Key.PORTAL_APIS_SHOW_TAGS_IN_APIHEADER, ParameterReferenceType.ENVIRONMENT)) {
+            api.setLabels(new ArrayList<>());
+        }
+        if (
+            !parameterService.findAsBoolean(
+                executionContext,
+                Key.PORTAL_APIS_SHOW_CATEGORIES_IN_APIHEADER,
+                ParameterReferenceType.ENVIRONMENT
+            )
+        ) {
+            api.setCategories(new ArrayList<>());
+        }
+        return Response.ok(api).build();
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -234,6 +234,7 @@ paths:
                 - Api
             parameters:
                 - $ref: "#/components/parameters/apiIncludeParam"
+                - $ref: "#/components/parameters/apiViewParam"
             summary: Get the API definition
             description: |
                 Get the detail of an API.
@@ -3611,6 +3612,13 @@ components:
                     enum:
                         - pages
                         - plans
+        apiViewParam:
+            name: view
+            in: query
+            required: false
+            description: Controls API visibility scope. When set to documentation, visibility is determined by NG Portal visibility rules.
+            schema:
+                $ref: "#/components/schemas/ApiView"
         ratingOrderQueryParam:
             name: order
             in: query
@@ -3895,6 +3903,13 @@ components:
                         - icon
                         - subscriptionSchema
     schemas:
+        #####################
+        # Enums             #
+        #####################
+        ApiView:
+            type: string
+            enum:
+                - documentation
         #####################
         # Responses Objects #
         #####################

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
@@ -22,6 +22,13 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
@@ -38,11 +45,13 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.*;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -51,10 +60,23 @@ import org.mockito.stubbing.Answer;
 public class ApiResourceTest extends AbstractResourceTest {
 
     private static final String API = "my-api";
+    private static final String ENV_ID = "DEFAULT";
+
+    @Autowired
+    private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
+
+    @Autowired
+    private MembershipQueryServiceInMemory membershipQueryService;
 
     @Override
     protected String contextPath() {
         return "apis/";
+    }
+
+    @AfterEach
+    public void tearDown() {
+        portalNavigationItemsQueryService.reset();
+        membershipQueryService.reset();
     }
 
     @BeforeEach
@@ -324,5 +346,95 @@ public class ApiResourceTest extends AbstractResourceTest {
         assertEquals("MARKDOWN", folderCatMarkdown.getName());
         assertEquals("MARKDOWN_FOLDER_SYS_FOLDER", folderCatMarkdown.getResourceRef());
         assertEquals(ResourceTypeEnum.PAGE, folderCatMarkdown.getResourceType());
+    }
+
+    @Test
+    public void should_get_api_with_documentation_view() {
+        portalNavigationItemsQueryService.initWith(
+            List.of(
+                PortalNavigationApi.builder()
+                    .id(PortalNavigationItemId.random())
+                    .organizationId("DEFAULT")
+                    .environmentId(ENV_ID)
+                    .title("Nav for " + API)
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .apiId(API)
+                    .published(true)
+                    .visibility(PortalVisibility.PUBLIC)
+                    .build()
+            )
+        );
+
+        final Response response = target(API).queryParam("view", "documentation").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        final Api responseApi = response.readEntity(Api.class);
+        assertNotNull(responseApi);
+    }
+
+    @Test
+    public void should_return_not_found_with_documentation_view_when_not_visible() {
+        portalNavigationItemsQueryService.initWith(
+            List.of(
+                PortalNavigationApi.builder()
+                    .id(PortalNavigationItemId.random())
+                    .organizationId("DEFAULT")
+                    .environmentId(ENV_ID)
+                    .title("Nav for " + API)
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .apiId(API)
+                    .published(true)
+                    .visibility(PortalVisibility.PRIVATE)
+                    .build()
+            )
+        );
+
+        final Response response = target(API).queryParam("view", "documentation").request().get();
+
+        assertEquals(NOT_FOUND_404, response.getStatus());
+        ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
+        List<Error> errors = errorResponse.getErrors();
+        assertNotNull(errors);
+        assertEquals(1, errors.size());
+        assertEquals("errors.api.notFound", errors.get(0).getCode());
+    }
+
+    @Test
+    public void should_get_api_with_documentation_view_when_private_and_member() {
+        portalNavigationItemsQueryService.initWith(
+            List.of(
+                PortalNavigationApi.builder()
+                    .id(PortalNavigationItemId.random())
+                    .organizationId("DEFAULT")
+                    .environmentId(ENV_ID)
+                    .title("Nav for " + API)
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .apiId(API)
+                    .published(true)
+                    .visibility(PortalVisibility.PRIVATE)
+                    .build()
+            )
+        );
+
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("membership-" + USER_NAME + "-" + API)
+                    .memberId(USER_NAME)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API)
+                    .referenceId(API)
+                    .build()
+            )
+        );
+
+        final Response response = target(API).queryParam("view", "documentation").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        final Api responseApi = response.readEntity(Api.class);
+        assertNotNull(responseApi);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/GetApiForPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/GetApiForPortalUseCase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetApiForPortalUseCase {
+
+    private final PortalNavigationApiVisibilityDomainService visibilityDomainService;
+
+    public Output execute(Input input) {
+        boolean visible = visibilityDomainService.isApiVisibleToUser(input.environmentId(), input.apiId(), input.userId());
+        return new Output(visible);
+    }
+
+    public record Input(String environmentId, String apiId, @Nullable String userId) {}
+
+    public record Output(boolean visible) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
@@ -87,6 +87,28 @@ public class PortalNavigationApiVisibilityDomainService {
     }
 
     /**
+     * Checks if an API is visible in portal navigation for the given user, looking it up by API ID.
+     */
+    public boolean isApiVisibleToUser(String environmentId, String apiId, @Nullable String userId) {
+        return queryService
+            .search(
+                PortalNavigationItemQueryCriteria.builder()
+                    .environmentId(environmentId)
+                    .published(true)
+                    .root(false)
+                    .type(PortalNavigationItemType.API)
+                    .apiIds(Set.of(apiId))
+                    .build()
+            )
+            .stream()
+            .filter(PortalNavigationApi.class::isInstance)
+            .map(PortalNavigationApi.class::cast)
+            .findFirst()
+            .map(item -> isVisibleToUser(item, userId))
+            .orElse(false);
+    }
+
+    /**
      * Checks visibility of a single PortalNavigationApi for the given user.
      */
     public boolean isVisibleToUser(PortalNavigationApi item, String userId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import jakarta.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemQueryCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemQueryCriteria.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
+import java.util.Set;
 import lombok.Builder;
 import lombok.Data;
 
@@ -28,5 +29,6 @@ public class PortalNavigationItemQueryCriteria {
     private PortalArea area;
     private Boolean published;
     private PortalVisibility visibility;
+    private Set<String> apiIds;
     private PortalNavigationItemType type;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
@@ -80,7 +80,10 @@ public class PortalNavigationItemsQueryServiceInMemory
                     (PARENT_ID_FILTER.test(item)) &&
                     (criteria.getPublished() == null || criteria.getPublished().equals(item.getPublished())) &&
                     (criteria.getVisibility() == null || criteria.getVisibility().equals(item.getVisibility())) &&
-                    (criteria.getType() == null || matchesType(item, criteria.getType()))
+                    (criteria.getType() == null || matchesType(item, criteria.getType())) &&
+                    (criteria.getApiIds() == null ||
+                        criteria.getApiIds().isEmpty() ||
+                        (item instanceof PortalNavigationApi api && criteria.getApiIds().contains(api.getApiId())))
             )
             .toList();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiForPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiForPortalUseCaseTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetApiForPortalUseCaseTest {
+
+    private static final String ENV_ID = "env-id";
+    private static final String ORG_ID = "org-id";
+    private static final String USER_ID = "user-1";
+    private static final String PUBLIC_API_ID = "public-api-1";
+    private static final String PRIVATE_API_ID = "private-api-1";
+
+    private GetApiForPortalUseCase useCase;
+    private PortalNavigationItemsQueryServiceInMemory navQueryService = new PortalNavigationItemsQueryServiceInMemory();
+    private MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
+    private SubscriptionQueryServiceInMemory subscriptionQueryService = new SubscriptionQueryServiceInMemory();
+
+    @BeforeEach
+    void setUp() {
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        useCase = new GetApiForPortalUseCase(new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService));
+    }
+
+    @Test
+    void should_return_visible_when_api_is_public() {
+        navQueryService.initWith(List.of(publishedApiNavItem(PUBLIC_API_ID, PortalVisibility.PUBLIC)));
+
+        var output = useCase.execute(new GetApiForPortalUseCase.Input(ENV_ID, PUBLIC_API_ID, null));
+
+        assertThat(output.visible()).isTrue();
+    }
+
+    @Test
+    void should_return_not_visible_when_api_is_private_and_anonymous() {
+        navQueryService.initWith(List.of(publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE)));
+
+        var output = useCase.execute(new GetApiForPortalUseCase.Input(ENV_ID, PRIVATE_API_ID, null));
+
+        assertThat(output.visible()).isFalse();
+    }
+
+    @Test
+    void should_return_visible_when_api_is_private_and_user_is_member() {
+        navQueryService.initWith(List.of(publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE)));
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("membership-" + USER_ID + "-" + PRIVATE_API_ID)
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API)
+                    .referenceId(PRIVATE_API_ID)
+                    .build()
+            )
+        );
+
+        var output = useCase.execute(new GetApiForPortalUseCase.Input(ENV_ID, PRIVATE_API_ID, USER_ID));
+
+        assertThat(output.visible()).isTrue();
+    }
+
+    @Test
+    void should_return_not_visible_when_api_not_in_portal_navigation() {
+        navQueryService.initWith(List.of(publishedApiNavItem(PUBLIC_API_ID, PortalVisibility.PUBLIC)));
+
+        var output = useCase.execute(new GetApiForPortalUseCase.Input(ENV_ID, "non-existent-api", USER_ID));
+
+        assertThat(output.visible()).isFalse();
+    }
+
+    private PortalNavigationApi publishedApiNavItem(String apiId, PortalVisibility visibility) {
+        return PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .title("Nav for " + apiId)
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .apiId(apiId)
+            .published(true)
+            .visibility(visibility)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainServiceTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -231,6 +232,50 @@ class PortalNavigationApiVisibilityDomainServiceTest {
     void private_item_is_not_visible_to_non_member_non_subscriber() {
         var item = publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE);
         assertThat(domainService.isVisibleToUser(item, USER_ID)).isFalse();
+    }
+
+    @Nested
+    class IsApiVisibleToUser {
+
+        @Test
+        void public_api_is_visible_to_anonymous_user_by_id() {
+            navQueryService.initWith(List.of(publishedApiNavItem(PUBLIC_API_ID, PortalVisibility.PUBLIC)));
+            assertThat(domainService.isApiVisibleToUser(ENV_ID, PUBLIC_API_ID, null)).isTrue();
+        }
+
+        @Test
+        void private_api_is_not_visible_to_anonymous_user_by_id() {
+            navQueryService.initWith(List.of(publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE)));
+            assertThat(domainService.isApiVisibleToUser(ENV_ID, PRIVATE_API_ID, null)).isFalse();
+        }
+
+        @Test
+        void private_api_is_visible_to_member_by_id() {
+            navQueryService.initWith(List.of(publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE)));
+            membershipQueryService.initWith(List.of(apiMembership(USER_ID, PRIVATE_API_ID)));
+            assertThat(domainService.isApiVisibleToUser(ENV_ID, PRIVATE_API_ID, USER_ID)).isTrue();
+        }
+
+        @Test
+        void private_api_is_visible_to_subscriber_by_id() {
+            var appId = "app-1";
+            navQueryService.initWith(List.of(publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE)));
+            membershipQueryService.initWith(List.of(applicationMembership(USER_ID, appId)));
+            subscriptionQueryService.initWith(List.of(aSubscription(appId, PRIVATE_API_ID, SubscriptionEntity.Status.ACCEPTED)));
+            assertThat(domainService.isApiVisibleToUser(ENV_ID, PRIVATE_API_ID, USER_ID)).isTrue();
+        }
+
+        @Test
+        void private_api_is_not_visible_to_non_member_non_subscriber_by_id() {
+            navQueryService.initWith(List.of(publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE)));
+            assertThat(domainService.isApiVisibleToUser(ENV_ID, PRIVATE_API_ID, USER_ID)).isFalse();
+        }
+
+        @Test
+        void unknown_api_is_not_visible_by_id() {
+            navQueryService.initWith(List.of(publishedApiNavItem(PUBLIC_API_ID, PortalVisibility.PUBLIC)));
+            assertThat(domainService.isApiVisibleToUser(ENV_ID, "non-existent-api", USER_ID)).isFalse();
+        }
     }
 
     // --- helpers ---


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12952

## Description

This Pull Request primarily introduces changes to enhance portal navigation and API retrieval based on new criteria like visibility and type. Additionally, several test cases are updated and expanded to validate these changes.

- **Enhancements to PortalNavigationItem criteria:** Added new fields like apiIds and type to filter APIs in navigation queries.
- **Repository implementations:** Updated JDBC and MongoDB repositories to support filtering using the new fields.
- **New GetApiForPortalUseCase:** Introduced a use case to determine API visibility for users in the portal based on specified criteria.
- **API enhancements:** Updated API Resource to handle a new query parameter view for determining data visibility using navigation rules.
- **Test updates and additions:** Extended test coverage for new functionalities, including changes to repository tests and new use cases.
- **API definition changes:** Updated OpenAPI documentation to reflect the new query parameter for API visibility.

Next PRs:
- Implement FE query param in portal-next for getting an api - https://github.com/gravitee-io/gravitee-api-management/pull/15704

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

