### PR TITLE
feat: add search endpoint for portal navigation APIs with include support

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PortalNavigationItemCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PortalNavigationItemCriteria.java
@@ -32,4 +32,5 @@ public class PortalNavigationItemCriteria {
     private Boolean published;
     private Boolean root;
     private String visibility;
+    private String type;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNavigationItemRepository.java
@@ -179,6 +179,16 @@ public class JdbcPortalNavigationItemRepository
                 clauses.add("visibility = ?");
                 params.add(criteria.getVisibility());
             }
+
+            if (hasText(criteria.getType())) {
+                try {
+                    PortalNavigationItem.Type type = PortalNavigationItem.Type.valueOf(criteria.getType());
+                    clauses.add("type = ?");
+                    params.add(type.name());
+                } catch (IllegalArgumentException e) {
+                    log.warn("Invalid portal navigation item type value: {}", criteria.getType());
+                }
+            }
         }
 
         return new CriteriaClauses(clauses, params);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNavigationItemRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNavigationItemRepository.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
@@ -125,6 +124,15 @@ public class MongoPortalNavigationItemRepository implements PortalNavigationItem
 
             if (criteria.getVisibility() != null) {
                 query.addCriteria(where("visibility").is(criteria.getVisibility()));
+            }
+
+            if (hasText(criteria.getType())) {
+                try {
+                    PortalNavigationItem.Type type = PortalNavigationItem.Type.valueOf(criteria.getType());
+                    query.addCriteria(where("type").is(type));
+                } catch (IllegalArgumentException e) {
+                    log.warn("Invalid portal navigation item type value: {}", criteria.getType());
+                }
             }
         }
         return query;

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
@@ -378,6 +378,107 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
         }
     }
 
