### PR TITLE
fix: update msgpack-core to 0.9.11 to fix security vulnerability

### DIFF
--- a/gravitee-apim-reporter/gravitee-apim-reporter-common/pom.xml
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-common/pom.xml
@@ -30,7 +30,7 @@
     <description>Common library for reporters. It contains formatters for JSON, Elastic or CSV format.</description>
 
     <properties>
-        <jackson-dataformat-msgpack.version>0.9.10</jackson-dataformat-msgpack.version>
+        <jackson-dataformat-msgpack.version>0.9.11</jackson-dataformat-msgpack.version>
         <commons-validator.version>1.10.1</commons-validator.version>
     </properties>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12726

## Description

Updated the msgpack-core dependency (via jackson-dataformat-msgpack) from 0.9.10 to 0.9.11. 

This version includes a fix for GHSA-cw39-r4h6-8j3x (CVE-2026-21452), which prevented a Remote Denial of Service via unbounded memory allocation.

## Additional context

Updated property in the reporter parent POM.

Successfully performed a clean build of the full APIM project.

