### PR TITLE
fix: persist env log filters

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.html
@@ -26,7 +26,7 @@
     <gio-banner-error data-testid="error-banner">{{ errorMsg }}</gio-banner-error>
   } @else if (log(); as log) {
     <div class="logs-details__container">
-      <a class="back-button" mat-flat-button [routerLink]="['..']" aria-label="Back to logs"
+      <a class="back-button" mat-flat-button [routerLink]="['..']" queryParamsHandling="preserve" aria-label="Back to logs"
         ><mat-icon svgIcon="gio:arrow-left"></mat-icon>Back to logs</a
       >
       <gio-header title="Log" />

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-filter-bar/env-logs-filter-bar.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-filter-bar/env-logs-filter-bar.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, computed, effect, inject, input, output, signal } from '@angular/core';
+import { Component, computed, effect, inject, input, OnInit, output, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
@@ -35,6 +35,7 @@ import {
   ENV_LOGS_DEFAULT_PERIOD,
   EnvLogsMoreFiltersForm,
 } from '../../models/env-logs-more-filters.model';
+import { EnvLogsInitialValues } from '../../models/env-logs-initial-values.model';
 import { ApiFilterService } from '../../../dashboards/ui/dashboard-viewer/filters/api-filter.service';
 import { ApplicationFilterService } from '../../../dashboards/ui/dashboard-viewer/filters/application-filter.service';
 import {
@@ -141,11 +142,12 @@ function buildMoreFilterChips(more: EnvLogsMoreFiltersForm): FilterChip[] {
     EnvLogsMoreFiltersComponent,
   ],
 })
-export class EnvLogsFilterBarComponent {
+export class EnvLogsFilterBarComponent implements OnInit {
   private readonly apiFilterService = inject(ApiFilterService);
   private readonly applicationFilterService = inject(ApplicationFilterService);
 
   loading = input(false);
+  initialValues = input<EnvLogsInitialValues | undefined>(undefined);
   refresh = output<void>();
   filtersChanged = output<EnvLogsFilterValues>();
 
@@ -212,6 +214,37 @@ export class EnvLogsFilterBarComponent {
 
   constructor() {
     effect(() => this.emitCurrentFilters());
+  }
+
+  ngOnInit() {
+    const initial = this.initialValues();
+    if (!initial) return;
+
+    if (initial.period) {
+      this.form.controls.period.setValue(initial.period);
+    }
+    if (initial.apiIds?.length) {
+      this.form.controls.apis.setValue(initial.apiIds);
+    }
+    if (initial.applicationIds?.length) {
+      this.form.controls.applications.setValue(initial.applicationIds);
+    }
+
+    const moreDefaults = createDefaultMoreFilters();
+    this.moreFiltersValues.set({
+      ...moreDefaults,
+      methods: initial.methods ?? null,
+      statuses: initial.statuses ?? new Set(),
+      entrypoints: initial.entrypoints ?? null,
+      plans: initial.plans ?? null,
+      transactionId: initial.transactionId ?? null,
+      requestId: initial.requestId ?? null,
+      uri: initial.uri ?? null,
+      responseTime: initial.responseTime ?? null,
+      from: initial.from ?? null,
+      to: initial.to ?? null,
+      errorKeys: initial.errorKeys ?? null,
+    });
   }
 
   private emitCurrentFilters() {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-table/env-logs-table.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-table/env-logs-table.component.html
@@ -25,7 +25,7 @@
 >
   <ng-template #timestampTemplate let-log>
     @if (log.timestamp) {
-      <a [routerLink]="['.', log.id]" [queryParams]="{ apiId: log.apiId }" class="log-timestamp-link">
+      <a [routerLink]="['.', log.id]" [queryParams]="{ apiId: log.apiId }" queryParamsHandling="merge" class="log-timestamp-link">
         {{ log.timestamp }}
       </a>
     } @else {
@@ -93,7 +93,13 @@
   </ng-template>
 
   <ng-template #previewTemplate let-log>
-    <a mat-icon-button [routerLink]="['.', log.id]" [queryParams]="{ apiId: log.apiId }" data-testid="env_logs_preview_button">
+    <a
+      mat-icon-button
+      [routerLink]="['.', log.id]"
+      [queryParams]="{ apiId: log.apiId }"
+      queryParamsHandling="merge"
+      data-testid="env_logs_preview_button"
+    >
       <mat-icon svgIcon="gio:eye-empty"></mat-icon>
     </a>
   </ng-template>

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.html
@@ -29,7 +29,12 @@
 }
 
 <mat-card class="logs-section">
-  <env-logs-filter-bar [loading]="loading()" (refresh)="onRefresh()" (filtersChanged)="onFiltersChanged($event)"></env-logs-filter-bar>
+  <env-logs-filter-bar
+    [loading]="loading()"
+    [initialValues]="initialValues()"
+    (refresh)="onRefresh()"
+    (filtersChanged)="onFiltersChanged($event)"
+  ></env-logs-filter-bar>
   <env-logs-table
     class="env-runtime-logs__table"
     [logs]="logs()"

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
@@ -15,6 +15,8 @@
  */
 
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatCardModule } from '@angular/material/card';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
@@ -381,4 +383,120 @@ describe('EnvLogsComponent', () => {
       expect(log.warnings).toEqual([{ key: 'SLOW_RESPONSE' }, { key: 'DEPRECATED_HEADER' }]);
     }));
   });
