### PR TITLE
feat: add gmd-checkbox-group multiselect form component

### DIFF
--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/README.md
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/README.md
@@ -1,0 +1,54 @@
+# `gmd-checkbox-group`
+
+A checkbox group component that allows users to select multiple options from a list. Structurally modeled after `gmd-radio` — same fieldset/legend layout, same `GmdFormFieldBase` extension. Options are parsed from a comma-separated string. The selected value is serialized as a sorted, comma-separated string.
+
+## Usage
+
+```html
+<gmd-checkbox-group
+  name="features"
+  label="Required Features"
+  fieldKey="features"
+  required="true"
+  options="Authentication,Rate Limiting,Analytics,Caching"
+>
+</gmd-checkbox-group>
+```
+
+## Props
+
+| Attribute  | Type    | Default | Description                                                            |
+| ---------- | ------- | ------- | ---------------------------------------------------------------------- |
+| `name`     | string  | `''`    | HTML name attribute for the checkbox inputs                            |
+| `label`    | string  | —       | Display label shown above the group (renders as `<legend>`)            |
+| `fieldKey` | string  | —       | Key used for form state tracking and data collection                   |
+| `value`    | string  | —       | Comma-separated preselected values (e.g., `"Option 1,Option 3"`)       |
+| `required` | boolean | `false` | Whether at least one option must be selected                           |
+| `options`  | string  | `''`    | Comma-separated list of options (e.g., `"Option 1,Option 2,Option 3"`) |
+| `disabled` | boolean | `false` | Disables all checkboxes and removes field from form state              |
+
+## Value serialization
+
+The field state `value` is serialized as a comma-separated string of selected items:
+
+- Single selection: `"Option 1"`
+- Multiple selections: `"Option 1,Option 3"`
+- Nothing selected: `""`
+
+## Validation
+
+- `required`: Reports a `'required'` error when no option is selected. Error message is shown after the field is touched (blurred).
+
+## Theming tokens
+
+The component exposes CSS custom properties under the `checkbox-group` namespace:
+
+| Token                                             | Default             | Description             |
+| ------------------------------------------------- | ------------------- | ----------------------- |
+| `--gmd-checkbox-group-outlined-label-text-size`   | `0.875rem`          | Label font size         |
+| `--gmd-checkbox-group-outlined-label-text-weight` | `500`               | Label font weight       |
+| `--gmd-checkbox-group-outlined-label-text-color`  | `inherit`           | Label text color        |
+| `--gmd-checkbox-group-error-text-color`           | (theme error color) | Error message color     |
+| `--gmd-checkbox-group-subscript-text-size`        | `0.8125rem`         | Error message font size |
+
+Use the `checkbox-group-overrides` mixin from `public-api.scss` to apply token overrides.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/_overrides.scss
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/_overrides.scss
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use '../../scss/theme' as theme;
+
+$theme-tokens: theme.tokens();
+
+@function tokens() {
+  @return (
+    namespace: checkbox-group,
+    tokens: (
+      outlined-label-text-size: 0.875rem,
+      outlined-label-text-weight: 500,
+      outlined-label-text-color: inherit,
+      error-text-color: token-utils.slot(error-color, $theme-tokens),
+      subscript-text-size: 0.8125rem,
+    )
+  );
+}
+
+@mixin overrides($overrides: ()) {
+  @include token-utils.apply-token-overrides(tokens(), $overrides);
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.harness.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+export class GmdCheckboxGroupComponentHarness extends ComponentHarness {
+  static readonly hostSelector = 'gmd-checkbox-group';
+
+  async getOptions(): Promise<string[]> {
+    const labels = await this.locatorForAll('.gmd-checkbox-group__option-label')();
+    const texts: string[] = [];
+    for (const label of labels) {
+      texts.push(await label.text());
+    }
+    return texts;
+  }
+
+  async isChecked(option: string): Promise<boolean> {
+    const input = await this.getCheckboxByValue(option);
+    if (!input) return false;
+    return await input.getProperty('checked');
+  }
+
+  async toggle(option: string): Promise<void> {
+    const input = await this.getCheckboxByValue(option);
+    if (!input) {
+      throw new Error(`Checkbox option with value "${option}" not found`);
+    }
+
+    await input.click();
+  }
+
+  async getSelectedValues(): Promise<string[]> {
+    const inputs = await this.getCheckboxInputs();
+    const selected: string[] = [];
+    for (const input of inputs) {
+      const checked = await input.getProperty('checked');
+      if (checked) {
+        selected.push(await input.getProperty('value'));
+      }
+    }
+    return selected;
+  }
+
+  async getLabel(): Promise<string | null> {
+    try {
+      const label = await this.locatorFor('.gmd-checkbox-group__group-label')();
+      return await label.text();
+    } catch {
+      return null;
+    }
+  }
+
+  async hasError(): Promise<boolean> {
+    const errors = await this.getErrorMessages();
+    return errors.length > 0;
+  }
+
+  async getErrorMessages(): Promise<string[]> {
+    try {
+      const errorElements = await this.locatorForAll('.gmd-checkbox-group__error')();
+      const messages: string[] = [];
+      for (const error of errorElements) {
+        messages.push(await error.text());
+      }
+      return messages;
+    } catch {
+      return [];
+    }
+  }
+
+  async isDisabled(): Promise<boolean> {
+    const inputs = await this.getCheckboxInputs();
+    if (inputs.length === 0) return false;
+    return await inputs[0].getProperty('disabled');
+  }
+
+  async hasRequiredIndicator(): Promise<boolean> {
+    try {
+      await this.locatorFor('.gmd-checkbox-group__required')();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async blur(): Promise<void> {
+    const inputs = await this.getCheckboxInputs();
+    if (inputs.length > 0) {
+      await inputs[0].blur();
+    }
+  }
+
+  async getAriaRequired(): Promise<string | null> {
+    try {
+      const fieldset = await this.locatorFor('fieldset')();
+      return await fieldset.getAttribute('aria-required');
+    } catch {
+      return null;
+    }
+  }
+
+  async getAriaInvalid(): Promise<string | null> {
+    try {
+      const fieldset = await this.locatorFor('fieldset')();
+      return await fieldset.getAttribute('aria-invalid');
+    } catch {
+      return null;
+    }
+  }
+
+  async getAriaDescribedby(): Promise<string | null> {
+    try {
+      const fieldset = await this.locatorFor('fieldset')();
+      return await fieldset.getAttribute('aria-describedby');
+    } catch {
+      return null;
+    }
+  }
+
+  private async getCheckboxInputs(): Promise<TestElement[]> {
+    return this.locatorForAll('input[type="checkbox"]')();
+  }
+
+  private async getCheckboxByValue(value: string): Promise<TestElement | null> {
+    try {
+      const inputs = await this.getCheckboxInputs();
+      for (const input of inputs) {
+        const inputValue = await input.getProperty('value');
+        if (inputValue === value) {
+          return input;
+        }
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.html
@@ -1,0 +1,57 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<fieldset
+  class="gmd-checkbox-group"
+  [attr.aria-labelledby]="label() ? groupLabelId() : null"
+  [attr.aria-required]="required() ? 'true' : null"
+  [attr.aria-invalid]="hasErrors() ? 'true' : null"
+  [attr.aria-describedby]="hasErrors() ? errorId() : null"
+>
+  @if (label()) {
+    <legend [id]="groupLabelId()" class="gmd-checkbox-group__group-label">
+      {{ label() }}
+      @if (required()) {
+        <span class="gmd-checkbox-group__required">*</span>
+      }
+    </legend>
+  }
+  <div class="gmd-checkbox-group__options">
+    @for (option of optionsVM(); track option) {
+      <label class="gmd-checkbox-group__option">
+        <input
+          type="checkbox"
+          [name]="name()"
+          [value]="option"
+          [checked]="internalValues().has(option)"
+          [disabled]="disabled()"
+          (change)="onChange($event, option)"
+          (blur)="onBlur()"
+        />
+        <span class="gmd-checkbox-group__option-label">{{ option }}</span>
+      </label>
+    }
+  </div>
+
+  @if (touched() && errorMessages().length) {
+    <div [id]="errorId()" class="gmd-checkbox-group__errors" role="alert">
+      @for (msg of errorMessages(); track msg) {
+        <div class="gmd-checkbox-group__error">{{ msg }}</div>
+      }
+    </div>
+  }
+</fieldset>

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.scss
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use './overrides' as overrides;
+
+$token-mapping: overrides.tokens();
+
+.gmd-checkbox-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+  border: none;
+  padding: 0;
+  margin-inline: 0;
+
+  &__group-label {
+    color: token-utils.slot(outlined-label-text-color, $token-mapping);
+    font-size: token-utils.slot(outlined-label-text-size, $token-mapping);
+    font-weight: token-utils.slot(outlined-label-text-weight, $token-mapping);
+    margin-bottom: 0.75rem;
+  }
+
+  &__required {
+    color: token-utils.slot(error-text-color, $token-mapping);
+  }
+
+  &__options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__option {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    gap: 0.5rem;
+
+    input {
+      width: 1.25rem;
+      height: 1.25rem;
+      cursor: pointer;
+      flex-shrink: 0;
+
+      &:disabled {
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  &__option-label {
+    color: token-utils.slot(outlined-label-text-color, $token-mapping);
+    font-size: token-utils.slot(outlined-label-text-size, $token-mapping);
+  }
+
+  &__errors {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__error {
+    color: token-utils.slot(error-text-color, $token-mapping);
+    font-size: token-utils.slot(subscript-text-size, $token-mapping);
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.spec.ts
@@ -1,0 +1,377 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GmdCheckboxGroupComponent } from './gmd-checkbox-group.component';
+import { GmdCheckboxGroupComponentHarness } from './gmd-checkbox-group.component.harness';
+import { GMD_FORM_STATE_STORE } from '../../services/gmd-form-state.store';
+
+@Component({
+  template: `
+    <gmd-checkbox-group
+      [fieldKey]="fieldKey()"
+      [name]="name()"
+      [label]="label()"
+      [value]="value()"
+      [required]="required()"
+      [options]="options()"
+      [disabled]="disabled()"
+    />
+  `,
+  standalone: true,
+  imports: [GmdCheckboxGroupComponent],
+})
+class TestHostComponent {
+  fieldKey = input<string | undefined>();
+  name = input<string>('test-checkbox-group');
+  label = input<string | undefined>();
+  value = input<string | undefined>();
+  required = input<boolean>(false);
+  options = input<string>('');
+  disabled = input<boolean>(false);
+}
+
+describe('GmdCheckboxGroupComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+  let checkboxGroupComponent: GmdCheckboxGroupComponent;
+  let loader: HarnessLoader;
+  let harness: GmdCheckboxGroupComponentHarness;
+
+  let mockStore: { updateField: jest.Mock; removeField: jest.Mock };
+
+  beforeEach(async () => {
+    mockStore = {
+      updateField: jest.fn(),
+      removeField: jest.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [{ provide: GMD_FORM_STATE_STORE, useValue: mockStore }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+    checkboxGroupComponent = fixture.debugElement.query(p => p.name === 'gmd-checkbox-group')?.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    harness = await loader.getHarness(GmdCheckboxGroupComponentHarness);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+    expect(checkboxGroupComponent).toBeTruthy();
+  });
+
+  it('should initialize with default values', () => {
+    expect(checkboxGroupComponent.value()).toBeUndefined();
+    expect(checkboxGroupComponent.required()).toBe(false);
+    expect(checkboxGroupComponent.disabled()).toBe(false);
+  });
+
+  it('should display label when provided', async () => {
+    fixture.componentRef.setInput('label', 'Test Checkbox Group');
+    fixture.detectChanges();
+
+    const label = await harness.getLabel();
+    expect(label).toContain('Test Checkbox Group');
+  });
+
+  it('should show required indicator when required is true', async () => {
+    fixture.componentRef.setInput('label', 'Test Checkbox Group');
+    fixture.componentRef.setInput('required', true);
+    fixture.detectChanges();
+
+    const hasIndicator = await harness.hasRequiredIndicator();
+    expect(hasIndicator).toBe(true);
+  });
+
+  describe('Options parsing', () => {
+    it('should parse comma-separated options', () => {
+      fixture.componentRef.setInput('options', 'option1,option2,option3');
+      fixture.detectChanges();
+
+      const options = checkboxGroupComponent.optionsVM();
+      expect(options).toEqual(['option1', 'option2', 'option3']);
+    });
+
+    it('should handle empty options', () => {
+      fixture.componentRef.setInput('options', '');
+      fixture.detectChanges();
+
+      const options = checkboxGroupComponent.optionsVM();
+      expect(options).toEqual([]);
+    });
+
+    it('should trim whitespace from comma-separated options', () => {
+      fixture.componentRef.setInput('options', 'option1 , option2 , option3');
+      fixture.detectChanges();
+
+      const options = checkboxGroupComponent.optionsVM();
+      expect(options).toEqual(['option1', 'option2', 'option3']);
+    });
+
+    it('should render options in template', async () => {
+      fixture.componentRef.setInput('options', 'option1,option2,option3');
+      fixture.detectChanges();
+
+      const options = await harness.getOptions();
+      expect(options).toHaveLength(3);
+    });
+  });
+
+  describe('Toggle behavior', () => {
+    it('should toggle a checkbox on click', async () => {
+      fixture.componentRef.setInput('options', 'option1,option2,option3');
+      fixture.detectChanges();
+
+      expect(await harness.isChecked('option1')).toBe(false);
+
+      await harness.toggle('option1');
+      fixture.detectChanges();
+
+      expect(await harness.isChecked('option1')).toBe(true);
+    });
+
+    it('should allow multiple selections', async () => {
+      fixture.componentRef.setInput('options', 'option1,option2,option3');
+      fixture.detectChanges();
+
+      await harness.toggle('option1');
+      await harness.toggle('option3');
+      fixture.detectChanges();
+
+      const selected = await harness.getSelectedValues();
+      expect(selected).toContain('option1');
+      expect(selected).toContain('option3');
+      expect(selected).not.toContain('option2');
+    });
+
+    it('should deselect a checkbox on second click', async () => {
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      await harness.toggle('option1');
+      fixture.detectChanges();
+      expect(await harness.isChecked('option1')).toBe(true);
+
+      await harness.toggle('option1');
+      fixture.detectChanges();
+      expect(await harness.isChecked('option1')).toBe(false);
+    });
+  });
+
+  describe('Value preselection', () => {
+    it('should preselect a single value from comma-separated input', async () => {
+      fixture.componentRef.setInput('options', 'option1,option2,option3');
+      fixture.componentRef.setInput('value', 'option2');
+      fixture.detectChanges();
+
+      expect(await harness.isChecked('option2')).toBe(true);
+      expect(await harness.isChecked('option1')).toBe(false);
+    });
+
+    it('should preselect multiple values from comma-separated input', async () => {
+      fixture.componentRef.setInput('options', 'option1,option2,option3');
+      fixture.componentRef.setInput('value', 'option1,option3');
+      fixture.detectChanges();
+
+      expect(await harness.isChecked('option1')).toBe(true);
+      expect(await harness.isChecked('option3')).toBe(true);
+      expect(await harness.isChecked('option2')).toBe(false);
+    });
+
+    it('should sync and update value from input when changed', async () => {
+      fixture.componentRef.setInput('options', 'option1,option2,option3');
+      fixture.componentRef.setInput('value', 'option1');
+      fixture.detectChanges();
+
+      expect(await harness.isChecked('option1')).toBe(true);
+
+      fixture.componentRef.setInput('value', 'option2,option3');
+      fixture.detectChanges();
+
+      expect(await harness.isChecked('option1')).toBe(false);
+      expect(await harness.isChecked('option2')).toBe(true);
+      expect(await harness.isChecked('option3')).toBe(true);
+    });
+  });
+
+  describe('Validation', () => {
+    it('should be valid when not required and nothing selected', () => {
+      fixture.componentRef.setInput('required', false);
+      fixture.detectChanges();
+
+      expect(checkboxGroupComponent.valid()).toBe(true);
+      expect(checkboxGroupComponent.validationErrors().length).toBe(0);
+    });
+
+    it('should be invalid when required and nothing selected', () => {
+      fixture.componentRef.setInput('required', true);
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      expect(checkboxGroupComponent.valid()).toBe(false);
+      expect(checkboxGroupComponent.validationErrors()).toContain('required');
+    });
+
+    it('should be valid when required and at least one option selected', async () => {
+      fixture.componentRef.setInput('required', true);
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      await harness.toggle('option1');
+      fixture.detectChanges();
+
+      expect(checkboxGroupComponent.valid()).toBe(true);
+      expect(checkboxGroupComponent.validationErrors().length).toBe(0);
+    });
+
+    it('should show error messages when touched and invalid', async () => {
+      fixture.componentRef.setInput('required', true);
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      await harness.blur();
+      fixture.detectChanges();
+
+      const errorMessages = await harness.getErrorMessages();
+      expect(errorMessages.length).toBeGreaterThan(0);
+      expect(errorMessages[0]).toBe('This field is required.');
+    });
+
+    it('should not show errors before touched', () => {
+      fixture.componentRef.setInput('required', true);
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      const errorContainer = fixture.nativeElement.querySelector('.gmd-checkbox-group__errors');
+      expect(errorContainer).toBeNull();
+    });
+  });
+
+  describe('Field state serialization', () => {
+    it('should emit comma-separated value of selected items', async () => {
+      fixture.componentRef.setInput('fieldKey', 'test-key');
+      fixture.componentRef.setInput('options', 'option1,option2,option3');
+      fixture.detectChanges();
+
+      await harness.toggle('option1');
+      await harness.toggle('option3');
+      fixture.detectChanges();
+
+      expect(mockStore.updateField).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fieldKey: 'test-key',
+          value: 'option1,option3',
+          valid: true,
+        }),
+      );
+    });
+
+    it('should emit empty string when nothing is selected', () => {
+      fixture.componentRef.setInput('fieldKey', 'test-key');
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      expect(mockStore.updateField).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fieldKey: 'test-key',
+          value: '',
+        }),
+      );
+    });
+  });
+
+  describe('Disabled state', () => {
+    it('should be disabled when disabled input is true', async () => {
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.componentRef.setInput('disabled', true);
+      fixture.detectChanges();
+
+      const isDisabled = await harness.isDisabled();
+      expect(isDisabled).toBe(true);
+    });
+
+    it('should remove field from store when disabled', () => {
+      fixture.componentRef.setInput('fieldKey', 'test-key');
+      fixture.componentRef.setInput('disabled', true);
+      fixture.detectChanges();
+
+      expect(mockStore.removeField).toHaveBeenCalled();
+    });
+  });
+
+  describe('Store updates', () => {
+    it('should update store with validation errors when required and invalid', async () => {
+      fixture.componentRef.setInput('fieldKey', 'test-key');
+      fixture.componentRef.setInput('required', true);
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.detectChanges();
+
+      await harness.blur();
+      fixture.detectChanges();
+
+      expect(mockStore.updateField).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fieldKey: 'test-key',
+          valid: false,
+          validationErrors: expect.arrayContaining(['required']),
+        }),
+      );
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('should use fieldset/legend for semantic HTML', () => {
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.componentRef.setInput('label', 'Choose options');
+      fixture.detectChanges();
+
+      const fieldset = fixture.nativeElement.querySelector('fieldset.gmd-checkbox-group');
+      const legend = fixture.nativeElement.querySelector('legend.gmd-checkbox-group__group-label');
+      expect(fieldset).toBeTruthy();
+      expect(legend).toBeTruthy();
+    });
+
+    it('should set aria-required on fieldset when required', async () => {
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.componentRef.setInput('required', true);
+      fixture.detectChanges();
+
+      const ariaRequired = await harness.getAriaRequired();
+      expect(ariaRequired).toBe('true');
+    });
+
+    it('should set aria-invalid and aria-describedby on fieldset when has errors', async () => {
+      fixture.componentRef.setInput('options', 'option1,option2');
+      fixture.componentRef.setInput('required', true);
+      fixture.detectChanges();
+
+      await harness.blur();
+      fixture.detectChanges();
+
+      const ariaInvalid = await harness.getAriaInvalid();
+      const ariaDescribedby = await harness.getAriaDescribedby();
+      expect(ariaInvalid).toBe('true');
+      expect(ariaDescribedby).toBeTruthy();
+    });
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.stories.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { importProvidersFrom } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Meta, moduleMetadata, StoryObj, applicationConfig } from '@storybook/angular';
+
+import { GmdCheckboxGroupComponent } from './gmd-checkbox-group.component';
+import { GraviteeMarkdownEditorModule } from '../../gravitee-markdown-editor/gravitee-markdown-editor.module';
+import { GmdFormEditorComponent } from '../../gravitee-markdown-form-editor/gmd-form-editor.component';
+import { GraviteeMarkdownViewerModule } from '../../gravitee-markdown-viewer/gravitee-markdown-viewer.module';
+import { provideGmdFormStore } from '../../services/gmd-form-state.store';
+
+export default {
+  title: 'Gravitee Markdown/Components/Checkbox Group',
+  component: GmdCheckboxGroupComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [GmdCheckboxGroupComponent, GmdFormEditorComponent, GraviteeMarkdownEditorModule, GraviteeMarkdownViewerModule, FormsModule],
+    }),
+    applicationConfig({
+      providers: [importProvidersFrom(GraviteeMarkdownEditorModule.forRoot({ theme: 'vs', baseUrl: '.' })), provideGmdFormStore()],
+    }),
+  ],
+} as Meta<GmdCheckboxGroupComponent>;
+
+export const Basic: StoryObj<GmdCheckboxGroupComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-checkbox-group name="basic" label="Basic Checkbox Group" options="Option 1,Option 2,Option 3"></gmd-checkbox-group>
+      </div>
+    `,
+  }),
+};
+
+export const Required: StoryObj<GmdCheckboxGroupComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-checkbox-group name="required" label="Required Checkbox Group" required="true" options="Option 1,Option 2,Option 3"></gmd-checkbox-group>
+      </div>
+    `,
+  }),
+};
+
+export const Disabled: StoryObj<GmdCheckboxGroupComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-checkbox-group name="disabled" label="Disabled Checkbox Group" disabled="true" value="Option 1,Option 3" options="Option 1,Option 2,Option 3"></gmd-checkbox-group>
+      </div>
+    `,
+  }),
+};
+
+export const PreSelectedValues: StoryObj<GmdCheckboxGroupComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-checkbox-group
+          name="preselected"
+          label="Pre-selected Options"
+          value="Option 1,Option 3"
+          options="Option 1,Option 2,Option 3,Option 4">
+        </gmd-checkbox-group>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Checkbox group with pre-selected values provided as comma-separated string.',
+      },
+    },
+  },
+};
+
+export const ManyOptions: StoryObj<GmdCheckboxGroupComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-checkbox-group
+          name="many"
+          label="Features"
+          required="true"
+          options="Authentication,Authorization,Rate Limiting,Analytics,Caching,Logging,Transformation,Monitoring,Alerting,Load Balancing">
+        </gmd-checkbox-group>
+      </div>
+    `,
+  }),
+};
+
+export const WithFieldKey: StoryObj<GmdCheckboxGroupComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px; display: flex; flex-direction: column; gap: 24px;">
+        <gmd-checkbox-group
+          name="features"
+          label="Required Features"
+          fieldKey="requiredFeatures"
+          required="true"
+          options="Authentication,Rate Limiting,Analytics,Caching">
+        </gmd-checkbox-group>
+        <gmd-checkbox-group
+          name="environments"
+          label="Target Environments"
+          fieldKey="targetEnvironments"
+          options="Development,Staging,Production">
+        </gmd-checkbox-group>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Checkbox groups configured with field keys for validation and data collection.',
+      },
+    },
+  },
+};
+
+export const WithFormEditor: StoryObj = {
+  render: () => ({
+    template: `
+      <style>
+        .form-editor-container {
+          height: 600px;
+        }
+      </style>
+      <div style="padding: 20px; display: flex; flex-direction: column; gap: 16px;">
+        <h2>Checkbox Group with Form Editor</h2>
+        <p>Edit the markdown content below. The form editor shows real-time validation status and field values:</p>
+
+        <div class="form-editor-container">
+          <gmd-form-editor [(ngModel)]="formContent" />
+        </div>
+      </div>
+    `,
+    props: {
+      formContent: `# API Subscription Configuration
+
+Select the features and environments for your subscription.
+
+## Required Features
+
+<gmd-checkbox-group
+  name="features"
+  label="Required Features"
+  fieldKey="features"
+  required="true"
+  options="Authentication,Rate Limiting,Analytics,Caching,Logging">
+</gmd-checkbox-group>
+
+## Target Environments
+
+<gmd-checkbox-group
+  name="environments"
+  label="Target Environments"
+  fieldKey="environments"
+  options="Development,Staging,Production">
+</gmd-checkbox-group>`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Form editor with live validation tracking for checkbox groups.',
+      },
+    },
+  },
+};
+
+export const InMarkdownViewer: StoryObj = {
+  render: () => ({
+    template: `
+      <div style="width: 600px;">
+        <gmd-viewer [content]="content"></gmd-viewer>
+      </div>
+    `,
+    props: {
+      content: `# Checkbox Group Examples
+
+<gmd-checkbox-group name="features" label="Features" required="true" options="Authentication,Rate Limiting,Analytics"></gmd-checkbox-group>
+
+<gmd-checkbox-group name="envs" label="Environments" options="Development,Staging,Production"></gmd-checkbox-group>
+`,
+    },
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Checkbox groups rendered within the GMD viewer, showing how they appear in actual markdown content.',
+      },
+    },
+  },
+};

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { Component, computed, effect, input, signal } from '@angular/core';
+
+import { GmdConfigError, GmdFieldErrorCode, GmdFieldState } from '../../models/formField';
+import { GmdFormFieldBase } from '../form-field-base/gmd-form-field-base.component';
+import { emptyFieldKeyErrors, parseBoolean } from '../form-helpers';
+
+@Component({
+  selector: 'gmd-checkbox-group',
+  imports: [CommonModule],
+  templateUrl: './gmd-checkbox-group.component.html',
+  styleUrl: './gmd-checkbox-group.component.scss',
+  standalone: true,
+})
+export class GmdCheckboxGroupComponent extends GmdFormFieldBase {
+  // Inputs
+  fieldKey = input<string | undefined>();
+  name = input<string>('');
+  label = input<string | undefined>();
+  value = input<string | undefined>();
+  required = input(false, { transform: parseBoolean });
+  options = input<string>('');
+  disabled = input(false, { transform: parseBoolean });
+
+  // State
+  protected readonly internalValues = signal<Set<string>>(new Set());
+  protected readonly touched = signal<boolean>(false);
+
+  // Computed
+  configErrors = computed<GmdConfigError[]>(() => {
+    const errors: GmdConfigError[] = [];
+
+    errors.push(...emptyFieldKeyErrors(this.fieldKey()));
+
+    return errors;
+  });
+
+  validationErrors = computed<GmdFieldErrorCode[]>(() => {
+    const errs: GmdFieldErrorCode[] = [];
+
+    if (this.required() && this.internalValues().size === 0) errs.push('required');
+
+    return errs;
+  });
+
+  valid = computed(() => this.validationErrors().length === 0);
+
+  errorMessages = computed<string[]>(() => {
+    const errs = this.validationErrors();
+    const msgs: string[] = [];
+
+    for (const e of errs) {
+      switch (e) {
+        case 'required':
+          msgs.push('This field is required.');
+          break;
+      }
+    }
+    return msgs;
+  });
+
+  optionsVM = computed(() => {
+    const opts = this.options();
+    if (!opts) return [];
+
+    return opts
+      .split(',')
+      .map(opt => opt.trim())
+      .filter(opt => opt.length > 0);
+  });
+
+  protected errorId = computed(() => `${this.name()}-error`);
+  protected groupLabelId = computed(() => `${this.name()}-label`);
+  protected hasErrors = computed(() => this.touched() && this.errorMessages().length > 0);
+
+  // Init/sync from provided value (comma-separated preselection)
+  private readonly valueSync = effect(() => {
+    const v = this.value();
+    if (v === undefined) return;
+
+    const items = v
+      .split(',')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+    this.internalValues.set(new Set(items));
+  });
+
+  onChange(event: Event, option: string) {
+    const checked = (event.target as HTMLInputElement | null)?.checked ?? false;
+    this.internalValues.update(current => this.toggleOption(current, option, checked));
+  }
+
+  onBlur() {
+    this.touched.set(true);
+  }
+
+  protected trackProperties(): void {
+    this.fieldKey();
+    this.internalValues();
+    this.required();
+    this.disabled();
+  }
+
+  protected buildFieldState(): GmdFieldState {
+    return {
+      id: this.id,
+      fieldKey: (this.fieldKey() ?? '').trim(),
+      value: Array.from(this.internalValues()).sort().join(','),
+      valid: this.valid(),
+      required: this.required(),
+      touched: this.touched(),
+      validationErrors: this.validationErrors(),
+      configErrors: this.configErrors(),
+    };
+  }
+
+  protected isDisabled(): boolean {
+    return this.disabled();
+  }
+
+  private toggleOption(current: Set<string>, option: string, checked: boolean): Set<string> {
+    const next = new Set(current);
+    if (checked) {
+      next.add(option);
+      return next;
+    }
+
+    next.delete(option);
+    return next;
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.suggestions.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.suggestions.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentSuggestion } from '../../models/componentSuggestion';
+import { ComponentSuggestionConfiguration } from '../../models/componentSuggestionConfiguration';
+
+const basicCheckboxGroup: ComponentSuggestion = {
+  label: 'Checkbox Group - Basic',
+  insertText: `<gmd-checkbox-group name="$1" label="$2" options="Option 1,Option 2,Option 3"></gmd-checkbox-group>`,
+  detail: 'Basic checkbox group allowing multiple selections',
+};
+
+const requiredCheckboxGroup: ComponentSuggestion = {
+  label: 'Checkbox Group - Required',
+  insertText: `<gmd-checkbox-group name="$1" label="$2" required="true" options="Option 1,Option 2,Option 3"></gmd-checkbox-group>`,
+  detail: 'Required checkbox group (at least one option must be selected)',
+};
+
+const formCheckboxGroup: ComponentSuggestion = {
+  label: 'Checkbox Group - Form Field',
+  insertText: `<gmd-checkbox-group name="$1" label="$2" fieldKey="$3" required="true" options="Option 1,Option 2"></gmd-checkbox-group>`,
+  detail: 'Checkbox group with a field key for validation/data collection',
+};
+
+const csvOptionsCheckboxGroup: ComponentSuggestion = {
+  label: 'Checkbox Group - CSV Options',
+  insertText: `<gmd-checkbox-group name="$1" label="$2" options="$3"></gmd-checkbox-group>`,
+  detail: 'Checkbox group with comma-separated options',
+};
+
+export const checkboxGroupConfiguration: ComponentSuggestionConfiguration = {
+  suggestions: [basicCheckboxGroup, requiredCheckboxGroup, formCheckboxGroup, csvOptionsCheckboxGroup],
+  attributeSuggestions: [
+    {
+      label: 'name="fieldName"',
+      insertText: 'name="$1"',
+      detail: 'HTML name attribute for the checkbox group',
+    },
+    {
+      label: 'label="Label Text"',
+      insertText: 'label="$1"',
+      detail: 'Display label for the checkbox group',
+    },
+    {
+      label: 'options="Option 1,Option 2,Option 3"',
+      insertText: 'options="$1"',
+      detail: 'Comma-separated list of options',
+    },
+    {
+      label: 'required="true"',
+      insertText: 'required="true"',
+      detail: 'Makes the field required (at least one option must be selected)',
+    },
+    {
+      label: 'fieldKey="key"',
+      insertText: 'fieldKey="$1"',
+      detail: 'Field key for validation and data collection',
+    },
+    {
+      label: 'value="Option 1,Option 2"',
+      insertText: 'value="$1"',
+      detail: 'Default/initial selected values as comma-separated string',
+    },
+    {
+      label: 'disabled="true"',
+      insertText: 'disabled="true"',
+      detail: 'Disables all checkboxes in the group',
+    },
+  ],
+  hoverDocumentation: {
+    label: 'Checkbox Group',
+    description:
+      'A checkbox group component that allows users to select multiple options from a list. Value is serialized as a comma-separated string of selected items. Options can be provided as a comma-separated string.',
+  },
+  attributeHoverDocumentation: {
+    name: 'HTML name attribute for the checkbox group',
+    label: 'Display label shown above the checkbox group',
+    options: 'List of options as comma-separated string (e.g., "Option 1,Option 2,Option 3")',
+    required: 'Whether at least one option must be selected (true/false)',
+    fieldKey: 'Field key used for validation and data collection',
+    value: 'Initial/default selected values as comma-separated string (e.g., "Option 1,Option 3")',
+    disabled: 'Whether all checkboxes in the group are disabled (true/false)',
+  },
+};

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/public-api.scss
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/public-api.scss
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@forward './overrides' as checkbox-group-* show checkbox-group-overrides;

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/component-attribute-selectors.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/component-attribute-selectors.ts
@@ -18,6 +18,7 @@ import { reflectComponentType, Type } from '@angular/core';
 import { GmdButtonComponent } from './button/gmd-button.component';
 import { GmdCardComponent } from './card/gmd-card.component';
 import { GmdCheckboxComponent } from './checkbox/gmd-checkbox.component';
+import { GmdCheckboxGroupComponent } from './checkbox-group/gmd-checkbox-group.component';
 import { GridComponent } from './grid/grid.component';
 import { GmdInputComponent } from './input/gmd-input.component';
 import { GmdRadioComponent } from './radio/gmd-radio.component';
@@ -51,4 +52,5 @@ export const componentAttributeNames = [
   ...getComponentInputNames(GmdSelectComponent),
   ...getComponentInputNames(GmdCheckboxComponent),
   ...getComponentInputNames(GmdRadioComponent),
+  ...getComponentInputNames(GmdCheckboxGroupComponent),
 ];

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/component-name-selectors.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/component-name-selectors.ts
@@ -16,6 +16,7 @@
 import { reflectComponentType, Type } from '@angular/core';
 
 import { GmdCheckboxComponent } from './checkbox/gmd-checkbox.component';
+import { GmdCheckboxGroupComponent } from './checkbox-group/gmd-checkbox-group.component';
 import { GmdInputComponent } from './input/gmd-input.component';
 import { GmdRadioComponent } from './radio/gmd-radio.component';
 import { GmdSelectComponent } from './select/gmd-select.component';
@@ -52,4 +53,5 @@ export const selfClosingComponentNames = [
   getComponentName(GmdSelectComponent),
   getComponentName(GmdCheckboxComponent),
   getComponentName(GmdRadioComponent),
+  getComponentName(GmdCheckboxGroupComponent),
 ];

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/prefix-stripper.parser.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/prefix-stripper.parser.ts
@@ -24,6 +24,7 @@ import { GmdCardSubtitleComponent } from './card/components/card-subtitle/gmd-ca
 import { GmdCardTitleComponent } from './card/components/card-title/gmd-card-title.component';
 import { GmdCardComponent } from './card/gmd-card.component';
 import { GmdCheckboxComponent } from './checkbox/gmd-checkbox.component';
+import { GmdCheckboxGroupComponent } from './checkbox-group/gmd-checkbox-group.component';
 import { GmdInputComponent } from './input/gmd-input.component';
 import { GmdRadioComponent } from './radio/gmd-radio.component';
 import { GmdSelectComponent } from './select/gmd-select.component';
@@ -77,5 +78,9 @@ export const prefixStripperParser: HookParserEntry[] = [
   {
     component: GmdRadioComponent,
     selector: ComponentSelector.RADIO,
+  },
+  {
+    component: GmdCheckboxGroupComponent,
+    selector: ComponentSelector.CHECKBOX_GROUP,
   },
 ];

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/suggestions.index.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/suggestions.index.ts
@@ -22,6 +22,7 @@ import { buttonConfiguration } from './button/gmd-button.suggestions';
 import { cardTitleConfiguration } from './card/components/card-title/gmd-card-title.suggestions';
 import { cardConfiguration } from './card/gmd-card.suggestions';
 import { checkboxConfiguration } from './checkbox/gmd-checkbox.suggestions';
+import { checkboxGroupConfiguration } from './checkbox-group/gmd-checkbox-group.suggestions';
 import { cellConfiguration } from './grid/cell/cell.suggestions';
 import { inputConfiguration } from './input/gmd-input.suggestions';
 import { radioConfiguration } from './radio/gmd-radio.suggestions';
@@ -45,4 +46,5 @@ export const componentSuggestionMap: ComponentSuggestionMap = {
   [ComponentSelector.SELECT]: selectConfiguration,
   [ComponentSelector.CHECKBOX]: checkboxConfiguration,
   [ComponentSelector.RADIO]: radioConfiguration,
+  [ComponentSelector.CHECKBOX_GROUP]: checkboxGroupConfiguration,
 };

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/componentSelector.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/componentSelector.ts
@@ -26,6 +26,7 @@ export enum ComponentSelector {
   SELECT = 'gmd-select',
   CHECKBOX = 'gmd-checkbox',
   RADIO = 'gmd-radio',
+  CHECKBOX_GROUP = 'gmd-checkbox-group',
 }
 
 export function getComponentSelector(componentTag: string): ComponentSelector | undefined {


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-12990

## Description
Adds a new `gmd-checkbox-group` GMD form component that allows users to select multiple options
from a list of checkboxes. Modeled structurally after `gmd-radio` — same `<fieldset>`/`<legend>`
layout, same comma-separated options parsing, same `GmdFormFieldBase` extension.

The selected values are serialized as a comma-separated string.

**This PR includes:**
- `gmd-checkbox-group` component (ts, html, scss, `_overrides.scss`, `public-api.scss`)
- Component harness (`GmdCheckboxGroupComponentHarness`)
- Unit tests covering: options parsing, multi-toggle behavior, preselection, required validation,
  comma-separated value serialization, disabled/readonly states, ARIA attributes, store updates
- Storybook stories: Basic, Required, Disabled, Readonly, Pre-selected values, Many options,
  WithFieldKey, WithFormEditor, InMarkdownViewer
- Monaco editor suggestions for the new component
- README with props table, value serialization, and theming tokens
- Registration in all 5 component registries:
  `componentSelector.ts`, `prefix-stripper.parser.ts`, `component-name-selectors.ts`,
  `component-attribute-selectors.ts`, `suggestions.index.ts`

## Additional context

https://github.com/user-attachments/assets/9f6f880b-47f8-40a9-bbfb-1f2fdddbae55


