### PR TITLE
fix(mcp): include operation description in generated MCP tool definitions

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.spec.ts
@@ -1229,6 +1229,104 @@ paths:
     });
   });
 
+  describe('description extraction', () => {
+    it('combines summary and description when both are present', async () => {
+      const spec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/sales-units': {
+            post: {
+              operationId: 'postSalesUnits',
+              summary: 'Create a sales unit',
+              description:
+                'The Manufactured Managed in Stock articles are not supported. This endpoint validates business rules before creation.',
+              responses: {
+                '201': { description: 'Created' },
+              },
+            },
+          },
+        },
+      });
+
+      const { result, errors } = await convertOpenApiToMcpTools(spec);
+
+      expect(errors).toHaveLength(0);
+      expect(result).toHaveLength(1);
+      expect(result[0].toolDefinition.description).toBe(
+        'Create a sales unit\n\nThe Manufactured Managed in Stock articles are not supported. This endpoint validates business rules before creation.',
+      );
+    });
+
+    it('uses only summary when description is absent', async () => {
+      const spec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/users': {
+            get: {
+              operationId: 'getUsers',
+              summary: 'List all users',
+              responses: {
+                '200': { description: 'OK' },
+              },
+            },
+          },
+        },
+      });
+
+      const { result, errors } = await convertOpenApiToMcpTools(spec);
+
+      expect(errors).toHaveLength(0);
+      expect(result[0].toolDefinition.description).toBe('List all users');
+    });
+
+    it('uses only description when summary is absent', async () => {
+      const spec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/users': {
+            get: {
+              operationId: 'getUsers',
+              description: 'Returns a list of all registered users with their details.',
+              responses: {
+                '200': { description: 'OK' },
+              },
+            },
+          },
+        },
+      });
+
+      const { result, errors } = await convertOpenApiToMcpTools(spec);
+
+      expect(errors).toHaveLength(0);
+      expect(result[0].toolDefinition.description).toBe('Returns a list of all registered users with their details.');
+    });
+
+    it('uses fallback when neither summary nor description is present', async () => {
+      const spec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/users': {
+            get: {
+              operationId: 'getUsers',
+              responses: {
+                '200': { description: 'OK' },
+              },
+            },
+          },
+        },
+      });
+
+      const { result, errors } = await convertOpenApiToMcpTools(spec);
+
+      expect(errors).toHaveLength(0);
+      expect(result[0].toolDefinition.description).toBe('API for GET /users');
+    });
+  });
+
   describe('Error cases', () => {
     it.each([
       [

--- a/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.ts
@@ -314,7 +314,7 @@ async function convertOpenApiToMcpTools(specString: string): Promise<OpenApiToMc
         usedNames.add(toolName);
       }
 
-      const description = op.summary || op.description || `API for ${method.toUpperCase()} ${path}`;
+      const description = [op.summary, op.description].filter(Boolean).join('\n\n') || `API for ${method.toUpperCase()} ${path}`;
       const mergedParams = mergeParameters(pathLevelParams, op.parameters || []);
       const paramSchema = extractParameterSchema(mergedParams);
       const bodySchema = extractRequestBodySchema(op.requestBody);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13045

## Description

Fix MCP tool generation from OpenAPI to include operation description alongside summary in tool definitions.
Previously, when both fields were present, only the short summary was used and the rich business rules from description were silently discarded

