### PR TITLE
chore: bump gravitee-reporter-tcp to 4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
         <gravitee-notifier-slack.version>2.0.0-alpha.1</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>2.0.0-alpha.1</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-tcp.version>4.0.0-alpha.1</gravitee-reporter-tcp.version>
+        <gravitee-reporter-tcp.version>4.0.1</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>3.0.0-alpha.1</gravitee-reporter-cloud.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>3.0.0</gravitee-gateway-services-ratelimit.version>    -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13290

## Description

Bump `gravitee-reporter-tcp` to 4.0.1  that solves a regression after vert.x 4.5 upgrade

