### PR TITLE
feat: add failover support for LLM proxy apis

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/failover.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/failover.ts
@@ -24,4 +24,6 @@ export interface Failover {
   openStateDuration?: number;
   maxFailures?: number;
   perSubscription?: boolean;
+  failureCondition?: string;
+  forceNextEndpointOnFailure?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.spec.ts
@@ -245,6 +245,23 @@ describe('ApiNavigationComponent', () => {
       );
     });
 
+    it('should compute menu search items for V4 LLM_PROXY API', async () => {
+      fixture.detectChanges();
+      expectApiGetRequest(fakeApiV4({ id: API_ID, type: 'LLM_PROXY' }));
+
+      expect(addSearchItemByGroupIds).toHaveBeenCalledTimes(1);
+      expect(addSearchItemByGroupIds).toHaveBeenCalledWith(
+        expect.arrayContaining(
+          ['Endpoints', 'Endpoints', 'Failover'].map(name =>
+            expect.objectContaining({
+              name,
+              routerLink: expect.not.stringContaining('./') && expect.stringContaining(`${ENVIRONMENT_ID}/apis/${API_ID}/`),
+            }),
+          ),
+        ),
+      );
+    });
+
     it('should compute menu search items for V2 API', async () => {
       fixture.detectChanges();
       expectApiGetRequest(fakeApiV2({ id: API_ID }));

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -228,7 +228,7 @@ export class ApiV4MenuService implements ApiMenuService {
       });
     }
 
