### PR TITLE
fix: refactor payload for api product when removing api

### DIFF
--- a/gravitee-apim-e2e/api-test/src/apis/plans/mapi-v1/api-product-deletion-scenarios.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/plans/mapi-v1/api-product-deletion-scenarios.spec.ts
@@ -344,13 +344,12 @@ describeIfClientGatewaySupportingApiProduct(
         await noContent(v2ApisResourceAsApiPublisher.deleteApiRaw({ envId, apiId: api1.id, closePlans: true }));
         // Mark as deleted so afterAll skips a second delete attempt.
         api1 = { ...api1, id: '' };
-
-        // Allow the gateway time to process the undeploy event.
         await new Promise((resolve) => setTimeout(resolve, 6000));
       });
 
       test('api1 path should return 404 after the underlying API is removed from the gateway', async () => {
-        const response = await fetch(`${process.env.GATEWAY_BASE_URL}${(api1.listeners[0] as HttpListener).paths[0].path}`, {
+        const api1Path = (api1.listeners[0] as HttpListener).paths[0].path;
+        const response = await fetch(`${process.env.GATEWAY_BASE_URL}${api1Path}`, {
           method: 'GET',
           headers: { 'X-Gravitee-Api-Key': apiKey },
         } as any);

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4IntegrationTest.java
@@ -217,6 +217,39 @@ class ApiProductV4IntegrationTest {
             assertStatus(client, API_1_PATH, KEY_ALPHA, 401);
             assertStatus(client, API_2_PATH, KEY_ALPHA, 200);
         }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        @DeployApiProducts(PRODUCT_RESOURCE)
+        void should_keep_sibling_api_accessible_after_underlying_api_is_undeployed_from_gateway(HttpClient client) {
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+            allowKeyForApi(KEY_ALPHA, API_2_ID);
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 200);
+
+            undeploy(API_1_ID);
+            redeployApiProduct(product(PRODUCT_ID, Set.of(API_2_ID)));
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 404);
+            assertStatus(client, API_2_PATH, KEY_ALPHA, 200);
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        @DeployApiProducts(PRODUCT_RESOURCE)
+        void should_return_401_for_all_apis_when_last_api_is_undeployed_and_product_redeployed_with_no_apis(HttpClient client) {
+            allowKeyForApi(KEY_ALPHA, API_1_ID);
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 200);
+
+            undeploy(API_1_ID);
+            redeployApiProduct(product(PRODUCT_ID, Set.of()));
+
+            assertStatus(client, API_1_PATH, KEY_ALPHA, 404);
+        }
     }
 
     @Nested

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4SecurityIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4SecurityIntegrationTest.java
@@ -100,7 +100,9 @@ class ApiProductV4SecurityIntegrationTest {
 
     private static final String ENV_ID = "DEFAULT";
     private static final String API_1_ID = "my-api-v4-1";
+    private static final String API_2_ID = "my-api-v4-2";
     private static final String API_1_PATH = "/test-1";
+    private static final String API_2_PATH = "/test-2";
 
     @Nested
     class JwtSecurityTypeScenarios extends SecurityTestPreparer {
@@ -135,6 +137,31 @@ class ApiProductV4SecurityIntegrationTest {
             assertThat(getStatus(client, API_1_PATH)).isEqualTo(401);
             assertThat(getStatusWithHeader(client, API_1_PATH, "Authorization", "Bearer a-jwt-token")).isEqualTo(401);
             assertThat(getStatusWithHeader(client, API_1_PATH, "X-Gravitee-Api-Key", "an-api-key")).isEqualTo(401);
+        }
+
+        @Test
+        @DeployApi(
+            { "/apis/v4/http/api-product/api-1.json", "/apis/v4/http/api-product/api-2.json", "/apis/v4/http/api-product/api-3.json" }
+        )
+        void should_keep_sibling_api_accessible_via_jwt_after_one_api_is_removed_from_product(HttpClient client) throws Exception {
+            final String productId = "jwt-product-deletion-sibling";
+            final String planId = "jwt-product-plan-deletion-sibling";
+            ReactableApiProduct p = product(productId, Set.of(API_1_ID, API_2_ID));
+            registerProductPlans(p, List.of(productJwtPlan(planId, PlanStatus.PUBLISHED)));
+            deployApiProduct(p);
+            allowJwtSubscriptionForApiAndPlan(API_1_ID, planId, JWT_CLIENT_ID);
+            allowJwtSubscriptionForApiAndPlan(API_2_ID, planId, JWT_CLIENT_ID);
+
+            assertThat(getStatusWithHeader(client, API_1_PATH, "Authorization", "Bearer " + generateJWT(5000))).isEqualTo(200);
+            assertThat(getStatusWithHeader(client, API_2_PATH, "Authorization", "Bearer " + generateJWT(5000))).isEqualTo(200);
+
+            undeploy(API_1_ID);
+            ReactableApiProduct updatedProduct = product(productId, Set.of(API_2_ID));
+            registerProductPlans(updatedProduct, List.of(productJwtPlan(planId, PlanStatus.PUBLISHED)));
+            redeployApiProduct(updatedProduct);
+
+            assertThat(getStatusWithHeader(client, API_1_PATH, "Authorization", "Bearer " + generateJWT(5000))).isEqualTo(404);
+            assertThat(getStatusWithHeader(client, API_2_PATH, "Authorization", "Bearer " + generateJWT(5000))).isEqualTo(200);
         }
 
         @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
@@ -202,7 +202,9 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                     "LEFT JOIN " +
                     API_PRODUCT_APIS +
                     " apa ON ap.id = apa.api_product_id " +
-                    "WHERE apa.api_id = ? " +
+                    "WHERE ap.id IN (SELECT api_product_id FROM " +
+                    API_PRODUCT_APIS +
+                    " WHERE api_id = ?) " +
                     "ORDER BY ap.id",
                 (ResultSet rs, int rowNum) -> {
                     ApiProduct apiProduct = getOrm().getRowMapper().mapRow(rs, rowNum);
@@ -241,9 +243,11 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 "LEFT JOIN " +
                 API_PRODUCT_APIS +
                 " apa ON ap.id = apa.api_product_id " +
-                "WHERE apa.api_id IN (" +
+                "WHERE ap.id IN (SELECT api_product_id FROM " +
+                API_PRODUCT_APIS +
+                " WHERE api_id IN (" +
                 getOrm().buildInClause(idList) +
-                ") ORDER BY ap.id";
+                ")) ORDER BY ap.id";
             List<ApiProduct> apiProducts = jdbcTemplate.query(
                 sql,
                 (ResultSet rs, int rowNum) -> {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiProductRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiProductRepositoryTest.java
@@ -142,6 +142,11 @@ public class ApiProductRepositoryTest extends AbstractManagementRepositoryTest {
         var apiProducts = apiProductsRepository.findByApiId("api1");
 
         assertThat(apiProducts).hasSize(2).are(containingApi("api1"));
+        // Must return every API in the product, not only the queried id (used when removing one API from a product).
+        assertThat(apiProducts)
+            .filteredOn(p -> "f66274c9-3d8f-44c5-a274-c93d8fb4c5f3".equals(p.getId()))
+            .singleElement()
+            .satisfies(p -> assertThat(p.getApiIds()).containsExactlyInAnyOrder("api1", "api2"));
     }
 
     @Test
@@ -157,6 +162,14 @@ public class ApiProductRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertThat(products).isNotEmpty();
         assertThat(products).allMatch(p -> p.getApiIds() != null && (p.getApiIds().contains("api1") || p.getApiIds().contains("api2")));
+        assertThat(products)
+            .filteredOn(p -> "f66274c9-3d8f-44c5-a274-c93d8fb4c5f3".equals(p.getId()))
+            .singleElement()
+            .satisfies(p -> assertThat(p.getApiIds()).containsExactlyInAnyOrder("api1", "api2"));
+        assertThat(products)
+            .filteredOn(p -> "459a022c-e79c-4411-9a02-2ce79c141165".equals(p.getId()))
+            .singleElement()
+            .satisfies(p -> assertThat(p.getApiIds()).containsExactlyInAnyOrder("api2", "api3"));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/DeployApiProductDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/DeployApiProductDomainService.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import static java.util.Map.entry;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductDeploymentPayload;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.event.crud_service.EventCrudService;
+import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
+import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.rest.api.model.EventType;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class DeployApiProductDomainService {
+
+    private final PlanQueryService planQueryService;
+    private final EventCrudService eventCrudService;
+    private final EventLatestCrudService eventLatestCrudService;
+
+    public void deploy(AuditInfo auditInfo, ApiProduct apiProduct) {
+        var plans = planQueryService
+            .findAllByReferenceIdAndReferenceType(apiProduct.getId(), GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .stream()
+            .map(io.gravitee.apim.core.plan.model.Plan::getPlanDefinitionHttpV4)
+            .filter(Objects::nonNull)
+            .toList();
+
+        var payload = ApiProductDeploymentPayload.builder()
+            .id(apiProduct.getId())
+            .name(apiProduct.getName())
+            .description(apiProduct.getDescription())
+            .version(apiProduct.getVersion())
+            .apiIds(apiProduct.getApiIds())
+            .environmentId(apiProduct.getEnvironmentId())
+            .plans(plans)
+            .build();
+
+        final Event event = eventCrudService.createEvent(
+            auditInfo.organizationId(),
+            auditInfo.environmentId(),
+            Set.of(auditInfo.environmentId()),
+            EventType.DEPLOY_API_PRODUCT,
+            payload,
+            Map.ofEntries(
+                entry(Event.EventProperties.USER, auditInfo.actor().userId()),
+                entry(Event.EventProperties.API_PRODUCT_ID, apiProduct.getId())
+            )
+        );
+
+        eventLatestCrudService.createOrPatchLatestEvent(auditInfo.organizationId(), apiProduct.getId(), event);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/RemoveApiFromApiProductsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/RemoveApiFromApiProductsDomainService.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.apim.core.api_product.domain_service;
 
-import static java.util.Map.entry;
-
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
@@ -27,12 +25,8 @@ import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.ApiProductAuditEvent;
-import io.gravitee.apim.core.event.crud_service.EventCrudService;
-import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
-import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.common.utils.TimeProvider;
-import io.gravitee.rest.api.model.EventType;
 import java.util.Map;
 import java.util.Set;
 import lombok.CustomLog;
@@ -46,8 +40,7 @@ public class RemoveApiFromApiProductsDomainService {
     private final ApiProductQueryService apiProductQueryService;
     private final ApiProductCrudService apiProductCrudService;
     private final ValidateApiProductService validateApiProductService;
-    private final EventCrudService eventCrudService;
-    private final EventLatestCrudService eventLatestCrudService;
+    private final DeployApiProductDomainService deployApiProductDomainService;
     private final AuditDomainService auditDomainService;
 
     public void removeApiFromApiProducts(String apiId, String organizationId, String environmentId, String userId) {
@@ -70,26 +63,11 @@ public class RemoveApiFromApiProductsDomainService {
             createAuditLog(auditInfo, updated);
             try {
                 validateApiProductService.validateForDeploy(updated);
-                publishDeployEvent(auditInfo, updated);
+                deployApiProductDomainService.deploy(auditInfo, updated);
             } catch (ValidationDomainException e) {
                 log.warn("API Product [{}] cannot be auto-deployed after API [{}] removal: {}", updated.getId(), apiId, e.getMessage());
             }
         });
-    }
-
-    private void publishDeployEvent(AuditInfo auditInfo, ApiProduct apiProduct) {
-        final Event event = eventCrudService.createEvent(
-            auditInfo.organizationId(),
-            auditInfo.environmentId(),
-            Set.of(auditInfo.environmentId()),
-            EventType.DEPLOY_API_PRODUCT,
-            apiProduct,
-            Map.ofEntries(
-                entry(Event.EventProperties.USER, auditInfo.actor().userId()),
-                entry(Event.EventProperties.API_PRODUCT_ID, apiProduct.getId())
-            )
-        );
-        eventLatestCrudService.createOrPatchLatestEvent(auditInfo.organizationId(), apiProduct.getId(), event);
     }
 
     private void createAuditLog(AuditInfo auditInfo, ApiProduct after) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
@@ -16,14 +16,13 @@
 package io.gravitee.apim.core.api_product.use_case;
 
 import static io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService.oneShotIndexation;
-import static java.util.Map.entry;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
+import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
-import io.gravitee.apim.core.api_product.model.ApiProductDeploymentPayload;
 import io.gravitee.apim.core.api_product.model.CreateApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -31,9 +30,6 @@ import io.gravitee.apim.core.audit.model.ApiProductAuditLogEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.ApiProductAuditEvent;
-import io.gravitee.apim.core.event.crud_service.EventCrudService;
-import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
-import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
@@ -41,15 +37,11 @@ import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerFac
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
 import io.gravitee.apim.core.notification.model.config.NotificationConfig;
-import io.gravitee.apim.core.plan.query_service.PlanQueryService;
-import io.gravitee.rest.api.model.EventType;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
@@ -63,12 +55,10 @@ public class CreateApiProductUseCase {
     private final AuditDomainService auditService;
     private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
     private final ApiProductPrimaryOwnerFactory apiProductPrimaryOwnerFactory;
-    private final EventCrudService eventCrudService;
-    private final EventLatestCrudService eventLatestCrudService;
     private final LicenseDomainService licenseDomainService;
     private final ApiProductIndexerDomainService apiProductIndexerDomainService;
     private final NotificationConfigCrudService notificationConfigCrudService;
-    private final PlanQueryService planQueryService;
+    private final DeployApiProductDomainService deployApiProductDomainService;
 
     public record Input(CreateApiProduct createApiProduct, AuditInfo auditInfo) {}
 
@@ -123,43 +113,10 @@ public class CreateApiProductUseCase {
         apiProductIndexerDomainService.index(oneShotIndexation(auditInfo), created, primaryOwner);
 
         createDefaultMailNotification(created);
-        publishDeployEvent(auditInfo, created);
+        deployApiProductDomainService.deploy(auditInfo, created);
         createAuditLog(created, auditInfo);
 
         return new Output(created);
-    }
-
-    private void publishDeployEvent(AuditInfo auditInfo, ApiProduct apiProduct) {
-        var plans = planQueryService
-            .findAllByReferenceIdAndReferenceType(apiProduct.getId(), GenericPlanEntity.ReferenceType.API_PRODUCT)
-            .stream()
-            .map(io.gravitee.apim.core.plan.model.Plan::getPlanDefinitionHttpV4)
-            .filter(Objects::nonNull)
-            .toList();
-
-        var payload = ApiProductDeploymentPayload.builder()
-            .id(apiProduct.getId())
-            .name(apiProduct.getName())
-            .description(apiProduct.getDescription())
-            .version(apiProduct.getVersion())
-            .apiIds(apiProduct.getApiIds())
-            .environmentId(apiProduct.getEnvironmentId())
-            .plans(plans)
-            .build();
-
-        final Event event = eventCrudService.createEvent(
-            auditInfo.organizationId(),
-            auditInfo.environmentId(),
-            Set.of(auditInfo.environmentId()),
-            EventType.DEPLOY_API_PRODUCT,
-            payload,
-            Map.ofEntries(
-                entry(Event.EventProperties.USER, auditInfo.actor().userId()),
-                entry(Event.EventProperties.API_PRODUCT_ID, apiProduct.getId())
-            )
-        );
-
-        eventLatestCrudService.createOrPatchLatestEvent(auditInfo.organizationId(), apiProduct.getId(), event);
     }
 
     private void createDefaultMailNotification(ApiProduct apiProduct) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCase.java
@@ -15,27 +15,16 @@
  */
 package io.gravitee.apim.core.api_product.use_case;
 
-import static java.util.Map.entry;
-
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
-import io.gravitee.apim.core.api_product.model.ApiProductDeploymentPayload;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.apim.core.event.crud_service.EventCrudService;
-import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
-import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
-import io.gravitee.apim.core.plan.query_service.PlanQueryService;
-import io.gravitee.rest.api.model.EventType;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -47,11 +36,9 @@ import lombok.RequiredArgsConstructor;
 public class DeployApiProductUseCase {
 
     private final ApiProductQueryService apiProductQueryService;
-    private final EventCrudService eventCrudService;
-    private final EventLatestCrudService eventLatestCrudService;
     private final LicenseDomainService licenseDomainService;
-    private final PlanQueryService planQueryService;
     private final ValidateApiProductService validateApiProductService;
+    private final DeployApiProductDomainService deployApiProductDomainService;
 
     public Output execute(Input input) {
         if (!licenseDomainService.isApiProductDeploymentAllowed(input.auditInfo().organizationId())) {
@@ -63,41 +50,8 @@ public class DeployApiProductUseCase {
         }
         ApiProduct apiProduct = apiProductOpt.get();
         validateApiProductService.validateForDeploy(apiProduct);
-        publishDeployEvent(input.auditInfo(), apiProduct);
+        deployApiProductDomainService.deploy(input.auditInfo(), apiProduct);
         return new Output(apiProduct);
-    }
-
-    private void publishDeployEvent(AuditInfo auditInfo, ApiProduct apiProduct) {
-        var plans = planQueryService
-            .findAllByReferenceIdAndReferenceType(apiProduct.getId(), GenericPlanEntity.ReferenceType.API_PRODUCT)
-            .stream()
-            .map(io.gravitee.apim.core.plan.model.Plan::getPlanDefinitionHttpV4)
-            .filter(Objects::nonNull)
-            .toList();
-
-        var payload = ApiProductDeploymentPayload.builder()
-            .id(apiProduct.getId())
-            .name(apiProduct.getName())
-            .description(apiProduct.getDescription())
-            .version(apiProduct.getVersion())
-            .apiIds(apiProduct.getApiIds())
-            .environmentId(apiProduct.getEnvironmentId())
-            .plans(plans)
-            .build();
-
-        final Event event = eventCrudService.createEvent(
-            auditInfo.organizationId(),
-            auditInfo.environmentId(),
-            Set.of(auditInfo.environmentId()),
-            EventType.DEPLOY_API_PRODUCT,
-            payload,
-            Map.ofEntries(
-                entry(Event.EventProperties.USER, auditInfo.actor().userId()),
-                entry(Event.EventProperties.API_PRODUCT_ID, apiProduct.getId())
-            )
-        );
-
-        eventLatestCrudService.createOrPatchLatestEvent(auditInfo.organizationId(), apiProduct.getId(), event);
     }
 
     public record Input(String apiProductId, AuditInfo auditInfo) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
@@ -16,16 +16,15 @@
 package io.gravitee.apim.core.api_product.use_case;
 
 import static io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService.oneShotIndexation;
-import static java.util.Map.entry;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
+import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
-import io.gravitee.apim.core.api_product.model.ApiProductDeploymentPayload;
 import io.gravitee.apim.core.api_product.model.UpdateApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -33,21 +32,14 @@ import io.gravitee.apim.core.audit.model.ApiProductAuditLogEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.ApiProductAuditEvent;
-import io.gravitee.apim.core.event.crud_service.EventCrudService;
-import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
-import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
-import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.common.utils.TimeProvider;
-import io.gravitee.rest.api.model.EventType;
-import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import lombok.CustomLog;
@@ -63,12 +55,10 @@ public class UpdateApiProductUseCase {
     private final ApiProductQueryService apiProductQueryService;
     private final ValidateApiProductService validateApiProductService;
     private final ApiStateDomainService apiStateDomainService;
-    private final EventCrudService eventCrudService;
-    private final EventLatestCrudService eventLatestCrudService;
     private final LicenseDomainService licenseDomainService;
-    private final PlanQueryService planQueryService;
     private final ApiProductIndexerDomainService apiProductIndexerDomainService;
     private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
+    private final DeployApiProductDomainService deployApiProductDomainService;
 
     public Output execute(Input input) {
         if (!licenseDomainService.isApiProductDeploymentAllowed(input.auditInfo().organizationId())) {
@@ -119,42 +109,9 @@ public class UpdateApiProductUseCase {
         }
         apiProductIndexerDomainService.index(oneShotIndexation(input.auditInfo()), updated, primaryOwner);
 
-        publishDeployEvent(input.auditInfo(), updated);
+        deployApiProductDomainService.deploy(input.auditInfo(), updated);
         createAuditLog(beforeUpdate, updated, input.auditInfo());
         return new Output(updated);
-    }
-
-    private void publishDeployEvent(AuditInfo auditInfo, ApiProduct apiProduct) {
-        var plans = planQueryService
-            .findAllByReferenceIdAndReferenceType(apiProduct.getId(), GenericPlanEntity.ReferenceType.API_PRODUCT)
-            .stream()
-            .map(io.gravitee.apim.core.plan.model.Plan::getPlanDefinitionHttpV4)
-            .filter(Objects::nonNull)
-            .toList();
-
-        var payload = ApiProductDeploymentPayload.builder()
-            .id(apiProduct.getId())
-            .name(apiProduct.getName())
-            .description(apiProduct.getDescription())
-            .version(apiProduct.getVersion())
-            .apiIds(apiProduct.getApiIds())
-            .environmentId(apiProduct.getEnvironmentId())
-            .plans(plans)
-            .build();
-
-        final Event event = eventCrudService.createEvent(
-            auditInfo.organizationId(),
-            auditInfo.environmentId(),
-            Set.of(auditInfo.environmentId()),
-            EventType.DEPLOY_API_PRODUCT,
-            payload,
-            Map.ofEntries(
-                entry(Event.EventProperties.USER, auditInfo.actor().userId()),
-                entry(Event.EventProperties.API_PRODUCT_ID, apiProduct.getId())
-            )
-        );
-
-        eventLatestCrudService.createOrPatchLatestEvent(auditInfo.organizationId(), apiProduct.getId(), event);
     }
 
     public record Input(String apiProductId, UpdateApiProduct updateApiProduct, AuditInfo auditInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/RemoveApiFromApiProductsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/RemoveApiFromApiProductsDomainServiceTest.java
@@ -30,6 +30,7 @@ import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.model.ApiProductDeploymentPayload;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
@@ -41,6 +42,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class RemoveApiFromApiProductsDomainServiceTest extends AbstractUseCaseTest {
 
@@ -70,12 +72,12 @@ class RemoveApiFromApiProductsDomainServiceTest extends AbstractUseCaseTest {
             planQueryService,
             apiProductQueryService
         );
+        var deployApiProductDomainService = new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService);
         domainService = new RemoveApiFromApiProductsDomainService(
             apiProductQueryService,
             apiProductCrudService,
             validateApiProductService,
-            eventCrudService,
-            eventLatestCrudService,
+            deployApiProductDomainService,
             auditDomainService
         );
     }
@@ -165,6 +167,71 @@ class RemoveApiFromApiProductsDomainServiceTest extends AbstractUseCaseTest {
 
                 verify(eventCrudService, times(2)).createEvent(any(), any(), any(), any(), any(), any());
                 verify(eventLatestCrudService, times(2)).createOrPatchLatestEvent(any(), any(), any());
+            }
+
+            @Test
+            void should_publish_deploy_event_with_api_product_deployment_payload_including_plans() {
+                domainService.removeApiFromApiProducts(API_ID, ORG_ID, ENV_ID, USER_ID);
+
+                ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+                verify(eventCrudService, times(2)).createEvent(any(), any(), any(), any(), payloadCaptor.capture(), any());
+
+                payloadCaptor
+                    .getAllValues()
+                    .forEach(payload -> {
+                        assertThat(payload).isInstanceOf(ApiProductDeploymentPayload.class);
+                        ApiProductDeploymentPayload deployPayload = (ApiProductDeploymentPayload) payload;
+                        assertThat(deployPayload.getPlans()).isNotNull().isNotEmpty();
+                        assertThat(deployPayload.getApiIds()).doesNotContain(API_ID);
+                    });
+            }
+
+            @Test
+            void should_publish_deploy_event_with_empty_plans_when_product_has_no_product_level_plans() {
+                planQueryService.reset();
+                planQueryService.initWith(
+                    List.of(
+                        PlanFixtures.aPlanHttpV4()
+                            .toBuilder()
+                            .id("plan-other-api")
+                            .referenceId("other-api")
+                            .referenceType(GenericPlanEntity.ReferenceType.API)
+                            .build()
+                    )
+                );
+
+                domainService.removeApiFromApiProducts(API_ID, ORG_ID, ENV_ID, USER_ID);
+
+                ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+                verify(eventCrudService, times(2)).createEvent(any(), any(), any(), any(), payloadCaptor.capture(), any());
+
+                payloadCaptor
+                    .getAllValues()
+                    .forEach(payload -> {
+                        assertThat(payload).isInstanceOf(ApiProductDeploymentPayload.class);
+                        ApiProductDeploymentPayload deployPayload = (ApiProductDeploymentPayload) payload;
+                        assertThat(deployPayload.getPlans()).isNotNull().isEmpty();
+                    });
+            }
+
+            @Test
+            void should_publish_deploy_event_for_product_that_has_zero_apis_after_removal() {
+                // PRODUCT_2 initially had only API_ID — after removal apiIds is empty.
+                domainService.removeApiFromApiProducts(API_ID, ORG_ID, ENV_ID, USER_ID);
+
+                ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+                verify(eventCrudService, times(2)).createEvent(any(), any(), any(), any(), payloadCaptor.capture(), any());
+
+                var product2Payload = payloadCaptor
+                    .getAllValues()
+                    .stream()
+                    .map(p -> (ApiProductDeploymentPayload) p)
+                    .filter(p -> PRODUCT_2.equals(p.getId()))
+                    .findFirst();
+
+                assertThat(product2Payload).isPresent();
+                assertThat(product2Payload.get().getApiIds()).isEmpty();
+                assertThat(product2Payload.get().getPlans()).isNotNull();
             }
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -39,6 +39,7 @@ import inmemory.PlanQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
+import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.model.CreateApiProduct;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -131,12 +132,10 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
             auditService,
             apiProductPrimaryOwnerDomainService,
             apiProductPrimaryOwnerFactory,
-            eventCrudService,
-            eventLatestCrudService,
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
             apiProductIndexerDomainService,
             notificationConfigCrudService,
-            planQueryService
+            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService)
         );
 
         initRoles();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCaseTest.java
@@ -31,6 +31,7 @@ import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
@@ -68,11 +69,9 @@ class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
         );
         deployApiProductUseCase = new DeployApiProductUseCase(
             apiProductQueryService,
-            eventCrudService,
-            eventLatestCrudService,
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
-            planQueryService,
-            validateApiProductService
+            validateApiProductService,
+            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService)
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
@@ -38,6 +38,7 @@ import inmemory.PlanQueryServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
+import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
@@ -90,12 +91,10 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
             apiProductQueryService,
             validateApiProductService,
             apiStateDomainService,
-            eventCrudService,
-            eventLatestCrudService,
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
-            planQueryService,
             apiProductIndexerDomainService,
-            apiProductPrimaryOwnerDomainService
+            apiProductPrimaryOwnerDomainService,
+            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService)
         );
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13079

## Description

When an API was deleted from the system, RemoveApiFromApiProductsDomainService fired a DEPLOY_API_PRODUCT gateway event with the raw ApiProduct object as the payload instead of an ApiProductDeploymentPayload (which includes plans) and this is required post refactorisation done in APIM-13079 original PR.

The gateway received an event with no plans and stripped plan configuration for the product, causing all remaining APIs in that product to return 401.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

