### PR TITLE
fix: validate null filter values in analytics queries

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/analytics/computation/AnalyticsComputationResourceTest.java
@@ -187,6 +187,34 @@ class AnalyticsComputationResourceTest extends ApiResourceTest {
         }
 
         @Test
+        void should_fail_with_null_filter_value() {
+            var json = """
+                {
+                    "timeRange": {
+                        "from": "2025-01-01T00:00:00Z",
+                        "to": "2025-01-02T00:00:00Z"
+                    },
+                    "filters": [
+                        {
+                            "name": "API_TYPE",
+                            "operator": "EQ",
+                            "value": null
+                        }
+                    ],
+                    "metrics": [
+                        {
+                            "name": "HTTP_REQUESTS",
+                            "measures": ["COUNT"]
+                        }
+                    ]
+                }
+                """;
+            var response = rootTarget().path("measures").request().post(Entity.json(json));
+
+            assertThat(response).hasStatus(400);
+        }
+
+        @Test
         void should_return_response_time_with_milliseconds_unit() {
             var queryContext = new QueryContext(ORGANIZATION, ENVIRONMENT);
             when(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidator.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.analytics_engine.exception.InvalidQueryException;
 import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
+import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.TimeRange;
@@ -49,11 +50,13 @@ public class AnalyticsQueryValidator {
 
     public void validateMeasuresRequest(MeasuresRequest request) {
         validateTimeRange(request.timeRange());
+        validateFilters(request.filters());
         validateMetricsAndMeasures(request.metrics());
     }
 
     public void validateFacetsRequest(FacetsRequest request) {
         validateTimeRange(request.timeRange());
+        validateFilters(request.filters());
         validateFacetsSize(request);
         validateFacetMetricsAndMeasures(request.metrics());
         validateFacets(request.facets(), request.metrics());
@@ -63,6 +66,7 @@ public class AnalyticsQueryValidator {
 
     public void validateTimeSeriesRequest(TimeSeriesRequest request) {
         validateTimeRange(request.timeRange());
+        validateFilters(request.filters());
         validateFacetsSize(request);
         validateFacetMetricsAndMeasures(request.metrics());
         validateFacets(request.facets(), request.metrics());
@@ -125,6 +129,20 @@ public class AnalyticsQueryValidator {
         }
     }
 
+    private void validateFilters(List<Filter> filters) {
+        if (filters == null) {
+            return;
+        }
+        for (var filter : filters) {
+            if (filter.name() == null) {
+                throw new InvalidQueryException("Filter name cannot be null");
+            }
+            if (filter.value() == null) {
+                throw InvalidQueryException.forNullFilterValue(filter.name().name());
+            }
+        }
+    }
+
     private void validateTimeRange(TimeRange timeRange) {
         if (timeRange == null) {
             throw new InvalidQueryException("Time range cannot be null");
@@ -141,6 +159,9 @@ public class AnalyticsQueryValidator {
     }
 
     private void validateFacetMetricsAndMeasures(List<FacetMetricMeasuresRequest> queries) {
+        for (var query : queries) {
+            validateFilters(query.filters());
+        }
         validateMetricsAndMeasures(
             queries
                 .stream()
@@ -151,6 +172,9 @@ public class AnalyticsQueryValidator {
 
     private void validateMetricsAndMeasures(List<MetricMeasuresRequest> queries) {
         for (var query : queries) {
+            // Needed for the direct MeasuresRequest path; no-op when called via validateFacetMetricsAndMeasures
+            // (which projects to MetricMeasuresRequest with empty filters).
+            validateFilters(query.filters());
             var metric = query.name();
             var metricSpec = definition.findMetric(metric).orElseThrow(() -> forUnknownMetric(metric.name()));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/exception/InvalidQueryException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/exception/InvalidQueryException.java
@@ -59,7 +59,11 @@ public class InvalidQueryException extends ValidationDomainException {
         return new InvalidQueryException("Measure " + measure + " is not supported for metric " + metric);
     }
 
+    public static InvalidQueryException forNullFilterValue(String filterName) {
+        return new InvalidQueryException("Filter '" + filterName + "' requires a non-null value");
+    }
+
     public static InvalidQueryException forUnknownAPIType(String apiType) {
-        return new InvalidQueryException("Unknown API type " + apiType);
+        return new InvalidQueryException("Unknown API type '" + apiType + "'");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformer.java
@@ -93,6 +93,9 @@ public class ApiTypeFilterTransformer implements QueryFilterTransformer {
     }
 
     private static ApiType mapApiType(String value) {
+        if (value == null) {
+            throw InvalidQueryException.forNullFilterValue(FilterSpec.Name.API_TYPE.name());
+        }
         var apiType = API_TYPE_MAPPING.get(value);
         if (apiType == null) {
             throw InvalidQueryException.forUnknownAPIType(value);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/domain_service/AnalyticsQueryValidatorTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.analytics_engine.exception.InvalidQueryException;
+import io.gravitee.apim.core.analytics_engine.model.*;
+import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.observability.model.FilterOperator;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AnalyticsQueryValidatorTest {
+
+    private static final TimeRange VALID_TIME_RANGE = new TimeRange(
+        Instant.parse("2025-01-01T00:00:00Z"),
+        Instant.parse("2025-01-02T00:00:00Z")
+    );
+
+    private static final MetricSpec HTTP_REQUESTS_SPEC = new MetricSpec(
+        MetricSpec.Name.HTTP_REQUESTS,
+        "HTTP Requests",
+        List.of(),
+        MetricSpec.Unit.NUMBER,
+        List.of(MetricSpec.Measure.COUNT),
+        List.of(),
+        List.of(FacetSpec.Name.HTTP_STATUS)
+    );
+
+    private AnalyticsQueryValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        var definitionQueryService = mock(AnalyticsDefinitionQueryService.class);
+        when(definitionQueryService.findMetric(any())).thenReturn(Optional.of(HTTP_REQUESTS_SPEC));
+        validator = new AnalyticsQueryValidator(definitionQueryService);
+    }
+
+    @Nested
+    class NullFilterValidation {
+
+        @Test
+        void should_reject_null_filter_value_in_measures_request() {
+            var nullValueFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, null);
+            var request = new MeasuresRequest(
+                VALID_TIME_RANGE,
+                List.of(nullValueFilter),
+                List.of(new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT)))
+            );
+
+            assertThatThrownBy(() -> validator.validateMeasuresRequest(request))
+                .isInstanceOf(InvalidQueryException.class)
+                .hasMessageContaining("requires a non-null value");
+        }
+
+        @Test
+        void should_reject_null_filter_value_in_facets_request() {
+            var nullValueFilter = new Filter(FilterSpec.Name.APPLICATION, FilterOperator.EQ, null);
+            var request = new FacetsRequest(
+                VALID_TIME_RANGE,
+                List.of(nullValueFilter),
+                List.of(new FacetMetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT), List.of())),
+                List.of(FacetSpec.Name.HTTP_STATUS),
+                null,
+                List.of()
+            );
+
+            assertThatThrownBy(() -> validator.validateFacetsRequest(request))
+                .isInstanceOf(InvalidQueryException.class)
+                .hasMessageContaining("requires a non-null value");
+        }
+
+        @Test
+        void should_reject_null_filter_value_in_time_series_request() {
+            var nullValueFilter = new Filter(FilterSpec.Name.GATEWAY, FilterOperator.EQ, null);
+            var request = new TimeSeriesRequest(
+                VALID_TIME_RANGE,
+                3600000L,
+                List.of(nullValueFilter),
+                List.of(new FacetMetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT), List.of())),
+                List.of(),
+                null,
+                List.of()
+            );
+
+            assertThatThrownBy(() -> validator.validateTimeSeriesRequest(request))
+                .isInstanceOf(InvalidQueryException.class)
+                .hasMessageContaining("requires a non-null value");
+        }
+
+        @Test
+        void should_reject_null_filter_value_in_metric_level_filters() {
+            var nullValueFilter = new Filter(FilterSpec.Name.API, FilterOperator.EQ, null);
+            var request = new MeasuresRequest(
+                VALID_TIME_RANGE,
+                List.of(),
+                List.of(
+                    new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT), List.of(nullValueFilter))
+                )
+            );
+
+            assertThatThrownBy(() -> validator.validateMeasuresRequest(request))
+                .isInstanceOf(InvalidQueryException.class)
+                .hasMessageContaining("requires a non-null value");
+        }
+
+        @Test
+        void should_reject_null_filter_name() {
+            var nullNameFilter = new Filter(null, FilterOperator.EQ, "some-value");
+            var request = new MeasuresRequest(
+                VALID_TIME_RANGE,
+                List.of(nullNameFilter),
+                List.of(new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT)))
+            );
+
+            assertThatThrownBy(() -> validator.validateMeasuresRequest(request))
+                .isInstanceOf(InvalidQueryException.class)
+                .hasMessageContaining("Filter name cannot be null");
+        }
+
+        @Test
+        void should_accept_valid_filters() {
+            var validFilter = new Filter(FilterSpec.Name.API, FilterOperator.EQ, "api-1");
+            var request = new MeasuresRequest(
+                VALID_TIME_RANGE,
+                List.of(validFilter),
+                List.of(new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT)))
+            );
+
+            validator.validateMeasuresRequest(request);
+        }
+
+        @Test
+        void should_accept_null_filters_list() {
+            var request = new MeasuresRequest(
+                VALID_TIME_RANGE,
+                null,
+                List.of(new MetricMeasuresRequest(MetricSpec.Name.HTTP_REQUESTS, List.of(MetricSpec.Measure.COUNT)))
+            );
+
+            validator.validateMeasuresRequest(request);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/ApiTypeFilterTransformerTest.java
@@ -199,7 +199,17 @@ class ApiTypeFilterTransformerTest {
 
         assertThatThrownBy(() -> transformer.transform(context, List.of(apiTypeFilter)))
             .isInstanceOf(InvalidQueryException.class)
-            .hasMessageContaining("Unknown API type UNKNOWN");
+            .hasMessageContaining("Unknown API type 'UNKNOWN'");
+    }
+
+    @Test
+    void should_throw_on_null_api_type_value() {
+        var context = buildContext(Set.of("api-1"));
+        var apiTypeFilter = new Filter(FilterSpec.Name.API_TYPE, FilterOperator.EQ, null);
+
+        assertThatThrownBy(() -> transformer.transform(context, List.of(apiTypeFilter)))
+            .isInstanceOf(InvalidQueryException.class)
+            .hasMessageContaining("requires a non-null value");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2596

## Description

When sending a filter with a null value to the analytics API, the server returned a 500 NullPointerException instead of a 400 validation error.

- Add validateFilters() in AnalyticsQueryValidator for top-level and per-metric filters
- Add forNullFilterValue() factory method in InvalidQueryException
- Add defensive null check in ApiTypeFilterTransformer.mapApiType()
- Quote API type value in forUnknownAPIType() error message
- Add unit test and integration test for null filter values
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

