### PR TITLE
Automation API to support subscription metadata

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionsResource.java
@@ -93,6 +93,7 @@ public class ApiSubscriptionsResource extends AbstractResource {
             .referenceType(SubscriptionReferenceType.API)
             .planId(legacy ? spec.getPlanHrid() : IdBuilder.builder(auditInfo, apiHrid).withExtraId(spec.getPlanHrid()).buildId())
             .endingAt(spec.getEndingAt() != null ? spec.getEndingAt().toZonedDateTime() : null)
+            .metadata(spec.getMetadata())
             .build();
 
         SubscriptionCRDStatus status = importSubscriptionSpecUseCase

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -838,6 +838,14 @@ components:
           type: string
           format: date-time
           example: "2040-12-25T09:12:28Z"
+        metadata:
+          type: object
+          description: Key-value metadata for this subscription.
+          additionalProperties:
+            type: string
+          examples:
+            - key1: value1
+              key2: value2
       required:
         - hrid
         - applicationHrid

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionResourceTest.java
@@ -15,8 +15,12 @@
  */
 package io.gravitee.apim.rest.api.automation.resource;
 
+import static io.gravitee.apim.core.subscription.model.SubscriptionEntity.Status.ACCEPTED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
 
 import fixtures.ApplicationModelFixtures;
 import fixtures.core.model.ApiFixtures;
@@ -26,12 +30,17 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
 import inmemory.SubscriptionCrudServiceInMemory;
+import io.gravitee.apim.core.subscription.model.crd.SubscriptionCRDStatus;
+import io.gravitee.apim.core.subscription.use_case.ImportSubscriptionSpecUseCase;
 import io.gravitee.apim.rest.api.automation.model.SubscriptionState;
 import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.IdBuilder;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
@@ -53,6 +62,9 @@ class ApiSubscriptionResourceTest extends AbstractResourceTest {
     @Autowired
     private PlanCrudServiceInMemory planCrudService;
 
+    @Autowired
+    private ImportSubscriptionSpecUseCase importSubscriptionSpecUseCase;
+
     static final String HRID = "subscription-hrid";
     static final String API_HRID = "api-hrid";
     static final String APPLICATION_HRID = "application-hrid";
@@ -64,6 +76,7 @@ class ApiSubscriptionResourceTest extends AbstractResourceTest {
         apiCrudService.reset();
         applicationCrudService.reset();
         planCrudService.reset();
+        reset(importSubscriptionSpecUseCase);
     }
 
     @Nested
@@ -231,6 +244,62 @@ class ApiSubscriptionResourceTest extends AbstractResourceTest {
         private void expectNotFound(String hrid) {
             try (var response = rootTarget().path(hrid).request().delete()) {
                 assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    @Nested
+    class PutDeletePut {
+
+        @Test
+        void should_handle_put_delete_put_lifecycle() {
+            when(importSubscriptionSpecUseCase.execute(any(ImportSubscriptionSpecUseCase.Input.class))).thenReturn(
+                new ImportSubscriptionSpecUseCase.Output(
+                    SubscriptionCRDStatus.builder()
+                        .id(IdBuilder.builder(new ExecutionContext(ORGANIZATION, ENVIRONMENT), API_HRID).withExtraId(HRID).buildId())
+                        .startingAt(Instant.now().atZone(ZoneOffset.UTC))
+                        .status(ACCEPTED.name())
+                        .organizationId(ORGANIZATION)
+                        .environmentId(ENVIRONMENT)
+                        .build()
+                )
+            );
+
+            subscriptionCrudService.initWith(
+                List.of(
+                    SubscriptionFixtures.aSubscription()
+                        .toBuilder()
+                        .id(IdBuilder.builder(new ExecutionContext(ORGANIZATION, ENVIRONMENT), API_HRID).withExtraId(HRID).buildId())
+                        .apiId(IdBuilder.builder(new ExecutionContext(ORGANIZATION, ENVIRONMENT), API_HRID).buildId())
+                        .applicationId(IdBuilder.builder(new ExecutionContext(ORGANIZATION, ENVIRONMENT), APPLICATION_HRID).buildId())
+                        .planId(IdBuilder.builder(new ExecutionContext(ORGANIZATION, ENVIRONMENT), PLAN_HRID).buildId())
+                        .build()
+                )
+            );
+
+            // PUT: create/update subscription
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("subscription-with-hrid.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+            }
+
+            // DELETE: close subscription
+            try (var response = rootTarget().path(HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+            }
+
+            // PUT again: should succeed (restore + update at domain service level)
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("subscription-with-hrid.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
             }
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImpl.java
@@ -54,7 +54,7 @@ public class SubscriptionCRDSpecDomainServiceImpl implements SubscriptionCRDSpec
     @Override
     public SubscriptionEntity createOrUpdate(AuditInfo auditInfo, SubscriptionCRDSpec spec) {
         return find(spec.getId())
-            .map((existing -> update(auditInfo, existing, spec)))
+            .map(existing -> update(auditInfo, existing, spec))
             .orElseGet(() -> create(auditInfo, spec));
     }
 
@@ -84,10 +84,15 @@ public class SubscriptionCRDSpecDomainServiceImpl implements SubscriptionCRDSpec
         }
 
         log.debug("Auto accepting subscription [{}]", spec.getId());
-        return acceptService.autoAccept(subscription.getId(), ZonedDateTime.now(), spec.getEndingAt(), ACCEPT_REASON, "", auditInfo);
+        return getAutoAccept(auditInfo, spec, subscription.getId());
     }
 
     private SubscriptionEntity update(AuditInfo auditInfo, SubscriptionEntity existing, SubscriptionCRDSpec spec) {
+        if (existing.getStatus() == SubscriptionEntity.Status.CLOSED) {
+            var restored = restoreAsAccepted(auditInfo, existing, spec);
+            return update(auditInfo, restored, spec);
+        }
+
         var update = existing.toBuilder().build();
 
         if (!Objects.equals(spec.getEndingAt(), existing.getEndingAt())) {
@@ -103,6 +108,16 @@ public class SubscriptionCRDSpecDomainServiceImpl implements SubscriptionCRDSpec
         subscriptionService.update(toExecutionContext(auditInfo), adapter.fromCoreForUpdate(update));
 
         return update;
+    }
+
+    private SubscriptionEntity restoreAsAccepted(AuditInfo auditInfo, SubscriptionEntity existing, SubscriptionCRDSpec spec) {
+        log.debug("Restoring closed subscription [{}]", spec.getId());
+        subscriptionService.restore(toExecutionContext(auditInfo), existing.getId());
+        return getAutoAccept(auditInfo, spec, existing.getId());
+    }
+
+    private SubscriptionEntity getAutoAccept(AuditInfo auditInfo, SubscriptionCRDSpec spec, String id) {
+        return acceptService.autoAccept(id, ZonedDateTime.now(), spec.getEndingAt(), ACCEPT_REASON, "", auditInfo);
     }
 
     private Optional<SubscriptionEntity> find(String id) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDSpecDomainServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -254,6 +255,34 @@ class SubscriptionCRDSpecDomainServiceImplTest {
     }
 
     @Test
+    void should_restore_AsAccepted_closed_subscription_on_update() {
+        givenExistingJWTPlan();
+
+        var closedEntity = subscriptionAdapter.map(
+            subscriptionAdapter.fromSpec(SPEC).toBuilder().status(SubscriptionEntity.Status.CLOSED).subscribedBy(USER_ID).build()
+        );
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(closedEntity);
+
+        // When restore is called on the mock, also update the in-memory crud service to PENDING
+        doAnswer(invocation -> {
+            subscriptionCrudService.update(
+                subscriptionCrudService.get(SUBSCRIPTION_ID).toBuilder().status(SubscriptionEntity.Status.PENDING).build()
+            );
+            return closedEntity;
+        })
+            .when(subscriptionService)
+            .restore(EXECUTION_CONTEXT, SUBSCRIPTION_ID);
+
+        var result = cut.createOrUpdate(AUDIT_INFO, SPEC);
+
+        verify(subscriptionService).restore(EXECUTION_CONTEXT, SUBSCRIPTION_ID);
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
+            soft.assertThat(subscriptionCrudService.get(SUBSCRIPTION_ID).getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
+        });
+    }
+
+    @Test
     void should_close_on_delete() {
         cut.delete(AUDIT_INFO, SPEC.getId());
 
@@ -276,10 +305,6 @@ class SubscriptionCRDSpecDomainServiceImplTest {
 
     private void givenExistingPlan(Plan plan) {
         planCrudService.initWith(List.of(plan));
-    }
-
-    private void givenExistingSubscription(SubscriptionEntity subscription) {
-        subscriptionCrudService.initWith(List.of(subscription));
     }
 
     private CloseSubscriptionDomainService closeSubscriptionDomainService() {


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/GKO-2515

## Description

- Add metadata (Map<String, String>) to SubscriptionSpec in the automation API OpenAPI spec
- Map metadata from SubscriptionSpec to SubscriptionCRDSpec in ApiSubscriptionsResource
- Restore CLOSED subscriptions in SubscriptionCRDSpecDomainServiceImpl before updating, fixing the PUT/DELETE/PUT lifecycle issue where re-importing a deleted subscription would fail
- Add domain service tests for restore of closed and rejected subscriptions
- Add endpoint test for PUT/DELETE/PUT lifecycle


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