+});
+
+describe('EnvLogsComponent — query param persistence', () => {
+  let component: EnvLogsComponent;
+  let fixture: ComponentFixture<EnvLogsComponent>;
+  let httpTestingController: HttpTestingController;
+
+  function createComponentWithQueryParams(queryParams: Record<string, string>) {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioTestingModule, MatCardModule, GioBannerModule, EnvLogsComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { queryParams },
+            queryParams: of(queryParams),
+          },
+        },
+      ],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture = TestBed.createComponent(EnvLogsComponent);
+    component = fixture.componentInstance;
+  }
+
+  function flushErrorKeys() {
+    const reqs = httpTestingController.match(req => req.url.includes('/analytics/error-keys'));
+    reqs.forEach(req => req.flush([]));
+  }
+
+  afterEach(() => {
+    flushErrorKeys();
+    httpTestingController.verify();
+    fixture?.destroy();
+  });
+
+  it('should_restore_filters_from_query_params', fakeAsync(() => {
+    createComponentWithQueryParams({
+      period: '-7d',
+      methods: 'GET,POST',
+      statuses: '200,404',
+      apiIds: 'api-1,api-2',
+    });
+
+    fixture.detectChanges();
+    tick();
+
+    const searchReq = httpTestingController.expectOne(req => req.method === 'POST' && req.url.includes('/logs/search'));
+    const body = searchReq.request.body;
+
+    expect(body.filters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'HTTP_METHOD', operator: 'IN', value: ['GET', 'POST'] }),
+        expect.objectContaining({ name: 'API', operator: 'IN', value: ['api-1', 'api-2'] }),
+        expect.objectContaining({ name: 'HTTP_STATUS', operator: 'IN', value: ['200', '404'] }),
+      ]),
+    );
+    searchReq.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+  }));
+
+  it('should_restore_pagination_from_query_params', fakeAsync(() => {
+    createComponentWithQueryParams({
+      perPage: '25',
+      methods: 'GET',
+    });
+
+    fixture.detectChanges();
+    tick();
+
+    // Verify the pagination signal was updated with restored perPage
+    expect(component.pagination().perPage).toBe(25);
+
+    // Flush any pending search requests
+    const searchReqs = httpTestingController.match(req => req.method === 'POST' && req.url.includes('/logs/search'));
+    searchReqs.forEach(req =>
+      req.flush({ data: [], pagination: { page: 1, perPage: 25, pageCount: 0, pageItemsCount: 0, totalCount: 0 } }),
+    );
+  }));
+
+  it('should_return_undefined_when_no_filter_query_params_exist', fakeAsync(() => {
+    createComponentWithQueryParams({});
+
+    fixture.detectChanges();
+    tick();
+
+    // With no query params, parseQueryParams returns undefined and default period is used
+    const searchReq = httpTestingController.expectOne(req => req.method === 'POST' && req.url.includes('/logs/search'));
+    searchReq.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+  }));
+
+  it('should_restore_more_filter_values_from_query_params', fakeAsync(() => {
+    createComponentWithQueryParams({
+      transactionId: 'txn-123',
+      requestId: 'req-456',
+      uri: '/api/test',
+      responseTime: '500',
+      methods: 'GET',
+    });
+
+    fixture.detectChanges();
+    tick();
+
+    const searchReq = httpTestingController.expectOne(req => req.method === 'POST' && req.url.includes('/logs/search'));
+    const body = searchReq.request.body;
+
+    expect(body.filters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'TRANSACTION_ID', value: 'txn-123' }),
+        expect.objectContaining({ name: 'REQUEST_ID', value: 'req-456' }),
+        expect.objectContaining({ name: 'URI', value: '/api/test' }),
+        expect.objectContaining({ name: 'RESPONSE_TIME', operator: 'GTE', value: 500 }),
+      ]),
+    );
+    searchReq.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+  }));
 });

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
@@ -18,14 +18,21 @@ import { DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, inject, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { GioBannerModule } from '@gravitee/ui-particles-angular';
 import { EMPTY } from 'rxjs';
 import { catchError, debounceTime, switchMap, tap } from 'rxjs/operators';
+import moment from 'moment';
 
 import type { EnvLog } from './models/env-log.model';
 
-import { EnvLogsFilterBarComponent, EnvLogsFilterValues } from './components/env-logs-filter-bar/env-logs-filter-bar.component';
+import { EnvLogsInitialValues } from './models/env-logs-initial-values.model';
+import {
+  EnvLogsFilterBarComponent,
+  EnvLogsFilterValues,
+  ENV_LOGS_PERIODS,
+} from './components/env-logs-filter-bar/env-logs-filter-bar.component';
 import { EnvLogsTableComponent } from './components/env-logs-table/env-logs-table.component';
 
 import { EnvironmentLogsService, EnvironmentApiLog, SearchLogsParam } from '../../../services-ngx/environment-logs.service';
@@ -35,6 +42,7 @@ import { Pagination } from '../../../entities/management-api-v2';
 import { GioHeaderComponent } from '../../../shared/components/gio-header/gio-header.component';
 
 const EMPTY_FIELD = '—';
+const DEFAULT_PER_PAGE = 10;
 
 @Component({
   selector: 'env-logs',
@@ -48,11 +56,15 @@ export class EnvLogsComponent {
   private readonly environmentLogsService = inject(EnvironmentLogsService);
   private readonly snackBarService = inject(SnackBarService);
   private readonly datePipe = inject(DatePipe);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly router = inject(Router);
 
-  pagination = signal<Pagination>({ page: 1, perPage: 10, totalCount: 0 });
+  pagination = signal<Pagination>({ page: 1, perPage: DEFAULT_PER_PAGE, totalCount: 0 });
   filters = signal<EnvLogsFilterValues | null>(null);
   loading = signal(true);
   error = signal<string | null>(null);
+
+  initialValues = signal<EnvLogsInitialValues | undefined>(this.parseQueryParams());
 
   private readonly searchParams = computed(() => ({
     pagination: this.pagination(),
@@ -83,10 +95,79 @@ export class EnvLogsComponent {
   onFiltersChanged(filters: EnvLogsFilterValues) {
     this.filters.set(filters);
     this.pagination.update(prev => (prev.page === 1 ? prev : { ...prev, page: 1 }));
+    this.syncQueryParams(filters, this.pagination());
   }
 
   onPaginationUpdated(event: GioTableWrapperPagination) {
     this.pagination.update(prev => ({ ...prev, page: event.index, perPage: event.size }));
+    this.syncQueryParams(this.filters(), this.pagination());
+  }
+
+  private syncQueryParams(filters: EnvLogsFilterValues | null, pagination: Pagination) {
+    const queryParams: Record<string, string | null> = {
+      page: pagination.page > 1 ? String(pagination.page) : null,
+      perPage: pagination.perPage === DEFAULT_PER_PAGE ? null : String(pagination.perPage),
+      period: filters?.period && filters.period !== '0' ? filters.period : null,
+      apiIds: filters?.apiIds?.length ? filters.apiIds.join(',') : null,
+      applicationIds: filters?.applicationIds?.length ? filters.applicationIds.join(',') : null,
+      methods: filters?.more?.methods?.length ? filters.more.methods.join(',') : null,
+      statuses: filters?.more?.statuses?.size ? [...filters.more.statuses].join(',') : null,
+      entrypoints: filters?.more?.entrypoints?.length ? filters.more.entrypoints.join(',') : null,
+      planIds: filters?.more?.plans?.length ? filters.more.plans.join(',') : null,
+      transactionId: filters?.more?.transactionId ?? null,
+      requestId: filters?.more?.requestId ?? null,
+      uri: filters?.more?.uri ?? null,
+      responseTime: filters?.more?.responseTime != null && filters.more.responseTime > 0 ? String(filters.more.responseTime) : null,
+      from: filters?.more?.from?.toISOString() ?? null,
+      to: filters?.more?.to?.toISOString() ?? null,
+      errorKeys: filters?.more?.errorKeys?.length ? filters.more.errorKeys.join(',') : null,
+    };
+
+    this.router.navigate(['.'], {
+      relativeTo: this.activatedRoute,
+      queryParams,
+      replaceUrl: true,
+    });
+  }
+
+  private parseQueryParams(): EnvLogsInitialValues | undefined {
+    const queryParams = this.activatedRoute.snapshot.queryParams;
+    this.restorePagination(queryParams);
+
+    const nonFilterKeys = new Set(['apiId', 'page', 'perPage']);
+    const hasAnyFilter = Object.keys(queryParams).some(k => !nonFilterKeys.has(k));
+    if (!hasAnyFilter) return undefined;
+
+    const period = queryParams['period'] ? ENV_LOGS_PERIODS.find(p => p.value === queryParams['period']) : undefined;
+    const splitOrUndefined = (key: string): string[] | undefined => queryParams[key]?.split(',').filter(Boolean) || undefined;
+
+    return {
+      period,
+      apiIds: splitOrUndefined('apiIds'),
+      applicationIds: splitOrUndefined('applicationIds'),
+      methods: splitOrUndefined('methods'),
+      statuses: queryParams['statuses'] ? new Set(queryParams['statuses'].split(',').map(Number)) : undefined,
+      entrypoints: splitOrUndefined('entrypoints'),
+      plans: splitOrUndefined('planIds'),
+      transactionId: queryParams['transactionId'] || undefined,
+      requestId: queryParams['requestId'] || undefined,
+      uri: queryParams['uri'] || undefined,
+      responseTime: queryParams['responseTime'] ? Number(queryParams['responseTime']) : undefined,
+      from: queryParams['from'] ? moment(queryParams['from']) : undefined,
+      to: queryParams['to'] ? moment(queryParams['to']) : undefined,
+      errorKeys: splitOrUndefined('errorKeys'),
+    };
+  }
+
+  private restorePagination(queryParams: Record<string, string>) {
+    const page = Number(queryParams['page']);
+    if (page > 1) {
+      this.pagination.update(prev => ({ ...prev, page }));
+    }
+    const perPage = Number(queryParams['perPage']);
+    if (perPage && perPage !== DEFAULT_PER_PAGE) {
+      this.pagination.update(prev => ({ ...prev, perPage }));
+    }
   }
 
   private fetchLogs(params: { pagination: Pagination; filters: EnvLogsFilterValues | null }) {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/models/env-logs-initial-values.model.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/models/env-logs-initial-values.model.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Moment } from 'moment';
+
+export type EnvLogsInitialValues = {
+  period?: { label: string; value: string };
+  apiIds?: string[];
+  applicationIds?: string[];
+  methods?: string[];
+  statuses?: Set<number>;
+  entrypoints?: string[];
+  plans?: string[];
+  transactionId?: string;
+  requestId?: string;
+  uri?: string;
+  responseTime?: number;
+  from?: Moment;
+  to?: Moment;
+  errorKeys?: string[];
+};


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2601
## Description

Selected filters do not persist after viewing log details page and then navigating back to logs list view. 

Updated to behave just like api runtime logs:
- Write filters to URL query params when the user changes filters or pagination
- Read filters from query params when the component initializes (e.g., after navigating back from details)
- Preserve query params when navigating to/from the detail view


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

