### PR TITLE
fix: apply NG portal visibility rules to permissions.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
@@ -27,6 +27,7 @@ import { ConfirmDialogHarness } from '../../../../../components/confirm-dialog/c
 import { SubscriptionInfoHarness } from '../../../../../components/subscription-info/subscription-info.harness';
 import { Api } from '../../../../../entities/api/api';
 import { fakeApi } from '../../../../../entities/api/api.fixtures';
+import { PortalApiViewParam } from '../../../../../entities/api/portal-api-view-param';
 import { Application } from '../../../../../entities/application/application';
 import { fakeApplication } from '../../../../../entities/application/application.fixture';
 import { Configuration } from '../../../../../entities/configuration/configuration';
@@ -401,11 +402,23 @@ describe('SubscriptionsDetailsComponent', () => {
   }
 
   function expectGetApi(api: Api = fakeApi()) {
-    httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/${api.id}?view=documentation`).flush(api);
+    httpTestingController
+      .expectOne(
+        request =>
+          request.url === `${TESTING_BASE_URL}/apis/${api.id}` &&
+          request.params.get(PortalApiViewParam.QUERY_PARAM_NAME) === PortalApiViewParam.DOCUMENTATION,
+      )
+      .flush(api);
   }
 
   function expectGetApiPermissions(permissions = fakeUserApiPermissions({ PLAN: ['R'] })) {
-    httpTestingController.expectOne(`${TESTING_BASE_URL}/permissions?apiId=${API_ID}`).flush(permissions);
+    const req = httpTestingController.expectOne(
+      request =>
+        request.url === `${TESTING_BASE_URL}/permissions` &&
+        request.params.get('apiId') === API_ID &&
+        request.params.get(PortalApiViewParam.QUERY_PARAM_NAME) === PortalApiViewParam.DOCUMENTATION,
+    );
+    req.flush(permissions);
   }
 
   function expectPostChangeConsumerStatus() {

--- a/gravitee-apim-portal-webui-next/src/entities/api/portal-api-view-param.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/portal-api-view-param.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Mirrors the backend's {@code PortalApiViewParam} — centralises
+ * the query-parameter name and its known values for the portal REST API.
+ */
+export const PortalApiViewParam = {
+  QUERY_PARAM_NAME: 'view',
+  DOCUMENTATION: 'documentation',
+} as const;

--- a/gravitee-apim-portal-webui-next/src/services/api.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api.service.spec.ts
@@ -19,6 +19,7 @@ import { TestBed } from '@angular/core/testing';
 import { ApiService } from './api.service';
 import { fakeApi, fakeApisResponse } from '../entities/api/api.fixtures';
 import { ApisResponse } from '../entities/api/apis-response';
+import { PortalApiViewParam } from '../entities/api/portal-api-view-param';
 import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
 describe('ApiService', () => {
@@ -77,7 +78,11 @@ describe('ApiService', () => {
         done();
       });
 
-      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/${apiId}?view=documentation`);
+      const req = httpTestingController.expectOne(
+        request =>
+          request.url === `${TESTING_BASE_URL}/apis/${apiId}` &&
+          request.params.get(PortalApiViewParam.QUERY_PARAM_NAME) === PortalApiViewParam.DOCUMENTATION,
+      );
       expect(req.request.method).toEqual('GET');
       req.flush(api);
     });

--- a/gravitee-apim-portal-webui-next/src/services/api.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api.service.ts
@@ -20,6 +20,7 @@ import { Observable } from 'rxjs';
 import { ConfigService } from './config.service';
 import { Api } from '../entities/api/api';
 import { ApisResponse } from '../entities/api/apis-response';
