### PR TITLE
fix: align log details body sections

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.scss
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.scss
@@ -95,6 +95,7 @@
 
       &--flush {
         margin-top: 0;
+        flex-grow: 1;
       }
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2600
## Description

fixes issue so that body sections are aligned. 
Before:
<img width="1264" height="629" alt="Screenshot 2026-03-16 at 10 39 47 AM" src="https://github.com/user-attachments/assets/e94795a7-a4c8-4423-92f8-f36ade93b746" />


After:
<img width="1277" height="547" alt="Screenshot 2026-03-16 at 10 39 31 AM" src="https://github.com/user-attachments/assets/30108efc-37f1-4c05-acb3-89d0f333a754" />

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