+    //////////////////////////////////////
+    ////   SEARCH BY TYPE TESTS
+    //////////////////////////////////////
+
+    @Test
+    public void should_search_by_type_page() throws Exception {
+        PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+            .environmentId("env-1")
+            .type(PortalNavigationItem.Type.PAGE.name())
+            .build();
+
+        List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+        assertThat(items).hasSize(4);
+        assertThat(items).extracting("type").containsOnly(PortalNavigationItem.Type.PAGE);
+        assertThat(items)
+            .extracting("id")
+            .containsExactlyInAnyOrder(
+                "2d7b9f6c-1a2b-4c3d-8e9f-0a1b2c3d4e5f",
+                "6b1c2d3e-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
+                "7c2d3e4f-5f6a-7b8c-9d0e-1f2a3b4c5d6e",
+                "8d3e4f5a-6a7b-8c9d-0e1f-2a3b4c5d6e7f"
+            );
+    }
+
+    @Test
+    public void should_search_by_type_link() throws Exception {
+        PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+            .environmentId("env-1")
+            .type(PortalNavigationItem.Type.LINK.name())
+            .build();
+
+        List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+        assertThat(items).hasSize(1);
+        assertThat(items.getFirst().getId()).isEqualTo("3e8c0d7f-2b3c-4d5e-9f0a-1b2c3d4e5f6a");
+        assertThat(items.getFirst().getType()).isEqualTo(PortalNavigationItem.Type.LINK);
+    }
+
+    @Test
+    public void should_search_by_type_folder() throws Exception {
+        PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+            .environmentId("env-1")
+            .type(PortalNavigationItem.Type.FOLDER.name())
+            .build();
+
+        List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+        assertThat(items).hasSize(1);
+        assertThat(items.getFirst().getId()).isEqualTo("5a0b1c2d-3d4e-5f6a-7b8c-9d0e1f2a3b4c");
+        assertThat(items.getFirst().getType()).isEqualTo(PortalNavigationItem.Type.FOLDER);
+    }
+
+    @Test
+    public void should_search_by_type_api() throws Exception {
+        PortalNavigationItem apiItem = PortalNavigationItem.builder()
+            .id("type-api-item")
+            .organizationId("org-1")
+            .environmentId("env-1")
+            .title("My API")
+            .type(PortalNavigationItem.Type.API)
+            .apiId("some-api-id")
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(99)
+            .published(true)
+            .configuration("{}")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("type-api-item")
+            .build();
+
+        portalNavigationItemRepository.create(apiItem);
+
+        try {
+            PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+                .environmentId("env-1")
+                .type(PortalNavigationItem.Type.API.name())
+                .build();
+
+            List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+            assertThat(items).hasSize(1);
+            assertThat(items.getFirst().getId()).isEqualTo("type-api-item");
+            assertThat(items.getFirst().getType()).isEqualTo(PortalNavigationItem.Type.API);
+            assertThat(items.getFirst().getApiId()).isEqualTo("some-api-id");
+        } finally {
+            portalNavigationItemRepository.delete("type-api-item");
+        }
+    }
+
+    @Test
+    public void should_search_by_type_returns_empty_when_no_match() throws Exception {
+        PortalNavigationItemCriteria criteria = PortalNavigationItemCriteria.builder()
+            .environmentId("env-1")
+            .type(PortalNavigationItem.Type.API.name())
+            .build();
+
+        List<PortalNavigationItem> items = portalNavigationItemRepository.searchByCriteria(criteria);
+
+        assertThat(items).isEmpty();
+    }
+
     @Test
     public void should_search_public_items() throws Exception {
         // Create a private item for testing

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -26,10 +26,11 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
-import io.gravitee.rest.api.portal.rest.model.PortalPageContentType;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -82,5 +83,21 @@ public interface PortalNavigationItemMapper {
 
     default String map(PortalPageContentId portalPageContentId) {
         return portalPageContentId.json();
+    }
+
+    default Set<io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude> map(
+        Set<io.gravitee.rest.api.portal.rest.model.PortalNavigationSearchInclude> includes
+    ) {
+        if (includes == null) {
+            return Set.of();
+        }
+        return includes
+            .stream()
+            .map(i ->
+                switch (i) {
+                    case API -> io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude.API;
+                }
+            )
+            .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
@@ -17,15 +17,24 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionContext;
 
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
+import io.gravitee.apim.core.portal_page.use_case.GetVisiblePortalNavigationApisUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.portal.rest.mapper.ApiMapper;
 import io.gravitee.rest.api.portal.rest.mapper.PortalNavigationItemMapper;
+import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
 import io.gravitee.rest.api.portal.rest.model.PortalArea;
+import io.gravitee.rest.api.portal.rest.model.PortalNavigationItemsSearchResponse;
+import io.gravitee.rest.api.portal.rest.model.PortalNavigationSearchInclude;
+import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -34,7 +43,12 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class PortalNavigationItemsResource extends AbstractResource {
 
@@ -43,6 +57,12 @@ public class PortalNavigationItemsResource extends AbstractResource {
 
     @Inject
     private ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase;
+
+    @Inject
+    private GetVisiblePortalNavigationApisUseCase getVisiblePortalNavigationApisUseCase;
+
+    @Inject
+    private ApiMapper apiMapper;
 
     private final PortalNavigationItemMapper portalNavigationItemMapper = PortalNavigationItemMapper.INSTANCE;
 
@@ -63,6 +83,103 @@ public class PortalNavigationItemsResource extends AbstractResource {
         );
         var output = listPortalNavigationItemsUseCase.execute(input);
         return Response.ok(portalNavigationItemMapper.map(output.items())).build();
+    }
+
+    @GET
+    @Path("_search")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response searchPortalNavigationItems(
+        @QueryParam("query") String query,
+        @QueryParam("type") String type,
+        @QueryParam("include") Set<String> include,
+        @BeanParam PaginationParam paginationParam
+    ) {
+        if (!"api".equalsIgnoreCase(type)) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(new ErrorResponse()).build();
+        }
+
+        Set<io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude> coreIncludes = parseIncludes(include);
+
+        var executionContext = getExecutionContext();
+        var output = getVisiblePortalNavigationApisUseCase.execute(
+            new GetVisiblePortalNavigationApisUseCase.Input(
+                executionContext.getEnvironmentId(),
+                executionContext.getOrganizationId(),
+                Optional.ofNullable(getAuthenticatedUserOrNull()),
+                new PageableImpl(paginationParam.getPage(), paginationParam.getSize()),
+                Optional.ofNullable(query),
+                coreIncludes
+            )
+        );
+
+        var page = output.apis();
+        List<io.gravitee.rest.api.portal.rest.model.PortalNavigationItem> pageItems = mapPageItems(page.getContent());
+        List<io.gravitee.rest.api.portal.rest.model.Api> includedApis = loadIncludedApiEntities(executionContext, output.includedApis());
+
+        var responseBody = new PortalNavigationItemsSearchResponse()
+            .data(pageItems)
+            .metadata(buildSearchMetadata(paginationParam, page.getTotalElements(), pageItems.size()))
+            .links(computePaginatedLinks(paginationParam.getPage(), paginationParam.getSize(), (int) page.getTotalElements()));
+
+        if (!includedApis.isEmpty()) {
+            responseBody.apis(includedApis);
+        }
+
+        return Response.ok(responseBody).build();
+    }
+
+    private Map<String, Map<String, Object>> buildSearchMetadata(PaginationParam paginationParam, long totalElements, int dataTotal) {
+        int pageNumber = paginationParam.getPage();
+        int pageSize = paginationParam.getSize();
+        int totalPages = pageSize > 0 ? (int) Math.ceil((double) totalElements / pageSize) : 0;
+        int startIndex = pageSize > 0 ? (pageNumber - 1) * pageSize : 0;
+        int lastIndex = pageSize > 0 ? (int) Math.min((long) startIndex + pageSize, totalElements) : (int) totalElements;
+
+        Map<String, Object> paginationMetadata = new HashMap<>();
+        paginationMetadata.put(METADATA_PAGINATION_TOTAL_KEY, (int) totalElements);
+        paginationMetadata.put(METADATA_PAGINATION_SIZE_KEY, pageSize);
+        paginationMetadata.put(METADATA_PAGINATION_CURRENT_PAGE_KEY, pageNumber);
+        paginationMetadata.put(METADATA_PAGINATION_TOTAL_PAGE_KEY, totalPages);
+        paginationMetadata.put(METADATA_PAGINATION_FIRST_ITEM_INDEX_KEY, totalElements > 0 ? startIndex + 1 : 0);
+        paginationMetadata.put(METADATA_PAGINATION_LAST_ITEM_INDEX_KEY, lastIndex);
+
+        Map<String, Map<String, Object>> metadata = new HashMap<>();
+        metadata.put(METADATA_PAGINATION_KEY, paginationMetadata);
+        metadata.put(METADATA_DATA_KEY, Map.of(METADATA_DATA_TOTAL_KEY, dataTotal));
+        return metadata;
+    }
+
+    private Set<io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude> parseIncludes(Set<String> include) {
+        Set<PortalNavigationSearchInclude> restIncludes = include == null
+            ? Set.of()
+            : include.stream().map(PortalNavigationSearchInclude::fromValue).collect(Collectors.toSet());
+        return portalNavigationItemMapper.map(restIncludes);
+    }
+
+    private List<io.gravitee.rest.api.portal.rest.model.PortalNavigationItem> mapPageItems(
+        List<io.gravitee.apim.core.portal_page.model.PortalNavigationApi> content
+    ) {
+        return portalNavigationItemMapper.map(
+            content
+                .stream()
+                .map(i -> (PortalNavigationItem) i)
+                .toList()
+        );
+    }
+
+    private List<io.gravitee.rest.api.portal.rest.model.Api> loadIncludedApiEntities(
+        io.gravitee.rest.api.service.common.ExecutionContext executionContext,
+        List<io.gravitee.apim.core.api.model.Api> domainApis
+    ) {
+        if (domainApis.isEmpty()) {
+            return List.of();
+        }
+        Set<String> ids = domainApis.stream().map(io.gravitee.apim.core.api.model.Api::getId).collect(Collectors.toSet());
+        return apiSearchService
+            .findGenericByEnvironmentAndIdIn(executionContext, ids)
+            .stream()
+            .map(entity -> apiMapper.convert(executionContext, entity))
+            .toList();
     }
 
     @Path("{portalNavigationItemId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3196,6 +3196,60 @@ paths:
                 500:
                     $ref: "#/components/responses/InternalServerError"
 
+    /portal-navigation-items/_search:
+        get:
+            tags:
+                - Portal
+            summary: Search portal navigation items.
+            operationId: searchPortalNavigationItems
+            security:
+                - {}
+                - BasicAuth: []
+                - CookieAuth: []
+            parameters:
+                - name: query
+                  in: query
+                  required: false
+                  schema:
+                      type: string
+                - name: type
+                  in: query
+                  required: true
+                  schema:
+                      type: string
+                      enum:
+                          - api
+                - name: include
+                  in: query
+                  required: false
+                  schema:
+                      type: array
+                      items:
+                          $ref: "#/components/schemas/PortalNavigationSearchInclude"
+                - name: page
+                  in: query
+                  required: false
+                  schema:
+                      type: integer
+                      default: 1
+                - name: size
+                  in: query
+                  required: false
+                  schema:
+                      type: integer
+                      default: 10
+            responses:
+                200:
+                    description: Search results
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PortalNavigationItemsSearchResponse"
+                400:
+                    $ref: "#/components/responses/BadRequestError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+
     /portal-navigation-items/{portalNavigationItemId}:
         parameters:
             - name: portalNavigationItemId
@@ -3844,6 +3898,21 @@ components:
         #####################
         # Responses Objects #
         #####################
+        PortalNavigationItemsSearchResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/PortalNavigationItem"
+                metadata:
+                    $ref: "#/components/schemas/MetadataMap"
+                apis:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/Api"
+                links:
+                    $ref: "#/components/schemas/Links"
         SubscriptionForm:
             type: object
             description: Subscription form returned to API consumers when the form is enabled. Contains only the form content (GMD).
@@ -6427,6 +6496,10 @@ components:
             type: string
             description: The portal area (used by portal navigation items)
             enum: [HOMEPAGE, TOP_NAVBAR]
+        PortalNavigationSearchInclude:
+            type: string
+            enum:
+                - api
         BasePortalNavigationItem:
             type: object
             description: Base portal navigation item

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResourceTest.java
@@ -16,19 +16,30 @@
 package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+import inmemory.ApiPortalSearchQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -38,6 +49,9 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
 
     @Autowired
     private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
+
+    @Autowired
+    private ApiPortalSearchQueryServiceInMemory apiPortalSearchQueryService;
 
     @Override
     protected String contextPath() {
@@ -53,6 +67,7 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
     public void tearDown() {
         GraviteeContext.cleanContext();
         portalNavigationItemsQueryService.reset();
+        apiPortalSearchQueryService.reset();
     }
 
     @Test
@@ -169,20 +184,6 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
             );
     }
 
-    private String getIdFromItem(io.gravitee.rest.api.portal.rest.model.PortalNavigationItem item) {
-        Object actual = item.getActualInstance();
-
-        if (actual instanceof io.gravitee.rest.api.portal.rest.model.PortalNavigationPage page) {
-            return page.getId();
-        } else if (actual instanceof io.gravitee.rest.api.portal.rest.model.PortalNavigationFolder folder) {
-            return folder.getId();
-        } else if (actual instanceof io.gravitee.rest.api.portal.rest.model.PortalNavigationLink link) {
-            return link.getId();
-        }
-
-        return null;
-    }
-
     @Test
     void should_return_navigation_items_when_user_is_authenticated() {
         // Given
@@ -203,5 +204,148 @@ public class PortalNavigationItemsResourceTest extends AbstractResourceTest {
             new jakarta.ws.rs.core.GenericType<List<io.gravitee.rest.api.portal.rest.model.PortalNavigationItem>>() {}
         );
         assertThat(result).hasSize(items.size());
+    }
+
+    // --- _search endpoint tests ---
+
+    @Test
+    void should_return_400_when_type_param_is_missing() {
+        Response response = target("/_search").queryParam("query", "auth").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void should_return_400_when_type_param_is_blank() {
+        Response response = target("/_search").queryParam("query", "auth").queryParam("type", "").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void should_return_paginated_api_navigation_items() {
+        // Given
+        var apiItem = PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Auth API")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .apiId("api-uuid-1")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+        portalNavigationItemsQueryService.initWith(List.of(apiItem));
+        apiPortalSearchQueryService.initWith(List.of(Api.builder().id("api-uuid-1").name("Auth API").environmentId(ENV_ID).build()));
+
+        // When
+        Response response = target("/_search")
+            .queryParam("query", "auth")
+            .queryParam("type", "api")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .get();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        assertThat(result).containsKey("data");
+        @SuppressWarnings("unchecked")
+        var data = (List<Object>) result.get("data");
+        assertThat(data).hasSize(1);
+        assertThat(result).containsKey("metadata");
+        @SuppressWarnings("unchecked")
+        var metadata = (Map<String, Object>) result.get("metadata");
+        assertThat(metadata).containsKey("pagination");
+        @SuppressWarnings("unchecked")
+        var pagination = (Map<String, Object>) metadata.get("pagination");
+        assertThat(pagination).containsEntry("total", 1);
+        assertThat(pagination).containsEntry("current_page", 1);
+    }
+
+    @Test
+    void should_return_empty_results_when_query_matches_nothing() {
+        // Given
+        var apiItem = PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Auth API")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .apiId("api-uuid-1")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+        portalNavigationItemsQueryService.initWith(List.of(apiItem));
+
+        // When - query that doesn't match
+        Response response = target("/_search").queryParam("query", "xyz-no-match").queryParam("type", "api").request().get();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        var data = (List<Object>) result.get("data");
+        assertThat(data).isEmpty();
+    }
+
+    @Test
+    void should_include_api_objects_in_apis_field_when_include_api() {
+        // Given
+        String apiId = "api-uuid-1";
+        var apiItem = PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId("org")
+            .environmentId(ENV_ID)
+            .title("Auth API")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .apiId(apiId)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+        portalNavigationItemsQueryService.initWith(List.of(apiItem));
+        apiPortalSearchQueryService.initWith(List.of(Api.builder().id(apiId).name("Auth API").environmentId(ENV_ID).build()));
+
+        var mockApiEntity = Mockito.mock(GenericApiEntity.class);
+        when(apiSearchService.findGenericByEnvironmentAndIdIn(any(), any())).thenReturn(Set.of(mockApiEntity));
+        var mockApi = new io.gravitee.rest.api.portal.rest.model.Api();
+        mockApi.setId(apiId);
+        mockApi.setName("Auth API");
+        when(apiMapper.convert(any(), any())).thenReturn(mockApi);
+
+        // When
+        Response response = target("/_search")
+            .queryParam("query", "auth")
+            .queryParam("type", "api")
+            .queryParam("include", "api")
+            .request()
+            .get();
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(200);
+        var result = response.readEntity(new jakarta.ws.rs.core.GenericType<Map<String, Object>>() {});
+        assertThat(result).containsKey("metadata");
+        assertThat(result).containsKey("apis");
+        @SuppressWarnings("unchecked")
+        var apis = (List<Object>) result.get("apis");
+        assertThat(apis).hasSize(1);
+    }
+
+    private String getIdFromItem(io.gravitee.rest.api.portal.rest.model.PortalNavigationItem item) {
+        Object actual = item.getActualInstance();
+
+        if (actual instanceof io.gravitee.rest.api.portal.rest.model.PortalNavigationPage page) {
+            return page.getId();
+        } else if (actual instanceof io.gravitee.rest.api.portal.rest.model.PortalNavigationFolder folder) {
+            return folder.getId();
+        } else if (actual instanceof io.gravitee.rest.api.portal.rest.model.PortalNavigationLink link) {
+            return link.getId();
+        }
+
+        return null;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -21,13 +21,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiExposedEntrypointDomainServiceInMemory;
+import inmemory.ApiPortalSearchQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
 import inmemory.SubscriptionSearchQueryServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
@@ -89,7 +92,9 @@ import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryServic
 import io.gravitee.apim.core.logs_engine.use_case.GetLogsFilterDefinitionsUseCase;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
+import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.domain_service.PublishPlanDomainService;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
 import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
 import io.gravitee.apim.core.parameters.domain_service.ParametersDomainService;
@@ -101,6 +106,7 @@ import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
@@ -108,6 +114,7 @@ import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQuerySer
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
+import io.gravitee.apim.core.portal_page.use_case.GetVisiblePortalNavigationApisUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.promotion.service_provider.CockpitPromotionServiceProvider;
@@ -128,6 +135,7 @@ import io.gravitee.apim.core.shared_policy_group.use_case.UpdateSharedPolicyGrou
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDSpecDomainService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
@@ -1061,6 +1069,45 @@ public class ResourceContextConfiguration {
         PortalNavigationItemsQueryService portalNavigationItemsQueryService
     ) {
         return new ListPortalNavigationItemsUseCase(portalNavigationItemsQueryService);
+    }
+
+    @Bean
+    public ApiPortalSearchQueryServiceInMemory apiPortalSearchQueryService() {
+        return new ApiPortalSearchQueryServiceInMemory();
+    }
+
+    @Bean
+    public MembershipQueryServiceInMemory membershipQueryService() {
+        return new MembershipQueryServiceInMemory();
+    }
+
+    @Bean
+    public SubscriptionQueryServiceInMemory subscriptionQueryService() {
+        return new SubscriptionQueryServiceInMemory();
+    }
+
+    @Bean
+    public ApiPortalMembershipDomainService apiPortalMembershipDomainService(
+        MembershipQueryService membershipQueryService,
+        SubscriptionQueryService subscriptionQueryService
+    ) {
+        return new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+    }
+
+    @Bean
+    public PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService(
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        ApiPortalMembershipDomainService apiPortalMembershipDomainService
+    ) {
+        return new PortalNavigationApiVisibilityDomainService(portalNavigationItemsQueryService, apiPortalMembershipDomainService);
+    }
+
+    @Bean
+    public GetVisiblePortalNavigationApisUseCase getVisiblePortalNavigationApisUseCase(
+        PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService,
+        ApiPortalSearchQueryServiceInMemory apiPortalSearchQueryService
+    ) {
+        return new GetVisiblePortalNavigationApisUseCase(portalNavigationApiVisibilityDomainService, apiPortalSearchQueryService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/query_service/ApiPortalSearchQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/query_service/ApiPortalSearchQueryService.java
@@ -20,15 +20,55 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
 import jakarta.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface ApiPortalSearchQueryService {
-    Page<Api> search(
+    Page<Api> search(Query query);
+
+    default Page<Api> search(
         String environmentId,
         String organizationId,
         @Nullable String query,
         Set<String> allowedApiIds,
         Pageable pageable,
         Sortable sortable
-    );
+    ) {
+        return search(
+            new Query(
+                environmentId,
+                organizationId,
+                Optional.ofNullable(query),
+                allowedApiIds,
+                Optional.ofNullable(pageable),
+                Optional.ofNullable(sortable)
+            )
+        );
+    }
+
+    default List<Api> search(String environmentId, String organizationId, String query, Set<String> allowedApiIds) {
+        return search(new Query(environmentId, organizationId, query, allowedApiIds)).getContent();
+    }
+
+    default List<Api> search(String environmentId, String organizationId, Set<String> allowedApiIds) {
+        return search(new Query(environmentId, organizationId, allowedApiIds)).getContent();
+    }
+
+    record Query(
+        String environmentId,
+        String organizationId,
+        Optional<String> query,
+        Set<String> allowedApiIds,
+        Optional<Pageable> pageable,
+        Optional<Sortable> sortable
+    ) {
+        public Query(String environmentId, String organizationId, String query, Set<String> allowedApiIds) {
+            this(environmentId, organizationId, Optional.of(query), allowedApiIds, Optional.empty(), Optional.empty());
+        }
+
+        public Query(String environmentId, String organizationId, Set<String> allowedApiIds) {
+            this(environmentId, organizationId, Optional.empty(), allowedApiIds, Optional.empty(), Optional.empty());
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/SearchApisForPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/SearchApisForPortalUseCase.java
@@ -26,6 +26,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
 import jakarta.annotation.Nullable;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
@@ -37,11 +38,10 @@ public class SearchApisForPortalUseCase {
     private final ApiPortalSearchQueryService apiPortalSearchQueryService;
 
     public Output execute(Input input) {
-        Set<String> allowedIds = visibilityDomainService
-            .resolveVisibleItems(input.environmentId(), input.userId())
-            .stream()
-            .map(PortalNavigationApi::getApiId)
-            .collect(toSet());
+        List<PortalNavigationApi> visible = input.userId() != null
+            ? visibilityDomainService.resolveVisibleItems(input.environmentId(), input.userId())
+            : visibilityDomainService.resolveVisibleItems(input.environmentId());
+        Set<String> allowedIds = visible.stream().map(PortalNavigationApi::getApiId).collect(toSet());
 
         return new Output(
             apiPortalSearchQueryService.search(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
@@ -15,20 +15,16 @@
  */
 package io.gravitee.apim.core.portal_page.domain_service;
 
-import static java.util.stream.Collectors.toSet;
-
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
-import io.gravitee.common.data.domain.Page;
-import io.gravitee.rest.api.model.common.Pageable;
-import jakarta.annotation.Nullable;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
@@ -39,59 +35,63 @@ public class PortalNavigationApiVisibilityDomainService {
     private final ApiPortalMembershipDomainService apiMembershipDomainService;
 
     /**
+     * Resolves visible APIs for unauthenticated portal access where only public APIs should be exposed.
+     */
+    public List<PortalNavigationApi> resolveVisibleItems(String environmentId) {
+        return fetchApiItems(environmentId)
+            .stream()
+            .filter(i -> PortalVisibility.PUBLIC.equals(i.getVisibility()))
+            .toList();
+    }
+
+    /**
      * Enforces portal navigation access control by filtering APIs based on visibility rules and user permissions.
      */
-    public List<PortalNavigationApi> resolveVisibleItems(String environmentId, @Nullable String userId) {
-        return resolveVisibleItemsStream(environmentId, userId).toList();
+    public List<PortalNavigationApi> resolveVisibleItems(String environmentId, String userId) {
+        List<PortalNavigationApi> apiItems = fetchApiItems(environmentId);
+
+        Set<String> publicIds = new HashSet<>();
+        Set<String> privateIds = new HashSet<>();
+        for (PortalNavigationApi item : apiItems) {
+            if (PortalVisibility.PUBLIC.equals(item.getVisibility())) {
+                publicIds.add(item.getApiId());
+            } else {
+                privateIds.add(item.getApiId());
+            }
+        }
+
+        Set<String> allowedIds = new HashSet<>(publicIds);
+        allowedIds.addAll(apiMembershipDomainService.filterApiIdsByUserMembership(userId, privateIds));
+        allowedIds.addAll(apiMembershipDomainService.filterAllowedApiIdsBySubscription(userId, privateIds));
+
+        return apiItems
+            .stream()
+            .filter(i -> allowedIds.contains(i.getApiId()))
+            .toList();
     }
 
-    public Page<PortalNavigationApi> resolveVisibleItemsPage(String environmentId, @Nullable String userId, Pageable pageable) {
-        List<PortalNavigationApi> all = resolveVisibleItemsStream(environmentId, userId).toList();
-        int skip = (pageable.getPageNumber() - 1) * pageable.getPageSize();
-        int limit = pageable.getPageSize();
-        List<PortalNavigationApi> content = all.stream().skip(skip).limit(limit).toList();
-        return new Page<>(content, pageable.getPageNumber(), content.size(), all.size());
-    }
-
-    private Stream<PortalNavigationApi> resolveVisibleItemsStream(String environmentId, @Nullable String userId) {
-        List<PortalNavigationApi> apiItems = queryService
-            .search(PortalNavigationItemQueryCriteria.builder().environmentId(environmentId).published(true).root(false).build())
+    private List<PortalNavigationApi> fetchApiItems(String environmentId) {
+        return queryService
+            .search(
+                PortalNavigationItemQueryCriteria.builder()
+                    .environmentId(environmentId)
+                    .published(true)
+                    .root(false)
+                    .type(PortalNavigationItemType.API)
+                    .build()
+            )
             .stream()
             .filter(PortalNavigationApi.class::isInstance)
             .map(PortalNavigationApi.class::cast)
             .toList();
-
-        Set<String> allowedIds = apiItems
-            .stream()
-            .filter(i -> PortalVisibility.PUBLIC.equals(i.getVisibility()))
-            .map(PortalNavigationApi::getApiId)
-            .collect(toSet());
-
-        if (userId == null) {
-            return apiItems.stream().filter(i -> allowedIds.contains(i.getApiId()));
-        }
-
-        Set<String> privateApiIds = apiItems
-            .stream()
-            .filter(i -> PortalVisibility.PRIVATE.equals(i.getVisibility()))
-            .map(PortalNavigationApi::getApiId)
-            .collect(toSet());
-
-        allowedIds.addAll(apiMembershipDomainService.filterApiIdsByUserMembership(userId, privateApiIds));
-        allowedIds.addAll(apiMembershipDomainService.filterAllowedApiIdsBySubscription(userId, privateApiIds));
-
-        return apiItems.stream().filter(i -> allowedIds.contains(i.getApiId()));
     }
 
     /**
      * Checks visibility of a single PortalNavigationApi for the given user.
      */
-    public boolean isVisibleToUser(PortalNavigationApi item, @Nullable String userId) {
+    public boolean isVisibleToUser(PortalNavigationApi item, String userId) {
         if (PortalVisibility.PUBLIC.equals(item.getVisibility())) {
             return true;
-        }
-        if (userId == null) {
-            return false;
         }
         Set<String> candidate = Set.of(item.getApiId());
         return (

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationSearchInclude.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationSearchInclude.java
@@ -15,18 +15,6 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
-import lombok.Builder;
-import lombok.Data;
-
-@Data
-@Builder
-public class PortalNavigationItemQueryCriteria {
-
-    private String environmentId;
-    private Boolean root;
-    private PortalNavigationItemId parentId;
-    private PortalArea area;
-    private Boolean published;
-    private PortalVisibility visibility;
-    private PortalNavigationItemType type;
+public enum PortalNavigationSearchInclude {
+    API,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCase.java
@@ -15,12 +15,19 @@
  */
 package io.gravitee.apim.core.portal_page.use_case;
 
+import static java.util.stream.Collectors.toSet;
+
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.query_service.ApiPortalSearchQueryService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationSearchInclude;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
-import jakarta.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -28,12 +35,68 @@ import lombok.RequiredArgsConstructor;
 public class GetVisiblePortalNavigationApisUseCase {
 
     private final PortalNavigationApiVisibilityDomainService visibilityDomainService;
+    private final ApiPortalSearchQueryService apiPortalSearchQueryService;
 
     public Output execute(Input input) {
-        return new Output(visibilityDomainService.resolveVisibleItemsPage(input.environmentId(), input.userId(), input.pageable()));
+        List<PortalNavigationApi> visible = input.userId().isPresent()
+            ? visibilityDomainService.resolveVisibleItems(input.environmentId(), input.userId().get())
+            : visibilityDomainService.resolveVisibleItems(input.environmentId());
+
+        List<Api> searchedApis = List.of();
+        Optional<String> queryText = input.query().filter(q -> !q.isBlank());
+
+        List<PortalNavigationApi> filtered;
+        if (queryText.isEmpty()) {
+            filtered = visible;
+        } else {
+            Set<String> allowedApiIds = visible.stream().map(PortalNavigationApi::getApiId).collect(toSet());
+            searchedApis = apiPortalSearchQueryService.search(
+                input.environmentId(),
+                input.organizationId(),
+                queryText.get(),
+                allowedApiIds
+            );
+            Set<String> matchingIds = searchedApis.stream().map(Api::getId).collect(toSet());
+            filtered = visible
+                .stream()
+                .filter(i -> matchingIds.contains(i.getApiId()))
+                .toList();
+        }
+
+        int skip = (input.pageable().getPageNumber() - 1) * input.pageable().getPageSize();
+        List<PortalNavigationApi> pageItems = filtered.stream().skip(skip).limit(input.pageable().getPageSize()).toList();
+        Page<PortalNavigationApi> page = new Page<>(pageItems, input.pageable().getPageNumber(), pageItems.size(), filtered.size());
+
+        List<Api> includedApis = resolveIncludedApis(input, searchedApis, pageItems);
+
+        return new Output(page, includedApis);
     }
 
-    public record Input(String environmentId, @Nullable String userId, Pageable pageable) {}
+    private List<Api> resolveIncludedApis(Input input, List<Api> searchedApis, List<PortalNavigationApi> pageItems) {
+        if (!input.includes().contains(PortalNavigationSearchInclude.API)) {
+            return List.of();
+        }
+        Set<String> pageApiIds = pageItems.stream().map(PortalNavigationApi::getApiId).collect(toSet());
+        if (pageApiIds.isEmpty()) {
+            return List.of();
+        }
+        if (!searchedApis.isEmpty()) {
+            return searchedApis
+                .stream()
+                .filter(a -> pageApiIds.contains(a.getId()))
+                .toList();
+        }
+        return apiPortalSearchQueryService.search(input.environmentId(), input.organizationId(), pageApiIds);
+    }
 
-    public record Output(Page<PortalNavigationApi> apis) {}
+    public record Input(
+        String environmentId,
+        String organizationId,
+        Optional<String> userId,
+        Pageable pageable,
+        Optional<String> query,
+        Set<PortalNavigationSearchInclude> includes
+    ) {}
+
+    public record Output(Page<PortalNavigationApi> apis, List<Api> includedApis) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImpl.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -45,36 +46,39 @@ public class ApiPortalSearchQueryServiceImpl implements ApiPortalSearchQueryServ
     }
 
     @Override
-    public Page<Api> search(
-        String environmentId,
-        String organizationId,
-        String query,
-        Set<String> allowedApiIds,
-        Pageable pageable,
-        Sortable sortable
-    ) {
-        int pageNumber = pageable != null ? pageable.getPageNumber() : 1;
+    public Page<Api> search(Query query) {
+        Set<String> allowedApiIds = query.allowedApiIds();
+        Optional<String> queryText = query.query().filter(s -> !s.isBlank());
+        Optional<Pageable> pageable = query.pageable();
+        Optional<Sortable> sortable = query.sortable();
 
-        if (allowedApiIds == null || allowedApiIds.isEmpty()) {
+        int pageNumber = pageable.map(Pageable::getPageNumber).orElse(1);
+
+        if (allowedApiIds.isEmpty()) {
             return new Page<>(List.of(), pageNumber, 0, 0);
         }
 
-        if (query == null || query.isBlank()) {
+        if (queryText.isEmpty()) {
             // No text query: delegate sorting and pagination to the repository
             return apiQueryService.search(
-                ApiSearchCriteria.builder().ids(List.copyOf(allowedApiIds)).environmentId(environmentId).build(),
-                toCoreSortable(sortable),
-                pageable,
+                ApiSearchCriteria.builder().ids(List.copyOf(allowedApiIds)).environmentId(query.environmentId()).build(),
+                sortable.map(this::toCoreSortable).orElse(null),
+                pageable.orElse(null),
                 null
             );
         }
 
-        var executionContext = new ExecutionContext(organizationId, environmentId);
-        Collection<String> luceneIds = apiSearchService.searchIds(executionContext, query.trim(), Map.of(), sortable);
+        var executionContext = new ExecutionContext(query.organizationId(), query.environmentId());
+        Collection<String> luceneIds = apiSearchService.searchIds(
+            executionContext,
+            queryText.get().trim(),
+            Map.of(),
+            sortable.orElse(null)
+        );
         List<String> intersected = luceneIds.stream().filter(allowedApiIds::contains).toList();
 
         int total = intersected.size();
-        int pageSize = pageable != null ? pageable.getPageSize() : 10;
+        int pageSize = pageable.map(Pageable::getPageSize).orElse(10);
 
         if (total == 0 || pageSize <= 0) {
             return new Page<>(List.of(), pageNumber, 0, total);
@@ -88,7 +92,7 @@ public class ApiPortalSearchQueryServiceImpl implements ApiPortalSearchQueryServ
 
         // Fetch by IDs then reorder to preserve Lucene relevance order
         Map<String, Api> apiById = apiQueryService
-            .search(ApiSearchCriteria.builder().ids(pageSubset).environmentId(environmentId).build(), null, null, null)
+            .search(ApiSearchCriteria.builder().ids(pageSubset).environmentId(query.environmentId()).build(), null, null, null)
             .getContent()
             .stream()
             .collect(Collectors.toMap(Api::getId, Function.identity()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiPortalSearchQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiPortalSearchQueryServiceInMemory.java
@@ -29,14 +29,13 @@ import java.util.Set;
 public class ApiPortalSearchQueryServiceInMemory extends AbstractQueryServiceInMemory<Api> implements ApiPortalSearchQueryService {
 
     @Override
-    public Page<Api> search(
-        String environmentId,
-        String organizationId,
-        String query,
-        Set<String> allowedApiIds,
-        Pageable pageable,
-        Sortable sortable
-    ) {
+    public Page<Api> search(Query q) {
+        String environmentId = q.environmentId();
+        String query = q.query().orElse(null);
+        Set<String> allowedApiIds = q.allowedApiIds();
+        Pageable pageable = q.pageable().orElse(null);
+        Sortable sortable = q.sortable().orElse(null);
+
         int pageNumber = pageable != null ? pageable.getPageNumber() : 1;
         int pageSize = pageable != null ? pageable.getPageSize() : 10;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
@@ -16,9 +16,11 @@
 package inmemory;
 
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.ArrayList;
 import java.util.List;
@@ -77,9 +79,14 @@ public class PortalNavigationItemsQueryServiceInMemory
                     (criteria.getArea() == null || criteria.getArea().equals(item.getArea())) &&
                     (PARENT_ID_FILTER.test(item)) &&
                     (criteria.getPublished() == null || criteria.getPublished().equals(item.getPublished())) &&
-                    (criteria.getVisibility() == null || criteria.getVisibility().equals(item.getVisibility()))
+                    (criteria.getVisibility() == null || criteria.getVisibility().equals(item.getVisibility())) &&
+                    (criteria.getType() == null || matchesType(item, criteria.getType()))
             )
             .toList();
+    }
+
+    private boolean matchesType(PortalNavigationItem item, PortalNavigationItemType type) {
+        return type == item.getType();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
@@ -17,9 +17,11 @@ package io.gravitee.apim.core.portal_page.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import inmemory.ApiPortalSearchQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
@@ -29,6 +31,8 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -47,15 +51,17 @@ class GetVisiblePortalNavigationApisUseCaseTest {
     private GetVisiblePortalNavigationApisUseCase useCase;
     private PortalNavigationItemsQueryServiceInMemory navQueryService;
     private MembershipQueryServiceInMemory membershipQueryService;
+    private ApiPortalSearchQueryServiceInMemory apiSearchQueryService;
 
     @BeforeEach
     void setUp() {
         navQueryService = new PortalNavigationItemsQueryServiceInMemory();
         membershipQueryService = new MembershipQueryServiceInMemory();
+        apiSearchQueryService = new ApiPortalSearchQueryServiceInMemory();
         var subscriptionQueryService = new SubscriptionQueryServiceInMemory();
         var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
         var visibilityDomainService = new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService);
-        useCase = new GetVisiblePortalNavigationApisUseCase(visibilityDomainService);
+        useCase = new GetVisiblePortalNavigationApisUseCase(visibilityDomainService, apiSearchQueryService);
     }
 
     @Test
@@ -67,7 +73,16 @@ class GetVisiblePortalNavigationApisUseCaseTest {
             )
         );
 
-        var result = useCase.execute(new GetVisiblePortalNavigationApisUseCase.Input(ENV_ID, null, new PageableImpl(1, 10)));
+        var result = useCase.execute(
+            new GetVisiblePortalNavigationApisUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                Optional.empty(),
+                new PageableImpl(1, 10),
+                Optional.empty(),
+                Set.of()
+            )
+        );
 
         assertThat(result.apis().getContent()).extracting(PortalNavigationApi::getApiId).containsExactly(PUBLIC_API_ID);
         assertThat(result.apis().getTotalElements()).isEqualTo(1);
@@ -83,7 +98,16 @@ class GetVisiblePortalNavigationApisUseCaseTest {
         );
         membershipQueryService.initWith(List.of(apiMembership(USER_ID, PRIVATE_API_ID)));
 
-        var result = useCase.execute(new GetVisiblePortalNavigationApisUseCase.Input(ENV_ID, USER_ID, new PageableImpl(1, 10)));
+        var result = useCase.execute(
+            new GetVisiblePortalNavigationApisUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                Optional.of(USER_ID),
+                new PageableImpl(1, 10),
+                Optional.empty(),
+                Set.of()
+            )
+        );
 
         assertThat(result.apis().getContent())
             .extracting(PortalNavigationApi::getApiId)
@@ -101,7 +125,16 @@ class GetVisiblePortalNavigationApisUseCaseTest {
             )
         );
 
-        var result = useCase.execute(new GetVisiblePortalNavigationApisUseCase.Input(ENV_ID, null, new PageableImpl(1, 2)));
+        var result = useCase.execute(
+            new GetVisiblePortalNavigationApisUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                Optional.empty(),
+                new PageableImpl(1, 2),
+                Optional.empty(),
+                Set.of()
+            )
+        );
 
         assertThat(result.apis().getContent()).hasSize(2);
         assertThat(result.apis().getTotalElements()).isEqualTo(3);
@@ -117,7 +150,16 @@ class GetVisiblePortalNavigationApisUseCaseTest {
             )
         );
 
-        var result = useCase.execute(new GetVisiblePortalNavigationApisUseCase.Input(ENV_ID, null, new PageableImpl(2, 2)));
+        var result = useCase.execute(
+            new GetVisiblePortalNavigationApisUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                Optional.empty(),
+                new PageableImpl(2, 2),
+                Optional.empty(),
+                Set.of()
+            )
+        );
 
         assertThat(result.apis().getContent()).hasSize(1);
         assertThat(result.apis().getTotalElements()).isEqualTo(3);
@@ -133,10 +175,40 @@ class GetVisiblePortalNavigationApisUseCaseTest {
             )
         );
 
-        var result = useCase.execute(new GetVisiblePortalNavigationApisUseCase.Input(ENV_ID, null, new PageableImpl(1, 10)));
+        var result = useCase.execute(
+            new GetVisiblePortalNavigationApisUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                Optional.empty(),
+                new PageableImpl(1, 10),
+                Optional.empty(),
+                Set.of()
+            )
+        );
 
         assertThat(result.apis().getTotalElements()).isEqualTo(3);
         assertThat(result.apis().getContent()).hasSize(3);
+    }
+
+    @Test
+    void filters_by_query_using_api_search() {
+        navQueryService.initWith(
+            List.of(publishedApiNavItem("api-auth", PortalVisibility.PUBLIC), publishedApiNavItem("api-other", PortalVisibility.PUBLIC))
+        );
+        apiSearchQueryService.initWith(List.of(anApi("api-auth", "Auth Service", ENV_ID), anApi("api-other", "Other Service", ENV_ID)));
+
+        var result = useCase.execute(
+            new GetVisiblePortalNavigationApisUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                Optional.empty(),
+                new PageableImpl(1, 10),
+                Optional.of("auth"),
+                Set.of()
+            )
+        );
+
+        assertThat(result.apis().getContent()).extracting(PortalNavigationApi::getApiId).containsExactly("api-auth");
     }
 
     // --- helpers ---
@@ -153,6 +225,10 @@ class GetVisiblePortalNavigationApisUseCaseTest {
             .published(true)
             .visibility(visibility)
             .build();
+    }
+
+    private Api anApi(String id, String name, String envId) {
+        return Api.builder().id(id).name(name).environmentId(envId).build();
     }
 
     private Membership apiMembership(String userId, String apiId) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13064

## Description

Adds a /_search endpoint for portal navigation items and refactors the surrounding domain layer:

- PortalNavigationItemsResource: New GET /_search?type=api&query=...&include=api endpoint backed by GetVisiblePortalNavigationApisUseCase. Fixed JAX-RS enum conversion for include param by accepting Set<String> and delegating to PortalNavigationSearchInclude.fromValue().
- ApiPortalSearchQueryService: Introduces a Query record as the primary abstraction (search(Query) is now the single abstract method). Two default List<Api> convenience overloads eliminate PageableImpl(1, MAX_VALUE) boilerplate at call sites.
- PortalNavigationApiVisibilityDomainService: resolveVisibleItems and isVisibleToUser are split into two non-nullable overloads (with/without userId), removing @Nullable and an intermediate private stream method.
- GetVisiblePortalNavigationApisUseCase: resolveIncludedApis extracted from execute, replacing multiple early returns with a focused private helper.
- PortalNavigationItemCriteria: query field removed — text search is handled by Elasticsearch/Lucene, not the repository layer. Corresponding blocks removed from MongoDB, JDBC, and in-memory implementations.  