### PR TITLE
fix(console): fetch full plan before reorder to preserve flows

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.spec.ts
@@ -229,6 +229,7 @@ describe('ApiPlanListComponent', () => {
 
         component.dropRow({ previousIndex: 1, currentIndex: 0 } as any);
 
+        expectApiPlanGetRequest(plan2);
         expectApiPlanUpdateRequest({ ...plan2, order: 1 });
         expectApiGetRequest();
         expectApiPlansListRequest(
@@ -248,6 +249,7 @@ describe('ApiPlanListComponent', () => {
 
         component.dropRow({ previousIndex: 1, currentIndex: 0 } as any);
 
+        expectApiPlanGetRequest(plan2);
         expectApiPlanUpdateRequestFail({ ...plan2, order: 1 });
         expectApiGetRequest();
         expectApiPlansListRequest(
@@ -258,6 +260,30 @@ describe('ApiPlanListComponent', () => {
           [...PLAN_STATUS],
         );
         expect(snackBarSpy).toHaveBeenCalled();
+      });
+
+      it('should preserve flows when reordering (APIM-13161)', async () => {
+        // Simulate list response with flows stripped (as returned by fields=-flow)
+        const plan1 = fakePlanV2({ name: 'Plan 1️⃣', order: 1, flows: [] });
+        const plan2 = fakePlanV2({ name: 'Plan 2️⃣', order: 2, flows: [] });
+        await initComponent([plan1, plan2]);
+
+        component.dropRow({ previousIndex: 1, currentIndex: 0 } as any);
+
+        // GET returns the full plan — fixture defaults include a Mock policy flow
+        const plan2WithFlows = fakePlanV2({ name: 'Plan 2️⃣', order: 2 });
+        expectApiPlanGetRequest(plan2, plan2WithFlows);
+
+        // PUT body must include the flows from the GET response, not the stripped list entry
+        expectApiPlanUpdateRequest({ ...plan2WithFlows, order: 1 });
+        expectApiGetRequest();
+        expectApiPlansListRequest(
+          [
+            { ...plan2, order: 1 },
+            { ...plan1, order: 2 },
+          ],
+          [...PLAN_STATUS],
+        );
       });
     });
 
@@ -781,6 +807,12 @@ describe('ApiPlanListComponent', () => {
         'GET',
       )
       .flush(response);
+    fixture.detectChanges();
+  }
+
+  function expectApiPlanGetRequest(plan: Plan, response: Plan = plan) {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${plan.id}`, 'GET');
+    req.flush(response);
     fixture.detectChanges();
   }
 

--- a/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/list/api-plan-list.component.ts
@@ -113,16 +113,18 @@ export class ApiPlanListComponent implements OnInit, OnDestroy {
     this.plansTableDS = [...currentData];
 
     const movedPlan = this.plansTableDS[event.currentIndex];
-    movedPlan.order = event.currentIndex + 1;
+    const newOrder = event.currentIndex + 1;
 
     this.plansService
-      .update(this.api.id, movedPlan.id, movedPlan)
+      .get(this.api.id, movedPlan.id)
       .pipe(
+        switchMap((fullPlan) => this.plansService.update(this.api.id, movedPlan.id, { ...fullPlan, order: newOrder })),
+        tap(() => this.ngOnInit()),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);
-          return of({});
+          this.ngOnInit();
+          return EMPTY;
         }),
-        tap(() => this.ngOnInit()),
         takeUntil(this.unsubscribe$),
       )
       .subscribe();


### PR DESCRIPTION
### Issue
https://gravitee.atlassian.net/browse/APIM-13161

### Summary
- Drag-and-drop a plan to reorder was wiping all plan flows (policies). The plan list endpoint excludes flows `fields=-flow`, so the table rows had flows: undefined. The old dropRow() sent that incomplete object directly to `PUT  /plans/{id}`, causing the backend to overwrite existing flows with an empty list.
- Fixed by fetching the full plan via `GET /plans/{id}` before the update, ensuring flows are always included in the `PUT` body.
- Hardened `catchError` to safely handle `non-HttpErrorResponse` errors (e.g. network timeouts) that would previously cause a secondary uncaught `TypeError`.
- Added a regression test that explicitly simulates the bug precondition: a flows-stripped plan in the table, with the `GET` response returning real flows, asserting they are preserved in the `PUT` body.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

