### PR TITLE
fix: Application menu not showing up on first login

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -318,6 +318,12 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 membership.setCreatedAt(updateDate);
                 membership.setUpdatedAt(updateDate);
                 membershipRepository.create(membership);
+                invalidateRoleCache(
+                    membership.getReferenceType().name(),
+                    membership.getReferenceId(),
+                    membership.getMemberType().name(),
+                    membership.getMemberId()
+                );
                 createAuditLog(executionContext, MEMBERSHIP_CREATED, membership.getCreatedAt(), null, membership);
 
                 if (MembershipReferenceType.APPLICATION.equals(reference.getType())) {
@@ -393,6 +399,12 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 membership.setCreatedAt(updateDate);
                 membership.setUpdatedAt(updateDate);
                 membershipRepository.create(membership);
+                invalidateRoleCache(
+                    membership.getReferenceType().name(),
+                    membership.getReferenceId(),
+                    membership.getMemberType().name(),
+                    membership.getMemberId()
+                );
                 createAuditLog(executionContext, MEMBERSHIP_CREATED, membership.getCreatedAt(), null, membership);
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_AddRoleToMemberOnReferenceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_AddRoleToMemberOnReferenceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
@@ -57,6 +58,7 @@ import io.gravitee.rest.api.service.exceptions.NotAuthorizedMembershipException;
 import io.gravitee.rest.api.service.exceptions.RoleNotFoundException;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -495,5 +497,90 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
                 new MembershipService.MembershipRole(RoleScope.APPLICATION, "PRIMARY_OWNER")
             )
         ).isInstanceOf(NotAuthorizedMembershipException.class);
+    }
+
+    @Test
+    public void shouldInvalidateRoleCacheAfterAddingUserMembership() throws Exception {
+        // Reproduces the first-SSO-login bug: getRoles caches an empty set for a brand-new user,
+        // then addRoleToMemberOnReference creates the membership — the cache must be invalidated
+        // so that the next getRoles call returns the correct role from the DB.
+        String userId = "user-id";
+        String envId = "DEFAULT";
+
+        RoleEntity envRole = RoleEntity.builder()
+            .id("ENV_MEMBER")
+            .name("MEMBER")
+            .scope(RoleScope.ENVIRONMENT)
+            .permissions(Map.of())
+            .build();
+        when(roleService.findByScopeAndName(RoleScope.ENVIRONMENT, "MEMBER", GraviteeContext.getCurrentOrganization())).thenReturn(
+            Optional.of(envRole)
+        );
+        when(roleService.findById("ENV_MEMBER")).thenReturn(envRole);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        when(userService.findById(GraviteeContext.getExecutionContext(), userId)).thenReturn(userEntity);
+
+        Membership createdMembership = new Membership();
+        createdMembership.setId("membership-id");
+        createdMembership.setReferenceType(io.gravitee.repository.management.model.MembershipReferenceType.ENVIRONMENT);
+        createdMembership.setReferenceId(envId);
+        createdMembership.setMemberId(userId);
+        createdMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.USER);
+        createdMembership.setRoleId("ENV_MEMBER");
+
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceIdAndRoleId(
+                userId,
+                io.gravitee.repository.management.model.MembershipMemberType.USER,
+                io.gravitee.repository.management.model.MembershipReferenceType.ENVIRONMENT,
+                envId,
+                "ENV_MEMBER"
+            )
+        ).thenReturn(Collections.emptySet());
+
+        // 1st call: getRoles() loader (empty — no membership yet)
+        // 2nd call: userRolesOnReference check inside addRoleToMemberOnReference
+        // 3rd call: getUserMember() inside addRoleToMemberOnReference
+        // 4th call: getRoles() loader after cache invalidation
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
+                userId,
+                io.gravitee.repository.management.model.MembershipMemberType.USER,
+                io.gravitee.repository.management.model.MembershipReferenceType.ENVIRONMENT,
+                envId
+            )
+        ).thenReturn(Collections.emptySet(), Set.of(createdMembership), Set.of(createdMembership), Set.of(createdMembership));
+
+        when(membershipRepository.create(any())).thenReturn(createdMembership);
+        when(node.id()).thenReturn("node-id");
+
+        // Step 1: prime a stale empty cache entry for this user/environment
+        Set<RoleEntity> rolesBefore = membershipService.getRoles(
+            MembershipReferenceType.ENVIRONMENT,
+            envId,
+            MembershipMemberType.USER,
+            userId
+        );
+        assertTrue(rolesBefore.isEmpty(), "Cache should start empty for a brand-new user");
+
+        // Step 2: add the ENVIRONMENT membership (must invalidate the stale cache entry)
+        membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getExecutionContext(),
+            new MembershipService.MembershipReference(MembershipReferenceType.ENVIRONMENT, envId),
+            new MembershipService.MembershipMember(userId, null, MembershipMemberType.USER),
+            new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, "MEMBER")
+        );
+
+        // Step 3: getRoles must now reflect the new membership, not the stale empty cache
+        Set<RoleEntity> rolesAfter = membershipService.getRoles(
+            MembershipReferenceType.ENVIRONMENT,
+            envId,
+            MembershipMemberType.USER,
+            userId
+        );
+        assertFalse(rolesAfter.isEmpty(), "Role cache should have been invalidated after membership creation");
+        assertEquals(envRole, rolesAfter.iterator().next());
     }
 }


### PR DESCRIPTION
Problem
When a new user logs in for the first time via an OIDC/social identity provider (e.g. Keycloak), the Applications tab is missing from the developer portal navigation. It only appears after a manual page refresh.
Root Cause
In createNewExternalUser(), the user was created with addDefaultRole=false, meaning no default role was assigned at creation time. In 4.8.x, a request-scoped cache captured the user before roles were assigned by refreshUserMemberships(), causing GET /user to return empty permissions on first login.
Fix
Default roles are assigned before the user is cached.

https://gravitee.atlassian.net/browse/APIM-11810
