### PR TITLE
fix: default time period must be defined

### DIFF
--- a/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.spec.ts
@@ -172,6 +172,71 @@ describe('EnvironmentLogsService', () => {
 
       req.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
     });
+
+    describe('time range resolution', () => {
+      const EMPTY_RESPONSE = { data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } };
+
+      it('should_always_include_timeRange_in_request_body_when_period_is_none', done => {
+        service.searchLogs({ period: '0' }).subscribe(() => done());
+
+        const req = httpTestingController.expectOne({ method: 'POST' });
+        expect(req.request.body.timeRange).toBeDefined();
+        expect(req.request.body.timeRange.from).toBeDefined();
+        expect(req.request.body.timeRange.to).toBeDefined();
+        req.flush(EMPTY_RESPONSE);
+      });
+
+      it('should_use_7_day_window_when_period_is_none', done => {
+        const beforeCall = Date.now();
+        service.searchLogs({ period: '0' }).subscribe(() => done());
+
+        const req = httpTestingController.expectOne({ method: 'POST' });
+        const fromMs = new Date(req.request.body.timeRange.from).getTime();
+        const toMs = new Date(req.request.body.timeRange.to).getTime();
+        const sevenDaysMs = 7 * 86_400_000;
+        expect(toMs - fromMs).toBeGreaterThanOrEqual(sevenDaysMs - 1000);
+        expect(toMs - fromMs).toBeLessThan(sevenDaysMs + 1000);
+        expect(toMs).toBeGreaterThanOrEqual(beforeCall);
+        req.flush(EMPTY_RESPONSE);
+      });
+
+      it('should_use_period_shorthand_for_time_range', done => {
+        const beforeCall = Date.now();
+        service.searchLogs({ period: '-1h' }).subscribe(() => done());
+
+        const req = httpTestingController.expectOne({ method: 'POST' });
+        const fromMs = new Date(req.request.body.timeRange.from).getTime();
+        const toMs = new Date(req.request.body.timeRange.to).getTime();
+        expect(toMs - fromMs).toBeGreaterThanOrEqual(3_600_000 - 1000);
+        expect(toMs - fromMs).toBeLessThan(3_600_000 + 1000);
+        expect(toMs).toBeGreaterThanOrEqual(beforeCall);
+        req.flush(EMPTY_RESPONSE);
+      });
+
+      it('should_use_explicit_from_and_to_when_provided', done => {
+        const from = '2025-01-01T00:00:00Z';
+        const to = '2025-01-02T00:00:00Z';
+        service.searchLogs({ from, to }).subscribe(() => done());
+
+        const req = httpTestingController.expectOne({ method: 'POST' });
+        expect(req.request.body.timeRange).toEqual({ from, to });
+        req.flush(EMPTY_RESPONSE);
+      });
+
+      it('should_default_to_7_days_when_no_period_or_dates_provided', done => {
+        const beforeCall = Date.now();
+        service.searchLogs({}).subscribe(() => done());
+
+        const req = httpTestingController.expectOne({ method: 'POST' });
+        const fromMs = new Date(req.request.body.timeRange.from).getTime();
+        const toMs = new Date(req.request.body.timeRange.to).getTime();
+        const sevenDaysMs = 7 * 86_400_000;
+        expect(toMs - fromMs).toBeGreaterThanOrEqual(sevenDaysMs - 1000);
+        expect(toMs - fromMs).toBeLessThan(sevenDaysMs + 1000);
+        expect(toMs).toBeGreaterThanOrEqual(beforeCall);
+        req.flush(EMPTY_RESPONSE);
+      });
+    });
   });
 });
 

--- a/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment-logs.service.ts
@@ -96,7 +96,7 @@ export function periodToMs(period: string): number | null {
 type LogFilter = { name: string; operator: string; value: string | string[] | number };
 
 type SearchLogsRequestBody = {
-  timeRange?: TimeRange;
+  timeRange: TimeRange;
   filters?: LogFilter[];
 };
 
@@ -132,6 +132,7 @@ function buildFilters(param?: SearchLogsParam): LogFilter[] {
 }
 
 const WIDE_SEARCH_WINDOW_MS = 315_576_000_000;
+const SEVEN_DAYS_MS = 7 * 86_400_000;
 
 @Injectable({
   providedIn: 'root',
@@ -148,8 +149,7 @@ export class EnvironmentLogsService {
     params = params.append('perPage', param?.perPage ?? 10);
 
     const filters = buildFilters(param);
-    const timeRange = this.resolveTimeRange(param);
-    const body: SearchLogsRequestBody = timeRange ? { timeRange } : {};
+    const body: SearchLogsRequestBody = { timeRange: this.resolveTimeRange(param) };
 
     if (filters.length > 0) {
       body.filters = filters;
@@ -160,9 +160,9 @@ export class EnvironmentLogsService {
 
   /**
    * Resolves the time range for a search request.
-   * Precedence: explicit timeRange > from/to > period > requestId wide window > default (24h).
+   * Precedence: explicit timeRange > from/to > period > requestId wide window > default (7 days).
    */
-  private resolveTimeRange(param?: SearchLogsParam): TimeRange | undefined {
+  private resolveTimeRange(param?: SearchLogsParam): TimeRange {
     if (param?.timeRange) {
       return param.timeRange;
     }
@@ -177,9 +177,9 @@ export class EnvironmentLogsService {
       return { from: param.from, to: now.toISOString() };
     }
 
-    // Period 'None' — no time filter, return all logs
+    // Period 'None' — default to last 7 days
     if (param?.period === '0') {
-      return undefined;
+      return { from: new Date(now.getTime() - SEVEN_DAYS_MS).toISOString(), to: now.toISOString() };
     }
 
     // Period shorthand (e.g. '-1h')
@@ -196,8 +196,7 @@ export class EnvironmentLogsService {
       return { from: wideWindowStart.toISOString(), to: now.toISOString() };
     }
 
-    // Default: last 24 hours
-    const oneDayAgo = new Date(now.getTime() - 86_400_000);
-    return { from: oneDayAgo.toISOString(), to: now.toISOString() };
+    // Default: last 7 days
+    return { from: new Date(now.getTime() - SEVEN_DAYS_MS).toISOString(), to: now.toISOString() };
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2613
## Description

Fix of a fix. Earlier, changed logic to match that of api runtime log period filter, but backends differ:
- Runtime logs → the v2 API logs endpoint, which accepts from/to as nullable query params
- Env logs → POST /v2/logs/search, which has NotNull on timeRange in the request body

So without a backend change to make timeRange optional in the env logs search endpoint, we can't omit it entirely.
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

