### PR TITLE
feat: enable update for existing v4 apis via import process

### DIFF
--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/update-api-definition/api-v4-update-from-swagger.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/update-api-definition/api-v4-update-from-swagger.spec.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, test } from '@jest/globals';
+import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
+import { forManagementV2AsAdminUser } from '@gravitee/utils/configuration';
+import * as openapiv3 from '@api-test-resources/openapi-withExtensions.json';
+import { created, fail, noContent, succeed } from '@lib/jest-utils';
+import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
+import { faker } from '@faker-js/faker';
+
+const envId = 'DEFAULT';
+
+const v2ApisResource = new APIsApi(forManagementV2AsAdminUser());
+
+describe('API - V4 - Update via Swagger/OpenAPI import', () => {
+  const specification = JSON.stringify(openapiv3);
+
+  describe('Update an existing API from an OpenAPI specification', () => {
+    let createdApi: ApiV4;
+
+    beforeAll(async () => {
+      createdApi = await created(
+        v2ApisResource.createApiFromSwaggerRaw({
+          envId,
+          importSwaggerDescriptor: { payload: specification },
+        }),
+      );
+    });
+
+    test('should update the API via PUT /_import/swagger', async () => {
+      const updatedApi = await succeed(
+        v2ApisResource.updateApiFromSwaggerRaw({
+          envId,
+          apiId: createdApi.id,
+          importSwaggerDescriptor: { payload: specification },
+        }),
+      );
+
+      expect(updatedApi).toBeTruthy();
+      expect(updatedApi.id).toStrictEqual(createdApi.id);
+      expect(updatedApi.name).toBe('Gravitee.io Swagger API');
+      expect(updatedApi.apiVersion).toBe('1.2.3');
+    });
+
+    test('should get updated API with data from the specification', async () => {
+      const fetchedApi = await succeed(
+        v2ApisResource.getApiRaw({
+          envId,
+          apiId: createdApi.id,
+        }),
+      );
+      expect(fetchedApi.id).toStrictEqual(createdApi.id);
+      expect(fetchedApi.name).toBe('Gravitee.io Swagger API');
+    });
+
+    afterAll(async () => {
+      if (createdApi) {
+        await noContent(v2ApisResource.deleteApiRaw({ envId, apiId: createdApi.id }));
+      }
+    });
+  });
+
+  describe('Update a non-existent API from Swagger returns 404', () => {
+    test('should fail with 404 when API does not exist', async () => {
+      await fail(
+        v2ApisResource.updateApiFromSwaggerRaw({
+          envId,
+          apiId: faker.string.uuid(),
+          importSwaggerDescriptor: { payload: specification },
+        }),
+        404,
+      );
+    });
+  });
+
+  describe('Update API from Swagger preserves the API ID', () => {
+    let importedApi: ApiV4;
+
+    afterEach(async () => {
+      if (importedApi) {
+        await noContent(v2ApisResource.deleteApiRaw({ envId, apiId: importedApi.id }));
+      }
+    });
+
+    test('should keep the same API ID after update', async () => {
+      importedApi = await created(
+        v2ApisResource.createApiFromSwaggerRaw({
+          envId,
+          importSwaggerDescriptor: { payload: specification },
+        }),
+      );
+
+      const updatedApi = await succeed(
+        v2ApisResource.updateApiFromSwaggerRaw({
+          envId,
+          apiId: importedApi.id,
+          importSwaggerDescriptor: { payload: specification },
+        }),
+      );
+
+      expect(updatedApi.id).toStrictEqual(importedApi.id);
+    });
+
+    test('should update the API flows from the specification', async () => {
+      importedApi = await created(
+        v2ApisResource.createApiFromSwaggerRaw({
+          envId,
+          importSwaggerDescriptor: { payload: specification },
+        }),
+      );
+
+      const updatedApi = await succeed(
+        v2ApisResource.updateApiFromSwaggerRaw({
+          envId,
+          apiId: importedApi.id,
+          importSwaggerDescriptor: { payload: specification },
+        }),
+      );
+
+      expect(updatedApi.flows).toBeDefined();
+      expect(updatedApi.flows.length).toBeGreaterThan(0);
+    });
+
+    test('should preserve flow ids when re-importing the same OpenAPI', async () => {
+      importedApi = await created(
+        v2ApisResource.createApiFromSwaggerRaw({
+          envId,
+          importSwaggerDescriptor: { payload: specification },
+        }),
+      );
+
+      const beforeUpdate = await succeed(
+        v2ApisResource.getApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      const flowIdsBefore = ('flows' in beforeUpdate ? (beforeUpdate.flows ?? []) : []).map((flow) => flow.id);
+
+      await succeed(
+        v2ApisResource.updateApiFromSwaggerRaw({
+          envId,
+          apiId: importedApi.id,
+          importSwaggerDescriptor: { payload: specification },
+        }),
+      );
+
+      const afterUpdate = await succeed(
+        v2ApisResource.getApiRaw({
+          envId,
+          apiId: importedApi.id,
+        }),
+      );
+      const flowIdsAfter = ('flows' in afterUpdate ? (afterUpdate.flows ?? []) : []).map((flow) => flow.id);
+
+      expect(flowIdsBefore.length).toBeGreaterThan(0);
+      expect(flowIdsAfter.length).toEqual(flowIdsBefore.length);
+      expect(new Set(flowIdsAfter)).toEqual(new Set(flowIdsBefore));
+    });
+  });
+});

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/update-api-definition/api-v4-update-with-definition.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/update-api-definition/api-v4-update-with-definition.spec.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, describe, expect, test } from '@jest/globals';
+import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
+import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
+import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
+import { created, fail, noContent, succeed } from '@lib/jest-utils';
+
+const envId = 'DEFAULT';
+
+const v2ApisResource = new APIsApi(forManagementV2AsApiUser());
+
+describe('API - V4 - Update via definition import', () => {
+  describe('Update an existing PROXY API with a new definition', () => {
+    let createdApi: ApiV4;
+    const originalDefinition = MAPIV2ApisFaker.apiImportV4();
+
+    test('should create a v4 PROXY API to update later', async () => {
+      createdApi = await created(
+        v2ApisResource.createApiWithImportDefinitionRaw({
+          envId,
+          exportApiV4: originalDefinition,
+        }),
+      );
+      expect(createdApi).toBeTruthy();
+      expect(createdApi.id).toBeTruthy();
+    });
+
+    test('should update the PROXY API via PUT /_import/definition', async () => {
+      const updatedDefinition = MAPIV2ApisFaker.apiImportV4({
+        api: MAPIV2ApisFaker.apiV4Proxy({
+          name: 'Updated API Name',
+          apiVersion: '2.0.0',
+          description: 'Updated via definition import',
+          listeners: createdApi.listeners,
+        }),
+      });
+
+      const updatedApi = await succeed(
+        v2ApisResource.updateApiWithDefinitionRaw({
+          envId,
+          apiId: createdApi.id,
+          exportApiV4: updatedDefinition,
+        }),
+      );
+
+      expect(updatedApi).toBeTruthy();
+      expect(updatedApi.id).toStrictEqual(createdApi.id);
+      expect(updatedApi.name).toBe('Updated API Name');
+      expect(updatedApi.apiVersion).toBe('2.0.0');
+      expect(updatedApi.description).toBe('Updated via definition import');
+    });
+
+    test('should get updated PROXY API with new data', async () => {
+      const fetchedApi = await succeed(
+        v2ApisResource.getApiRaw({
+          envId,
+          apiId: createdApi.id,
+        }),
+      );
+      expect(fetchedApi.id).toStrictEqual(createdApi.id);
+      expect(fetchedApi.name).toBe('Updated API Name');
+      expect(fetchedApi.apiVersion).toBe('2.0.0');
+    });
+
+    afterAll(async () => {
+      if (createdApi) {
+        await noContent(v2ApisResource.deleteApiRaw({ envId, apiId: createdApi.id }));
+      }
+    });
+  });
+
+  describe('Update an existing MESSAGE API with a new definition', () => {
+    let createdApi: ApiV4;
+
+    test('should create a v4 MESSAGE API to update later', async () => {
+      createdApi = await created(
+        v2ApisResource.createApiWithImportDefinitionRaw({
+          envId,
+          exportApiV4: MAPIV2ApisFaker.apiImportV4({
+            api: MAPIV2ApisFaker.apiV4Message(),
+          }),
+        }),
+      );
+      expect(createdApi).toBeTruthy();
+      expect(createdApi.id).toBeTruthy();
+      expect(createdApi.type).toBe('MESSAGE');
+    });
+
+    test('should update the MESSAGE API via PUT /_import/definition', async () => {
+      const updatedDefinition = MAPIV2ApisFaker.apiImportV4({
+        api: MAPIV2ApisFaker.apiV4Message({
+          name: 'Updated Message API',
+          apiVersion: '3.0.0',
+          description: 'Updated message API via definition import',
+          listeners: createdApi.listeners,
+        }),
+      });
+
+      const updatedApi = await succeed(
+        v2ApisResource.updateApiWithDefinitionRaw({
+          envId,
+          apiId: createdApi.id,
+          exportApiV4: updatedDefinition,
+        }),
+      );
+
+      expect(updatedApi).toBeTruthy();
+      expect(updatedApi.id).toStrictEqual(createdApi.id);
+      expect(updatedApi.name).toBe('Updated Message API');
+      expect(updatedApi.apiVersion).toBe('3.0.0');
+      expect(updatedApi.description).toBe('Updated message API via definition import');
+    });
+
+    test('should get updated MESSAGE API with new data', async () => {
+      const fetchedApi = await succeed(
+        v2ApisResource.getApiRaw({
+          envId,
+          apiId: createdApi.id,
+        }),
+      );
+      expect(fetchedApi.id).toStrictEqual(createdApi.id);
+      expect(fetchedApi.name).toBe('Updated Message API');
+      expect(fetchedApi.apiVersion).toBe('3.0.0');
+    });
+
+    afterAll(async () => {
+      if (createdApi) {
+        await noContent(v2ApisResource.deleteApiRaw({ envId, apiId: createdApi.id }));
+      }
+    });
+  });
+
+  describe('Update API with a conflicting context path returns 400', () => {
+    let api1: ApiV4;
+    let api2: ApiV4;
+
+    test('should create first API', async () => {
+      api1 = await created(
+        v2ApisResource.createApiWithImportDefinitionRaw({
+          envId,
+          exportApiV4: MAPIV2ApisFaker.apiImportV4(),
+        }),
+      );
+    });
+
+    test('should create second API', async () => {
+      api2 = await created(
+        v2ApisResource.createApiWithImportDefinitionRaw({
+          envId,
+          exportApiV4: MAPIV2ApisFaker.apiImportV4(),
+        }),
+      );
+    });
+
+    test('should fail to update second API with the same context path as first API', async () => {
+      await fail(
+        v2ApisResource.updateApiWithDefinitionRaw({
+          envId,
+          apiId: api2.id,
+          exportApiV4: MAPIV2ApisFaker.apiImportV4({
+            api: MAPIV2ApisFaker.apiV4Proxy({
+              listeners: api1.listeners,
+            }),
+          }),
+        }),
+        400,
+      );
+    });
+
+    afterAll(async () => {
+      if (api1) await noContent(v2ApisResource.deleteApiRaw({ envId, apiId: api1.id }));
+      if (api2) await noContent(v2ApisResource.deleteApiRaw({ envId, apiId: api2.id }));
+    });
+  });
+
+  describe('Update API preserves the API ID', () => {
+    let createdApi: ApiV4;
+
+    test('should create an API', async () => {
+      createdApi = await created(
+        v2ApisResource.createApiWithImportDefinitionRaw({
+          envId,
+          exportApiV4: MAPIV2ApisFaker.apiImportV4(),
+        }),
+      );
+      expect(createdApi.id).toBeTruthy();
+    });
+
+    test('should preserve API ID after update even when definition contains a different id', async () => {
+      const updatedDefinition = MAPIV2ApisFaker.apiImportV4({
+        api: MAPIV2ApisFaker.apiV4Proxy({
+          id: 'some-other-id',
+          name: 'API With Different ID In Definition',
+          listeners: createdApi.listeners,
+        }),
+      });
+
+      const updatedApi = await succeed(
+        v2ApisResource.updateApiWithDefinitionRaw({
+          envId,
+          apiId: createdApi.id,
+          exportApiV4: updatedDefinition,
+        }),
+      );
+
+      expect(updatedApi.id).toStrictEqual(createdApi.id);
+      expect(updatedApi.name).toBe('API With Different ID In Definition');
+    });
+
+    afterAll(async () => {
+      if (createdApi) {
+        await noContent(v2ApisResource.deleteApiRaw({ envId, apiId: createdApi.id }));
+      }
+    });
+  });
+});

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -23,6 +23,7 @@ import static java.util.Collections.singletonList;
 
 import io.gravitee.apim.core.api.model.UpdateNativeApi;
 import io.gravitee.apim.core.api.model.crd.IDExportStrategy;
