### PR TITLE
fix: restrict API product visibility based on user permissions

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
@@ -46,7 +46,12 @@ describe('GioSideNavComponent', () => {
   const expirationDateInOneYear = new Date();
   expirationDateInOneYear.setFullYear(expirationDateInOneYear.getFullYear() + 1);
 
-  const init = async (licenseNotificationEnabled = true, hasLicenseMgmtPermission = true, scoringEnabled = true) => {
+  const init = async (
+    licenseNotificationEnabled = true,
+    hasLicenseMgmtPermission = true,
+    scoringEnabled = true,
+    hasApiProductPermission = true,
+  ) => {
     await TestBed.configureTestingModule({
       declarations: [GioSideNavComponent],
       imports: [NoopAnimationsModule, GioTestingModule, GioSideNavModule, MatIconTestingModule],
@@ -58,6 +63,10 @@ describe('GioSideNavComponent', () => {
               const isMatchingLicenseNotificationPermission =
                 permissions.length === 1 && permissions[0] === 'organization-license_management-r';
               if (isMatchingLicenseNotificationPermission && !hasLicenseMgmtPermission) {
+                return false;
+              }
+              const isMatchingApiProductPermission = permissions.length === 1 && permissions[0] === 'environment-api_product-r';
+              if (isMatchingApiProductPermission && !hasApiProductPermission) {
                 return false;
               }
               // Return default true for all the rest of 'hasMatching' permission checks
@@ -226,6 +235,22 @@ describe('GioSideNavComponent', () => {
         context: 'environment',
       });
       expect(apiProductsItem?.iconRight$).toBeDefined();
+    });
+
+    it('should hide API Products menu item when user lacks environment-api_product-r permission', async () => {
+      await init(true, true, true, false);
+      expectLicense({ tier: '', features: [], packs: [], expiresAt: new Date() });
+
+      const apiProductsItem = fixture.componentInstance.mainMenuItems.find(item => item.displayName === 'API Products');
+      expect(apiProductsItem).toBeUndefined();
+    });
+
+    it('should show API Products menu item when user has environment-api_product-r permission', async () => {
+      await init(true, true, true, true);
+      expectLicense({ tier: '', features: [], packs: [], expiresAt: new Date() });
+
+      const apiProductsItem = fixture.componentInstance.mainMenuItems.find(item => item.displayName === 'API Products');
+      expect(apiProductsItem).toBeDefined();
     });
   });
 

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -152,6 +152,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
         routerLink: './api-products',
         displayName: 'API Products',
         category: 'API Products',
+        permissions: ['environment-api_product-r'],
         licenseOptions: apiProductsLicenseOptions,
         iconRight$: apiProductsIconRight$,
       },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
@@ -155,7 +155,9 @@ public class ApiProductsResource extends AbstractResource {
             searchQuery.getQuery(),
             ids.isEmpty() ? null : ids,
             paginationParam.toPageable(),
-            apiProductSortByParam.toSortable()
+            apiProductSortByParam.toSortable(),
+            getAuthenticatedUser(),
+            isAdmin()
         );
         var output = searchApiProductsUseCase.execute(input);
         var page = output.page();
@@ -188,7 +190,12 @@ public class ApiProductsResource extends AbstractResource {
     public Response getApiProducts(@BeanParam @Valid PaginationParam paginationParam) {
         var executionContext = GraviteeContext.getExecutionContext();
         var output = getApiProductsUseCase.execute(
-            GetApiProductsUseCase.Input.of(executionContext.getEnvironmentId(), executionContext.getOrganizationId())
+            GetApiProductsUseCase.Input.of(
+                executionContext.getEnvironmentId(),
+                executionContext.getOrganizationId(),
+                getAuthenticatedUser(),
+                isAdmin()
+            )
         );
         Set<ApiProduct> allApiProducts = output.apiProducts();
         List<ApiProduct> paginationApiProducts = computePaginationData(allApiProducts, paginationParam);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
@@ -24,10 +24,13 @@ import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.apim.core.event.query_service.EventLatestQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
+import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.EventType;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
@@ -45,6 +48,7 @@ public class GetApiProductsUseCase {
     private final EventLatestQueryService eventLatestQueryService;
     private final PlanQueryService planQueryService;
     private final ObjectMapper objectMapper;
+    private final MembershipQueryService membershipQueryService;
 
     public Output execute(Input input) {
         if (input.apiProductId() != null) {
@@ -53,17 +57,33 @@ public class GetApiProductsUseCase {
                 .map(product -> addPrimaryOwnerToApiProduct(product, input.organizationId()))
                 .map(this::computeDeploymentState);
             return Output.single(apiProduct);
-        } else if (input.environmentId() != null) {
-            Set<ApiProduct> apiProducts = apiProductQueryService
-                .findByEnvironmentId(input.environmentId())
-                .stream()
-                .map(product -> addPrimaryOwnerToApiProduct(product, input.organizationId()))
-                .map(this::computeDeploymentState)
-                .collect(Collectors.toSet());
-            return Output.multiple(apiProducts);
-        } else {
+        }
+
+        if (input.environmentId() == null) {
             throw new IllegalArgumentException("environmentId must be provided for listing API Products");
         }
+
+        Set<ApiProduct> apiProducts = findAccessibleApiProducts(input)
+            .stream()
+            .map(product -> addPrimaryOwnerToApiProduct(product, input.organizationId()))
+            .map(this::computeDeploymentState)
+            .collect(Collectors.toSet());
+        return Output.multiple(apiProducts);
+    }
+
+    private Set<ApiProduct> findAccessibleApiProducts(Input input) {
+        if (input.isAdmin()) {
+            return apiProductQueryService.findByEnvironmentId(input.environmentId());
+        }
+        Set<String> allowedIds = membershipQueryService
+            .findByMemberIdAndMemberTypeAndReferenceType(input.userId(), Membership.Type.USER, Membership.ReferenceType.API_PRODUCT)
+            .stream()
+            .map(Membership::getReferenceId)
+            .collect(Collectors.toSet());
+        if (allowedIds.isEmpty()) {
+            return Set.of();
+        }
+        return apiProductQueryService.findByEnvironmentIdAndIdIn(input.environmentId(), allowedIds);
     }
 
     private ApiProduct addPrimaryOwnerToApiProduct(ApiProduct apiProduct, String organizationId) {
@@ -148,13 +168,13 @@ public class GetApiProductsUseCase {
         return current.size() == deployed.size() && current.containsAll(deployed);
     }
 
-    public record Input(String environmentId, String apiProductId, String organizationId) {
-        public static Input of(String environmentId, String organizationId) {
-            return new Input(environmentId, null, organizationId);
+    public record Input(String environmentId, String apiProductId, String organizationId, String userId, boolean isAdmin) {
+        public static Input of(String environmentId, String organizationId, String userId, boolean isAdmin) {
+            return new Input(environmentId, null, organizationId, userId, isAdmin);
         }
 
         public static Input of(String environmentId, String apiProductId, String organizationId) {
-            return new Input(environmentId, apiProductId, organizationId);
+            return new Input(environmentId, apiProductId, organizationId, null, false);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCase.java
@@ -18,10 +18,15 @@ package io.gravitee.apim.core.api_product.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -29,29 +34,73 @@ import lombok.RequiredArgsConstructor;
 public class SearchApiProductsUseCase {
 
     private final ApiProductSearchQueryService apiProductSearchQueryService;
+    private final MembershipQueryService membershipQueryService;
 
     public Output execute(Input input) {
-        Page<ApiProduct> page = apiProductSearchQueryService.search(
-            input.environmentId(),
-            input.organizationId(),
-            input.query(),
-            input.ids(),
-            input.pageable(),
-            input.sortable()
-        );
-        return new Output(page);
+        if (input.isAdmin()) {
+            return search(input, input.ids());
+        }
+        Optional<Set<String>> resolved = findAccessibleApiProductIds(input);
+        if (resolved.isEmpty()) {
+            return emptyPage(input);
+        }
+        return search(input, resolved.get());
     }
 
-    public record Input(String environmentId, String organizationId, String query, Set<String> ids, Pageable pageable, Sortable sortable) {
+    private Optional<Set<String>> findAccessibleApiProductIds(Input input) {
+        Set<String> allowedIds = membershipQueryService
+            .findByMemberIdAndMemberTypeAndReferenceType(input.userId(), Membership.Type.USER, Membership.ReferenceType.API_PRODUCT)
+            .stream()
+            .map(Membership::getReferenceId)
+            .collect(Collectors.toSet());
+        if (allowedIds.isEmpty()) {
+            return Optional.empty();
+        }
+        if (input.ids() != null && !input.ids().isEmpty()) {
+            Set<String> filtered = input.ids().stream().filter(allowedIds::contains).collect(Collectors.toSet());
+            return filtered.isEmpty() ? Optional.empty() : Optional.of(filtered);
+        }
+        return Optional.of(allowedIds);
+    }
+
+    private Output emptyPage(Input input) {
+        return new Output(new Page<>(List.of(), input.pageable() != null ? input.pageable().getPageNumber() : 1, 0, 0));
+    }
+
+    private Output search(Input input, Set<String> ids) {
+        return new Output(
+            apiProductSearchQueryService.search(
+                input.environmentId(),
+                input.organizationId(),
+                input.query(),
+                ids,
+                input.pageable(),
+                input.sortable()
+            )
+        );
+    }
+
+    public record Input(
+        String environmentId,
+        String organizationId,
+        String query,
+        Set<String> ids,
+        Pageable pageable,
+        Sortable sortable,
+        String userId,
+        boolean isAdmin
+    ) {
         public static Input of(
             String environmentId,
             String organizationId,
             String query,
             Set<String> ids,
             Pageable pageable,
-            Sortable sortable
+            Sortable sortable,
+            String userId,
+            boolean isAdmin
         ) {
-            return new Input(environmentId, organizationId, query != null ? query.trim() : null, ids, pageable, sortable);
+            return new Input(environmentId, organizationId, query != null ? query.trim() : null, ids, pageable, sortable, userId, isAdmin);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
@@ -100,7 +100,8 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
             apiProductPrimaryOwnerDomainService,
             eventLatestQueryService,
             planQueryService,
-            objectMapper
+            objectMapper,
+            membershipQueryService
         );
     }
 
@@ -172,13 +173,58 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
             )
         );
 
-        var input = GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID);
+        var input = GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID, USER_ID, false);
         var output = getApiProductsUseCase.execute(input);
         Set<ApiProduct> products = output.apiProducts();
         assertThat(products).hasSize(2);
         assertThat(products).extracting(ApiProduct::getId).containsExactlyInAnyOrder("id1", "id2");
         assertThat(products).allMatch(product -> product.getPrimaryOwner() != null);
         assertThat(products).allMatch(product -> product.getPrimaryOwner().id().equals(USER_ID));
+    }
+
+    @Test
+    void should_return_only_owned_api_products_for_non_admin_user() {
+        ApiProduct product1 = ApiProduct.builder().id("id1").name("P1").environmentId(ENV_ID).build();
+        ApiProduct product2 = ApiProduct.builder().id("id2").name("P2").environmentId(ENV_ID).build();
+        ApiProduct product3 = ApiProduct.builder().id("id3").name("P3").environmentId(ENV_ID).build();
+        apiProductQueryService.initWith(List.of(product1, product2, product3));
+
+        membershipCrudService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("membership-1")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("id1")
+                    .roleId(apiProductPrimaryOwnerRoleId(ORG_ID))
+                    .source("system")
+                    .build()
+            )
+        );
+
+        var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID, USER_ID, false));
+        assertThat(output.apiProducts()).hasSize(1);
+        assertThat(output.apiProducts()).extracting(ApiProduct::getId).containsExactly("id1");
+    }
+
+    @Test
+    void should_return_all_api_products_for_admin_user() {
+        ApiProduct product1 = ApiProduct.builder().id("id1").name("P1").environmentId(ENV_ID).build();
+        ApiProduct product2 = ApiProduct.builder().id("id2").name("P2").environmentId(ENV_ID).build();
+        apiProductQueryService.initWith(List.of(product1, product2));
+
+        var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID, USER_ID, true));
+        assertThat(output.apiProducts()).hasSize(2);
+    }
+
+    @Test
+    void should_return_empty_list_when_non_admin_user_has_no_api_product_memberships() {
+        ApiProduct product1 = ApiProduct.builder().id("id1").name("P1").environmentId(ENV_ID).build();
+        apiProductQueryService.initWith(List.of(product1));
+
+        var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID, USER_ID, false));
+        assertThat(output.apiProducts()).isEmpty();
     }
 
     @Test
@@ -288,7 +334,7 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
             eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, product)));
             planQueryService.initWith(List.of(aPublishedApiProductPlan(API_PRODUCT_ID, BEFORE_DEPLOY)));
 
