### PR TITLE
fix:Webhook Logs toggle not updated after save/publish

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/webhook-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/webhook-logs.component.ts
@@ -16,8 +16,8 @@
 import { isNumber } from 'angular';
 
 import { Component, inject, OnInit } from '@angular/core';
-import { map, shareReplay, switchMap, take, catchError, finalize } from 'rxjs/operators';
-import { ReplaySubject, of, Observable } from 'rxjs';
+import { map, switchMap, take, catchError, finalize } from 'rxjs/operators';
+import { ReplaySubject, of, Observable, EMPTY } from 'rxjs';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
@@ -75,7 +75,8 @@ export class WebhookLogsComponent implements OnInit {
   private readonly applicationService = inject(ApplicationService);
   private readonly dialog = inject(MatDialog);
   private readonly snackBarService = inject(SnackBarService);
-  private readonly api$ = this.apiService.get(this.activatedRoute.snapshot.params.apiId).pipe(shareReplay(1));
+  private readonly apiSubject$ = new ReplaySubject<Api>(1);
+  private readonly api$: Observable<Api> = this.apiSubject$.asObservable();
 
   isReportingDisabled$ = this.api$.pipe(
     map((api) => {
@@ -108,6 +109,7 @@ export class WebhookLogsComponent implements OnInit {
   loading = false;
 
   ngOnInit(): void {
+    this.loadApi();
     const qp = this.activatedRoute.snapshot.queryParams;
 
     const initialStatuses = qp?.statuses
@@ -559,6 +561,7 @@ export class WebhookLogsComponent implements OnInit {
       )
       .subscribe((result) => {
         if (result?.saved) {
+          this.loadApi();
           const qp = this.activatedRoute.snapshot.queryParams;
           const page = qp?.page ? Number(qp.page) : 1;
           const perPage = qp?.perPage ? Number(qp.perPage) : 10;
@@ -608,6 +611,19 @@ export class WebhookLogsComponent implements OnInit {
 
   private isApiV4(api: Api): api is ApiV4 {
     return api?.definitionVersion === 'V4';
+  }
+
+  private loadApi(): void {
+    this.apiService
+      .get(this.activatedRoute.snapshot.params.apiId)
+      .pipe(
+        take(1),
+        catchError(() => {
+          this.snackBarService.error('Failed to load API settings');
+          return EMPTY;
+        }),
+      )
+      .subscribe((api) => this.apiSubject$.next(api));
   }
 
   /**

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/webhook-logs.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/webhook-logs.spec.ts
@@ -23,6 +23,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of, firstValueFrom } from 'rxjs';
 import { HarnessLoader } from '@angular/cdk/testing';
+import { MatDialog } from '@angular/material/dialog';
 
 import { WebhookLogsComponent } from './webhook-logs.component';
 import { WebhookLogsHarness } from './webhook-logs.harness';
@@ -352,6 +353,77 @@ describe('WebhookLogsComponent', () => {
 
     const dialog = await rootLoader.getHarness(WebhookSettingsDialogHarness);
     expect(dialog).not.toBeNull();
+  });
+
+  it('should re-fetch API after settings dialog is saved and pass updated data to the next dialog open', async () => {
+    // API with webhook logging initially disabled
+    const disabledWebhookApi = {
+      ...defaultApi,
+      listeners: [
+        {
+          type: 'SUBSCRIPTION',
+          entrypoints: [{ type: 'webhook', configuration: { logging: { enabled: false } } }],
+        },
+      ],
+    } as ApiV4;
+    await setupComponent({ api: disabledWebhookApi });
+
+    const updatedApi = {
+      ...disabledWebhookApi,
+      listeners: [
+        {
+          type: 'SUBSCRIPTION',
+          entrypoints: [{ type: 'webhook', configuration: { logging: { enabled: true } } }],
+        },
+      ],
+    } as ApiV4;
+
+    // Open the real settings dialog
+    await harness.clickConfigureReporting();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Simulate a successful save by closing the dialog with { saved: true }
+    const matDialog = TestBed.inject(MatDialog);
+    matDialog.openDialogs[0].close({ saved: true });
+    fixture.detectChanges();
+
+    // Drain Zone.js tasks so that afterClosed() emits and triggers loadApi() + loadWebhookLogs()
+    await fixture.whenStable();
+
+    // Handle the GET request triggered by loadApi() after dialog close
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env?.v2BaseURL}/apis/${API_ID}`, method: 'GET' }).flush(updatedApi);
+
+    // Also handle the loadWebhookLogs request triggered alongside the refresh
+    expectWebhookLogs();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Open the dialog a second time — it must receive the updated (re-fetched) API.
+    // Spy directly on the component's injected dialog instance to ensure we intercept the right object.
+    const componentDialog = (fixture.componentInstance as any)['dialog'];
+    const openSpy = jest.spyOn(componentDialog, 'open').mockReturnValue({ afterClosed: () => of(undefined) } as any);
+    fixture.componentInstance.openSettingsDialog();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(openSpy).toHaveBeenCalledWith(
+      WebhookSettingsDialogComponent,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          api: expect.objectContaining({
+            listeners: expect.arrayContaining([
+              expect.objectContaining({
+                entrypoints: expect.arrayContaining([
+                  expect.objectContaining({ configuration: expect.objectContaining({ logging: { enabled: true } }) }),
+                ]),
+              }),
+            ]),
+          }),
+        }),
+      }),
+    );
   });
 
   it('should show the reporting disabled banner when entrypoint logging is disabled', async () => {


### PR DESCRIPTION
This PR addresses a UI state synchronization bug where the Webhook Logs reporting toggle (and potentially other API settings) fails to reflect the correct state immediately after a Save and Publish action.
The root cause was  data stream using shareReplay(1). This cached the initial API definition and prevented the UI from reflecting updates sent to the backend until a manual browser refresh was performed.
Changes:
The proposed fix addresses the state-synchronization lag by replacing the static, performance-cached api$ observable with a dynamic ReplaySubject<Api>(1). This architectural shift decouples the data stream from the initial HTTP request, allowing the UI to remain subscribed to a consistent observable while the underlying data is updated in the background. To manage this, a new loadApi() method was introduced to explicitly fetch the latest API definition from the apiService using a take(1) pipe for memory efficiency. This method is now integrated into two critical lifecycle points: first in ngOnInit() for the initial page load, and again within the openSettingsDialog() success callback. By triggering this re-fetch immediately after a successful save (result?.saved), the local UI state is forced to synchronize with the Management API's truth, ensuring the Webhook Logs toggle accurately reflects the enabled state without requiring a manual browser refresh.