### PR TITLE
fix(gateway): handle HTTP/2 streaming requests without Content-Length in v4 emulation engine

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/invoker/EndpointInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/invoker/EndpointInvoker.java
@@ -17,19 +17,19 @@ package io.gravitee.gateway.core.invoker;
 
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.HttpVersion;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Invoker;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.endpoint.resolver.EndpointResolver;
 import io.gravitee.gateway.api.endpoint.resolver.ProxyEndpoint;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.proxy.ProxyConnection;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
 import io.gravitee.gateway.api.stream.ReadStream;
 import io.gravitee.gateway.core.logging.LoggableProxyConnectionDecorator;
 import io.gravitee.gateway.core.proxy.DirectProxyConnection;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import org.springframework.core.NestedExceptionUtils;
 
 /**
@@ -69,6 +69,18 @@ public class EndpointInvoker implements Invoker {
                 final ProxyRequest proxyRequest = endpoint.createProxyRequest(context.request(), proxyRequestBuilder ->
                     proxyRequestBuilder.method(getHttpMethod(context))
                 );
+
+                // HTTP/2 inbound requests may lack Content-Length and Transfer-Encoding headers.
+                // The legacy connector needs one of these to stream the body to the backend over HTTP/1.1.
+                // We skip gRPC requests (application/grpc) as they use HTTP/2 end-to-end.
+                if (
+                    context.request().version() == HttpVersion.HTTP_2 &&
+                    proxyRequest.headers().get(HttpHeaderNames.CONTENT_LENGTH) == null &&
+                    proxyRequest.headers().get(HttpHeaderNames.TRANSFER_ENCODING) == null &&
+                    !isGrpcRequest(proxyRequest)
+                ) {
+                    proxyRequest.headers().set(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+                }
 
                 endpoint
                     .connector()
@@ -113,5 +125,10 @@ public class EndpointInvoker implements Invoker {
             ExecutionContext.ATTR_REQUEST_METHOD
         );
         return (overrideMethod == null) ? context.request().method() : overrideMethod;
+    }
+
+    private static boolean isGrpcRequest(ProxyRequest request) {
+        String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        return contentType != null && contentType.startsWith("application/grpc");
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/invoker/EndpointInvokerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/core/invoker/EndpointInvokerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.core.invoker;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpVersion;
+import io.gravitee.gateway.api.Connector;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.endpoint.resolver.EndpointResolver;
+import io.gravitee.gateway.api.endpoint.resolver.ProxyEndpoint;
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.api.proxy.ProxyConnection;
+import io.gravitee.gateway.api.proxy.ProxyRequest;
+import io.gravitee.gateway.api.stream.ReadStream;
+import io.gravitee.reporter.api.http.Metrics;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EndpointInvokerTest {
+
+    @Mock
+    private EndpointResolver endpointResolver;
+
+    @Mock
+    private ExecutionContext context;
+
+    @Mock
+    private Request request;
+
+    @Mock
+    private ReadStream<Buffer> stream;
+
+    @Mock
+    private Handler<ProxyConnection> connectionHandler;
+
+    @Mock
+    private ProxyEndpoint proxyEndpoint;
+
+    @Mock
+    private ProxyRequest proxyRequest;
+
+    @Mock
+    private HttpHeaders proxyRequestHeaders;
+
+    @Mock
+    private Connector connector;
+
+    @Mock
+    private Metrics requestMetrics;
+
+    private EndpointInvoker cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new EndpointInvoker(endpointResolver);
+        lenient().when(context.request()).thenReturn(request);
+        lenient().when(request.method()).thenReturn(HttpMethod.PUT);
+        lenient().when(request.metrics()).thenReturn(requestMetrics);
+    }
+
+    @Test
+    void shouldAddTransferEncodingChunkedForHttp2RequestWithoutContentLength() {
+        when(endpointResolver.resolve(any())).thenReturn(proxyEndpoint);
+        when(proxyEndpoint.available()).thenReturn(true);
+        when(proxyEndpoint.createProxyRequest(eq(request), any(Function.class))).thenReturn(proxyRequest);
+        when(proxyEndpoint.connector()).thenReturn(connector);
+        when(proxyRequest.headers()).thenReturn(proxyRequestHeaders);
+        when(request.version()).thenReturn(HttpVersion.HTTP_2);
+        when(proxyRequestHeaders.get(HttpHeaderNames.CONTENT_LENGTH)).thenReturn(null);
+        when(proxyRequestHeaders.get(HttpHeaderNames.TRANSFER_ENCODING)).thenReturn(null);
+
+        cut.invoke(context, stream, connectionHandler);
+
+        verify(proxyRequestHeaders).set(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+    }
+
+    @Test
+    void shouldNotAddTransferEncodingForHttp2RequestWithContentLength() {
+        when(endpointResolver.resolve(any())).thenReturn(proxyEndpoint);
+        when(proxyEndpoint.available()).thenReturn(true);
+        when(proxyEndpoint.createProxyRequest(eq(request), any(Function.class))).thenReturn(proxyRequest);
+        when(proxyEndpoint.connector()).thenReturn(connector);
+        when(proxyRequest.headers()).thenReturn(proxyRequestHeaders);
+        when(request.version()).thenReturn(HttpVersion.HTTP_2);
+        when(proxyRequestHeaders.get(HttpHeaderNames.CONTENT_LENGTH)).thenReturn("42");
+
+        cut.invoke(context, stream, connectionHandler);
+
+        verify(proxyRequestHeaders, never()).set(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+    }
+
+    @Test
+    void shouldNotAddTransferEncodingForHttp1Request() {
+        when(endpointResolver.resolve(any())).thenReturn(proxyEndpoint);
+        when(proxyEndpoint.available()).thenReturn(true);
+        when(proxyEndpoint.createProxyRequest(eq(request), any(Function.class))).thenReturn(proxyRequest);
+        when(proxyEndpoint.connector()).thenReturn(connector);
+        lenient().when(proxyRequest.headers()).thenReturn(proxyRequestHeaders);
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+
+        cut.invoke(context, stream, connectionHandler);
+
+        verify(proxyRequestHeaders, never()).set(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+    }
+
+    @Test
+    void shouldNotAddTransferEncodingWhenAlreadyChunked() {
+        when(endpointResolver.resolve(any())).thenReturn(proxyEndpoint);
+        when(proxyEndpoint.available()).thenReturn(true);
+        when(proxyEndpoint.createProxyRequest(eq(request), any(Function.class))).thenReturn(proxyRequest);
+        when(proxyEndpoint.connector()).thenReturn(connector);
+        when(proxyRequest.headers()).thenReturn(proxyRequestHeaders);
+        when(request.version()).thenReturn(HttpVersion.HTTP_2);
+        when(proxyRequestHeaders.get(HttpHeaderNames.CONTENT_LENGTH)).thenReturn(null);
+        when(proxyRequestHeaders.get(HttpHeaderNames.TRANSFER_ENCODING)).thenReturn("chunked");
+
+        cut.invoke(context, stream, connectionHandler);
+
+        verify(proxyRequestHeaders, never()).set(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+    }
+
+    @Test
+    void shouldNotAddTransferEncodingForGrpcRequest() {
+        when(endpointResolver.resolve(any())).thenReturn(proxyEndpoint);
+        when(proxyEndpoint.available()).thenReturn(true);
+        when(proxyEndpoint.createProxyRequest(eq(request), any(Function.class))).thenReturn(proxyRequest);
+        when(proxyEndpoint.connector()).thenReturn(connector);
+        when(proxyRequest.headers()).thenReturn(proxyRequestHeaders);
+        when(request.version()).thenReturn(HttpVersion.HTTP_2);
+        when(proxyRequestHeaders.get(HttpHeaderNames.CONTENT_LENGTH)).thenReturn(null);
+        when(proxyRequestHeaders.get(HttpHeaderNames.TRANSFER_ENCODING)).thenReturn(null);
+        when(proxyRequestHeaders.get(HttpHeaderNames.CONTENT_TYPE)).thenReturn("application/grpc");
+
+        cut.invoke(context, stream, connectionHandler);
+
+        verify(proxyRequestHeaders, never()).set(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12924

## Description

  - Fix HTTP/2 streaming requests failing with `IllegalStateException` in the V4 Emulation
  Engine
  - When an HTTP/2 client sends a body without `Content-Length`, the legacy connector cannot
  stream it to the backend over HTTP/1.1
  - Add `Transfer-Encoding: chunked` on the proxy request so the legacy connector enables
  chunked writing

