### PR TITLE
fix(mcp): include path-level parameters in generated tool inputSchema

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.spec.ts
@@ -1127,6 +1127,108 @@ paths:
     });
   });
 
+  describe('Path-level parameters inheritance', () => {
+    it('includes path-level parameters in inputSchema and gatewayMapping', async () => {
+      const spec = `
+openapi: 3.0.1
+info:
+  title: mcp-path-param-test
+  version: '1.0'
+paths:
+  '/items/{itemId}':
+    parameters:
+      - name: itemId
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      operationId: getItem
+      summary: Get an item by ID
+      parameters:
+        - name: includeDetails
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+`;
+
+      const { result, errors } = await convertOpenApiToMcpTools(spec);
+
+      expect(errors).toHaveLength(0);
+      expect(result).toHaveLength(1);
+
+      const tool = result[0];
+
+      const properties = tool.toolDefinition.inputSchema['properties'];
+      expect(properties).toHaveProperty('itemId');
+      expect(properties['itemId'].type).toBe('integer');
+      expect(properties).toHaveProperty('includeDetails');
+      expect(properties['includeDetails'].type).toBe('boolean');
+
+      expect(tool.toolDefinition.inputSchema['required']).toContain('itemId');
+
+      expect(tool.gatewayMapping.http.path).toBe('/items/:itemId');
+      expect(tool.gatewayMapping.http.pathParams).toEqual(['itemId']);
+      expect(tool.gatewayMapping.http.queryParams).toEqual(['includeDetails']);
+    });
+
+    it('operation-level parameter overrides path-level parameter with same name', async () => {
+      const spec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/items/{itemId}': {
+            parameters: [
+              {
+                name: 'itemId',
+                in: 'path',
+                required: true,
+                schema: { type: 'integer' },
+                description: 'Path-level description',
+              },
+            ],
+            get: {
+              operationId: 'getItem',
+              summary: 'Get item',
+              parameters: [
+                {
+                  name: 'itemId',
+                  in: 'path',
+                  required: true,
+                  schema: { type: 'string' },
+                  description: 'Operation-level description',
+                },
+              ],
+              responses: { '200': { description: 'OK' } },
+            },
+          },
+        },
+      });
+
+      const { result, errors } = await convertOpenApiToMcpTools(spec);
+
+      expect(errors).toHaveLength(0);
+      expect(result).toHaveLength(1);
+
+      const properties = result[0].toolDefinition.inputSchema['properties'];
+
+      expect(properties['itemId'].type).toBe('string');
+      expect(properties['itemId'].description).toBe('Operation-level description');
+    });
+  });
+
   describe('Error cases', () => {
     it.each([
       [

--- a/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.ts
@@ -131,6 +131,20 @@ function generateGatewayMapping(op: OperationObject, method: string, path: strin
   };
 }
 
+// Operation-level params override path-level params with the same (in, name) key (OpenAPI spec §4.8.9).
+function mergeParameters(
+  pathLevelParams: (ParameterObject | ReferenceObject)[],
+  operationParams: (ParameterObject | ReferenceObject)[],
+): (ParameterObject | ReferenceObject)[] {
+  const merged = new Map<string, ParameterObject | ReferenceObject>();
+
+  for (const param of [...pathLevelParams, ...operationParams] as ParameterObject[]) {
+    merged.set(`${param.in}:${param.name}`, param);
+  }
+
+  return Array.from(merged.values());
+}
+
 function extractParameterSchema(parameters: (ParameterObject | ReferenceObject)[]): ParameterSchema {
   const pathParams: ParameterSchema['pathParams'] = {};
   const queryParams: ParameterSchema['queryParams'] = {};
@@ -282,6 +296,8 @@ async function convertOpenApiToMcpTools(specString: string): Promise<OpenApiToMc
   const usedNames = new Set<string>();
 
   for (const [path, pathItem] of Object.entries(api.paths || {})) {
+    const pathLevelParams = pathItem?.parameters || [];
+
     for (const [method, operation] of Object.entries(pathItem || {})) {
       // if method is not a valid HTTP method, skip it
       if (!['get', 'post', 'put', 'delete', 'patch', 'options', 'head'].includes(method)) {
@@ -299,7 +315,8 @@ async function convertOpenApiToMcpTools(specString: string): Promise<OpenApiToMc
       }
 
       const description = op.summary || op.description || `API for ${method.toUpperCase()} ${path}`;
-      const paramSchema = extractParameterSchema(op.parameters || []);
+      const mergedParams = mergeParameters(pathLevelParams, op.parameters || []);
+      const paramSchema = extractParameterSchema(mergedParams);
       const bodySchema = extractRequestBodySchema(op.requestBody);
       const responseSchema = extractResponseSchema(op.responses);
       const annotations = extractAnnotations(op);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12806

## Description

Path-level parameters (`pathItem.parameters`) were silently dropped when generating MCP tools from OpenAPI specs. Only operation-level parameters were included in the `inputSchema`. The fix merges both levels before building the schema, with operation-level taking precedence per OpenAPI spec §4.8.9