+import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
 import io.gravitee.apim.core.api.model.utils.MigrationResult;
 import io.gravitee.apim.core.api.use_case.DetachAutomatedApiUseCase;
 import io.gravitee.apim.core.api.use_case.ExportApiCRDUseCase;
@@ -30,7 +31,9 @@ import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.MigrateApiUseCase;
+import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateFederatedApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateNativeApiUseCase;
 import io.gravitee.apim.core.audit.model.AuditActor;
@@ -59,6 +62,8 @@ import io.gravitee.rest.api.management.v2.rest.model.ApiRollback;
 import io.gravitee.rest.api.management.v2.rest.model.ApiTransferOwnership;
 import io.gravitee.rest.api.management.v2.rest.model.DuplicateApiOptions;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.ImportSwaggerDescriptor;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationReportResponses;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationReportResponsesIssuesInner;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationStateType;
@@ -84,6 +89,7 @@ import io.gravitee.rest.api.management.v2.rest.resource.api.specgen.ApiSpecGenRe
 import io.gravitee.rest.api.management.v2.rest.resource.documentation.ApiPagesResource;
 import io.gravitee.rest.api.management.v2.rest.resource.param.LifecycleAction;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
+import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
 import io.gravitee.rest.api.model.InlinePictureEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.RoleEntity;
