### PR TITLE
feat: persist validation constraints for subscription forms

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/SubscriptionForm.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/SubscriptionForm.java
@@ -52,4 +52,10 @@ public class SubscriptionForm {
      * Whether the form is enabled and visible to API consumers.
      */
     private boolean enabled;
+
+    /**
+     * JSON string of validation constraints per field key, derived from the GMD content.
+     * {@code null} when nothing is stored (empty rule sets are typically not persisted).
+     */
+    private String validationConstraints;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionFormRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionFormRepository.java
@@ -50,6 +50,7 @@ public class JdbcSubscriptionFormRepository
             .addColumn("environment_id", Types.NVARCHAR, String.class)
             .addColumn("gmd_content", Types.LONGNVARCHAR, String.class)
             .addColumn("enabled", Types.BIT, boolean.class)
+            .addColumn("validation_constraints", Types.CLOB, String.class)
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/11_add_validation_constraints_to_subscription_forms.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/11_add_validation_constraints_to_subscription_forms.yml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.11.0_11_add_validation_constraints_to_subscription_forms
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}subscription_forms
+            columns:
+              - column:
+                  name: validation_constraints
+                  type: nclob
+                  defaultValue: '{}'
+                  constraints:
+                    nullable: false

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -319,6 +319,8 @@ databaseChangeLog:
     - include:
         - file: liquibase/changelogs/v4_11_0/10_make_root_id_not_null_portal_navigation_items.yml
     - include:
+        - file: liquibase/changelogs/v4_11_0/11_add_validation_constraints_to_subscription_forms.yml
+    - include:
         - file: liquibase/changelogs/v4_12_0/00_add_tags_key_column.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/01_add_tenants_key_column.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/SubscriptionFormMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/SubscriptionFormMongo.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.mongodb.management.internal.model;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NonNull;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -36,4 +37,7 @@ public class SubscriptionFormMongo {
     private String environmentId;
     private String gmdContent;
     private boolean enabled;
+
+    @NonNull
+    private String validationConstraints;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/subscriptionform/SubscriptionFormValidationConstraintsMongoUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/subscriptionform/SubscriptionFormValidationConstraintsMongoUpgrader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.subscriptionform;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.portalnavigationitem.PortalNavigationItemDefaultRootIdMongoUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Backfills the {@code validationConstraints} field with an empty JSON object ({@code "{}"}) for
+ * subscription form documents that predate the introduction of this field.
+ *
+ * <p>MongoDB does not apply column defaults, so existing documents simply lack the field (stored as
+ * {@code null} / missing). The subsequent {@code SubscriptionFormConstraintsUpgrader} then replaces
+ * {@code "{}"} with the actual constraints derived from each form's GMD content.</p>
+ */
+@Component
+public class SubscriptionFormValidationConstraintsMongoUpgrader extends MongoUpgrader {
+
+    public static final int SUBSCRIPTION_FORM_VALIDATION_CONSTRAINTS_MONGO_UPGRADER_ORDER =
+        PortalNavigationItemDefaultRootIdMongoUpgrader.PORTAL_NAVIGATION_ITEM_DEFAULT_ROOT_ID_MONGO_UPGRADER_ORDER + 1;
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public boolean upgrade() {
+        var result = this.getCollection("subscription_forms").updateMany(
+            Filters.eq("validationConstraints", null),
+            Updates.set("validationConstraints", "{}")
+        );
+        return result.wasAcknowledged();
+    }
+
+    @Override
+    public int getOrder() {
+        return SUBSCRIPTION_FORM_VALIDATION_CONSTRAINTS_MONGO_UPGRADER_ORDER;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionFormRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionFormRepositoryTest.java
@@ -42,6 +42,7 @@ public class SubscriptionFormRepositoryTest extends AbstractManagementRepository
         assertThat(form.getEnvironmentId()).isEqualTo("env-1");
         assertThat(form.getGmdContent()).contains("gmd-grid");
         assertThat(form.isEnabled()).isTrue();
+        assertThat(form.getValidationConstraints()).isEqualTo("{\"email\":[{\"type\":\"required\"}]}");
     }
 
     @Test
@@ -94,8 +95,9 @@ public class SubscriptionFormRepositoryTest extends AbstractManagementRepository
         SubscriptionForm form = SubscriptionForm.builder()
             .id("sub-form-new")
             .environmentId("env-new")
-            .gmdContent("<gmd-card><gmd-input name=\"field\" label=\"Field\"/></gmd-card>")
+            .gmdContent("<gmd-card><gmd-input name=\"field\" label=\"Field\" fieldKey=\"field\"/></gmd-card>")
             .enabled(false)
+            .validationConstraints("{\"field\":[]}")
             .build();
 
         Set<SubscriptionForm> allBefore = subscriptionFormRepository.findAll();
@@ -111,6 +113,7 @@ public class SubscriptionFormRepositoryTest extends AbstractManagementRepository
         assertThat(saved.getEnvironmentId()).isEqualTo("env-new");
         assertThat(saved.getGmdContent()).contains("gmd-input");
         assertThat(saved.isEnabled()).isFalse();
+        assertThat(saved.getValidationConstraints()).isEqualTo("{\"field\":[]}");
     }
 
     @Test
@@ -123,19 +126,22 @@ public class SubscriptionFormRepositoryTest extends AbstractManagementRepository
 
         SubscriptionForm updated = existing
             .toBuilder()
-            .gmdContent("<gmd-card><gmd-input name=\"updated\" label=\"Updated\"/></gmd-card>")
+            .gmdContent("<gmd-card><gmd-input name=\"updated\" label=\"Updated\" fieldKey=\"updated\"/></gmd-card>")
             .enabled(true)
+            .validationConstraints("{\"updated\":[]}")
             .build();
 
         SubscriptionForm result = subscriptionFormRepository.update(updated);
 
         assertThat(result.getGmdContent()).contains("updated");
         assertThat(result.isEnabled()).isTrue();
+        assertThat(result.getValidationConstraints()).contains("updated");
 
         Optional<SubscriptionForm> reloaded = subscriptionFormRepository.findById("sub-form-update");
         assertThat(reloaded).isPresent();
         assertThat(reloaded.get().getGmdContent()).contains("updated");
         assertThat(reloaded.get().isEnabled()).isTrue();
+        assertThat(reloaded.get().getValidationConstraints()).contains("updated");
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/subscriptionform-tests/subscriptionForms.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/subscriptionform-tests/subscriptionForms.json
@@ -2,31 +2,36 @@
    {
       "id": "sub-form-find-by-id",
       "environmentId": "env-1",
-      "gmdContent": "<gmd-grid columns=\"2\"><gmd-card><gmd-card-title>Info</gmd-card-title><gmd-input name=\"email\" label=\"Email\" required=\"true\"/></gmd-card></gmd-grid>",
-      "enabled": true
+      "gmdContent": "<gmd-grid columns=\"2\"><gmd-card><gmd-card-title>Info</gmd-card-title><gmd-input name=\"email\" label=\"Email\" fieldKey=\"email\" required=\"true\"/></gmd-card></gmd-grid>",
+      "enabled": true,
+      "validationConstraints": "{\"email\":[{\"type\":\"required\"}]}"
    },
    {
       "id": "sub-form-update",
       "environmentId": "env-update",
       "gmdContent": "<gmd-card><gmd-input name=\"name\" label=\"Name\"/></gmd-card>",
-      "enabled": false
+      "enabled": false,
+      "validationConstraints": "{}"
    },
    {
       "id": "sub-form-delete",
       "environmentId": "env-delete",
       "gmdContent": "<gmd-card><gmd-input name=\"test\" label=\"Test\"/></gmd-card>",
-      "enabled": true
+      "enabled": true,
+      "validationConstraints": "{}"
    },
    {
       "id": "sub-form-find-by-env",
       "environmentId": "env-find",
       "gmdContent": "<gmd-grid columns=\"1\"><gmd-card><gmd-card-title>Subscription</gmd-card-title><gmd-textarea name=\"useCase\" label=\"Use case\"/></gmd-card></gmd-grid>",
-      "enabled": true
+      "enabled": true,
+      "validationConstraints": "{}"
    },
    {
       "id": "sub-form-delete-by-env",
       "environmentId": "env-delete-by-env",
       "gmdContent": "<gmd-card><gmd-input name=\"field\" label=\"Field\"/></gmd-card>",
-      "enabled": true
+      "enabled": true,
+      "validationConstraints": "{}"
    }
 ]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactory.java
