### PR TITLE
feat(quick-setup): add useXForwardedProto to ssl-enforcement 

### DIFF
--- a/docker/quick-setup/https-nginx/echo-v2-1-0.json
+++ b/docker/quick-setup/https-nginx/echo-v2-1-0.json
@@ -42,6 +42,7 @@
                             "configuration": {
                                 "requiresClientAuthentication": true,
                                 "requiresSsl": true,
+                                "useXForwardedProto": true,
                                 "whitelistClientCertificates": [
                                     "C=FR,ST=France,L=Lille,O=GraviteeSource,OU=Demo,CN=nginx,EMAILADDRESS=nginx@graviteesource.com",
                                     "C=FR,ST=France,L=Lille,O=GraviteeSource,OU=Demo,CN=localhost,EMAILADDRESS=client@graviteesource.com"

--- a/docker/quick-setup/https-nginx/echo-v4-1-0.json
+++ b/docker/quick-setup/https-nginx/echo-v4-1-0.json
@@ -138,6 +138,7 @@
                             "configuration": {
                                 "requiresClientAuthentication": true,
                                 "requiresSsl": true,
+                                "useXForwardedProto": true,
                                 "whitelistClientCertificates": [
                                     "C=FR,ST=France,L=Lille,O=GraviteeSource,OU=Demo,CN=nginx,EMAILADDRESS=nginx@graviteesource.com",
                                     "C=FR,ST=France,L=Lille,O=GraviteeSource,OU=Demo,CN=localhost,EMAILADDRESS=client@graviteesource.com"

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <gravitee-policy-rest-to-soap.version>1.14.1</gravitee-policy-rest-to-soap.version>
         <gravitee-policy-retry.version>3.1.0</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>2.0.0</gravitee-policy-role-based-access-control.version>
-        <gravitee-policy-ssl-enforcement.version>1.5.0</gravitee-policy-ssl-enforcement.version>
+        <gravitee-policy-ssl-enforcement.version>1.6.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>3.0.0</gravitee-policy-traffic-shadowing.version>
         <gravitee-policy-transform-avro-json.version>3.0.0</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>


### PR DESCRIPTION
…ps-nginx example

## Issue

https://gravitee.atlassian.net/browse/APIM-13081

## Description

Add trustXForwardedProto to ssl-enforcement in https-nginx example
Bump SSL changes https://github.com/gravitee-io/gravitee-policy-ssl-enforcement/pull/60