### PR TITLE
fix: Once I migrate certain V2 APIs to V4, they disappear from the list (/apis) in the UI

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCase.java
@@ -260,7 +260,6 @@ public class MigrateApiUseCase {
                 .build()
         );
         var indexerContext = new ApiIndexerDomainService.Context(input.auditInfo(), false);
-        apiIndexerDomainService.delete(indexerContext, api);
         apiIndexerDomainService.index(indexerContext, upgraded, apiPrimaryOwner);
         // Plans
         migration.plans().forEach(planService::update);


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13296

ScheduledSearchIndexerService polls every 5 seconds and processes all pending commands. When it picks up both commands in the same cycle, the processing order depends on the database query order.

If DELETE is processed AFTER INDEX (wrong order):
1. INDEX command → fetches V4 API from PostgreSQL, indexes it in Lucene → API visible
2. DELETE command → deletes the API from Lucene → API disappears!

**Fix**

The migration should NOT send separate DELETE + INDEX commands. Since the API ID doesn't change during migration, a single INDEX command is sufficient — Lucene's updateDocument() already replaces the existing document with the same ID.