### PR TITLE
chore(master): bump gravitee-reactor-native-kafka from 6.0.0-alpha.4 to 6.0.0-alpha.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>10.0.0-alpha.2</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>6.0.0-alpha.4</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>6.0.0-alpha.6</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.0</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>2.0.0-alpha.3</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0-alpha.1</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka)** from `6.0.0-alpha.4` to `6.0.0-alpha.6` on branch `master`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases) page for details.

## Jira

[APIM-13126](https://gravitee.atlassian.net/browse/APIM-13126)

[APIM-13126]: https://gravitee.atlassian.net/browse/APIM-13126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