### PR TITLE
feat: add metadata property to SubscriptionCRDSpec for /spec/_import

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionsResource.java
@@ -93,6 +93,7 @@ public class ApiSubscriptionsResource extends AbstractResource {
             .referenceType(SubscriptionReferenceType.API)
             .planId(legacy ? spec.getPlanHrid() : IdBuilder.builder(auditInfo, apiHrid).withExtraId(spec.getPlanHrid()).buildId())
             .endingAt(spec.getEndingAt() != null ? spec.getEndingAt().toZonedDateTime() : null)
+            .metadata(spec.getMetadata())
             .build();
 
         SubscriptionCRDStatus status = importSubscriptionSpecUseCase

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -838,6 +838,14 @@ components:
           type: string
           format: date-time
           example: "2040-12-25T09:12:28Z"
+        metadata:
+          type: object
+          description: Key-value metadata for this subscription.
+          additionalProperties:
+            type: string
+          examples:
+            - key1: value1
+              key2: value2
       required:
         - hrid
         - applicationHrid

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionResourceTest.java
@@ -15,8 +15,12 @@
  */
 package io.gravitee.apim.rest.api.automation.resource;
 
+import static io.gravitee.apim.core.subscription.model.SubscriptionEntity.Status.ACCEPTED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 import fixtures.ApplicationModelFixtures;
 import fixtures.core.model.ApiFixtures;
@@ -26,12 +30,17 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
 import inmemory.SubscriptionCrudServiceInMemory;
+import io.gravitee.apim.core.subscription.model.crd.SubscriptionCRDStatus;
+import io.gravitee.apim.core.subscription.use_case.ImportSubscriptionSpecUseCase;
 import io.gravitee.apim.rest.api.automation.model.SubscriptionState;
 import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.IdBuilder;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
@@ -53,6 +62,9 @@ class ApiSubscriptionResourceTest extends AbstractResourceTest {
     @Autowired
     private PlanCrudServiceInMemory planCrudService;
 
+    @Autowired
+    private ImportSubscriptionSpecUseCase importSubscriptionSpecUseCase;
+
     static final String HRID = "subscription-hrid";
     static final String API_HRID = "api-hrid";
     static final String APPLICATION_HRID = "application-hrid";
@@ -64,6 +76,7 @@ class ApiSubscriptionResourceTest extends AbstractResourceTest {
         apiCrudService.reset();
         applicationCrudService.reset();
         planCrudService.reset();
+        reset(importSubscriptionSpecUseCase);
     }
 
     @Nested
@@ -231,6 +244,62 @@ class ApiSubscriptionResourceTest extends AbstractResourceTest {
         private void expectNotFound(String hrid) {
             try (var response = rootTarget().path(hrid).request().delete()) {
                 assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    @Nested
+    class PutDeletePut {
+
+        @Test
+        void should_handle_put_delete_put_lifecycle() {
+            when(importSubscriptionSpecUseCase.execute(any(ImportSubscriptionSpecUseCase.Input.class))).thenReturn(
+                new ImportSubscriptionSpecUseCase.Output(
+                    SubscriptionCRDStatus.builder()
+                        .id(IdBuilder.builder(new ExecutionContext(ORGANIZATION, ENVIRONMENT), API_HRID).withExtraId(HRID).buildId())
+                        .startingAt(Instant.now().atZone(ZoneOffset.UTC))
+                        .status(ACCEPTED.name())
+                        .organizationId(ORGANIZATION)
+                        .environmentId(ENVIRONMENT)
+                        .build()
+                )
+            );
+
+            subscriptionCrudService.initWith(
+                List.of(
+                    SubscriptionFixtures.aSubscription()
+                        .toBuilder()
+                        .id(IdBuilder.builder(new ExecutionContext(ORGANIZATION, ENVIRONMENT), API_HRID).withExtraId(HRID).buildId())
+                        .apiId(IdBuilder.builder(new ExecutionContext(ORGANIZATION, ENVIRONMENT), API_HRID).buildId())
+                        .applicationId(IdBuilder.builder(new ExecutionContext(ORGANIZATION, ENVIRONMENT), APPLICATION_HRID).buildId())
+                        .planId(IdBuilder.builder(new ExecutionContext(ORGANIZATION, ENVIRONMENT), PLAN_HRID).buildId())
+                        .build()
+                )
+            );
+
+            // PUT: create/update subscription
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("subscription-with-hrid.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+            }
+
+            // DELETE: close subscription
+            try (var response = rootTarget().path(HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+            }
+
+            // PUT again: should succeed (restore + update at domain service level)
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("subscription-with-hrid.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
             }
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/model/crd/SubscriptionCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/model/crd/SubscriptionCRDSpec.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.subscription.model.crd;
 
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import java.time.ZonedDateTime;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -56,4 +57,5 @@ public class SubscriptionCRDSpec {
 
     private String planId;
     private ZonedDateTime endingAt;
+    private Map<String, String> metadata;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/SubscriptionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/SubscriptionAdapter.java
@@ -114,7 +114,7 @@ public abstract class SubscriptionAdapter {
     @Mapping(target = "processedBy", ignore = true)
     @Mapping(target = "processedAt", ignore = true)
     @Mapping(target = "pausedAt", ignore = true)
-    @Mapping(target = "metadata", ignore = true)
+    @Mapping(target = "metadata", source = "metadata")
     @Mapping(target = "generalConditionsContentRevision", ignore = true)
     @Mapping(target = "generalConditionsContentPageId", ignore = true)
     @Mapping(target = "generalConditionsAccepted", ignore = true)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImpl.java
@@ -95,6 +95,11 @@ public class SubscriptionCRDSpecDomainServiceImpl implements SubscriptionCRDSpec
             update.setEndingAt(spec.getEndingAt());
         }
 
+        if (!Objects.equals(spec.getMetadata(), existing.getMetadata())) {
+            log.debug("Updating metadata for subscription [{}]", spec.getId());
+            update.setMetadata(spec.getMetadata());
+        }
+
         subscriptionService.update(toExecutionContext(auditInfo), adapter.fromCoreForUpdate(update));
 
         return update;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImpl.java
@@ -54,7 +54,7 @@ public class SubscriptionCRDSpecDomainServiceImpl implements SubscriptionCRDSpec
     @Override
     public SubscriptionEntity createOrUpdate(AuditInfo auditInfo, SubscriptionCRDSpec spec) {
         return find(spec.getId())
-            .map((existing -> update(auditInfo, existing, spec)))
+            .map(existing -> update(auditInfo, existing, spec))
             .orElseGet(() -> create(auditInfo, spec));
     }
 
@@ -84,10 +84,15 @@ public class SubscriptionCRDSpecDomainServiceImpl implements SubscriptionCRDSpec
         }
 
         log.debug("Auto accepting subscription [{}]", spec.getId());
-        return acceptService.autoAccept(subscription.getId(), ZonedDateTime.now(), spec.getEndingAt(), ACCEPT_REASON, "", auditInfo);
+        return getAutoAccept(auditInfo, spec, subscription.getId());
     }
 
     private SubscriptionEntity update(AuditInfo auditInfo, SubscriptionEntity existing, SubscriptionCRDSpec spec) {
+        if (existing.getStatus() == SubscriptionEntity.Status.CLOSED) {
+            var restored = restoreAsAccepted(auditInfo, existing, spec);
+            return update(auditInfo, restored, spec);
+        }
+
         var update = existing.toBuilder().build();
 
         if (!Objects.equals(spec.getEndingAt(), existing.getEndingAt())) {
@@ -103,6 +108,16 @@ public class SubscriptionCRDSpecDomainServiceImpl implements SubscriptionCRDSpec
         subscriptionService.update(toExecutionContext(auditInfo), adapter.fromCoreForUpdate(update));
 
         return update;
+    }
+
+    private SubscriptionEntity restoreAsAccepted(AuditInfo auditInfo, SubscriptionEntity existing, SubscriptionCRDSpec spec) {
+        log.debug("Restoring closed subscription [{}]", spec.getId());
+        subscriptionService.restore(toExecutionContext(auditInfo), existing.getId());
+        return getAutoAccept(auditInfo, spec, existing.getId());
+    }
+
+    private SubscriptionEntity getAutoAccept(AuditInfo auditInfo, SubscriptionCRDSpec spec, String id) {
+        return acceptService.autoAccept(id, ZonedDateTime.now(), spec.getEndingAt(), ACCEPT_REASON, "", auditInfo);
     }
 
     private Optional<SubscriptionEntity> find(String id) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/SubscriptionAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/SubscriptionAdapterTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import fixtures.core.model.SubscriptionFixtures;
 import io.gravitee.apim.core.subscription.model.SubscriptionConfiguration;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.model.crd.SubscriptionCRDSpec;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDeserializer;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonSerializer;
 import io.gravitee.repository.management.model.Subscription;
@@ -193,6 +195,48 @@ class SubscriptionAdapterTest {
 
             var subscription = subscriptionAdapter.fromEntity(entity);
             assertThat(subscription.getConfiguration()).isNull();
+        }
+    }
+
+    @Nested
+    class FromSpec {
+
+        @Test
+        void should_map_metadata_from_spec() {
+            var metadata = Map.of("key1", "value1", "key2", "value2");
+            var spec = SubscriptionCRDSpec.builder()
+                .id("sub-id")
+                .referenceId("api-id")
+                .referenceType(SubscriptionReferenceType.API)
+                .applicationId("app-id")
+                .planId("plan-id")
+                .metadata(metadata)
+                .build();
+
+            SubscriptionEntity entity = subscriptionAdapter.fromSpec(spec);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(entity.getId()).isEqualTo("sub-id");
+                soft.assertThat(entity.getReferenceId()).isEqualTo("api-id");
+                soft.assertThat(entity.getApplicationId()).isEqualTo("app-id");
+                soft.assertThat(entity.getPlanId()).isEqualTo("plan-id");
+                soft.assertThat(entity.getMetadata()).isEqualTo(metadata);
+            });
+        }
+
+        @Test
+        void should_map_null_metadata_from_spec() {
+            var spec = SubscriptionCRDSpec.builder()
+                .id("sub-id")
+                .referenceId("api-id")
+                .referenceType(SubscriptionReferenceType.API)
+                .applicationId("app-id")
+                .planId("plan-id")
+                .build();
+
+            SubscriptionEntity entity = subscriptionAdapter.fromSpec(spec);
+
+            assertThat(entity.getMetadata()).isNull();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -254,6 +255,34 @@ class SubscriptionCRDSpecDomainServiceImplTest {
     }
 
     @Test
+    void should_restore_AsAccepted_closed_subscription_on_update() {
+        givenExistingJWTPlan();
+
+        var closedEntity = subscriptionAdapter.map(
+            subscriptionAdapter.fromSpec(SPEC).toBuilder().status(SubscriptionEntity.Status.CLOSED).subscribedBy(USER_ID).build()
+        );
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(closedEntity);
+
+        // When restore is called on the mock, also update the in-memory crud service to PENDING
+        doAnswer(invocation -> {
+            subscriptionCrudService.update(
+                subscriptionCrudService.get(SUBSCRIPTION_ID).toBuilder().status(SubscriptionEntity.Status.PENDING).build()
+            );
+            return closedEntity;
+        })
+            .when(subscriptionService)
+            .restore(EXECUTION_CONTEXT, SUBSCRIPTION_ID);
+
+        var result = cut.createOrUpdate(AUDIT_INFO, SPEC);
+
+        verify(subscriptionService).restore(EXECUTION_CONTEXT, SUBSCRIPTION_ID);
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
+            soft.assertThat(subscriptionCrudService.get(SUBSCRIPTION_ID).getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
+        });
+    }
+
+    @Test
     void should_close_on_delete() {
         cut.delete(AUDIT_INFO, SPEC.getId());
 
@@ -276,10 +305,6 @@ class SubscriptionCRDSpecDomainServiceImplTest {
 
     private void givenExistingPlan(Plan plan) {
         planCrudService.initWith(List.of(plan));
-    }
-
-    private void givenExistingSubscription(SubscriptionEntity subscription) {
-        subscriptionCrudService.initWith(List.of(subscription));
     }
 
     private CloseSubscriptionDomainService closeSubscriptionDomainService() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImplTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.domain_service.subscription;
 
 import static fixtures.core.model.MembershipFixtures.anApplicationPrimaryOwnerUserMembership;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -54,6 +55,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -190,6 +192,38 @@ class SubscriptionCRDSpecDomainServiceImplTest {
     }
 
     @Test
+    void should_create_with_metadata() {
+        givenExistingJWTPlan();
+
+        var metadata = Map.of("key1", "value1", "key2", "value2");
+        var specWithMetadata = SPEC.toBuilder().metadata(metadata).build();
+
+        when(subscriptionService.create(eq(EXECUTION_CONTEXT), any(), isNull(), eq(SUBSCRIPTION_ID))).thenReturn(
+            subscriptionAdapter.map(subscriptionAdapter.fromSpec(specWithMetadata))
+        );
+
+        subscriptionCrudService.initWith(
+            List.of(
+                subscriptionAdapter
+                    .fromSpec(specWithMetadata)
+                    .toBuilder()
+                    .status(SubscriptionEntity.Status.PENDING)
+                    .subscribedBy(USER_ID)
+                    .build()
+            )
+        );
+
+        cut.createOrUpdate(AUDIT_INFO, specWithMetadata);
+
+        SoftAssertions.assertSoftly(soft -> {
+            var subscription = subscriptionCrudService.get(SUBSCRIPTION_ID);
+            soft.assertThat(subscription).isNotNull();
+            soft.assertThat(subscription.getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
+            soft.assertThat(subscription.getMetadata()).isEqualTo(metadata);
+        });
+    }
+
+    @Test
     void should_update() {
         givenExistingJWTPlan();
 
@@ -201,6 +235,22 @@ class SubscriptionCRDSpecDomainServiceImplTest {
             soft.assertThat(subscriptionCrudService.get(SUBSCRIPTION_ID)).isNotNull();
             soft.assertThat(subscriptionCrudService.get(SUBSCRIPTION_ID).getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
         });
+    }
+
+    @Test
+    void should_update_metadata() {
+        givenExistingJWTPlan();
+
+        var existingEntity = subscriptionAdapter.map(
+            subscriptionAdapter.fromSpec(SPEC).toBuilder().status(SubscriptionEntity.Status.ACCEPTED).build()
+        );
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(existingEntity);
+
+        var metadata = Map.of("key1", "value1");
+        var result = cut.createOrUpdate(AUDIT_INFO, SPEC.toBuilder().metadata(metadata).build());
+
+        verify(subscriptionService).update(eq(EXECUTION_CONTEXT), any(io.gravitee.rest.api.model.UpdateSubscriptionEntity.class));
+        assertThat(result.getMetadata()).isEqualTo(metadata);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2511

- Subscription Metadata: Added a new metadata property, a Map<String, String>, to the SubscriptionCRDSpec to allow custom data to be associated with subscriptions.
- Data Mapping: Updated the SubscriptionAdapter to correctly map the new metadata field when converting SubscriptionCRDSpec to SubscriptionEntity.
- Metadata Persistence and Updates: Implemented logic in SubscriptionCRDSpecDomainServiceImpl to handle the persistence and updates of the metadata property for subscriptions.
- Test Coverage: Added comprehensive unit tests for SubscriptionAdapter and SubscriptionCRDSpecDomainServiceImpl to ensure the correct handling, mapping, creation, and updating of the metadata field.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

