### PR TITLE
fix: export API categories by name

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CategoryDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/CategoryDomainService.java
@@ -16,7 +16,6 @@
 package io.gravitee.apim.core.api.domain_service;
 
 import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.repository.exceptions.TechnicalException;
 import java.util.Collection;
 import java.util.Set;
 
@@ -27,6 +26,8 @@ import java.util.Set;
 public interface CategoryDomainService {
     Set<String> toCategoryId(Api api, String environmentId);
     Set<String> toCategoryKey(Api api, String environmentId);
+
+    Set<String> resolveToCategoryIds(String environmentId, Set<String> categoryIdsOrKeys);
 
     void updateOrderCategoriesOfApi(String apiId, Collection<String> categoryIds);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ImportDefinitionCreateDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ImportDefinitionCreateDomainService.java
@@ -19,6 +19,7 @@ import static io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService.o
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api.exception.ApiCreatedWithErrorException;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.api.model.NewApiMetadata;
 import io.gravitee.apim.core.api.model.factory.ApiModelFactory;
@@ -67,6 +68,7 @@ public class ImportDefinitionCreateDomainService {
     private final ApiIdsCalculatorDomainService apiIdsCalculatorDomainService;
     private final MetadataCrudService metadataCrudService;
     private final DocumentationValidationDomainService documentationValidationDomainService;
+    private final CategoryDomainService categoryDomainService;
 
     public ImportDefinitionCreateDomainService(
         ApiImportDomainService apiImportDomainService,
@@ -78,7 +80,8 @@ public class ImportDefinitionCreateDomainService {
         CreateApiDocumentationDomainService createApiDocumentationDomainService,
         ApiIdsCalculatorDomainService apiIdsCalculatorDomainService,
         MetadataCrudService metadataCrudService,
-        DocumentationValidationDomainService documentationValidationDomainService
+        DocumentationValidationDomainService documentationValidationDomainService,
+        CategoryDomainService categoryDomainService
     ) {
         this.apiImportDomainService = apiImportDomainService;
         this.apiPrimaryOwnerFactory = apiPrimaryOwnerFactory;
@@ -90,6 +93,7 @@ public class ImportDefinitionCreateDomainService {
         this.apiIdsCalculatorDomainService = apiIdsCalculatorDomainService;
         this.metadataCrudService = metadataCrudService;
         this.documentationValidationDomainService = documentationValidationDomainService;
+        this.categoryDomainService = categoryDomainService;
     }
 
     public ApiWithFlows create(AuditInfo auditInfo, ImportDefinition importDefinition) {
@@ -102,11 +106,14 @@ public class ImportDefinitionCreateDomainService {
             .orElse(auditInfo.actor().userId());
         PrimaryOwnerEntity primaryOwner = resolvePrimaryOwner(organizationId, environmentId, primaryOwnerId, auditInfo);
         var apiWithIds = apiIdsCalculatorDomainService.recalculateApiDefinitionIds(environmentId, importDefinition);
+        var api = ApiModelFactory.fromApiExport(apiWithIds.getApiExport(), environmentId);
+        var apiWithResolvedCategories = resolveCategoriesForImport(api, environmentId);
         var createdApi = createApiDomainService.create(
-            ApiModelFactory.fromApiExport(apiWithIds.getApiExport(), environmentId),
+            apiWithResolvedCategories,
             primaryOwner,
             auditInfo,
-            api -> validateApiDomainService.validateAndSanitizeForCreation(api, primaryOwner, environmentId, organizationId),
+            apiToValidate ->
+                validateApiDomainService.validateAndSanitizeForCreation(apiToValidate, primaryOwner, environmentId, organizationId),
             oneShotIndexation(auditInfo)
         );
 
@@ -119,6 +126,14 @@ public class ImportDefinitionCreateDomainService {
             .createAll();
 
         return createdApi;
+    }
+
+    private Api resolveCategoriesForImport(Api api, String environmentId) {
+        if (api.getCategories() == null || api.getCategories().isEmpty()) {
+            return api;
+        }
+        var resolvedIds = categoryDomainService.resolveToCategoryIds(environmentId, api.getCategories());
+        return resolvedIds != null ? api.toBuilder().categories(resolvedIds).build() : api;
     }
 
     private PrimaryOwnerEntity resolvePrimaryOwner(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImpl.java
@@ -34,6 +34,7 @@ import io.gravitee.apim.core.api.model.import_definition.ApiMember;
 import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
 import io.gravitee.apim.core.api.model.import_definition.PageExport;
 import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
+import io.gravitee.apim.core.api.query_service.ApiCategoryQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.Excludable;
 import io.gravitee.apim.core.documentation.query_service.PageQueryService;
@@ -93,6 +94,7 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
     private final PlanCrudService planCrudService;
     private final IntegrationCrudService integrationCrudService;
     private final FlowCrudService flowCrudService;
+    private final ApiCategoryQueryService apiCategoryQueryService;
 
     @Override
     public GraviteeDefinition export(String apiId, AuditInfo auditInfo, Collection<Excludable> excluded) {
@@ -129,14 +131,16 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
                 Function<Plan, PlanDescriptor.V4> mapPlanV4 = DEFINITION_ADAPTER::mapPlanV4;
                 var plans = mapPlan(apiId, mapPlanV4.andThen(this::planWithFlowV4), excluded);
                 var flows = flowCrudService.getApiV4Flows(apiId);
-                var api = DEFINITION_ADAPTER.mapV4(api1, apiPrimaryOwner, workflowState, groups, metadata, flows);
+                var apiWithCategoryKeys = apiWithCategoryKeys(api1);
+                var api = DEFINITION_ADAPTER.mapV4(apiWithCategoryKeys, apiPrimaryOwner, workflowState, groups, metadata, flows);
                 yield GraviteeDefinition.from(api, members, metadata, pages, plans, medias, api1.getPicture(), api1.getBackground());
             }
             case V4_NATIVE -> {
                 Function<Plan, PlanDescriptor.Native> mapPlanNative = DEFINITION_ADAPTER::mapPlanNative;
                 var plans = mapPlan(apiId, mapPlanNative.andThen(this::planWithFlowNative), excluded);
                 var flows = flowCrudService.getNativeApiFlows(apiId);
-                var api = DEFINITION_ADAPTER.mapNative(api1, apiPrimaryOwner, workflowState, groups, metadata, flows);
+                var apiWithCategoryKeys = apiWithCategoryKeys(api1);
+                var api = DEFINITION_ADAPTER.mapNative(apiWithCategoryKeys, apiPrimaryOwner, workflowState, groups, metadata, flows);
                 yield GraviteeDefinition.from(api, members, metadata, pages, plans, medias, api1.getPicture(), api1.getBackground());
             }
             case FEDERATED -> {
@@ -248,5 +252,13 @@ public class ApiExportDomainServiceImpl implements ApiExportDomainService {
 
     private PlanDescriptor.Native planWithFlowNative(PlanDescriptor.Native planNative) {
         return planNative.withFlow(flowCrudService.getNativePlanFlows(planNative.id()));
+    }
+
+    private Api apiWithCategoryKeys(Api api) {
+        var categoryKeys = apiCategoryQueryService.findApiCategoryKeys(api);
+        if (categoryKeys.isEmpty() && (api.getCategories() == null || api.getCategories().isEmpty())) {
+            return api;
+        }
+        return api.toBuilder().categories(Set.copyOf(categoryKeys)).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/CategoryDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/CategoryDomainServiceImpl.java
@@ -57,6 +57,11 @@ public class CategoryDomainServiceImpl implements CategoryDomainService {
     }
 
     @Override
+    public Set<String> resolveToCategoryIds(String environmentId, Set<String> categoryIdsOrKeys) {
+        return categoryMapper.toCategoryId(environmentId, categoryIdsOrKeys);
+    }
+
+    @Override
     public void updateOrderCategoriesOfApi(String apiId, @Nullable Collection<String> categoryIds) {
         try {
             var previousCategories = apiCategoryOrderRepository.findAllByApiId(apiId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/initializers/ImportDefinitionCreateDomainServiceTestInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/initializers/ImportDefinitionCreateDomainServiceTestInitializer.java
@@ -22,6 +22,8 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiMetadataQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
+import inmemory.CategoryDomainServiceInMemory;
+import inmemory.CategoryQueryServiceInMemory;
 import inmemory.CreateCategoryApiDomainServiceInMemory;
 import inmemory.EntrypointPluginQueryServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
@@ -48,6 +50,7 @@ import io.gravitee.apim.core.api.domain_service.ApiImportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiIndexerDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
+import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ImportDefinitionCreateDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
@@ -109,6 +112,7 @@ public class ImportDefinitionCreateDomainServiceTestInitializer {
     public final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
     public final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
     public final CreateCategoryApiDomainService createCategoryApiDomainService = new CreateCategoryApiDomainServiceInMemory();
+    public final CategoryDomainService categoryDomainService = new CategoryDomainServiceInMemory(new CategoryQueryServiceInMemory());
 
     public ImportDefinitionCreateDomainServiceTestInitializer(ApiCrudServiceInMemory apiCrudService) {
         var membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
@@ -214,7 +218,8 @@ public class ImportDefinitionCreateDomainServiceTestInitializer {
             createApiDocumentationDomainService,
             apiIdsCalculatorDomainService,
             metadataCrudService,
-            documentationValidationDomainService
+            documentationValidationDomainService,
+            categoryDomainService
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/CategoryDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/CategoryDomainServiceInMemory.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * In-memory implementation of CategoryDomainService for tests.
+ * Uses CategoryQueryServiceInMemory for resolveToCategoryIds.
+ */
+public class CategoryDomainServiceInMemory implements CategoryDomainService {
+
+    private final CategoryQueryServiceInMemory categoryQueryService;
+
+    public CategoryDomainServiceInMemory() {
+        this(new CategoryQueryServiceInMemory());
+    }
+
+    public CategoryDomainServiceInMemory(CategoryQueryServiceInMemory categoryQueryService) {
+        this.categoryQueryService = categoryQueryService;
+    }
+
+    @Override
+    public Set<String> toCategoryId(Api api, String environmentId) {
+        return resolveToCategoryIds(environmentId, api.getCategories());
+    }
+
+    @Override
+    public Set<String> toCategoryKey(Api api, String environmentId) {
+        if (api.getCategories() == null || api.getCategories().isEmpty()) {
+            return api.getCategories();
+        }
+        return api
+            .getCategories()
+            .stream()
+            .map(idOrKey -> categoryQueryService.findByIdOrKey(idOrKey, environmentId))
+            .filter(java.util.Optional::isPresent)
+            .map(opt -> opt.get().getKey())
+            .filter(key -> key != null)
+            .collect(Collectors.toCollection(HashSet::new));
+    }
+
+    @Override
+    public Set<String> resolveToCategoryIds(String environmentId, Set<String> categoryIdsOrKeys) {
+        if (CollectionUtils.isEmpty(categoryIdsOrKeys)) {
+            return categoryIdsOrKeys;
+        }
+        return categoryIdsOrKeys
+            .stream()
+            .map(idOrKey -> categoryQueryService.findByIdOrKey(idOrKey, environmentId))
+            .filter(java.util.Optional::isPresent)
+            .map(opt -> opt.get().getId())
+            .collect(Collectors.toCollection(HashSet::new));
+    }
+
+    @Override
+    public void updateOrderCategoriesOfApi(String apiId, Collection<String> categoryIds) {
+        // No-op for in-memory tests; ApiCategoryOrderRepository is used elsewhere
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ExportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ExportApiUseCaseTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
+import inmemory.ApiCategoryQueryServiceInMemory;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
@@ -101,6 +102,7 @@ class ExportApiUseCaseTest {
     PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
     IntegrationCrudServiceInMemory integrationCrudService = new IntegrationCrudServiceInMemory();
     FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
+    ApiCategoryQueryServiceInMemory apiCategoryQueryService = new ApiCategoryQueryServiceInMemory();
 
     ApiExportDomainService apiExportDomainService;
 
@@ -133,7 +135,8 @@ class ExportApiUseCaseTest {
             apiPrimaryOwnerDomainService,
             planCrudService,
             integrationCrudService,
-            flowCrudService
+            flowCrudService,
+            apiCategoryQueryService
         );
         sut = new ExportApiUseCase(apiExportDomainService);
         roleQueryService.initWith(
@@ -176,7 +179,8 @@ class ExportApiUseCaseTest {
             apiCrudService,
             planCrudService,
             integrationCrudService,
-            flowCrudService
+            flowCrudService,
+            apiCategoryQueryService
         ).forEach(InMemoryAlternative::reset);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImplTest.java
@@ -34,6 +34,7 @@ import io.gravitee.apim.core.api.model.import_definition.ApiMemberRole;
 import io.gravitee.apim.core.api.model.import_definition.GraviteeDefinition;
 import io.gravitee.apim.core.api.model.import_definition.PageExport;
 import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
+import io.gravitee.apim.core.api.query_service.ApiCategoryQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.Excludable;
 import io.gravitee.apim.core.documentation.model.AccessControl;
@@ -151,6 +152,9 @@ class ApiExportDomainServiceImplTest {
     @Mock
     IntegrationCrudService integrationCrudService;
 
+    @Mock
+    ApiCategoryQueryService apiCategoryQueryService;
+
     @InjectMocks
     ApiExportDomainServiceImpl sut;
 
@@ -167,6 +171,7 @@ class ApiExportDomainServiceImplTest {
                 )
             )
             .thenReturn(true);
+        lenient().when(apiCategoryQueryService.findApiCategoryKeys(any(Api.class))).thenReturn(List.of());
     }
 
     @AfterEach
@@ -247,6 +252,53 @@ class ApiExportDomainServiceImplTest {
                 assertThat(dynamicProperty.getType()).isEqualTo("http-dynamic-properties");
                 assertThat(dynamicProperty.getConfiguration()).isEqualTo(configuration);
             });
+    }
+
+    @Test
+    void should_export_v4_api_categories_as_keys_not_ids() {
+        // Given
+        String apiId = UUID.randomUUID().toString();
+        Api api = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .id(apiId)
+            .environmentId("DEFAULT")
+            .categories(Set.of("cat-id-1", "cat-id-2"))
+            .build();
+        when(apiCrudService.findById(anyString())).thenReturn(Optional.of(api));
+        when(apiCategoryQueryService.findApiCategoryKeys(any(Api.class))).thenReturn(List.of("proxy", "common"));
+
+        // When
+        GraviteeDefinition export = sut.export(
+            apiId,
+            AuditInfo.builder().environmentId("DEFAULT").build(),
+            EnumSet.noneOf(Excludable.class)
+        );
+
+        // Then
+        assertThat(export.api().categories())
+            .as("V4 API must export categories as keys/names, not internal IDs")
+            .containsExactlyInAnyOrder("proxy", "common");
+    }
+
+    @Test
+    void should_export_v4_native_api_categories_as_keys_not_ids() {
+        // Given
+        String apiId = UUID.randomUUID().toString();
+        Api api = ApiFixtures.aNativeApi().toBuilder().environmentId("DEFAULT").categories(Set.of("cat-id-native")).build();
+        when(apiCrudService.findById(anyString())).thenReturn(Optional.of(api));
+        when(apiCategoryQueryService.findApiCategoryKeys(any(Api.class))).thenReturn(List.of("native-key"));
+
+        // When
+        GraviteeDefinition export = sut.export(
+            apiId,
+            AuditInfo.builder().environmentId("DEFAULT").build(),
+            EnumSet.noneOf(Excludable.class)
+        );
+
+        // Then
+        assertThat(export.api().categories())
+            .as("V4 native API must export categories as keys/names, not internal IDs")
+            .containsExactly("native-key");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11792

## Description


Area | File | Change
-- | -- | --
Export | ApiExportDomainServiceImpl.java | Injected ApiCategoryQueryService; for V4 and V4_NATIVE, use apiWithCategoryKeys() to convert category IDs to keys before export so definitions are portable across environments.
Domain Service | CategoryDomainService.java | Added resolveToCategoryIds(String environmentId, Set<String> categoryIdsOrKeys).
Domain Service | CategoryDomainServiceImpl.java | Implemented resolveToCategoryIds() by delegating to CategoryMapper.toCategoryId().
Import | ImportDefinitionCreateDomainService.java | Injected CategoryDomainService; before create, resolve category keys to IDs via resolveCategoriesForImport() so imports keep category associations when using keys in the export.


After fix: 
<img width="1035" height="809" alt="image" src="https://github.com/user-attachments/assets/0c9ab8b1-9dbf-4d64-bd19-32be9378f9dd" />


<img width="1035" height="809" alt="image" src="https://github.com/user-attachments/assets/4b21bf1d-bae6-4ba4-bfcd-6ac96af26cbc" />


