### PR TITLE
feat: redirect from catalog to documentation on api click.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.spec.ts
@@ -23,6 +23,7 @@ import { ApiCardHarness } from '../../components/api-card/api-card.harness';
 import { PaginationHarness } from '../../components/pagination/pagination.harness';
 import { fakeApi, fakeApisResponse } from '../../entities/api/api.fixtures';
 import { ApisResponse } from '../../entities/api/apis-response';
+import { PortalNavigationItemsSearchResponse } from '../../entities/portal-navigation/portal-navigation-apis-search';
 import { AppTestingModule, TESTING_BASE_URL } from '../../testing/app-testing.module';
 
 describe('CatalogComponent', () => {
@@ -48,14 +49,16 @@ describe('CatalogComponent', () => {
       apisResponse: ApisResponse;
       page: number;
       size: number;
+      hasNextPage: boolean;
     }> = {
       apisResponse: fakeApisResponse(),
       page: 1,
       size: 20,
+      hasNextPage: false,
     },
   ) => {
     await initBase();
-    expectApiList(params.apisResponse, params.page, params.size);
+    expectApiList(params.apisResponse, params.page ?? 1, params.size ?? 20, params.hasNextPage ?? false);
     fixture.detectChanges();
   };
 
@@ -95,6 +98,7 @@ describe('CatalogComponent', () => {
             },
           },
         }),
+        hasNextPage: true,
       });
     });
 
