### PR TITLE
fix: invalidate password reset token after first use (APIM-13037)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/UserService.java
@@ -93,6 +93,15 @@ public interface UserService {
         String confirmationPageUrl
     );
 
+    Map<String, Object> getTokenRegistrationParams(
+        ExecutionContext executionContext,
+        UserEntity userEntity,
+        String portalUri,
+        ACTION action,
+        String confirmationPageUrl,
+        String passwordDigest
+    );
+
     UserEntity create(ExecutionContext executionContext, NewPreRegisterUserEntity newPreRegisterUserEntity);
 
     UserEntity createOrUpdateUserFromSocialIdentityProvider(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/JWTHelper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/JWTHelper.java
@@ -36,6 +36,7 @@ public interface JWTHelper {
         String LASTNAME = "lastname";
         String ACTION = "action";
         String ORG = "org";
+        String PASSWORD_DIGEST = "pwd_digest";
     }
 
     interface DefaultValues {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -149,6 +149,9 @@ import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.search.query.Query;
 import io.gravitee.rest.api.service.search.query.QueryBuilder;
 import jakarta.xml.bind.DatatypeConverter;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -168,6 +171,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.util.encoders.Hex;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -658,6 +662,15 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                     .orElseThrow(() -> new UserNotFoundException(username));
             }
 
+            // Verify the password digest to ensure the token hasn't already been used
+            String tokenPasswordDigest = jwt.getClaim(Claims.PASSWORD_DIGEST).asString();
+            if (tokenPasswordDigest != null) {
+                String currentDigest = computePasswordDigest(user.getPassword());
+                if (!tokenPasswordDigest.equals(currentDigest)) {
+                    throw new UserStateConflictException("Password reset token has already been used");
+                }
+            }
+
             // Set date fields
             user.setUpdatedAt(new Date());
 
@@ -690,6 +703,19 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 ex
             );
             throw new TechnicalManagementException(ex.getMessage(), ex);
+        }
+    }
+
+    static String computePasswordDigest(String passwordHash) {
+        if (passwordHash == null || passwordHash.isEmpty()) {
+            return "";
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(passwordHash.getBytes(StandardCharsets.UTF_8));
+            return Hex.toHexString(hash).substring(0, 16);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
         }
     }
 
@@ -1095,7 +1121,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         final String managementUri,
         final ACTION action
     ) {
-        return getTokenRegistrationParams(executionContext, userEntity, managementUri, action, null);
+        return getTokenRegistrationParams(executionContext, userEntity, managementUri, action, null, null);
     }
 
     @Override
@@ -1105,6 +1131,18 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
         final String managementUri,
         final ACTION action,
         final String targetPageUrl
+    ) {
+        return getTokenRegistrationParams(executionContext, userEntity, managementUri, action, targetPageUrl, null);
+    }
+
+    @Override
+    public Map<String, Object> getTokenRegistrationParams(
+        ExecutionContext executionContext,
+        final UserEntity userEntity,
+        final String managementUri,
+        final ACTION action,
+        final String targetPageUrl,
+        final String passwordDigest
     ) {
         // generate a JWT to store user's information and for security purpose
         final String jwtSecret = environment.getProperty("jwt.secret");
@@ -1123,7 +1161,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 )
             );
 
-        final String token = JWT.create()
+        var jwtBuilder = JWT.create()
             .withIssuer(environment.getProperty("jwt.issuer", DEFAULT_JWT_ISSUER))
             .withIssuedAt(issueAt)
             .withExpiresAt(Date.from(expireAt))
@@ -1131,8 +1169,13 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             .withClaim(Claims.EMAIL, userEntity.getEmail())
             .withClaim(Claims.FIRSTNAME, userEntity.getFirstname())
             .withClaim(Claims.LASTNAME, userEntity.getLastname())
-            .withClaim(Claims.ACTION, action.name())
-            .sign(algorithm);
+            .withClaim(Claims.ACTION, action.name());
+
+        if (passwordDigest != null) {
+            jwtBuilder = jwtBuilder.withClaim(Claims.PASSWORD_DIGEST, passwordDigest);
+        }
+
+        final String token = jwtBuilder.sign(algorithm);
 
         String userURL = "";
         String managementURL = installationAccessQueryService.getConsoleUrl(executionContext.getOrganizationId());
@@ -1523,12 +1566,14 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 }
             }
 
