### PR TITLE
fix: get rid of unnecessary logging registration

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/DefaultExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/DefaultExecutionContext.java
@@ -19,15 +19,12 @@ import io.gravitee.el.TemplateVariableProvider;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.core.component.ComponentProvider;
-import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.logging.AbstractBaseExecutionContextAwareLogger;
 import io.gravitee.gateway.reactive.api.logging.ExecutionContextLazyLogger;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.node.logging.LogEntry;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
@@ -39,14 +36,6 @@ import org.slf4j.Logger;
  * @author GraviteeSource Team
  */
 public class DefaultExecutionContext extends AbstractExecutionContext<MutableRequest, MutableResponse> implements MutableExecutionContext {
-
-    private static final Set<Class<?>> CONTEXT_CLASSES;
-
-    static {
-        Set<Class<?>> classes = new HashSet<>();
-        collectParentClasses(DefaultExecutionContext.class, classes);
-        CONTEXT_CLASSES = Set.copyOf(classes);
-    }
 
     private ConcurrentHashMap<Logger, Logger> loggers;
 
@@ -108,25 +97,6 @@ public class DefaultExecutionContext extends AbstractExecutionContext<MutableReq
         );
     }
 
-    /**
-     * Collects all the parent classes and interfaces of the given class, adding them to the specified set.
-     * Avoids including duplicates and stops processing once the base class `BaseExecutionContext` is encountered.
-     *
-     * @param clazz the class whose parent classes and interfaces are to be collected
-     * @param classes the set that will contain the collected parent classes and interfaces
-     */
-    private static void collectParentClasses(Class<?> clazz, Set<Class<?>> classes) {
-        if (clazz == null) {
-            return;
-        }
-        if (classes.add(clazz) && !BaseExecutionContext.class.equals(clazz)) {
-            for (Class<?> inter : clazz.getInterfaces()) {
-                collectParentClasses(inter, classes);
-            }
-            collectParentClasses(clazz.getSuperclass(), classes);
-        }
-    }
-
     private class DefaultExecutionContextAwareLogger extends AbstractBaseExecutionContextAwareLogger<DefaultExecutionContext> {
 
         public DefaultExecutionContextAwareLogger(DefaultExecutionContext context, Logger logger) {
@@ -138,21 +108,6 @@ public class DefaultExecutionContext extends AbstractExecutionContext<MutableReq
             super.registerLogEntries(entries);
             if (logEntries != null) {
                 entries.addAll(logEntries);
-            }
-        }
-
-        /**
-         * Registers log sources for the provided map. This includes the {@link DefaultExecutionContext}
-         * and all parent classes defined in the static {@code CONTEXT_CLASSES} set.
-         *
-         * @param logSources the map where log sources are registered, mapping a class to an instance or context.
-         */
-        @Override
-        protected void registerLogSources(Map<Class<?>, Object> logSources) {
-            super.registerLogSources(logSources);
-            logSources.putIfAbsent(DefaultExecutionContext.class, context);
-            for (Class<?> clazz : CONTEXT_CLASSES) {
-                logSources.putIfAbsent(clazz, context);
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <gravitee-exchange.version>2.0.1</gravitee-exchange.version>
         <gravitee-expression-language.version>4.3.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>5.0.0-alpha.6</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>5.0.0</gravitee-gateway-api.version>
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.7.1</gravitee-kubernetes.version>
@@ -301,7 +301,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>10.0.0-alpha.3</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>6.0.0-alpha.6</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>6.0.0-alpha.7</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.0</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>2.0.0-alpha.3</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0-alpha.1</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12307

## Description

Initialization of Execution Context interface hierarchy is now computed at gravitee-gateway-api level. It allows to get rid of boilerplate in implementations.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

