### PR TITLE
chore(4.9.x): bump gravitee-reactor-native-kafka from 4.4.1 to 4.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.0.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>8.0.0</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>4.4.1</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>4.4.2</gravitee-reactor-native-kafka.version>
         <gravitee-apim-repository-bridge.version>7.0.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka)** from `4.4.1` to `4.4.2` on branch `4.9.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases) page for details.

## Jira

[APIM-13126](https://gravitee.atlassian.net/browse/APIM-13126)

[APIM-13126]: https://gravitee.atlassian.net/browse/APIM-13126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