### PR TITLE
feat: add subscription form schema model, GMD parser, and submission validator

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactory.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.domain_service;
+
+import io.gravitee.apim.core.subscription_form.model.Constraint;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxGroupField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.Field;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.MaxLengthAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.MinLengthAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.OptionsAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.PatternAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.ReadOnlyValueAttribute;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds {@link SubscriptionFormFieldConstraints} from a parsed {@link SubscriptionFormSchema}.
+ *
+ * @author Gravitee.io Team
+ */
+public final class SubscriptionFormConstraintsFactory {
+
+    private SubscriptionFormConstraintsFactory() {}
+
+    public static SubscriptionFormFieldConstraints fromSchema(SubscriptionFormSchema schema) {
+        if (schema == null || schema.isEmpty()) {
+            return SubscriptionFormFieldConstraints.empty();
+        }
+        Map<String, List<Constraint>> map = new LinkedHashMap<>();
+        for (Field field : schema.fields()) {
+            map.put(field.fieldKey(), List.copyOf(constraintsFor(field)));
+        }
+        return new SubscriptionFormFieldConstraints(map);
+    }
+
+    private static List<Constraint> constraintsFor(Field field) {
+        if (field instanceof ReadOnlyValueAttribute ro && ro.readonlyValue() != null) {
+            return List.of(new Constraint.ReadOnly(ro.readonlyValue()));
+        }
+
+        var out = new ArrayList<Constraint>();
+
+        if (field.required()) {
+            if (field instanceof CheckboxField) {
+                out.add(new Constraint.MustBeTrue());
+            } else if (field instanceof CheckboxGroupField) {
+                out.add(new Constraint.NonEmptySelection());
+            } else {
+                out.add(new Constraint.Required());
+            }
+        }
+
+        if (field instanceof MinLengthAttribute min && min.minLength() != null) {
+            out.add(new Constraint.MinLength(min.minLength()));
+        }
+        if (field instanceof MaxLengthAttribute max && max.maxLength() != null) {
+            out.add(new Constraint.MaxLength(max.maxLength()));
+        }
+        if (field instanceof PatternAttribute pat && pat.pattern() != null) {
+            out.add(new Constraint.MatchesPattern(pat.pattern()));
+        }
+
+        if (field instanceof OptionsAttribute opt && hasOptions(opt.options())) {
+            if (field instanceof CheckboxGroupField) {
+                out.add(new Constraint.EachOf(opt.options()));
+            } else {
+                out.add(new Constraint.OneOf(opt.options()));
+            }
+        }
+
+        return out;
+    }
+
+    private static boolean hasOptions(List<String> options) {
+        return options != null && !options.isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSchemaGenerator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSchemaGenerator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.domain_service;
+
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+
+/**
+ * Parses GMD (Gravitee Markdown) content and extracts a {@link SubscriptionFormSchema}
+ * capturing the validation rules for each form field.
+ *
+ * <p>The implementation lives in the infrastructure layer because it depends on an HTML
+ * parsing library (Jsoup) to traverse the GMD element tree.</p>
+ *
+ * @author Gravitee.io Team
+ */
+public interface SubscriptionFormSchemaGenerator {
+    /**
+     * Parses the given GMD content and returns a schema describing all form fields
+     * and their validation constraints.
+     *
+     * @param gmdContent GMD value object whose raw content will be parsed
+     * @return a {@link SubscriptionFormSchema} with zero or more fields; never null
+     */
+    SubscriptionFormSchema generate(GraviteeMarkdown gmdContent);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSubmissionValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSubmissionValidator.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.domain_service;
+
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Validates a subscription form submission using {@link SubscriptionFormFieldConstraints}.
+ *
+ * <p>Prefer {@link #SubscriptionFormSubmissionValidator(SubscriptionFormFieldConstraints)} when constraints are
+ * loaded from storage; use {@link #SubscriptionFormSubmissionValidator(SubscriptionFormSchema)} to derive constraints
+ * from a schema in memory (e.g. tests).</p>
+ *
+ * <p>All field errors are collected before throwing so that the client receives a complete list of violations in a
+ * single response.</p>
+ *
+ * @author Gravitee.io Team
+ */
+public class SubscriptionFormSubmissionValidator {
+
+    private final SubscriptionFormFieldConstraints fieldConstraints;
+
+    public SubscriptionFormSubmissionValidator(SubscriptionFormSchema schema) {
+        this(SubscriptionFormConstraintsFactory.fromSchema(schema));
+    }
+
+    public SubscriptionFormSubmissionValidator(SubscriptionFormFieldConstraints fieldConstraints) {
+        this.fieldConstraints = fieldConstraints;
+    }
+
+    /**
+     * Validates the submitted key-value pairs.
+     *
+     * @param submittedValues field values keyed by fieldKey; must not be null. When a key is absent the value is
+     *                        treated as empty. If a key is present, its value must not be {@code null} (callers that
+     *                        build this map in domain code should normalize accordingly).
+     * @throws SubscriptionFormValidationException with all collected field errors when the submission is invalid
+     */
+    public void validate(Map<String, String> submittedValues) {
+        if (fieldConstraints.isEmpty()) {
+            return;
+        }
+        List<String> errors = fieldConstraints
+            .byFieldKey()
+            .entrySet()
+            .stream()
+            .flatMap(entry -> {
+                String fieldKey = entry.getKey();
+                String value = submittedValues.getOrDefault(fieldKey, "").trim();
+                return entry
+                    .getValue()
+                    .stream()
+                    .filter(c -> !c.check(value))
+                    .map(c -> c.formatErrorMessage(fieldKey, value))
+                    .filter(msg -> !msg.isEmpty());
+            })
+            .toList();
+
+        if (!errors.isEmpty()) {
+            throw new SubscriptionFormValidationException(errors);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/exception/SubscriptionFormValidationException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/exception/SubscriptionFormValidationException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import java.util.List;
+import java.util.Map;
+import lombok.Getter;
+
+/**
+ * Thrown when submitted subscription form values fail schema validation.
+ *
+ * <p>The REST layer maps this exception to an HTTP 400 response and includes
+ * the individual field errors in the response body.</p>
+ *
+ * @author Gravitee.io Team
+ */
+@Getter
+public class SubscriptionFormValidationException extends ValidationDomainException {
+
+    private final List<String> errors;
+
+    public SubscriptionFormValidationException(List<String> errors) {
+        this(errors, String.join(", ", errors));
+    }
+
+    private SubscriptionFormValidationException(List<String> errors, String joinedErrors) {
+        super("Subscription form submission is invalid: " + joinedErrors, Map.of("errors", joinedErrors));
+        this.errors = List.copyOf(errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/Constraint.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/Constraint.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.model;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Stream;
+
+/**
+ * A single validation rule for a subscription form field.
+ *
+ * <p>Constraints are extracted from a {@link SubscriptionFormSchema} at save time and persisted
+ * alongside the schema. At submission time the validator iterates the constraint map and calls
+ * {@link #validate(String, String)} — no schema knowledge required.</p>
+ *
+ * <p>Implementations split rule logic ({@link #check(String)}) from the human-readable message
+ * ({@link #formatErrorMessage(String, String)}); the default {@link #validate(String, String)} composes
+ * those as an empty list when {@link #check(String)} passes, or a one-element list otherwise.
+ * {@link EachOf} joins several per-value messages with newline ({@code \n}) inside that single string.</p>
+ *
+ * @author Gravitee.io Team
+ */
+public sealed interface Constraint
+    permits
+        Constraint.Required,
+        Constraint.MustBeTrue,
+        Constraint.NonEmptySelection,
+        Constraint.ReadOnly,
+        Constraint.MinLength,
+        Constraint.MaxLength,
+        Constraint.MatchesPattern,
+        Constraint.OneOf,
+        Constraint.EachOf {
+    /**
+     * Whether the submitted value satisfies this constraint. The value is already trimmed; an empty string means absent.
+     */
+    boolean check(String value);
+
+    /**
+     * Message when {@link #check(String)} is {@code false}. {@link EachOf} may return several lines separated by {@code \n}.
+     */
+    String formatErrorMessage(String fieldKey, String value);
+
+    /**
+     * Validates the given value against this constraint.
+     *
+     * @param fieldKey the field identifier (used in error messages)
+     * @param value    the submitted value, already trimmed; empty string when absent
+     * @return an empty list if the value is valid, or otherwise typically one message per constraint (several lines
+     *         in one string for {@link EachOf})
+     */
+    default List<String> validate(String fieldKey, String value) {
+        return check(value) ? List.of() : List.of(formatErrorMessage(fieldKey, value));
+    }
+
+    /** Text field must not be blank. */
+    record Required() implements Constraint {
+        @Override
+        public boolean check(String value) {
+            return !value.isEmpty();
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            return String.format("Field '%s' is required", fieldKey);
+        }
+    }
+
+    /** Checkbox must be checked ({@code "true"}). */
+    record MustBeTrue() implements Constraint {
+        @Override
+        public boolean check(String value) {
+            return "true".equals(value);
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            return String.format("Field '%s' is required", fieldKey);
+        }
+    }
+
+    /** Checkbox-group must have at least one selected value in a comma-separated string. */
+    record NonEmptySelection() implements Constraint {
+        @Override
+        public boolean check(String value) {
+            return splitCsv(value).findAny().isPresent();
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            return String.format("Field '%s' is required", fieldKey);
+        }
+    }
+
+    /** Field value must equal the preset read-only reference. */
+    record ReadOnly(String reference) implements Constraint {
+        @Override
+        public boolean check(String value) {
+            return reference.equals(value);
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            return String.format("Field '%s': read-only field cannot be modified", fieldKey);
+        }
+    }
+
+    /** Value must be at least {@code min} characters long (skipped when empty). */
+    record MinLength(int min) implements Constraint {
+        @Override
+        public boolean check(String value) {
+            return value.isEmpty() || value.length() >= min;
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            return String.format("Field '%s' must be at least %d characters long", fieldKey, min);
+        }
+    }
+
+    /** Value must be at most {@code max} characters long (skipped when empty). */
+    record MaxLength(int max) implements Constraint {
+        @Override
+        public boolean check(String value) {
+            return value.isEmpty() || value.length() <= max;
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            return String.format("Field '%s' must be at most %d characters long", fieldKey, max);
+        }
+    }
+
+    /** Value must match the given regular expression (skipped when empty). */
+    record MatchesPattern(String pattern) implements Constraint {
+        @Override
+        public boolean check(String value) {
+            if (value.isEmpty()) {
+                return true;
+            }
+            try {
+                return value.matches(pattern);
+            } catch (PatternSyntaxException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            if (value.isEmpty()) {
+                return "";
+            }
+            try {
+                return value.matches(pattern) ? "" : String.format("Field '%s' does not match the required pattern", fieldKey);
+            } catch (PatternSyntaxException e) {
+                return String.format("Field '%s' has an invalid pattern configuration", fieldKey);
+            }
+        }
+    }
+
+    /** Single value must be one of the allowed options (skipped when empty). */
+    record OneOf(List<String> options) implements Constraint {
+        @Override
+        public boolean check(String value) {
+            return options == null || options.isEmpty() || value.isEmpty() || options.contains(value);
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            return String.format("Field '%s': value '%s' is not among the allowed options", fieldKey, value);
+        }
+    }
+
+    /** Every value in a comma-separated string must be one of the allowed options (skipped when empty). */
+    record EachOf(List<String> options) implements Constraint {
+        @Override
+        public boolean check(String value) {
+            if (options == null || options.isEmpty() || value.isEmpty()) {
+                return true;
+            }
+            Set<String> allowed = new HashSet<>(options);
+            return splitCsv(value).allMatch(allowed::contains);
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            if (options == null || options.isEmpty() || value.isEmpty()) {
+                return "";
+            }
+            Set<String> allowed = new HashSet<>(options);
+            var lines = splitCsv(value)
+                .filter(item -> !allowed.contains(item))
+                .map(item -> String.format("Field '%s': value '%s' is not among the allowed options", fieldKey, item))
+                .toList();
+            return String.join("\n", lines);
+        }
+    }
+
+    private static Stream<String> splitCsv(String value) {
+        return Arrays.stream(value.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/SubscriptionFormFieldConstraints.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/SubscriptionFormFieldConstraints.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.model;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Validation rules per field key, derived from a {@link SubscriptionFormSchema}.
+ * Intended for persistence and submit-time validation without re-parsing GMD or walking schema field types.
+ *
+ * @author Gravitee.io Team
+ */
+public record SubscriptionFormFieldConstraints(Map<String, List<Constraint>> byFieldKey) {
+    private static final SubscriptionFormFieldConstraints EMPTY = new SubscriptionFormFieldConstraints(Map.of());
+
+    public SubscriptionFormFieldConstraints {
+        Objects.requireNonNull(byFieldKey);
+        var copy = new LinkedHashMap<String, List<Constraint>>();
+        for (var e : byFieldKey.entrySet()) {
+            copy.put(e.getKey(), List.copyOf(e.getValue()));
+        }
+        byFieldKey = Collections.unmodifiableMap(copy);
+    }
+
+    public static SubscriptionFormFieldConstraints empty() {
+        return EMPTY;
+    }
+
+    public boolean isEmpty() {
+        return byFieldKey.isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/SubscriptionFormSchema.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/SubscriptionFormSchema.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.model;
+
+import java.util.List;
+
+/**
+ * Represents the validation schema extracted from a subscription form's GMD content.
+ *
+ * <p>The schema captures field-level validation rules (required, length constraints, allowed values)
+ * for use at subscription submit time. It is generated from the GMD content when the form is saved
+ * and persisted alongside the form content.</p>
+ *
+ * <p>At subscription time, submitted values are validated against this schema without reparsing
+ * the GMD template.</p>
+ *
+ * @author Gravitee.io Team
+ */
+public record SubscriptionFormSchema(List<Field> fields) {
+    public boolean isEmpty() {
+        return fields == null || fields.isEmpty();
+    }
+
+    public interface RequiredAttribute {
+        boolean required();
+    }
+
+    public interface ReadOnlyValueAttribute {
+        String readonlyValue();
+    }
+
+    public interface MinLengthAttribute {
+        Integer minLength();
+    }
+
+    public interface MaxLengthAttribute {
+        Integer maxLength();
+    }
+
+    public interface PatternAttribute {
+        String pattern();
+    }
+
+    public interface OptionsAttribute {
+        List<String> options();
+    }
+
+    /**
+     * Marker interface for all field types in a subscription form schema.
+     * Each implementation captures only the validation attributes relevant to its component type.
+     */
+    public sealed interface Field
+        extends RequiredAttribute
+        permits InputField, TextareaField, SelectField, RadioField, CheckboxField, CheckboxGroupField {
+        String fieldKey();
+    }
+
+    /** Text input — supports required, readonly, minLength, maxLength, pattern. */
+    public record InputField(
+        String fieldKey,
+        boolean required,
+        String readonlyValue,
+        Integer minLength,
+        Integer maxLength,
+        String pattern
+    ) implements Field, ReadOnlyValueAttribute, MinLengthAttribute, MaxLengthAttribute, PatternAttribute {}
+
+    /** Multi-line textarea — supports required, readonly, minLength, maxLength. */
+    public record TextareaField(String fieldKey, boolean required, String readonlyValue, Integer minLength, Integer maxLength) implements
+        Field, ReadOnlyValueAttribute, MinLengthAttribute, MaxLengthAttribute {}
+
+    /** Single-value dropdown — supports required, options. No readonly (not supported by the GMD component). */
+    public record SelectField(String fieldKey, boolean required, List<String> options) implements Field, OptionsAttribute {}
+
+    /** Single-value radio group — supports required, readonly, options. */
+    public record RadioField(String fieldKey, boolean required, String readonlyValue, List<String> options) implements
+        Field, ReadOnlyValueAttribute, OptionsAttribute {}
+
+    /** Boolean checkbox — supports required, readonly. Value is "true"/"false". */
+    public record CheckboxField(String fieldKey, boolean required, String readonlyValue) implements Field, ReadOnlyValueAttribute {}
+
+    /** Multi-value checkbox group — supports required, options. No readonly (not supported by the GMD component). */
+    public record CheckboxGroupField(String fieldKey, boolean required, List<String> options) implements Field, OptionsAttribute {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormSchemaGeneratorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormSchemaGeneratorImpl.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.subscription_form;
+
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxGroupField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.Field;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.InputField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.RadioField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.SelectField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.TextareaField;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Service;
+
+/**
+ * Parses GMD content using Jsoup and extracts validation-relevant field attributes
+ * into a {@link SubscriptionFormSchema}.
+ *
+ * <p>Only the following GMD components are recognized as form fields:
+ * {@code gmd-input}, {@code gmd-textarea}, {@code gmd-select}, {@code gmd-radio},
+ * {@code gmd-checkbox}, {@code gmd-checkbox-group}.</p>
+ *
+ * <p>UI-only attributes (label, placeholder, disabled, rows, type) are
+ * intentionally not captured in the schema.</p>
+ *
+ * @author Gravitee.io Team
+ */
+@Service
+public class SubscriptionFormSchemaGeneratorImpl implements SubscriptionFormSchemaGenerator {
+
+    private static final Set<String> FORM_FIELD_TAGS = Set.of(
+        "gmd-input",
+        "gmd-textarea",
+        "gmd-select",
+        "gmd-radio",
+        "gmd-checkbox",
+        "gmd-checkbox-group"
+    );
+
+    @Override
+    public SubscriptionFormSchema generate(GraviteeMarkdown gmdContent) {
+        String raw = gmdContent.value();
+        if (raw == null || raw.isBlank()) {
+            return new SubscriptionFormSchema(List.of());
+        }
+
+        List<Field> fields = Jsoup.parseBodyFragment(raw)
+            .body()
+            .getAllElements()
+            .stream()
+            .filter(el -> FORM_FIELD_TAGS.contains(el.tagName()))
+            .map(this::toFieldSchema)
+            .toList();
+
+        return new SubscriptionFormSchema(fields);
+    }
+
+    private Field toFieldSchema(Element el) {
+        String fieldKey = el.attr("fieldkey").trim();
+        if (fieldKey.isEmpty()) {
+            throw new IllegalArgumentException("GMD form field is missing required 'fieldkey' attribute for element: " + el.tagName());
+        }
+        boolean required = Boolean.parseBoolean(el.attr("required"));
+
+        return switch (el.tagName()) {
+            case "gmd-input" -> new InputField(
+                fieldKey,
+                required,
+                parseReadonlyValue(el, fieldKey),
+                parseNullableInt(el, "minlength"),
+                parseNullableInt(el, "maxlength"),
+                el.hasAttr("pattern") ? el.attr("pattern").trim() : null
+            );
+            case "gmd-textarea" -> new TextareaField(
+                fieldKey,
+                required,
+                parseReadonlyValue(el, fieldKey),
+                parseNullableInt(el, "minlength"),
+                parseNullableInt(el, "maxlength")
+            );
+            case "gmd-select" -> new SelectField(fieldKey, required, parseOptions(el));
+            case "gmd-radio" -> new RadioField(fieldKey, required, parseReadonlyValue(el, fieldKey), parseOptions(el));
+            case "gmd-checkbox" -> new CheckboxField(fieldKey, required, parseReadonlyValue(el, fieldKey));
+            case "gmd-checkbox-group" -> new CheckboxGroupField(fieldKey, required, parseOptions(el));
+            default -> throw new IllegalArgumentException("Unknown GMD form field tag: " + el.tagName());
+        };
+    }
+
+    private String parseReadonlyValue(Element el, String fieldKey) {
+        boolean readonly = Boolean.parseBoolean(el.attr("readonly"));
+        if (readonly && !el.hasAttr("value")) {
+            throw new IllegalArgumentException("Readonly field '" + fieldKey + "' (" + el.tagName() + ") must have a 'value' attribute");
+        }
+        return readonly ? el.attr("value").trim() : null;
+    }
+
+    private List<String> parseOptions(Element el) {
+        return el.hasAttr("options") ? parseCommaList(el.attr("options")) : null;
+    }
+
+    private Integer parseNullableInt(Element el, String attrName) {
+        if (!el.hasAttr(attrName)) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(el.attr(attrName).trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private List<String> parseCommaList(String raw) {
+        return Arrays.stream(raw.split(","))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .toList();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactoryTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.subscription_form.model.Constraint;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxGroupField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.InputField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.RadioField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.SelectField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.TextareaField;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionFormConstraintsFactoryTest {
+
+    @Test
+    void should_return_empty_when_schema_is_null() {
+        assertThat(SubscriptionFormConstraintsFactory.fromSchema(null).isEmpty()).isTrue();
+    }
+
+    @Test
+    void should_return_empty_when_schema_has_no_fields() {
+        var schema = new SubscriptionFormSchema(List.of());
+        assertThat(SubscriptionFormConstraintsFactory.fromSchema(schema).isEmpty()).isTrue();
+    }
+
+    @Test
+    void should_map_readonly_input_to_single_read_only_constraint() {
+        var schema = new SubscriptionFormSchema(List.of(new InputField("ref", false, "REF-1", 1, 9, ".*")));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("ref")).containsExactly(new Constraint.ReadOnly("REF-1"));
+    }
+
+    @Test
+    void should_ignore_required_and_options_when_radio_is_readonly() {
+        var schema = new SubscriptionFormSchema(List.of(new RadioField("plan", true, "Free", List.of("Free", "Pro"))));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("plan")).containsExactly(new Constraint.ReadOnly("Free"));
+    }
+
+    @Test
+    void should_stack_input_constraints_in_defined_order() {
+        var schema = new SubscriptionFormSchema(List.of(new InputField("code", true, null, 2, 10, "[A-Z]+")));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("code")).containsExactly(
+            new Constraint.Required(),
+            new Constraint.MinLength(2),
+            new Constraint.MaxLength(10),
+            new Constraint.MatchesPattern("[A-Z]+")
+        );
+    }
+
+    @Test
+    void should_map_textarea_without_pattern() {
+        var schema = new SubscriptionFormSchema(List.of(new TextareaField("bio", true, null, 1, 500)));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("bio")).containsExactly(
+            new Constraint.Required(),
+            new Constraint.MinLength(1),
+            new Constraint.MaxLength(500)
+        );
+    }
+
+    @Test
+    void should_map_select_optional_with_one_of_only() {
+        var schema = new SubscriptionFormSchema(List.of(new SelectField("plan", false, List.of("Free", "Pro"))));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("plan")).containsExactly(new Constraint.OneOf(List.of("Free", "Pro")));
+    }
+
+    @Test
+    void should_map_required_checkbox_to_must_be_true() {
+        var schema = new SubscriptionFormSchema(List.of(new CheckboxField("terms", true, null)));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("terms")).containsExactly(new Constraint.MustBeTrue());
+    }
+
+    @Test
+    void should_map_checkbox_group_required_with_each_of() {
+        var schema = new SubscriptionFormSchema(List.of(new CheckboxGroupField("tags", true, List.of("A", "B"))));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("tags")).containsExactly(
+            new Constraint.NonEmptySelection(),
+            new Constraint.EachOf(List.of("A", "B"))
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSubmissionValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSubmissionValidatorTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxGroupField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.InputField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.RadioField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.SelectField;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionFormSubmissionValidatorTest {
+
+    @Nested
+    class WhenSchemaIsAbsent {
+
+        @Test
+        void should_skip_validation_when_schema_has_no_fields() {
+            var schema = new SubscriptionFormSchema(List.of());
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, Map.of()));
+        }
+    }
+
+    @Nested
+    class WhenValidatingRequired {
+
+        @Test
+        void should_throw_when_required_field_is_missing() {
+            var schema = schema(requiredInput("company"));
+            assertThatThrownBy(() -> validateSubmission(schema, Map.of()))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'company' is required"));
+        }
+
+        @Test
+        void should_throw_when_required_field_is_blank() {
+            var schema = schema(requiredInput("company"));
+            var values = Map.of("company", "  ");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'company' is required"));
+        }
+
+        @Test
+        void should_not_throw_when_required_field_has_value() {
+            var schema = schema(requiredInput("company"));
+            var values = Map.of("company", "Acme");
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
+        }
+
+        @Test
+        void should_not_throw_when_optional_field_is_missing() {
+            var schema = schema(optionalInput("notes"));
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, Map.of()));
+        }
+
+        @Test
+        void should_throw_when_required_checkbox_is_unchecked() {
+            var schema = schema(new CheckboxField("terms", true, null));
+            var values = Map.of("terms", "false");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'terms' is required"));
+        }
+
+        @Test
+        void should_not_throw_when_required_checkbox_is_checked() {
+            var schema = schema(new CheckboxField("terms", true, null));
+            var values = Map.of("terms", "true");
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
+        }
+
+        @Test
+        void should_throw_when_required_checkbox_group_has_only_separators() {
+            var schema = schema(new CheckboxGroupField("tags", true, List.of("A", "B")));
+            var values = Map.of("tags", " , , ");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'tags' is required"));
+        }
+    }
+
+    @Nested
+    class WhenValidatingOptions {
+
+        @Test
+        void should_throw_when_value_not_in_allowed_options() {
+            var schema = schema(new SelectField("plan", true, List.of("Free", "Pro", "Enterprise")));
+            var values = Map.of("plan", "Premium");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'plan': value 'Premium' is not among the allowed options"));
+        }
+
+        @Test
+        void should_not_throw_when_value_is_in_allowed_options() {
+            var schema = schema(new SelectField("plan", true, List.of("Free", "Pro", "Enterprise")));
+            var values = Map.of("plan", "Pro");
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
+        }
+
+        @Test
+        void should_not_throw_when_optional_select_is_missing() {
+            var schema = schema(new SelectField("plan", false, List.of("Free", "Pro")));
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, Map.of()));
+        }
+    }
+
+    @Nested
+    class WhenValidatingCheckboxGroup {
+
+        @Test
+        void should_throw_when_one_value_not_in_options() {
+            var schema = schema(new CheckboxGroupField("tags", false, List.of("Alpha", "Beta", "Gamma")));
+            var values = Map.of("tags", "Alpha,Delta");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'tags': value 'Delta' is not among the allowed options"));
+        }
+
+        @Test
+        void should_not_throw_when_all_values_are_valid() {
+            var schema = schema(new CheckboxGroupField("tags", false, List.of("Alpha", "Beta", "Gamma")));
+            var values = Map.of("tags", "Alpha,Gamma");
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
+        }
+
+        @Test
+        void should_report_one_error_per_invalid_value() {
+            var schema = schema(new CheckboxGroupField("tags", false, List.of("Alpha", "Beta")));
+            var values = Map.of("tags", "Alpha,Delta,Omega");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> {
+                    assertThat(errors).hasSize(1);
+                    assertThat(errors.get(0).lines().toList()).containsExactly(
+                        "Field 'tags': value 'Delta' is not among the allowed options",
+                        "Field 'tags': value 'Omega' is not among the allowed options"
+                    );
+                });
+        }
+    }
+
+    @Nested
+    class WhenValidatingLength {
+
+        @Test
+        void should_throw_when_value_is_shorter_than_minLength() {
+            var schema = schema(new InputField("company", false, null, 5, null, null));
+            var values = Map.of("company", "Acm");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'company' must be at least 5 characters long"));
+        }
+
+        @Test
+        void should_throw_when_value_is_longer_than_maxLength() {
+            var schema = schema(new InputField("company", false, null, null, 10, null));
+            var values = Map.of("company", "A very long company name indeed");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'company' must be at most 10 characters long"));
+        }
+
+        @Test
+        void should_not_throw_when_value_is_within_boundaries() {
+            var schema = schema(new InputField("company", false, null, 3, 10, null));
+            var values = Map.of("company", "Acme");
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
+        }
+    }
+
+    @Nested
+    class WhenValidatingPattern {
+
+        @Test
+        void should_throw_when_value_does_not_match_pattern() {
+            var schema = schema(new InputField("code", false, null, null, null, "[A-Z]{3}-\\d{4}"));
+            var values = Map.of("code", "invalid-code");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'code' does not match the required pattern"));
+        }
+
+        @Test
+        void should_not_throw_when_value_matches_pattern() {
+            var schema = schema(new InputField("code", false, null, null, null, "[A-Z]{3}-\\d{4}"));
+            var values = Map.of("code", "ABC-1234");
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
+        }
+
+        @Test
+        void should_add_error_when_pattern_is_invalid_regex() {
+            var schema = schema(new InputField("code", false, null, null, null, "[invalid(regex"));
+            var values = Map.of("code", "anything");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'code' has an invalid pattern configuration"));
+        }
+    }
+
+    @Nested
+    class WhenValidatingMultipleFields {
+
+        @Test
+        void should_collect_errors_from_all_fields_before_throwing() {
+            var schema = schema(
+                requiredInput("company"),
+                new SelectField("plan", true, List.of("Free", "Pro")),
+                new InputField("code", false, null, null, null, "[A-Z]+")
+            );
+            var values = Map.of("company", "", "plan", "Enterprise", "code", "123");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).hasSize(3));
+        }
+
+        @Test
+        void should_not_throw_for_valid_full_submission() {
+            var schema = schema(
+                requiredInput("company"),
+                new SelectField("plan", true, List.of("Free", "Pro")),
+                new CheckboxGroupField("tags", false, List.of("A", "B", "C"))
+            );
+            var values = Map.of("company", "Acme Corp", "plan", "Pro", "tags", "A,C");
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
+        }
+    }
+
+    @Nested
+    class WhenValidatingReadonlyFields {
+
+        @Test
+        void should_not_throw_when_readonly_value_matches_preset() {
+            var schema = schema(new InputField("ref", false, "REF-123", null, null, null));
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, Map.of("ref", "REF-123")));
+        }
+
+        @Test
+        void should_throw_when_readonly_value_does_not_match_preset() {
+            var schema = schema(new InputField("ref", false, "REF-123", null, null, null));
+            var values = Map.of("ref", "REF-999");
+            assertThatThrownBy(() -> validateSubmission(schema, values))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors -> assertThat(errors).containsExactly("Field 'ref': read-only field cannot be modified"));
+        }
+
+        @Test
+        void should_not_apply_other_validations_to_readonly_fields() {
+            // readonly RadioField has required=true and options, but readonly check takes precedence
+            var schema = schema(new RadioField("plan", true, "Free", List.of("Free", "Pro")));
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, Map.of("plan", "Free")));
+        }
+    }
+
+    @Nested
+    class WhenUsingPrebuiltFieldConstraints {
+
+        @Test
+        void should_validate_submission_from_field_constraints_without_schema() {
+            var schema = schema(requiredInput("company"));
+            var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+            assertThatNoException().isThrownBy(() -> validateSubmission(constraints, Map.of("company", "Acme")));
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private void validateSubmission(SubscriptionFormSchema schema, Map<String, String> values) {
+        new SubscriptionFormSubmissionValidator(schema).validate(values);
+    }
+
+    private void validateSubmission(SubscriptionFormFieldConstraints constraints, Map<String, String> values) {
+        new SubscriptionFormSubmissionValidator(constraints).validate(values);
+    }
+
+    private SubscriptionFormSchema schema(SubscriptionFormSchema.Field... fields) {
+        return new SubscriptionFormSchema(List.of(fields));
+    }
+
+    private InputField requiredInput(String fieldKey) {
+        return new InputField(fieldKey, true, null, null, null, null);
+    }
+
+    private InputField optionalInput(String fieldKey) {
+        return new InputField(fieldKey, false, null, null, null, null);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormSchemaGeneratorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormSchemaGeneratorImplTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.subscription_form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxGroupField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.InputField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.RadioField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.SelectField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.TextareaField;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SubscriptionFormSchemaGeneratorImplTest {
+
+    SubscriptionFormSchemaGeneratorImpl generator = new SubscriptionFormSchemaGeneratorImpl();
+
+    @ParameterizedTest(name = "content={0}")
+    @NullAndEmptySource
+    @ValueSource(strings = { "   " })
+    void should_return_empty_schema_for_blank_or_null_content(String content) {
+        assertThat(generator.generate(GraviteeMarkdown.of(content)).fields()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_schema_when_no_form_fields() {
+        assertThat(generator.generate(GraviteeMarkdown.of("<p>No form fields here</p>")).fields()).isEmpty();
+    }
+
+    @Test
+    void should_parse_gmd_input_with_all_validation_attributes() {
+        String gmd = """
+            <gmd-input fieldKey="company" required="true" minLength="2" maxLength="100" pattern="[A-Za-z]+"/>
+            """;
+
+        SubscriptionFormSchema schema = generator.generate(GraviteeMarkdown.of(gmd));
+
+        assertThat(schema.fields()).hasSize(1);
+        assertThat(schema.fields().getFirst())
+            .isInstanceOf(InputField.class)
+            .satisfies(f -> {
+                InputField field = (InputField) f;
+                assertThat(field.fieldKey()).isEqualTo("company");
+                assertThat(field.required()).isTrue();
+                assertThat(field.minLength()).isEqualTo(2);
+                assertThat(field.maxLength()).isEqualTo(100);
+                assertThat(field.pattern()).isEqualTo("[A-Za-z]+");
+                assertThat(field.readonlyValue()).isNull();
+            });
+    }
+
+    @Test
+    void should_parse_gmd_input_with_missing_optional_attributes() {
+        assertThat(generator.generate(GraviteeMarkdown.of("<gmd-input fieldKey=\"email\" required=\"false\"/>")).fields().getFirst())
+            .isInstanceOf(InputField.class)
+            .satisfies(f -> {
+                InputField field = (InputField) f;
+                assertThat(field.fieldKey()).isEqualTo("email");
+                assertThat(field.required()).isFalse();
+                assertThat(field.minLength()).isNull();
+                assertThat(field.maxLength()).isNull();
+                assertThat(field.pattern()).isNull();
+                assertThat(field.readonlyValue()).isNull();
+            });
+    }
+
+    @Test
+    void should_parse_gmd_textarea_with_length_constraints() {
+        assertThat(
+            generator
+                .generate(GraviteeMarkdown.of("<gmd-textarea fieldKey=\"use_case\" required=\"true\" minLength=\"20\" maxLength=\"500\"/>"))
+                .fields()
+                .getFirst()
+        )
+            .isInstanceOf(TextareaField.class)
+            .satisfies(f -> {
+                TextareaField field = (TextareaField) f;
+                assertThat(field.fieldKey()).isEqualTo("use_case");
+                assertThat(field.required()).isTrue();
+                assertThat(field.minLength()).isEqualTo(20);
+                assertThat(field.maxLength()).isEqualTo(500);
+            });
+    }
+
+    @ParameterizedTest(name = "<{0}> → {1}")
+    @MethodSource("optionsBearingComponents")
+    void should_parse_options_bearing_component_with_comma_separated_options(
+        String tagName,
+        Class<? extends SubscriptionFormSchema.Field> expectedType
+    ) {
+        String gmd = "<" + tagName + " fieldKey=\"field\" required=\"true\" options=\"Free Tier,Starter,Professional\"/>";
+
+        SubscriptionFormSchema.Field field = generator.generate(GraviteeMarkdown.of(gmd)).fields().getFirst();
+
+        assertThat(field).isInstanceOf(expectedType);
+        assertThat(field.fieldKey()).isEqualTo("field");
+        assertThat(field.required()).isTrue();
+        assertThat(optionsOf(field)).containsExactly("Free Tier", "Starter", "Professional");
+    }
+
+    static Stream<Arguments> optionsBearingComponents() {
+        return Stream.of(
+            Arguments.of("gmd-select", SelectField.class),
+            Arguments.of("gmd-radio", RadioField.class),
+            Arguments.of("gmd-checkbox-group", CheckboxGroupField.class)
+        );
+    }
+
+    @Test
+    void should_parse_gmd_checkbox_as_simple_boolean_field() {
+        assertThat(generator.generate(GraviteeMarkdown.of("<gmd-checkbox fieldKey=\"terms\" required=\"true\"/>")).fields().getFirst())
+            .isInstanceOf(CheckboxField.class)
+            .satisfies(f -> {
+                CheckboxField field = (CheckboxField) f;
+                assertThat(field.fieldKey()).isEqualTo("terms");
+                assertThat(field.required()).isTrue();
+            });
+    }
+
+    @Test
+    void should_trim_whitespace_in_options() {
+        SubscriptionFormSchema.Field field = generator
+            .generate(GraviteeMarkdown.of("<gmd-select fieldKey=\"env\" options=\" Production , Staging , Development \"/>"))
+            .fields()
+            .getFirst();
+
+        assertThat(optionsOf(field)).containsExactly("Production", "Staging", "Development");
+    }
+
+    @Test
+    void should_return_null_options_when_options_attribute_is_absent() {
+        SubscriptionFormSchema.Field field = generator
+            .generate(GraviteeMarkdown.of("<gmd-select fieldKey=\"plan\" required=\"true\"/>"))
+            .fields()
+            .getFirst();
+
+        assertThat(optionsOf(field)).isNull();
+    }
+
+    @Test
+    void should_capture_readonly_value() {
+        assertThat(
+            generator.generate(GraviteeMarkdown.of("<gmd-input fieldKey=\"ref\" readonly=\"true\" value=\"REF-123\"/>")).fields().getFirst()
+        )
+            .isInstanceOf(InputField.class)
+            .satisfies(f -> assertThat(((InputField) f).readonlyValue()).isEqualTo("REF-123"));
+    }
+
+    @Test
+    void should_throw_when_readonly_field_has_no_value_attribute() {
+        assertThatThrownBy(() -> generator.generate(GraviteeMarkdown.of("<gmd-input fieldKey=\"ref\" readonly=\"true\"/>")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("ref")
+            .hasMessageContaining("value");
+    }
+
+    @Test
+    void should_throw_when_fieldkey_attribute_is_absent() {
+        assertThatThrownBy(() -> generator.generate(GraviteeMarkdown.of("<gmd-input required=\"true\"/>")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("fieldkey")
+            .hasMessageContaining("gmd-input");
+    }
+
+    @Test
+    void should_throw_when_fieldkey_attribute_is_blank() {
+        assertThatThrownBy(() -> generator.generate(GraviteeMarkdown.of("<gmd-input fieldKey=\"   \" required=\"true\"/>")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("fieldkey")
+            .hasMessageContaining("gmd-input");
+    }
+
+    @Test
+    void should_parse_multiple_fields_preserving_order() {
+        String gmd = """
+            <gmd-input fieldKey="company" required="true"/>
+            <gmd-select fieldKey="plan" required="true" options="Free,Pro"/>
+            <gmd-checkbox fieldKey="terms" required="true"/>
+            """;
+
+        List<SubscriptionFormSchema.Field> fields = generator.generate(GraviteeMarkdown.of(gmd)).fields();
+
+        assertThat(fields).hasSize(3);
+        assertThat(fields).extracting(SubscriptionFormSchema.Field::fieldKey).containsExactly("company", "plan", "terms");
+    }
+
+    @Test
+    void should_ignore_non_form_elements() {
+        String gmd = """
+            <p>Some paragraph</p>
+            <gmd-input fieldKey="name" required="true"/>
+            <div class="wrapper">text</div>
+            """;
+
+        List<SubscriptionFormSchema.Field> fields = generator.generate(GraviteeMarkdown.of(gmd)).fields();
+
+        assertThat(fields).hasSize(1);
+        assertThat(fields.getFirst().fieldKey()).isEqualTo("name");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private List<String> optionsOf(SubscriptionFormSchema.Field field) {
+        return switch (field) {
+            case SelectField f -> f.options();
+            case RadioField f -> f.options();
+            case CheckboxGroupField f -> f.options();
+            default -> throw new IllegalArgumentException("Field type has no options: " + field.getClass().getSimpleName());
+        };
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12990

## Description
**PR 1/3** — Domain layer for subscription form backend validation.

This PR adds:
- **`SubscriptionFormSchema` / `SubscriptionFormFieldSchema`** records — flat model capturing only validation-relevant attributes (`required`, `minLength`, `maxLength`, `pattern`, `options`). UI-only fields (`label`, `placeholder`, `readonly`, `disabled`) are intentionally excluded so cosmetic edits won't create new form versions in the future versioning system.
- **`SubscriptionFormSchemaGenerator`** interface (core) + **`SubscriptionFormSchemaGeneratorImpl`** (infra, Jsoup) — parses GMD HTML and extracts per-field validation rules.
- **`SubscriptionFormSubmissionValidator`** — collects all field errors in a single pass then throws `SubscriptionFormValidationException`; handles `required`, `options` (including `checkbox-group` multi-value comma-split), `minLength`, `maxLength`, and `pattern`.

**Not in this PR** (coming in subsequent PRs):
- `formSchema` column/field on `SubscriptionForm` + DB migrations (PR 2/3)
- Use-case wiring, REST resource changes, and integration tests (PR 3/3)

