### PR TITLE
feat: add API definition PATCH for v4 APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -47,6 +47,7 @@ import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFacetSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFilterSpecUseCase;
+import io.gravitee.apim.core.api.domain_service.ApiDefinitionJsonPatchDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiImportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
@@ -188,6 +189,7 @@ import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.JsonPatchService;
 import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.OrganizationService;
@@ -199,6 +201,7 @@ import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
+import io.gravitee.rest.api.service.impl.ApiDefinitionJsonPatchDomainServiceImpl;
 import io.gravitee.rest.api.service.impl.configuration.application.ApplicationTypeServiceImpl;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
@@ -829,6 +832,16 @@ public class ResourceContextConfiguration {
     @Bean
     public HtmlSanitizer htmlSanitizer(io.gravitee.rest.api.service.sanitizer.HtmlSanitizer delegate) {
         return new HtmlSanitizerImpl(delegate);
+    }
+
+    @Bean
+    public JsonPatchService jsonPatchService() {
+        return mock(JsonPatchService.class);
+    }
+
+    @Bean
+    public ApiDefinitionJsonPatchDomainService apiDefinitionJsonPatchDomainService(JsonPatchService jsonPatchService) {
+        return new ApiDefinitionJsonPatchDomainServiceImpl(jsonPatchService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -293,8 +293,8 @@ public interface ApiMapper {
     Page map(io.gravitee.apim.core.api.model.crd.PageCRD crd);
 
     io.gravitee.apim.core.api.model.crd.PageCRD map(Page crd);
+    UpdateApiV4 mapToUpdateApiV4(ApiV4 api);
 
-    // UpdateApi
     @Mapping(target = "listeners", qualifiedByName = "toHttpListeners")
     @Mapping(target = "id", expression = "java(apiId)")
     UpdateApiEntity map(UpdateApiV4 updateApi, String apiId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -30,6 +30,7 @@ import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.MigrateApiUseCase;
+import io.gravitee.apim.core.api.use_case.PatchApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateFederatedApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateNativeApiUseCase;
@@ -41,8 +42,10 @@ import io.gravitee.apim.infra.adapter.ApiAdapter;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -59,6 +62,7 @@ import io.gravitee.rest.api.management.v2.rest.model.ApiRollback;
 import io.gravitee.rest.api.management.v2.rest.model.ApiTransferOwnership;
 import io.gravitee.rest.api.management.v2.rest.model.DuplicateApiOptions;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationReportResponses;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationReportResponsesIssuesInner;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationStateType;
@@ -85,6 +89,7 @@ import io.gravitee.rest.api.management.v2.rest.resource.documentation.ApiPagesRe
 import io.gravitee.rest.api.management.v2.rest.resource.param.LifecycleAction;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.model.InlinePictureEntity;
+import io.gravitee.rest.api.model.JsonPatch;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
@@ -100,7 +105,6 @@ import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
-import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
@@ -136,7 +140,9 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -154,6 +160,7 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -201,6 +208,9 @@ public class ApiResource extends AbstractResource {
 
     @Inject
     private ExportApiUseCase exportApiUseCase;
+
+    @Inject
+    private PatchApiDefinitionUseCase patchApiDefinitionUseCase;
 
     @Inject
     private SubscriptionService subscriptionService;
@@ -523,6 +533,47 @@ public class ApiResource extends AbstractResource {
         return Response.ok(ImportExportApiMapper.INSTANCE.map(export.definition()))
             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=%s".formatted(export.filename()))
             .build();
+    }
+
+    @PATCH
+    @Path("/definition")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions(
+        {
+            @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE),
+            @Permission(value = RolePermission.API_GATEWAY_DEFINITION, acls = RolePermissionAction.UPDATE),
+        }
+    )
+    public Response patchApiDefinition(
+        @Context HttpHeaders headers,
+        @PathParam("apiId") String apiId,
+        @RequestBody(required = true) @Valid @NotNull Collection<JsonPatch> patches,
+        @QueryParam("dryRun") @DefaultValue("false") boolean dryRun
+    ) {
+        final GenericApiEntity currentEntity = getGenericApiEntityById(apiId, false, false, false, false);
+        evaluateIfMatch(headers, Long.toString(currentEntity.getUpdatedAt().getTime()));
+
+        if (!supportsJsonPatchDefinition(currentEntity)) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(apiDefinitionPatchNotSupported(apiId)).build();
+        }
+
+        var patchOutput = patchApiDefinitionUseCase.execute(new PatchApiDefinitionUseCase.Input(apiId, getAuditInfo(), patches, dryRun));
+
+        return switch (patchOutput) {
+            case PatchApiDefinitionUseCase.Result.PatchTestFailed failed -> Response.status(Response.Status.PRECONDITION_FAILED)
+                .entity(
+                    new Error()
+                        .httpStatus(Response.Status.PRECONDITION_FAILED.getStatusCode())
+                        .message(failed.failureMessage())
+                        .technicalCode("jsonPatch.testFailed")
+                )
+                .build();
+            case PatchApiDefinitionUseCase.Result.DryRun(String json) -> Response.ok(
+                ImportExportApiMapper.INSTANCE.definitionToExportApiV4(json)
+            ).build();
+            case PatchApiDefinitionUseCase.Result.ApplyPatch(String json) -> responseAfterPatchedDefinitionPersist(currentEntity, json);
+        };
     }
 
     @GET
@@ -1129,6 +1180,28 @@ public class ApiResource extends AbstractResource {
             .message("Api [" + apiId + "] is not valid.")
             .putParametersItem("apiId", apiId)
             .technicalCode("api.invalid");
+    }
+
+    private static boolean supportsJsonPatchDefinition(GenericApiEntity currentEntity) {
+        if (!(currentEntity instanceof ApiEntity api)) {
+            return false;
+        }
+        return currentEntity.getDefinitionVersion() == DefinitionVersion.V4 && api.getType() == ApiType.PROXY;
+    }
+
+    private static Error apiDefinitionPatchNotSupported(String apiId) {
+        return new Error()
+            .httpStatus(Response.Status.BAD_REQUEST.getStatusCode())
+            .message("JSON Patch on the API definition is only available for V4 HTTP Proxy APIs; this API type is not supported.")
+            .putParametersItem("apiId", apiId)
+            .technicalCode("api.definition.patch.unsupported");
+    }
+
+    private Response responseAfterPatchedDefinitionPersist(GenericApiEntity currentEntity, String patchedExportJson) {
+        ExportApiV4 patchedExport = ImportExportApiMapper.INSTANCE.definitionToExportApiV4(patchedExportJson);
+        UpdateApiV4 updateApiV4 = ApiMapper.INSTANCE.mapToUpdateApiV4(patchedExport.getApi());
+        GenericApiEntity updatedEntity = updateApiV4(currentEntity, updateApiV4);
+        return apiResponse(updatedEntity);
     }
 
     private void checkApiReviewWorkflow(final GenericApiEntity api, final String action) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -561,6 +561,57 @@ paths:
                                 $ref: "#/components/schemas/ExportApiV4"
                 default:
                     $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/{apiId}/definition:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        patch:
+            tags:
+                - APIs
+            summary: Patch API definition
+            description: |-
+                Apply JSON Patch operations to the exported API definition for a V4 HTTP Proxy API.
+
+                The document patched is the same shape as returned by `GET .../_export/definition`. When `dryRun` is false, the API is updated using the same rules as `PUT .../apis/{apiId}` for a V4 API (including gateway-definition permission constraints on listeners).
+
+                User must have API_DEFINITION[UPDATE] or API_GATEWAY_DEFINITION[UPDATE] permissions.
+            operationId: patchApiDefinition
+            parameters:
+                - name: dryRun
+                  in: query
+                  required: false
+                  description: When true, the patch is evaluated against the export but the API is not persisted.
+                  schema:
+                      type: boolean
+                      default: false
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: array
+                            items:
+                                $ref: "#/components/schemas/ApiDefinitionJsonPatch"
+            responses:
+                "200":
+                    description: |-
+                        With `dryRun=true`: patched API definition in `ExportApiV4` form (same shape as `GET .../_export/definition`). The body is a preview only and is not persisted; `ETag` and `Last-Modified` are omitted, like the export endpoint.
+
+                        With `dryRun=false`: the API is persisted then the response body is the updated API resource (`Api`), same shape as `GET .../apis/{apiId}`. `ETag` and `Last-Modified` reflect the stored API after persist.
+                    content:
+                        application/json:
+                            schema:
+                                oneOf:
+                                    - $ref: "#/components/schemas/ExportApiV4"
+                                    - $ref: "#/components/schemas/Api"
+                "412":
+                    description: JSON Patch could not be applied (for example a `test` operation did not match). The API was not modified.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                default:
+                    $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}/_start:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -3750,6 +3801,28 @@ components:
                     description: The list of API's media used in pages.
                     items:
                         $ref: "#/components/schemas/Media"
+
+        ApiDefinitionJsonPatch:
+            type: object
+            description: Gravitee JSON Patch entry (JSON Pointer path and operation).
+            required:
+                - jsonPath
+            properties:
+                jsonPath:
+                    type: string
+                    description: JSON Pointer path within the exported definition document.
+                    example: $.api.name
+                value:
+                    description: Value for add, replace, or test operations.
+                operation:
+                    type: string
+                    description: Patch operation; defaults to REPLACE when omitted.
+                    enum:
+                        - ADD
+                        - REMOVE
+                        - REPLACE
+                        - TEST
+                    default: REPLACE
 
         ImportSwaggerDescriptor:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -38,6 +38,7 @@ import inmemory.PrimaryOwnerDomainServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import inmemory.UserDomainServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
@@ -124,6 +125,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected ExportApiUseCase exportApiUseCase;
+
+    @Autowired
+    protected ApiExportDomainService apiExportDomainService;
 
     @Autowired
     protected PermissionService permissionService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
@@ -43,6 +43,7 @@ public abstract class ApiResourceTest extends AbstractResourceTest {
         Mockito.reset(
             apiSearchServiceV4,
             apiImagesService,
+            apiExportDomainService,
             exportApiUseCase,
             apiStateServiceV4,
             parameterService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiDefinitionTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static io.gravitee.common.http.HttpStatusCode.PRECONDITION_FAILED_412;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.ApiFixtures;
+import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
+import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
+import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
+import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.management.v2.rest.model.Api;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
+import io.gravitee.rest.api.model.JsonPatch;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
+import io.gravitee.rest.api.model.v4.nativeapi.NativeApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests JSON Patch on {@link ApiResource} at {@code PATCH .../apis/{apiId}/definition}.
+ */
+class ApiResource_PatchApiDefinitionTest extends ApiResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis";
+    }
+
+    @Test
+    void should_return_200_when_dry_run_without_persist() {
+        Date fixedDate = new Date(1_700_000_000_000L);
+        ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(fixedDate).build();
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(apiEntity);
+        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(minimalProxyExport("original-name")));
+
+        Response response = rootTarget(API + "/definition")
+            .queryParam("dryRun", true)
+            .request(MediaType.APPLICATION_JSON)
+            .method("PATCH", Entity.json(List.of(jsonPatchReplace("$.api.name", "dry-run-name-only"))));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        ExportApiV4 body = response.readEntity(ExportApiV4.class);
+        assertThat(body.getApi().getName()).isEqualTo("dry-run-name-only");
+        verify(apiServiceV4, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_return_200_with_new_etag_when_persist_with_matching_if_match() {
+        Date before = new Date(1_700_000_000_000L);
+        Date after = new Date(1_700_000_000_001L);
+        ApiEntity current = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).name("before").updatedAt(before).build();
+        ApiEntity updated = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).name("tes-api-key-patched").updatedAt(after).build();
+
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(current);
+        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(minimalProxyExport("before")));
+        when(
+            apiServiceV4.update(eq(GraviteeContext.getExecutionContext()), eq(API), any(UpdateApiEntity.class), eq(false), eq(USER_NAME))
+        ).thenReturn(updated);
+
+        Response response = rootTarget(API + "/definition")
+            .request(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.IF_MATCH, "\"" + before.getTime() + "\"")
+            .method("PATCH", Entity.json(List.of(jsonPatchReplace("$.api.name", "tes-api-key-patched"))));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        assertThat(response.getHeaderString(HttpHeaders.ETAG)).isEqualTo("\"" + after.getTime() + "\"");
+        assertThat(response.readEntity(Api.class).getApiV4().getName()).isEqualTo("tes-api-key-patched");
+        verify(apiServiceV4, times(1)).update(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(API),
+            any(UpdateApiEntity.class),
+            eq(false),
+            eq(USER_NAME)
+        );
+        verify(exportApiUseCase, times(1)).execute(any());
+    }
+
+    @Test
+    void should_return_200_when_persist_without_if_match() {
+        Date updated = new Date(1_700_000_000_002L);
+        ApiEntity current = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(updated).build();
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(current);
+        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(minimalProxyExport("api-name")));
+        when(
+            apiServiceV4.update(eq(GraviteeContext.getExecutionContext()), eq(API), any(UpdateApiEntity.class), eq(false), eq(USER_NAME))
+        ).thenReturn(current);
+
+        Response response = rootTarget(API + "/definition")
+            .request(MediaType.APPLICATION_JSON)
+            .method("PATCH", Entity.json(List.of(jsonPatchReplace("$.api.description", "Updated via PATCH"))));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        verify(apiServiceV4, times(1)).update(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(API),
+            any(UpdateApiEntity.class),
+            eq(false),
+            eq(USER_NAME)
+        );
+        verify(exportApiUseCase, times(1)).execute(any());
+    }
+
+    @Test
+    void should_return_412_when_if_match_does_not_match() {
+        Date currentRevision = new Date(1_700_000_000_000L);
+        ApiEntity current = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(currentRevision).build();
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(current);
+        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(minimalProxyExport("x")));
+
+        Response response = rootTarget(API + "/definition")
+            .request(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.IF_MATCH, "\"0\"")
+            .method("PATCH", Entity.json(List.of(jsonPatchReplace("$.api.name", "will-not-apply"))));
+
+        assertThat(response.getStatus()).isEqualTo(PRECONDITION_FAILED_412);
+        verify(apiServiceV4, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_return_400_when_api_is_not_v4_http_proxy() {
+        NativeApiEntity nativeApi = ApiFixtures.aModelNativeApiV4().withId(API);
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(nativeApi);
+
+        Response response = rootTarget(API + "/definition")
+            .request(MediaType.APPLICATION_JSON)
+            .method("PATCH", Entity.json(List.of(jsonPatchReplace("$.api.name", "x"))));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        Error error = response.readEntity(Error.class);
+        assertThat(error.getMessage())
+            .contains("JSON Patch on the API definition is only available for V4 HTTP Proxy APIs")
+            .contains("not supported");
+        assertThat(error.getTechnicalCode()).isEqualTo("api.definition.patch.unsupported");
+        assertThat(error.getParameters()).containsEntry("apiId", API);
+    }
+
+    @Test
+    void should_return_403_when_missing_definition_update_permissions() {
+        ApiEntity current = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).build();
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(current);
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_DEFINITION),
+                eq(API),
+                eq(RolePermissionAction.UPDATE)
+            )
+        ).thenReturn(false);
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_GATEWAY_DEFINITION),
+                eq(API),
+                eq(RolePermissionAction.UPDATE)
+            )
+        ).thenReturn(false);
+
+        Response response = rootTarget(API + "/definition")
+            .request(MediaType.APPLICATION_JSON)
+            .method("PATCH", Entity.json(List.of(jsonPatchReplace("$.api.name", "x"))));
+
+        assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
+        Error error = response.readEntity(Error.class);
+        assertThat(error.getMessage()).isEqualTo("You do not have sufficient rights to access this resource");
+    }
+
+    @Test
+    void should_return_412_when_json_patch_test_fails() {
+        Date fixedDate = new Date(1_700_000_000_000L);
+        ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).name("actual-name").updatedAt(fixedDate).build();
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(apiEntity);
+        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(minimalProxyExport("actual-name")));
+
+        Response response = rootTarget(API + "/definition")
+            .request(MediaType.APPLICATION_JSON)
+            .method("PATCH", Entity.json(List.of(jsonPatchTest("$.api.name", "this-is-not-the-current-name"))));
+
+        assertThat(response.getStatus()).isEqualTo(PRECONDITION_FAILED_412);
+        Error error = response.readEntity(Error.class);
+        assertThat(error.getHttpStatus()).isEqualTo(PRECONDITION_FAILED_412);
+        assertThat(error.getTechnicalCode()).isEqualTo("jsonPatch.testFailed");
+        assertThat(error.getMessage()).isEqualTo(
+            "The json patch does not validate the condition $.api.name == this-is-not-the-current-name"
+        );
+        verify(apiServiceV4, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    private static GraviteeDefinition minimalProxyExport(String apiName) {
+        return GraviteeDefinition.from(
+            ApiDescriptor.ApiDescriptorV4.builder().id(API).crossId("cross").name(apiName).apiVersion("1.0").type(ApiType.PROXY).build(),
+            Set.of(),
+            List.of(),
+            List.of(),
+            List.<PlanDescriptor.V4>of(),
+            List.of(),
+            null,
+            null
+        );
+    }
+
+    private static JsonPatch jsonPatchReplace(String path, String value) {
+        JsonPatch p = new JsonPatch();
+        p.setJsonPath(path);
+        p.setOperation(JsonPatch.Operation.REPLACE);
+        p.setValue(value);
+        return p;
+    }
+
+    private static JsonPatch jsonPatchTest(String path, String value) {
+        JsonPatch p = new JsonPatch();
+        p.setJsonPath(path);
+        p.setOperation(JsonPatch.Operation.TEST);
+        p.setValue(value);
+        return p;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiDefinitionTest.java
@@ -32,7 +32,6 @@ import fixtures.ApiFixtures;
 import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
 import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
 import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
-import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.rest.api.management.v2.rest.model.Api;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
@@ -68,7 +67,7 @@ class ApiResource_PatchApiDefinitionTest extends ApiResourceTest {
         Date fixedDate = new Date(1_700_000_000_000L);
         ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(fixedDate).build();
         when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(apiEntity);
-        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(minimalProxyExport("original-name")));
+        when(apiExportDomainService.export(eq(API), any(), any())).thenReturn(minimalProxyExport("original-name"));
 
         Response response = rootTarget(API + "/definition")
             .queryParam("dryRun", true)
@@ -89,7 +88,7 @@ class ApiResource_PatchApiDefinitionTest extends ApiResourceTest {
         ApiEntity updated = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).name("tes-api-key-patched").updatedAt(after).build();
 
         when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(current);
-        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(minimalProxyExport("before")));
+        when(apiExportDomainService.export(eq(API), any(), any())).thenReturn(minimalProxyExport("before"));
         when(
             apiServiceV4.update(eq(GraviteeContext.getExecutionContext()), eq(API), any(UpdateApiEntity.class), eq(false), eq(USER_NAME))
         ).thenReturn(updated);
@@ -109,7 +108,7 @@ class ApiResource_PatchApiDefinitionTest extends ApiResourceTest {
             eq(false),
             eq(USER_NAME)
         );
-        verify(exportApiUseCase, times(1)).execute(any());
+        verify(apiExportDomainService, times(1)).export(eq(API), any(), any());
     }
 
     @Test
