### PR TITLE
fix: load error types based on period set in quick filter

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-filter-bar/components/env-logs-more-filters/env-logs-more-filters.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-filter-bar/components/env-logs-more-filters/env-logs-more-filters.component.ts
@@ -34,6 +34,7 @@ import { DEFAULT_MORE_FILTERS, EnvLogsMoreFiltersForm } from '../../../../models
 import { DATE_TIME_FORMATS } from '../../../../../../../shared/utils/timeFrameRanges';
 import { HTTP_METHODS } from '../../../../../../../entities/management-api-v2';
 import { AnalyticsService } from '../../../../../../../services-ngx/analytics.service';
+import { periodToMs } from '../../../../../../../services-ngx/environment-logs.service';
 import { SnackBarService } from '../../../../../../../services-ngx/snack-bar.service';
 import { ApiPlanV2Service } from '../../../../../../../services-ngx/api-plan-v2.service';
 
@@ -95,6 +96,7 @@ export class EnvLogsMoreFiltersComponent {
 
   showMoreFilters = input(false);
   formValues = input<EnvLogsMoreFiltersForm>(DEFAULT_MORE_FILTERS);
+  period = input<string>('0');
 
   /**
    * IDs of the APIs currently selected in the quick filter bar.
@@ -237,10 +239,22 @@ export class EnvLogsMoreFiltersComponent {
   private initSideEffects(): void {
     effect(() => {
       this.updateFormFromInput(this.formValues());
-      const from = this.formValues().from?.valueOf() ?? Date.now() - 24 * 60 * 60 * 1000;
-      const to = this.formValues().to?.valueOf() ?? Date.now();
+      const from = this.formValues().from?.valueOf();
+      const to = this.formValues().to?.valueOf();
+      let effectiveFrom: number;
+      let effectiveTo: number;
+
+      if (from && to) {
+        effectiveFrom = from;
+        effectiveTo = to;
+      } else {
+        const ms = periodToMs(this.period());
+        effectiveTo = Date.now();
+        effectiveFrom = effectiveTo - (ms ?? 24 * 60 * 60 * 1000);
+      }
+
       this.analyticsService
-        .getEnvironmentErrorKeys(from, to)
+        .getEnvironmentErrorKeys(effectiveFrom, effectiveTo)
         .pipe(
           catchError(() => of([])),
           takeUntilDestroyed(this.destroyRef),
@@ -264,8 +278,13 @@ export class EnvLogsMoreFiltersComponent {
         switchMap(() => {
           const from = this.form.controls.from.value?.valueOf();
           const to = this.form.controls.to.value?.valueOf();
-          if (!from || !to) return of(this.errorKeysOptions);
-          return this.analyticsService.getEnvironmentErrorKeys(from, to).pipe(catchError(() => of([])));
+          if (from && to) {
+            return this.analyticsService.getEnvironmentErrorKeys(from, to).pipe(catchError(() => of([])));
+          }
+          const ms = periodToMs(this.period());
+          const effectiveTo = Date.now();
+          const effectiveFrom = effectiveTo - (ms ?? 24 * 60 * 60 * 1000);
+          return this.analyticsService.getEnvironmentErrorKeys(effectiveFrom, effectiveTo).pipe(catchError(() => of([])));
         }),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-filter-bar/env-logs-filter-bar.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-filter-bar/env-logs-filter-bar.component.html
@@ -49,6 +49,7 @@
             [showMoreFilters]="showMoreFilters()"
             [formValues]="moreFiltersValues()"
             [selectedApiIds]="selectedApiIds()"
+            [period]="form.controls.period.value.value"
             (closeMoreFilters)="showMoreFilters.set(false)"
             (applyMoreFilters)="applyMoreFilters($event)"
           ></env-logs-more-filters>

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-filter-bar/env-logs-filter-bar.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-filter-bar/env-logs-filter-bar.component.spec.ts
@@ -340,11 +340,14 @@ describe('EnvLogsFilterBarComponent', () => {
       expect(chip?.value).toBe('api-1');
     });
 
-    it('should not produce chips for errorKeys (they appear in filtersParam only)', () => {
+    it('should produce chips for errorKeys', () => {
       component.moreFiltersValues.set({ ...DEFAULT_MORE_FILTERS, errorKeys: ['TIMEOUT'] });
       fixture.detectChanges();
 
-      expect(component.filterChips().some(c => c.key === 'errorKeys')).toBe(false);
+      const chip = component.filterChips().find(c => c.key === 'errorKeys');
+      expect(chip).toBeDefined();
+      expect(chip?.value).toBe('TIMEOUT');
+      expect(chip?.display).toBe('TIMEOUT');
     });
 
     it('should fall back to the raw id when the API id is not in the name map', () => {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-filter-bar/env-logs-filter-bar.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-filter-bar/env-logs-filter-bar.component.ts
@@ -75,8 +75,8 @@ type FilterChip = {
   display: string;
 };
 
-type MoreFilterArrayKey = 'entrypoints' | 'methods' | 'plans';
-const MORE_FILTER_ARRAY_KEYS: readonly MoreFilterArrayKey[] = ['entrypoints', 'methods', 'plans'];
+type MoreFilterArrayKey = 'entrypoints' | 'methods' | 'plans' | 'errorKeys';
+const MORE_FILTER_ARRAY_KEYS: readonly MoreFilterArrayKey[] = ['entrypoints', 'methods', 'plans', 'errorKeys'];
 
 function isMoreFilterArrayKey(key: string): key is MoreFilterArrayKey {
   return (MORE_FILTER_ARRAY_KEYS as readonly string[]).includes(key);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2602
## Description

Make sure error type dropdown is populated based on the values set in quick filters. Otherwise, user has to set to/from date in more filters section, which is more, unnecessary work. 
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