@@ -160,7 +164,7 @@ describe('CatalogComponent', () => {
       it('should show empty API list', async () => {
         await initBase();
         httpTestingController
-          .expectOne(`${TESTING_BASE_URL}/apis/_search?page=1&category=&size=20&q=`)
+          .expectOne(portalSearchUrl(1, 20))
           .flush({ error: { message: 'Error occurred' } }, { status: 500, statusText: 'Internal Error' });
         fixture.detectChanges();
 
@@ -171,7 +175,46 @@ describe('CatalogComponent', () => {
     });
   });
 
-  function expectApiList(apisResponse: ApisResponse = fakeApisResponse(), page: number = 1, size: number = 20) {
-    httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/_search?page=${page}&category=&size=${size}&q=`).flush(apisResponse);
+  function portalSearchUrl(page: number, size: number, q = '') {
+    const base = `${TESTING_BASE_URL}/portal-navigation-items/_search?type=api&include=api&page=${page}&size=${size}`;
+    return q ? `${base}&query=${encodeURIComponent(q)}` : base;
+  }
+
+  function toPortalSearchResponse(
+    apisResponse: ApisResponse,
+    page: number,
+    size: number,
+    hasNextPage = false,
+  ): PortalNavigationItemsSearchResponse {
+    const apis = apisResponse.data ?? [];
+    const links = { ...apisResponse.links };
+    if (hasNextPage) links.next = `${TESTING_BASE_URL}/portal-navigation-items/_search?page=${page + 1}&size=${size}`;
+    const pagination = apisResponse.metadata?.pagination;
+    return {
+      data: apis.map(api => ({
+        type: 'API' as const,
+        apiId: api.id,
+        id: `nav-${api.id}`,
+        rootId: `root-${page}`,
+      })),
+      apis,
+      links,
+      metadata: pagination
+        ? {
+            pagination: {
+              current_page: pagination.current_page ?? page,
+              size: pagination.size ?? size,
+              total: pagination.total ?? apis.length,
+              total_pages: pagination.total_pages ?? 1,
+            },
+          }
+        : undefined,
+    } as PortalNavigationItemsSearchResponse;
+  }
+
+  function expectApiList(apisResponse: ApisResponse = fakeApisResponse(), page: number = 1, size: number = 20, hasNextPage = false) {
+    const url = `${TESTING_BASE_URL}/portal-navigation-items/_search?type=api&include=api&page=${page}&size=${size}`;
+    const req = httpTestingController.expectOne(url);
+    req.flush(toPortalSearchResponse(apisResponse, page, size, hasNextPage));
   }
 });

--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.ts
@@ -33,9 +33,8 @@ import { LoaderComponent } from '../../components/loader/loader.component';
 import { PaginationComponent } from '../../components/pagination/pagination.component';
 import { SearchBarComponent } from '../../components/search-bar/search-bar.component';
 import { MobileClassDirective } from '../../directives/mobile-class.directive';
-import { ApisResponse } from '../../entities/api/apis-response';
-import { ApiService } from '../../services/api.service';
 import { ObservabilityBreakpointService } from '../../services/observability-breakpoint.service';
+import { PortalNavigationItemsService } from '../../services/portal-navigation-items.service';
 
 interface ApiVM {
   id: string;
@@ -45,6 +44,8 @@ interface ApiVM {
   isEnabledMcpServer: boolean;
   picture?: string;
   labels?: string[];
+  rootId: string;
+  navItemId: string;
 }
 
 interface ApiPaginatorVM {
@@ -80,7 +81,7 @@ export class CatalogComponent {
   pageSizeOptions = [8, 20, 40, 80];
   viewMode = signal<'grid' | 'list'>('grid');
 
-  private readonly apiService = inject(ApiService);
+  private readonly portalNavigationItemsService = inject(PortalNavigationItemsService);
   private readonly breakpointService = inject(ObservabilityBreakpointService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
@@ -89,7 +90,9 @@ export class CatalogComponent {
   private readonly page$ = new BehaviorSubject<number>(1);
   protected readonly query = toSignal(this.route.queryParams.pipe(map(p => p['query'] ?? '')), { initialValue: '' });
   protected readonly tableColumns = computed(() => (this.isMobile() ? ['name', 'version', 'mcp'] : ['name', 'labels', 'version', 'mcp']));
-  protected apiPaginator: Signal<ApiPaginatorVM> = toSignal(this.loadApis$(), { initialValue: { data: [], page: 1, totalResults: 0 } });
+  protected apiPaginator: Signal<ApiPaginatorVM> = toSignal(this.loadNavigationItemsWithApis$(), {
+    initialValue: { data: [], page: 1, totalResults: 0 },
+  });
 
   constructor() {
     effect(() => {
@@ -122,27 +125,36 @@ export class CatalogComponent {
   }
 
   navigateToApi(id: string) {
-    this.router.navigate(['api', id], { relativeTo: this.route });
+    const api = this.apiPaginator().data.find(api => api.id === id);
+    if (api) {
+      this.router.navigate(['/documentation', api.rootId], { queryParams: { selectedId: api.navItemId } });
+    } else {
+      this.router.navigate(['/404']);
+    }
   }
 
-  private loadApis$(): Observable<ApiPaginatorVM> {
+  private loadNavigationItemsWithApis$(): Observable<ApiPaginatorVM> {
     return this.page$.pipe(
-      map(currentPage => ({ currentPage, pageSize: this.pageSize, query: this.query() })),
+      map(page => ({ page, pageSize: this.pageSize, query: this.query() })),
       distinctUntilChanged((previous, current) => isEqual(previous, current)),
       tap(_ => this.loadingPage.set(true)),
-      switchMap(({ currentPage, pageSize, query }) => this.searchApis$(currentPage, pageSize, query)),
+      switchMap(({ page, pageSize, query }) =>
+        this.portalNavigationItemsService
+          .searchNavigationItemsWithApis(page, query, pageSize)
+          .pipe(catchError(_ => of({ data: [], metadata: undefined }))),
+      ),
       map(resp => {
-        const data = resp.data
-          ? resp.data.map(api => ({
-              id: api.id,
-              content: api.description,
-              version: api.version,
-              title: api.name,
-              picture: api._links?.picture,
-              isEnabledMcpServer: !!api.mcp,
-              labels: api.labels,
-            }))
-          : [];
+        const data = resp.data.map(item => ({
+          id: item.id,
+          content: item.description,
+          version: item.version,
+          title: item.name,
+          picture: item._links?.picture,
+          isEnabledMcpServer: !!item.mcp,
+          labels: item.labels,
+          rootId: item.rootId,
+          navItemId: item.navItemId,
+        }));
 
         const page = resp.metadata?.pagination?.current_page ?? 1;
         const totalResults = resp.metadata?.pagination?.total ?? 0;
@@ -154,9 +166,5 @@ export class CatalogComponent {
       }),
       tap(_ => this.loadingPage.set(false)),
     );
-  }
-
-  private searchApis$(page: number, size: number, query?: string): Observable<ApisResponse> {
-    return this.apiService.search(page, 'all', query ?? '', size).pipe(catchError(_ => of({ data: [], metadata: undefined })));
   }
 }

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-apis-search.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-navigation-apis-search.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PortalNavigationItem } from './portal-navigation-item';
+import { Api } from '../api/api';
+import { ApiLinks } from '../api/api-links';
+import { Mcp } from '../api/mcp';
+import { Links } from '../pagination/links';
+
+export interface PortalNavigationApiSearchItem {
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  _links?: ApiLinks;
+  mcp?: Mcp;
+  labels?: string[];
+  rootId: string;
+  navItemId: string;
+}
+
+export interface PortalNavigationSearchMetadata {
+  pagination: {
+    current_page: number;
+    size: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
+export interface PortalNavigationItemsSearchResponse {
+  data?: PortalNavigationItem[];
+  apis?: Api[];
+  links?: Links;
+  metadata?: PortalNavigationSearchMetadata;
+}
+
+export interface PortalNavigationApisSearchResponse {
+  data: PortalNavigationApiSearchItem[];
+  metadata?: PortalNavigationSearchMetadata;
+  links?: Links;
+}

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.spec.ts
@@ -18,6 +18,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { ConfigService } from './config.service';
 import { PortalNavigationItemsService } from './portal-navigation-items.service';
+import { fakeApi } from '../entities/api/api.fixtures';
 import { PortalNavigationItem } from '../entities/portal-navigation/portal-navigation-item';
 import { AppTestingModule } from '../testing/app-testing.module';
 
@@ -154,5 +155,53 @@ describe('PortalNavigationItemsService', () => {
     const req = httpMock.expectOne(r => r.method === 'GET' && r.url === `${baseURL}/portal-navigation-items/${id}`);
 
     req.flush(mockItem);
+  });
+
+  it('should search APIs and map to PortalNavigationApisSearchResponse', done => {
+    const api = fakeApi({ id: 'api-1', name: 'Test API', version: '1.0', description: 'Desc' });
+    const rawResponse = {
+      data: [{ type: 'API' as const, apiId: api.id, id: 'nav-1', rootId: 'root-1' }],
+      apis: [api],
+      links: {},
+      metadata: {
+        pagination: {
+          current_page: 1,
+          size: 10,
+          total: 42,
+          total_pages: 5,
+        },
+      },
+    };
+
+    service.searchNavigationItemsWithApis(1, '', 10).subscribe(res => {
+      expect(res.data).toHaveLength(1);
+      expect(res.data[0]).toEqual({
+        id: api.id,
+        name: api.name,
+        version: api.version,
+        description: api.description,
+        _links: api._links,
+        mcp: api.mcp,
+        labels: api.labels,
+        rootId: 'root-1',
+        navItemId: 'nav-1',
+      });
+      expect(res.metadata?.pagination?.current_page).toBe(1);
+      expect(res.metadata?.pagination?.size).toBe(10);
+      expect(res.metadata?.pagination?.total).toBe(42);
+      expect(res.metadata?.pagination?.total_pages).toBe(5);
+      done();
+    });
+
+    const req = httpMock.expectOne(
+      r =>
+        r.method === 'GET' &&
+        r.url === `${baseURL}/portal-navigation-items/_search` &&
+        r.params.get('type') === 'api' &&
+        r.params.get('include') === 'api' &&
+        r.params.get('page') === '1' &&
+        r.params.get('size') === '10',
+    );
+    req.flush(rawResponse);
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal-navigation-items.service.ts
@@ -15,11 +15,16 @@
  */
 import { HttpClient } from '@angular/common/http';
 import { Injectable, signal, WritableSignal } from '@angular/core';
-import { catchError, Observable, switchMap } from 'rxjs';
+import { catchError, map, Observable, switchMap } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
 
 import { ConfigService } from './config.service';
-import { PortalArea, PortalNavigationItem } from '../entities/portal-navigation/portal-navigation-item';
+import {
+  PortalNavigationApisSearchResponse,
+  PortalNavigationApiSearchItem,
+  PortalNavigationItemsSearchResponse,
+} from '../entities/portal-navigation/portal-navigation-apis-search';
+import { PortalNavigationApi, PortalNavigationItem, PortalArea } from '../entities/portal-navigation/portal-navigation-item';
 import { PortalPageContent } from '../entities/portal-navigation/portal-page-content';
 
 @Injectable({
@@ -60,5 +65,52 @@ export class PortalNavigationItemsService {
         return of(undefined);
       }),
     );
+  }
+
+  searchNavigationItemsWithApis(page = 1, query = '', size = 8): Observable<PortalNavigationApisSearchResponse> {
+    const params: Record<string, string | number> = {
+      type: 'api',
+      include: 'api',
+      page,
+      size,
+    };
+    if (query) params['query'] = query;
+
+    return this.http
+      .get<PortalNavigationItemsSearchResponse>(`${this.configService.baseURL}/portal-navigation-items/_search`, { params })
+      .pipe(map(res => this.mapToSearchResponse(res)));
+  }
+
+  private mapToSearchResponse(res: PortalNavigationItemsSearchResponse): PortalNavigationApisSearchResponse {
+    const navItems = res.data ?? [];
+    const apis = res.apis ?? [];
+    const apiById = new Map(apis.map(api => [api.id, api]));
+
+    const data: PortalNavigationApiSearchItem[] = navItems
+      .filter((item): item is PortalNavigationApi => item.type === 'API')
+      .flatMap(item => {
+        const api = apiById.get(item.apiId);
+        return api
+          ? [
+              {
+                id: api.id,
+                name: api.name,
+                version: api.version,
+                description: api.description,
+                _links: api._links,
+                mcp: api.mcp,
+                labels: api.labels,
+                rootId: item.rootId,
+                navItemId: item.id,
+              },
+            ]
+          : [];
+      });
+
+    return {
+      data,
+      metadata: res.metadata,
+      links: res.links,
+    };
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11817

## Description

Catalog API cards now redirect to the API documentation page (portal navigation tree) instead of the legacy API detail route.

## Changes

### Catalog behavior
- `navigateToApi(id)` now routes to `/documentation/{rootId}?selectedId={navItemId}` instead of `/api/{id}`
- Falls back to `/404` when the API is not found in the catalog list
- Catalog fetches data from `portal-navigation-items/_search` instead of `apis/_search`

### Data source migration
- Replaced `ApiService.search()` with `PortalNavigationItemsService.searchNavigationItemsWithApis()`
- Catalog now consumes portal navigation items, which include `rootId` and `navItemId` for documentation routing

### New types and service
- Added `portal-navigation-apis-search-response.ts` with:
  - `PortalNavigationApiSearchItem`, `PortalNavigationSearchMetadata`
  - `PortalNavigationItemsSearchResponse`, `PortalNavigationApisSearchResponse`
- Added `searchNavigationItemsWithApis()` to `PortalNavigationItemsService`:
  - Calls `portal-navigation-items/_search` with `type=api` and `include=api`
  - Maps response to `PortalNavigationApisSearchResponse`, forwards backend pagination metadata