### PR TITLE
fix(elasticsearch): idempotent Lucene value escaping for body/payload search (APIM-13030)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
@@ -96,7 +96,7 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
                     .size(MAX_RESULT_WINDOW)
                     .query(logQueryString)
                     .build();
-                final String sQuery = this.createSafeElasticsearchJsonQuery(logQuery);
+                final String sQuery = this.createElasticsearchJsonQuery(logQuery);
 
                 Single<SearchResponse> result = this.client.search(
                     this.indexNameGenerator.getIndexName(queryContext.placeholder(), Type.LOG, from, to, clusters),
@@ -127,7 +127,7 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
                     result = this.client.search(
                         this.indexNameGenerator.getIndexName(queryContext.placeholder(), Type.REQUEST, from, to, clusters),
                         !info.getVersion().canUseTypeRequests() ? null : Type.REQUEST.getType(),
-                        this.createSafeElasticsearchJsonQuery(requestQueryBuilder.build())
+                        this.createElasticsearchJsonQuery(requestQueryBuilder.build())
                     );
                 }
 
@@ -140,25 +140,31 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
         }
     }
 
-    private String getQuery(final QueryFilter query, final boolean log) {
+    String getQuery(final QueryFilter query, final boolean log) {
         if (query == null) {
             return null;
         }
         final String filterSeparator = " AND ";
         final String[] filters = query.filter().split(filterSeparator);
         return stream(filters)
-            .map(f -> f.split(":"))
-            .filter(filter -> {
-                final String filterKey = filter[0];
-                return (log && filterKey.contains("body")) || (!log && !filterKey.contains("body"));
+            .filter(f -> {
+                int colonIdx = f.indexOf(':');
+                String key = colonIdx >= 0 ? f.substring(0, colonIdx) : f;
+                return (log && key.contains("body")) || (!log && !key.contains("body"));
             })
-            .map(filter -> {
-                final String filterKey = filter[0];
-                if ("body".equals(filterKey)) {
-                    return "\\\\*.body" + ":" + filter[1];
-                } else {
-                    return filterKey + ":" + filter[1];
+            .map(f -> {
+                int colonIdx = f.indexOf(':');
+                if (colonIdx < 0) {
+                    logger.warn("Log query filter segment has no field:value separator: {}", f);
+                    return escapeValueForLuceneJson(f);
                 }
+                String field = f.substring(0, colonIdx);
+                String value = f.substring(colonIdx + 1);
+                String escapedValue = escapeValueForLuceneJson(value);
+                if ("body".equals(field)) {
+                    return "\\\\*.body:" + escapedValue;
+                }
+                return field + ":" + escapedValue;
             })
             .collect(joining(filterSeparator));
     }
@@ -252,9 +258,11 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
     }
 
     /**
-     * Fix APIM-12955: Escapes Lucene special characters in the query string.
-     * Quadruple backslashes are required to survive both Java and JSON parsing levels
-     * so that Lucene finally receives the mandatory single backslash escape (e.g., \( ).
+     * Fix APIM-12955: Escapes Lucene special characters in query filter values.
+     * Only escapes the value portion of each field:value clause, preserving field
+     * patterns like {@code \\*.body} which use backslashes intentionally.
+     * Quadruple backslashes survive both Java and JSON parsing so Lucene receives
+     * the single backslash escape (e.g., \( ).
      */
     private String createSafeElasticsearchJsonQuery(final TabularQuery query) {
         String json = this.createElasticsearchJsonQuery(query);
@@ -263,12 +271,93 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
             String filter = query.query().filter();
 
             if (!filter.isEmpty()) {
-                String escaped = filter.replace("\\", "\\\\\\\\").replace("/", "\\\\/").replace("(", "\\\\(").replace(")", "\\\\)");
+                String escaped = escapeFilterValues(filter);
 
                 // Targeted replacement within quotes to protect JSON structure
                 json = json.replace("\"" + filter + "\"", "\"" + escaped + "\"");
             }
         }
         return json;
+    }
+
+    /**
+     * Escapes Lucene special characters only in the value portions of field:value
+     * clauses, preserving field names and patterns (e.g. \\*.body wildcard fields).
+     */
+    private String escapeFilterValues(String filter) {
+        final String andSeparator = " AND ";
+        return stream(filter.split(andSeparator)).map(ElasticLogRepository::escapeClauseValues).collect(joining(andSeparator));
+    }
+
+    private static String escapeClauseValues(String clause) {
+        // Handle OR-separated sub-clauses (e.g. "_id:x OR _id:y")
+        if (clause.contains(" OR ")) {
+            return stream(clause.split(" OR ")).map(ElasticLogRepository::escapeSingleClauseValue).collect(joining(" OR "));
+        }
+        return escapeSingleClauseValue(clause);
+    }
+
+    private static String escapeSingleClauseValue(String clause) {
+        int colonIdx = clause.indexOf(':');
+        if (colonIdx < 0) {
+            return escapeValueForLuceneJson(clause);
+        }
+        String field = clause.substring(0, colonIdx + 1);
+        String value = clause.substring(colonIdx + 1);
+        return field + escapeValueForLuceneJson(value);
+    }
+
+    // Lucene special characters that must be escaped in query values (backslash handled separately).
+    // * and ? are intentionally absent — they serve as wildcards in body searches.
+    private static final String LUCENE_SPECIAL = "+-!(){}[]^~:/&|=\"";
+
+    /**
+     * Idempotent Lucene escaping that handles two pre-escape conventions:
+     *
+     * <ul>
+     *   <li>The console uses a 2-backslash convention: each special char X is sent as {@code \\X}
+     *       (two backslashes + X). Detected by looking 3 chars ahead for the pattern
+     *       {@code \} {@code \} {@code X} — passed through as-is.</li>
+     *   <li>Raw API clients may use a 1-backslash convention ({@code \X}) or no escaping at all.
+     *       Both are normalised to {@code \\X}.</li>
+     * </ul>
+     *
+     * In all cases the output is {@code \\X} in the Java string, which FreeMarker places verbatim
+     * into the JSON query body. After JSON parsing Elasticsearch/Lucene receives {@code \X},
+     * the standard Lucene escape for a literal {@code X}.
+     */
+    private static String escapeValueForLuceneJson(String value) {
+        StringBuilder sb = new StringBuilder(value.length() * 2);
+        int i = 0;
+        final int n = value.length();
+        while (i < n) {
+            char c = value.charAt(i);
+            if (c == '\\') {
+                if (i + 2 < n && value.charAt(i + 1) == '\\' && LUCENE_SPECIAL.indexOf(value.charAt(i + 2)) >= 0) {
+                    // \\X — console pre-escaped special char (2-backslash convention). Pass through.
+                    sb.append("\\\\").append(value.charAt(i + 2));
+                    i += 3;
+                } else if (i + 1 < n && value.charAt(i + 1) == '\\') {
+                    // \\ — escaped backslash (console encodes literal \ as \\). Output \\\\.
+                    sb.append("\\\\\\\\");
+                    i += 2;
+                } else if (i + 1 < n && LUCENE_SPECIAL.indexOf(value.charAt(i + 1)) >= 0) {
+                    // \X — single-backslash pre-escape (raw client). Normalise to \\X.
+                    sb.append("\\\\").append(value.charAt(i + 1));
+                    i += 2;
+                } else {
+                    // Lone \ — literal backslash. Output \\\\.
+                    sb.append("\\\\\\\\");
+                    i++;
+                }
+            } else if (LUCENE_SPECIAL.indexOf(c) >= 0) {
+                sb.append("\\\\").append(c); // unescaped special char → \\X
+                i++;
+            } else {
+                sb.append(c);
+                i++;
+            }
+        }
+        return sb.toString();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/LuceneEscapeTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/LuceneEscapeTest.java
@@ -17,6 +17,8 @@ package io.gravitee.repository.elasticsearch.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.gravitee.repository.analytics.query.QueryFilter;
+import java.lang.reflect.Method;
 import org.apache.lucene.queryparser.classic.QueryParser;
 import org.junit.jupiter.api.Test;
 
@@ -24,19 +26,196 @@ public class LuceneEscapeTest {
 
     @Test
     public void compareImplementationWithStandardParser() {
+        // Original APIM-12955 regression test
         String input = "status:200 AND custom.userAgent:RMel/1.0.0 (Ubuntu)";
 
         String luceneStandard = QueryParser.escape(input);
 
-        String result = input.replace("\\", "\\\\\\\\").replace("/", "\\\\/").replace("(", "\\\\(").replace(")", "\\\\)");
+        // escapeFilterValues splits field:value and only escapes values
+        String result = invokeEscapeFilterValues(input);
 
         assertThat(result).contains("RMel\\\\/1.0.0");
         assertThat(result).contains("\\\\(Ubuntu\\\\)");
 
-        // NO REGRESSION Test
+        // NO REGRESSION: field names preserved
         assertThat(result).contains("status:200");
         assertThat(result).contains("custom.userAgent:");
 
         assertThat(luceneStandard).contains("status\\:200");
+    }
+
+    @Test
+    public void escapeFilterValues_preservesFieldNames() {
+        String result = invokeEscapeFilterValues("status:200 AND api:some-uuid");
+        assertThat(result).isEqualTo("status:200 AND api:some\\\\-uuid");
+    }
+
+    @Test
+    public void escapeFilterValues_escapesSlashInValue() {
+        String result = invokeEscapeFilterValues("custom.userAgent:RMel/1.0.0");
+        assertThat(result).isEqualTo("custom.userAgent:RMel\\\\/1.0.0");
+    }
+
+    @Test
+    public void escapeFilterValues_escapesParensInValue() {
+        String result = invokeEscapeFilterValues("custom.userAgent:App (v2)");
+        assertThat(result).isEqualTo("custom.userAgent:App \\\\(v2\\\\)");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_noSpecialChars() {
+        String result = invokeEscapeValue("searchterm");
+        assertThat(result).isEqualTo("searchterm");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_escapesParens() {
+        String result = invokeEscapeValue("error(500)");
+        assertThat(result).isEqualTo("error\\\\(500\\\\)");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_escapesSlash() {
+        String result = invokeEscapeValue("path/to/resource");
+        assertThat(result).isEqualTo("path\\\\/to\\\\/resource");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_doesNotEscapeDollarOrAt() {
+        // $ and @ are not Lucene special chars
+        String result = invokeEscapeValue("$99 user@example.com");
+        assertThat(result).isEqualTo("$99 user@example.com");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_escapesTilde() {
+        String result = invokeEscapeValue("fuzzy~2");
+        assertThat(result).isEqualTo("fuzzy\\\\~2");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_idempotent_preEscapedParens() {
+        // Raw-client 1-backslash pre-escape: \( → \\(
+        String result = invokeEscapeValue("RMel\\(Ubuntu\\)");
+        assertThat(result).isEqualTo("RMel\\\\(Ubuntu\\\\)");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_idempotent_preEscapedTilde() {
+        // Raw-client 1-backslash pre-escape: \~ → \\~
+        String result = invokeEscapeValue("fuzzy\\~2");
+        assertThat(result).isEqualTo("fuzzy\\\\~2");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_idempotent_preEscapedSlash() {
+        // Raw-client 1-backslash pre-escape: \/ → \\/
+        String result = invokeEscapeValue("path\\/to");
+        assertThat(result).isEqualTo("path\\\\/to");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_idempotent_consolePreEscapedParens() {
+        // Console 2-backslash convention: \\( → \\( (pass through unchanged)
+        // Browser sends %5C%5C%28 → Java runtime: \\(
+        String result = invokeEscapeValue("RMel\\\\(Ubuntu\\\\)");
+        assertThat(result).isEqualTo("RMel\\\\(Ubuntu\\\\)");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_idempotent_consolePreEscapedTilde() {
+        // Console 2-backslash convention: \\~ → \\~ (pass through unchanged)
+        String result = invokeEscapeValue("fuzzy\\\\~2");
+        assertThat(result).isEqualTo("fuzzy\\\\~2");
+    }
+
+    @Test
+    public void escapeValueForLuceneJson_idempotent_consolePreEscapedSlash() {
+        // Console 2-backslash convention: \\/ → \\/ (pass through unchanged)
+        String result = invokeEscapeValue("path\\\\/to");
+        assertThat(result).isEqualTo("path\\\\/to");
+    }
+
+    @Test
+    public void escapeFilterValues_doesNotEscapeBodyWildcardFieldPattern() {
+        // \\*.body is the Lucene wildcard field pattern for body/payload searches (APIM-13030 regression guard).
+        // escapeFilterValues must not corrupt the leading backslashes — only the value is escaped.
+        String result = invokeEscapeFilterValues("\\\\*.body:application/json");
+        assertThat(result).isEqualTo("\\\\*.body:application\\\\/json");
+    }
+
+    @Test
+    public void escapeFilterValues_handlesOrSubclauses() {
+        // OR-separated sub-clauses (e.g. _id:x OR _id:y generated from logIdsQuery)
+        String result = invokeEscapeFilterValues("custom.path:a/b OR custom.path:c/d");
+        assertThat(result).isEqualTo("custom.path:a\\\\/b OR custom.path:c\\\\/d");
+    }
+
+    // --- getQuery() unit tests (live path) ---
+
+    @Test
+    public void getQuery_returnsNullForNullFilter() {
+        assertThat(new ElasticLogRepository().getQuery(null, true)).isNull();
+    }
+
+    @Test
+    public void getQuery_routesBodyToWildcardField() {
+        // APIM-13030: body filter must produce \\*.body:value, not a corrupted field pattern
+        String result = new ElasticLogRepository().getQuery(new QueryFilter("body:hello"), true);
+        assertThat(result).isEqualTo("\\\\*.body:hello");
+    }
+
+    @Test
+    public void getQuery_escapesSpecialCharsInBodyValue() {
+        String result = new ElasticLogRepository().getQuery(new QueryFilter("body:test/path"), true);
+        assertThat(result).isEqualTo("\\\\*.body:test\\\\/path");
+    }
+
+    @Test
+    public void getQuery_excludesBodyClauseWhenLogFalse() {
+        // non-body query (log=false) must strip body filter and keep only non-body clauses
+        String result = new ElasticLogRepository().getQuery(new QueryFilter("status:200 AND body:test"), false);
+        assertThat(result).isEqualTo("status:200");
+    }
+
+    @Test
+    public void getQuery_excludesNonBodyClauseWhenLogTrue() {
+        // body query (log=true) must strip non-body filters and keep only body clause
+        String result = new ElasticLogRepository().getQuery(new QueryFilter("status:200 AND body:hello"), true);
+        assertThat(result).isEqualTo("\\\\*.body:hello");
+    }
+
+    @Test
+    public void getQuery_handlesValueWithColon() {
+        // value containing colons (e.g. URL) — indexOf(':') must not truncate after the first colon
+        String result = new ElasticLogRepository().getQuery(new QueryFilter("body:http://example.com:8080"), true);
+        assertThat(result).isEqualTo("\\\\*.body:http\\\\:\\\\/\\\\/example.com\\\\:8080");
+    }
+
+    @Test
+    public void getQuery_doesNotEscapeWildcards() {
+        // * and ? are intentional Lucene wildcards — the console uses body:*term* for contains-search
+        String result = new ElasticLogRepository().getQuery(new QueryFilter("body:*hello*"), true);
+        assertThat(result).isEqualTo("\\\\*.body:*hello*");
+    }
+
+    private String invokeEscapeFilterValues(String filter) {
+        try {
+            Method method = ElasticLogRepository.class.getDeclaredMethod("escapeFilterValues", String.class);
+            method.setAccessible(true);
+            return (String) method.invoke(new ElasticLogRepository(), filter);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String invokeEscapeValue(String value) {
+        try {
+            Method method = ElasticLogRepository.class.getDeclaredMethod("escapeValueForLuceneJson", String.class);
+            method.setAccessible(true);
+            return (String) method.invoke(null, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **APIM-13030**: Body/payload search in Analytics → Logs returns no results — regression introduced by APIM-12955
- Root cause: `createSafeElasticsearchJsonQuery()` applied Lucene escaping to the full query string including field patterns, corrupting the `\\*.body` wildcard field prefix used for body searches
- Fix: escaping is now applied **only to values**, not field names or patterns, across all three query paths
- Escaping is **idempotent**: detects both the console's 2-backslash pre-escape convention (`\\X`) and raw-client 1-backslash convention (`\X`), normalising both to the same Lucene-safe output — prevents double-escaping when the console or API clients pre-escape before sending

## What changed

- `getQuery()` — escapes values when building body-field queries; preserves `\\*.body` wildcard field prefix intact
- `escapeValueForLuceneJson()` — new 3-char lookahead algorithm: detects `\\X` (console convention, pass-through) and `\X` (raw-client, normalise to `\\X`); `*` and `?` intentionally not escaped (Lucene wildcards)
- `createSafeElasticsearchJsonQuery()` / `escapeFilterValues()` — same idempotent logic for the non-body query path
- 24 unit tests in `LuceneEscapeTest` covering all escaping scenarios including regression guards for both APIM-12955 and APIM-13030

## Test plan

- [ ] Body search with plain word returns results
- [ ] Body search with special chars in value — `*(Ubuntu)*`, `*RMel/1.0.0*` — returns results
- [ ] Non-body filter with special chars — `custom.userAgent:RMel/1.0.0 (Ubuntu)` — works (APIM-12955 regression)
- [ ] Combined query — `status:200 AND body:term` — works
- [ ] Wildcard body search — `body:*term*` — works
- [ ] Unit tests pass (`LuceneEscapeTest` — 24 tests)

🔗 [APIM-13030](https://gravitee.atlassian.net/browse/APIM-13030)

[APIM-13030]: https://gravitee.atlassian.net/browse/APIM-13030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