### PR TITLE
fix: if no details, do not show details sections

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.html
@@ -85,183 +85,185 @@
             </mat-card-content>
           </mat-card>
 
-          <h3>Headers</h3>
+          @if (hasDetailData()) {
+            <h3>Headers</h3>
 
-          <mat-card class="card">
-            <mat-card-content>
-              <h5>Request</h5>
-              <div class="card__container">
-                <div class="card__section">
-                  <span class="mat-body-strong">Consumer</span>
-                  <dl class="card__section__kv">
-                    <env-logs-details-row label="Method">
-                      @if (log.entrypointRequest?.method; as method) {
-                        <div [class]="'gio-method-badge-' + method.toLocaleLowerCase()">{{ method }}</div>
-                      } @else {
-                        —
+            <mat-card class="card">
+              <mat-card-content>
+                <h5>Request</h5>
+                <div class="card__container">
+                  <div class="card__section">
+                    <span class="mat-body-strong">Consumer</span>
+                    <dl class="card__section__kv">
+                      <env-logs-details-row label="Method">
+                        @if (log.entrypointRequest?.method; as method) {
+                          <div [class]="'gio-method-badge-' + method.toLocaleLowerCase()">{{ method }}</div>
+                        } @else {
+                          —
+                        }
+                      </env-logs-details-row>
+                      <env-logs-details-row label="URI">{{ log.entrypointRequest?.uri ?? '—' }}</env-logs-details-row>
+                    </dl>
+                    <div class="mat-body card__section__label">Headers</div>
+                    <dl class="card__section__kv card__section__kv--flush">
+                      @for (header of requestHeaders(); track header.key) {
+                        <env-logs-details-row [label]="header.key">{{ header.value }}</env-logs-details-row>
                       }
-                    </env-logs-details-row>
-                    <env-logs-details-row label="URI">{{ log.entrypointRequest?.uri ?? '—' }}</env-logs-details-row>
-                  </dl>
-                  <div class="mat-body card__section__label">Headers</div>
-                  <dl class="card__section__kv card__section__kv--flush">
-                    @for (header of requestHeaders(); track header.key) {
-                      <env-logs-details-row [label]="header.key">{{ header.value }}</env-logs-details-row>
-                    }
-                  </dl>
+                    </dl>
 
-                  <!-- Body for Consumer Request -->
-                  <div class="payload">
-                    <div class="mat-body card__section__label">Body</div>
-                    @if (requestBody()) {
-                      <div gioMonacoClipboardCopy class="editor">
-                        <gio-monaco-editor
-                          disabled
-                          [options]="monacoEditorOptions"
-                          [singleLineMode]="false"
-                          [ngModel]="requestBody()"
-                          [disableMiniMap]="true"
-                        ></gio-monaco-editor>
-                      </div>
-                    } @else {
-                      <p class="payload__empty">No request body captured.</p>
-                    }
+                    <!-- Body for Consumer Request -->
+                    <div class="payload">
+                      <div class="mat-body card__section__label">Body</div>
+                      @if (requestBody()) {
+                        <div gioMonacoClipboardCopy class="editor">
+                          <gio-monaco-editor
+                            disabled
+                            [options]="monacoEditorOptions"
+                            [singleLineMode]="false"
+                            [ngModel]="requestBody()"
+                            [disableMiniMap]="true"
+                          ></gio-monaco-editor>
+                        </div>
+                      } @else {
+                        <p class="payload__empty">No request body captured.</p>
+                      }
+                    </div>
+                  </div>
+
+                  <div class="card__section">
+                    <span class="mat-body-strong">Gateway</span>
+                    <dl class="card__section__kv">
+                      <env-logs-details-row label="Method">
+                        @if (log.endpointRequest?.method; as method) {
+                          <div [class]="'gio-method-badge-' + method.toLocaleLowerCase()">{{ method }}</div>
+                        } @else {
+                          —
+                        }
+                      </env-logs-details-row>
+                      <env-logs-details-row label="URI">{{ log.endpointRequest?.uri ?? '—' }}</env-logs-details-row>
+                    </dl>
+                    <div class="mat-body card__section__label">Headers</div>
+                    <dl class="card__section__kv card__section__kv--flush">
+                      @for (header of gatewayRequestHeaders(); track header.key) {
+                        <env-logs-details-row [label]="header.key">{{ header.value }}</env-logs-details-row>
+                      }
+                    </dl>
+
+                    <!-- Body for Gateway Request -->
+                    <div class="payload">
+                      <div class="mat-body card__section__label">Body</div>
+                      @if (gatewayRequestBody()) {
+                        <div gioMonacoClipboardCopy class="editor">
+                          <gio-monaco-editor
+                            disabled
+                            [options]="monacoEditorOptions"
+                            [singleLineMode]="false"
+                            [ngModel]="gatewayRequestBody()"
+                            [disableMiniMap]="true"
+                          ></gio-monaco-editor>
+                        </div>
+                      } @else {
+                        <p class="payload__empty">No request body captured.</p>
+                      }
+                    </div>
                   </div>
                 </div>
+              </mat-card-content>
+            </mat-card>
 
-                <div class="card__section">
-                  <span class="mat-body-strong">Gateway</span>
-                  <dl class="card__section__kv">
-                    <env-logs-details-row label="Method">
-                      @if (log.endpointRequest?.method; as method) {
-                        <div [class]="'gio-method-badge-' + method.toLocaleLowerCase()">{{ method }}</div>
-                      } @else {
-                        —
+            <mat-card class="card">
+              <mat-card-content>
+                <h5>Response</h5>
+                <div class="card__container">
+                  <div class="card__section">
+                    <span class="mat-body-strong">Response</span>
+                    <dl class="card__section__kv">
+                      <env-logs-details-row label="Status">
+                        @if (log.entrypointResponse?.status != null) {
+                          @let status = log.entrypointResponse!.status;
+                          <span
+                            [class.gio-badge-success]="status < 400"
+                            [class.gio-badge-warning]="status >= 400 && status <= 499"
+                            [class.gio-badge-error]="status >= 500 || status === 0"
+                            >{{ status }}</span
+                          >
+                        } @else {
+                          —
+                        }
+                      </env-logs-details-row>
+                    </dl>
+                    <div class="mat-body card__section__label">Headers</div>
+                    <dl class="card__section__kv card__section__kv--flush">
+                      @for (header of responseHeaders(); track header.key) {
+                        <env-logs-details-row [label]="header.key">{{ header.value }}</env-logs-details-row>
                       }
-                    </env-logs-details-row>
-                    <env-logs-details-row label="URI">{{ log.endpointRequest?.uri ?? '—' }}</env-logs-details-row>
-                  </dl>
-                  <div class="mat-body card__section__label">Headers</div>
-                  <dl class="card__section__kv card__section__kv--flush">
-                    @for (header of gatewayRequestHeaders(); track header.key) {
-                      <env-logs-details-row [label]="header.key">{{ header.value }}</env-logs-details-row>
-                    }
-                  </dl>
+                    </dl>
 
-                  <!-- Body for Gateway Request -->
-                  <div class="payload">
-                    <div class="mat-body card__section__label">Body</div>
-                    @if (gatewayRequestBody()) {
-                      <div gioMonacoClipboardCopy class="editor">
-                        <gio-monaco-editor
-                          disabled
-                          [options]="monacoEditorOptions"
-                          [singleLineMode]="false"
-                          [ngModel]="gatewayRequestBody()"
-                          [disableMiniMap]="true"
-                        ></gio-monaco-editor>
-                      </div>
-                    } @else {
-                      <p class="payload__empty">No request body captured.</p>
-                    }
+                    <!-- Body for Consumer -->
+                    <div class="payload">
+                      <div class="mat-body card__section__label">Body</div>
+                      @if (responseBody()) {
+                        <div gioMonacoClipboardCopy class="editor">
+                          <gio-monaco-editor
+                            disabled
+                            [options]="monacoEditorOptions"
+                            [singleLineMode]="false"
+                            [ngModel]="responseBody()"
+                            [disableMiniMap]="true"
+                          ></gio-monaco-editor>
+                        </div>
+                      } @else {
+                        <p class="payload__empty">No response body captured.</p>
+                      }
+                    </div>
+                  </div>
+
+                  <div class="card__section">
+                    <span class="mat-body-strong">Gateway</span>
+                    <dl class="card__section__kv">
+                      <env-logs-details-row label="Status">
+                        @if (log.endpointResponse?.status != null) {
+                          @let status = log.endpointResponse!.status;
+                          <span
+                            [class.gio-badge-success]="status < 400"
+                            [class.gio-badge-warning]="status >= 400 && status <= 499"
+                            [class.gio-badge-error]="status >= 500 || status === 0"
+                            >{{ status }}</span
+                          >
+                        } @else {
+                          —
+                        }
+                      </env-logs-details-row>
+                    </dl>
+                    <div class="mat-body card__section__label">Headers</div>
+                    <dl class="card__section__kv card__section__kv--flush">
+                      @for (header of gatewayResponseHeaders(); track header.key) {
+                        <env-logs-details-row [label]="header.key">{{ header.value }}</env-logs-details-row>
+                      }
+                    </dl>
+
+                    <!-- Body for Gateway -->
+                    <div class="payload">
+                      <div class="mat-body card__section__label">Body</div>
+                      @if (gatewayResponseBody()) {
+                        <div gioMonacoClipboardCopy class="editor">
+                          <gio-monaco-editor
+                            disabled
+                            [options]="monacoEditorOptions"
+                            [singleLineMode]="false"
+                            [ngModel]="gatewayResponseBody()"
+                            [disableMiniMap]="true"
+                          ></gio-monaco-editor>
+                        </div>
+                      } @else {
+                        <p class="payload__empty">No response body captured.</p>
+                      }
+                    </div>
                   </div>
                 </div>
-              </div>
-            </mat-card-content>
-          </mat-card>
-
-          <mat-card class="card">
-            <mat-card-content>
-              <h5>Response</h5>
-              <div class="card__container">
-                <div class="card__section">
-                  <span class="mat-body-strong">Response</span>
-                  <dl class="card__section__kv">
-                    <env-logs-details-row label="Status">
-                      @if (log.entrypointResponse?.status != null) {
-                        @let status = log.entrypointResponse!.status;
-                        <span
-                          [class.gio-badge-success]="status < 400"
-                          [class.gio-badge-warning]="status >= 400 && status <= 499"
-                          [class.gio-badge-error]="status >= 500 || status === 0"
-                          >{{ status }}</span
-                        >
-                      } @else {
-                        —
-                      }
-                    </env-logs-details-row>
-                  </dl>
-                  <div class="mat-body card__section__label">Headers</div>
-                  <dl class="card__section__kv card__section__kv--flush">
-                    @for (header of responseHeaders(); track header.key) {
-                      <env-logs-details-row [label]="header.key">{{ header.value }}</env-logs-details-row>
-                    }
-                  </dl>
-
-                  <!-- Body for Consumer -->
-                  <div class="payload">
-                    <div class="mat-body card__section__label">Body</div>
-                    @if (responseBody()) {
-                      <div gioMonacoClipboardCopy class="editor">
-                        <gio-monaco-editor
-                          disabled
-                          [options]="monacoEditorOptions"
-                          [singleLineMode]="false"
-                          [ngModel]="responseBody()"
-                          [disableMiniMap]="true"
-                        ></gio-monaco-editor>
-                      </div>
-                    } @else {
-                      <p class="payload__empty">No response body captured.</p>
-                    }
-                  </div>
-                </div>
-
-                <div class="card__section">
-                  <span class="mat-body-strong">Gateway</span>
-                  <dl class="card__section__kv">
-                    <env-logs-details-row label="Status">
-                      @if (log.endpointResponse?.status != null) {
-                        @let status = log.endpointResponse!.status;
-                        <span
-                          [class.gio-badge-success]="status < 400"
-                          [class.gio-badge-warning]="status >= 400 && status <= 499"
-                          [class.gio-badge-error]="status >= 500 || status === 0"
-                          >{{ status }}</span
-                        >
-                      } @else {
-                        —
-                      }
-                    </env-logs-details-row>
-                  </dl>
-                  <div class="mat-body card__section__label">Headers</div>
-                  <dl class="card__section__kv card__section__kv--flush">
-                    @for (header of gatewayResponseHeaders(); track header.key) {
-                      <env-logs-details-row [label]="header.key">{{ header.value }}</env-logs-details-row>
-                    }
-                  </dl>
-
-                  <!-- Body for Gateway -->
-                  <div class="payload">
-                    <div class="mat-body card__section__label">Body</div>
-                    @if (gatewayResponseBody()) {
-                      <div gioMonacoClipboardCopy class="editor">
-                        <gio-monaco-editor
-                          disabled
-                          [options]="monacoEditorOptions"
-                          [singleLineMode]="false"
-                          [ngModel]="gatewayResponseBody()"
-                          [disableMiniMap]="true"
-                        ></gio-monaco-editor>
-                      </div>
-                    } @else {
-                      <p class="payload__empty">No response body captured.</p>
-                    }
-                  </div>
-                </div>
-              </div>
-            </mat-card-content>
-          </mat-card>
+              </mat-card-content>
+            </mat-card>
+          }
         </div>
       </div>
     </div>

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.spec.ts
@@ -268,4 +268,37 @@ describe('EnvLogsDetailsComponent', () => {
     expect(await harness.getTitleText()).toContain('Log');
     expect(await harness.getStatusBadgeText()).toBe('200');
   });
+
+  it('should show the Headers section when detail data is present', async () => {
+    const { fixture: f, harness } = await createComponent();
+    flushRequests();
+    f.detectChanges();
+
+    expect(await harness.hasHeadersSection()).toBe(true);
+  });
+
+  it('should hide the Headers section when detail endpoint fails', async () => {
+    const { fixture: f, harness } = await createComponent();
+
+    expectSearchRequest().flush(MOCK_SEARCH_RESPONSE);
+    expectDetailRequest().flush('Not Found', { status: 404, statusText: 'Not Found' });
+    expectMetricsRequest().flush(MOCK_METRICS);
+    f.detectChanges();
+
+    expect(await harness.hasHeadersSection()).toBe(false);
+    // Overview should still be visible
+    expect(await harness.getTitleText()).toContain('Log');
+  });
+
+  it('should hide the Headers section when both detail and metrics endpoints fail', async () => {
+    const { fixture: f, harness } = await createComponent();
+
+    expectSearchRequest().flush(MOCK_SEARCH_RESPONSE);
+    expectDetailRequest().flush('Not Found', { status: 404, statusText: 'Not Found' });
+    expectMetricsRequest().flush('Not Found', { status: 404, statusText: 'Not Found' });
+    f.detectChanges();
+
+    expect(await harness.hasHeadersSection()).toBe(false);
+    expect(await harness.getStatusBadgeText()).toBe('200');
+  });
 });

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.ts
@@ -56,13 +56,10 @@ import { ApiAnalyticsV2Service } from '../../../../../services-ngx/api-analytics
   standalone: true,
 })
 export class EnvLogsDetailsComponent {
-  // 1. Injections
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly environmentLogsService = inject(EnvironmentLogsService);
   private readonly apiLogsV2Service = inject(ApiLogsV2Service);
   private readonly apiAnalyticsV2Service = inject(ApiAnalyticsV2Service);
-
-  // 2. State
   private readonly logId = this.activatedRoute.snapshot.params['logId'] as string | undefined;
   /**
    * The apiId query param acts as a guard: we only fetch data when both logId and apiId are present.
@@ -75,7 +72,6 @@ export class EnvLogsDetailsComponent {
   error = signal<string | null>(null);
   private loaded = signal(false);
 
-  // 3. Computed signals derived from the log signal
   log = toSignal(this.buildLogStream(), { initialValue: undefined });
   isLoading = computed(() => !this.loaded() && this.error() === null && !!this.logId && !!this.apiId);
 
@@ -87,6 +83,10 @@ export class EnvLogsDetailsComponent {
   responseBody = computed(() => this.log()?.entrypointResponse?.body ?? '');
   gatewayResponseHeaders = computed(() => this.formatHeaders(this.log()?.endpointResponse?.headers));
   gatewayResponseBody = computed(() => this.log()?.endpointResponse?.body ?? '');
+  hasDetailData = computed(() => {
+    const log = this.log();
+    return !!log?.entrypointRequest || !!log?.endpointRequest || !!log?.entrypointResponse || !!log?.endpointResponse;
+  });
 
   readonly monacoEditorOptions: editor.IStandaloneEditorConstructionOptions = {
     renderLineHighlight: 'none',
@@ -101,8 +101,6 @@ export class EnvLogsDetailsComponent {
       useShadows: false,
     },
   };
-
-  // 4. Private methods
 
   private buildLogStream(): Observable<EnvLog | undefined> {
     if (!this.logId || !this.apiId) {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.harness.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.harness.ts
@@ -66,4 +66,12 @@ export class EnvLogsDetailsHarness extends ComponentHarness {
     const loadingEl = await this.locatorForOptional('.logs-details__loading')();
     return loadingEl !== null;
   }
+
+  async hasHeadersSection(): Promise<boolean> {
+    const headers = await this.locatorForAll('h3')();
+    for (const h of headers) {
+      if ((await h.text()).trim() === 'Headers') return true;
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2608
## Description

Not necessarily a bug, but it's bothering me. Only show the section of the details page if there is anything to show. Otherwise, you see the section, but with every property blank. 

Updated to match behavior of runtime logs. 
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

