### PR TITLE
feat: wire constraint generation on form save and validate on subscri…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -160,6 +160,7 @@ import io.gravitee.apim.core.subscription.use_case.GetSubscriptionsUseCase;
 import io.gravitee.apim.core.subscription.use_case.ImportSubscriptionSpecUseCase;
 import io.gravitee.apim.core.subscription.use_case.RejectSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.UpdateSubscriptionUseCase;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapterImpl;
@@ -1083,5 +1084,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ClusterConfigurationSchemaService clusterConfigurationSchemaService() {
         return mock(ClusterConfigurationSchemaService.class);
+    }
+
+    @Bean
+    public SubscriptionFormSchemaGenerator subscriptionFormSchemaGenerator() {
+        return mock(SubscriptionFormSchemaGenerator.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -189,6 +189,7 @@ import io.gravitee.apim.core.subscription.use_case.GetSubscriptionsUseCase;
 import io.gravitee.apim.core.subscription.use_case.ImportSubscriptionSpecUseCase;
 import io.gravitee.apim.core.subscription.use_case.RejectSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.UpdateSubscriptionUseCase;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.apim.core.user.domain_service.UserDomainService;
 import io.gravitee.apim.core.user.use_case.GetUserApisUseCase;
@@ -1266,5 +1267,10 @@ public class ResourceContextConfiguration {
     @Bean
     public GetUserGroupsUseCase getUserGroupsUseCase() {
         return mock(GetUserGroupsUseCase.class);
+    }
+
+    @Bean
+    public SubscriptionFormSchemaGenerator subscriptionFormSchemaGenerator() {
+        return mock(SubscriptionFormSchemaGenerator.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -30,6 +30,7 @@ import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
+import inmemory.SubscriptionFormQueryServiceInMemory;
 import inmemory.SubscriptionSearchQueryServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
@@ -148,6 +149,8 @@ import io.gravitee.apim.core.subscription.use_case.DeleteSubscriptionSpecUseCase
 import io.gravitee.apim.core.subscription.use_case.GetSubscriptionsUseCase;
 import io.gravitee.apim.core.subscription.use_case.ImportSubscriptionSpecUseCase;
 import io.gravitee.apim.core.subscription.use_case.UpdateSubscriptionUseCase;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
+import io.gravitee.apim.core.subscription_form.query_service.SubscriptionFormQueryService;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapterImpl;
@@ -1258,6 +1261,16 @@ public class ResourceContextConfiguration {
     @Bean
     public ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService() {
         return mock(ApplicationCertificatesUpdateDomainService.class);
+    }
+
+    @Bean
+    public SubscriptionFormQueryService subscriptionFormQueryService() {
+        return new SubscriptionFormQueryServiceInMemory();
+    }
+
+    @Bean
+    public SubscriptionFormSchemaGenerator subscriptionFormSchemaGenerator() {
+        return mock(SubscriptionFormSchemaGenerator.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.portal.rest.resource;
 import static org.mockito.Mockito.reset;
 
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.rest.api.portal.rest.JerseySpringTest;
 import io.gravitee.rest.api.portal.rest.mapper.AnalyticsMapper;
 import io.gravitee.rest.api.portal.rest.mapper.ApiMapper;
@@ -318,6 +319,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected EndpointConnectorPluginService endpointConnectorPluginService;
+
+    @Autowired
+    protected SubscriptionFormSchemaGenerator subscriptionFormSchemaGenerator;
 
     public AbstractResourceTest() {
         super(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
@@ -35,6 +35,7 @@ import static org.mockito.internal.util.collections.Sets.newSet;
 
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.ApiKeyEntity;
@@ -58,6 +59,7 @@ import io.gravitee.rest.api.service.v4.exception.SubscriptionMetadataInvalidExce
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -229,6 +231,19 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
             .application(APPLICATION)
             .plan(PLAN)
             .metadata(Map.of("bad key", "value"));
+
+        final Response response = target().request().post(Entity.json(subscriptionInput));
+        Assertions.assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        verify(createSubscriptionUseCase, times(1)).execute(any());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenSubscriptionFormMetadataIsInvalid() {
+        doThrow(new SubscriptionFormValidationException(List.of("Field 'email' is required")))
+            .when(createSubscriptionUseCase)
+            .execute(any());
+
+        SubscriptionInput subscriptionInput = new SubscriptionInput().application(APPLICATION).plan(PLAN).metadata(Map.of());
 
         final Response response = target().request().post(Entity.json(subscriptionInput));
         Assertions.assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -145,6 +145,7 @@ import io.gravitee.apim.core.subscription.use_case.DeleteSubscriptionSpecUseCase
 import io.gravitee.apim.core.subscription.use_case.GetSubscriptionsUseCase;
 import io.gravitee.apim.core.subscription.use_case.ImportSubscriptionSpecUseCase;
 import io.gravitee.apim.core.subscription.use_case.UpdateSubscriptionUseCase;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapterImpl;
@@ -1226,5 +1227,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ClusterConfigurationSchemaService clusterConfigurationSchemaService() {
         return mock(ClusterConfigurationSchemaService.class);
+    }
+
+    @Bean
+    SubscriptionFormSchemaGenerator subscriptionFormSchemaGenerator() {
+        return mock(SubscriptionFormSchemaGenerator.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCase.java
@@ -19,11 +19,16 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.subscription_form.crud_service.SubscriptionFormCrudService;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormConstraintsFactory;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSubmissionValidator;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormNotFoundException;
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
-import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
 import io.gravitee.apim.core.subscription_form.query_service.SubscriptionFormQueryService;
+import java.util.List;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -42,6 +47,7 @@ public class UpdateSubscriptionFormUseCase {
     private final SubscriptionFormCrudService subscriptionFormCrudService;
     private final SubscriptionFormQueryService subscriptionFormQueryService;
     private final GraviteeMarkdownValidator graviteeMarkdownValidator;
+    private final SubscriptionFormSchemaGenerator schemaGenerator;
 
     public Output execute(Input input) {
         graviteeMarkdownValidator.validateNotEmpty(GraviteeMarkdown.of(input.gmdContent()));
@@ -55,12 +61,24 @@ public class UpdateSubscriptionFormUseCase {
                 )
             );
 
-        existingForm.update(GraviteeMarkdown.of(input.gmdContent()), SubscriptionFormFieldConstraints.empty());
+        var gmd = GraviteeMarkdown.of(input.gmdContent());
+        var schema = schemaGenerator.generate(gmd);
+        validateFieldCount(schema);
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        existingForm.update(gmd, constraints);
         var savedForm = subscriptionFormCrudService.update(existingForm);
 
         log.info("Updated subscription form [{}] for environment [{}]", input.subscriptionFormId(), input.environmentId());
 
         return new Output(savedForm);
+    }
+
+    private void validateFieldCount(SubscriptionFormSchema schema) {
+        if (schema != null && schema.fields().size() > SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT) {
+            throw new SubscriptionFormValidationException(
+                List.of("Subscription form must not exceed " + SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT + " fields")
+            );
+        }
     }
 
     public record Input(String environmentId, SubscriptionFormId subscriptionFormId, String gmdContent) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
@@ -18,6 +18,9 @@ package io.gravitee.rest.api.service.v4.impl.validation;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSubmissionValidator;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
+import io.gravitee.apim.core.subscription_form.query_service.SubscriptionFormQueryService;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.rest.api.model.NewSubscriptionEntity;
 import io.gravitee.rest.api.model.PlanSecurityType;
@@ -32,6 +35,7 @@ import io.gravitee.rest.api.service.v4.exception.SubscriptionEntrypointIdMissing
 import io.gravitee.rest.api.service.v4.validation.SubscriptionMetadataSanitizer;
 import io.gravitee.rest.api.service.v4.validation.SubscriptionValidationService;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +52,7 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
 
     private final EntrypointConnectorPluginService entrypointService;
     private final SubscriptionMetadataSanitizer subscriptionMetadataSanitizer;
+    private final SubscriptionFormQueryService subscriptionFormQueryService;
 
     private final ClientCertificateCrudService clientCertificateCrudService;
 
@@ -57,6 +62,22 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
         if (subscription.getMetadata() != null) {
             subscription.setMetadata(subscriptionMetadataSanitizer.sanitizeAndValidate(subscription.getMetadata()));
         }
+        validateSubscriptionFormMetadataIfApplicable(genericPlanEntity, subscription.getMetadata());
+    }
+
+    private void validateSubscriptionFormMetadataIfApplicable(
+        final GenericPlanEntity genericPlanEntity,
+        final Map<String, String> metadata
+    ) {
+        subscriptionFormQueryService
+            .findDefaultForEnvironmentId(genericPlanEntity.getEnvironmentId())
+            .filter(SubscriptionForm::isEnabled)
+            .map(SubscriptionForm::getValidationConstraints)
+            .filter(constraints -> !constraints.isEmpty())
+            .ifPresent(constraints -> {
+                var submitted = metadata != null ? metadata : Map.<String, String>of();
+                new SubscriptionFormSubmissionValidator(constraints).validate(submitted);
+            });
     }
 
     @Override
@@ -70,6 +91,7 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
         if (subscription.getMetadata() != null) {
             subscription.setMetadata(subscriptionMetadataSanitizer.sanitizeAndValidate(subscription.getMetadata()));
         }
+        validateSubscriptionFormMetadataIfApplicable(genericPlanEntity, subscription.getMetadata());
     }
 
     private void validateTls(final GenericPlanEntity genericPlanEntity, final UpdateSubscriptionEntity subscription, String applicationId) {
@@ -109,6 +131,7 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
                 subscriptionMetadataSanitizer.sanitizeAndValidate(subscriptionConfiguration.getMetadata())
             );
         }
+        validateSubscriptionFormMetadataIfApplicable(genericPlanEntity, subscriptionConfiguration.getMetadata());
     }
 
     private SubscriptionConfigurationEntity validateAndSanitizeSubscriptionConfiguration(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCaseTest.java
@@ -24,10 +24,13 @@ import inmemory.SubscriptionFormQueryServiceInMemory;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.gravitee_markdown.exception.GraviteeMarkdownContentEmptyException;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSubmissionValidator;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormNotFoundException;
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
-import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
+import io.gravitee.apim.infra.domain_service.subscription_form.SubscriptionFormSchemaGeneratorImpl;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,13 +40,15 @@ class UpdateSubscriptionFormUseCaseTest {
     private final SubscriptionFormCrudServiceInMemory crudService = new SubscriptionFormCrudServiceInMemory();
     private final SubscriptionFormQueryServiceInMemory queryService = new SubscriptionFormQueryServiceInMemory();
     private final GraviteeMarkdownValidator gmdValidator = new GraviteeMarkdownValidator();
+    private final SubscriptionFormSchemaGenerator schemaGenerator = new SubscriptionFormSchemaGeneratorImpl();
+
     private UpdateSubscriptionFormUseCase useCase;
 
     @BeforeEach
     void setUp() {
         crudService.reset();
         queryService.reset();
-        useCase = new UpdateSubscriptionFormUseCase(crudService, queryService, gmdValidator);
+        useCase = new UpdateSubscriptionFormUseCase(crudService, queryService, gmdValidator, schemaGenerator);
     }
 
     @Test
@@ -67,7 +72,22 @@ class UpdateSubscriptionFormUseCaseTest {
             GraviteeMarkdown.of("<gmd-input name=\"updated\" fieldKey=\"updated\"/>")
         );
         assertThat(result.subscriptionForm().getId()).isEqualTo(existingForm.getId());
-        assertThat(result.subscriptionForm().getValidationConstraints()).isEqualTo(SubscriptionFormFieldConstraints.empty());
+        assertThat(result.subscriptionForm().getValidationConstraints()).isNotNull();
+        assertThat(result.subscriptionForm().getValidationConstraints().byFieldKey()).containsKey("updated");
+    }
+
+    @Test
+    void should_persist_empty_constraints_when_gmd_has_no_form_fields() {
+        SubscriptionForm existingForm = SubscriptionFormFixtures.aSubscriptionForm();
+        crudService.initWith(List.of(existingForm));
+        queryService.initWith(List.of(existingForm));
+
+        var result = useCase.execute(
+            new UpdateSubscriptionFormUseCase.Input(existingForm.getEnvironmentId(), existingForm.getId(), "<p>Only static content</p>")
+        );
+
+        assertThat(result.subscriptionForm().getValidationConstraints()).isNotNull();
+        assertThat(result.subscriptionForm().getValidationConstraints().isEmpty()).isTrue();
     }
 
     @Test
@@ -78,6 +98,30 @@ class UpdateSubscriptionFormUseCaseTest {
             "<gmd-input name=\"test\" fieldKey=\"test\"/>"
         );
         assertThatThrownBy(() -> useCase.execute(input)).isInstanceOf(SubscriptionFormNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_when_form_exceeds_max_field_count() {
+        SubscriptionForm existingForm = SubscriptionFormFixtures.aSubscriptionForm();
+        crudService.initWith(List.of(existingForm));
+        queryService.initWith(List.of(existingForm));
+
+        int tooMany = SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT + 1;
+        StringBuilder gmd = new StringBuilder();
+        for (int i = 0; i < tooMany; i++) {
+            gmd.append("<gmd-input fieldKey=\"field").append(i).append("\"/>");
+        }
+
+        var input = new UpdateSubscriptionFormUseCase.Input(existingForm.getEnvironmentId(), existingForm.getId(), gmd.toString());
+
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(SubscriptionFormValidationException.class)
+            .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+            .satisfies(errors ->
+                assertThat(errors).containsExactly(
+                    "Subscription form must not exceed " + SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT + " fields"
+                )
+            );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
@@ -16,14 +16,22 @@
 package io.gravitee.rest.api.service.v4.impl.validation;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
+import fixtures.core.model.SubscriptionFormFixtures;
+import inmemory.SubscriptionFormQueryServiceInMemory;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormConstraintsFactory;
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.rest.api.model.NewSubscriptionEntity;
@@ -41,6 +49,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -70,13 +80,17 @@ public class SubscriptionValidationServiceImplTest {
     @Mock
     private SubscriptionMetadataSanitizer subscriptionMetadataSanitizer;
 
+    private SubscriptionFormQueryServiceInMemory subscriptionFormQueryService;
+
     private PlanEntity planEntity;
 
     @BeforeEach
     void setUp() {
+        subscriptionFormQueryService = new SubscriptionFormQueryServiceInMemory();
         cut = new SubscriptionValidationServiceImpl(
             entrypointConnectorPluginService,
             subscriptionMetadataSanitizer,
+            subscriptionFormQueryService,
             clientCertificateCrudService
         );
         lenient()
@@ -84,8 +98,12 @@ public class SubscriptionValidationServiceImplTest {
             .thenAnswer(invocation -> invocation.getArgument(0));
 
         planEntity = new PlanEntity();
-        PlanSecurity security = new PlanSecurity();
-        planEntity.setSecurity(security);
+        planEntity.setSecurity(new PlanSecurity());
+    }
+
+    @AfterEach
+    void tearDown() {
+        subscriptionFormQueryService.reset();
     }
 
     @Nested
@@ -353,6 +371,343 @@ public class SubscriptionValidationServiceImplTest {
 
                 assertThat(updateSubscriptionConfigurationEntity.getConfiguration()).isNull();
             }
+        }
+    }
+
+    @Nested
+    class Subscription_form_metadata {
+
+        private static SubscriptionFormFieldConstraints required_email_constraints() {
+            return SubscriptionFormConstraintsFactory.fromSchema(
+                new SubscriptionFormSchema(List.of(new SubscriptionFormSchema.InputField("email", true, null, null, null, null)))
+            );
+        }
+
+        @BeforeEach
+        void beforeEach() {
+            planEntity.setEnvironmentId(SubscriptionFormFixtures.ENVIRONMENT_ID);
+        }
+
+        @Test
+        void should_throw_when_form_enabled_and_metadata_invalid() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var subscription = new NewSubscriptionEntity();
+            subscription.setMetadata(Map.of());
+
+            assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, subscription)).isInstanceOf(
+                SubscriptionFormValidationException.class
+            );
+        }
+
+        @Test
+        void should_not_throw_when_form_enabled_and_metadata_valid() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var subscription = new NewSubscriptionEntity();
+            subscription.setMetadata(Map.of("email", "user@example.com"));
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_not_validate_when_validation_constraints_null() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionForm.builder()
+                        .id(SubscriptionFormId.of(SubscriptionFormFixtures.FORM_ID))
+                        .environmentId(SubscriptionFormFixtures.ENVIRONMENT_ID)
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .enabled(true)
+                        .validationConstraints(null)
+                        .build()
+                )
+            );
+
+            var subscription = new NewSubscriptionEntity();
+            subscription.setMetadata(Map.of());
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_not_validate_when_validation_constraints_empty() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(SubscriptionFormFieldConstraints.empty())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var subscription = new NewSubscriptionEntity();
+            subscription.setMetadata(Map.of());
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_not_validate_when_form_disabled_even_if_constraints_present() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(false)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var subscription = new NewSubscriptionEntity();
+            subscription.setMetadata(Map.of());
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_not_validate_when_no_form_for_environment() {
+            // storage is empty — no form registered for any environment
+
+            var subscription = new NewSubscriptionEntity();
+            subscription.setMetadata(Map.of());
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_treat_null_metadata_as_empty_map_when_validating() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var subscription = new NewSubscriptionEntity();
+            subscription.setMetadata(null);
+
+            assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, subscription)).isInstanceOf(
+                SubscriptionFormValidationException.class
+            );
+        }
+    }
+
+    @Nested
+    class Subscription_form_metadata_on_update_configuration {
+
+        private static SubscriptionFormFieldConstraints required_email_constraints() {
+            return SubscriptionFormConstraintsFactory.fromSchema(
+                new SubscriptionFormSchema(List.of(new SubscriptionFormSchema.InputField("email", true, null, null, null, null)))
+            );
+        }
+
+        @BeforeEach
+        void beforeEach() {
+            planEntity.setEnvironmentId(SubscriptionFormFixtures.ENVIRONMENT_ID);
+        }
+
+        @Test
+        void should_throw_when_form_enabled_and_metadata_invalid() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setMetadata(Map.of());
+
+            assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).isInstanceOf(
+                SubscriptionFormValidationException.class
+            );
+        }
+
+        @Test
+        void should_not_throw_when_form_enabled_and_metadata_valid() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setMetadata(Map.of("email", "user@example.com"));
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_not_validate_when_form_disabled() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(false)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setMetadata(Map.of());
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_not_validate_when_no_form_for_environment() {
+            var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setMetadata(Map.of());
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_treat_null_metadata_as_empty_map_when_validating() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setMetadata(null);
+
+            assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).isInstanceOf(
+                SubscriptionFormValidationException.class
+            );
+        }
+    }
+
+    @Nested
+    class Subscription_form_metadata_on_update_subscription {
+
+        private static SubscriptionFormFieldConstraints required_email_constraints() {
+            return SubscriptionFormConstraintsFactory.fromSchema(
+                new SubscriptionFormSchema(List.of(new SubscriptionFormSchema.InputField("email", true, null, null, null, null)))
+            );
+        }
+
+        @BeforeEach
+        void beforeEach() {
+            planEntity.setEnvironmentId(SubscriptionFormFixtures.ENVIRONMENT_ID);
+        }
+
+        @Test
+        void should_throw_when_form_enabled_and_metadata_invalid() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setMetadata(Map.of());
+
+            assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).isInstanceOf(
+                SubscriptionFormValidationException.class
+            );
+        }
+
+        @Test
+        void should_not_throw_when_form_enabled_and_metadata_valid() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setMetadata(Map.of("email", "user@example.com"));
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_not_validate_when_form_disabled() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(false)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setMetadata(Map.of());
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_not_validate_when_no_form_for_environment() {
+            var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setMetadata(Map.of());
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_treat_null_metadata_as_empty_map_when_validating() {
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(required_email_constraints())
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+
+            var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setMetadata(null);
+
+            assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).isInstanceOf(
+                SubscriptionFormValidationException.class
+            );
         }
     }
 }


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-12990

## Description
**PR 3/3** — Resource layer: constraint generation on form save + submission validation.
Previous: [#15864 (PR 2/3 — repository layer, constraint persistence)](https://github.com/gravitee-io/gravitee-api-management/pull/15864)

This PR adds:
- `UpdateSubscriptionFormUseCase` now generates constraints from GMD on every save
  (`GMD → schemaGenerator.generate() → ConstraintsFactory.fromSchema() → persist`)
- `SubscriptionForm.update()` simplified — always replaces constraints, null-as-skip removed
- `SubscriptionValidationServiceImpl` validates submitted metadata against stored constraints
  at subscription creation time (only when form exists, is enabled, and has non-empty constraints)
- Tests for `UpdateSubscriptionFormUseCase` (constraint generation scenarios)
- Tests for `SubscriptionValidationServiceImpl` (all guard conditions: form absent, disabled,
  empty constraints, null metadata, valid/invalid submission)
- Portal resource test: `SubscriptionFormValidationException` → HTTP 400

**Not in this PR** (coming in following story):
- EL-based dynamic options validation
- Frontend integration

## Additional context
The validator is intentionally "dumb" — it only validates metadata keys that have constraints
defined in the form. Metadata from other sources is passed through without validation.