### PR TITLE
chore(master): bump gravitee-endpoint-kafka from 6.0.0-alpha.1 to 6.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
         <gravitee-entrypoint-agent-to-agent.version>2.0.0-alpha.2</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp-tool-server.version>2.0.0-alpha.3</gravitee-entrypoint-mcp-tool-server.version>
         <gravitee-endpoint-jms.version>2.0.0-alpha.1</gravitee-endpoint-jms.version>
-        <gravitee-endpoint-kafka.version>6.0.0-alpha.1</gravitee-endpoint-kafka.version>
+        <gravitee-endpoint-kafka.version>6.0.1</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>5.0.0-alpha.1</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>4.0.0-alpha.1</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>4.0.0-alpha.1</gravitee-endpoint-solace.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-endpoint-kafka](https://github.com/gravitee-io/gravitee-endpoint-kafka)** from `6.0.0-alpha.1` to `6.0.1` on branch `master`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-endpoint-kafka/releases) page for details.

## Jira

[APIM-13018](https://gravitee.atlassian.net/browse/APIM-13018)

[APIM-13018]: https://gravitee.atlassian.net/browse/APIM-13018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