@@ -247,6 +253,12 @@ public class ApiResource extends AbstractResource {
     @Inject
     private DetachAutomatedApiUseCase detachAutomatedApiUseCase;
 
+    @Inject
+    private UpdateApiDefinitionFromImportUseCase updateApiDefinitionUseCase;
+
+    @Inject
+    private OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
+
     @Context
     protected UriInfo uriInfo;
 
@@ -320,6 +332,61 @@ public class ApiResource extends AbstractResource {
     public Response getApiById(@PathParam("apiId") String apiId) {
         final GenericApiEntity apiEntity = getGenericApiEntityById(apiId, true);
         return apiResponse(apiEntity);
+    }
+
+    @PUT
+    @Path("/_import/definition")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response updateApiWithDefinition(@PathParam("apiId") String apiId, @Valid ExportApiV4 apiToImport) {
+        verifyImage(apiToImport.getApiPicture(), "picture");
+        verifyImage(apiToImport.getApiBackground(), "background");
+
+        ImportDefinition importDefinition = ImportExportApiMapper.INSTANCE.toImportDefinition(apiToImport);
+
+        var audit = getAuditInfo();
+        UpdateApiDefinitionFromImportUseCase.Output output = updateApiDefinitionUseCase.execute(
+            new UpdateApiDefinitionFromImportUseCase.Input(apiId, importDefinition, audit)
+        );
+
+        boolean isSynchronized = apiStateService.isSynchronized(
+            GraviteeContext.getExecutionContext(),
+            getGenericApiEntityById(apiId, false)
+        );
+
+        return Response.ok().entity(ApiMapper.INSTANCE.map(output.apiWithFlows(), uriInfo, isSynchronized)).build();
+    }
+
+    @PUT
+    @Path("/_import/swagger")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response updateApiFromSwagger(@PathParam("apiId") String apiId, @Valid @NotNull ImportSwaggerDescriptor descriptor) {
+        var audit = getAuditInfo();
+        var importSwaggerDescriptor = ImportSwaggerDescriptorEntity.builder()
+            .payload(descriptor.getPayload())
+            .withPolicies(descriptor.getWithPolicies() != null ? new ArrayList<>(descriptor.getWithPolicies()) : null)
+            .withPolicyPaths(Boolean.TRUE.equals(descriptor.getWithPolicyPaths()))
+            .build();
+
+        var output = oaiToUpdateApiUseCase.execute(
+            OAIToUpdateApiUseCase.Input.builder()
+                .apiId(apiId)
+                .importSwaggerDescriptor(importSwaggerDescriptor)
+                .withDocumentation(Boolean.TRUE.equals(descriptor.getWithDocumentation()))
+                .withOASValidationPolicy(Boolean.TRUE.equals(descriptor.getWithOASValidationPolicy()))
+                .withPolicyPaths(Boolean.TRUE.equals(descriptor.getWithPolicyPaths()))
+                .auditInfo(audit)
+                .build()
+        );
+
+        boolean isSynchronized = apiStateService.isSynchronized(
+            GraviteeContext.getExecutionContext(),
+            getGenericApiEntityById(apiId, false)
+        );
+        return Response.ok().entity(ApiMapper.INSTANCE.map(output.apiWithFlows(), uriInfo, isSynchronized)).build();
     }
 
     @PUT
@@ -1166,6 +1233,14 @@ public class ApiResource extends AbstractResource {
     private void assertNoPrimaryOwnerReassignment(String poRole) {
         if (PRIMARY_OWNER.name().equals(poRole)) {
             throw new TransferOwnershipNotAllowedException(poRole);
+        }
+    }
+
+    private static void verifyImage(String imageContent, String imageUsage) {
+        try {
+            ImageUtils.verify(imageContent);
+        } catch (InvalidImageException e) {
+            throw new BadRequestException("Invalid image format for api " + imageUsage);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -561,6 +561,66 @@ paths:
                                 $ref: "#/components/schemas/ExportApiV4"
                 default:
                     $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/{apiId}/_import/definition:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        put:
+            tags:
+                - APIs
+            summary: Update API from definition
+            description: |-
+                Update an existing API by importing a Gravitee API definition.<br>
+                This definition can be retrieved from `GET /environments/{envId}/apis/{apiId}/_export/definition`
+
+                User must have the API_DEFINITION[UPDATE] permission.
+            operationId: updateApiWithDefinition
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ExportApiV4"
+                required: true
+            responses:
+                "200":
+                    description: API successfully updated
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiV4"
+                default:
+                    $ref: "#/components/responses/Error"
+
+    /environments/{envId}/apis/{apiId}/_import/swagger:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        put:
+            tags:
+                - APIs
+            summary: Update API from OpenAPI descriptor
+            description: |-
+                Update an existing API by importing an OpenAPI (Swagger) descriptor.<br>
+                The descriptor payload must be a valid OpenAPI 2.x or 3.x document in JSON or YAML format.
+
+                User must have the API_DEFINITION[UPDATE] permission.
+            operationId: updateApiFromSwagger
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ImportSwaggerDescriptor"
+                required: true
+            responses:
+                "200":
+                    description: API successfully updated
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiV4"
+                default:
+                    $ref: "#/components/responses/Error"
+
     /environments/{envId}/apis/{apiId}/_start:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -3722,6 +3782,15 @@ components:
                 withOASValidationPolicy:
                     type: boolean
                     description: Add an OpenAPI Specification validation policy based on OpenAPI specification.
+                withPolicies:
+                    type: array
+                    description: Policy visitor IDs to apply during OpenAPI import.
+                    items:
+                        type: string
+                    uniqueItems: true
+                withPolicyPaths:
+                    type: boolean
+                    description: Create a flow for each path declared in the OpenAPI specification.
 
         UpdateApi:
             oneOf:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -26,6 +26,7 @@ import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.ApplicationMetadataCrudServiceInMemory;
 import inmemory.ApplicationMetadataQueryServiceInMemory;
 import inmemory.CategoryQueryServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
 import inmemory.ImportApplicationCRDDomainServiceInMemory;
@@ -39,8 +40,11 @@ import inmemory.RoleQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import inmemory.UserDomainServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
+import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
+import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
+import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.specgen.use_case.SpecGenRequestUseCase;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
@@ -127,6 +131,15 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     protected ExportApiUseCase exportApiUseCase;
 
     @Autowired
+    protected UpdateApiDefinitionFromImportUseCase updateApiDefinitionUseCase;
+
+    @Autowired
+    protected OAIDomainService oaiDomainService;
+
+    @Autowired
+    protected OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
+
+    @Autowired
     protected PermissionService permissionService;
 
     @Autowired
@@ -200,6 +213,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected ApiCrudServiceInMemory apiCrudService;
+
+    @Autowired
+    protected FlowCrudServiceInMemory flowCrudService;
 
     @Autowired
     protected PrimaryOwnerDomainServiceInMemory primaryOwnerDomainService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
@@ -53,7 +53,9 @@ public abstract class ApiResourceTest extends AbstractResourceTest {
             apiWorkflowStateService,
             roleService,
             apiDuplicatorService,
-            apiDuplicateService
+            apiDuplicateService,
+            updateApiDefinitionUseCase,
+            oaiToUpdateApiUseCase
         );
         GraviteeContext.cleanContext();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromSwaggerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromSwaggerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.exception.InvalidApiDefinitionException;
+import io.gravitee.apim.core.api.exception.InvalidPathsException;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.ImportSwaggerDescriptor;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+class ApiResource_UpdateApiFromSwaggerTest extends ApiResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/_import/swagger";
+    }
+
+    @Test
+    void should_return_403_when_no_definition_update_permission() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_DEFINITION,
+                API,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(false);
+
+        Response response = rootTarget().request().put(Entity.json(new ImportSwaggerDescriptor()));
+
+        assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
+    }
+
+    @Test
+    void should_return_404_when_api_not_found() {
+        when(oaiToUpdateApiUseCase.execute(any())).thenThrow(new ApiNotFoundException(API));
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("{}"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(NOT_FOUND_404);
+    }
+
+    @Test
+    void should_return_200_and_updated_api_on_success() {
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API).environmentId(ENVIRONMENT).build();
+        var apiWithFlows = new ApiWithFlows(existingApi, java.util.List.of());
+
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(apiWithFlows));
+        when(apiSearchServiceV4.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(
+            io.gravitee.rest.api.model.v4.api.ApiEntity.builder().id(API).name("Test API").apiVersion("1.0").build()
+        );
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("{}"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        var body = response.readEntity(ApiV4.class);
+        assertThat(body).isNotNull();
+        assertThat(body.getId()).isEqualTo(API);
+    }
+
+    @Test
+    void should_return_400_when_swagger_cannot_be_read() {
+        when(oaiToUpdateApiUseCase.execute(any())).thenThrow(new InvalidApiDefinitionException("Unable to read the swagger specification"));
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("{}"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_400_when_invalid_paths_exception() {
+        when(oaiToUpdateApiUseCase.execute(any())).thenThrow(new InvalidPathsException("Path [/foo] already exists"));
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("{}"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    private ImportSwaggerDescriptor buildDescriptor(String payload) {
+        var descriptor = new ImportSwaggerDescriptor();
+        descriptor.setPayload(payload);
+        return descriptor;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiWithDefinitionTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.exception.InvalidPathsException;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+class ApiResource_UpdateApiWithDefinitionTest extends ApiResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/_import/definition";
+    }
+
+    @Test
+    void should_return_403_when_no_definition_update_permission() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_DEFINITION,
+                API,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(false);
+
+        Response response = rootTarget().request().put(Entity.json(new ExportApiV4()));
+
+        assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
+    }
+
+    @Test
+    void should_return_404_when_api_not_found() {
+        when(updateApiDefinitionUseCase.execute(any())).thenThrow(new ApiNotFoundException(API));
+
+        var exportApiV4 = buildMinimalExportApiV4();
+        Response response = rootTarget().request().put(Entity.entity(exportApiV4, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(NOT_FOUND_404);
+    }
+
+    @Test
+    void should_return_400_when_definition_version_not_supported() {
+        when(updateApiDefinitionUseCase.execute(any())).thenThrow(
+            new ApiDefinitionVersionNotSupportedException(DefinitionVersion.V2.getLabel())
+        );
+
+        var exportApiV4 = buildMinimalExportApiV4();
+        Response response = rootTarget().request().put(Entity.entity(exportApiV4, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void should_return_200_and_updated_api_on_success() {
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API).environmentId(ENVIRONMENT).build();
+        var apiWithFlows = new ApiWithFlows(existingApi, java.util.List.of());
+
+        when(updateApiDefinitionUseCase.execute(any())).thenReturn(new UpdateApiDefinitionFromImportUseCase.Output(apiWithFlows));
+
+        // mock getGenericApiEntityById used for isSynchronized check
+        when(apiSearchServiceV4.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(
+            io.gravitee.rest.api.model.v4.api.ApiEntity.builder().id(API).name("Test API").apiVersion("1.0").build()
+        );
+
+        var exportApiV4 = buildMinimalExportApiV4();
+        Response response = rootTarget().request().put(Entity.entity(exportApiV4, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        var body = response.readEntity(ApiV4.class);
+        assertThat(body).isNotNull();
+        assertThat(body.getId()).isEqualTo(API);
+    }
+
+    @Test
+    void should_return_400_when_invalid_paths_exception() {
+        when(updateApiDefinitionUseCase.execute(any())).thenThrow(new InvalidPathsException("Path [/foo] already exists"));
+
+        var exportApiV4 = buildMinimalExportApiV4();
+        Response response = rootTarget().request().put(Entity.entity(exportApiV4, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_400_when_api_picture_is_invalid() {
+        var exportApiV4 = buildMinimalExportApiV4();
+        exportApiV4.setApiPicture("not-a-valid-image");
+
+        Response response = rootTarget().request().put(Entity.entity(exportApiV4, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_400_when_api_background_is_invalid() {
+        var exportApiV4 = buildMinimalExportApiV4();
+        exportApiV4.setApiBackground("not-a-valid-image");
+
+        Response response = rootTarget().request().put(Entity.entity(exportApiV4, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    private ExportApiV4 buildMinimalExportApiV4() {
+        var apiV4 = new io.gravitee.rest.api.management.v2.rest.model.ApiV4();
+        apiV4.setId(API);
+        apiV4.setName("Test API");
+        apiV4.setApiVersion("1.0");
+        apiV4.setDefinitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4);
+        apiV4.setType(io.gravitee.rest.api.management.v2.rest.model.ApiType.PROXY);
+
+        var exportApiV4 = new ExportApiV4();
+        exportApiV4.setApi(apiV4);
+        return exportApiV4;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -67,7 +67,9 @@ import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
+import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
@@ -577,6 +579,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    @Primary
+    public UpdateApiDefinitionFromImportUseCase updateApiDefinitionUseCase() {
+        return mock(UpdateApiDefinitionFromImportUseCase.class);
+    }
+
+    @Bean
+    @Primary
     public GetApiDefinitionUseCase getApiDefinitionUseCase() {
         return mock(GetApiDefinitionUseCase.class);
     }
@@ -589,6 +598,12 @@ public class ResourceContextConfiguration {
     @Bean
     public OAIDomainService oaiDomainService() {
         return mock(OAIDomainService.class);
+    }
+
+    @Bean
+    @Primary
+    public OAIToUpdateApiUseCase oaiToUpdateApiUseCase() {
+        return mock(OAIToUpdateApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionPageDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionPageDomainService.java
@@ -24,6 +24,8 @@ import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.common.utils.TimeProvider;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -50,17 +52,35 @@ class ImportDefinitionPageDomainService {
         }
 
         var savedPages = apiDocumentationDomainService.getApiPages(apiId, null);
-        var pageMap = savedPages.stream().collect(Collectors.toMap(Page::getCrossId, Function.identity()));
+        var pageMap = savedPages
+            .stream()
+            .filter(p -> p.getCrossId() != null)
+            .collect(Collectors.toMap(Page::getCrossId, Function.identity()));
         var now = Date.from(TimeProvider.now().toInstant());
 
         for (var importedPage : pagesToImport) {
-            var existingPage = pageMap.get(importedPage.getCrossId());
+            var existingPage = findSavedPageForImport(pageMap, savedPages, importedPage);
             var pageToSave = importedPage.toBuilder().referenceType(Page.ReferenceType.API).referenceId(apiId).updatedAt(now);
-            if (existingPage == null) {
+            if (existingPage.isEmpty()) {
                 createApiDocumentationDomainService.createPage(pageToSave.createdAt(now).build(), auditInfo);
             } else {
-                updateApiDocumentationDomainService.updatePage(pageToSave.build(), existingPage, auditInfo);
+                // Match is by crossId; the imported page may carry a different id (e.g. after id generation on update).
+                // Persistence must use the existing row id.
+                var mergedForUpdate = pageToSave.id(existingPage.get().getId()).createdAt(existingPage.get().getCreatedAt()).build();
+                updateApiDocumentationDomainService.updatePage(mergedForUpdate, existingPage.get(), auditInfo);
             }
         }
+    }
+
+    /** Match by {@code crossId} when present and found; else by matching type and name. */
+    private static Optional<Page> findSavedPageForImport(Map<String, Page> savedByCrossId, List<Page> savedPages, Page importedPage) {
+        if (importedPage.getCrossId() != null) {
+            var byCrossId = Optional.ofNullable(savedByCrossId.get(importedPage.getCrossId()));
+            if (byCrossId.isPresent()) return byCrossId;
+        }
+        return savedPages
+            .stream()
+            .filter(p -> p.getType() == importedPage.getType() && importedPage.getName().equals(p.getName()))
+            .findFirst();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionPlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionPlanDomainService.java
@@ -24,8 +24,11 @@ import io.gravitee.apim.core.plan.domain_service.DeletePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.model.PlanWithFlows;
+import jakarta.validation.constraints.NotNull;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -49,28 +52,53 @@ class ImportDefinitionPlanDomainService {
         this.planCrudService = planCrudService;
     }
 
-    void upsertPlanWithFlows(Api api, Set<PlanWithFlows> plansWithFlows, AuditInfo auditInfo) {
-        var savedPlans = planCrudService.findByApiId(api.getId());
-        var crossIds = savedPlans.stream().map(Plan::getCrossId).collect(Collectors.toCollection(HashSet::new));
+    void upsertPlanWithFlows(Api api, @NotNull Set<PlanWithFlows> plansWithFlows, AuditInfo auditInfo) {
+        if (plansWithFlows.isEmpty()) {
+            return;
+        }
 
-        if (plansWithFlows != null) {
-            for (PlanWithFlows planWithFlow : plansWithFlows) {
-                var crossId = planWithFlow.getCrossId();
-                if (crossIds.contains(crossId)) {
-                    updatePlanDomainService.update(planWithFlow, planWithFlow.getFlows(), Collections.emptyMap(), api, auditInfo);
-                } else {
-                    createPlanDomainService.create(planWithFlow, planWithFlow.getFlows(), api, auditInfo);
-                }
-                crossIds.remove(crossId);
-            }
+        var savedPlans = planCrudService.findByApiId(api.getId());
+
+        // Build indexed lookups once — O(m) — to avoid O(n*m) per-item streaming inside the loop.
+        var savedByCrossId = savedPlans
+            .stream()
+            .filter(p -> p.getCrossId() != null)
+            .collect(Collectors.toMap(Plan::getCrossId, p -> p, (a, b) -> a));
+        var savedById = savedPlans.stream().collect(Collectors.toMap(Plan::getId, p -> p, (a, b) -> a));
+
+        var unmatchedSavedPlanIds = new HashSet<>(savedById.keySet());
+
+        for (PlanWithFlows planWithFlow : plansWithFlows) {
+            findSavedPlanForImport(savedByCrossId, savedById, planWithFlow).ifPresentOrElse(
+                existing -> updateMatchedPlan(existing, planWithFlow, unmatchedSavedPlanIds, api, auditInfo),
+                () -> createPlanDomainService.create(planWithFlow, planWithFlow.getFlows(), api, auditInfo)
+            );
         }
 
         // FIXME: Support closing plans when export includes closed ones (currently mimics V2 promotion behavior and remove missing plans).
-        if (!crossIds.isEmpty()) {
-            savedPlans
-                .stream()
-                .filter(plan -> crossIds.contains(plan.getCrossId()))
-                .forEach(removedPlan -> deletePlanDomainService.delete(removedPlan, auditInfo));
+        unmatchedSavedPlanIds.forEach(planId -> deletePlanDomainService.delete(savedById.get(planId), auditInfo));
+    }
+
+    private void updateMatchedPlan(Plan existing, PlanWithFlows incoming, HashSet<String> unmatchedIds, Api api, AuditInfo auditInfo) {
+        incoming.setId(existing.getId());
+        incoming.setReferenceId(existing.getReferenceId());
+        incoming.setReferenceType(existing.getReferenceType());
+        updatePlanDomainService.update(incoming, incoming.getFlows(), Collections.emptyMap(), api, auditInfo);
+        unmatchedIds.remove(existing.getId());
+    }
+
+    /** Match by {@code crossId} when present and found; else by {@code id}. */
+    private static Optional<Plan> findSavedPlanForImport(
+        Map<String, Plan> savedByCrossId,
+        Map<String, Plan> savedById,
+        PlanWithFlows incomingPlan
+    ) {
+        if (incomingPlan.getCrossId() != null) {
+            var byCrossId = Optional.ofNullable(savedByCrossId.get(incomingPlan.getCrossId()));
+            if (byCrossId.isPresent()) return byCrossId;
         }
+        // incomingPlan.getId() is null only in manually crafted definitions that omit the id field.
+        // A normal Gravitee export always includes the plan id; the guard prevents NPE in the map lookup.
+        return incomingPlan.getId() == null ? Optional.empty() : Optional.ofNullable(savedById.get(incomingPlan.getId()));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainService.java
@@ -19,22 +19,29 @@ import static io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService.o
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api.domain_service.ApiIdsCalculatorDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiImportDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateNativeApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.factory.ApiModelFactory;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
+import io.gravitee.apim.core.api.model.import_definition.ApiMember;
 import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
 import io.gravitee.apim.core.api.model.import_definition.ImportDefinitionSubEntityProcessor;
 import io.gravitee.apim.core.api.service_provider.ApiImagesServiceProvider;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.media.model.Media;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.nativeapi.NativeListener;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 
 @DomainService
@@ -49,6 +56,7 @@ public class ImportDefinitionUpdateDomainService {
     private final ImportDefinitionMetadataDomainService importDefinitionMetadataDomainService;
     private final ImportDefinitionPlanDomainService importDefinitionPlanDomainService;
     private final ImportDefinitionPageDomainService importDefinitionPageDomainService;
+    private final ApiImportDomainService apiImportDomainService;
 
     ImportDefinitionUpdateDomainService(
         UpdateApiDomainService updateApiDomainService,
@@ -59,7 +67,8 @@ public class ImportDefinitionUpdateDomainService {
         ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService,
         ImportDefinitionMetadataDomainService importDefinitionMetadataDomainService,
         ImportDefinitionPlanDomainService importDefinitionPlanDomainService,
-        ImportDefinitionPageDomainService importDefinitionPageDomainService
+        ImportDefinitionPageDomainService importDefinitionPageDomainService,
+        ApiImportDomainService apiImportDomainService
     ) {
         this.updateApiDomainService = updateApiDomainService;
         this.apiImagesServiceProvider = apiImagesServiceProvider;
@@ -70,6 +79,7 @@ public class ImportDefinitionUpdateDomainService {
         this.importDefinitionMetadataDomainService = importDefinitionMetadataDomainService;
         this.importDefinitionPlanDomainService = importDefinitionPlanDomainService;
         this.importDefinitionPageDomainService = importDefinitionPageDomainService;
+        this.apiImportDomainService = apiImportDomainService;
     }
 
     public Api update(ImportDefinition importDefinition, Api existingPromotedApi, AuditInfo auditInfo) {
@@ -77,9 +87,18 @@ public class ImportDefinitionUpdateDomainService {
         var apiWithIds = apiIdsCalculatorDomainService.recalculateApiDefinitionIds(auditInfo.environmentId(), importDefinition);
         var apiExport = apiWithIds.getApiExport();
 
+        if (
+            (apiExport.getProperties() == null || apiExport.getProperties().isEmpty()) &&
+            existingPromotedApi.getApiDefinitionValue() instanceof AbstractApi existingDefinition &&
+            existingDefinition.getProperties() != null &&
+            !existingDefinition.getProperties().isEmpty()
+        ) {
+            apiExport.setProperties(existingDefinition.getProperties());
+        }
+
         var updatedApi = switch (existingPromotedApi.getType()) {
             case PROXY, MESSAGE -> updateApiDomainService.updateV4(
-                ApiModelFactory.fromApiExport(apiExport, auditInfo.environmentId()),
+                ApiModelFactory.fromApiExport(apiExport, auditInfo.environmentId()).toBuilder().id(apiId).build(),
                 auditInfo
             );
             case NATIVE -> updateNativeApi(apiId, apiWithIds.getApiExport(), auditInfo);
@@ -90,16 +109,36 @@ public class ImportDefinitionUpdateDomainService {
         apiImagesServiceProvider.updateApiBackground(apiId, apiExport.getBackground(), auditInfo);
 
         new ImportDefinitionSubEntityProcessor(updatedApi.getId())
+            .addSubEntity("Members", () -> importMembersIfPresent(importDefinition.getMembers(), apiId))
             .addSubEntity("Metadata", () ->
                 importDefinitionMetadataDomainService.upsertMetadata(apiId, importDefinition.getMetadata(), auditInfo)
             )
             .addSubEntity("Pages", () -> importDefinitionPageDomainService.upsertPages(apiId, apiWithIds.getPages(), auditInfo))
             .addSubEntity("Plans", () ->
-                importDefinitionPlanDomainService.upsertPlanWithFlows(existingPromotedApi, importDefinition.getPlans(), auditInfo)
+                importDefinitionPlanDomainService.upsertPlanWithFlows(
+                    existingPromotedApi,
+                    Objects.requireNonNullElse(importDefinition.getPlans(), Set.of()),
+                    auditInfo
+                )
             )
+            .addSubEntity("Media", () -> importMediaIfPresent(importDefinition.getApiMedia(), apiId, auditInfo))
             .process();
 
         return updatedApi;
+    }
+
+    private void importMembersIfPresent(Set<ApiMember> members, String apiId) {
+        if (members == null || members.isEmpty()) {
+            return;
+        }
+        apiImportDomainService.createMembers(members, apiId);
+    }
+
+    private void importMediaIfPresent(List<Media> apiMedia, String apiId, AuditInfo auditInfo) {
+        if (apiMedia == null || apiMedia.isEmpty()) {
+            return;
+        }
+        apiImportDomainService.createMedias(apiMedia, apiId, new ExecutionContext(auditInfo.organizationId(), auditInfo.environmentId()));
     }
 
     private Api updateNativeApi(String apiId, ApiExport apiExport, AuditInfo auditInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/OAIToUpdateApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/OAIToUpdateApiUseCase.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.OAIDomainService;
+import io.gravitee.apim.core.api.exception.InvalidApiDefinitionException;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
+import io.gravitee.definition.model.v4.flow.AbstractFlow;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@CustomLog
+@RequiredArgsConstructor
+public class OAIToUpdateApiUseCase {
+
+    @Builder
+    public record Input(
+        String apiId,
+        ImportSwaggerDescriptorEntity importSwaggerDescriptor,
+        boolean withDocumentation,
+        boolean withOASValidationPolicy,
+        boolean withPolicyPaths,
+        AuditInfo auditInfo
+    ) {}
+
+    public record Output(ApiWithFlows apiWithFlows) {}
+
+    private final OAIDomainService oaiDomainService;
+    private final FlowCrudService flowCrudService;
+    private final UpdateApiDefinitionFromImportUseCase updateApiDefinitionUseCase;
+
+    public Output execute(Input input) {
+        var audit = input.auditInfo();
+        var importDefinition = oaiDomainService.convert(
+            audit.organizationId(),
+            audit.environmentId(),
+            input.importSwaggerDescriptor(),
+            input.withDocumentation(),
+            input.withOASValidationPolicy()
+        );
+
+        if (importDefinition == null) {
+            throw new InvalidApiDefinitionException("Unable to read the swagger specification");
+        }
+
+        if (!input.withPolicyPaths()) {
+            restoreApiFlowIdsByKey(
+                importDefinition.getApiExport() != null ? importDefinition.getApiExport().getFlows() : null,
+                input.apiId()
+            );
+        }
+
+        var output = updateApiDefinitionUseCase.execute(
+            new UpdateApiDefinitionFromImportUseCase.Input(input.apiId(), importDefinition, audit)
+        );
+
+        return new Output(output.apiWithFlows());
+    }
+
+    private void restoreApiFlowIdsByKey(List<? extends AbstractFlow> flows, String apiId) {
+        if (flows == null || flows.stream().noneMatch(f -> f instanceof Flow flow && flow.getId() == null)) {
+            return;
+        }
+
+        var idByKey = flowCrudService
+            .getApiV4Flows(apiId)
+            .stream()
+            .filter(f -> f instanceof Flow flow && flow.getId() != null)
+            .collect(Collectors.toMap(this::httpFlowKey, Flow::getId, (firstId, duplicateId) -> keepFirstId(apiId, firstId)));
+
+        flows
+            .stream()
+            .filter(f -> f instanceof Flow flow && flow.getId() == null)
+            .map(Flow.class::cast)
+            .forEach(flow -> {
+                // remove so the same existing ID cannot be assigned to more than one incoming flow
+                var existingId = idByKey.remove(httpFlowKey(flow));
+                if (existingId != null) {
+                    flow.setId(existingId);
+                }
+            });
+    }
+
+    private String httpFlowKey(AbstractFlow abstractFlow) {
+        if (!(abstractFlow instanceof Flow flow) || flow.getSelectors() == null) {
+            return "";
+        }
+        return flow
+            .getSelectors()
+            .stream()
+            .filter(HttpSelector.class::isInstance)
+            .map(HttpSelector.class::cast)
+            .map(this::httpSelectorKey)
+            .collect(Collectors.joining(";"));
+    }
+
+    private String httpSelectorKey(HttpSelector http) {
+        var methods = http.getMethods() != null ? http.getMethods().stream().map(Enum::name).sorted().collect(Collectors.joining(",")) : "";
+        return http.getPath() + "|" + methods;
+    }
+
+    private String keepFirstId(String apiId, String firstId) {
+        log.warn("Duplicate HTTP flow key found among persisted flows for API [{}], keeping first flow id [{}]", apiId, firstId);
+        return firstId;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateApiDefinitionFromImportUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateApiDefinitionFromImportUseCase.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.import_definition.ImportDefinitionUpdateDomainService;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.exception.InvalidApiDefinitionException;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.model.import_definition.ApiExport;
+import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
+import lombok.CustomLog;
+
+@UseCase
+@CustomLog
+public class UpdateApiDefinitionFromImportUseCase {
+
+    public record Input(String apiId, ImportDefinition importDefinition, AuditInfo auditInfo) {}
+
+    public record Output(ApiWithFlows apiWithFlows) {}
+
+    private final ApiCrudService apiCrudService;
+    private final ImportDefinitionUpdateDomainService importDefinitionUpdateDomainService;
+    private final FlowCrudService flowCrudService;
+
+    public UpdateApiDefinitionFromImportUseCase(
+        ApiCrudService apiCrudService,
+        ImportDefinitionUpdateDomainService importDefinitionUpdateDomainService,
+        FlowCrudService flowCrudService
+    ) {
+        this.apiCrudService = apiCrudService;
+        this.importDefinitionUpdateDomainService = importDefinitionUpdateDomainService;
+        this.flowCrudService = flowCrudService;
+    }
+
+    public Output execute(Input input) {
+        ensureIsV4Api(input.importDefinition().getApiExport());
+
+        var existingApi = apiCrudService.findById(input.apiId()).orElseThrow(() -> new ApiNotFoundException(input.apiId()));
+
+        var updatedApi = importDefinitionUpdateDomainService.update(input.importDefinition(), existingApi, input.auditInfo());
+
+        var apiId = updatedApi.getId();
+        var flows = ApiType.NATIVE.equals(updatedApi.getType())
+            ? flowCrudService.getNativeApiFlows(apiId)
+            : flowCrudService.getApiV4Flows(apiId);
+
+        return new Output(new ApiWithFlows(updatedApi, flows));
+    }
+
+    private void ensureIsV4Api(ApiExport api) {
+        if (api == null) {
+            throw new InvalidApiDefinitionException("The API definition is required");
+        }
+        if (api.getDefinitionVersion() != DefinitionVersion.V4) {
+            throw new ApiDefinitionVersionNotSupportedException(api.getDefinitionVersion().getLabel());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionPageDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionPageDomainServiceTest.java
@@ -84,6 +84,37 @@ class ImportDefinitionPageDomainServiceTest {
     }
 
     @Test
+    void should_update_page_using_stored_id_when_cross_id_matches_but_imported_id_differs() {
+        var crossId = "same-cross-id";
+        var storedId = "stored-page-id";
+        var wrongImportedId = "generated-import-id";
+        var createdAt = Instant.parse("2020-10-12T10:15:30Z");
+        var existingInDb = PageFixtures.aPage()
+            .toBuilder()
+            .id(storedId)
+            .crossId(crossId)
+            .createdAt(Date.from(createdAt))
+            .updatedAt(Date.from(createdAt))
+            .content("old")
+            .build();
+        initializer.pageCrudServiceInMemory.createDocumentationPage(existingInDb);
+        initializer.pageQueryServiceInMemory.initWith(List.of(existingInDb));
+
+        var importedWithWrongId = existingInDb.toBuilder().id(wrongImportedId).content("new body").build();
+        service.upsertPages(API_ID, List.of(importedWithWrongId), AUDIT_INFO);
+
+        assertThat(initializer.pageCrudServiceInMemory.storage())
+            .hasSize(1)
+            .first()
+            .satisfies(p -> {
+                assertThat(p.getId()).isEqualTo(storedId);
+                assertThat(p.getCrossId()).isEqualTo(crossId);
+                assertThat(p.getContent()).isEqualTo("new body");
+                assertThat(p.getUpdatedAt()).isEqualTo(INSTANT_NOW);
+            });
+    }
+
+    @Test
     void should_update_new_page() {
         var createdAt = Instant.parse("2020-10-12T10:15:30Z");
         var pageToUpdate = PageFixtures.aPage().toBuilder().createdAt(Date.from(createdAt)).updatedAt(null).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionPlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionPlanDomainServiceTest.java
@@ -209,4 +209,134 @@ class ImportDefinitionPlanDomainServiceTest {
         var apiPlans = initializer.planCrudServiceInMemory.findByApiId(API_ID);
         assertThat(apiPlans).hasSize(1).extracting(Plan::getCrossId).containsExactlyInAnyOrder(planToUpdate.getCrossId());
     }
+
+    @Test
+    @SneakyThrows
+    void should_update_api_plan_when_export_has_plan_id_but_no_cross_id() {
+        var planToUpdate = PlanFixtures.HttpV4.anApiKey()
+            .toBuilder()
+            .crossId("plan-cross-for-db-only")
+            .apiId(API_ID)
+            .referenceType(GenericPlanEntity.ReferenceType.API)
+            .referenceId(API_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .build();
+        initializer.planCrudServiceInMemory.initWith(List.of(planToUpdate));
+
+        Set<PlanWithFlows> importDefinitionPlans = Set.of(
+            PlanWithFlows.builder()
+                .id(planToUpdate.getId())
+                .crossId(null)
+                .apiId(planToUpdate.getApiId())
+                .referenceType(GenericPlanEntity.ReferenceType.API)
+                .referenceId(API_ID)
+                .environmentId(planToUpdate.getEnvironmentId())
+                .definitionVersion(planToUpdate.getDefinitionVersion())
+                .type(planToUpdate.getType())
+                .planDefinitionHttpV4(planToUpdate.getPlanDefinitionHttpV4())
+                .name("updated after re-import without crossId in export")
+                .flows(List.of(FlowFixtures.aMessageFlowV4().toBuilder().id("flow-after-reimport").build()))
+                .build()
+        );
+
+        service.upsertPlanWithFlows(EXISTING_API, importDefinitionPlans, AUDIT_INFO);
+
+        var apiPlans = initializer.planCrudServiceInMemory.findByApiId(API_ID);
+        assertThat(apiPlans)
+            .hasSize(1)
+            .first()
+            .satisfies(updatedPlan -> {
+                assertThat(updatedPlan.getId()).isEqualTo(planToUpdate.getId());
+                assertThat(updatedPlan.getName()).isEqualTo("updated after re-import without crossId in export");
+                assertThat(updatedPlan.getCrossId()).isEqualTo("plan-cross-for-db-only");
+            });
+
+        assertThat(initializer.flowCrudServiceInMemory.getPlanV4Flows(planToUpdate.getId()))
+            .extracting(Flow::getId)
+            .containsOnly("flow-after-reimport");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_preserve_reference_id_when_imported_plan_has_null_reference_fields() {
+        var planToUpdate = PlanFixtures.HttpV4.anApiKey()
+            .toBuilder()
+            .crossId("plan-cross-for-db-only")
+            .apiId(API_ID)
+            .referenceType(GenericPlanEntity.ReferenceType.API)
+            .referenceId(API_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .build();
+        initializer.planCrudServiceInMemory.initWith(List.of(planToUpdate));
+
+        // Simulate import payload where referenceId/referenceType are absent (as produced by toHttpPlanWithFlows)
+        Set<PlanWithFlows> importDefinitionPlans = Set.of(
+            PlanWithFlows.builder()
+                .id(planToUpdate.getId())
+                .crossId(null)
+                .referenceId(null)
+                .referenceType(null)
+                .definitionVersion(planToUpdate.getDefinitionVersion())
+                .type(planToUpdate.getType())
+                .planDefinitionHttpV4(planToUpdate.getPlanDefinitionHttpV4())
+                .name("updated without reference fields in payload")
+                .flows(Collections.emptyList())
+                .build()
+        );
+
+        service.upsertPlanWithFlows(EXISTING_API, importDefinitionPlans, AUDIT_INFO);
+
+        // Plan must still be findable by API id (referenceId must not have been nulled out)
+        var apiPlans = initializer.planCrudServiceInMemory.findByApiId(API_ID);
+        assertThat(apiPlans)
+            .hasSize(1)
+            .first()
+            .satisfies(updatedPlan -> {
+                assertThat(updatedPlan.getId()).isEqualTo(planToUpdate.getId());
+                assertThat(updatedPlan.getReferenceId()).isEqualTo(API_ID);
+                assertThat(updatedPlan.getReferenceType()).isEqualTo(GenericPlanEntity.ReferenceType.API);
+                assertThat(updatedPlan.getName()).isEqualTo("updated without reference fields in payload");
+            });
+    }
+
+    @Test
+    @SneakyThrows
+    void should_update_by_plan_id_when_import_cross_id_does_not_match_any_saved_plan() {
+        var planToUpdate = PlanFixtures.HttpV4.anApiKey()
+            .toBuilder()
+            .crossId("stored-cross-id")
+            .apiId(API_ID)
+            .referenceType(GenericPlanEntity.ReferenceType.API)
+            .referenceId(API_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .build();
+        initializer.planCrudServiceInMemory.initWith(List.of(planToUpdate));
+
+        Set<PlanWithFlows> importDefinitionPlans = Set.of(
+            PlanWithFlows.builder()
+                .id(planToUpdate.getId())
+                .crossId("stale-or-wrong-cross-id-from-export")
+                .apiId(planToUpdate.getApiId())
+                .referenceType(GenericPlanEntity.ReferenceType.API)
+                .referenceId(API_ID)
+                .environmentId(planToUpdate.getEnvironmentId())
+                .definitionVersion(planToUpdate.getDefinitionVersion())
+                .type(planToUpdate.getType())
+                .planDefinitionHttpV4(planToUpdate.getPlanDefinitionHttpV4())
+                .name("updated via id fallback")
+                .flows(Collections.emptyList())
+                .build()
+        );
+
+        service.upsertPlanWithFlows(EXISTING_API, importDefinitionPlans, AUDIT_INFO);
+
+        var apiPlans = initializer.planCrudServiceInMemory.findByApiId(API_ID);
+        assertThat(apiPlans)
+            .hasSize(1)
+            .first()
+            .satisfies(p -> {
+                assertThat(p.getId()).isEqualTo(planToUpdate.getId());
+                assertThat(p.getName()).isEqualTo("updated via id fallback");
+            });
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import fakes.FakeApiImagesService;
 import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.PlanFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
@@ -34,22 +35,31 @@ import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.model.PlanWithFlows;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.v4.ApiImagesService;
 import io.gravitee.rest.api.service.v4.ApiService;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -146,6 +156,77 @@ class ImportDefinitionUpdateDomainServiceTest {
     }
 
     @Test
+    public void should_preserve_existing_properties_when_proxy_api_updated_with_oas_import_having_no_properties() {
+        List<Property> existingProperties = new ArrayList<>(
+            List.of(Property.builder().key("existing-key").value("existing-value").build())
+        );
+        var baseProxyApi = ApiFixtures.aProxyApiV4();
+        ((io.gravitee.definition.model.v4.Api) baseProxyApi.getApiDefinitionValue()).setProperties(existingProperties);
+        var existingApi = baseProxyApi
+            .toBuilder()
+            .id(PROMOTED_API_ID)
+            .crossId(PROMOTED_API_CROSS_ID)
+            .environmentId(TARGET_ENVIRONMENT_ID)
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(existingApi));
+        apiQueryServiceInMemory.initWith(List.of(existingApi));
+
+        // OAS import produces no Gravitee-specific properties
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(ApiExport.builder().id(PROMOTED_API_ID).crossId(PROMOTED_API_CROSS_ID).name("updated name").build())
+            .build();
+
+        var updated = service.update(importDefinition, existingApi, AUDIT_INFO);
+
+        assertThat(updated).isNotNull();
+        assertThat(((io.gravitee.definition.model.v4.Api) updated.getApiDefinitionValue()).getProperties())
+            .usingRecursiveComparison()
+            .isEqualTo(existingProperties);
+    }
+
+    @Test
+    public void should_preserve_existing_properties_when_native_api_updated_with_oas_import_having_no_properties() {
+        List<Property> existingProperties = new ArrayList<>(
+            List.of(Property.builder().key("existing-key").value("existing-value").build())
+        );
+        var baseNativeApi = ApiFixtures.aNativeApi();
+        ((NativeApi) baseNativeApi.getApiDefinitionValue()).setProperties(existingProperties);
+        var existingApi = baseNativeApi
+            .toBuilder()
+            .id(PROMOTED_API_ID)
+            .crossId(PROMOTED_API_CROSS_ID)
+            .environmentId(TARGET_ENVIRONMENT_ID)
+            .build();
+        apiCrudServiceInMemory.initWith(List.of(existingApi));
+        apiQueryServiceInMemory.initWith(List.of(existingApi));
+
+        var apiExport = ApiExport.builder()
+            .id(PROMOTED_API_ID)
+            .crossId(PROMOTED_API_CROSS_ID)
+            .name("updated name")
+            .type(ApiType.NATIVE)
+            // No properties — simulating OAS import
+            .build();
+
+        when(
+            importDefinitionUpdateInitializer.validateApiDomainService.validateAndSanitizeForUpdate(
+                any(),
+                any(),
+                any(),
+                eq(TARGET_ENVIRONMENT_ID),
+                eq(ORGANIZATION_ID)
+            )
+        ).thenAnswer(invocation -> invocation.getArgument(1));
+
+        var importDefinition = ImportDefinition.builder().apiExport(apiExport).build();
+
+        var updated = service.update(importDefinition, existingApi, AUDIT_INFO);
+
+        assertThat(updated).isNotNull();
+        assertThat(updated.getApiDefinitionNativeV4().getProperties()).usingRecursiveComparison().isEqualTo(existingProperties);
+    }
+
+    @Test
     void should_throw_an_exception_when_api_not_supported() {
         var existingApi = ApiFixtures.aLLMProxyApiV4().toBuilder().id(PROMOTED_API_ID).crossId(PROMOTED_API_CROSS_ID).build();
         var importDefinition = ImportDefinition.builder()
@@ -217,6 +298,159 @@ class ImportDefinitionUpdateDomainServiceTest {
         assertThat(apiImagesService.apiPictures.get(PROMOTED_API_ID)).isEqualTo(picture);
         assertThat(apiImagesService.apiBackgrounds.get(PROMOTED_API_ID)).isEqualTo(background);
         assertNativeApiMatchExport(updated, apiExport);
+    }
+
+    @Nested
+    class PlansUpsert {
+
+        private final PlanWithFlows anApiKeyPlan = PlanWithFlows.builder()
+            .crossId("api-key-cross-id")
+            .name("API Key Plan")
+            .apiId(PROMOTED_API_ID)
+            .type(Plan.PlanType.API)
+            .referenceType(Plan.ReferenceType.API)
+            .referenceId(PROMOTED_API_ID)
+            .environmentId(TARGET_ENVIRONMENT_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .planDefinitionHttpV4(
+                io.gravitee.definition.model.v4.plan.Plan.builder()
+                    .security(PlanSecurity.builder().type("api-key").build())
+                    .mode(PlanMode.STANDARD)
+                    .build()
+            )
+            .flows(List.of())
+            .build();
+
+        @BeforeEach
+        void stubApiService() {
+            when(apiService.update(any(), eq(PROMOTED_API_ID), any(), any(Boolean.class), any())).thenAnswer(inv ->
+                io.gravitee.rest.api.model.v4.api.ApiEntity.builder().id(PROMOTED_API_ID).name("api name").apiVersion("1.0").build()
+            );
+        }
+
+        @Test
+        void should_create_plan_when_not_present_in_saved_plans() {
+            var existingApi = ApiFixtures.aProxyApiV4()
+                .toBuilder()
+                .id(PROMOTED_API_ID)
+                .crossId(PROMOTED_API_CROSS_ID)
+                .environmentId(TARGET_ENVIRONMENT_ID)
+                .build();
+            apiCrudServiceInMemory.initWith(List.of(existingApi));
+            apiQueryServiceInMemory.initWith(List.of(existingApi));
+            // no saved plans
+
+            var importDefinition = ImportDefinition.builder()
+                .apiExport(ApiExport.builder().id(PROMOTED_API_ID).crossId(PROMOTED_API_CROSS_ID).name("api name").build())
+                .plans(Set.of(anApiKeyPlan))
+                .build();
+
+            service.update(importDefinition, existingApi, AUDIT_INFO);
+
+            var savedPlans = importDefinitionUpdateInitializer.planDomainServiceInitializer.planCrudServiceInMemory.findByApiId(
+                PROMOTED_API_ID
+            );
+            assertThat(savedPlans)
+                .hasSize(1)
+                .first()
+                .satisfies(p -> {
+                    assertThat(p.getCrossId()).isEqualTo("api-key-cross-id");
+                    assertThat(p.getName()).isEqualTo("API Key Plan");
+                    assertThat(p.getApiId()).isEqualTo(PROMOTED_API_ID);
+                });
+        }
+
+        @Test
+        void should_update_plan_when_matching_by_crossId() {
+            var existingApi = ApiFixtures.aProxyApiV4()
+                .toBuilder()
+                .id(PROMOTED_API_ID)
+                .crossId(PROMOTED_API_CROSS_ID)
+                .environmentId(TARGET_ENVIRONMENT_ID)
+                .build();
+            apiCrudServiceInMemory.initWith(List.of(existingApi));
+            apiQueryServiceInMemory.initWith(List.of(existingApi));
+
+            var savedPlan = PlanFixtures.HttpV4.anApiKey()
+                .toBuilder()
+                .crossId("api-key-cross-id")
+                .apiId(PROMOTED_API_ID)
+                .referenceType(GenericPlanEntity.ReferenceType.API)
+                .referenceId(PROMOTED_API_ID)
+                .environmentId(TARGET_ENVIRONMENT_ID)
+                .name("Old Name")
+                .build();
+            importDefinitionUpdateInitializer.planDomainServiceInitializer.planCrudServiceInMemory.initWith(List.of(savedPlan));
+            importDefinitionUpdateInitializer.planDomainServiceInitializer.planQueryServiceInMemory.initWith(List.of(savedPlan));
+
+            var incomingPlan = anApiKeyPlan.toBuilder().id(savedPlan.getId()).name("Updated Name").build();
+            var importDefinition = ImportDefinition.builder()
+                .apiExport(ApiExport.builder().id(PROMOTED_API_ID).crossId(PROMOTED_API_CROSS_ID).name("api name").build())
+                .plans(Set.of(incomingPlan))
+                .build();
+
+            service.update(importDefinition, existingApi, AUDIT_INFO);
+
+            var savedPlans = importDefinitionUpdateInitializer.planDomainServiceInitializer.planCrudServiceInMemory.findByApiId(
+                PROMOTED_API_ID
+            );
+            assertThat(savedPlans)
+                .hasSize(1)
+                .first()
+                .satisfies(p -> {
+                    assertThat(p.getId()).isEqualTo(savedPlan.getId());
+                    assertThat(p.getCrossId()).isEqualTo("api-key-cross-id");
+                    assertThat(p.getName()).isEqualTo("Updated Name");
+                });
+        }
+
+        @Test
+        void should_delete_plan_absent_from_import_definition() {
+            var existingApi = ApiFixtures.aProxyApiV4()
+                .toBuilder()
+                .id(PROMOTED_API_ID)
+                .crossId(PROMOTED_API_CROSS_ID)
+                .environmentId(TARGET_ENVIRONMENT_ID)
+                .build();
+            apiCrudServiceInMemory.initWith(List.of(existingApi));
+            apiQueryServiceInMemory.initWith(List.of(existingApi));
+
+            var planToKeep = PlanFixtures.HttpV4.anApiKey()
+                .toBuilder()
+                .crossId("api-key-cross-id")
+                .apiId(PROMOTED_API_ID)
+                .referenceType(GenericPlanEntity.ReferenceType.API)
+                .referenceId(PROMOTED_API_ID)
+                .environmentId(TARGET_ENVIRONMENT_ID)
+                .build();
+            var planToDelete = PlanFixtures.HttpV4.aKeyless()
+                .toBuilder()
+                .crossId("keyless-to-delete")
+                .apiId(PROMOTED_API_ID)
+                .referenceType(GenericPlanEntity.ReferenceType.API)
+                .referenceId(PROMOTED_API_ID)
+                .environmentId(TARGET_ENVIRONMENT_ID)
+                .build();
+            importDefinitionUpdateInitializer.planDomainServiceInitializer.planCrudServiceInMemory.initWith(
+                List.of(planToKeep, planToDelete)
+            );
+            importDefinitionUpdateInitializer.planDomainServiceInitializer.planQueryServiceInMemory.initWith(
+                List.of(planToKeep, planToDelete)
+            );
+
+            // import only contains planToKeep — planToDelete is absent
+            var importDefinition = ImportDefinition.builder()
+                .apiExport(ApiExport.builder().id(PROMOTED_API_ID).crossId(PROMOTED_API_CROSS_ID).name("api name").build())
+                .plans(Set.of(anApiKeyPlan.toBuilder().id(planToKeep.getId()).build()))
+                .build();
+
+            service.update(importDefinition, existingApi, AUDIT_INFO);
+
+            var savedPlans = importDefinitionUpdateInitializer.planDomainServiceInitializer.planCrudServiceInMemory.findByApiId(
+                PROMOTED_API_ID
+            );
+            assertThat(savedPlans).hasSize(1).extracting(Plan::getCrossId).containsOnly("api-key-cross-id");
+        }
     }
 
     private static void assertNativeApiMatchExport(Api api, ApiExport apiExport) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainServiceTestInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/import_definition/ImportDefinitionUpdateDomainServiceTestInitializer.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.api.domain_service.import_definition;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 
@@ -37,21 +39,19 @@ import inmemory.RoleQueryServiceInMemory;
 import inmemory.TriggerNotificationDomainServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.ApiIdsCalculatorDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiImportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateNativeApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
-import io.gravitee.apim.core.api.service_provider.ApiImagesServiceProvider;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.apim.core.plan.domain_service.DeprecatePlanDomainService;
-import io.gravitee.apim.infra.domain_service.api.ApiImagesServiceProviderImpl;
 import io.gravitee.apim.infra.domain_service.api.UpdateApiDomainServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
-import io.gravitee.rest.api.service.v4.ApiImagesService;
 import io.gravitee.rest.api.service.v4.ApiService;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -62,6 +62,7 @@ public class ImportDefinitionUpdateDomainServiceTestInitializer {
     public final ApiService apiService = mock(ApiService.class);
     public final CategoryDomainService categoryDomainService = mock(CategoryDomainService.class);
     public final ValidateApiDomainService validateApiDomainService = mock(ValidateApiDomainService.class);
+    public final ApiImportDomainService apiImportDomainService = mock(ApiImportDomainService.class);
 
     // In Memory
     public ApiCrudServiceInMemory apiCrudServiceInMemory;
@@ -90,7 +91,7 @@ public class ImportDefinitionUpdateDomainServiceTestInitializer {
     // Sub entities initializers
     private final ImportDefinitionMetadataDomainServiceTestInitializer metadataDomainServiceInitializer =
         new ImportDefinitionMetadataDomainServiceTestInitializer();
-    private final ImportDefinitionPlanDomainServiceTestInitializer planDomainServiceInitializer =
+    public final ImportDefinitionPlanDomainServiceTestInitializer planDomainServiceInitializer =
         new ImportDefinitionPlanDomainServiceTestInitializer();
     private final ImportDefinitionPageDomainServiceTestInitializer pageDomainServiceTestInitializer =
         new ImportDefinitionPageDomainServiceTestInitializer();
@@ -101,6 +102,9 @@ public class ImportDefinitionUpdateDomainServiceTestInitializer {
 
     public ImportDefinitionUpdateDomainServiceTestInitializer(ApiCrudServiceInMemory apiCrudService) {
         apiCrudServiceInMemory = Objects.requireNonNullElseGet(apiCrudService, ApiCrudServiceInMemory::new);
+
+        doNothing().when(apiImportDomainService).createMembers(any(), any());
+        doNothing().when(apiImportDomainService).createMedias(any(), any(), any());
 
         apiIdsCalculatorDomainService = new ApiIdsCalculatorDomainService(
             apiQueryServiceInMemory,
@@ -149,7 +153,8 @@ public class ImportDefinitionUpdateDomainServiceTestInitializer {
             apiPrimaryOwnerDomainService,
             metadataDomainServiceInitializer.initialize(),
             planDomainServiceInitializer.initialize(environmentId),
-            pageDomainServiceTestInitializer.initialize()
+            pageDomainServiceTestInitializer.initialize(),
+            apiImportDomainService
         );
     }
 
@@ -171,10 +176,15 @@ public class ImportDefinitionUpdateDomainServiceTestInitializer {
         ).forEach(InMemoryAlternative::reset);
 
         metadataDomainServiceInitializer.tearDown();
+        planDomainServiceInitializer.tearDown();
+        pageDomainServiceTestInitializer.tearDown();
 
         reset(apiService);
         reset(categoryDomainService);
         reset(validateApiDomainService);
+        reset(apiImportDomainService);
+        doNothing().when(apiImportDomainService).createMembers(any(), any());
+        doNothing().when(apiImportDomainService).createMedias(any(), any(), any());
 
         apiImagesServiceProvider.reset();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToUpdateApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToUpdateApiUseCaseTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.AuditInfoFixtures;
+import inmemory.FlowCrudServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.OAIDomainService;
+import io.gravitee.apim.core.api.exception.InvalidApiDefinitionException;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.model.import_definition.ApiExport;
+import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class OAIToUpdateApiUseCaseTest {
+
+    private static final String API_ID = "my-api";
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo("org-id", "env-id", "user-id");
+
+    private OAIDomainService oaiDomainService;
+    private FlowCrudServiceInMemory flowCrudService;
+    private UpdateApiDefinitionFromImportUseCase updateApiDefinitionUseCase;
+    private OAIToUpdateApiUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        oaiDomainService = mock(OAIDomainService.class);
+        flowCrudService = new FlowCrudServiceInMemory();
+        updateApiDefinitionUseCase = mock(UpdateApiDefinitionFromImportUseCase.class);
+        cut = new OAIToUpdateApiUseCase(oaiDomainService, flowCrudService, updateApiDefinitionUseCase);
+    }
+
+    @Test
+    void should_throw_when_oai_conversion_returns_null() {
+        when(oaiDomainService.convert(anyString(), anyString(), any(), anyBoolean(), anyBoolean())).thenReturn(null);
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                OAIToUpdateApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .importSwaggerDescriptor(new ImportSwaggerDescriptorEntity())
+                    .auditInfo(AUDIT_INFO)
+                    .build()
+            )
+        )
+            .isInstanceOf(InvalidApiDefinitionException.class)
+            .hasMessage("Unable to read the swagger specification");
+    }
+
+    @Test
+    void should_reuse_persisted_http_flow_id_when_swagger_import_matches_path_and_methods() {
+        var persistedSelector = HttpSelector.builder().pathOperator(Operator.EQUALS).path("/pets").methods(Set.of(HttpMethod.GET)).build();
+        var persistedFlow = Flow.builder().id("persisted-flow-id").selectors(List.of(persistedSelector)).build();
+        flowCrudService.saveApiFlows(API_ID, List.of(persistedFlow));
+
+        var importSelector = HttpSelector.builder().pathOperator(Operator.EQUALS).path("/pets").methods(Set.of(HttpMethod.GET)).build();
+        var importedFlow = Flow.builder().id(null).selectors(List.of(importSelector)).build();
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(ApiExport.builder().definitionVersion(DefinitionVersion.V4).flows(List.of(importedFlow)).build())
+            .build();
+
+        when(oaiDomainService.convert(anyString(), anyString(), any(), anyBoolean(), anyBoolean())).thenReturn(importDefinition);
+
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(updateApiDefinitionUseCase.execute(any())).thenReturn(
+            new UpdateApiDefinitionFromImportUseCase.Output(new ApiWithFlows(existingApi, List.of()))
+        );
+
+        cut.execute(
+            OAIToUpdateApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .importSwaggerDescriptor(new ImportSwaggerDescriptorEntity())
+                .withPolicyPaths(false)
+                .auditInfo(AUDIT_INFO)
+                .build()
+        );
+
+        var inputCaptor = ArgumentCaptor.forClass(UpdateApiDefinitionFromImportUseCase.Input.class);
+        org.mockito.Mockito.verify(updateApiDefinitionUseCase).execute(inputCaptor.capture());
+        var flowsPassedToUseCase = inputCaptor.getValue().importDefinition().getApiExport().getFlows();
+        assertThat(flowsPassedToUseCase).hasSize(1);
+        assertThat(flowsPassedToUseCase.getFirst().getId()).isEqualTo("persisted-flow-id");
+    }
+
+    @Test
+    void should_not_set_flow_id_when_no_persisted_flow_matches_swagger_import() {
+        var importSelector = HttpSelector.builder().pathOperator(Operator.EQUALS).path("/unknown").methods(Set.of(HttpMethod.POST)).build();
+        var importedFlow = Flow.builder().id(null).selectors(List.of(importSelector)).build();
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(ApiExport.builder().definitionVersion(DefinitionVersion.V4).flows(List.of(importedFlow)).build())
+            .build();
+
+        when(oaiDomainService.convert(anyString(), anyString(), any(), anyBoolean(), anyBoolean())).thenReturn(importDefinition);
+
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(updateApiDefinitionUseCase.execute(any())).thenReturn(
+            new UpdateApiDefinitionFromImportUseCase.Output(new ApiWithFlows(existingApi, List.of()))
+        );
+
+        cut.execute(
+            OAIToUpdateApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .importSwaggerDescriptor(new ImportSwaggerDescriptorEntity())
+                .withPolicyPaths(false)
+                .auditInfo(AUDIT_INFO)
+                .build()
+        );
+
+        var inputCaptor = ArgumentCaptor.forClass(UpdateApiDefinitionFromImportUseCase.Input.class);
+        org.mockito.Mockito.verify(updateApiDefinitionUseCase).execute(inputCaptor.capture());
+        var flowsPassedToUseCase = inputCaptor.getValue().importDefinition().getApiExport().getFlows();
+        assertThat(flowsPassedToUseCase).hasSize(1);
+        assertThat(flowsPassedToUseCase.getFirst().getId()).isNull();
+    }
+
+    @Test
+    void should_assign_persisted_flow_id_only_to_first_incoming_flow_when_two_incoming_flows_share_same_key() {
+        var persistedSelector = HttpSelector.builder().pathOperator(Operator.EQUALS).path("/pets").methods(Set.of(HttpMethod.GET)).build();
+        var persistedFlow = Flow.builder().id("persisted-flow-id").selectors(List.of(persistedSelector)).build();
+        flowCrudService.saveApiFlows(API_ID, List.of(persistedFlow));
+
+        var selector = HttpSelector.builder().pathOperator(Operator.EQUALS).path("/pets").methods(Set.of(HttpMethod.GET)).build();
+        var firstIncomingFlow = Flow.builder().id(null).selectors(List.of(selector)).build();
+        var secondIncomingFlow = Flow.builder().id(null).selectors(List.of(selector)).build();
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(
+                ApiExport.builder().definitionVersion(DefinitionVersion.V4).flows(List.of(firstIncomingFlow, secondIncomingFlow)).build()
+            )
+            .build();
+
+        when(oaiDomainService.convert(anyString(), anyString(), any(), anyBoolean(), anyBoolean())).thenReturn(importDefinition);
+
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(updateApiDefinitionUseCase.execute(any())).thenReturn(
+            new UpdateApiDefinitionFromImportUseCase.Output(new ApiWithFlows(existingApi, List.of()))
+        );
+
+        cut.execute(
+            OAIToUpdateApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .importSwaggerDescriptor(new ImportSwaggerDescriptorEntity())
+                .withPolicyPaths(false)
+                .auditInfo(AUDIT_INFO)
+                .build()
+        );
+
+        var inputCaptor = ArgumentCaptor.forClass(UpdateApiDefinitionFromImportUseCase.Input.class);
+        org.mockito.Mockito.verify(updateApiDefinitionUseCase).execute(inputCaptor.capture());
+        var flowsPassedToUseCase = inputCaptor.getValue().importDefinition().getApiExport().getFlows();
+        assertThat(flowsPassedToUseCase).hasSize(2);
+        // first flow claims the persisted ID; second flow gets null and will be created as new
+        assertThat(flowsPassedToUseCase.get(0).getId()).isEqualTo("persisted-flow-id");
+        assertThat(flowsPassedToUseCase.get(1).getId()).isNull();
+    }
+
+    @Test
+    void should_assign_first_persisted_flow_id_when_two_persisted_flows_share_same_key() {
+        var selector = HttpSelector.builder().pathOperator(Operator.EQUALS).path("/pets").methods(Set.of(HttpMethod.GET)).build();
+        var firstPersistedFlow = Flow.builder().id("persisted-flow-id-1").selectors(List.of(selector)).build();
+        var secondPersistedFlow = Flow.builder().id("persisted-flow-id-2").selectors(List.of(selector)).build();
+        flowCrudService.saveApiFlows(API_ID, List.of(firstPersistedFlow, secondPersistedFlow));
+
+        var importedFlow = Flow.builder().id(null).selectors(List.of(selector)).build();
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(ApiExport.builder().definitionVersion(DefinitionVersion.V4).flows(List.of(importedFlow)).build())
+            .build();
+
+        when(oaiDomainService.convert(anyString(), anyString(), any(), anyBoolean(), anyBoolean())).thenReturn(importDefinition);
+
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(updateApiDefinitionUseCase.execute(any())).thenReturn(
+            new UpdateApiDefinitionFromImportUseCase.Output(new ApiWithFlows(existingApi, List.of()))
+        );
+
+        cut.execute(
+            OAIToUpdateApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .importSwaggerDescriptor(new ImportSwaggerDescriptorEntity())
+                .withPolicyPaths(false)
+                .auditInfo(AUDIT_INFO)
+                .build()
+        );
+
+        var inputCaptor = ArgumentCaptor.forClass(UpdateApiDefinitionFromImportUseCase.Input.class);
+        org.mockito.Mockito.verify(updateApiDefinitionUseCase).execute(inputCaptor.capture());
+        var flowsPassedToUseCase = inputCaptor.getValue().importDefinition().getApiExport().getFlows();
+        assertThat(flowsPassedToUseCase).hasSize(1);
+        // merge function keeps first persisted ID on duplicate key
+        assertThat(flowsPassedToUseCase.getFirst().getId()).isEqualTo("persisted-flow-id-1");
+    }
+
+    @Test
+    void should_not_reuse_persisted_flow_id_when_with_policy_paths_is_true() {
+        var persistedSelector = HttpSelector.builder().pathOperator(Operator.EQUALS).path("/pets").methods(Set.of(HttpMethod.GET)).build();
+        var persistedFlow = Flow.builder().id("persisted-flow-id").selectors(List.of(persistedSelector)).build();
+        flowCrudService.saveApiFlows(API_ID, List.of(persistedFlow));
+
+        var importSelector = HttpSelector.builder().pathOperator(Operator.EQUALS).path("/pets").methods(Set.of(HttpMethod.GET)).build();
+        var importedFlow = Flow.builder().id(null).selectors(List.of(importSelector)).build();
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(ApiExport.builder().definitionVersion(DefinitionVersion.V4).flows(List.of(importedFlow)).build())
+            .build();
+
+        when(oaiDomainService.convert(anyString(), anyString(), any(), anyBoolean(), anyBoolean())).thenReturn(importDefinition);
+
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(updateApiDefinitionUseCase.execute(any())).thenReturn(
+            new UpdateApiDefinitionFromImportUseCase.Output(new ApiWithFlows(existingApi, List.of()))
+        );
+
+        cut.execute(
+            OAIToUpdateApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .importSwaggerDescriptor(new ImportSwaggerDescriptorEntity())
+                .withPolicyPaths(true)
+                .auditInfo(AUDIT_INFO)
+                .build()
+        );
+
+        var inputCaptor = ArgumentCaptor.forClass(UpdateApiDefinitionFromImportUseCase.Input.class);
+        org.mockito.Mockito.verify(updateApiDefinitionUseCase).execute(inputCaptor.capture());
+        var flowsPassedToUseCase = inputCaptor.getValue().importDefinition().getApiExport().getFlows();
+        assertThat(flowsPassedToUseCase).hasSize(1);
+        assertThat(flowsPassedToUseCase.getFirst().getId()).isNull();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateApiDefinitionFromImportUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateApiDefinitionFromImportUseCaseTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static fixtures.core.model.ApiFixtures.aProxyApiV4;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.AuditInfoFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.domain_service.import_definition.ImportDefinitionUpdateDomainServiceTestInitializer;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.exception.InvalidApiDefinitionException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.import_definition.ApiExport;
+import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UpdateApiDefinitionFromImportUseCaseTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2024-04-23T11:06:00Z");
+    private static final String API_ID = "api-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
+    ImportDefinitionUpdateDomainServiceTestInitializer importDefinitionUpdateDomainServiceTestInitializer;
+
+    UpdateApiDefinitionFromImportUseCase useCase;
+
+    @BeforeAll
+    static void beforeAll() {
+        io.gravitee.common.utils.TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        io.gravitee.common.utils.TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        importDefinitionUpdateDomainServiceTestInitializer = new ImportDefinitionUpdateDomainServiceTestInitializer(apiCrudService);
+
+        useCase = new UpdateApiDefinitionFromImportUseCase(
+            apiCrudService,
+            importDefinitionUpdateDomainServiceTestInitializer.initialize(ENVIRONMENT_ID),
+            flowCrudService
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        importDefinitionUpdateDomainServiceTestInitializer.tearDown();
+        Stream.of(apiCrudService, flowCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @ParameterizedTest(name = "Test for API update with {0} definition version")
+    @EnumSource(value = DefinitionVersion.class, names = { "V2", "FEDERATED", "FEDERATED_AGENT" })
+    void should_not_allow_update_with_non_v4_definition_version(DefinitionVersion definitionVersion) {
+        // Given
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(ApiExport.builder().definitionVersion(definitionVersion).build())
+            .build();
+
+        // When
+        var throwable = catchThrowable(() ->
+            useCase.execute(new UpdateApiDefinitionFromImportUseCase.Input(API_ID, importDefinition, AUDIT_INFO))
+        );
+
+        // Then
+        assertThat(throwable).isInstanceOf(ApiDefinitionVersionNotSupportedException.class);
+    }
+
+    @Test
+    void should_throw_when_api_export_is_null() {
+        // Given
+        var importDefinition = ImportDefinition.builder().apiExport(null).build();
+
+        // When
+        var throwable = catchThrowable(() ->
+            useCase.execute(new UpdateApiDefinitionFromImportUseCase.Input(API_ID, importDefinition, AUDIT_INFO))
+        );
+
+        // Then
+        assertThat(throwable).isInstanceOf(InvalidApiDefinitionException.class).hasMessageContaining("API definition is required");
+    }
+
+    @Test
+    void should_throw_when_api_does_not_exist() {
+        // Given — apiCrudService starts empty
+        var importDefinition = ImportDefinition.builder()
+            .apiExport(ApiExport.builder().id(API_ID).definitionVersion(DefinitionVersion.V4).build())
+            .build();
+
+        // When
+        var throwable = catchThrowable(() ->
+            useCase.execute(new UpdateApiDefinitionFromImportUseCase.Input(API_ID, importDefinition, AUDIT_INFO))
+        );
+
+        // Then
+        assertThat(throwable).isInstanceOf(ApiNotFoundException.class);
+    }
+
+    @Nested
+    class UpdateProxyApi {
+
+        @BeforeEach
+        void setUp() {
+            // Stub ValidateApiDomainService so update flow proceeds
+            when(
+                importDefinitionUpdateDomainServiceTestInitializer.validateApiDomainService.validateAndSanitizeForUpdate(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
+            ).thenAnswer(inv -> inv.getArgument(1));
+
+            // Stub ApiService.update used by UpdateApiDomainServiceImpl.updateV4:
+            // delegate.update(executionContext, api.getId(), updateApiEntity, false, userId) — 5 args
+            when(importDefinitionUpdateDomainServiceTestInitializer.apiService.update(any(), any(), any(), anyBoolean(), any())).thenAnswer(
+                inv -> {
+                    io.gravitee.rest.api.model.v4.api.UpdateApiEntity updateApi = inv.getArgument(2);
+                    return io.gravitee.rest.api.model.v4.api.ApiEntity.builder()
+                        .id(API_ID)
+                        .name(updateApi.getName())
+                        .apiVersion(updateApi.getApiVersion())
+                        .build();
+                }
+            );
+        }
+
+        @Test
+        void should_update_proxy_api_from_import_definition() {
+            // Given
+            var existingApi = aProxyApiV4().toBuilder().id(API_ID).environmentId(ENVIRONMENT_ID).build();
+            apiCrudService.initWith(List.of(existingApi));
+
+            var importDefinition = ImportDefinition.builder()
+                .apiExport(
+                    ApiExport.builder().id(API_ID).name("Updated API").apiVersion("2.0").definitionVersion(DefinitionVersion.V4).build()
+                )
+                .build();
+
+            // When
+            var output = useCase.execute(new UpdateApiDefinitionFromImportUseCase.Input(API_ID, importDefinition, AUDIT_INFO));
+
+            // Then
+            assertThat(output).isNotNull();
+            assertThat(output.apiWithFlows()).isNotNull();
+            assertThat(output.apiWithFlows().getId()).isEqualTo(API_ID);
+        }
+
+        @Test
+        void should_return_actual_api_flows_after_update() {
+            // Given
+            var existingApi = aProxyApiV4().toBuilder().id(API_ID).environmentId(ENVIRONMENT_ID).build();
+            apiCrudService.initWith(List.of(existingApi));
+            flowCrudService.saveApiFlows(API_ID, List.of(Flow.builder().id("flow-1").enabled(true).build()));
+
+            var importDefinition = ImportDefinition.builder()
+                .apiExport(
+                    ApiExport.builder().id(API_ID).name("Updated API").apiVersion("2.0").definitionVersion(DefinitionVersion.V4).build()
+                )
+                .build();
+
+            // When
+            var output = useCase.execute(new UpdateApiDefinitionFromImportUseCase.Input(API_ID, importDefinition, AUDIT_INFO));
+
+            // Then
+            assertThat(output.apiWithFlows().getFlows()).hasSize(1);
+            assertThat(((Flow) output.apiWithFlows().getFlows().get(0)).getId()).isEqualTo("flow-1");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCaseTest.java
@@ -227,13 +227,13 @@ class ProcessPromotionUseCaseTest {
         environmentCrudService.initWith(List.of(ENVIRONMENT));
 
         var v4proxyApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).crossId(CROSS_ID).build();
-        var aleadyPromotedApi = ApiFixtures.aProxyApiV4()
+        var promotedApiInTargetEnv = ApiFixtures.aProxyApiV4()
             .toBuilder()
-            .id(API_ID)
+            .id("already-promoted-api")
             .crossId(CROSS_ID)
             .environmentId(ENVIRONMENT.getId())
             .build();
-        apiCrudServiceInMemory.initWith(List.of(v4proxyApi, aleadyPromotedApi));
+        apiCrudServiceInMemory.initWith(List.of(v4proxyApi, promotedApiInTargetEnv));
 
         when(cockpitPromotionServiceProvider.processPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
 
@@ -375,13 +375,13 @@ class ProcessPromotionUseCaseTest {
         environmentCrudService.initWith(List.of(ENVIRONMENT));
 
         var v4proxyApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).crossId(CROSS_ID).build();
-        var aleadyPromotedApi = ApiFixtures.aProxyApiV4()
+        var promotedApiInTargetEnv = ApiFixtures.aProxyApiV4()
             .toBuilder()
-            .id(API_ID)
+            .id("already-promoted-api")
             .crossId(CROSS_ID)
             .environmentId(ENVIRONMENT.getId())
             .build();
-        apiCrudServiceInMemory.initWith(List.of(v4proxyApi, aleadyPromotedApi));
+        apiCrudServiceInMemory.initWith(List.of(v4proxyApi, promotedApiInTargetEnv));
 
         Throwable throwable = catchThrowable(() ->
             useCase.execute(


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12010

## Description

Prior to this change, the import mechanism in Gravitee APIM only supported **creating** new V4 APIs from a Gravitee definition or an OpenAPI/Swagger descriptor. Updating an existing V4 API through the import flow was explicitly blocked — the import button was disabled for V4 APIs in the console.

This PR removes that restriction and introduces full **update-via-import** support for V4 APIs (HTTP Proxy, Message, and Native types), both from the console UI and the management REST API.

## What Was Achieved

- Users can now open the import modal from the **General Info** page of an existing V4 API and update it by uploading a Gravitee API definition (JSON) or an OpenAPI/Swagger descriptor.
- - The system validates that the imported definition is V4 before applying any changes, rejecting V1/V2 definitions with a clear error.
- - All sub-entities (metadata, pages/documentation, plans with flows) are upserted as part of the update — not just the top-level API fields.

## How the System Works Now

**Frontend (Console):**

1. The "Import" button on `api-general-info.component.html` was previously disabled for V4 APIs (`api.definitionVersion === 'V4'`). That condition has been removed so V4 APIs can now trigger the import modal.
2. 2. A new dedicated Angular dialog component `ApiImportV4Component` (`api-import-v4/`) handles the V4 update flow. It accepts an `ApiImportV4DialogData` input containing the `apiId`, which signals that this is an **update** operation rather than a create.
3. 3. The component calls either `ApiV2Service.importUpdate(apiId, payload)` (for Gravitee definitions) or `ApiV2Service.importSwaggerApiUpdate(apiId, descriptor)` (for OpenAPI specs), which both issue `PUT` requests to the backend.
**Backend (Management API v2):**

1. Two new `PUT` endpoints have been added to `ApiResource.java`:
2.    - `PUT /apis/{apiId}/_import/definition` — updates a V4 API from a Gravitee export definition.
3.    - `PUT /apis/{apiId}/_import/swagger` — updates a V4 API from an OpenAPI/Swagger descriptor (the descriptor is first converted to an import definition via the existing `OAIToImportApiUseCase`).
4. 2. Both endpoints delegate to the new `UpdateApiDefinitionUseCase`, which:
5.    - Validates that the incoming definition is V4 (throws `ApiDefinitionVersionNotSupportedException` otherwise).
6.    - Looks up the existing API by ID (throws `ApiNotFoundException` if not found).
7.    - Delegates the actual update to `ImportDefinitionUpdateDomainService`.
8. 3. `ImportDefinitionUpdateDomainService` orchestrates the full update:
9.    - Recalculates API definition IDs via `ApiIdsCalculatorDomainService`.
10.    - Calls `UpdateApiDomainService.updateV4()` for HTTP Proxy/Message APIs or a native-specific update path for Native APIs.
11.    - Updates pictures and background images.
12.    - Upserts metadata, documentation pages, and plans with flows.
13. 4. The OpenAPI spec path (`openapi-apis.yaml`) has been updated to document the two new PUT endpoints.
## Commits

| Commit | SHA | What & Why |
|--------|-----|------------|
| `feat(console): update V4 APIs from import modal` | `c6e1ff4` | Adds the Angular `ApiImportV4Component` dialog and wires it into the General Info page. Removes the V4 disable condition from the import button and adds two new service methods (`importUpdate`, `importSwaggerApiUpdate`) that call the new PUT endpoints. |
| `feat(mAPI): add PUT calls to update V4 APIs` | `7797fcd` | Adds the two new `PUT` REST endpoints in `ApiResource.java`, the `UpdateApiDefinitionUseCase`, the `ImportDefinitionUpdateDomainService`, updates the OpenAPI spec, and adds full test coverage. |

## Files Changed & Why

**Frontend**

- `api-general-info.component.html` — Removed `api.definitionVersion === 'V4'` from the import button's `[disabled]` condition so V4 APIs can use the import/update flow.
- - `api-general-info.component.ts` — Wires up the new `ApiImportV4Component` dialog and passes the `apiId` so the component knows it is in update mode.
- - `api-import-v4/api-import-v4.component.ts` — New component that handles the V4 import/update dialog, detects update mode from the injected `apiId`, and calls the appropriate service method.
- - `api-import-v4/api-import-v4.component.html` — Template for the V4 import dialog (file picker + format selection).
- - `api-import-v4/api-import-v4.component.scss` — Styles for the dialog.
- - `api-import-v4/api-import-v4.component.spec.ts` — Unit tests for the component.
- - `api-import-v4/api-import-v4.harness.ts` — Angular CDK test harness for the component.
- - `application-general.module.ts` — Registers `ApiImportV4Component` in the module.
- - `api-v2.service.ts` — Adds `importUpdate(apiId, payload)` and `importSwaggerApiUpdate(apiId, descriptor)` methods, both issuing `PUT` to `/apis/{apiId}/_import/definition` and `/apis/{apiId}/_import/swagger` respectively.
**Backend**

- `ApiResource.java` — Adds `updateApiWithDefinition()` and `updateApiFromSwagger()` methods with `PUT` mappings. Both are guarded by `api-definition[C]` permission and delegate to `UpdateApiDefinitionUseCase`.
- - `openapi-apis.yaml` — Documents the two new `PUT` endpoints in the OpenAPI spec so they appear correctly in API docs and client generators.
- - `UpdateApiDefinitionUseCase.java` *(new)* — Use-case encapsulating the update logic: validates V4, fetches existing API, delegates to `ImportDefinitionUpdateDomainService`, returns the updated API with flows.
- - `ImportDefinitionUpdateDomainService.java` *(new)* — Domain service that orchestrates the full update: recalculates IDs, dispatches to the correct update service based on API type (PROXY/MESSAGE vs NATIVE), updates images, and upserts all sub-entities (metadata, pages, plans).
- - `ImportDefinitionPageDomainService.java` — Modified to support the upsert-pages flow needed during import updates.
- - `ApiResource_UpdateApiWithDefinitionTest.java` *(new)* — Integration tests covering the new PUT endpoint for definition-based updates.
- - `ApiResourceTest.java` — Updated to include new test cases for the update paths.
- - `AbstractResourceTest.java` — Base test setup updated to support the new use-case injection.
- - `ResourceContextConfiguration.java` — Spring context updated to wire `UpdateApiDefinitionUseCase` into the test context.
- - `ImportDefinitionPageDomainServiceTest.java` — Tests for the page upsert logic.
- - `UpdateApiDefinitionUseCaseTest.java` *(new)* — Unit tests for the use-case (V4 validation, not-found handling, happy path).
- - `ProcessPromotionUseCaseTest.java` —
 Updated to remain consistent with changes in `ImportDefinitionUpdateDomainService`.
 
 
https://github.com/user-attachments/assets/1b1fc0e3-1114-4888-a923-7e9e3d253e57



https://github.com/user-attachments/assets/015a73c8-1816-439e-bc59-3553bc55cc44



https://github.com/user-attachments/assets/913d75a7-1cf9-4c2e-ad65-c8351a12afd1



After discussion with Elliot & Jourdi -
Modified Import & update UI (removed Remote/Local file check until we support it)



https://github.com/user-attachments/assets/f02aacd3-48fa-4015-aa6f-37da6dd3322c




