### PR TITLE
feat: redirect from catalog to API documentation page.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
@@ -32,7 +32,7 @@
       <app-tree-component
         class="documentation-folder__sidenav__tree"
         [tree]="tree()"
-        [selectedId]="pageId$ | async"
+        [selectedId]="selectedId$ | async"
         (selectNode)="onSelect($event)"
       />
     } @else {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
@@ -34,7 +34,7 @@ describe('DocumentationFolderComponent', () => {
   let harness: DocumentationFolderComponentHarness;
   let navigationServiceSpy: PortalNavigationItemsService;
   let routerSpy: jest.Mocked<Router>;
-  let queryParamsSubject: BehaviorSubject<{ pageId?: string }>;
+  let queryParamsSubject: BehaviorSubject<{ selectedId?: string }>;
 
   const MOCK_ITEM = { title: 'Test item' };
   const MOCK_CHILDREN = MOCK_ITEMS;
@@ -43,8 +43,8 @@ describe('DocumentationFolderComponent', () => {
   const gmdViewerContent = (content: string) => `<p>${content}</p>\n`;
 
   const init = async (
-    params: Partial<{ queryParams: { pageId?: string }; items: PortalNavigationItem[]; content: string; isAuthenticated: boolean }> = {
-      queryParams: { pageId: 'p1' },
+    params: Partial<{ queryParams: { selectedId?: string }; items: PortalNavigationItem[]; content: string; isAuthenticated: boolean }> = {
+      queryParams: { selectedId: 'p1' },
       items: MOCK_CHILDREN,
       content: MOCK_CONTENT,
       isAuthenticated: true,
@@ -85,7 +85,15 @@ describe('DocumentationFolderComponent', () => {
 
         const tree = await harness.getTreeHarness();
         expect(tree).not.toBeNull();
-        expect(await tree!.getAllItemTitles()).toEqual(['Folder 1', 'Folder 2', 'Page 1', 'Page 2', 'Page 3']);
+        expect(await tree!.getAllItemTitles()).toEqual([
+          'Folder 1',
+          'Folder 2',
+          'Page 1',
+          'API 1',
+          'API 1 Documentation',
+          'Page 2',
+          'Page 3',
+        ]);
 
         const treeEmptyState = await harness.getSidenavEmptyState();
         expect(await treeEmptyState?.getText()).toBeUndefined();
@@ -106,7 +114,7 @@ describe('DocumentationFolderComponent', () => {
 
         expect(routerSpy.navigate).toHaveBeenCalledWith([], {
           relativeTo: expect.anything(),
-          queryParams: { pageId: 'p1' },
+          queryParams: { selectedId: 'p1' },
         });
 
         const treeHarness = await harness.getTreeHarness();
@@ -119,7 +127,7 @@ describe('DocumentationFolderComponent', () => {
       });
 
       it('should select page when pageId is provided', async () => {
-        await init({ items: MOCK_CHILDREN, queryParams: { pageId: 'p2' }, content: MOCK_CONTENT });
+        await init({ items: MOCK_CHILDREN, queryParams: { selectedId: 'p2' }, content: MOCK_CONTENT });
 
         const treeHarness = await harness.getTreeHarness();
         const selectedItem = await treeHarness?.getSelectedItem();
@@ -131,7 +139,7 @@ describe('DocumentationFolderComponent', () => {
       });
 
       it('should not show subscribe button when selected page has no API ancestor', async () => {
-        await init({ items: MOCK_CHILDREN, queryParams: { pageId: 'p2' }, content: MOCK_CONTENT });
+        await init({ items: MOCK_CHILDREN, queryParams: { selectedId: 'p2' }, content: MOCK_CONTENT });
 
         const subscribeButton = await harness.getSubscribeButton();
         expect(subscribeButton).toBeNull();
@@ -160,8 +168,45 @@ describe('DocumentationFolderComponent', () => {
       });
 
       it('should redirect to 404 when provided pageId is unknown', async () => {
-        await init({ items: MOCK_CHILDREN, queryParams: { pageId: 'p999' }, content: MOCK_CONTENT });
+        await init({ items: MOCK_CHILDREN, queryParams: { selectedId: 'p999' }, content: MOCK_CONTENT });
         expect(routerSpy.navigate).toHaveBeenCalledWith(['/404']);
+      });
+
+      it('should redirect to first page when selectedId is folder', async () => {
+        await init({ items: MOCK_CHILDREN, queryParams: { selectedId: 'f1' }, content: MOCK_CONTENT });
+
+        expect(routerSpy.navigate).toHaveBeenCalledWith([], {
+          relativeTo: expect.anything(),
+          queryParams: { selectedId: 'p1' },
+        });
+
+        const treeHarness = await harness.getTreeHarness();
+        const selectedItem = await treeHarness?.getSelectedItem();
+        expect(selectedItem).toBeDefined();
+        expect(await selectedItem!.getText()).toEqual('Page 1');
+
+        const breadcrumbs = await harness.getBreadcrumbs();
+        expect(await breadcrumbs?.getText()).toEqual('Test item/Folder 1/Folder 2/Page 1');
+      });
+
+      it('should redirect to first page when selectedId is API', async () => {
+        const apiItem = makeItem('api1', 'API', 'API 1', 0, undefined);
+        const apiPage = makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1');
+        await init({ items: [apiItem, apiPage], queryParams: { selectedId: 'api1' }, content: MOCK_CONTENT });
+
+        expect(routerSpy.navigate).toHaveBeenCalledWith([], {
+          relativeTo: expect.anything(),
+          queryParams: { selectedId: 'p-api1' },
+        });
+
+        const treeHarness = await harness.getTreeHarness();
+        const selectedItem = await treeHarness?.getSelectedItem();
+        expect(selectedItem).toBeDefined();
+        expect(await selectedItem!.getText()).toEqual('API 1 Documentation');
+
+        const viewer = await harness.getGmdViewer();
+        expect(viewer).not.toBeNull();
+        expect(await viewer!.getRenderedHtml()).toEqual(gmdViewerContent(MOCK_CONTENT));
       });
     });
 
@@ -202,7 +247,7 @@ describe('DocumentationFolderComponent', () => {
 
       expect(routerSpy.navigate).toHaveBeenCalledWith([], {
         relativeTo: expect.anything(),
-        queryParams: { pageId: 'p2' },
+        queryParams: { selectedId: 'p2' },
       });
 
       const selectedItem = await tree?.getSelectedItem();
@@ -222,7 +267,7 @@ describe('DocumentationFolderComponent', () => {
     it('should show subscribe button when api documentation is clicked', async () => {
       const apiItem = makeItem('api1', 'API', 'API 1', 0, undefined);
       const apiPage = makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1');
-      await init({ items: [apiItem, apiPage], queryParams: { pageId: 'p-api1' }, content: MOCK_CONTENT });
+      await init({ items: [apiItem, apiPage], queryParams: { selectedId: 'p-api1' }, content: MOCK_CONTENT });
 
       expect(await harness.getSubscribeButton()).not.toBeNull();
     });
@@ -230,7 +275,7 @@ describe('DocumentationFolderComponent', () => {
     it('should navigate to subscribe page when subscribe button is clicked and user is authenticated', async () => {
       const apiItem = makeItem('api1', 'API', 'API 1', 0, undefined);
       const apiPage = makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1');
-      await init({ items: [apiItem, apiPage], queryParams: { pageId: 'p-api1' }, content: MOCK_CONTENT });
+      await init({ items: [apiItem, apiPage], queryParams: { selectedId: 'p-api1' }, content: MOCK_CONTENT });
 
       const subscribeButton = await harness.getSubscribeButton();
       expect(subscribeButton).not.toBeNull();
@@ -245,7 +290,7 @@ describe('DocumentationFolderComponent', () => {
     it('should show disabled button when user is not authenticated', async () => {
       const apiItem = makeItem('api1', 'API', 'API 1', 0, undefined);
       const apiPage = makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1');
-      await init({ items: [apiItem, apiPage], queryParams: { pageId: 'p-api1' }, content: MOCK_CONTENT, isAuthenticated: false });
+      await init({ items: [apiItem, apiPage], queryParams: { selectedId: 'p-api1' }, content: MOCK_CONTENT, isAuthenticated: false });
 
       const subscribeButton = await harness.getSubscribeButton();
       expect(subscribeButton).not.toBeNull();

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -60,7 +60,7 @@ enum NavParamsChange {
 export class DocumentationFolderComponent {
   navItem = input.required<PortalNavigationItem>();
   navId$ = toObservable(this.navItem).pipe(map(({ id }) => id));
-  pageId$ = this.activatedRoute.queryParams.pipe(map(({ pageId }) => pageId));
+  selectedId$ = this.activatedRoute.queryParams.pipe(map(({ selectedId }) => selectedId));
 
   folderData = toSignal<FolderData | undefined>(this.loadFolderData());
   tree = signal<TreeNode[]>([]);
@@ -90,15 +90,15 @@ export class DocumentationFolderComponent {
   }
 
   private loadFolderData(): Observable<FolderData | undefined> {
-    return merge(this.navId$.pipe(map(() => NavParamsChange.NAV_ID)), this.pageId$.pipe(map(() => NavParamsChange.PAGE_ID))).pipe(
-      debounceTime(0), // merge simultaneous change of navId and pageId
-      withLatestFrom(this.navId$, this.pageId$),
-      switchMap(([changedData, navId, pageId]) => {
+    return merge(this.navId$.pipe(map(() => NavParamsChange.NAV_ID)), this.selectedId$.pipe(map(() => NavParamsChange.PAGE_ID))).pipe(
+      debounceTime(0), // merge simultaneous change of navId and selectedId
+      withLatestFrom(this.navId$, this.selectedId$),
+      switchMap(([changedData, navId, selectedId]) => {
         switch (changedData) {
           case NavParamsChange.NAV_ID:
-            return this.loadChildrenAndContent(navId, pageId);
+            return this.loadChildrenAndContent(navId, selectedId);
           case NavParamsChange.PAGE_ID:
-            return this.loadContentOrRedirect(pageId);
+            return this.loadContentOrRedirect(selectedId);
           default:
             return of(this.folderData());
         }
@@ -107,16 +107,16 @@ export class DocumentationFolderComponent {
     );
   }
 
-  private loadChildrenAndContent(navId: string, pageId: string): Observable<FolderData> {
+  private loadChildrenAndContent(navId: string, selectedId: string): Observable<FolderData> {
     return this.itemsService.getNavigationItems('TOP_NAVBAR', true, navId).pipe(
       tap(children => this.treeService.init(this.navItem(), children)),
       tap(() => this.tree.set(this.treeService.getTree())),
-      switchMap(children => this.loadContentOrRedirect(pageId, children)),
+      switchMap(children => this.loadContentOrRedirect(selectedId, children)),
     );
   }
 
-  private loadContentOrRedirect(pageId: string, children = this.folderData()?.children ?? []): Observable<FolderData> {
-    if (!pageId) {
+  private loadContentOrRedirect(selectedId: string, children = this.folderData()?.children ?? []): Observable<FolderData> {
+    if (!selectedId) {
       return of({ children, selectedPageContent: null }).pipe(
         tap(() => this.breadcrumbs.set(this.treeService.getBreadcrumbsByDefault())),
         tap(() => this.subscribeApiId.set(null)),
@@ -124,13 +124,20 @@ export class DocumentationFolderComponent {
       );
     }
 
-    if (!children.some(item => item.id === pageId)) {
+    const child = children.find(item => item.id === selectedId);
+    if (!child) {
       return of({ children, selectedPageContent: null }).pipe(tap(() => this.navigateToNotFound()));
     }
 
-    return this.itemsService.getNavigationItemContent(pageId).pipe(
-      tap(() => this.breadcrumbs.set(this.treeService.getBreadcrumbsByNodeId(pageId))),
-      tap(() => this.subscribeApiId.set(this.treeService.getAncestorApiId(pageId))),
+    if (child.type === 'API' || child.type === 'FOLDER') {
+      // APIs and folders are not selectable, so we need to navigate to the first page within the API or folder
+      const firstPageId = this.treeService.findFirstPageIdWithinNode(selectedId);
+      return of({ children, selectedPageContent: null }).pipe(tap(() => firstPageId && this.navigateToPage(firstPageId)));
+    }
+
+    return this.itemsService.getNavigationItemContent(selectedId).pipe(
+      tap(() => this.breadcrumbs.set(this.treeService.getBreadcrumbsByNodeId(selectedId))),
+      tap(() => this.subscribeApiId.set(this.treeService.getAncestorApiId(selectedId))),
       map(selectedPageContent => ({ children, selectedPageContent })),
     );
   }
@@ -142,10 +149,10 @@ export class DocumentationFolderComponent {
     }
   }
 
-  private navigateToPage(pageId: string) {
+  private navigateToPage(selectedId: string) {
     this.router.navigate([], {
       relativeTo: this.activatedRoute,
-      queryParams: { pageId },
+      queryParams: { selectedId },
     });
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.spec.ts
@@ -15,7 +15,7 @@
  */
 import { TreeService } from './tree.service';
 import { fakePortalNavigationFolder } from '../../../entities/portal-navigation/portal-navigation-item.fixture';
-import { MOCK_ITEMS } from '../../../mocks/portal-navigation-item.mocks';
+import { makeItem, MOCK_ITEMS } from '../../../mocks/portal-navigation-item.mocks';
 
 const parentItem = fakePortalNavigationFolder();
 
@@ -33,13 +33,17 @@ describe('DocumentationTreeService', () => {
     expect(itemsTree).toBeTruthy();
     expect(itemsTree[0].id).toEqual('f1');
 
-    expect(itemsTree[0].children).toHaveLength(2);
+    expect(itemsTree[0].children).toHaveLength(3);
     expect(itemsTree[0].children![0].id).toEqual('f2');
 
     expect(itemsTree[0].children![0].children).toHaveLength(1);
     expect(itemsTree[0].children![0].children![0].id).toEqual('p1');
 
-    expect(itemsTree[0].children![1].id).toEqual('p2');
+    expect(itemsTree[0].children![1].id).toEqual('api1');
+    expect(itemsTree[0].children![1].children).toHaveLength(1);
+    expect(itemsTree[0].children![1].children![0].id).toEqual('p-api1');
+
+    expect(itemsTree[0].children![2].id).toEqual('p2');
 
     expect(itemsTree[1].id).toEqual('p3');
   });
@@ -85,6 +89,43 @@ describe('DocumentationTreeService', () => {
           label: 'Page 1',
         },
       ]);
+    });
+  });
+
+  describe('findFirstPageIdWithinNode', () => {
+    it('should return first page within folder', () => {
+      expect(service.findFirstPageIdWithinNode('f1')).toEqual('p1');
+      expect(service.findFirstPageIdWithinNode('f2')).toEqual('p1');
+    });
+
+    it('should return null when node has no pages', () => {
+      const items = [
+        makeItem('f1', 'FOLDER', 'Folder 1', 0),
+        makeItem('f2', 'FOLDER', 'Folder 2', 0, 'f1'),
+        makeItem('l1', 'LINK', 'Link 1', 0, 'f2'),
+      ];
+      service.init(parentItem, items);
+      expect(service.findFirstPageIdWithinNode('f1')).toBeNull();
+      expect(service.findFirstPageIdWithinNode('f2')).toBeNull();
+    });
+
+    it('should return first page within API node', () => {
+      const items = [makeItem('api1', 'API', 'API 1', 0), makeItem('p-api1', 'PAGE', 'API doc', 0, 'api1')];
+      service.init(parentItem, items);
+      expect(service.findFirstPageIdWithinNode('api1')).toEqual('p-api1');
+    });
+  });
+
+  describe('getAncestorApiId', () => {
+    it('should return apiId when page is under API', () => {
+      const items = [makeItem('api1', 'API', 'API 1', 0), makeItem('p-api1', 'PAGE', 'API doc', 0, 'api1')];
+      service.init(parentItem, items);
+      expect(service.getAncestorApiId('p-api1')).toEqual('api-api1');
+    });
+
+    it('should return null when page has no API ancestor', () => {
+      expect(service.getAncestorApiId('p1')).toBeNull();
+      expect(service.getAncestorApiId('p3')).toBeNull();
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/services/tree.service.ts
@@ -74,6 +74,12 @@ export class TreeService {
     return this.findFirstPageIdRecursively(this.treeNodes);
   }
 
+  findFirstPageIdWithinNode(nodeId: string): string | null {
+    const node = this.treeNodesById.get(nodeId);
+    if (!node?.children?.length) return null;
+    return this.findFirstPageIdRecursively(node.children as TreeNode[]);
+  }
+
   private findFirstPageIdRecursively(nodes: TreeNode[]): string | null {
     for (const node of nodes) {
       if (node.type === 'PAGE') {

--- a/gravitee-apim-portal-webui-next/src/mocks/portal-navigation-item.mocks.ts
+++ b/gravitee-apim-portal-webui-next/src/mocks/portal-navigation-item.mocks.ts
@@ -49,4 +49,6 @@ export const MOCK_ITEMS = [
   makeItem('p1', 'PAGE', 'Page 1', 0, 'f2', 'f1'),
   makeItem('p2', 'PAGE', 'Page 2', 1, 'f1', 'f1'),
   makeItem('p3', 'PAGE', 'Page 3', 1), // root
+  makeItem('api1', 'API', 'API 1', 0, 'f1', 'f1'),
+  makeItem('p-api1', 'PAGE', 'API 1 Documentation', 0, 'api1'),
 ];


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11817

## Description

Change the routing behavior in documentation-folder.component to handle folders and APIs as selected IDs.

If a folder or an API is selected -> redirect to the first page within the folder or API.