-    if ((api.type === 'PROXY' && !hasTcpListeners) || api.type === 'MESSAGE')
+    if ((api.type === 'PROXY' && !hasTcpListeners) || api.type === 'MESSAGE' || api.type === 'LLM_PROXY')
       tabs.push({
         displayName: 'Failover',
         routerLink: 'v4/failover',

--- a/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.html
+++ b/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.html
@@ -51,6 +51,19 @@
       <mat-divider></mat-divider>
 
       <div class="failover-card__control">
+        <gio-form-slide-toggle class="failover-card__enable-toggle">
+          <gio-form-label>Force next endpoint on failure</gio-form-label>
+          Force to use the next endpoint instead of relying on the load balancer.
+          <mat-slide-toggle
+            gioFormSlideToggle
+            formControlName="forceNextEndpointOnFailure"
+            aria-label="Force next endpoint on failure toggle"
+            name="forceNextEndpointOnFailure"
+          ></mat-slide-toggle>
+        </gio-form-slide-toggle>
+      </div>
+
+      <div class="failover-card__control">
         <div class="failover-card__control__label">Max retries</div>
         <p class="failover-card__control__hint">
           Limit the number of retry attempts before recording an error. Each attempt dynamically selects an endpoint based on the load
@@ -65,6 +78,19 @@
           @if (failoverForm.controls.maxRetries.hasError('required')) {
             <mat-error>Max Retries is required</mat-error>
           }
+        </mat-form-field>
+      </div>
+
+      <div class="failover-card__control">
+        <div class="failover-card__control__label">Failure condition</div>
+        <p class="failover-card__control__hint">
+          An EL expression evaluated against the response to determine if it should be considered a failure (e.g.
+          <code>{{ '{' }}#response.status >= 500{{ '}' }}</code
+          >).
+        </p>
+        <mat-form-field class="failover-card__control__form-field">
+          <mat-label>Failure condition</mat-label>
+          <input matInput formControlName="failureCondition" type="text" />
         </mat-form-field>
       </div>
 

--- a/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.spec.ts
@@ -79,9 +79,19 @@ describe('ApiV4FailoverComponent', () => {
     expect(await enabledSlideToggle.isChecked()).toEqual(false);
 
     // Check each field is disabled
+    const forceNextToggle = await loader.getHarness(
+      MatSlideToggleHarness.with({ selector: '[formControlName="forceNextEndpointOnFailure"]' }),
+    );
+    expect(await forceNextToggle.isChecked()).toEqual(false);
+    expect(await forceNextToggle.isDisabled()).toBe(true);
+
     const maxRetriesInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="maxRetries"]' }));
     expect(await maxRetriesInput.isDisabled()).toBe(true);
     expect(await maxRetriesInput.getValue()).toEqual('2');
+
+    const failureConditionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="failureCondition"]' }));
+    expect(await failureConditionInput.isDisabled()).toBe(true);
+    expect(await failureConditionInput.getValue()).toEqual('');
 
     const slowCallDurationInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="slowCallDuration"]' }));
     expect(await slowCallDurationInput.isDisabled()).toBe(true);
@@ -115,7 +125,9 @@ describe('ApiV4FailoverComponent', () => {
     const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}` });
     expect(req.request.body.failover).toStrictEqual({
       enabled: true,
+      forceNextEndpointOnFailure: false,
       maxRetries: 2,
+      failureCondition: undefined,
       slowCallDuration: 200,
       openStateDuration: 2000,
       maxFailures: 2,
@@ -207,7 +219,9 @@ describe('ApiV4FailoverComponent', () => {
     const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}` });
     expect(req.request.body.failover).toStrictEqual({
       enabled: true,
+      forceNextEndpointOnFailure: false,
       maxRetries: 3,
+      failureCondition: undefined,
       slowCallDuration: 300,
       openStateDuration: 3000,
       maxFailures: 3,
@@ -230,8 +244,16 @@ describe('ApiV4FailoverComponent', () => {
     expect(await enabledSlideToggle.isChecked()).toEqual(false);
 
     // Check each field is disabled
+    const forceNextToggle = await loader.getHarness(
+      MatSlideToggleHarness.with({ selector: '[formControlName="forceNextEndpointOnFailure"]' }),
+    );
+    expect(await forceNextToggle.isDisabled()).toBe(true);
+
     const maxRetriesInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="maxRetries"]' }));
     expect(await maxRetriesInput.isDisabled()).toBe(true);
+
+    const failureConditionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="failureCondition"]' }));
+    expect(await failureConditionInput.isDisabled()).toBe(true);
 
     const slowCallDurationInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="slowCallDuration"]' }));
     expect(await slowCallDurationInput.isDisabled()).toBe(true);
@@ -245,6 +267,58 @@ describe('ApiV4FailoverComponent', () => {
     const perSubscriptionToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="perSubscription"]' }));
     expect(await perSubscriptionToggle.isDisabled()).toBe(true);
     expect(await perSubscriptionToggle.isChecked()).toEqual(true);
+  });
+
+  it('should display and submit failureCondition and forceNextEndpointOnFailure', async () => {
+    const api = fakeApiV4({
+      id: API_ID,
+      failover: {
+        enabled: true,
+        maxRetries: 2,
+        slowCallDuration: 200,
+        openStateDuration: 2000,
+        maxFailures: 2,
+        perSubscription: true,
+        failureCondition: '{#response.status >= 500}',
+        forceNextEndpointOnFailure: true,
+      },
+    });
+    expectApiGetRequest(api);
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+
+    // Verify forceNextEndpointOnFailure toggle is loaded with correct value
+    const forceNextToggle = await loader.getHarness(
+      MatSlideToggleHarness.with({ selector: '[formControlName="forceNextEndpointOnFailure"]' }),
+    );
+    expect(await forceNextToggle.isChecked()).toEqual(true);
+    expect(await forceNextToggle.isDisabled()).toBe(false);
+
+    // Verify failureCondition input is loaded with correct value
+    const failureConditionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="failureCondition"]' }));
+    expect(await failureConditionInput.getValue()).toEqual('{#response.status >= 500}');
+    expect(await failureConditionInput.isDisabled()).toBe(false);
+
+    // Modify values via UI controls
+    await forceNextToggle.toggle();
+    await failureConditionInput.setValue('{#response.status >= 502}');
+    await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="maxRetries"]' })).then(input => input.setValue('3'));
+
+    expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+    await saveBar.clickSubmit();
+
+    // Expect fetch api and update
+    expectApiGetRequest(api);
+    const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}` });
+    expect(req.request.body.failover).toStrictEqual({
+      enabled: true,
+      forceNextEndpointOnFailure: false,
+      maxRetries: 3,
+      failureCondition: '{#response.status >= 502}',
+      slowCallDuration: 200,
+      openStateDuration: 2000,
+      maxFailures: 2,
+      perSubscription: true,
+    });
   });
 
   function expectApiGetRequest(api: ApiV4) {

--- a/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/failover-v4/api-failover-v4.component.ts
@@ -34,7 +34,9 @@ import {
 
 export type FailoverForm = {
   enabled: FormControl<boolean>;
+  forceNextEndpointOnFailure: FormControl<boolean>;
   maxRetries: FormControl<number>;
+  failureCondition: FormControl<string>;
   slowCallDuration: FormControl<number>;
   openStateDuration: FormControl<number>;
   maxFailures: FormControl<number>;
@@ -89,12 +91,26 @@ export class ApiFailoverV4Component implements OnInit, OnDestroy {
 
     this.failoverForm = this.formBuilder.group({
       enabled: [{ value: failover?.enabled, disabled: isReadOnly }, []],
+      forceNextEndpointOnFailure: [
+        {
+          value: failover?.forceNextEndpointOnFailure ?? false,
+          disabled: isFailoverReadOnly,
+        },
+        [],
+      ],
       maxRetries: [
         {
           value: failover?.maxRetries ?? 2,
           disabled: isFailoverReadOnly,
         },
         [Validators.required, Validators.min(0)],
+      ],
+      failureCondition: [
+        {
+          value: failover?.failureCondition ?? '',
+          disabled: isFailoverReadOnly,
+        },
+        [],
       ],
       slowCallDuration: [
         { value: failover?.slowCallDuration ?? 2000, disabled: isFailoverReadOnly },
@@ -117,7 +133,15 @@ export class ApiFailoverV4Component implements OnInit, OnDestroy {
   }
 
   private setupDisablingFields() {
-    const controlKeys = ['maxRetries', 'slowCallDuration', 'openStateDuration', 'maxFailures', 'perSubscription'];
+    const controlKeys = [
+      'forceNextEndpointOnFailure',
+      'maxRetries',
+      'failureCondition',
+      'slowCallDuration',
+      'openStateDuration',
+      'maxFailures',
+      'perSubscription',
+    ];
     this.failoverForm
       .get('enabled')
       .valueChanges.pipe(takeUntil(this.unsubscribe$))
@@ -129,7 +153,16 @@ export class ApiFailoverV4Component implements OnInit, OnDestroy {
   }
 
   onSubmit() {
-    const { enabled, maxRetries, slowCallDuration, openStateDuration, maxFailures, perSubscription } = this.failoverForm.getRawValue();
+    const {
+      enabled,
+      forceNextEndpointOnFailure,
+      maxRetries,
+      failureCondition,
+      slowCallDuration,
+      openStateDuration,
+      maxFailures,
+      perSubscription,
+    } = this.failoverForm.getRawValue();
     let confirmUpdate$: Observable<boolean>;
     if (enabled && !perSubscription) {
       confirmUpdate$ = this.matDialog
@@ -161,8 +194,11 @@ export class ApiFailoverV4Component implements OnInit, OnDestroy {
           this.apiService.update(api.id, {
             ...api,
             failover: {
+              ...api.failover,
               enabled,
+              forceNextEndpointOnFailure,
               maxRetries,
+              failureCondition: failureCondition || undefined,
               slowCallDuration,
               openStateDuration,
               maxFailures,

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/failover/Failover.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/failover/Failover.java
@@ -52,4 +52,6 @@ public class Failover implements Serializable {
 
     @Builder.Default
     private boolean perSubscription = DEFAULT_PER_SUBSCRIPTION;
+
+    private String failureCondition;
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/failover/Failover.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/failover/Failover.java
@@ -54,4 +54,7 @@ public class Failover implements Serializable {
     private boolean perSubscription = DEFAULT_PER_SUBSCRIPTION;
 
     private String failureCondition;
+
+    @Builder.Default
+    private boolean forceNextEndpointOnFailure = false;
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverConditionMatchException.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverConditionMatchException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.failover;
+
+/**
+ * Exception thrown when the failover failure condition EL expression evaluates to true,
+ * indicating that the response should be considered a failure and a retry should be attempted.
+ */
+public class FailoverConditionMatchException extends RuntimeException {
+
+    public FailoverConditionMatchException(String message) {
+        super(message);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.CustomLog;
+import org.springframework.util.StringUtils;
 
 @CustomLog
 public class FailoverInvoker implements HttpInvoker, Invoker {
@@ -70,7 +71,7 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
      * @param failoverConfiguration the {@link Failover} configuration that specifies the failover behavior and settings.
      * @param apiId the identifier of the API for which this invoker is instantiated.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(since = "4.11.0", forRemoval = true)
     public FailoverInvoker(HttpInvoker delegate, Failover failoverConfiguration, String apiId) {
         this(delegate, failoverConfiguration, apiId, null);
     }
@@ -107,16 +108,24 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
     @Override
     public Completable invoke(HttpExecutionContext ctx) {
         final String originalEndpoint = ctx.getAttribute(ATTR_REQUEST_ENDPOINT);
-        final AtomicInteger attemptIndex = new AtomicInteger(0);
-        final AtomicReference<List<String>> capturedEndpoints = new AtomicReference<>();
+        final AtomicInteger totalAttempts = new AtomicInteger(0);
+        final AtomicReference<List<String>> endpointRotation = new AtomicReference<>();
+        final AtomicReference<String> firstFailedEndpoint = new AtomicReference<>();
 
         return Completable.defer(() -> {
+            int attempt = totalAttempts.getAndIncrement();
+
+            // On retry, capture the endpoint that failed in the previous attempt
+            if (attempt > 0) {
+                firstFailedEndpoint.compareAndSet(null, resolveCurrentEndpointName(ctx));
+            }
+
             // EndpointInvoker overrides the request endpoint. We need to set it back to original state to retry properly
             ctx.setAttribute(ATTR_REQUEST_ENDPOINT, originalEndpoint);
             // Entrypoint connectors skip response handling if there is an error. In the case of a retry, we need to reset the failure.
             ctx.removeInternalAttribute(ATTR_INTERNAL_EXECUTION_FAILURE);
 
-            forceNextEndpoint(ctx, attemptIndex, capturedEndpoints);
+            forceNextEndpoint(ctx, attempt, endpointRotation);
 
             // Consume body and ignore it. Consuming it with .body() method internally enables caching of chunks, which is mandatory to retry the request in case of failure.
             return ctx.request().body().ignoreElement().andThen(delegate.invoke(ctx)).andThen(evaluateFailureCondition(ctx));
@@ -124,10 +133,25 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
             .timeout(failoverConfiguration.getSlowCallDuration(), TimeUnit.MILLISECONDS)
             .retry(failoverConfiguration.getMaxRetries())
             .compose(CircuitBreakerOperator.of(circuitBreaker(ctx)))
-            .onErrorResumeNext(t -> ctx.interruptWith(new ExecutionFailure(502).cause(t)));
+            .onErrorResumeNext(t -> ctx.interruptWith(new ExecutionFailure(502).cause(t)))
+            .doFinally(() -> recordFailoverMetrics(ctx, totalAttempts.get(), firstFailedEndpoint.get()));
     }
 
-    private void forceNextEndpoint(HttpExecutionContext ctx, AtomicInteger attemptIndex, AtomicReference<List<String>> capturedEndpoints) {
+    /**
+     * Forces the invocation to switch to the next available endpoint in the rotation if the configured
+     * failover settings permit this behavior, and the current attempt is not the first one.
+     * If the rotation cannot be computed (e.g., no managed endpoint in context, or single endpoint in the group),
+     * the default load balancer selection is preserved.
+     *
+     * @param ctx the {@link HttpExecutionContext} of the current invocation, which provides access
+     *            to request and plugin execution details.
+     * @param attempt the current invocation attempt count. A value of 0 indicates the first attempt,
+     *                and no endpoint rotation will occur.
+     * @param endpointRotation a mutable {@link AtomicReference} holding the list of available
+     *                         endpoints for failover. The list is lazily initialized on the first
+     *                         invocation.
+     */
+    private void forceNextEndpoint(HttpExecutionContext ctx, int attempt, AtomicReference<List<String>> endpointRotation) {
         if (!failoverConfiguration.isForceNextEndpointOnFailure()) {
             return;
         }
@@ -135,68 +159,97 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
             ctx.withLogger(log).warn("Endpoint manager is null, cannot force next endpoint");
             return;
         }
-
-        int attempt = attemptIndex.getAndIncrement();
         if (attempt == 0) {
-            // First attempt: let the LB pick the endpoint normally, we'll capture it after invocation
-            // Capture happens on retry (attempt > 0), using the ManagedEndpoint set by HttpEndpointInvoker
+            // First attempt: let the LB pick the endpoint normally
+            ctx.withLogger(log).debug("First attempt, using load balancer to pick endpoint");
             return;
         }
 
-        List<String> endpoints = capturedEndpoints.get();
-        if (endpoints == null) {
-            // Build the ordered list of endpoints starting from the one after the initially selected endpoint
-            endpoints = buildEndpointRotation(ctx);
-            capturedEndpoints.set(endpoints);
-        }
+        List<String> rotation = initEndpointRotation(ctx, endpointRotation);
 
-        if (endpoints != null && !endpoints.isEmpty()) {
-            // Select the next endpoint in the rotation (attempt-1 because attempt 0 was the LB pick)
-            int index = (attempt - 1) % endpoints.size();
-            ctx.setAttribute(ATTR_REQUEST_ENDPOINT, endpoints.get(index) + ":");
+        if (rotation != null && !rotation.isEmpty()) {
+            int index = (attempt - 1) % rotation.size();
+            ctx.setAttribute(ATTR_REQUEST_ENDPOINT, rotation.get(index) + ":");
         }
     }
 
+    /**
+     * Initializes the endpoint rotation for failover handling. If the endpoint rotation list is not
+     * already initialized, this method builds the endpoint rotation from the provided execution context
+     * and sets it in the given atomic reference. The rotation ensures the endpoints are processed
+     * cyclically in failover scenarios.
+     *
+     * @param ctx the {@link HttpExecutionContext} providing the invocation context,
+     *            including attributes and execution details.
+     * @param endpointRotation a mutable {@link AtomicReference} holding the list of available
+     *                         endpoints for failover. The list is lazily initialized if null.
+     * @return the initialized or existing list of endpoint names in rotation order, or {@code null}
+     *         if no endpoints are available or could be determined from the context.
+     */
+    private List<String> initEndpointRotation(HttpExecutionContext ctx, AtomicReference<List<String>> endpointRotation) {
+        List<String> rotation = endpointRotation.get();
+        if (rotation == null) {
+            rotation = buildEndpointRotation(ctx);
+            endpointRotation.set(rotation);
+        }
+        return rotation;
+    }
+
+    /**
+     * Builds the rotation of endpoints for failover handling based on the provided execution context.
+     * The rotation is calculated by starting from the endpoint immediately following the currently
+     * selected one, cycling through the list of endpoints, and including the selected endpoint at the end.
+     * If the currently selected endpoint cannot be determined, or if there's only one endpoint available,
+     * the rotation will not be created.
+     *
+     * @param ctx the {@link HttpExecutionContext} providing the invocation context and attributes.
+     *            It should contain the currently selected endpoint as an internal attribute.
+     * @return a list of endpoint names in the calculated rotation order, or {@code null} if no
+     *         valid endpoints are available or the rotation could not be determined.
+     */
     private List<String> buildEndpointRotation(HttpExecutionContext ctx) {
         ManagedEndpoint selectedEndpoint = ctx.getInternalAttribute(ATTR_INTERNAL_FAILOVER_MANAGED_ENDPOINT);
         if (selectedEndpoint == null) {
             return null;
         }
 
-        String selectedGroupName = selectedEndpoint.getGroup().getDefinition().getName();
         String selectedEndpointName = selectedEndpoint.getDefinition().getName();
 
-        // Get all endpoints from the same group
-        List<ManagedEndpoint> allEndpoints = endpointManager.all();
-        List<String> groupEndpointNames = new ArrayList<>();
-        int selectedIndex = -1;
-
-        for (ManagedEndpoint ep : allEndpoints) {
-            if (ep.getGroup().getDefinition().getName().equals(selectedGroupName)) {
-                String name = ep.getDefinition().getName();
-                if (name.equals(selectedEndpointName)) {
-                    selectedIndex = groupEndpointNames.size();
-                }
-                groupEndpointNames.add(name);
-            }
-        }
-
-        if (groupEndpointNames.size() <= 1 || selectedIndex == -1) {
+        // Use the group definition to get endpoints in their declaration order
+        List<? extends io.gravitee.definition.model.v4.endpointgroup.Endpoint> definedEndpoints = selectedEndpoint
+            .getGroup()
+            .getDefinition()
+            .getEndpoints();
+        if (definedEndpoints == null || definedEndpoints.size() <= 1) {
             return null;
         }
 
-        // Build rotation starting from the endpoint after the selected one
-        List<String> rotation = new ArrayList<>(groupEndpointNames.size() - 1);
-        for (int i = 1; i < groupEndpointNames.size(); i++) {
-            int idx = (selectedIndex + i) % groupEndpointNames.size();
-            rotation.add(groupEndpointNames.get(idx));
+        List<String> endpointNames = new ArrayList<>(definedEndpoints.size());
+        int selectedIndex = -1;
+        for (int i = 0; i < definedEndpoints.size(); i++) {
+            String name = definedEndpoints.get(i).getName();
+            endpointNames.add(name);
+            if (name.equals(selectedEndpointName)) {
+                selectedIndex = i;
+            }
+        }
+
+        if (selectedIndex == -1) {
+            return null;
+        }
+
+        // Build full rotation starting from the endpoint after the selected one, cycling back to include it
+        List<String> rotation = new ArrayList<>(endpointNames.size());
+        for (int i = 1; i <= endpointNames.size(); i++) {
+            int idx = (selectedIndex + i) % endpointNames.size();
+            rotation.add(endpointNames.get(idx));
         }
         return rotation;
     }
 
     private Completable evaluateFailureCondition(HttpExecutionContext ctx) {
         String condition = failoverConfiguration.getFailureCondition();
-        if (condition == null || condition.isEmpty()) {
+        if (!StringUtils.hasText(condition)) {
             return Completable.complete();
         }
         return ctx
@@ -209,6 +262,26 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
                 return Completable.complete();
             })
             .onErrorComplete(t -> !(t instanceof FailoverConditionMatchException));
+    }
+
+    private String resolveCurrentEndpointName(HttpExecutionContext ctx) {
+        ManagedEndpoint endpoint = ctx.getInternalAttribute(ATTR_INTERNAL_FAILOVER_MANAGED_ENDPOINT);
+        return endpoint != null ? endpoint.getDefinition().getName() : null;
+    }
+
+    private void recordFailoverMetrics(HttpExecutionContext ctx, int totalAttempts, String firstFailed) {
+        int failoverCount = totalAttempts - 1;
+        if (failoverCount <= 0) {
+            return;
+        }
+        ctx.metrics().putAdditionalMetric("long_failover_count", (long) failoverCount);
+        if (firstFailed != null) {
+            ctx.metrics().putAdditionalKeywordMetric("keyword_failover_first-failed-endpoint", firstFailed);
+        }
+        ManagedEndpoint successfulEndpoint = ctx.getInternalAttribute(ATTR_INTERNAL_FAILOVER_MANAGED_ENDPOINT);
+        if (successfulEndpoint != null) {
+            ctx.metrics().putAdditionalKeywordMetric("keyword_failover_successful-endpoint", successfulEndpoint.getDefinition().getName());
+        }
     }
 
     private CircuitBreaker circuitBreaker(HttpExecutionContext ctx) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.reactive.core.failover;
 
 import static io.gravitee.gateway.reactive.api.context.ContextAttributes.ATTR_REQUEST_ENDPOINT;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE;
+import static io.gravitee.gateway.reactive.core.v4.invoker.HttpEndpointInvoker.ATTR_INTERNAL_FAILOVER_MANAGED_ENDPOINT;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
@@ -30,15 +31,22 @@ import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.invoker.HttpInvoker;
 import io.gravitee.gateway.reactive.api.invoker.Invoker;
+import io.gravitee.gateway.reactive.core.v4.endpoint.EndpointManager;
+import io.gravitee.gateway.reactive.core.v4.endpoint.ManagedEndpoint;
 import io.reactivex.rxjava3.core.Completable;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class FailoverInvoker implements HttpInvoker, Invoker {
 
     private final HttpInvoker delegate;
     private final Failover failoverConfiguration;
+    private final EndpointManager endpointManager;
 
     @VisibleForTesting
     final CircuitBreaker circuitBreaker;
@@ -51,9 +59,10 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
         return "failover-invoker";
     }
 
-    public FailoverInvoker(HttpInvoker delegate, Failover failoverConfiguration, String apiId) {
+    public FailoverInvoker(HttpInvoker delegate, Failover failoverConfiguration, String apiId, EndpointManager endpointManager) {
         this.delegate = delegate;
         this.failoverConfiguration = failoverConfiguration;
+        this.endpointManager = endpointManager;
         final CircuitBreakerConfig circuitBreakerConfiguration = CircuitBreakerConfig.custom()
             .permittedNumberOfCallsInHalfOpenState(1)
             .slowCallDurationThreshold(Duration.of(failoverConfiguration.getSlowCallDuration(), ChronoUnit.MILLIS))
@@ -82,11 +91,17 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
     @Override
     public Completable invoke(HttpExecutionContext ctx) {
         final String originalEndpoint = ctx.getAttribute(ATTR_REQUEST_ENDPOINT);
+        final AtomicInteger attemptIndex = new AtomicInteger(0);
+        final AtomicReference<List<String>> capturedEndpoints = new AtomicReference<>();
+
         return Completable.defer(() -> {
             // EndpointInvoker overrides the request endpoint. We need to set it back to original state to retry properly
             ctx.setAttribute(ATTR_REQUEST_ENDPOINT, originalEndpoint);
             // Entrypoint connectors skip response handling if there is an error. In the case of a retry, we need to reset the failure.
             ctx.removeInternalAttribute(ATTR_INTERNAL_EXECUTION_FAILURE);
+
+            forceNextEndpoint(ctx, attemptIndex, capturedEndpoints);
+
             // Consume body and ignore it. Consuming it with .body() method internally enables caching of chunks, which is mandatory to retry the request in case of failure.
             return ctx.request().body().ignoreElement().andThen(delegate.invoke(ctx)).andThen(evaluateFailureCondition(ctx));
         })
@@ -94,6 +109,69 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
             .retry(failoverConfiguration.getMaxRetries())
             .compose(CircuitBreakerOperator.of(circuitBreaker(ctx)))
             .onErrorResumeNext(t -> ctx.interruptWith(new ExecutionFailure(502).cause(t)));
+    }
+
+    private void forceNextEndpoint(HttpExecutionContext ctx, AtomicInteger attemptIndex, AtomicReference<List<String>> capturedEndpoints) {
+        if (!failoverConfiguration.isForceNextEndpointOnFailure()) {
+            return;
+        }
+
+        int attempt = attemptIndex.getAndIncrement();
+        if (attempt == 0) {
+            // First attempt: let the LB pick the endpoint normally, we'll capture it after invocation
+            // Capture happens on retry (attempt > 0), using the ManagedEndpoint set by HttpEndpointInvoker
+            return;
+        }
+
+        List<String> endpoints = capturedEndpoints.get();
+        if (endpoints == null) {
+            // Build the ordered list of endpoints starting from the one after the initially selected endpoint
+            endpoints = buildEndpointRotation(ctx);
+            capturedEndpoints.set(endpoints);
+        }
+
+        if (endpoints != null && !endpoints.isEmpty()) {
+            // Select the next endpoint in the rotation (attempt-1 because attempt 0 was the LB pick)
+            int index = (attempt - 1) % endpoints.size();
+            ctx.setAttribute(ATTR_REQUEST_ENDPOINT, endpoints.get(index));
+        }
+    }
+
+    private List<String> buildEndpointRotation(HttpExecutionContext ctx) {
+        ManagedEndpoint selectedEndpoint = ctx.getInternalAttribute(ATTR_INTERNAL_FAILOVER_MANAGED_ENDPOINT);
+        if (selectedEndpoint == null) {
+            return null;
+        }
+
+        String selectedGroupName = selectedEndpoint.getGroup().getDefinition().getName();
+        String selectedEndpointName = selectedEndpoint.getDefinition().getName();
+
+        // Get all endpoints from the same group
+        List<ManagedEndpoint> allEndpoints = endpointManager.all();
+        List<String> groupEndpointNames = new ArrayList<>();
+        int selectedIndex = -1;
+
+        for (ManagedEndpoint ep : allEndpoints) {
+            if (ep.getGroup().getDefinition().getName().equals(selectedGroupName)) {
+                String name = ep.getDefinition().getName();
+                if (name.equals(selectedEndpointName)) {
+                    selectedIndex = groupEndpointNames.size();
+                }
+                groupEndpointNames.add(name);
+            }
+        }
+
+        if (groupEndpointNames.size() <= 1 || selectedIndex == -1) {
+            return null;
+        }
+
+        // Build rotation starting from the endpoint after the selected one
+        List<String> rotation = new ArrayList<>(groupEndpointNames.size() - 1);
+        for (int i = 1; i < groupEndpointNames.size(); i++) {
+            int idx = (selectedIndex + i) % groupEndpointNames.size();
+            rotation.add(groupEndpointNames.get(idx));
+        }
+        return rotation;
     }
 
     private Completable evaluateFailureCondition(HttpExecutionContext ctx) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
@@ -88,12 +88,29 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
             // Entrypoint connectors skip response handling if there is an error. In the case of a retry, we need to reset the failure.
             ctx.removeInternalAttribute(ATTR_INTERNAL_EXECUTION_FAILURE);
             // Consume body and ignore it. Consuming it with .body() method internally enables caching of chunks, which is mandatory to retry the request in case of failure.
-            return ctx.request().body().ignoreElement().andThen(delegate.invoke(ctx));
+            return ctx.request().body().ignoreElement().andThen(delegate.invoke(ctx)).andThen(evaluateFailureCondition(ctx));
         })
             .timeout(failoverConfiguration.getSlowCallDuration(), TimeUnit.MILLISECONDS)
             .retry(failoverConfiguration.getMaxRetries())
             .compose(CircuitBreakerOperator.of(circuitBreaker(ctx)))
             .onErrorResumeNext(t -> ctx.interruptWith(new ExecutionFailure(502).cause(t)));
+    }
+
+    private Completable evaluateFailureCondition(HttpExecutionContext ctx) {
+        String condition = failoverConfiguration.getFailureCondition();
+        if (condition == null || condition.isEmpty()) {
+            return Completable.complete();
+        }
+        return ctx
+            .getTemplateEngine()
+            .eval(condition, Boolean.class)
+            .flatMapCompletable(isFailure -> {
+                if (Boolean.TRUE.equals(isFailure)) {
+                    return Completable.error(new FailoverConditionMatchException("Failover condition matched: " + condition));
+                }
+                return Completable.complete();
+            })
+            .onErrorComplete(t -> !(t instanceof FailoverConditionMatchException));
     }
 
     private CircuitBreaker circuitBreaker(HttpExecutionContext ctx) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
@@ -133,7 +133,7 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
         if (endpoints != null && !endpoints.isEmpty()) {
             // Select the next endpoint in the rotation (attempt-1 because attempt 0 was the LB pick)
             int index = (attempt - 1) % endpoints.size();
-            ctx.setAttribute(ATTR_REQUEST_ENDPOINT, endpoints.get(index));
+            ctx.setAttribute(ATTR_REQUEST_ENDPOINT, endpoints.get(index) + ":");
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
@@ -41,7 +41,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.CustomLog;
 
+@CustomLog
 public class FailoverInvoker implements HttpInvoker, Invoker {
 
     private final HttpInvoker delegate;
@@ -57,6 +59,20 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
     @Override
     public String getId() {
         return "failover-invoker";
+    }
+
+    /**
+     * Constructs a new instance of {@code FailoverInvoker}.
+     * This constructor is deprecated and marked for removal. Use the alternative constructor
+     * that includes an {@code EndpointManager} parameter instead.
+     *
+     * @param delegate the {@link HttpInvoker} delegate used for HTTP invocations.
+     * @param failoverConfiguration the {@link Failover} configuration that specifies the failover behavior and settings.
+     * @param apiId the identifier of the API for which this invoker is instantiated.
+     */
+    @Deprecated(forRemoval = true)
+    public FailoverInvoker(HttpInvoker delegate, Failover failoverConfiguration, String apiId) {
+        this(delegate, failoverConfiguration, apiId, null);
     }
 
     public FailoverInvoker(HttpInvoker delegate, Failover failoverConfiguration, String apiId, EndpointManager endpointManager) {
@@ -113,6 +129,10 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
 
     private void forceNextEndpoint(HttpExecutionContext ctx, AtomicInteger attemptIndex, AtomicReference<List<String>> capturedEndpoints) {
         if (!failoverConfiguration.isForceNextEndpointOnFailure()) {
+            return;
+        }
+        if (endpointManager == null) {
+            ctx.withLogger(log).warn("Endpoint manager is null, cannot force next endpoint");
             return;
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/invoker/HttpEndpointInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/invoker/HttpEndpointInvoker.java
@@ -51,6 +51,7 @@ public class HttpEndpointInvoker implements HttpInvoker, Invoker {
 
     public static final String NO_ENDPOINT_FOUND_KEY = "NO_ENDPOINT_FOUND";
     public static final String INVALID_HTTP_METHOD = "INVALID_HTTP_METHOD";
+    public static final String ATTR_INTERNAL_FAILOVER_MANAGED_ENDPOINT = "failover.managedEndpoint";
 
     private final EndpointManager endpointManager;
 
@@ -125,6 +126,7 @@ public class HttpEndpointInvoker implements HttpInvoker, Invoker {
         if (managedEndpoint != null) {
             HttpEndpointConnector endpointConnector = managedEndpoint.getConnector();
             ctx.setInternalAttribute(ATTR_INTERNAL_ENDPOINT_CONNECTOR_ID, endpointConnector.id());
+            ctx.setInternalAttribute(ATTR_INTERNAL_FAILOVER_MANAGED_ENDPOINT, managedEndpoint);
             return (T) endpointConnector;
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/failover/FailoverInvokerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/failover/FailoverInvokerTest.java
@@ -33,6 +33,7 @@ import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.reactive.core.context.MutableRequest;
 import io.gravitee.gateway.reactive.core.context.MutableResponse;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
+import io.gravitee.gateway.reactive.core.v4.endpoint.EndpointManager;
 import io.gravitee.gateway.reactive.core.v4.invoker.HttpEndpointInvoker;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Completable;
@@ -71,6 +72,9 @@ class FailoverInvokerTest {
     @Mock
     private Metrics metrics;
 
+    @Mock
+    private EndpointManager endpointManager;
+
     private HttpExecutionContext executionContext;
 
     private FailoverInvoker cut;
@@ -84,13 +88,13 @@ class FailoverInvokerTest {
 
     @Test
     void should_return_id() {
-        cut = new FailoverInvoker(endpointInvoker, Failover.builder().build(), API_ID);
+        cut = new FailoverInvoker(endpointInvoker, Failover.builder().build(), API_ID, endpointManager);
         assertThat(cut.getId()).isEqualTo("failover-invoker");
     }
 
     @Test
     void should_configure_one_circuit_breaker_if_not_per_subscription() {
-        cut = new FailoverInvoker(endpointInvoker, Failover.builder().perSubscription(false).build(), API_ID);
+        cut = new FailoverInvoker(endpointInvoker, Failover.builder().perSubscription(false).build(), API_ID, endpointManager);
         assertThat(cut.circuitBreaker).isNotNull();
         assertThat(cut.circuitBreaker.getName()).isEqualTo(API_ID);
         assertThat(cut.circuitBreakerRegistry).isNull();
@@ -98,7 +102,7 @@ class FailoverInvokerTest {
 
     @Test
     void should_configure_circuit_breaker_registry_if_per_subscription() {
-        cut = new FailoverInvoker(endpointInvoker, Failover.builder().perSubscription(true).build(), API_ID);
+        cut = new FailoverInvoker(endpointInvoker, Failover.builder().perSubscription(true).build(), API_ID, endpointManager);
         assertThat(cut.circuitBreaker).isNull();
         assertThat(cut.circuitBreakerRegistry).isNotNull();
     }
@@ -108,7 +112,8 @@ class FailoverInvokerTest {
         cut = new FailoverInvoker(
             endpointInvoker,
             Failover.builder().slowCallDuration(50).maxRetries(2).perSubscription(true).build(),
-            API_ID
+            API_ID,
+            endpointManager
         );
         when(endpointInvoker.invoke(executionContext)).thenReturn(Completable.complete());
         executionContext.setAttribute(ContextAttributes.ATTR_REQUEST_ENDPOINT, "endpoint-name");
@@ -134,7 +139,8 @@ class FailoverInvokerTest {
         cut = new FailoverInvoker(
             endpointInvoker,
             Failover.builder().slowCallDuration(50).maxRetries(2).perSubscription(false).build(),
-            API_ID
+            API_ID,
+            endpointManager
         );
         when(endpointInvoker.invoke(executionContext)).thenReturn(Completable.complete().delay(100, TimeUnit.MILLISECONDS));
         executionContext.setAttribute(ContextAttributes.ATTR_REQUEST_ENDPOINT, "endpoint-name");
@@ -161,7 +167,8 @@ class FailoverInvokerTest {
         cut = new FailoverInvoker(
             endpointInvoker,
             Failover.builder().slowCallDuration(50000).maxRetries(2).perSubscription(false).build(),
-            API_ID
+            API_ID,
+            endpointManager
         );
         when(endpointInvoker.invoke(executionContext)).thenReturn(
             executionContext.interruptWith(new ExecutionFailure(505)),
@@ -185,7 +192,8 @@ class FailoverInvokerTest {
         cut = new FailoverInvoker(
             endpointInvoker,
             Failover.builder().slowCallDuration(50).maxRetries(0).perSubscription(false).build(),
-            API_ID
+            API_ID,
+            endpointManager
         );
         when(endpointInvoker.invoke(executionContext)).thenReturn(Completable.complete().delay(100, TimeUnit.MILLISECONDS));
         executionContext.setAttribute(ContextAttributes.ATTR_REQUEST_ENDPOINT, "endpoint-name");
@@ -237,7 +245,8 @@ class FailoverInvokerTest {
             cut = new FailoverInvoker(
                 endpointInvoker,
                 Failover.builder().failureCondition(CONDITION).slowCallDuration(50000).maxRetries(2).perSubscription(false).build(),
-                API_ID
+                API_ID,
+                endpointManager
             );
             when(templateEngine.eval(CONDITION, Boolean.class)).thenReturn(Maybe.just(true));
             when(endpointInvoker.invoke(mockCtx)).thenReturn(Completable.complete());
@@ -263,7 +272,8 @@ class FailoverInvokerTest {
             cut = new FailoverInvoker(
                 endpointInvoker,
                 Failover.builder().failureCondition(CONDITION).slowCallDuration(50000).maxRetries(2).perSubscription(false).build(),
-                API_ID
+                API_ID,
+                endpointManager
             );
             when(templateEngine.eval(CONDITION, Boolean.class)).thenReturn(Maybe.just(false));
             when(endpointInvoker.invoke(mockCtx)).thenReturn(Completable.complete());
@@ -281,7 +291,8 @@ class FailoverInvokerTest {
             cut = new FailoverInvoker(
                 endpointInvoker,
                 Failover.builder().slowCallDuration(50000).maxRetries(2).perSubscription(false).build(),
-                API_ID
+                API_ID,
+                endpointManager
             );
             when(endpointInvoker.invoke(mockCtx)).thenReturn(Completable.complete());
 
@@ -299,7 +310,8 @@ class FailoverInvokerTest {
             cut = new FailoverInvoker(
                 endpointInvoker,
                 Failover.builder().failureCondition(CONDITION).slowCallDuration(50000).maxRetries(2).perSubscription(false).build(),
-                API_ID
+                API_ID,
+                endpointManager
             );
             when(templateEngine.eval(CONDITION, Boolean.class)).thenReturn(Maybe.error(new RuntimeException("EL evaluation error")));
             when(endpointInvoker.invoke(mockCtx)).thenReturn(Completable.complete());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/failover/FailoverInvokerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/failover/FailoverInvokerTest.java
@@ -16,12 +16,14 @@
 package io.gravitee.gateway.reactive.core.failover;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.v4.failover.Failover;
+import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
@@ -39,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -202,5 +205,110 @@ class FailoverInvokerTest {
         assertThat(executionContextArgumentCaptor.getAllValues())
             .hasSize(1)
             .allSatisfy(ctx -> assertThat(ctx.<String>getAttribute(ContextAttributes.ATTR_REQUEST_ENDPOINT)).isEqualTo("endpoint-name"));
+    }
+
+    @Nested
+    class FailureConditionEvaluation {
+
+        private static final String CONDITION = "{#response.status >= 500}";
+
+        @Mock
+        private TemplateEngine templateEngine;
+
+        @Mock
+        private HttpExecutionContext mockCtx;
+
+        @BeforeEach
+        void setUpConditionTests() {
+            lenient().when(mockCtx.getAttribute(ContextAttributes.ATTR_REQUEST_ENDPOINT)).thenReturn("endpoint-name");
+            lenient().when(mockCtx.request()).thenReturn(request);
+            lenient().when(mockCtx.getTemplateEngine()).thenReturn(templateEngine);
+            lenient()
+                .when(mockCtx.interruptWith(any()))
+                .thenAnswer(invocation -> {
+                    ExecutionFailure failure = invocation.getArgument(0);
+                    return Completable.error(new InterruptionFailureException(failure));
+                });
+        }
+
+        @Test
+        void should_retry_when_failure_condition_matches() {
+            // Given
+            cut = new FailoverInvoker(
+                endpointInvoker,
+                Failover.builder().failureCondition(CONDITION).slowCallDuration(50000).maxRetries(2).perSubscription(false).build(),
+                API_ID
+            );
+            when(templateEngine.eval(CONDITION, Boolean.class)).thenReturn(Maybe.just(true));
+            when(endpointInvoker.invoke(mockCtx)).thenReturn(Completable.complete());
+
+            // When - condition always true → retries exhausted → 502
+            cut
+                .invoke(mockCtx)
+                .test()
+                .awaitDone(2, TimeUnit.SECONDS)
+                .assertError(
+                    t ->
+                        t instanceof InterruptionFailureException &&
+                        ((InterruptionFailureException) t).getExecutionFailure().statusCode() == 502
+                );
+
+            // Then - 1 initial + 2 retries = 3 invocations
+            verify(endpointInvoker, times(3)).invoke(mockCtx);
+        }
+
+        @Test
+        void should_not_retry_when_condition_does_not_match() {
+            // Given
+            cut = new FailoverInvoker(
+                endpointInvoker,
+                Failover.builder().failureCondition(CONDITION).slowCallDuration(50000).maxRetries(2).perSubscription(false).build(),
+                API_ID
+            );
+            when(templateEngine.eval(CONDITION, Boolean.class)).thenReturn(Maybe.just(false));
+            when(endpointInvoker.invoke(mockCtx)).thenReturn(Completable.complete());
+
+            // When
+            cut.invoke(mockCtx).test().awaitDone(2, TimeUnit.SECONDS).assertComplete();
+
+            // Then
+            verify(endpointInvoker, times(1)).invoke(mockCtx);
+        }
+
+        @Test
+        void should_not_evaluate_when_no_condition_configured() {
+            // Given
+            cut = new FailoverInvoker(
+                endpointInvoker,
+                Failover.builder().slowCallDuration(50000).maxRetries(2).perSubscription(false).build(),
+                API_ID
+            );
+            when(endpointInvoker.invoke(mockCtx)).thenReturn(Completable.complete());
+
+            // When
+            cut.invoke(mockCtx).test().awaitDone(2, TimeUnit.SECONDS).assertComplete();
+
+            // Then
+            verify(endpointInvoker, times(1)).invoke(mockCtx);
+            verify(templateEngine, times(0)).eval(CONDITION, Boolean.class);
+        }
+
+        @Test
+        void should_ignore_el_evaluation_error() {
+            // Given
+            cut = new FailoverInvoker(
+                endpointInvoker,
+                Failover.builder().failureCondition(CONDITION).slowCallDuration(50000).maxRetries(2).perSubscription(false).build(),
+                API_ID
+            );
+            when(templateEngine.eval(CONDITION, Boolean.class)).thenReturn(Maybe.error(new RuntimeException("EL evaluation error")));
+            when(endpointInvoker.invoke(mockCtx)).thenReturn(Completable.complete());
+
+            // When
+            cut.invoke(mockCtx).test().awaitDone(2, TimeUnit.SECONDS).assertComplete();
+
+            // Then - no retry, error is silently ignored
+            verify(endpointInvoker, times(1)).invoke(mockCtx);
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -296,7 +296,7 @@ public class DefaultApiReactor extends AbstractApiReactor {
     protected HttpInvoker endpointInvoker(EndpointManager endpointManager) {
         final HttpEndpointInvoker endpointInvoker = new HttpEndpointInvoker(endpointManager);
         if (api.getDefinition().failoverEnabled()) {
-            return new FailoverInvoker(endpointInvoker, api.getDefinition().getFailover(), api.getId());
+            return new FailoverInvoker(endpointInvoker, api.getDefinition().getFailover(), api.getId(), endpointManager);
         }
         return endpointInvoker;
     }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.integration.tests.http.failover;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_APIKEY_ID;
 import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
@@ -669,6 +670,84 @@ public class FailoverV4IntegrationTest extends FailoverV4EmulationIntegrationTes
         @Test
         void should_success_on_first_retry(HttpClient client) {
             super.should_success_on_first_retry(client);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    class FailureConditionEvaluation extends AbstractGatewayTest {
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-failure-condition.json")
+        void should_retry_when_failure_condition_matches_and_succeed_on_second_attempt(HttpClient client) {
+            // Given a backend that returns 500 on the first call, then 200 on the second
+            wiremock.stubFor(
+                get("/endpoint")
+                    .inScenario("failure-condition")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(serverError().withBody("error"))
+                    .willSetStateTo("recovered")
+            );
+            wiremock.stubFor(
+                get("/endpoint").inScenario("failure-condition").whenScenarioStateIs("recovered").willReturn(ok(RESPONSE_FROM_BACKEND))
+            );
+
+            // When requesting the API
+            client
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    // Then the response should be 200 (recovered on retry)
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response).hasToString(RESPONSE_FROM_BACKEND);
+                    return true;
+                });
+
+            // Then the backend should have been called 2 times (1st 500 + 2nd 200)
+            wiremock.verify(2, getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-failure-condition.json")
+        void should_not_retry_when_response_is_successful(HttpClient client) {
+            // Given a backend that returns 200 directly
+            wiremock.stubFor(get("/endpoint").willReturn(ok(RESPONSE_FROM_BACKEND)));
+
+            // When requesting the API
+            client
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    // Then the response should be 200
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response).hasToString(RESPONSE_FROM_BACKEND);
+                    return true;
+                });
+
+            // Then the backend should have been called only once (no retry)
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
         }
     }
 

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
@@ -65,14 +65,12 @@ import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.buffer.Buffer;
 import io.vertx.rxjava3.core.http.HttpClient;
 import io.vertx.rxjava3.core.http.HttpClientRequest;
 import io.vertx.rxjava3.core.http.HttpClientResponse;
-import io.vertx.rxjava3.core.http.HttpServer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -690,19 +688,6 @@ public class FailoverV4IntegrationTest extends FailoverV4EmulationIntegrationTes
 
         @Override
         public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
-            final int availablePort = getAvailablePort();
-            final HttpServer httpServer = Vertx.vertx().createHttpServer(new HttpServerOptions().setPort(availablePort));
-            httpServer.connectionHandler(connection -> {
-                System.out.println("🤞connection");
-            });
-            httpServer.requestHandler(request -> {
-                System.out.println(" request: " + request.absoluteURI());
-                if (request.absoluteURI().contains("dynamic-param")) {
-                    //                    request.response().setStatusCode(200).end("ok from backend - 1");
-                }
-            });
-            httpServer.listen().subscribe();
-
             if (isLegacyApi(definitionClass)) {
                 throw new IllegalStateException("should be testing a v4 API");
             }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
@@ -44,8 +44,10 @@ import io.gravitee.apim.gateway.tests.sdk.connector.fakes.ConnectionLatencyMockE
 import io.gravitee.apim.gateway.tests.sdk.connector.fakes.ConnectionLatencyMockEndpointConnectorFactory;
 import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
 import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
 import io.gravitee.apim.plugin.reactor.ReactorPlugin;
 import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.Subscription;
@@ -61,9 +63,11 @@ import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.policy.apikey.ApiKeyPolicy;
 import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
 import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
+import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
@@ -79,6 +83,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer;
@@ -790,6 +795,239 @@ public class FailoverV4IntegrationTest extends FailoverV4EmulationIntegrationTes
             wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint-1")));
             wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint-2")));
             wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint-3")));
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-three-endpoints-force-next-full-loop.json")
+        void should_loop_back_to_first_endpoint_after_exhausting_all(HttpClient client) {
+            // Given endpoint-1 always returns 500, endpoint-3 always returns 500,
+            // and endpoint-2 returns 500 on first call then 200 on second call
+            wiremock.stubFor(get("/endpoint-1").willReturn(serverError().withBody("error-1")));
+            wiremock.stubFor(
+                get("/endpoint-2")
+                    .inScenario("full-loop")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(serverError().withBody("error-2"))
+                    .willSetStateTo("second-pass")
+            );
+            wiremock.stubFor(
+                get("/endpoint-2").inScenario("full-loop").whenScenarioStateIs("second-pass").willReturn(ok(RESPONSE_FROM_BACKEND))
+            );
+            wiremock.stubFor(get("/endpoint-3").willReturn(serverError().withBody("error-3")));
+
+            // When requesting the API
+            // Expected flow: default(500) → second(500) → third(500) → default(500) → second(200)
+            client
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response).hasToString(RESPONSE_FROM_BACKEND);
+                    return true;
+                });
+
+            // Then endpoint-1 should have been called twice (initial + loop back)
+            wiremock.verify(2, getRequestedFor(urlPathEqualTo("/endpoint-1")));
+            // Then endpoint-2 should have been called twice (first fail + second success)
+            wiremock.verify(2, getRequestedFor(urlPathEqualTo("/endpoint-2")));
+            // Then endpoint-3 should have been called once
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint-3")));
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    class FailoverMetrics extends AbstractGatewayTest {
+
+        BehaviorSubject<Metrics> metricsSubject;
+
+        @BeforeEach
+        void setUpMetrics() {
+            metricsSubject = BehaviorSubject.create();
+            FakeReporter fakeReporter = getBean(FakeReporter.class);
+            fakeReporter.setReportableHandler(reportable -> {
+                if (reportable instanceof Metrics metrics) {
+                    metricsSubject.onNext(metrics.toBuilder().build());
+                }
+            });
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (api.getDefinition() instanceof Api apiDefinition) {
+                var analytics = new Analytics();
+                analytics.setEnabled(true);
+                apiDefinition.setAnalytics(analytics);
+            }
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-failure-condition.json")
+        void should_record_failover_metrics_when_retry_succeeds(HttpClient client) {
+            // Given a backend that returns 500 on the first call, then 200 on the second
+            wiremock.stubFor(
+                get("/endpoint")
+                    .inScenario("metrics-retry")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(serverError().withBody("error"))
+                    .willSetStateTo("recovered")
+            );
+            wiremock.stubFor(
+                get("/endpoint").inScenario("metrics-retry").whenScenarioStateIs("recovered").willReturn(ok(RESPONSE_FROM_BACKEND))
+            );
+
+            // When requesting the API
+            client
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete();
+
+            // Then failover metrics should be recorded
+            metricsSubject
+                .take(1)
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertValue(metrics -> {
+                    assertThat(metrics.longAdditionalMetrics()).isNotNull().containsEntry("long_failover_count", 1L);
+                    assertThat(metrics.keywordAdditionalMetrics())
+                        .isNotNull()
+                        .containsKey("keyword_failover_first-failed-endpoint")
+                        .containsEntry("keyword_failover_successful-endpoint", "default");
+                    return true;
+                });
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-failure-condition.json")
+        void should_not_record_failover_metrics_when_no_retry(HttpClient client) {
+            // Given a backend that returns 200 directly
+            wiremock.stubFor(get("/endpoint").willReturn(ok(RESPONSE_FROM_BACKEND)));
+
+            // When requesting the API
+            client
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete();
+
+            // Then no failover metrics should be recorded
+            metricsSubject
+                .take(1)
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertValue(metrics -> {
+                    assertThat(metrics.longAdditionalMetrics()).isNullOrEmpty();
+                    assertThat(metrics.keywordAdditionalMetrics()).isNullOrEmpty();
+                    return true;
+                });
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-three-endpoints-force-next.json")
+        void should_record_failover_count_matching_number_of_retries(HttpClient client) {
+            // Given endpoint-1 and endpoint-2 return 500, endpoint-3 returns 200
+            wiremock.stubFor(get("/endpoint-1").willReturn(serverError().withBody("error-1")));
+            wiremock.stubFor(get("/endpoint-2").willReturn(serverError().withBody("error-2")));
+            wiremock.stubFor(get("/endpoint-3").willReturn(ok(RESPONSE_FROM_BACKEND)));
+
+            // When requesting the API
+            client
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete();
+
+            // Then failover metrics should reflect 2 hops and endpoint-3 as successful
+            metricsSubject
+                .take(1)
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertValue(metrics -> {
+                    assertThat(metrics.longAdditionalMetrics()).isNotNull().containsEntry("long_failover_count", 2L);
+                    assertThat(metrics.keywordAdditionalMetrics())
+                        .isNotNull()
+                        .containsKey("keyword_failover_first-failed-endpoint")
+                        .containsEntry("keyword_failover_successful-endpoint", "third");
+                    return true;
+                });
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-three-endpoints-force-next-full-loop.json")
+        void should_record_failover_metrics_after_full_loop(HttpClient client) {
+            // Given endpoint-1 always 500, endpoint-3 always 500,
+            // endpoint-2 returns 500 first then 200
+            // Expected flow: default(500) → second(500) → third(500) → default(500) → second(200)
+            wiremock.stubFor(get("/endpoint-1").willReturn(serverError().withBody("error-1")));
+            wiremock.stubFor(
+                get("/endpoint-2")
+                    .inScenario("metrics-full-loop")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(serverError().withBody("error-2"))
+                    .willSetStateTo("second-pass")
+            );
+            wiremock.stubFor(
+                get("/endpoint-2").inScenario("metrics-full-loop").whenScenarioStateIs("second-pass").willReturn(ok(RESPONSE_FROM_BACKEND))
+            );
+            wiremock.stubFor(get("/endpoint-3").willReturn(serverError().withBody("error-3")));
+
+            // When requesting the API
+            client
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete();
+
+            // Then failover metrics should reflect 4 hops and endpoint-2 (second) as successful
+            metricsSubject
+                .take(1)
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertValue(metrics -> {
+                    assertThat(metrics.longAdditionalMetrics()).isNotNull().containsEntry("long_failover_count", 4L);
+                    assertThat(metrics.keywordAdditionalMetrics())
+                        .isNotNull()
+                        .containsKey("keyword_failover_first-failed-endpoint")
+                        .containsEntry("keyword_failover_successful-endpoint", "second");
+                    return true;
+                });
         }
     }
 

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
@@ -753,6 +753,48 @@ public class FailoverV4IntegrationTest extends FailoverV4EmulationIntegrationTes
 
     @Nested
     @GatewayTest
+    class ForceNextEndpointOnFailure extends AbstractGatewayTest {
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-three-endpoints-force-next.json")
+        void should_try_different_endpoints_on_each_retry(HttpClient client) {
+            // Given all endpoints return 500 (triggering failureCondition "{#response.status >= 500}")
+            wiremock.stubFor(get("/endpoint-1").willReturn(serverError().withBody("error-1")));
+            wiremock.stubFor(get("/endpoint-2").willReturn(serverError().withBody("error-2")));
+            wiremock.stubFor(get("/endpoint-3").willReturn(serverError().withBody("error-3")));
+
+            // When requesting the API (all retries fail → 502)
+            client
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(HttpClientRequest::rxSend)
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response.statusCode()).isEqualTo(502);
+                    return true;
+                });
+
+            // Then all three endpoints should have been called exactly once each
+            // (forceNextEndpointOnFailure ensures different endpoints on each retry)
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint-1")));
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint-2")));
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint-3")));
+        }
+    }
+
+    @Nested
+    @GatewayTest
     class DynamicRoutingToGroup extends FailoverV4EmulationIntegrationTest.DynamicRoutingToGroup {
 
         @Override

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-failure-condition.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-failure-condition.json
@@ -1,0 +1,70 @@
+{
+  "id": "my-api-v4-failure-condition",
+  "name": "my-api-v4-failure-condition",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 5000,
+    "perSubscription": false,
+    "failureCondition": "{#response.status >= 500}"
+  },
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-three-endpoints-force-next-full-loop.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-three-endpoints-force-next-full-loop.json
@@ -1,0 +1,101 @@
+{
+  "id": "my-api-v4-force-next-full-loop",
+  "name": "my-api-v4-force-next-full-loop",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 4,
+    "slowCallDuration": 5000,
+    "perSubscription": false,
+    "failureCondition": "{#response.status >= 500}",
+    "forceNextEndpointOnFailure": true
+  },
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-1"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        },
+        {
+          "name": "second",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-2"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        },
+        {
+          "name": "third",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-3"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-three-endpoints-force-next.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-three-endpoints-force-next.json
@@ -1,0 +1,101 @@
+{
+  "id": "my-api-v4-force-next-endpoint",
+  "name": "my-api-v4-force-next-endpoint",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 5000,
+    "perSubscription": false,
+    "failureCondition": "{#response.status >= 500}",
+    "forceNextEndpointOnFailure": true
+  },
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-1"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        },
+        {
+          "name": "second",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-2"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        },
+        {
+          "name": "third",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-3"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "GET"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -2161,6 +2161,10 @@ components:
           type: boolean
           description: If true, a circuit breaker breaker will be dedicated for each subscriber, else, one and only circuit breaker will be used for the API.
           default: true
+        failureCondition:
+          type: string
+          nullable: true
+          description: An EL expression evaluated on the response to determine if it should be considered a failure (e.g. "{#response.status >= 500}"). If null, response content is not evaluated.
     Metadata:
       description: Metadata is a generic data structure used internally
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -2165,6 +2165,10 @@ components:
           type: string
           nullable: true
           description: An EL expression evaluated on the response to determine if it should be considered a failure (e.g. "{#response.status >= 500}"). If null, response content is not evaluated.
+        forceNextEndpointOnFailure:
+          type: boolean
+          description: If true, on retry the next endpoint in the group is forced instead of relying on the shared load balancer. This ensures retries target different endpoints.
+          default: false
     Metadata:
       description: Metadata is a generic data structure used internally
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -7601,6 +7601,10 @@ components:
                     type: string
                     nullable: true
                     description: An EL expression evaluated on the response to determine if it should be considered a failure (e.g. "{#response.status >= 500}"). If null, response content is not evaluated.
+                forceNextEndpointOnFailure:
+                    type: boolean
+                    description: If true, on retry the next endpoint in the group is forced instead of relying on the shared load balancer. This ensures retries target different endpoints.
+                    default: false
 
         CreateDocumentation:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -7597,6 +7597,10 @@ components:
                     type: boolean
                     description: If true, a circuit breaker breaker will be dedicated for each subscriber, else, one and only circuit breaker will be used for the API.
                     default: true
+                failureCondition:
+                    type: string
+                    nullable: true
+                    description: An EL expression evaluated on the response to determine if it should be considered a failure (e.g. "{#response.status >= 500}"). If null, response content is not evaluated.
 
         CreateDocumentation:
             type: object

--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
         <gravitee-reactor-message.version>10.0.0</gravitee-reactor-message.version>
         <gravitee-reactor-native-kafka.version>6.0.0</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.0</gravitee-reactor-mcp-proxy.version>
-        <gravitee-reactor-llm-proxy.version>2.0.0</gravitee-reactor-llm-proxy.version>
+        <gravitee-reactor-llm-proxy.version>2.2.0</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0-alpha.1</gravitee-reactor-a2a-proxy.version>
         <gravitee-resource-ai-vector-store-redis.version>1.0.0</gravitee-resource-ai-vector-store-redis.version>
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13229

## Description

Enhances the V4 failover mechanism with two new capabilities:                                                      
   
  - failureCondition: an EL expression evaluated after each endpoint call to determine if the response should be     
  considered a failure (e.g. {#response.status >= 500}). When matched, failover retries on the next endpoint.
  - forceNextEndpointOnFailure: advances the load balancer to the next endpoint on failure, preventing concurrent    
  requests from retrying the same failing endpoint.                                                                  
   
  Gateway: implemented both features in FailoverInvoker, exposed selected ManagedEndpoint via internal attribute in  
  HttpEndpointInvoker, added dedicated FailoverConditionMatchException, deprecated old constructor for backward
  compatibility.                                                                                                     
                  
  REST API: added failureCondition and forceNextEndpointOnFailure to FailoverV4 OpenAPI schema (management-v2 and    
  automation).
                                                                                                                     
  Console UI: added failover tab for LLM Proxy APIs, added UI controls for both new fields, ensured new fields are   
  preserved on form submission.
                                                                                                                     
  Tests: unit tests for failure condition evaluation, integration tests for both features.                           
   
  Also bumps the LLM reactor.    

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