+            final String passwordDigest = computePasswordDigest(user.getPassword());
             final Map<String, Object> params = getTokenRegistrationParams(
                 executionContext,
                 convert(user, false),
                 RESET_PASSWORD_PATH,
                 RESET_PASSWORD,
-                resetPageUrl
+                resetPageUrl,
+                passwordDigest
             );
 
             notifierService.trigger(executionContext, PortalHook.PASSWORD_RESET, params);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -951,17 +951,21 @@ public class UserServiceTest {
         when(environment.getProperty("jwt.secret")).thenReturn(JWT_SECRET);
         when(passwordValidator.validate(anyString())).thenReturn(true);
 
+        String existingPasswordHash = "$2a$10$existingBcryptHash";
+        String passwordDigest = UserServiceImpl.computePasswordDigest(existingPasswordHash);
+
         User user = new User();
         user.setId("CUSTOM_LONG_ID");
         user.setEmail(EMAIL);
         user.setFirstname(FIRST_NAME);
         user.setLastname(LAST_NAME);
         user.setOrganizationId(ORGANIZATION);
+        user.setPassword(existingPasswordHash);
         when(userRepository.findById(USER_NAME)).thenReturn(Optional.of(user));
         when(userRepository.update(any())).thenAnswer(returnsFirstArg());
 
         ResetPasswordUserEntity userEntity = new ResetPasswordUserEntity();
-        userEntity.setToken(createJWT(System.currentTimeMillis() / 1000 + 100, RESET_PASSWORD.name()));
+        userEntity.setToken(createJWT(System.currentTimeMillis() / 1000 + 100, RESET_PASSWORD.name(), passwordDigest));
         userEntity.setPassword(PASSWORD);
 
         userService.finalizeResetPassword(EXECUTION_CONTEXT, userEntity);
@@ -970,6 +974,30 @@ public class UserServiceTest {
             eq(EXECUTION_CONTEXT),
             argThat(auditLogData -> auditLogData.getEvent().equals(PASSWORD_CHANGED))
         );
+    }
+
+    @Test(expected = UserStateConflictException.class)
+    public void changePassword_tokenAlreadyUsed() throws TechnicalException {
+        when(environment.getProperty("jwt.secret")).thenReturn(JWT_SECRET);
+
+        String originalPasswordHash = "$2a$10$originalBcryptHash";
+        String newPasswordHash = "$2a$10$newBcryptHashAfterReset";
+        String originalDigest = UserServiceImpl.computePasswordDigest(originalPasswordHash);
+
+        User user = new User();
+        user.setId("CUSTOM_LONG_ID");
+        user.setEmail(EMAIL);
+        user.setFirstname(FIRST_NAME);
+        user.setLastname(LAST_NAME);
+        user.setOrganizationId(ORGANIZATION);
+        user.setPassword(newPasswordHash);
+        when(userRepository.findById(USER_NAME)).thenReturn(Optional.of(user));
+
+        ResetPasswordUserEntity userEntity = new ResetPasswordUserEntity();
+        userEntity.setToken(createJWT(System.currentTimeMillis() / 1000 + 100, RESET_PASSWORD.name(), originalDigest));
+        userEntity.setPassword(PASSWORD);
+
+        userService.finalizeResetPassword(EXECUTION_CONTEXT, userEntity);
     }
 
     @Test(expected = PasswordFormatInvalidException.class)
@@ -1242,12 +1270,16 @@ public class UserServiceTest {
     }
 
     private String createJWT(long expirationSeconds, String action) {
+        return createJWT(expirationSeconds, action, null);
+    }
+
+    private String createJWT(long expirationSeconds, String action, String passwordDigest) {
         Algorithm algorithm = Algorithm.HMAC256(JWT_SECRET);
 
         Date issueAt = new Date();
         Instant expireAt = issueAt.toInstant().plus(Duration.ofSeconds(expirationSeconds));
 
-        return JWT.create()
+        var builder = JWT.create()
             .withIssuer(environment.getProperty("jwt.issuer", DEFAULT_JWT_ISSUER))
             .withIssuedAt(issueAt)
             .withExpiresAt(Date.from(expireAt))
@@ -1255,18 +1287,13 @@ public class UserServiceTest {
             .withClaim(JWTHelper.Claims.EMAIL, EMAIL)
             .withClaim(JWTHelper.Claims.FIRSTNAME, FIRST_NAME)
             .withClaim(JWTHelper.Claims.LASTNAME, LAST_NAME)
-            .withClaim(JWTHelper.Claims.ACTION, action)
-            .sign(algorithm);
-        /*
-        HashMap<String, Object> claims = new HashMap<>();
-        claims.put(JWTHelper.Claims.SUBJECT, USER_NAME);
-        claims.put(JWTHelper.Claims.EMAIL, EMAIL);
-        claims.put(JWTHelper.Claims.FIRSTNAME, FIRST_NAME);
-        claims.put(JWTHelper.Claims.LASTNAME, LAST_NAME);
-        claims.put(JWTHelper.Claims.ACTION, USER_REGISTRATION);
-        claims.put("exp", expirationSeconds);
-        return new JWTSigner(JWT_SECRET).sign(claims);
-         */
+            .withClaim(JWTHelper.Claims.ACTION, action);
+
+        if (passwordDigest != null) {
+            builder = builder.withClaim(JWTHelper.Claims.PASSWORD_DIGEST, passwordDigest);
+        }
+
+        return builder.sign(algorithm);
     }
 
     private String createJWT(long expirationSeconds) {


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13040
## Summary
- Embed a SHA-256 digest of the user's current password hash in the password reset JWT (`pwd_digest` claim)
- On reset, verify the digest still matches before allowing the password change — reused tokens are rejected with `UserStateConflictException`
- Backward compatible: tokens issued before this change (without the claim) are still accepted


