### PR TITLE
Update logs filter to avoid over-escaping URI special characters

### DIFF
--- a/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.spec.ts
+++ b/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.spec.ts
@@ -512,8 +512,7 @@ describe('LogsFiltersController', () => {
 
       const query = controller['buildQuery'](filters);
 
-      // The buildQuery escapes forward slashes, so / becomes \\/
-      expect(query).toContain('uri:\\\\/test\\\\/path*');
+      expect(query).toContain('uri:/test/path*');
     });
 
     it('should add trailing asterisk to uri if missing', () => {
@@ -523,8 +522,7 @@ describe('LogsFiltersController', () => {
 
       const query = controller['buildQuery'](filters);
 
-      // The buildQuery escapes forward slashes, so / becomes \\/
-      expect(query).toContain('uri:\\\\/test\\\\/path*');
+      expect(query).toContain('uri:/test/path*');
     });
 
     it('should escape special characters in uri', () => {
@@ -534,7 +532,8 @@ describe('LogsFiltersController', () => {
 
       const query = controller['buildQuery'](filters);
 
-      expect(query).toContain('\\+');
+      expect(query).toContain(String.raw`uri:/test\\+path*`);
+      expect(query).not.toContain('uri:/test path*');
     });
 
     it('should wrap body filter with wildcards', () => {

--- a/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts
+++ b/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts
@@ -357,9 +357,10 @@ class LogsFiltersController {
       }
 
       // 2. escape reserved characters
-      // + - = && || > < ! ( ) { } [ ] ^ " ~ ? : \ /
+      // + = && || > < ! ( ) { } [ ] ^ " ~ ? : \
+      const escapeSequenceRegex = /(&{2}|\|{2}|[+=><!(){}[\]^"~?:\\])/g;
       if (typeof val === 'string' || val instanceof String) {
-        val = val.replace(/(\+|-|=|&{2}|\|{2}|>|<|!|\(|\)|{|}|\[|]|\^|"|~|\?|:|\\|\/)/g, '\\\\$1');
+        val = val.replaceAll(escapeSequenceRegex, String.raw`\\$1`);
       }
 
       // 3. add the last * for uri


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13241

## Description

Updating the regex to support accepting forward slashes and hyphen. 

## Additional context

Prefix behaviour: 


https://github.com/user-attachments/assets/4f0c920d-ccf6-4924-b611-3fe595559926



Post fix behaviour: 

https://github.com/user-attachments/assets/cbf55698-b94d-4b59-ab0e-464476964c55