@@ -21,11 +21,12 @@ import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxGroupField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.Field;
-import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.MaxLengthAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.InputField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.MinLengthAttribute;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.OptionsAttribute;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.PatternAttribute;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.ReadOnlyValueAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.TextareaField;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -33,6 +34,9 @@ import java.util.Map;
 
 /**
  * Builds {@link SubscriptionFormFieldConstraints} from a parsed {@link SubscriptionFormSchema}.
+ *
+ * <p>System-level length limits are always enforced regardless of user configuration.
+ * See {@link Constraint.MaxLength#INPUT_MAX_LENGTH} and {@link Constraint.MaxLength#TEXTAREA_MAX_LENGTH}.</p>
  *
  * @author Gravitee.io Team
  */
@@ -71,8 +75,12 @@ public final class SubscriptionFormConstraintsFactory {
         if (field instanceof MinLengthAttribute min && min.minLength() != null) {
             out.add(new Constraint.MinLength(min.minLength()));
         }
-        if (field instanceof MaxLengthAttribute max && max.maxLength() != null) {
-            out.add(new Constraint.MaxLength(max.maxLength()));
+        if (field instanceof InputField input) {
+            out.add(input.maxLength() != null ? Constraint.MaxLength.forInput(input.maxLength()) : Constraint.MaxLength.forInput());
+        } else if (field instanceof TextareaField textarea) {
+            out.add(
+                textarea.maxLength() != null ? Constraint.MaxLength.forTextarea(textarea.maxLength()) : Constraint.MaxLength.forTextarea()
+            );
         }
         if (field instanceof PatternAttribute pat && pat.pattern() != null) {
             out.add(new Constraint.MatchesPattern(pat.pattern()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSubmissionValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSubmissionValidator.java
@@ -35,6 +35,9 @@ import java.util.Map;
  */
 public class SubscriptionFormSubmissionValidator {
 
+    /** Maximum number of metadata entries accepted in a subscription form submission. */
+    public static final int MAX_METADATA_COUNT = 25;
+
     private final SubscriptionFormFieldConstraints fieldConstraints;
 
     public SubscriptionFormSubmissionValidator(SubscriptionFormSchema schema) {
@@ -56,6 +59,11 @@ public class SubscriptionFormSubmissionValidator {
     public void validate(Map<String, String> submittedValues) {
         if (fieldConstraints.isEmpty()) {
             return;
+        }
+        if (submittedValues.size() > MAX_METADATA_COUNT) {
+            throw new SubscriptionFormValidationException(
+                List.of("Subscription metadata must not exceed " + MAX_METADATA_COUNT + " entries")
+            );
         }
         List<String> errors = fieldConstraints
             .byFieldKey()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/Constraint.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/Constraint.java
@@ -152,6 +152,26 @@ public sealed interface Constraint
 
     /** Value must be at most {@code max} characters long (skipped when empty). */
     record MaxLength(int max) implements Constraint {
+        public static final int INPUT_MAX_LENGTH = 256;
+
+        public static final int TEXTAREA_MAX_LENGTH = 1024;
+
+        public static MaxLength forInput() {
+            return new MaxLength(INPUT_MAX_LENGTH);
+        }
+
+        public static MaxLength forInput(int userDefined) {
+            return new MaxLength(Math.min(userDefined, INPUT_MAX_LENGTH));
+        }
+
+        public static MaxLength forTextarea() {
+            return new MaxLength(TEXTAREA_MAX_LENGTH);
+        }
+
+        public static MaxLength forTextarea(int userDefined) {
+            return new MaxLength(Math.min(userDefined, TEXTAREA_MAX_LENGTH));
+        }
+
         @Override
         public boolean check(String value) {
             return value.isEmpty() || value.length() <= max;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/Constraint.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/Constraint.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.subscription_form.model;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -25,8 +27,8 @@ import java.util.stream.Stream;
 /**
  * A single validation rule for a subscription form field.
  *
- * <p>Constraints are extracted from a {@link SubscriptionFormSchema} at save time and persisted
- * alongside the schema. At submission time the validator iterates the constraint map and calls
+ * <p>Constraints are derived from a {@link SubscriptionFormSchema} at save time and persisted as JSON.
+ * At submission time the validator iterates the constraint map and calls
  * {@link #validate(String, String)} — no schema knowledge required.</p>
  *
  * <p>Implementations split rule logic ({@link #check(String)}) from the human-readable message
@@ -36,6 +38,20 @@ import java.util.stream.Stream;
  *
  * @author Gravitee.io Team
  */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes(
+    {
+        @JsonSubTypes.Type(value = Constraint.Required.class, name = "required"),
+        @JsonSubTypes.Type(value = Constraint.MustBeTrue.class, name = "mustBeTrue"),
+        @JsonSubTypes.Type(value = Constraint.NonEmptySelection.class, name = "nonEmptySelection"),
+        @JsonSubTypes.Type(value = Constraint.ReadOnly.class, name = "readOnly"),
+        @JsonSubTypes.Type(value = Constraint.MinLength.class, name = "minLength"),
+        @JsonSubTypes.Type(value = Constraint.MaxLength.class, name = "maxLength"),
+        @JsonSubTypes.Type(value = Constraint.MatchesPattern.class, name = "matchesPattern"),
+        @JsonSubTypes.Type(value = Constraint.OneOf.class, name = "oneOf"),
+        @JsonSubTypes.Type(value = Constraint.EachOf.class, name = "eachOf"),
+    }
+)
 public sealed interface Constraint
     permits
         Constraint.Required,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/SubscriptionForm.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/SubscriptionForm.java
@@ -43,12 +43,14 @@ public class SubscriptionForm {
 
     private GraviteeMarkdown gmdContent;
     private boolean enabled;
+    private SubscriptionFormFieldConstraints validationConstraints;
 
     /**
-     * Updates this form with new GMD content (mutates in place).
+     * Updates this form (mutates in place).
      */
-    public void update(GraviteeMarkdown gmdContent) {
+    public void update(GraviteeMarkdown gmdContent, SubscriptionFormFieldConstraints constraints) {
         this.gmdContent = gmdContent;
+        this.validationConstraints = constraints;
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCase.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.subscription_form.crud_service.SubscriptionFormCrudService;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormNotFoundException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
 import io.gravitee.apim.core.subscription_form.query_service.SubscriptionFormQueryService;
 import lombok.CustomLog;
@@ -54,7 +55,7 @@ public class UpdateSubscriptionFormUseCase {
                 )
             );
 
-        existingForm.update(GraviteeMarkdown.of(input.gmdContent()));
+        existingForm.update(GraviteeMarkdown.of(input.gmdContent()), SubscriptionFormFieldConstraints.empty());
         var savedForm = subscriptionFormCrudService.update(existingForm);
 
         log.info("Updated subscription form [{}] for environment [{}]", input.subscriptionFormId(), input.environmentId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/SubscriptionFormAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/SubscriptionFormAdapter.java
@@ -15,9 +15,16 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.subscription_form.model.Constraint;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
+import java.util.List;
+import java.util.Map;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -32,12 +39,41 @@ import org.mapstruct.factory.Mappers;
 public interface SubscriptionFormAdapter {
     SubscriptionFormAdapter INSTANCE = Mappers.getMapper(SubscriptionFormAdapter.class);
 
+    ObjectMapper FIELD_CONSTRAINTS_JSON = new ObjectMapper().findAndRegisterModules();
+
+    static String writeFieldConstraintsJson(SubscriptionFormFieldConstraints constraints) {
+        if (constraints == null || constraints.isEmpty()) {
+            return "{}";
+        }
+        try {
+            return FIELD_CONSTRAINTS_JSON.writerFor(new TypeReference<Map<String, List<Constraint>>>() {}).writeValueAsString(
+                constraints.byFieldKey()
+            );
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize subscription form field constraints", e);
+        }
+    }
+
+    static SubscriptionFormFieldConstraints parseFieldConstraintsJson(String json) {
+        if (json == null || json.isBlank()) {
+            return SubscriptionFormFieldConstraints.empty();
+        }
+        try {
+            Map<String, List<Constraint>> map = FIELD_CONSTRAINTS_JSON.readValue(json, new TypeReference<>() {});
+            return map.isEmpty() ? SubscriptionFormFieldConstraints.empty() : new SubscriptionFormFieldConstraints(map);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to deserialize subscription form field constraints", e);
+        }
+    }
+
     @Mapping(target = "id", source = "id", qualifiedByName = "idToSubscriptionFormId")
     @Mapping(target = "gmdContent", source = "gmdContent", qualifiedByName = "stringToGraviteeMarkdown")
+    @Mapping(target = "validationConstraints", source = "validationConstraints", qualifiedByName = "jsonToFieldConstraints")
     SubscriptionForm toEntity(io.gravitee.repository.management.model.SubscriptionForm subscriptionForm);
 
     @Mapping(target = "id", source = "id", qualifiedByName = "subscriptionFormIdToId")
     @Mapping(target = "gmdContent", source = "gmdContent", qualifiedByName = "graviteeMarkdownToString")
+    @Mapping(target = "validationConstraints", source = "validationConstraints", qualifiedByName = "fieldConstraintsToJson")
     io.gravitee.repository.management.model.SubscriptionForm toRepository(SubscriptionForm subscriptionForm);
 
     @Named("idToSubscriptionFormId")
@@ -58,5 +94,15 @@ public interface SubscriptionFormAdapter {
     @Named("graviteeMarkdownToString")
     default String graviteeMarkdownToString(GraviteeMarkdown gmd) {
         return gmd != null ? gmd.value() : null;
+    }
+
+    @Named("jsonToFieldConstraints")
+    default SubscriptionFormFieldConstraints jsonToFieldConstraints(String json) {
+        return parseFieldConstraintsJson(json);
+    }
+
+    @Named("fieldConstraintsToJson")
+    default String fieldConstraintsToJson(SubscriptionFormFieldConstraints constraints) {
+        return writeFieldConstraintsJson(constraints);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/subscription_form/SubscriptionFormCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/subscription_form/SubscriptionFormCrudServiceImpl.java
@@ -48,6 +48,7 @@ public class SubscriptionFormCrudServiceImpl implements SubscriptionFormCrudServ
                 .environmentId(subscriptionForm.getEnvironmentId())
                 .gmdContent(subscriptionForm.getGmdContent())
                 .enabled(subscriptionForm.isEnabled())
+                .validationConstraints(subscriptionForm.getValidationConstraints())
                 .build()
             : subscriptionForm;
         try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultSubscriptionFormUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultSubscriptionFormUpgrader.java
@@ -74,6 +74,7 @@ public class DefaultSubscriptionFormUpgrader implements Upgrader {
                     .environmentId(environment.getId())
                     .gmdContent(getDefaultFormContent())
                     .enabled(false) // Disabled by default
+                    .validationConstraints("{}")
                     .build();
 
                 subscriptionFormRepository.create(defaultForm);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormConstraintsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormConstraintsUpgrader.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.SUBSCRIPTION_FORM_CONSTRAINTS_UPGRADER;
+
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormConstraintsFactory;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
+import io.gravitee.apim.infra.adapter.SubscriptionFormAdapter;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.SubscriptionFormRepository;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Upgrader that generates and persists validation constraints for existing subscription forms
+ * that were created before constraint generation was introduced.
+ *
+ * <p>Forms whose {@code validationConstraints} is the empty-object sentinel {@code "{}"} are processed:
+ * the GMD content is parsed, constraints are derived, and the result (or {@code "{}"} when the form has
+ * no constrained fields) is stored. Forms that already carry real constraints are skipped.</p>
+ *
+ * @author Gravitee.io Team
+ */
+@Component
+@CustomLog
+public class SubscriptionFormConstraintsUpgrader implements Upgrader {
+
+    private final SubscriptionFormRepository subscriptionFormRepository;
+    private final SubscriptionFormSchemaGenerator schemaGenerator;
+
+    public SubscriptionFormConstraintsUpgrader(
+        @Lazy SubscriptionFormRepository subscriptionFormRepository,
+        @Lazy SubscriptionFormSchemaGenerator schemaGenerator
+    ) {
+        this.subscriptionFormRepository = subscriptionFormRepository;
+        this.schemaGenerator = schemaGenerator;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::applyUpgrade);
+    }
+
+    private boolean applyUpgrade() throws TechnicalException {
+        var forms = subscriptionFormRepository.findAll();
+        int updated = 0;
+
+        for (var form : forms) {
+            if (!form.getValidationConstraints().equals("{}")) {
+                continue;
+            }
+            try {
+                var schema = schemaGenerator.generate(GraviteeMarkdown.of(form.getGmdContent()));
+                var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+                String json = SubscriptionFormAdapter.writeFieldConstraintsJson(constraints);
+                form.setValidationConstraints(json);
+                subscriptionFormRepository.update(form);
+                updated++;
+            } catch (Exception e) {
+                log.error("Failed to generate validation constraints for subscription form [{}]", form.getId(), e);
+            }
+        }
+
+        log.info("Subscription form constraints upgrader completed. Generated constraints for {}/{} forms.", updated, forms.size());
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return SUBSCRIPTION_FORM_CONSTRAINTS_UPGRADER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -64,6 +64,7 @@ public class UpgraderOrder {
     public static final int PORTAL_NAVIGATION_ITEM_ROOT_ID_UPGRADER = 715;
     public static final int TAG_KEY_UPGRADER = 716;
     public static final int TENANT_KEY_UPGRADER = 717;
+    public static final int SUBSCRIPTION_FORM_CONSTRAINTS_UPGRADER = 718;
     public static final int CLUSTER_ROLES_UPGRADER = 900;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;
     public static final int API_PRODUCT_ROLES_UPGRADER = 950;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizer.java
@@ -23,9 +23,13 @@ import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
 /**
- * Validates and sanitizes subscription form metadata (keys, value length).
+ * Sanitizes subscription metadata: validates key format and strips HTML tags from values.
  * Values are plain text; HTML tags are stripped to prevent XSS when metadata is rendered.
  * No HTML encoding is applied, so characters like {@code @}, {@code +}, {@code =} are stored as-is.
+ *
+ * <p>Business-level limits (max value length, max entry count) are enforced separately by
+ * {@link io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSubmissionValidator}
+ * for subscriptions that go through a subscription form.</p>
  *
  * @author GraviteeSource Team
  */
@@ -34,27 +38,18 @@ public class SubscriptionMetadataSanitizer {
 
     private static final Pattern KEY_PATTERN = Pattern.compile("^[A-Za-z0-9_-]{1,100}$");
     private static final Pattern HTML_TAG = Pattern.compile("<[^>]*>");
-    private static final int MAX_VALUE_LENGTH = 1024;
-    private static final int MAX_METADATA_COUNT = 25;
 
     /**
-     * Validates metadata keys and value lengths, then strips HTML tags from each value.
+     * Validates metadata key format, strips HTML tags from each value, and omits blank values.
      * Any remaining characters (including {@code <}, {@code >}, non-Latin, etc.) are stored as-is.
      *
      * @param metadata raw metadata from the client
      * @return sanitized metadata, or empty map if input is null
-     * @throws SubscriptionMetadataInvalidException if a key is invalid or a value exceeds max length
+     * @throws SubscriptionMetadataInvalidException if a key does not match the required format
      */
     public Map<String, String> sanitizeAndValidate(Map<String, String> metadata) {
         if (metadata == null) {
             return Collections.emptyMap();
-        }
-
-        if (metadata.size() > MAX_METADATA_COUNT) {
-            throw new SubscriptionMetadataInvalidException(
-                SubscriptionMetadataInvalidException.Reason.TOO_MANY,
-                "Too many metadata entries. Maximum is " + MAX_METADATA_COUNT + "."
-            );
         }
 
         Map<String, String> sanitizedMetadata = new HashMap<>();
@@ -67,15 +62,7 @@ public class SubscriptionMetadataSanitizer {
                 );
             }
 
-            String value = entry.getValue();
-            if (value != null && value.length() > MAX_VALUE_LENGTH) {
-                throw new SubscriptionMetadataInvalidException(
-                    SubscriptionMetadataInvalidException.Reason.VALUE_TOO_LONG,
-                    "Metadata value for key '" + key + "' is too long (max " + MAX_VALUE_LENGTH + " characters)."
-                );
-            }
-
-            String sanitizedValue = stripHtmlTags(value);
+            String sanitizedValue = stripHtmlTags(entry.getValue());
             if (sanitizedValue == null || sanitizedValue.isBlank()) {
                 continue;
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/SubscriptionFormFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/SubscriptionFormFixtures.java
@@ -17,6 +17,7 @@ package fixtures.core.model;
 
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
 
 /**
@@ -30,7 +31,7 @@ public class SubscriptionFormFixtures {
 
     public static final String FORM_ID = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
     public static final String ENVIRONMENT_ID = "environment-id";
-    public static final String GMD_CONTENT = "<gmd-input name=\"company\" label=\"Company\" required=\"true\"/>";
+    public static final String GMD_CONTENT = "<gmd-input name=\"company\" label=\"Company\" fieldKey=\"company\" required=\"true\"/>";
 
     public static SubscriptionForm aSubscriptionForm() {
         return SubscriptionForm.builder()
@@ -38,6 +39,7 @@ public class SubscriptionFormFixtures {
             .environmentId(ENVIRONMENT_ID)
             .gmdContent(GraviteeMarkdown.of(GMD_CONTENT))
             .enabled(false)
+            .validationConstraints(SubscriptionFormFieldConstraints.empty())
             .build();
     }
 
@@ -50,6 +52,7 @@ public class SubscriptionFormFixtures {
             .environmentId(ENVIRONMENT_ID)
             .gmdContent(GraviteeMarkdown.of(GMD_CONTENT))
             .enabled(false)
+            .validationConstraints(SubscriptionFormFieldConstraints.empty())
             .build();
     }
 
@@ -59,6 +62,7 @@ public class SubscriptionFormFixtures {
             .environmentId(ENVIRONMENT_ID)
             .gmdContent(GraviteeMarkdown.of(GMD_CONTENT))
             .enabled(true)
+            .validationConstraints(SubscriptionFormFieldConstraints.empty())
             .build();
     }
 
@@ -67,6 +71,7 @@ public class SubscriptionFormFixtures {
             .id(SubscriptionFormId.of(FORM_ID))
             .environmentId(ENVIRONMENT_ID)
             .gmdContent(GraviteeMarkdown.of(GMD_CONTENT))
-            .enabled(false);
+            .enabled(false)
+            .validationConstraints(SubscriptionFormFieldConstraints.empty());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionFormCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionFormCrudServiceInMemory.java
@@ -40,6 +40,7 @@ public class SubscriptionFormCrudServiceInMemory implements SubscriptionFormCrud
                 .environmentId(subscriptionForm.getEnvironmentId())
                 .gmdContent(subscriptionForm.getGmdContent())
                 .enabled(subscriptionForm.isEnabled())
+                .validationConstraints(subscriptionForm.getValidationConstraints())
                 .build()
             : subscriptionForm;
         storage.add(toStore);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactoryTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.subscription_form.domain_service;
 
+import static io.gravitee.apim.core.subscription_form.model.Constraint.MaxLength.INPUT_MAX_LENGTH;
+import static io.gravitee.apim.core.subscription_form.model.Constraint.MaxLength.TEXTAREA_MAX_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.core.subscription_form.model.Constraint;
@@ -90,6 +92,41 @@ class SubscriptionFormConstraintsFactoryTest {
         var schema = new SubscriptionFormSchema(List.of(new CheckboxField("terms", true, null)));
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("terms")).containsExactly(new Constraint.MustBeTrue());
+    }
+
+    @Test
+    void should_apply_system_max_length_to_input_when_no_user_max_defined() {
+        var schema = new SubscriptionFormSchema(List.of(new InputField("name", false, null, null, null, null)));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("name")).containsExactly(new Constraint.MaxLength(INPUT_MAX_LENGTH));
+    }
+
+    @Test
+    void should_apply_system_max_length_to_textarea_when_no_user_max_defined() {
+        var schema = new SubscriptionFormSchema(List.of(new TextareaField("bio", false, null, null, null)));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("bio")).containsExactly(new Constraint.MaxLength(TEXTAREA_MAX_LENGTH));
+    }
+
+    @Test
+    void should_cap_input_max_length_at_system_limit_when_user_exceeds_it() {
+        var schema = new SubscriptionFormSchema(List.of(new InputField("name", false, null, null, 1000, null)));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("name")).containsExactly(new Constraint.MaxLength(INPUT_MAX_LENGTH));
+    }
+
+    @Test
+    void should_cap_textarea_max_length_at_system_limit_when_user_exceeds_it() {
+        var schema = new SubscriptionFormSchema(List.of(new TextareaField("notes", false, null, null, 9999)));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("notes")).containsExactly(new Constraint.MaxLength(TEXTAREA_MAX_LENGTH));
+    }
+
+    @Test
+    void should_preserve_user_max_length_when_within_system_limit() {
+        var schema = new SubscriptionFormSchema(List.of(new InputField("code", false, null, null, 50, null)));
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("code")).containsExactly(new Constraint.MaxLength(50));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSubmissionValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSubmissionValidatorTest.java
@@ -290,6 +290,37 @@ class SubscriptionFormSubmissionValidatorTest {
     }
 
     @Nested
+    class WhenValidatingMetadataCount {
+
+        @Test
+        void should_throw_when_submission_exceeds_max_metadata_count() {
+            var schema = schema(requiredInput("company"));
+            Map<String, String> tooMany = new java.util.HashMap<>();
+            for (int i = 0; i < SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT + 1; i++) {
+                tooMany.put("key_" + i, "value");
+            }
+            assertThatThrownBy(() -> validateSubmission(schema, tooMany))
+                .isInstanceOf(SubscriptionFormValidationException.class)
+                .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+                .satisfies(errors ->
+                    assertThat(errors).containsExactly(
+                        "Subscription metadata must not exceed " + SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT + " entries"
+                    )
+                );
+        }
+
+        @Test
+        void should_not_throw_when_submission_is_at_max_metadata_count() {
+            var schema = schema(optionalInput("notes"));
+            Map<String, String> exactlyMax = new java.util.HashMap<>();
+            for (int i = 0; i < SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT; i++) {
+                exactlyMax.put("key_" + i, "value");
+            }
+            assertThatNoException().isThrownBy(() -> validateSubmission(schema, exactlyMax));
+        }
+    }
+
+    @Nested
     class WhenUsingPrebuiltFieldConstraints {
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCaseTest.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.gravitee_markdown.exception.GraviteeMarkdownContentEmptyException;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormNotFoundException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,12 +55,19 @@ class UpdateSubscriptionFormUseCaseTest {
 
         // When
         var result = useCase.execute(
-            new UpdateSubscriptionFormUseCase.Input(existingForm.getEnvironmentId(), existingForm.getId(), "<gmd-input name=\"updated\"/>")
+            new UpdateSubscriptionFormUseCase.Input(
+                existingForm.getEnvironmentId(),
+                existingForm.getId(),
+                "<gmd-input name=\"updated\" fieldKey=\"updated\"/>"
+            )
         );
 
         // Then
-        assertThat(result.subscriptionForm().getGmdContent()).isEqualTo(GraviteeMarkdown.of("<gmd-input name=\"updated\"/>"));
+        assertThat(result.subscriptionForm().getGmdContent()).isEqualTo(
+            GraviteeMarkdown.of("<gmd-input name=\"updated\" fieldKey=\"updated\"/>")
+        );
         assertThat(result.subscriptionForm().getId()).isEqualTo(existingForm.getId());
+        assertThat(result.subscriptionForm().getValidationConstraints()).isEqualTo(SubscriptionFormFieldConstraints.empty());
     }
 
     @Test
@@ -67,7 +75,7 @@ class UpdateSubscriptionFormUseCaseTest {
         var input = new UpdateSubscriptionFormUseCase.Input(
             "env-1",
             SubscriptionFormId.of("550e8400-e29b-41d4-a716-446655440000"),
-            "<gmd-input name=\"test\"/>"
+            "<gmd-input name=\"test\" fieldKey=\"test\"/>"
         );
         assertThatThrownBy(() -> useCase.execute(input)).isInstanceOf(SubscriptionFormNotFoundException.class);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormConstraintsUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/SubscriptionFormConstraintsUpgraderTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.SubscriptionFormRepository;
+import io.gravitee.repository.management.model.SubscriptionForm;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SubscriptionFormConstraintsUpgraderTest {
+
+    @Mock
+    SubscriptionFormRepository subscriptionFormRepository;
+
+    @Mock
+    SubscriptionFormSchemaGenerator schemaGenerator;
+
+    SubscriptionFormConstraintsUpgrader upgrader;
+
+    @BeforeEach
+    void setUp() {
+        upgrader = new SubscriptionFormConstraintsUpgrader(subscriptionFormRepository, schemaGenerator);
+    }
+
+    @Test
+    void should_generate_constraints_for_forms_with_empty_sentinel() throws Exception {
+        var form1 = SubscriptionForm.builder()
+            .id("form-1")
+            .environmentId("env-1")
+            .gmdContent("<gmd-input name=\"email\" fieldKey=\"email\" required />")
+            .validationConstraints("{}")
+            .build();
+        var form2 = SubscriptionForm.builder()
+            .id("form-2")
+            .environmentId("env-2")
+            .gmdContent("<gmd-select name=\"plan\" fieldKey=\"plan\" options=\"basic,pro\" />")
+            .validationConstraints("{}")
+            .build();
+
+        when(subscriptionFormRepository.findAll()).thenReturn(Set.of(form1, form2));
+        when(schemaGenerator.generate(any(GraviteeMarkdown.class))).thenReturn(
+            new SubscriptionFormSchema(List.of(new SubscriptionFormSchema.InputField("email", true, null, null, null, null)))
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<SubscriptionForm> captor = ArgumentCaptor.forClass(SubscriptionForm.class);
+        verify(subscriptionFormRepository, times(2)).update(captor.capture());
+
+        captor.getAllValues().forEach(updated -> assertThat(updated.getValidationConstraints()).isNotNull().contains("email"));
+    }
+
+    @Test
+    void should_process_forms_that_have_empty_json_sentinel() throws Exception {
+        var formWithSentinel = SubscriptionForm.builder()
+            .id("form-1")
+            .environmentId("env-1")
+            .gmdContent("<gmd-input name=\"email\" fieldKey=\"email\" required />")
+            .validationConstraints("{}")
+            .build();
+
+        when(subscriptionFormRepository.findAll()).thenReturn(Set.of(formWithSentinel));
+        when(schemaGenerator.generate(any(GraviteeMarkdown.class))).thenReturn(
+            new SubscriptionFormSchema(List.of(new SubscriptionFormSchema.InputField("email", true, null, null, null, null)))
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<SubscriptionForm> captor = ArgumentCaptor.forClass(SubscriptionForm.class);
+        verify(subscriptionFormRepository, times(1)).update(captor.capture());
+        assertThat(captor.getValue().getValidationConstraints()).isNotEqualTo("{}").contains("email");
+    }
+
+    @Test
+    void should_skip_forms_that_already_have_constraints() throws Exception {
+        var formWithConstraints = SubscriptionForm.builder()
+            .id("form-1")
+            .environmentId("env-1")
+            .gmdContent("<gmd-input name=\"email\" fieldKey=\"email\" />")
+            .validationConstraints("{\"email\":[{\"type\":\"required\"}]}")
+            .build();
+
+        when(subscriptionFormRepository.findAll()).thenReturn(Set.of(formWithConstraints));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(schemaGenerator, never()).generate(any());
+        verify(subscriptionFormRepository, never()).update(any());
+    }
+
+    @Test
+    void should_update_with_empty_json_when_gmd_yields_no_constraints() throws Exception {
+        var formWithNoFields = SubscriptionForm.builder()
+            .id("form-1")
+            .environmentId("env-1")
+            .gmdContent("This is plain markdown with no form components.")
+            .validationConstraints("{}")
+            .build();
+
+        when(subscriptionFormRepository.findAll()).thenReturn(Set.of(formWithNoFields));
+        when(schemaGenerator.generate(any(GraviteeMarkdown.class))).thenReturn(new SubscriptionFormSchema(List.of()));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<SubscriptionForm> captor = ArgumentCaptor.forClass(SubscriptionForm.class);
+        verify(subscriptionFormRepository, times(1)).update(captor.capture());
+        assertThat(captor.getValue().getValidationConstraints()).isEqualTo("{}");
+    }
+
+    @Test
+    void should_continue_processing_remaining_forms_when_one_fails() throws Exception {
+        var failingForm = SubscriptionForm.builder()
+            .id("form-fail")
+            .environmentId("env-fail")
+            .gmdContent("bad content")
+            .validationConstraints("{}")
+            .build();
+        var successForm = SubscriptionForm.builder()
+            .id("form-ok")
+            .environmentId("env-ok")
+            .gmdContent("<gmd-input name=\"x\" fieldKey=\"x\" />")
+            .validationConstraints("{}")
+            .build();
+
+        when(subscriptionFormRepository.findAll()).thenReturn(Set.of(failingForm, successForm));
+        when(schemaGenerator.generate(GraviteeMarkdown.of("bad content"))).thenThrow(new RuntimeException("parse failed"));
+        when(schemaGenerator.generate(GraviteeMarkdown.of("<gmd-input name=\"x\" fieldKey=\"x\" />"))).thenReturn(
+            new SubscriptionFormSchema(List.of(new SubscriptionFormSchema.InputField("x", false, null, null, null, null)))
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(subscriptionFormRepository, times(1)).update(any());
+    }
+
+    @Test
+    void should_throw_UpgraderException_when_repository_findAll_throws() throws TechnicalException {
+        when(subscriptionFormRepository.findAll()).thenThrow(new TechnicalException("db error"));
+
+        assertThatThrownBy(() -> upgrader.upgrade()).isInstanceOf(UpgraderException.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/validation/SubscriptionMetadataSanitizerTest.java
@@ -52,41 +52,6 @@ class SubscriptionMetadataSanitizerTest {
     }
 
     @Test
-    void should_throw_when_metadata_value_is_too_long() {
-        Map<String, String> tooLongValue = Map.of("valid_key", "a".repeat(1025));
-
-        var throwable = assertThrows(SubscriptionMetadataInvalidException.class, () -> cut.sanitizeAndValidate(tooLongValue));
-
-        assertThat(throwable.getTechnicalCode()).isEqualTo("subscription.metadata.value.too_long");
-        assertThat(throwable.getMessage()).isEqualTo("Metadata value for key 'valid_key' is too long (max 1024 characters).");
-    }
-
-    @Test
-    void should_throw_when_metadata_count_exceeds_maximum() {
-        Map<String, String> tooMany = new HashMap<>();
-        for (int i = 0; i < 26; i++) {
-            tooMany.put("key_" + i, "value");
-        }
-
-        var throwable = assertThrows(SubscriptionMetadataInvalidException.class, () -> cut.sanitizeAndValidate(tooMany));
-
-        assertThat(throwable.getTechnicalCode()).isEqualTo("subscription.metadata.too_many");
-        assertThat(throwable.getMessage()).isEqualTo("Too many metadata entries. Maximum is 25.");
-    }
-
-    @Test
-    void should_accept_metadata_at_maximum_count() {
-        Map<String, String> maxAllowed = new HashMap<>();
-        for (int i = 0; i < 25; i++) {
-            maxAllowed.put("key_" + i, "value");
-        }
-
-        var result = cut.sanitizeAndValidate(maxAllowed);
-
-        assertThat(result).hasSize(25);
-    }
-
-    @Test
     void should_strip_html_tags_and_omit_empty_values() {
         Map<String, String> metadata = new HashMap<>();
         metadata.put("field_a", "<script>alert(1)</script>");


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-12990

## Description
**PR 2/3 — Repository layer for subscription form validation constraints.**
Previous: [apim-12990-validation-domain (domain layer)](https://github.com/gravitee-io/gravitee-api-management/pull/15785)

This PR adds persistence of `SubscriptionFormFieldConstraints` derived from the GMD schema,
covering the full repository stack and a backfill upgrader for existing forms.

**What's in this PR:**
- DB migration: nullable `validation_constraints` column on `subscription_forms` (JDBC + MongoDB)
- JSON serialization/deserialization of `SubscriptionFormFieldConstraints` at the adapter boundary
- `SubscriptionFormConstraintsUpgrader`: backfills constraints for forms created before this feature

**Not in this PR** (coming in PR 3/3 — resource layer):
- REST resource changes and OpenAPI spec updates
- Constraint generation at save time (use case currently passes `null` to defer to the resource layer)
- Integration tests for the full save → persist → validate flow

## Additional context
The JSON format stored on DB is a flat field map:
`{"email":[{"type":"required"}],"company":[{"type":"required"},{"type":"minLength","min":2}]}`

Upgrader tested manually against PostgreSQL and MongoDB.
