### PR TITLE
fix(jdbc): handle null httpMethods in FlowHttpSelector to prevent NPE

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
@@ -868,6 +868,9 @@ public class JdbcFlowRepository extends JdbcAbstractCrudRepository<Flow, String>
     }
 
     private void storeSelectorHttpMethods(final String flowId, Set<HttpMethod> httpMethods, boolean deleteFirst) {
+        if (httpMethods == null || httpMethods.isEmpty()) {
+            return;
+        }
         storeMethods(
             FLOW_SELECTOR_HTTP_METHODS,
             flowId,

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowRepositoryTest.java
@@ -28,7 +28,9 @@ import io.gravitee.repository.management.model.flow.FlowConsumer;
 import io.gravitee.repository.management.model.flow.FlowConsumerType;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.repository.management.model.flow.FlowStep;
+import io.gravitee.repository.management.model.flow.selector.FlowHttpSelector;
 import io.gravitee.repository.management.model.flow.selector.FlowOperator;
+import io.gravitee.repository.management.model.flow.selector.FlowSelectorType;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
@@ -265,6 +267,34 @@ public class FlowRepositoryTest extends AbstractManagementRepositoryTest {
                 tuple("flow-to-update-1", "flow-to-update-1-updated"),
                 tuple("flow-to-update-2", "flow-to-update-2-updated")
             );
+    }
+
+    @Test
+    public void shouldCreateFlowWithHttpSelectorAndNullMethods() throws TechnicalException {
+        FlowHttpSelector httpSelector = new FlowHttpSelector();
+        httpSelector.setPath("/test");
+        httpSelector.setPathOperator(FlowOperator.STARTS_WITH);
+        // methods is intentionally left null to reproduce the NPE fix
+
+        Flow flow = Flow.builder()
+            .id("flow-null-http-methods")
+            .name("flow-null-http-methods")
+            .createdAt(new Date(1470157767000L))
+            .referenceId("my-api-id")
+            .referenceType(FlowReferenceType.API)
+            .order(1)
+            .selectors(List.of(httpSelector))
+            .build();
+
+        Flow created = flowRepository.create(flow);
+
+        assertThat(created.getId()).isEqualTo("flow-null-http-methods");
+        assertThat(created.getSelectors()).hasSize(1);
+        assertThat(created.getSelectors().get(0).getType()).isEqualTo(FlowSelectorType.HTTP);
+
+        FlowHttpSelector createdSelector = (FlowHttpSelector) created.getSelectors().get(0);
+        assertThat(createdSelector.getPath()).isEqualTo("/test");
+        assertThat(createdSelector.getPathOperator()).isEqualTo(FlowOperator.STARTS_WITH);
     }
 
     private Flow aFlow() {


### PR DESCRIPTION
## Summary
- Fix NPE in `JdbcFlowRepository.storeSelectorHttpMethods()` when `FlowHttpSelector.methods` is null (e.g. during OpenAPI import)
- Add null/empty guard before calling `.stream()` on `httpMethods`
- Add test `shouldCreateFlowWithHttpSelectorAndNullMethods` to cover the scenario

## Jira
https://gravitee.atlassian.net/browse/APIM-12660

## Test plan
- [ ] Run `FlowRepositoryTest.shouldCreateFlowWithHttpSelectorAndNullMethods` against JDBC (MSSQL, PostgreSQL, MySQL)
- [x] Import an OpenAPI spec via the API and verify no NPE is thrown