### PR TITLE
fix(jdbc): change dictionary property value column type to nclob

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_9_5/01_change_dictionary_property_value_datatype.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_9_5/01_change_dictionary_property_value_datatype.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.9.5_01_change_dictionary_property_value_datatype
+      author: GraviteeSource Team
+      changes:
+        - modifyDataType:
+            tableName: ${gravitee_prefix}dictionary_property
+            columnName: v
+            newDataType: nclob

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -287,3 +287,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_9_0/08_add_general_conditions_hrid_to_plan_table.yml
     - include:
         - file: liquibase/changelogs/v4_9_5/00_add_truststore_keystore_columns.yml
+    - include:
+        - file: liquibase/changelogs/v4_9_5/01_change_dictionary_property_value_datatype.yml


### PR DESCRIPTION
## Summary
- Change the `v` column type in `dictionary_property` from `nvarchar(1000)` to `nclob` to support larger property values
- `nclob` is suitable here since dictionary property values are not indexed

## Jira
https://gravitee.atlassian.net/browse/APIM-12355

## Test plan
- [ ] Verify Liquibase migration runs successfully on a fresh database
- [ ] Verify Liquibase migration runs successfully on an existing database with data
- [ ] Verify dictionary properties with values > 1000 characters can be stored and retrieved

🤖 Generated with [Claude Code](https://claude.com/claude-code)