-            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID));
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID, USER_ID, true));
 
             assertThat(output.apiProducts())
                 .extracting(ApiProduct::getDeploymentState)
@@ -307,7 +353,7 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
             eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, product)));
             planQueryService.initWith(List.of(aPublishedApiProductPlan(API_PRODUCT_ID, AFTER_DEPLOY)));
 
-            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID));
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID, USER_ID, true));
 
             assertThat(output.apiProducts())
                 .extracting(ApiProduct::getDeploymentState)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCaseTest.java
@@ -18,7 +18,10 @@ package io.gravitee.apim.core.api_product.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import inmemory.ApiProductSearchQueryServiceInMemory;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.common.SortableImpl;
 import java.util.List;
@@ -30,21 +33,27 @@ class SearchApiProductsUseCaseTest {
 
     private static final String ENV_ID = "env-id";
     private static final String ORG_ID = "org-id";
+    private static final String USER_ID = "user-id";
+    private static final String ROLE_ID = "role-id";
 
     private ApiProductSearchQueryServiceInMemory apiProductSearchQueryService;
+    private MembershipCrudServiceInMemory membershipCrudService;
+    private MembershipQueryServiceInMemory membershipQueryService;
     private SearchApiProductsUseCase useCase;
 
     @BeforeEach
     void setUp() {
         apiProductSearchQueryService = new ApiProductSearchQueryServiceInMemory();
-        useCase = new SearchApiProductsUseCase(apiProductSearchQueryService);
+        membershipCrudService = new MembershipCrudServiceInMemory();
+        membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
+        useCase = new SearchApiProductsUseCase(apiProductSearchQueryService, membershipQueryService);
     }
 
     @Test
-    void should_delegate_to_query_service_with_correct_arguments() {
+    void should_delegate_to_query_service_with_correct_arguments_for_admin() {
         var pageable = new PageableImpl(1, 10);
         var sortable = new SortableImpl("name", true);
-        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, "my query", Set.of("id-1"), pageable, sortable);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, "my query", Set.of("id-1"), pageable, sortable, USER_ID, true);
 
         var output = useCase.execute(input);
 
@@ -57,7 +66,7 @@ class SearchApiProductsUseCaseTest {
     @Test
     void should_trim_query_so_whitespace_only_becomes_null() {
         var pageable = new PageableImpl(1, 10);
-        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, "   \t  ", null, pageable, null);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, "   \t  ", null, pageable, null, USER_ID, true);
 
         var output = useCase.execute(input);
 
@@ -68,7 +77,7 @@ class SearchApiProductsUseCaseTest {
     @Test
     void should_pass_environment_id_and_organization_id_in_correct_order() {
         var pageable = new PageableImpl(2, 5);
-        var input = SearchApiProductsUseCase.Input.of("env-1", "org-1", null, null, pageable, null);
+        var input = SearchApiProductsUseCase.Input.of("env-1", "org-1", null, null, pageable, null, USER_ID, true);
 
         useCase.execute(input);
 
@@ -77,9 +86,9 @@ class SearchApiProductsUseCaseTest {
     }
 
     @Test
-    void should_return_empty_page_when_no_criteria() {
+    void should_return_empty_page_when_no_criteria_for_admin() {
         var pageable = new PageableImpl(1, 10);
-        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, pageable, null);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, pageable, null, USER_ID, true);
 
         var output = useCase.execute(input);
 
@@ -88,12 +97,12 @@ class SearchApiProductsUseCaseTest {
     }
 
     @Test
-    void should_return_product_matching_query_when_stored_in_memory() {
+    void should_return_product_matching_query_for_admin() {
         var product = ApiProduct.builder().id("product-1").name("My API Product").environmentId(ENV_ID).build();
         apiProductSearchQueryService.initWith(List.of(product));
 
         var pageable = new PageableImpl(1, 10);
-        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, "My API", null, pageable, null);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, "My API", null, pageable, null, USER_ID, true);
 
         var output = useCase.execute(input);
 
@@ -104,19 +113,124 @@ class SearchApiProductsUseCaseTest {
     }
 
     @Test
-    void should_return_products_filtered_by_ids_when_stored_in_memory() {
+    void should_return_products_filtered_by_ids_for_admin() {
         var product1 = ApiProduct.builder().id("id-1").name("Product One").environmentId(ENV_ID).build();
         var product2 = ApiProduct.builder().id("id-2").name("Product Two").environmentId(ENV_ID).build();
         var product3 = ApiProduct.builder().id("id-3").name("Product Three").environmentId(ENV_ID).build();
         apiProductSearchQueryService.initWith(List.of(product1, product2, product3));
 
         var pageable = new PageableImpl(1, 10);
-        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, Set.of("id-1", "id-3"), pageable, null);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, Set.of("id-1", "id-3"), pageable, null, USER_ID, true);
 
         var output = useCase.execute(input);
 
         assertThat(output.page().getContent()).hasSize(2);
         assertThat(output.page().getContent()).extracting(ApiProduct::getId).containsExactlyInAnyOrder("id-1", "id-3");
         assertThat(output.page().getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    void should_return_only_owned_products_for_non_admin_user() {
+        var product1 = ApiProduct.builder().id("id-1").name("Product One").environmentId(ENV_ID).build();
+        var product2 = ApiProduct.builder().id("id-2").name("Product Two").environmentId(ENV_ID).build();
+        var product3 = ApiProduct.builder().id("id-3").name("Product Three").environmentId(ENV_ID).build();
+        apiProductSearchQueryService.initWith(List.of(product1, product2, product3));
+
+        membershipCrudService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("m-1")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("id-1")
+                    .roleId(ROLE_ID)
+                    .build(),
+                Membership.builder()
+                    .id("m-2")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("id-3")
+                    .roleId(ROLE_ID)
+                    .build()
+            )
+        );
+
+        var pageable = new PageableImpl(1, 10);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, pageable, null, USER_ID, false);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page().getContent()).extracting(ApiProduct::getId).containsExactlyInAnyOrder("id-1", "id-3");
+    }
+
+    @Test
+    void should_intersect_requested_ids_with_owned_ids_for_non_admin() {
+        var product1 = ApiProduct.builder().id("id-1").name("Product One").environmentId(ENV_ID).build();
+        var product2 = ApiProduct.builder().id("id-2").name("Product Two").environmentId(ENV_ID).build();
+        apiProductSearchQueryService.initWith(List.of(product1, product2));
+
+        membershipCrudService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("m-1")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("id-1")
+                    .roleId(ROLE_ID)
+                    .build()
+            )
+        );
+
+        var pageable = new PageableImpl(1, 10);
+        // User requests id-1 and id-2 but only owns id-1
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, Set.of("id-1", "id-2"), pageable, null, USER_ID, false);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page().getContent()).extracting(ApiProduct::getId).containsExactly("id-1");
+    }
+
+    @Test
+    void should_return_empty_page_for_non_admin_with_no_memberships() {
+        var product1 = ApiProduct.builder().id("id-1").name("Product One").environmentId(ENV_ID).build();
+        apiProductSearchQueryService.initWith(List.of(product1));
+
+        var pageable = new PageableImpl(1, 10);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, pageable, null, USER_ID, false);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page().getContent()).isEmpty();
+        assertThat(output.page().getTotalElements()).isZero();
+    }
+
+    @Test
+    void should_return_empty_page_when_non_admin_requests_ids_they_do_not_own() {
+        var product1 = ApiProduct.builder().id("id-1").name("Product One").environmentId(ENV_ID).build();
+        apiProductSearchQueryService.initWith(List.of(product1));
+
+        membershipCrudService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("m-2")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("id-2")
+                    .roleId(ROLE_ID)
+                    .build()
+            )
+        );
+
+        var pageable = new PageableImpl(1, 10);
+        // User owns id-2 but requests id-1 (which they don't own)
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, Set.of("id-1"), pageable, null, USER_ID, false);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page().getContent()).isEmpty();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13137