@@ -117,7 +116,7 @@ class ApiResource_PatchApiDefinitionTest extends ApiResourceTest {
         Date updated = new Date(1_700_000_000_002L);
         ApiEntity current = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(updated).build();
         when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(current);
-        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(minimalProxyExport("api-name")));
+        when(apiExportDomainService.export(eq(API), any(), any())).thenReturn(minimalProxyExport("api-name"));
         when(
             apiServiceV4.update(eq(GraviteeContext.getExecutionContext()), eq(API), any(UpdateApiEntity.class), eq(false), eq(USER_NAME))
         ).thenReturn(current);
@@ -134,7 +133,7 @@ class ApiResource_PatchApiDefinitionTest extends ApiResourceTest {
             eq(false),
             eq(USER_NAME)
         );
-        verify(exportApiUseCase, times(1)).execute(any());
+        verify(apiExportDomainService, times(1)).export(eq(API), any(), any());
     }
 
     @Test
@@ -142,7 +141,7 @@ class ApiResource_PatchApiDefinitionTest extends ApiResourceTest {
         Date currentRevision = new Date(1_700_000_000_000L);
         ApiEntity current = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(currentRevision).build();
         when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(current);
-        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(minimalProxyExport("x")));
+        when(apiExportDomainService.export(eq(API), any(), any())).thenReturn(minimalProxyExport("x"));
 
         Response response = rootTarget(API + "/definition")
             .request(MediaType.APPLICATION_JSON)
