### PR TITLE
fix: align plan close with API and deploy validation for API Product

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ValidateApiProductService.java
@@ -28,7 +28,6 @@ import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import jakarta.annotation.Nonnull;
 import java.util.ArrayList;
@@ -102,6 +101,40 @@ public class ValidateApiProductService {
         throw new ValidationDomainException(String.join(". ", messages), parameters);
     }
 
+    public void validateForDeploy(ApiProduct apiProduct) {
+        Set<String> apiIds = apiProduct.getApiIds();
+        if (apiIds == null || apiIds.isEmpty()) {
+            return;
+        }
+
+        boolean productHasValidPlan = planQueryService
+            .findAllForApiProduct(apiProduct.getId())
+            .stream()
+            .anyMatch(plan -> plan.isPublished() || plan.isDeprecated());
+
+        if (productHasValidPlan) {
+            return;
+        }
+
+        // No valid product plan — every API must have its own published or deprecated plan
+        Set<String> envIds = Set.of(apiProduct.getEnvironmentId());
+        Set<String> apiIdsWithValidPlan = planQueryService
+            .findAllByApiIds(apiIds, envIds)
+            .stream()
+            .filter(plan -> plan.isPublished() || plan.isDeprecated())
+            .map(Plan::getReferenceId)
+            .collect(Collectors.toSet());
+
+        boolean allApisHaveOwnPlan = apiIds.stream().allMatch(apiIdsWithValidPlan::contains);
+
+        if (!allApisHaveOwnPlan) {
+            throw new ValidationDomainException(
+                "Cannot deploy API Product: some APIs have no published plan. " +
+                    "Add a published plan to each API, or publish an API Product plan."
+            );
+        }
+    }
+
     public List<Api> getApisToUndeployOnRemoval(Set<String> apiIds, String currentApiProductId) {
         if (apiIds == null || apiIds.isEmpty() || StringUtils.isEmpty(currentApiProductId)) {
             return List.of();
@@ -128,7 +161,7 @@ public class ValidateApiProductService {
         List<Plan> plans = planQueryService.findAllByApiIds(apiIds, envIds);
         return plans
             .stream()
-            .filter(p -> p.getPlanStatus() == PlanStatus.PUBLISHED || p.getPlanStatus() == PlanStatus.DEPRECATED)
+            .filter(plan -> plan.isPublished() || plan.isDeprecated())
             .map(Plan::getReferenceId)
             .collect(Collectors.toSet());
     }
@@ -149,8 +182,7 @@ public class ValidateApiProductService {
         List<Plan> plans = planQueryService.findAllForApiProducts(productIds, envIds);
         return plans
             .stream()
-            .filter(p -> p.getPlanStatus() == PlanStatus.PUBLISHED || p.getPlanStatus() == PlanStatus.DEPRECATED)
-            .filter(p -> p.getReferenceId() != null && p.getEnvironmentId() != null)
+            .filter(plan -> (plan.isPublished() || plan.isDeprecated()) && plan.getReferenceId() != null && plan.getEnvironmentId() != null)
             .collect(Collectors.groupingBy(Plan::getReferenceId, Collectors.mapping(Plan::getEnvironmentId, Collectors.toSet())));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCase.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.api_product.use_case;
 import static java.util.Map.entry;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
@@ -45,6 +46,7 @@ public class DeployApiProductUseCase {
     private final EventCrudService eventCrudService;
     private final EventLatestCrudService eventLatestCrudService;
     private final LicenseDomainService licenseDomainService;
+    private final ValidateApiProductService validateApiProductService;
 
     public Output execute(Input input) {
         if (!licenseDomainService.isApiProductDeploymentAllowed(input.auditInfo().organizationId())) {
@@ -55,6 +57,7 @@ public class DeployApiProductUseCase {
             throw new ApiProductNotFoundException(input.apiProductId());
         }
         ApiProduct apiProduct = apiProductOpt.get();
+        validateApiProductService.validateForDeploy(apiProduct);
         publishDeployEvent(input.auditInfo(), apiProduct);
         return new Output(apiProduct);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/ClosePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/ClosePlanDomainService.java
@@ -22,7 +22,6 @@ import io.gravitee.apim.core.audit.model.ApiProductAuditLogEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.PlanAuditEvent;
-import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
@@ -54,9 +53,15 @@ public class ClosePlanDomainService {
     }
 
     public void close(String planId, AuditInfo auditInfo) {
-        if (!subscriptionQueryService.findActiveSubscriptionsByPlan(planId).isEmpty()) {
-            throw new ValidationDomainException("Impossible to close a plan with active subscriptions");
-        }
+        subscriptionQueryService
+            .findActiveSubscriptionsByPlan(planId)
+            .forEach(subscription -> {
+                try {
+                    closeSubscriptionDomainService.closeSubscription(subscription.getId(), auditInfo);
+                } catch (Exception e) {
+                    log.warn("Could not close subscription {} while closing plan {}", subscription.getId(), planId, e);
+                }
+            });
 
         var planToClose = planCrudService.getById(planId);
         final Plan closedPlan = planToClose.close();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCaseTest.java
@@ -24,23 +24,34 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.LicenseFixtures;
+import fixtures.core.model.PlanFixtures;
 import inmemory.AbstractUseCaseTest;
+import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.node.api.license.LicenseManager;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
 
     private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
     private final EventCrudService eventCrudService = mock(EventCrudService.class);
     private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
     private final LicenseManager licenseManager = mock(LicenseManager.class);
@@ -49,11 +60,18 @@ class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
     @BeforeEach
     void setUp() {
         when(licenseManager.getOrganizationLicenseOrPlatform(any())).thenReturn(LicenseFixtures.anEnterpriseLicense());
+        var validateApiProductService = new ValidateApiProductService(
+            new ApiQueryServiceInMemory(),
+            new ApiCrudServiceInMemory(),
+            planQueryService,
+            mock(ApiProductQueryService.class)
+        );
         deployApiProductUseCase = new DeployApiProductUseCase(
             apiProductQueryService,
             eventCrudService,
             eventLatestCrudService,
-            new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager)
+            new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
+            validateApiProductService
         );
     }
 
@@ -82,6 +100,215 @@ class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
         assertThatThrownBy(() -> deployApiProductUseCase.execute(input))
             .isInstanceOf(ApiProductNotFoundException.class)
             .hasMessage("API Product not found.");
+    }
+
+    @Test
+    void should_deploy_when_all_apis_have_their_own_published_plan() {
+        var productId = "api-product-id";
+        var apiId = "api-1";
+        var apiProduct = ApiProduct.builder()
+            .id(productId)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .version("1.0.0")
+            .apiIds(Set.of(apiId))
+            .build();
+        apiProductQueryService.initWith(List.of(apiProduct));
+        planQueryService.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .referenceId(apiId)
+                    .referenceType(GenericPlanEntity.ReferenceType.API)
+                    .environmentId(ENV_ID)
+                    .planDefinitionHttpV4(
+                        PlanFixtures.aPlanHttpV4().getPlanDefinitionHttpV4().toBuilder().status(PlanStatus.PUBLISHED).build()
+                    )
+                    .build()
+            )
+        );
+
+        var output = deployApiProductUseCase.execute(new DeployApiProductUseCase.Input(productId, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getId()).isEqualTo(productId);
+        verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
+    }
+
+    @Test
+    void should_deploy_when_apis_without_own_plan_are_covered_by_a_published_product_plan() {
+        var productId = "api-product-id";
+        var apiId = "api-without-plan";
+        var apiProduct = ApiProduct.builder()
+            .id(productId)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .version("1.0.0")
+            .apiIds(Set.of(apiId))
+            .build();
+        apiProductQueryService.initWith(List.of(apiProduct));
+        planQueryService.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .referenceId(productId)
+                    .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                    .environmentId(ENV_ID)
+                    .planDefinitionHttpV4(
+                        PlanFixtures.aPlanHttpV4().getPlanDefinitionHttpV4().toBuilder().status(PlanStatus.PUBLISHED).build()
+                    )
+                    .build()
+            )
+        );
+
+        var output = deployApiProductUseCase.execute(new DeployApiProductUseCase.Input(productId, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getId()).isEqualTo(productId);
+        verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
+    }
+
+    @Test
+    void should_deploy_when_apis_without_own_plan_are_covered_by_a_deprecated_product_plan() {
+        var productId = "api-product-id";
+        var apiId = "api-without-plan";
+        var apiProduct = ApiProduct.builder()
+            .id(productId)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .version("1.0.0")
+            .apiIds(Set.of(apiId))
+            .build();
+        apiProductQueryService.initWith(List.of(apiProduct));
+        planQueryService.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .referenceId(productId)
+                    .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                    .environmentId(ENV_ID)
+                    .planDefinitionHttpV4(
+                        PlanFixtures.aPlanHttpV4().getPlanDefinitionHttpV4().toBuilder().status(PlanStatus.DEPRECATED).build()
+                    )
+                    .build()
+            )
+        );
+
+        var output = deployApiProductUseCase.execute(new DeployApiProductUseCase.Input(productId, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getId()).isEqualTo(productId);
+        verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
+    }
+
+    @Test
+    void should_deploy_when_all_apis_have_deprecated_plan_and_product_has_no_valid_plan() {
+        var productId = "api-product-id";
+        var apiId = "api-1";
+        var apiProduct = ApiProduct.builder()
+            .id(productId)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .version("1.0.0")
+            .apiIds(Set.of(apiId))
+            .build();
+        apiProductQueryService.initWith(List.of(apiProduct));
+        planQueryService.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .referenceId(apiId)
+                    .referenceType(GenericPlanEntity.ReferenceType.API)
+                    .environmentId(ENV_ID)
+                    .planDefinitionHttpV4(
+                        PlanFixtures.aPlanHttpV4().getPlanDefinitionHttpV4().toBuilder().status(PlanStatus.DEPRECATED).build()
+                    )
+                    .build()
+            )
+        );
+
+        var output = deployApiProductUseCase.execute(new DeployApiProductUseCase.Input(productId, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getId()).isEqualTo(productId);
+        verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
+    }
+
+    @Test
+    void should_throw_when_product_has_only_staging_plan_and_apis_have_no_plan() {
+        var productId = "api-product-id";
+        var apiId = "api-without-plan";
+        var apiProduct = ApiProduct.builder()
+            .id(productId)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .version("1.0.0")
+            .apiIds(Set.of(apiId))
+            .build();
+        apiProductQueryService.initWith(List.of(apiProduct));
+        planQueryService.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .referenceId(productId)
+                    .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                    .environmentId(ENV_ID)
+                    .planDefinitionHttpV4(
+                        PlanFixtures.aPlanHttpV4().getPlanDefinitionHttpV4().toBuilder().status(PlanStatus.STAGING).build()
+                    )
+                    .build()
+            )
+        );
+
+        assertThatThrownBy(() -> deployApiProductUseCase.execute(new DeployApiProductUseCase.Input(productId, AUDIT_INFO)))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("some APIs have no published plan");
+    }
+
+    @Test
+    void should_throw_when_api_has_no_own_plan_and_product_has_no_published_plan() {
+        var productId = "api-product-id";
+        var apiId = "api-without-plan";
+        var apiProduct = ApiProduct.builder()
+            .id(productId)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .version("1.0.0")
+            .apiIds(Set.of(apiId))
+            .build();
+        apiProductQueryService.initWith(List.of(apiProduct));
+        // No plans at all
+
+        assertThatThrownBy(() -> deployApiProductUseCase.execute(new DeployApiProductUseCase.Input(productId, AUDIT_INFO)))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("some APIs have no published plan");
+    }
+
+    @Test
+    void should_throw_when_api_has_only_staging_plan_and_product_has_no_published_plan() {
+        var productId = "api-product-id";
+        var apiId = "api-staging-plan";
+        var apiProduct = ApiProduct.builder()
+            .id(productId)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .version("1.0.0")
+            .apiIds(Set.of(apiId))
+            .build();
+        apiProductQueryService.initWith(List.of(apiProduct));
+        planQueryService.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .referenceId(apiId)
+                    .referenceType(GenericPlanEntity.ReferenceType.API)
+                    .environmentId(ENV_ID)
+                    .planDefinitionHttpV4(
+                        PlanFixtures.aPlanHttpV4().getPlanDefinitionHttpV4().toBuilder().status(PlanStatus.STAGING).build()
+                    )
+                    .build()
+            )
+        );
+
+        assertThatThrownBy(() -> deployApiProductUseCase.execute(new DeployApiProductUseCase.Input(productId, AUDIT_INFO)))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("some APIs have no published plan");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/ClosePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/ClosePlanDomainServiceTest.java
@@ -16,6 +16,10 @@
 package io.gravitee.apim.core.plan.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import fixtures.core.model.AuditInfoFixtures;
 import fixtures.core.model.PlanFixtures;
