### PR TITLE
fix: redirect to 404 from subscribe page when api is unpublished.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/resolvers/api.resolver.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/resolvers/api.resolver.spec.ts
@@ -13,21 +13,55 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpErrorResponse } from '@angular/common/http';
+import { ApplicationRef, Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { ResolveFn } from '@angular/router';
+import { NavigationEnd, provideRouter, Router } from '@angular/router';
+import { filter, firstValueFrom, take, throwError } from 'rxjs';
 
 import { apiResolver } from './api.resolver';
-import { Api } from '../entities/api/api';
+import { ApiService } from '../services/api.service';
 
 describe('apiResolver', () => {
-  const executeResolver: ResolveFn<Api> = (...resolverParameters) =>
-    TestBed.runInInjectionContext(() => apiResolver(...resolverParameters));
+  @Component({ standalone: true, template: '' })
+  class StubComponent {}
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
+  let router: Router;
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      providers: [
+        provideRouter([
+          { path: 'api/:apiId', component: StubComponent, resolve: { api: apiResolver } },
+          { path: '404', component: StubComponent },
+        ]),
+        {
+          provide: ApiService,
+          useValue: {
+            details: jest.fn().mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404, statusText: 'Not Found' }))),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
   });
 
-  it('should be created', () => {
-    expect(executeResolver).toBeTruthy();
+  it('should end navigation on /404 when api details return 404', async () => {
+    const navigatedTo404 = firstValueFrom(
+      router.events.pipe(
+        filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+        filter(e => e.urlAfterRedirects === '/404'),
+        take(1),
+      ),
+    );
+
+    router.navigateByUrl('/api/unknown');
+
+    await navigatedTo404;
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(router.url).toBe('/404');
   });
 });

--- a/gravitee-apim-portal-webui-next/src/resolvers/api.resolver.ts
+++ b/gravitee-apim-portal-webui-next/src/resolvers/api.resolver.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, ResolveFn, RouterStateSnapshot } from '@angular/router';
-import { Observable } from 'rxjs';
+import { ActivatedRouteSnapshot, ResolveFn, Router, RouterStateSnapshot } from '@angular/router';
+import { catchError, EMPTY, Observable } from 'rxjs';
 
 import { Api } from '../entities/api/api';
 import { ApiService } from '../services/api.service';
@@ -24,4 +25,14 @@ export const apiResolver = ((
   route: ActivatedRouteSnapshot,
   _: RouterStateSnapshot,
   apiService: ApiService = inject(ApiService),
-): Observable<Api> => apiService.details(route.params['apiId'])) satisfies ResolveFn<Api>;
+  router: Router = inject(Router),
+): Observable<Api> =>
+  apiService.details(route.params['apiId']).pipe(
+    catchError((err: unknown) => {
+      if (err instanceof HttpErrorResponse && err.status === 404) {
+        void router.navigate(['/404']);
+        return EMPTY;
+      }
+      throw err;
+    }),
+  )) satisfies ResolveFn<Api>;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13287

## Description

Fix a case when an API is unpublished and the subscribe page is accessed by URL and appears empty.


https://github.com/user-attachments/assets/137a4b61-611c-4f33-814a-ccc2b3c69a06