+import { PortalApiViewParam } from '../entities/api/portal-api-view-param';
 
 @Injectable({
   providedIn: 'root',
@@ -42,6 +43,8 @@ export class ApiService {
   }
 
   details(apiId: string): Observable<Api> {
-    return this.http.get<Api>(`${this.configService.baseURL}/apis/${apiId}?view=documentation`);
+    return this.http.get<Api>(`${this.configService.baseURL}/apis/${apiId}`, {
+      params: { [PortalApiViewParam.QUERY_PARAM_NAME]: PortalApiViewParam.DOCUMENTATION },
+    });
   }
 }

--- a/gravitee-apim-portal-webui-next/src/services/permissions.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/permissions.service.spec.ts
@@ -17,6 +17,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { PermissionsService } from './permissions.service';
+import { PortalApiViewParam } from '../entities/api/portal-api-view-param';
 import { fakeUserApiPermissions, fakeUserApplicationPermissions } from '../entities/permission/permission.fixtures';
 import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
@@ -49,7 +50,12 @@ describe('PermissionsService', () => {
       done();
     });
 
-    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/permissions?apiId=${apiId}`);
+    const req = httpTestingController.expectOne(
+      request =>
+        request.url === `${TESTING_BASE_URL}/permissions` &&
+        request.params.get('apiId') === apiId &&
+        request.params.get(PortalApiViewParam.QUERY_PARAM_NAME) === PortalApiViewParam.DOCUMENTATION,
+    );
     expect(req.request.method).toEqual('GET');
     req.flush(userApiPermissions);
   });

--- a/gravitee-apim-portal-webui-next/src/services/permissions.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/permissions.service.ts
@@ -18,6 +18,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { ConfigService } from './config.service';
+import { PortalApiViewParam } from '../entities/api/portal-api-view-param';
 import { UserApiPermissions, UserApplicationPermissions } from '../entities/permission/permission';
 
 @Injectable({
@@ -30,7 +31,9 @@ export class PermissionsService {
   ) {}
 
   getApiPermissions(apiId: string): Observable<UserApiPermissions> {
-    return this.http.get<UserApiPermissions>(`${this.configService.baseURL}/permissions`, { params: { apiId } });
+    return this.http.get<UserApiPermissions>(`${this.configService.baseURL}/permissions`, {
+      params: { apiId, [PortalApiViewParam.QUERY_PARAM_NAME]: PortalApiViewParam.DOCUMENTATION },
+    });
   }
 
   getApplicationPermissions(applicationId: string): Observable<UserApplicationPermissions> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
@@ -33,6 +33,7 @@ import io.gravitee.rest.api.portal.rest.mapper.PageMapper;
 import io.gravitee.rest.api.portal.rest.mapper.PlanMapper;
 import io.gravitee.rest.api.portal.rest.model.*;
 import io.gravitee.rest.api.portal.rest.model.Link.ResourceTypeEnum;
+import io.gravitee.rest.api.portal.rest.resource.param.PortalApiViewParam;
 import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import io.gravitee.rest.api.portal.rest.utils.HttpHeadersUtil;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
@@ -61,7 +62,6 @@ public class ApiResource extends AbstractResource {
 
     private static final String INCLUDE_PAGES = "pages";
     private static final String INCLUDE_PLANS = "plans";
-    private static final String VIEW_DOCUMENTATION = "documentation";
 
     @Context
     private ResourceContext resourceContext;
@@ -99,14 +99,14 @@ public class ApiResource extends AbstractResource {
     public Response getApiByApiId(
         @PathParam("apiId") String apiId,
         @QueryParam("include") List<String> include,
-        @QueryParam("view") String view
+        @QueryParam(PortalApiViewParam.QUERY_PARAM_NAME) String view
     ) {
         String username = getAuthenticatedUserOrNull();
 
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, apiId, false, false, true);
 
-        if (VIEW_DOCUMENTATION.equalsIgnoreCase(view)) {
+        if (PortalApiViewParam.isDocumentationView(view)) {
             var output = getApiForPortalUseCase.execute(
                 new GetApiForPortalUseCase.Input(executionContext.getEnvironmentId(), apiId, username)
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PermissionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PermissionsResource.java
@@ -15,11 +15,13 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.apim.core.api.use_case.GetApiForPortalUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.portal.rest.resource.param.PortalApiViewParam;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -48,13 +50,27 @@ public class PermissionsResource extends AbstractResource {
     @Inject
     private ApplicationService applicationService;
 
+    @Inject
+    private GetApiForPortalUseCase getApiForPortalUseCase;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getCurrentUserPermissions(@QueryParam("apiId") String apiId, @QueryParam("applicationId") String applicationId) {
+    public Response getCurrentUserPermissions(
+        @QueryParam("apiId") String apiId,
+        @QueryParam("applicationId") String applicationId,
+        @QueryParam(PortalApiViewParam.QUERY_PARAM_NAME) String view
+    ) {
         final String userId = getAuthenticatedUser();
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (apiId != null) {
-            if (!accessControlService.canAccessApiFromPortal(executionContext, apiId)) {
+            if (PortalApiViewParam.isDocumentationView(view)) {
+                var output = getApiForPortalUseCase.execute(
+                    new GetApiForPortalUseCase.Input(executionContext.getEnvironmentId(), apiId, getAuthenticatedUserOrNull())
+                );
+                if (!output.visible()) {
+                    throw new ApiNotFoundException(apiId);
+                }
+            } else if (!accessControlService.canAccessApiFromPortal(executionContext, apiId)) {
                 throw new ApiNotFoundException(apiId);
             }
             Map<String, char[]> permissions;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/param/PortalApiViewParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/param/PortalApiViewParam.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource.param;
+
+/**
+ * This parameter is used to control the visibility of APIs in the Next Gen Portal.
+ *
+ * Visibility rules take into account published state of the navigation item and public/private rules.
+ *
+ * The legacy API lifecycle PUBLISHED state is NOT taken into account.
+ */
+public final class PortalApiViewParam {
+
+    private PortalApiViewParam() {}
+
+    public static final String QUERY_PARAM_NAME = "view";
+
+    public static final String DOCUMENTATION = "documentation";
+
+    public static boolean isDocumentationView(String view) {
+        return view != null && DOCUMENTATION.equalsIgnoreCase(view);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -2578,6 +2578,7 @@ paths:
             parameters:
                 - $ref: "#/components/parameters/apiIdQueryParam"
                 - $ref: "#/components/parameters/applicationIdQueryParam"
+                - $ref: "#/components/parameters/apiViewParam"
             summary: Retrieve user's permissions
             description: |
                 Retrieve user's permissions.
@@ -3616,7 +3617,7 @@ components:
             name: view
             in: query
             required: false
-            description: Controls API visibility scope. When set to documentation, visibility is determined by NG Portal visibility rules.
+            description: Controls API visibility scope. When set to documentation, API visibility is determined by Next Gen Portal visibility rules; otherwise, Classic Portal visibility rules apply.
             schema:
                 $ref: "#/components/schemas/ApiView"
         ratingOrderQueryParam:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
@@ -37,6 +37,7 @@ import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.portal.rest.model.*;
 import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.portal.rest.model.Link.ResourceTypeEnum;
+import io.gravitee.rest.api.portal.rest.resource.param.PortalApiViewParam;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
@@ -366,7 +367,10 @@ public class ApiResourceTest extends AbstractResourceTest {
             )
         );
 
-        final Response response = target(API).queryParam("view", "documentation").request().get();
+        final Response response = target(API)
+            .queryParam(PortalApiViewParam.QUERY_PARAM_NAME, PortalApiViewParam.DOCUMENTATION)
+            .request()
+            .get();
 
         assertEquals(OK_200, response.getStatus());
         final Api responseApi = response.readEntity(Api.class);
@@ -391,7 +395,10 @@ public class ApiResourceTest extends AbstractResourceTest {
             )
         );
 
-        final Response response = target(API).queryParam("view", "documentation").request().get();
+        final Response response = target(API)
+            .queryParam(PortalApiViewParam.QUERY_PARAM_NAME, PortalApiViewParam.DOCUMENTATION)
+            .request()
+            .get();
 
         assertEquals(NOT_FOUND_404, response.getStatus());
         ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
@@ -431,7 +438,10 @@ public class ApiResourceTest extends AbstractResourceTest {
             )
         );
 
-        final Response response = target(API).queryParam("view", "documentation").request().get();
+        final Response response = target(API)
+            .queryParam(PortalApiViewParam.QUERY_PARAM_NAME, PortalApiViewParam.DOCUMENTATION)
+            .request()
+            .get();
 
         assertEquals(OK_200, response.getStatus());
         final Api responseApi = response.readEntity(Api.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PermissionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PermissionsResourceTest.java
@@ -18,24 +18,36 @@ package io.gravitee.rest.api.portal.rest.resource;
 import static io.gravitee.common.http.HttpStatusCode.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import io.gravitee.rest.api.portal.rest.resource.param.PortalApiViewParam;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.Response;
 import java.util.*;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
@@ -45,9 +57,22 @@ public class PermissionsResourceTest extends AbstractResourceTest {
 
     private static final String API = "my-api";
     private static final String APPLICATION = "my-app";
+    private static final String ENV_ID = "DEFAULT";
+
+    @Autowired
+    private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
+
+    @Autowired
+    private MembershipQueryServiceInMemory membershipQueryService;
 
     protected String contextPath() {
         return "permissions/";
+    }
+
+    @AfterEach
+    void tear_down_portal_navigation_state() {
+        portalNavigationItemsQueryService.reset();
+        membershipQueryService.reset();
     }
 
     @BeforeEach
@@ -136,5 +161,124 @@ public class PermissionsResourceTest extends AbstractResourceTest {
         assertEquals(OK_200, response.getStatus());
         final Map permissionsResponse = response.readEntity(Map.class);
         assertNotNull(permissionsResponse);
+    }
+
+    @Test
+    void should_return_permissions_with_documentation_view_when_can_access_from_portal_is_false_but_api_visible_in_nav() {
+        when(accessControlService.canAccessApiFromPortal(GraviteeContext.getExecutionContext(), API)).thenReturn(false);
+        portalNavigationItemsQueryService.initWith(
+            List.of(
+                PortalNavigationApi.builder()
+                    .id(PortalNavigationItemId.random())
+                    .organizationId("DEFAULT")
+                    .environmentId(ENV_ID)
+                    .title("Nav for " + API)
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .apiId(API)
+                    .published(true)
+                    .visibility(PortalVisibility.PUBLIC)
+                    .build()
+            )
+        );
+
+        final Response response = target()
+            .queryParam("apiId", API)
+            .queryParam(PortalApiViewParam.QUERY_PARAM_NAME, PortalApiViewParam.DOCUMENTATION)
+            .request()
+            .get();
+
+        assertEquals(OK_200, response.getStatus());
+        assertNotNull(response.readEntity(Map.class));
+    }
+
+    @Test
+    void should_return_not_found_with_documentation_view_when_api_not_visible_in_nav() {
+        portalNavigationItemsQueryService.initWith(
+            List.of(
+                PortalNavigationApi.builder()
+                    .id(PortalNavigationItemId.random())
+                    .organizationId("DEFAULT")
+                    .environmentId(ENV_ID)
+                    .title("Nav for " + API)
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .apiId(API)
+                    .published(true)
+                    .visibility(PortalVisibility.PRIVATE)
+                    .build()
+            )
+        );
+
+        final Response response = target()
+            .queryParam("apiId", API)
+            .queryParam(PortalApiViewParam.QUERY_PARAM_NAME, PortalApiViewParam.DOCUMENTATION)
+            .request()
+            .get();
+
+        assertEquals(NOT_FOUND_404, response.getStatus());
+        List<Error> errors = response.readEntity(ErrorResponse.class).getErrors();
+        assertEquals("errors.api.notFound", errors.get(0).getCode());
+    }
+
+    @Test
+    void should_fall_back_to_legacy_access_control_when_view_is_not_documentation() {
+        final Response response = target().queryParam("apiId", API).queryParam(PortalApiViewParam.QUERY_PARAM_NAME, "foo").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        verify(accessControlService).canAccessApiFromPortal(GraviteeContext.getExecutionContext(), API);
+    }
+
+    @Test
+    void should_ignore_view_param_for_application_permissions() {
+        final Response response = target()
+            .queryParam("applicationId", APPLICATION)
+            .queryParam(PortalApiViewParam.QUERY_PARAM_NAME, PortalApiViewParam.DOCUMENTATION)
+            .request()
+            .get();
+
+        assertEquals(OK_200, response.getStatus());
+        Map permissionsResponse = response.readEntity(Map.class);
+        assertTrue(permissionsResponse.containsKey("APPLICATION"));
+    }
+
+    @Test
+    void should_return_permissions_with_documentation_view_when_private_nav_and_user_is_member() {
+        when(accessControlService.canAccessApiFromPortal(GraviteeContext.getExecutionContext(), API)).thenReturn(false);
+        portalNavigationItemsQueryService.initWith(
+            List.of(
+                PortalNavigationApi.builder()
+                    .id(PortalNavigationItemId.random())
+                    .organizationId("DEFAULT")
+                    .environmentId(ENV_ID)
+                    .title("Nav for " + API)
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .apiId(API)
+                    .published(true)
+                    .visibility(PortalVisibility.PRIVATE)
+                    .build()
+            )
+        );
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("membership-" + USER_NAME + "-" + API)
+                    .memberId(USER_NAME)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API)
+                    .referenceId(API)
+                    .build()
+            )
+        );
+
+        final Response response = target()
+            .queryParam("apiId", API)
+            .queryParam(PortalApiViewParam.QUERY_PARAM_NAME, PortalApiViewParam.DOCUMENTATION)
+            .request()
+            .get();
+
+        assertEquals(OK_200, response.getStatus());
+        assertNotNull(response.readEntity(Map.class));
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13277

## Description

This PR follows the work done in this PR https://github.com/gravitee-io/gravitee-api-management/pull/15702

**Bugfix:** Subscription details in NG portal fails to load when the API nav item is visible via NG portal nav but API is not PUBLISHED, the `permissions` request uses `canAccessApiFromPortal` while `GET /apis/{id}?view=documentation` does not.

**Change:** `GET /permissions` accepts optional `view=documentation` and gates with `GetApiForPortalUseCase`, same as the API resource; default path unchanged.

**Verify:** Open subscription details for such an API; expect the screen to load. Without `view`, behavior stays Classic.