@@ -206,7 +205,7 @@ class ApiResource_PatchApiDefinitionTest extends ApiResourceTest {
         Date fixedDate = new Date(1_700_000_000_000L);
         ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).name("actual-name").updatedAt(fixedDate).build();
         when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(apiEntity);
-        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(minimalProxyExport("actual-name")));
+        when(apiExportDomainService.export(eq(API), any(), any())).thenReturn(minimalProxyExport("actual-name"));
 
         Response response = rootTarget(API + "/definition")
             .request(MediaType.APPLICATION_JSON)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import fakes.spring.FakeConfiguration;
 import fixtures.core.model.LicenseFixtures;
 import inmemory.ApiCRDExportDomainServiceInMemory;
@@ -228,6 +229,7 @@ import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.InstanceService;
+import io.gravitee.rest.api.service.JsonPatchService;
 import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.OrganizationService;
@@ -239,6 +241,7 @@ import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
+import io.gravitee.rest.api.service.impl.JsonPatchServiceImpl;
 import io.gravitee.rest.api.service.impl.configuration.application.ApplicationTypeServiceImpl;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
@@ -250,6 +253,7 @@ import io.gravitee.rest.api.service.v4.PlanService;
 import io.gravitee.rest.api.service.v4.PolicyPluginService;
 import io.vertx.rxjava3.core.Vertx;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -852,6 +856,14 @@ public class ResourceContextConfiguration {
     @Bean
     public io.gravitee.rest.api.service.sanitizer.HtmlSanitizer legacyHtmlSanitizer() {
         return new io.gravitee.rest.api.service.sanitizer.HtmlSanitizer(new MockEnvironment());
+    }
+
+    @Bean
+    public JsonPatchService jsonPatchService(
+        @Qualifier("defaultMapper") JsonMapper objectMapper,
+        io.gravitee.rest.api.service.sanitizer.HtmlSanitizer legacyHtmlSanitizer
+    ) {
+        return new JsonPatchServiceImpl(objectMapper, legacyHtmlSanitizer);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -51,6 +51,7 @@ import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFacetSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFilterSpecUseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.ApiDefinitionJsonPatchDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiImportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
@@ -241,6 +242,7 @@ import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
+import io.gravitee.rest.api.service.impl.ApiDefinitionJsonPatchDomainServiceImpl;
 import io.gravitee.rest.api.service.impl.JsonPatchServiceImpl;
 import io.gravitee.rest.api.service.impl.configuration.application.ApplicationTypeServiceImpl;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
@@ -864,6 +866,11 @@ public class ResourceContextConfiguration {
         io.gravitee.rest.api.service.sanitizer.HtmlSanitizer legacyHtmlSanitizer
     ) {
         return new JsonPatchServiceImpl(objectMapper, legacyHtmlSanitizer);
+    }
+
+    @Bean
+    public ApiDefinitionJsonPatchDomainService apiDefinitionJsonPatchDomainService(JsonPatchService jsonPatchService) {
+        return new ApiDefinitionJsonPatchDomainServiceImpl(jsonPatchService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -43,6 +43,7 @@ import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFacetSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFilterSpecUseCase;
+import io.gravitee.apim.core.api.domain_service.ApiDefinitionJsonPatchDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiImportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
@@ -238,6 +239,7 @@ import io.gravitee.rest.api.service.configuration.identity.IdentityProviderServi
 import io.gravitee.rest.api.service.configuration.spel.SpelService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
+import io.gravitee.rest.api.service.impl.ApiDefinitionJsonPatchDomainServiceImpl;
 import io.gravitee.rest.api.service.impl.swagger.policy.PolicyOperationVisitorManager;
 import io.gravitee.rest.api.service.promotion.PromotionService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
@@ -642,6 +644,11 @@ public class ResourceContextConfiguration {
     @Bean
     public JsonPatchService jsonPatchService() {
         return mock(JsonPatchService.class);
+    }
+
+    @Bean
+    public ApiDefinitionJsonPatchDomainService apiDefinitionJsonPatchDomainService(JsonPatchService jsonPatchService) {
+        return new ApiDefinitionJsonPatchDomainServiceImpl(jsonPatchService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -43,6 +43,7 @@ import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFacetSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFilterSpecUseCase;
+import io.gravitee.apim.core.api.domain_service.ApiDefinitionJsonPatchDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiImportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
@@ -208,6 +209,7 @@ import io.gravitee.rest.api.service.GenericNotificationConfigService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.HealthCheckService;
 import io.gravitee.rest.api.service.IdentityService;
+import io.gravitee.rest.api.service.JsonPatchService;
 import io.gravitee.rest.api.service.LogsService;
 import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.MembershipService;
@@ -235,6 +237,7 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
 import io.gravitee.rest.api.service.filtering.FilteringService;
+import io.gravitee.rest.api.service.impl.ApiDefinitionJsonPatchDomainServiceImpl;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import io.gravitee.rest.api.service.v4.ApiCategoryService;
 import io.gravitee.rest.api.service.v4.ApiEntrypointService;
@@ -941,6 +944,16 @@ public class ResourceContextConfiguration {
     @Bean
     public HtmlSanitizer htmlSanitizer(io.gravitee.rest.api.service.sanitizer.HtmlSanitizer delegate) {
         return new HtmlSanitizerImpl(delegate);
+    }
+
+    @Bean
+    public JsonPatchService jsonPatchService() {
+        return mock(JsonPatchService.class);
+    }
+
+    @Bean
+    public ApiDefinitionJsonPatchDomainService apiDefinitionJsonPatchDomainService(JsonPatchService jsonPatchService) {
+        return new ApiDefinitionJsonPatchDomainServiceImpl(jsonPatchService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiDefinitionJsonPatchDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiDefinitionJsonPatchDomainService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import io.gravitee.rest.api.model.JsonPatch;
+import java.util.Collection;
+
+/**
+ * Applies JSON Patch operations to an exported API definition JSON string.
+ *
+ * <p>Implementations typically delegate to {@code JsonPatchService}. A failed JSON Patch "test" operation is reported as {@link JsonPatchTestFailedException}.</p>
+ */
+public interface ApiDefinitionJsonPatchDomainService {
+    String apply(String json, Collection<JsonPatch> patches);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiDefinitionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiDefinitionUseCase.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static java.util.Collections.emptyList;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
+import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.json.GraviteeDefinitionSerializer;
+import io.gravitee.apim.core.json.JsonProcessingException;
+import io.gravitee.rest.api.model.JsonPatch;
+import io.gravitee.rest.api.service.JsonPatchService;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import io.gravitee.rest.api.service.exceptions.JsonPatchTestFailedException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.Collection;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@CustomLog
+@RequiredArgsConstructor
+public class PatchApiDefinitionUseCase {
+
+    private final ApiExportDomainService apiExportDomainService;
+    private final JsonPatchService jsonPatchService;
+    private final GraviteeDefinitionSerializer graviteeDefinitionSerializer;
+
+    public Result execute(Input input) {
+        var exported = apiExportDomainService.export(input.apiId(), input.auditInfo(), emptyList());
+        if (exported instanceof GraviteeDefinition.V4 definition) {
+            String definitionJson = exportDefinitionToJson(definition);
+            try {
+                String definitionModified = jsonPatchService.execute(definitionJson, input.patches());
+                if (input.dryRun()) {
+                    return new Result.DryRun(definitionModified);
+                }
+                return new Result.ApplyPatch(definitionModified);
+            } catch (JsonPatchTestFailedException e) {
+                log.debug("JSON Patch definition test did not apply for API [{}]", input.apiId(), e);
+                return new Result.PatchTestFailed(e.getMessage());
+            }
+        }
+        if (exported == null) {
+            throw new ApiNotFoundException(input.apiId());
+        }
+        throw new ApiDefinitionVersionNotSupportedException(exported.api().definitionVersion().getLabel());
+    }
+
+    private String exportDefinitionToJson(GraviteeDefinition definition) {
+        try {
+            return graviteeDefinitionSerializer.serialize(definition);
+        } catch (JsonProcessingException e) {
+            throw new TechnicalManagementException("Failed to serialize API definition", e);
+        }
+    }
+
+    public record Input(String apiId, AuditInfo auditInfo, Collection<JsonPatch> patches, boolean dryRun) {}
+
+    public sealed interface Result permits Result.PatchTestFailed, Result.DryRun, Result.ApplyPatch {
+        record PatchTestFailed(String failureMessage) implements Result {}
+
+        record DryRun(String patchedExportJson) implements Result {}
+
+        record ApplyPatch(String patchedExportJson) implements Result {}
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiDefinitionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiDefinitionUseCase.java
@@ -18,13 +18,13 @@ package io.gravitee.apim.core.api.use_case;
 import static java.util.Collections.emptyList;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.ApiDefinitionJsonPatchDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.json.GraviteeDefinitionSerializer;
 import io.gravitee.apim.core.json.JsonProcessingException;
 import io.gravitee.rest.api.model.JsonPatch;
-import io.gravitee.rest.api.service.JsonPatchService;
 import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.JsonPatchTestFailedException;
@@ -39,7 +39,7 @@ import lombok.RequiredArgsConstructor;
 public class PatchApiDefinitionUseCase {
 
     private final ApiExportDomainService apiExportDomainService;
-    private final JsonPatchService jsonPatchService;
+    private final ApiDefinitionJsonPatchDomainService apiDefinitionJsonPatchDomainService;
     private final GraviteeDefinitionSerializer graviteeDefinitionSerializer;
 
     public Result execute(Input input) {
@@ -47,7 +47,7 @@ public class PatchApiDefinitionUseCase {
         if (exported instanceof GraviteeDefinition.V4 definition) {
             String definitionJson = exportDefinitionToJson(definition);
             try {
-                String definitionModified = jsonPatchService.execute(definitionJson, input.patches());
+                String definitionModified = apiDefinitionJsonPatchDomainService.apply(definitionJson, input.patches());
                 if (input.dryRun()) {
                     return new Result.DryRun(definitionModified);
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDefinitionJsonPatchDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDefinitionJsonPatchDomainServiceImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import io.gravitee.apim.core.api.domain_service.ApiDefinitionJsonPatchDomainService;
+import io.gravitee.rest.api.model.JsonPatch;
+import io.gravitee.rest.api.service.JsonPatchService;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class ApiDefinitionJsonPatchDomainServiceImpl implements ApiDefinitionJsonPatchDomainService {
+
+    private final JsonPatchService jsonPatchService;
+
+    @Override
+    public String apply(String json, Collection<JsonPatch> patches) {
+        return jsonPatchService.execute(json, patches);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiDefinitionUseCaseTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.api.domain_service.ApiDefinitionJsonPatchDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
 import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
@@ -31,7 +32,6 @@ import io.gravitee.apim.core.json.GraviteeDefinitionSerializer;
 import io.gravitee.apim.core.json.JsonProcessingException;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.rest.api.model.JsonPatch;
-import io.gravitee.rest.api.service.JsonPatchService;
 import io.gravitee.rest.api.service.exceptions.JsonPatchTestFailedException;
 import java.util.List;
 import java.util.Set;
@@ -50,7 +50,7 @@ class PatchApiDefinitionUseCaseTest {
     private ApiExportDomainService apiExportDomainService;
 
     @Mock
-    private JsonPatchService jsonPatchService;
+    private ApiDefinitionJsonPatchDomainService apiDefinitionJsonPatchDomainService;
 
     @Mock
     private GraviteeDefinitionSerializer graviteeDefinitionSerializer;
@@ -59,7 +59,7 @@ class PatchApiDefinitionUseCaseTest {
 
     @BeforeEach
     void set_up() {
-        useCase = new PatchApiDefinitionUseCase(apiExportDomainService, jsonPatchService, graviteeDefinitionSerializer);
+        useCase = new PatchApiDefinitionUseCase(apiExportDomainService, apiDefinitionJsonPatchDomainService, graviteeDefinitionSerializer);
     }
 
     @Test
@@ -67,7 +67,7 @@ class PatchApiDefinitionUseCaseTest {
         var definition = minimalExport("n1");
         when(apiExportDomainService.export(any(), any(), any())).thenReturn(definition);
         when(graviteeDefinitionSerializer.serialize(any())).thenReturn("{}");
-        when(jsonPatchService.execute(anyString(), any())).thenReturn("{\"patched\":true}");
+        when(apiDefinitionJsonPatchDomainService.apply(anyString(), any())).thenReturn("{\"patched\":true}");
 
         var patches = List.<JsonPatch>of();
         var result = useCase.execute(new PatchApiDefinitionUseCase.Input(API_ID, auditInfo(), patches, true));
@@ -81,7 +81,7 @@ class PatchApiDefinitionUseCaseTest {
         var definition = minimalExport("n1");
         when(apiExportDomainService.export(any(), any(), any())).thenReturn(definition);
         when(graviteeDefinitionSerializer.serialize(any())).thenReturn("{}");
-        when(jsonPatchService.execute(anyString(), any())).thenReturn("{\"patched\":true}");
+        when(apiDefinitionJsonPatchDomainService.apply(anyString(), any())).thenReturn("{\"patched\":true}");
 
         var result = useCase.execute(new PatchApiDefinitionUseCase.Input(API_ID, auditInfo(), List.of(), false));
 
@@ -95,12 +95,12 @@ class PatchApiDefinitionUseCaseTest {
         when(apiExportDomainService.export(any(), any(), any())).thenReturn(definition);
         when(graviteeDefinitionSerializer.serialize(any())).thenReturn("{}");
         var failed = new JsonPatchTestFailedException(new JsonPatch());
-        when(jsonPatchService.execute(anyString(), any())).thenThrow(failed);
+        when(apiDefinitionJsonPatchDomainService.apply(anyString(), any())).thenThrow(failed);
 
         var result = useCase.execute(new PatchApiDefinitionUseCase.Input(API_ID, auditInfo(), List.of(), false));
 
         assertThat(result).isInstanceOf(PatchApiDefinitionUseCase.Result.PatchTestFailed.class);
-        verify(jsonPatchService).execute(anyString(), any());
+        verify(apiDefinitionJsonPatchDomainService).apply(anyString(), any());
     }
 
     private static AuditInfo auditInfo() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiDefinitionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiDefinitionUseCaseTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
+import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
+import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
+import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.json.GraviteeDefinitionSerializer;
+import io.gravitee.apim.core.json.JsonProcessingException;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.model.JsonPatch;
+import io.gravitee.rest.api.service.JsonPatchService;
+import io.gravitee.rest.api.service.exceptions.JsonPatchTestFailedException;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PatchApiDefinitionUseCaseTest {
+
+    private static final String API_ID = "api-id";
+
+    @Mock
+    private ApiExportDomainService apiExportDomainService;
+
+    @Mock
+    private JsonPatchService jsonPatchService;
+
+    @Mock
+    private GraviteeDefinitionSerializer graviteeDefinitionSerializer;
+
+    private PatchApiDefinitionUseCase useCase;
+
+    @BeforeEach
+    void set_up() {
+        useCase = new PatchApiDefinitionUseCase(apiExportDomainService, jsonPatchService, graviteeDefinitionSerializer);
+    }
+
+    @Test
+    void should_return_dry_run_with_patched_json() throws JsonProcessingException {
+        var definition = minimalExport("n1");
+        when(apiExportDomainService.export(any(), any(), any())).thenReturn(definition);
+        when(graviteeDefinitionSerializer.serialize(any())).thenReturn("{}");
+        when(jsonPatchService.execute(anyString(), any())).thenReturn("{\"patched\":true}");
+
+        var patches = List.<JsonPatch>of();
+        var result = useCase.execute(new PatchApiDefinitionUseCase.Input(API_ID, auditInfo(), patches, true));
+
+        assertThat(result).isInstanceOf(PatchApiDefinitionUseCase.Result.DryRun.class);
+        assertThat(((PatchApiDefinitionUseCase.Result.DryRun) result).patchedExportJson()).isEqualTo("{\"patched\":true}");
+    }
+
+    @Test
+    void should_return_apply_patch_when_not_dry_run() throws JsonProcessingException {
+        var definition = minimalExport("n1");
+        when(apiExportDomainService.export(any(), any(), any())).thenReturn(definition);
+        when(graviteeDefinitionSerializer.serialize(any())).thenReturn("{}");
+        when(jsonPatchService.execute(anyString(), any())).thenReturn("{\"patched\":true}");
+
+        var result = useCase.execute(new PatchApiDefinitionUseCase.Input(API_ID, auditInfo(), List.of(), false));
+
+        assertThat(result).isInstanceOf(PatchApiDefinitionUseCase.Result.ApplyPatch.class);
+        assertThat(((PatchApiDefinitionUseCase.Result.ApplyPatch) result).patchedExportJson()).isEqualTo("{\"patched\":true}");
+    }
+
+    @Test
+    void should_return_patch_test_failed_when_json_patch_service_throws() throws JsonProcessingException {
+        var definition = minimalExport("n1");
+        when(apiExportDomainService.export(any(), any(), any())).thenReturn(definition);
+        when(graviteeDefinitionSerializer.serialize(any())).thenReturn("{}");
+        var failed = new JsonPatchTestFailedException(new JsonPatch());
+        when(jsonPatchService.execute(anyString(), any())).thenThrow(failed);
+
+        var result = useCase.execute(new PatchApiDefinitionUseCase.Input(API_ID, auditInfo(), List.of(), false));
+
+        assertThat(result).isInstanceOf(PatchApiDefinitionUseCase.Result.PatchTestFailed.class);
+        verify(jsonPatchService).execute(anyString(), any());
+    }
+
+    private static AuditInfo auditInfo() {
+        return new AuditInfo("o", "e", AuditActor.builder().userId("u").userSource("source").userSourceId("sid").build());
+    }
+
+    private static GraviteeDefinition.V4 minimalExport(String name) {
+        return (GraviteeDefinition.V4) GraviteeDefinition.from(
+            ApiDescriptor.ApiDescriptorV4.builder().id(API_ID).crossId("c").name(name).apiVersion("1.0").type(ApiType.PROXY).build(),
+            Set.of(),
+            List.of(),
+            List.of(),
+            List.<PlanDescriptor.V4>of(),
+            List.of(),
+            null,
+            null
+        );
+    }
+}


### PR DESCRIPTION
## Issue`
`
https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Adds JSON Patch (RFC 6902) support for V4 HTTP Proxy APIs on
PATCH /management/v2/organizations/{orgId}/environments/{envId}/apis/{apiId}/definition, aligned with the same export shape as GET .../apis/{apiId}/_export/definition and the same update semantics as PUT .../apis/{apiId} for the api payload.

## Additional context

- New endpoint PATCH .../apis/{apiId}/definition to apply JSON Patch to the exported API definition; optional dryRun; persist reuses V4 update flow.
- Allows incremental, programmatic updates to large definitions without sending a full PUT body; supports conditional apply via patch test.
- V4 HTTP Proxy only; other types → 400 (api.definition.patch.unsupported).
- **API contract:** OpenAPI in openapi-apis.yaml (patchApiDefinition); request body: array of patch ops; responses: 200 (ExportApiV4 vs Api depending on dryRun), 412 on patch test failure, standard permission errors.
- Security / permissions: API_DEFINITION[UPDATE] or API_GATEWAY_DEFINITION[UPDATE]; concurrency via If-Match.
- **Implementation notes:** PatchApiDefinitionUseCase + existing JsonPatchService / ApiExportDomainService / serializers; no duplicate export logic in the resource.
- **Tests:** PatchApiDefinitionUseCaseTest, ApiResource_PatchApiDefinitionTest.


### Some Example:
**Success – dry run (200, body is patched JSON string)**
---
No persistence; If-Match optional.
```
curl -sS -X PATCH \
  "${BASE}/management/v2/environments/${ENV}/apis/${API_ID}/definition?dryRun=true" \
  -H 'Content-Type: application/json' \
  -u 'admin:admin' \
  --data '[{"jsonPath":"$.api.name","operation":"REPLACE","value":"test-patch-api-v4-dry-run"}]'
```

**Success – persist (200, full export JSON + new ETag)**
---
Use a current ETag from GET .../apis/{apiId} (or last PUT/PATCH response). Quotes around the tag value are common.
`ETAG='"1700000000000"'  # example: from GET /apis/{apiId} → ETag header`

```
curl -sS -D - -o /tmp/patch-body.json -X PATCH \
  "${BASE}/management/v2/environments/${ENV}/apis/${API_ID}/definition?dryRun=false" \
  -H 'Content-Type: application/json' \
  -H "If-Match: ${ETAG}" \
  -u 'admin:admin' \
  --data '[{"jsonPath":"$.api.name","operation":"REPLACE","value":"test-patch-api-v4"}]'
```
Check ETag in response headers and body in /tmp/patch-body.json.

**Failure – precondition failed (412)**
---
Wrong or stale If-Match:
```
curl -sS -o /dev/null -w '%{http_code}\n' -X PATCH \
  "${BASE}/management/v2/environments/${ENV}/apis/${API_ID}/definition?dryRun=false" \
  -H 'Content-Type: application/json' \
  -H 'If-Match: "0"' \
  -u 'admin:admin' \
  --data '[{"jsonPath":"$.api.name","operation":"REPLACE","value":"will-not-apply"}]'
```
Expected: 412.

**Failure – unsupported API kind (400)**
---
Use an API that is not V4 HTTP Proxy (e.g. Native V4). Same payload:
```
curl -sS -X PATCH \
  "${BASE}/management/v2/environments/${ENV}/apis/${NATIVE_OR_MESSAGE_API_ID}/definition" \
  -H 'Content-Type: application/json' \
  -u 'admin:admin' \
  --data '[{"jsonPath":"$.api.name","operation":"REPLACE","value":"x"}]'
```
Expected: 400 with message about V4 HTTP Proxy only.

**“Failure” – JSON Patch test op mismatch (204, no body)**
---
Export must contain api.name matching reality; TEST uses a wrong expected value:
```
curl -sS -o /dev/null -w '%{http_code}\n' -X PATCH \
  "${BASE}/management/v2/environments/${ENV}/apis/${API_ID}/definition" \
  -H 'Content-Type: application/json' \
  -u 'admin:admin' \
  --data '[{"jsonPath":"$.api.name","operation":"TEST","value":"not-the-real-name"}]'
```


https://github.com/user-attachments/assets/9c0a876f-418a-4fd1-9a9f-5cc5283f8676

