### PR TITLE
fix: remove DatePipe from imports array

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
@@ -48,7 +48,7 @@ const DEFAULT_PER_PAGE = 10;
   selector: 'env-logs',
   templateUrl: './env-logs.component.html',
   styleUrl: './env-logs.component.scss',
-  imports: [EnvLogsTableComponent, EnvLogsFilterBarComponent, MatCardModule, GioBannerModule, DatePipe, GioHeaderComponent],
+  imports: [EnvLogsTableComponent, EnvLogsFilterBarComponent, MatCardModule, GioBannerModule, GioHeaderComponent],
   providers: [DatePipe],
   standalone: true,
 })


### PR DESCRIPTION
Cherry pick of https://github.com/gravitee-io/gravitee-api-management/pull/15923

