### PR TITLE
fix: ensure endpoint shared configuration is visible when inherited

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.html
@@ -99,6 +99,7 @@
               <gio-form-json-schema
                 formControlName="sharedConfigurationOverride"
                 [jsonSchema]="endpointSchema?.sharedConfig"
+                (ready)="onSharedConfigSchemaReady($event)"
               ></gio-form-json-schema>
             </div>
           </mat-tab>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint/api-endpoint.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { catchError, filter, map, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { combineLatest, EMPTY, Observable, Subject } from 'rxjs';
 import { GioConfirmDialogComponent, GioConfirmDialogData, GioFormJsonSchemaComponent, GioJsonSchema } from '@gravitee/ui-particles-angular';
@@ -50,6 +50,7 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
   private groupIndex: number;
   private endpointIndex: number;
+  private sharedConfigDisplayValue: unknown = null;
   public endpointGroup: EndpointGroupV4;
   public isReadOnly = false;
   public formGroup: UntypedFormGroup;
@@ -76,6 +77,7 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
     private readonly permissionService: GioPermissionService,
     private readonly apiServicePluginsV2Service: ApiServicePluginsV2Service,
     private readonly tenantService: TenantService,
+    private readonly changeDetectorRef: ChangeDetectorRef,
   ) {}
 
   public ngOnInit(): void {
@@ -239,6 +241,17 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
     }
   }
 
+  public onSharedConfigSchemaReady(isReady: boolean): void {
+    if (!isReady) return;
+    const ctrl = this.formGroup?.get('sharedConfigurationOverride');
+    if (ctrl?.disabled && this.sharedConfigDisplayValue != null) {
+      setTimeout(() => {
+        ctrl.patchValue(this.sharedConfigDisplayValue, { emitEvent: false });
+        this.changeDetectorRef.detectChanges();
+      }, 0);
+    }
+  }
+
   private initForm() {
     let name = null;
     let isHealthCheckEnabled = false;
@@ -315,6 +328,8 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
           }
         });
     }
+
+    this.sharedConfigDisplayValue = sharedConfigurationOverride;
 
     this.formGroup = new UntypedFormGroup({
       name: new UntypedFormControl({ value: name, disabled: this.isReadOnly }, [


### PR DESCRIPTION
When an endpoint inherits configuration from a group, the GioFormJsonSchema 
internally resets the parent FormControl, resulting in an empty or greyed-out 
display in the UI even if the data exists in the API definition.

This fix:
- Restores the shared configuration display value after the schema component is ready.
- Ensures the form control state (disabled/enabled) correctly reflects the
  'inheritConfiguration' and 'isReadOnly' status without losing data visibility.
- Fixes the bug where custom headers at group level caused endpoint-specific 
  settings to appear empty or locked.
https://gravitee.atlassian.net/browse/APIM-12816