## Description

Previously, the API Products section in the Gravitee APIM Console was accessible to all authenticated users regardless of their permission level. The `GetApiProductsUseCase` and `SearchApiProductsUseCase` did not take user context into account, meaning every user — including those without any API Product permissions — could list and search all API products in the environment. Additionally, the "API Products" entry in the side navigation menu was visible to all users, regardless of whether they had the `environment-api_product-r` permission.

This PR fixes the visibility and access control for API Products on both the frontend and backend:

- **Frontend**: The "API Products" side navigation item is now gated behind the `environment-api_product-r` permission. Users who do not hold this permission will no longer see the menu entry.
- - **Backend**: The `GetApiProductsUseCase` and `SearchApiProductsUseCase` now accept the authenticated user's ID and admin status as input. For non-admin users, the use cases filter results to only return API products where the user is a member. Admin users continue to see all API products as before.
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

**Before this change:**
- Any logged-in user could see and retrieve the full list of API products via the UI and the REST API, regardless of their membership or permissions.
- - The side nav "API Products" link was shown to all users.
**After this change:**
- The "API Products" menu item is only shown to users with the `environment-api_product-r` permission.
- - API product list and search endpoints now return only the products the requesting user is a member of (for non-admin users), preventing unauthorized visibility of products they do not own or belong to.
- - Admin users are unaffected and retain full visibility of all API products.