### PR TITLE
fix(gateway): evict stale subscription cache entries on plan transfer (APIM-13160)

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -110,6 +110,15 @@ public class SubscriptionCacheService implements SubscriptionService {
             unregisterFromClientCertificate(cachedSubscription);
         }
 
+        // remove previous subscription plan entries from cache if plan has changed (e.g. subscription transfer)
+        if (
+            cachedSubscription != null &&
+            cachedSubscription.getPlan() != null &&
+            !cachedSubscription.getPlan().equals(subscription.getPlan())
+        ) {
+            unregisterFromClientCertificate(cachedSubscription);
+        }
+
         log.debug(
             "Load accepted subscription with client Id  [id: {}] [api: {}] [plan: {}] [application: {}]",
             subscription.getId(),
@@ -142,6 +151,15 @@ public class SubscriptionCacheService implements SubscriptionService {
             cachedSubscription != null &&
             cachedSubscription.getClientId() != null &&
             !cachedSubscription.getClientId().equals(subscription.getClientId())
+        ) {
+            unregisterFromClientId(cachedSubscription);
+        }
+
+        // remove previous subscription plan entries from cache if plan has changed (e.g. subscription transfer)
+        if (
+            cachedSubscription != null &&
+            cachedSubscription.getPlan() != null &&
+            !cachedSubscription.getPlan().equals(subscription.getPlan())
         ) {
             unregisterFromClientId(cachedSubscription);
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -215,6 +215,84 @@ class SubscriptionCacheServiceTest {
         }
 
         @Test
+        void should_remove_old_plan_cache_entries_when_subscription_plan_changes_for_client_id() {
+            String plan1 = "plan-1";
+            String plan2 = "plan-2";
+
+            // Register subscription on plan1
+            Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, plan1);
+            subscriptionService.register(subscription);
+
+            // Verify plan1 entry exists
+            String plan1Key = subscriptionService.buildCacheKeyFromClientInfo(API_ID, CLIENT_ID, plan1);
+            assertThat(cacheByApiClientId.get(plan1Key)).isNotNull();
+
+            // Transfer: re-register same subscription with plan2
+            Subscription transferred = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, plan2);
+            subscriptionService.register(transferred);
+
+            // Plan2 entry should exist
+            String plan2Key = subscriptionService.buildCacheKeyFromClientInfo(API_ID, CLIENT_ID, plan2);
+            assertThat(cacheByApiClientId.get(plan2Key)).isNotNull().isEqualTo(transferred);
+
+            // Plan1 entry should be gone (stale entry removed)
+            assertThat(cacheByApiClientId.get(plan1Key)).isNull();
+
+            // Subscription by ID should return the transferred subscription
+            assertThat(cacheBySubscriptionId.get(SUB_ID)).isEqualTo(transferred);
+        }
+
+        @Test
+        void should_remove_old_plan_cache_entries_when_subscription_plan_changes_for_client_certificate() {
+            String plan1 = "plan-1";
+            String plan2 = "plan-2";
+
+            // Register subscription on plan1
+            Subscription subscription = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, plan1);
+            subscriptionService.register(subscription);
+
+            // Verify plan1 entry exists
+            String plan1Key = subscriptionService.buildCacheKeyFromClientInfo(API_ID, CLIENT_CERTIFICATE, plan1);
+            assertThat(cacheByApiClientCertificate.get(plan1Key)).isNotNull();
+
+            // Transfer: re-register same subscription with plan2
+            Subscription transferred = buildAcceptedSubscriptionWithClientCertificate(SUB_ID, API_ID, CLIENT_CERTIFICATE, plan2);
+            subscriptionService.register(transferred);
+
+            // Plan2 entry should exist
+            String plan2Key = subscriptionService.buildCacheKeyFromClientInfo(API_ID, CLIENT_CERTIFICATE, plan2);
+            assertThat(cacheByApiClientCertificate.get(plan2Key)).isNotNull().isEqualTo(transferred);
+
+            // Plan1 entry should be gone (stale entry removed)
+            assertThat(cacheByApiClientCertificate.get(plan1Key)).isNull();
+
+            // Subscription by ID should return the transferred subscription
+            assertThat(cacheBySubscriptionId.get(SUB_ID)).isEqualTo(transferred);
+        }
+
+        @Test
+        void should_allow_close_after_plan_transfer_for_client_id() {
+            String plan1 = "plan-1";
+            String plan2 = "plan-2";
+
+            // Register on plan1, then transfer to plan2
+            Subscription sub1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, plan1);
+            subscriptionService.register(sub1);
+            Subscription sub2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, plan2);
+            subscriptionService.register(sub2);
+
+            // Close (unregister) the subscription
+            subscriptionService.unregister(sub2);
+
+            // Both plan keys should be gone
+            String plan1Key = subscriptionService.buildCacheKeyFromClientInfo(API_ID, CLIENT_ID, plan1);
+            String plan2Key = subscriptionService.buildCacheKeyFromClientInfo(API_ID, CLIENT_ID, plan2);
+            assertThat(cacheByApiClientId.get(plan1Key)).isNull();
+            assertThat(cacheByApiClientId.get(plan2Key)).isNull();
+            assertThat(cacheBySubscriptionId.get(SUB_ID)).isNull();
+        }
+
+        @Test
         void should_register_subscription_with_new_client_id_when_already_registered() {
             Subscription subscription = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscriptionService.register(subscription);


### PR DESCRIPTION
## Summary
- **Bug**: JWT subscription transfer not reflected in gateway routing; closing transferred subscription doesn't revoke access
- **Root cause**: `SubscriptionCacheService` caches subscriptions keyed by `api.clientId.plan` — on transfer, stale old-plan entry never removed
- **Fix**: Added plan-change detection in `registerFromClientId()` and `registerFromClientCertificate()` — evicts stale entries before adding new ones

## Changes
- `SubscriptionCacheService.java` — +18 lines (plan-change detection in both register methods)
- `SubscriptionCacheServiceTest.java` — +78 lines (3 new tests)

## Test plan
- [x] 3 new unit tests (client_id transfer, client_certificate transfer, close-after-transfer)
- [x] All 22 tests pass (3 new + 19 existing)
- [x] Integration verification: full transfer cycle (Plan1→Plan2→Plan1→Plan2→Close) works correctly

Fixes https://gravitee.atlassian.net/browse/APIM-13160
