### PR TITLE
fix: API export CRD failure

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcUserRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcUserRepository.java
@@ -110,6 +110,9 @@ public class JdbcUserRepository extends JdbcAbstractCrudRepository<User, String>
 
     @Override
     public Set<User> findByIds(final Collection<String> ids) throws TechnicalException {
+        if (ids == null || ids.isEmpty()) {
+            return Collections.emptySet();
+        }
         final String[] lastId = new String[1];
         List<String> uniqueIds = ids
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImpl.java
@@ -55,6 +55,9 @@ public class UserCrudServiceImpl implements UserCrudService {
 
     @Override
     public Set<BaseUserEntity> findBaseUsersByIds(List<String> userIds) {
+        if (userIds == null || userIds.isEmpty()) {
+            return Set.of();
+        }
         try {
             log.debug("Find users [userIds={}]", userIds);
             return userRepository.findByIds(userIds).stream().map(UserAdapter.INSTANCE::fromUser).collect(Collectors.toSet());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImpl.java
@@ -94,8 +94,10 @@ public class ApiCRDExportDomainServiceImpl implements ApiCRDExportDomainService 
 
         membersById.forEach((id, member) -> {
             var user = usersById.get(id);
-            member.setSourceId(user.getSourceId());
-            member.setSource(user.getSource());
+            if (user != null) {
+                member.setSourceId(user.getSourceId());
+                member.setSource(user.getSource());
+            }
             member.setId(null);
         });
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
@@ -36,6 +36,8 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 public class UserCrudServiceImplTest {
 
@@ -120,6 +122,13 @@ public class UserCrudServiceImplTest {
 
     @Nested
     class FindBaseUserByIds {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void should_return_empty_set_when_user_ids_is_null_or_empty(List<String> userIds) {
+            var result = service.findBaseUsersByIds(userIds);
+            assertThat(result).isEmpty();
+        }
 
         @Test
         void should_find_users_and_adapt_them() throws TechnicalException {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12926

## Description

| Area | File | Change |
|------|------|--------|
| **Repository** | `JdbcUserRepository.java` | In `findByIds(Collection<String> ids)`, return `Collections.emptySet()` when `ids` is null or empty to avoid invalid SQL `WHERE u.id IN ()`. |
| **Service** | `UserCrudServiceImpl.java` | In `findBaseUsersByIds(List<String> userIds)`, return `Set.of()` when `userIds` is null or empty so the repository is not called with an empty list. |
| **Export** | `ApiCRDExportDomainServiceImpl.java` | In `setMembersSourceId()`, only set `sourceId`/`source` when a user is found (`user != null`) so group-only members without a user record do not cause NPE. |



https://github.com/user-attachments/assets/1a0d182a-8baa-4830-84c1-bfaa53e4cdbe