### PR TITLE
chore: bump gravitee-policy-aws-lambda to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
         <!-- Versions of the plugins for the full distribution on dev environment-->
         <!-- Management API & Gateway -->
         <!-- Community plugins -->
-        <gravitee-policy-aws-lambda.version>2.0.0</gravitee-policy-aws-lambda.version>
+        <gravitee-policy-aws-lambda.version>2.1.0</gravitee-policy-aws-lambda.version>
         <gravitee-policy-circuit-breaker.version>2.0.0</gravitee-policy-circuit-breaker.version>
         <gravitee-policy-geoip-filtering.version>2.2.2</gravitee-policy-geoip-filtering.version>
         <gravitee-policy-javascript.version>1.3.3</gravitee-policy-javascript.version>


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-12532