### PR TITLE
fix: truncate "included in" API product names over 20 chars with ellipsis

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -167,7 +167,7 @@
                     @let displayedProducts = apiProducts().slice(0, displayedApiProductsCount);
                     @let remainingCount = apiProducts().length - displayedApiProductsCount;
                     @for (product of displayedProducts; track product.id) {
-                      {{ product.name }}
+                      {{ truncatedProductNameForList(product.name) }}
                       @if (!$last) {
                         ,
                       }

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
@@ -115,6 +115,8 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
 
   public readonly displayedApiProductsCount = 5;
 
+  private static readonly MAX_PRODUCT_NAME_DISPLAY_LENGTH = 20;
+
   private readonly destroyRef = inject(DestroyRef);
 
   constructor(
@@ -305,6 +307,14 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
+  }
+
+  truncatedProductNameForList(name: string | null | undefined): string {
+    const full = name ?? '';
+    if (full.length <= ApiGeneralInfoComponent.MAX_PRODUCT_NAME_DISPLAY_LENGTH) {
+      return full;
+    }
+    return full.slice(0, ApiGeneralInfoComponent.MAX_PRODUCT_NAME_DISPLAY_LENGTH) + '…';
   }
 
   openIncludedInDialog(): void {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13291

## Description

<img width="1727" height="925" alt="Screenshot 2026-03-23 at 9 44 42 PM" src="https://github.com/user-attachments/assets/12948627-2a73-4323-95e7-0d373813798a" />

<img width="1726" height="918" alt="Screenshot 2026-03-23 at 9 45 05 PM" src="https://github.com/user-attachments/assets/fe1ea35c-6f7a-4f52-ac50-cf99fb3a4c7c" />
