### PR TITLE
fix: api log console error

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/log/connectionLog.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/log/connectionLog.ts
@@ -50,10 +50,10 @@ export interface ConnectionLogDetail {
   timestamp: string;
   clientIdentifier: string;
   requestEnded: boolean;
-  entrypointRequest: ConnectionLogDetailRequest;
-  endpointRequest: ConnectionLogDetailRequest;
-  entrypointResponse: ConnectionLogDetailResponse;
-  endpointResponse: ConnectionLogDetailResponse;
+  entrypointRequest?: ConnectionLogDetailRequest;
+  endpointRequest?: ConnectionLogDetailRequest;
+  entrypointResponse?: ConnectionLogDetailResponse;
+  endpointResponse?: ConnectionLogDetailResponse;
   message?: string;
   errorKey?: string;
   errorComponentName?: string;

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.spec.ts
@@ -153,6 +153,41 @@ describe('ApiRuntimeLogsProxyComponent', () => {
     ]);
   });
 
+  it('should render request details when response logging is disabled (no entrypoint/endpoint response on payload)', async () => {
+    await initComponent();
+
+    expectApiMetric(
+      fakeApiMetricResponse({
+        apiId: API_ID,
+        requestId: REQUEST_ID,
+      }),
+    );
+    expectApiWithConnectionLog(
+      fakeConnectionLogDetail((base) => ({
+        ...base,
+        apiId: API_ID,
+        requestId: REQUEST_ID,
+        entrypointRequest: fakeConnectionLogDetailRequest({ body: 'entrypoint-only-body' }),
+        endpointRequest: fakeConnectionLogDetailRequest({ body: 'endpoint-only-body', uri: '' }),
+        entrypointResponse: undefined,
+        endpointResponse: undefined,
+      })),
+    );
+
+    const logHarness = await loader.getHarness(ApiProxyRequestLogOverviewHarness);
+    expect(await logHarness.getAllKeyValues()).toEqual([
+      { key: 'Method', value: 'GET' },
+      { key: 'URI', value: '/api-uri' },
+      { key: 'X-Header', value: 'first-header' },
+      { key: 'X-Header-Multiple', value: 'first-header,second-header' },
+      { key: 'Method', value: 'GET' },
+      { key: 'URI', value: null },
+      { key: 'X-Header', value: 'first-header' },
+      { key: 'X-Header-Multiple', value: 'first-header,second-header' },
+    ]);
+    expect(await logHarness.getBodies()).toEqual(['entrypoint-only-body', 'endpoint-only-body']);
+  });
+
   it('should display nothing when connection log is not found', async () => {
     await initComponent();
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-log-overview/api-proxy-request-log-overview.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/components/api-proxy-request-log-overview/api-proxy-request-log-overview.component.html
@@ -16,84 +16,104 @@
 
 -->
 @if (log(); as log) {
-  <div class="mat-h3">Details</div>
-  <mat-card class="card">
-    <mat-card-content>
-      <div class="mat-h5">Request</div>
-      <div class="card__container">
-        <div class="card__section">
-          <span class="body-strong">Consumer</span>
-          <dl class="card__section__kv">
-            <dt class="mat-caption">Method</dt>
-            <dd class="gio-caption-2">
-              <div [class]="'gio-method-badge-' + log.entrypointRequest.method.toLocaleLowerCase()">{{ log.entrypointRequest.method }}</div>
-            </dd>
-            <dt class="mat-caption">URI</dt>
-            <dd class="gio-caption-2">{{ log.entrypointRequest.uri }}</dd>
-          </dl>
+  @let hasRequest = log.entrypointRequest || log.endpointRequest;
+  @let hasResponse = log.entrypointResponse || log.endpointResponse;
+  @if (hasRequest || hasResponse) {
+    <div class="mat-h3">Details</div>
+    @if (hasRequest) {
+      <mat-card class="card">
+        <mat-card-content>
+          <div class="mat-h5">Request</div>
+          <div class="card__container">
+            @if (log.entrypointRequest) {
+              <div class="card__section">
+                <span class="body-strong">Consumer</span>
+                <dl class="card__section__kv">
+                  <dt class="mat-caption">Method</dt>
+                  <dd class="gio-caption-2">
+                    <div [class]="'gio-method-badge-' + log.entrypointRequest.method.toLocaleLowerCase()">
+                      {{ log.entrypointRequest.method }}
+                    </div>
+                  </dd>
+                  <dt class="mat-caption">URI</dt>
+                  <dd class="gio-caption-2">{{ log.entrypointRequest.uri }}</dd>
+                </dl>
 
-          <api-proxy-request-log-headers [headers]="log.entrypointRequest.headers" />
-          <api-proxy-request-log-body class="log__body" [body]="log.entrypointRequest.body" />
-        </div>
-        <div class="card__section">
-          <span class="body-strong">Gateway</span>
-          <dl class="card__section__kv">
-            <dt class="mat-caption">Method</dt>
-            <dd class="gio-caption-2">
-              <div [class]="'gio-method-badge-' + log.endpointRequest.method.toLocaleLowerCase()">{{ log.endpointRequest.method }}</div>
-            </dd>
-            <dt class="mat-caption">URI</dt>
-            <dd class="gio-caption-2">{{ log.endpointRequest.uri }}</dd>
-          </dl>
-
-          <api-proxy-request-log-headers [headers]="log.endpointRequest.headers" />
-          <api-proxy-request-log-body class="log__body" [body]="log.endpointRequest.body" />
-        </div>
-      </div>
-    </mat-card-content>
-  </mat-card>
-
-  <mat-card class="card">
-    <mat-card-content>
-      <div class="mat-h5">Response</div>
-      <div class="card__container">
-        <div class="card__section">
-          <span class="mat-body-strong">Consumer</span>
-          <dl class="card__section__kv">
-            <dt class="mat-caption">Status</dt>
-            <dd class="gio-caption-2">
-              <div
-                [class.gio-badge-success]="log.entrypointResponse.status < 400"
-                [class.gio-badge-warning]="log.entrypointResponse.status >= 400 && log.entrypointResponse.status <= 499"
-                [class.gio-badge-error]="log.entrypointResponse.status >= 500"
-              >
-                {{ log.entrypointResponse.status }}
+                <api-proxy-request-log-headers [headers]="log.entrypointRequest.headers" />
+                <api-proxy-request-log-body class="log__body" [body]="log.entrypointRequest.body" />
               </div>
-            </dd>
-          </dl>
+            }
+            @if (log.endpointRequest) {
+              <div class="card__section">
+                <span class="body-strong">Gateway</span>
+                <dl class="card__section__kv">
+                  <dt class="mat-caption">Method</dt>
+                  <dd class="gio-caption-2">
+                    <div [class]="'gio-method-badge-' + log.endpointRequest.method.toLocaleLowerCase()">
+                      {{ log.endpointRequest.method }}
+                    </div>
+                  </dd>
+                  <dt class="mat-caption">URI</dt>
+                  <dd class="gio-caption-2">{{ log.endpointRequest.uri }}</dd>
+                </dl>
 
-          <api-proxy-request-log-headers [headers]="log.entrypointResponse.headers" />
-          <api-proxy-request-log-body class="log__body" [body]="log.entrypointResponse.body" />
-        </div>
-        <div class="card__section">
-          <span class="mat-body-strong">Gateway</span>
-          <dl class="card__section__kv">
-            <dt class="mat-caption">Status</dt>
-            <dd class="gio-caption-2">
-              <div
-                [class.gio-badge-success]="log.endpointResponse.status < 400"
-                [class.gio-badge-warning]="log.endpointResponse.status >= 400 && log.endpointResponse.status <= 499"
-                [class.gio-badge-error]="log.endpointResponse.status >= 500"
-              >
-                {{ log.endpointResponse.status }}
+                <api-proxy-request-log-headers [headers]="log.endpointRequest.headers" />
+                <api-proxy-request-log-body class="log__body" [body]="log.endpointRequest.body" />
               </div>
-            </dd>
-          </dl>
+            }
+          </div>
+        </mat-card-content>
+      </mat-card>
+    }
 
-          <api-proxy-request-log-headers [headers]="log.endpointResponse.headers" />
-          <api-proxy-request-log-body class="log__body" [body]="log.endpointResponse.body" />
-        </div>
-      </div>
-    </mat-card-content>
-  </mat-card>
+    @if (hasResponse) {
+      <mat-card class="card">
+        <mat-card-content>
+          <div class="mat-h5">Response</div>
+          <div class="card__container">
+            @if (log.entrypointResponse) {
+              <div class="card__section">
+                <span class="mat-body-strong">Consumer</span>
+                <dl class="card__section__kv">
+                  <dt class="mat-caption">Status</dt>
+                  <dd class="gio-caption-2">
+                    <div
+                      [class.gio-badge-success]="log.entrypointResponse.status < 400"
+                      [class.gio-badge-warning]="log.entrypointResponse.status >= 400 && log.entrypointResponse.status <= 499"
+                      [class.gio-badge-error]="log.entrypointResponse.status >= 500"
+                    >
+                      {{ log.entrypointResponse.status }}
+                    </div>
+                  </dd>
+                </dl>
+
+                <api-proxy-request-log-headers [headers]="log.entrypointResponse.headers" />
+                <api-proxy-request-log-body class="log__body" [body]="log.entrypointResponse.body" />
+              </div>
+            }
+            @if (log.endpointResponse) {
+              <div class="card__section">
+                <span class="mat-body-strong">Gateway</span>
+                <dl class="card__section__kv">
+                  <dt class="mat-caption">Status</dt>
+                  <dd class="gio-caption-2">
+                    <div
+                      [class.gio-badge-success]="log.endpointResponse.status < 400"
+                      [class.gio-badge-warning]="log.endpointResponse.status >= 400 && log.endpointResponse.status <= 499"
+                      [class.gio-badge-error]="log.endpointResponse.status >= 500"
+                    >
+                      {{ log.endpointResponse.status }}
+                    </div>
+                  </dd>
+                </dl>
+
+                <api-proxy-request-log-headers [headers]="log.endpointResponse.headers" />
+                <api-proxy-request-log-body class="log__body" [body]="log.endpointResponse.body" />
+              </div>
+            }
+          </div>
+        </mat-card-content>
+      </mat-card>
+    }
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12623

## Description


Aspect | Details
-- | --
Problem | When Response (or other logging phases) is disabled in Reporter Settings, the API log detail page throws TypeError: can't access property "status", t.entrypointResponse is undefined and the Details section does not render.
Root cause | The backend omits entrypointRequest, endpointRequest, entrypointResponse, and endpointResponse when their logging phase is disabled. The UI always accessed these fields without checking if they existed.
Solution | Treat these fields as optional and render each section only when its data is present. Hide the "Details" heading when none of the four objects exist.
Files changed | connectionLog.ts – mark request/response fields as optional; api-proxy-request-log-overview.component.html – add conditional rendering for each section.
Behavior | With all logging enabled: unchanged. With partial logging: only sections with data are shown;.

Before fix: 

https://github.com/user-attachments/assets/e41a9fe1-9538-4226-90f2-2916d45f9a6a

After fix: 

https://github.com/user-attachments/assets/ae0b92e3-48e2-48d9-9bbc-f69db5269132
