### PR TITLE
fix: prevent alert condition fields from being hidden off-screen

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/_alert.scss
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/_alert.scss
@@ -12,6 +12,10 @@
     display: grid;
     flex-direction: row;
     flex-wrap: nowrap;
+
+    md-input-container {
+      min-width: 12.5rem;
+    }
   }
 
   .gv-alerts-alert_trigger-msg {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13048

## Description

Prevent alert condition fields from being hidden off-screen

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