@@ -158,23 +162,23 @@ class ClosePlanDomainServiceTest {
 
     @ParameterizedTest
     @EnumSource(value = SubscriptionEntity.Status.class, mode = EnumSource.Mode.EXCLUDE, names = { "CLOSED", "REJECTED" })
-    void should_throw_when_closing_plan_with_active_subscriptions(SubscriptionEntity.Status status) {
+    void should_close_active_subscriptions_before_closing_plan(SubscriptionEntity.Status status) {
         // Given
         var plan = givenExistingPlan(PlanFixtures.HttpV4.anApiKey());
-        givenExistingSubscriptions(SubscriptionFixtures.aSubscription().toBuilder().planId(plan.getId()).status(status).build());
+        var subscription = SubscriptionFixtures.aSubscription().toBuilder().planId(plan.getId()).status(status).build();
+        givenExistingSubscriptions(subscription);
 
         // When
-        var throwable = org.assertj.core.api.Assertions.catchThrowable(() -> service.close(plan.getId(), AUDIT_INFO));
+        service.close(plan.getId(), AUDIT_INFO);
 
         // Then
-        assertThat(throwable)
-            .isInstanceOf(ValidationDomainException.class)
-            .hasMessage("Impossible to close a plan with active subscriptions");
+        verify(closeSubscriptionDomainService).closeSubscription(eq(subscription.getId()), eq(AUDIT_INFO));
+        assertThat(planCrudService.storage().get(0).getPlanStatus()).isEqualTo(io.gravitee.definition.model.v4.plan.PlanStatus.CLOSED);
     }
 
     @ParameterizedTest
     @EnumSource(value = SubscriptionEntity.Status.class, mode = EnumSource.Mode.INCLUDE, names = { "CLOSED", "REJECTED" })
-    void should_close_plan_if_existing_subscriptions_are_inactive(SubscriptionEntity.Status status) {
+    void should_close_plan_without_touching_inactive_subscriptions(SubscriptionEntity.Status status) {
         // Given
         var plan = givenExistingPlan(PlanFixtures.HttpV4.anApiKey());
         givenExistingSubscriptions(SubscriptionFixtures.aSubscription().toBuilder().planId(plan.getId()).status(status).build());
@@ -183,6 +187,28 @@ class ClosePlanDomainServiceTest {
         service.close(plan.getId(), AUDIT_INFO);
 
         // Then
+        verifyNoInteractions(closeSubscriptionDomainService);
+        assertThat(planCrudService.storage().get(0).getPlanStatus()).isEqualTo(io.gravitee.definition.model.v4.plan.PlanStatus.CLOSED);
+    }
+
+    @Test
+    void should_still_close_plan_when_subscription_close_fails() {
+        // Given
+        var plan = givenExistingPlan(PlanFixtures.HttpV4.anApiKey());
+        var subscription = SubscriptionFixtures.aSubscription()
+            .toBuilder()
+            .planId(plan.getId())
+            .status(SubscriptionEntity.Status.ACCEPTED)
+            .build();
+        givenExistingSubscriptions(subscription);
+        doThrow(new RuntimeException("downstream failure"))
+            .when(closeSubscriptionDomainService)
+            .closeSubscription(eq(subscription.getId()), eq(AUDIT_INFO));
+
+        // When — should not propagate the exception
+        service.close(plan.getId(), AUDIT_INFO);
+
+        // Then — plan is still closed despite the subscription failure
         assertThat(planCrudService.storage().get(0).getPlanStatus()).isEqualTo(io.gravitee.definition.model.v4.plan.PlanStatus.CLOSED);
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13140

## Description

This PR addresses two separate but related lifecycle concerns in the APIM domain layer:

**1. Auto-close subscriptions on plan close**
Previously, `ClosePlanDomainService` threw a `ValidationDomainException` when active subscriptions were found on a plan being closed, blocking the operation entirely. The service now iterates through all active subscriptions and closes each one automatically via `CloseSubscriptionDomainService`. If an individual subscription closure fails (catching `RuntimeException`), a warning is logged and plan closure continues — ensuring resilience without letting a single subscription failure block the overall operation. The `ValidationDomainException` import has been removed as it is no longer used in this class.

**2. API Product deployment validation**
A new `validateForDeploy(ApiProduct)` method has been added to `ValidateApiProductService`. Before deploying an API Product, the system now checks:
- If the API Product itself has at least one published or deprecated plan → deployment proceeds.
- - If not, it fetches plans for all APIs in the product (scoped to the product's environment) and checks whether every API has its own published or deprecated plan.
- - If any API lacks a valid plan and the product also has no valid plan, a `ValidationDomainException` is thrown, blocking the deployment.
`DeployApiProductUseCase` now injects `ValidateApiProductService` and calls `validateForDeploy` before proceeding with deployment.

## Additional context

**Problem (before this fix):**
- When an admin closed a plan, the operation would fail with a `ValidationDomainException` if any active subscriptions existed. This forced manual cleanup of all subscriptions before a plan could be closed, causing friction and potential data inconsistencies.
- - API Products could be deployed even when none of the APIs they contained had a valid published or deprecated plan — neither at the API level nor at the product level — leading to potential access issues for consumers.
**What the fix does:**
- In `ClosePlanDomainService`, instead of throwing an exception when active subscriptions are found, the service iterates over them and closes each one. A `RuntimeException` caught during individual subscription closure is logged as a warning, but does not prevent the plan from closing.
- - In `ValidateApiProductService`, the new `validateForDeploy` method first checks whether the product itself has a valid plan. If it does, all APIs in the product are covered and deployment is allowed. If not, it verifies that every individual API has its own published or deprecated plan. If any API is uncovered, a `ValidationDomainException` is thrown with a clear error message.
- - `DeployApiProductUseCase` now calls `validateForDeploy` as a pre-deployment guard.
**Benefits:**
- Smoother plan lifecycle management: closing a plan is now a single atomic operation that also cleans up its subscriptions.
- - Improved safety for API Product deployments: prevents broken states where APIs in a product have no valid access plan.
- - Better resilience: a failed individual subscription closure no longer blocks the overall plan closure.
**Files changed:**
- `ClosePlanDomainService.java` — replace exception throw with subscription auto-close loop; remove `ValidationDomainException` import.
- - `ValidateApiProductService.java` — add `validateForDeploy` method with plan coverage check.
- - `DeployApiProductUseCase.java` — inject `ValidateApiProductService` and invoke `validateForDeploy` before deploy.
- - `ClosePlanDomainServiceTest.java` — update tests to assert subscriptions are closed on plan close; add test for resilience when subscription closure fails.
- - `DeployApiProductUseCaseTest.java` — add tests covering all validation scenarios (product plan covers APIs, each API has own plan, missing plans throw exception).