### PR TITLE
fix: handle API product refs in key audit logs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
@@ -17,7 +17,9 @@ package io.gravitee.rest.api.service;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.repository.management.model.Subscription;
+import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.NewSubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.TransferSubscriptionEntity;
@@ -29,7 +31,9 @@ import io.gravitee.rest.api.model.subscription.ReferenceDisplayInfo;
 import io.gravitee.rest.api.model.subscription.SubscribedReference;
 import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.notification.ApiHook;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -122,4 +126,29 @@ public interface SubscriptionService {
     List<SubscribedReference> getSubscribedReferences(ExecutionContext executionContext, String applicationId);
 
     Optional<ReferenceDisplayInfo> getReferenceDisplayInfo(ExecutionContext executionContext, String referenceType, String referenceId);
+
+    /**
+     * Builds the Console URL to open a subscription in the management UI (API or API Product).
+     */
+    Optional<String> buildSubscriptionConsoleUrl(ExecutionContext executionContext, SubscriptionEntity subscription);
+
+    /**
+     * Sends subscription-related notifications for an API Product subscription (same pipeline as the management API subscription flow).
+     *
+     * @param apiKey optional API key value carrier for hooks such as API key lifecycle events; may be {@code null}
+     * @param additionalParams optional extra notifier parameters (e.g. expiration date); merged into the built params, may be {@code null} or empty
+     */
+    void triggerSubscriptionNotificationsForApiProduct(
+        ExecutionContext executionContext,
+        String apiProductId,
+        String applicationId,
+        ApplicationEntity applicationEntity,
+        GenericPlanEntity genericPlanEntity,
+        SubscriptionEntity subscriptionEntity,
+        Optional<String> subscriptionsUrl,
+        boolean includeSubscribedByUser,
+        ApiHook hook,
+        ApiKey apiKey,
+        Map<String, Object> additionalParams
+    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -70,6 +70,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -709,7 +710,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             .getSubscriptions()
             .forEach(subscription -> {
                 boolean isApiProduct = isApiProductSubscription(subscription);
-                String referenceId = isApiProduct ? subscription.getReferenceId() : subscription.getApi();
+                String referenceId = subscription.getReferenceId() != null ? subscription.getReferenceId() : subscription.getApi();
                 String applicationId = key.getApplication() != null ? key.getApplication().getId() : null;
 
                 Map<Audit.AuditProperties, String> properties = new LinkedHashMap<>();
@@ -764,12 +765,26 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
         Set<SubscriptionEntity> subscriptions,
         NotificationParamsBuilder paramsBuilder
     ) {
+        Map<String, Object> additionalParams = new HashMap<>(paramsBuilder.build());
         subscriptions.forEach(subscription -> {
-            // Notifications are not applicable for API Product subscriptions (TODO: implement notifications for API Product subscriptions)
+            GenericPlanEntity genericPlanEntity = planSearchService.findById(executionContext, subscription.getPlan());
             if (isApiProductSubscription(subscription)) {
+                String apiProductId = subscription.getReferenceId() != null ? subscription.getReferenceId() : subscription.getApi();
+                subscriptionService.triggerSubscriptionNotificationsForApiProduct(
+                    executionContext,
+                    apiProductId,
+                    application.getId(),
+                    application,
+                    genericPlanEntity,
+                    subscription,
+                    subscriptionService.buildSubscriptionConsoleUrl(executionContext, subscription),
+                    false,
+                    apiHook,
+                    key,
+                    additionalParams
+                );
                 return;
             }
-            GenericPlanEntity genericPlanEntity = planSearchService.findById(executionContext, subscription.getPlan());
             GenericApiModel genericApiModel = apiTemplateService.findByIdForTemplates(executionContext, subscription.getApi());
             PrimaryOwnerEntity owner = application.getPrimaryOwner();
             Map<String, Object> params = paramsBuilder

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -21,6 +21,7 @@ import static io.gravitee.repository.management.model.ApiKey.AuditEvent.APIKEY_R
 import static io.gravitee.repository.management.model.ApiKey.AuditEvent.APIKEY_RENEWED;
 import static io.gravitee.repository.management.model.Audit.AuditProperties.API;
 import static io.gravitee.repository.management.model.Audit.AuditProperties.API_KEY;
+import static io.gravitee.repository.management.model.Audit.AuditProperties.API_PRODUCT;
 import static io.gravitee.repository.management.model.Audit.AuditProperties.APPLICATION;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
@@ -707,21 +708,30 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
         key
             .getSubscriptions()
             .forEach(subscription -> {
+                boolean isApiProduct = isApiProductSubscription(subscription);
+                String referenceId = isApiProduct ? subscription.getReferenceId() : subscription.getApi();
+                String applicationId = key.getApplication() != null ? key.getApplication().getId() : null;
+
                 Map<Audit.AuditProperties, String> properties = new LinkedHashMap<>();
                 properties.put(API_KEY, key.getKey());
-                properties.put(API, subscription.getApi());
-                properties.put(APPLICATION, key.getApplication().getId());
-                auditService.createApiAuditLog(
-                    executionContext,
-                    AuditService.AuditLogData.builder()
-                        .properties(properties)
-                        .event(event)
-                        .createdAt(eventDate)
-                        .oldValue(previousApiKey)
-                        .newValue(key)
-                        .build(),
-                    subscription.getApi()
-                );
+                properties.put(isApiProduct ? API_PRODUCT : API, referenceId);
+                properties.put(APPLICATION, applicationId);
+
+                AuditService.AuditLogData auditLogData = AuditService.AuditLogData.builder()
+                    .properties(properties)
+                    .event(event)
+                    .createdAt(eventDate)
+                    .oldValue(previousApiKey)
+                    .newValue(key)
+                    .build();
+
+                if (isApiProduct) {
+                    auditService.createApiProductAuditLog(executionContext, auditLogData, referenceId);
+                } else if (referenceId != null) {
+                    auditService.createApiAuditLog(executionContext, auditLogData, referenceId);
+                } else {
+                    auditService.createApplicationAuditLog(executionContext, auditLogData, applicationId);
+                }
             });
     }
 
@@ -774,7 +784,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
     }
 
     private boolean isApiProductSubscription(SubscriptionEntity subscription) {
-        var referenceType = subscription.getReferenceType();
-        return referenceType != null && SubscriptionReferenceType.API_PRODUCT.name().equals(referenceType);
+        return SubscriptionReferenceType.API_PRODUCT.name().equals(subscription.getReferenceType());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -791,7 +791,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 }
 
                 if (isApiProduct) {
-                    triggerSubscriptionNotificationsForApiProduct(
+                    this.triggerSubscriptionNotificationsForApiProduct(
                         executionContext,
                         referenceId,
                         application,
@@ -800,7 +800,9 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                         paramSubscription,
                         Optional.of(subscriptionsUrl),
                         true,
-                        ApiHook.SUBSCRIPTION_NEW
+                        ApiHook.SUBSCRIPTION_NEW,
+                        null,
+                        null
                     );
                 } else {
                     triggerSubscriptionNotificationsForApi(
@@ -918,7 +920,8 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         GenericPlanEntity genericPlanEntity,
         SubscriptionEntity subscriptionEntity,
         Optional<String> subscriptionsUrl,
-        boolean includeSubscribedByUser
+        boolean includeSubscribedByUser,
+        ApiKey apiKey
     ) throws TechnicalException {
         Optional<ApiProduct> apiProductOpt = apiProductsRepository.findById(apiProductId);
         if (apiProductOpt.isEmpty()) {
@@ -964,10 +967,14 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 }
             }
         }
+        if (apiKey != null) {
+            paramsBuilder.apikey(apiKey);
+        }
         return paramsBuilder.build();
     }
 
-    private void triggerSubscriptionNotificationsForApiProduct(
+    @Override
+    public void triggerSubscriptionNotificationsForApiProduct(
         ExecutionContext executionContext,
         String apiProductId,
         String applicationId,
@@ -976,26 +983,36 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         SubscriptionEntity subscriptionEntity,
         Optional<String> subscriptionsUrl,
         boolean includeSubscribedByUser,
-        ApiHook hook
-    ) throws TechnicalException {
-        Map<String, Object> params = buildSubscriptionNotificationParamsForApiProduct(
-            executionContext,
-            apiProductId,
-            applicationEntity,
-            genericPlanEntity,
-            subscriptionEntity,
-            subscriptionsUrl,
-            includeSubscribedByUser
-        );
-        if (!params.isEmpty()) {
-            triggerSubscriptionNotifications(
+        ApiHook hook,
+        ApiKey apiKey,
+        Map<String, Object> additionalParams
+    ) {
+        try {
+            Map<String, Object> params = buildSubscriptionNotificationParamsForApiProduct(
                 executionContext,
-                NotificationReferenceType.API_PRODUCT,
                 apiProductId,
-                applicationId,
-                params,
-                hook
+                applicationEntity,
+                genericPlanEntity,
+                subscriptionEntity,
+                subscriptionsUrl,
+                includeSubscribedByUser,
+                apiKey
             );
+            if (additionalParams != null && !additionalParams.isEmpty()) {
+                params.putAll(additionalParams);
+            }
+            if (!params.isEmpty()) {
+                triggerSubscriptionNotifications(
+                    executionContext,
+                    NotificationReferenceType.API_PRODUCT,
+                    apiProductId,
+                    applicationId,
+                    params,
+                    hook
+                );
+            }
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Failed to trigger subscription notifications for API Product", e);
         }
     }
 
@@ -1287,7 +1304,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             }
             final PrimaryOwnerEntity owner = application.getPrimaryOwner();
             if (isApiProduct) {
-                triggerSubscriptionNotificationsForApiProduct(
+                this.triggerSubscriptionNotificationsForApiProduct(
                     executionContext,
                     referenceId,
                     application.getId(),
@@ -1296,7 +1313,9 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                     result,
                     Optional.empty(),
                     false,
-                    ApiHook.SUBSCRIPTION_FAILED
+                    ApiHook.SUBSCRIPTION_FAILED,
+                    null,
+                    null
                 );
             } else if (owner != null) {
                 triggerSubscriptionNotificationsForApi(
@@ -1348,7 +1367,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             }
             final PrimaryOwnerEntity owner = application.getPrimaryOwner();
             if (isApiProduct) {
-                triggerSubscriptionNotificationsForApiProduct(
+                this.triggerSubscriptionNotificationsForApiProduct(
                     executionContext,
                     referenceId,
                     application.getId(),
@@ -1357,7 +1376,9 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                     result,
                     Optional.empty(),
                     false,
-                    ApiHook.SUBSCRIPTION_FAILED
+                    ApiHook.SUBSCRIPTION_FAILED,
+                    null,
+                    null
                 );
             } else if (owner != null) {
                 triggerSubscriptionNotificationsForApi(
@@ -1478,7 +1499,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 }
                 final PrimaryOwnerEntity owner = application.getPrimaryOwner();
                 if (isApiProduct) {
-                    triggerSubscriptionNotificationsForApiProduct(
+                    this.triggerSubscriptionNotificationsForApiProduct(
                         executionContext,
                         referenceId,
                         application.getId(),
@@ -1487,7 +1508,9 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                         convert(subscription),
                         Optional.empty(),
                         false,
-                        ApiHook.SUBSCRIPTION_PAUSED
+                        ApiHook.SUBSCRIPTION_PAUSED,
+                        null,
+                        null
                     );
                 } else if (owner != null) {
                     triggerSubscriptionNotificationsForApi(
@@ -1690,7 +1713,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 }
                 final PrimaryOwnerEntity owner = application.getPrimaryOwner();
                 if (isApiProduct) {
-                    triggerSubscriptionNotificationsForApiProduct(
+                    this.triggerSubscriptionNotificationsForApiProduct(
                         executionContext,
                         referenceId,
                         application.getId(),
@@ -1699,7 +1722,9 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                         convert(subscription),
                         Optional.empty(),
                         false,
-                        ApiHook.SUBSCRIPTION_RESUMED
+                        ApiHook.SUBSCRIPTION_RESUMED,
+                        null,
+                        null
                     );
                 } else if (owner != null) {
                     triggerSubscriptionNotificationsForApi(
@@ -2077,7 +2102,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             SubscriptionEntity subscriptionEntity = convert(subscription);
 
             if (isApiProduct) {
-                triggerSubscriptionNotificationsForApiProduct(
+                this.triggerSubscriptionNotificationsForApiProduct(
                     executionContext,
                     referenceId,
                     application.getId(),
@@ -2086,7 +2111,9 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                     subscriptionEntity,
                     Optional.empty(),
                     false,
-                    ApiHook.SUBSCRIPTION_TRANSFERRED
+                    ApiHook.SUBSCRIPTION_TRANSFERRED,
+                    null,
+                    null
                 );
             } else if (owner != null) {
                 triggerSubscriptionNotificationsForApi(
@@ -2503,5 +2530,40 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             .findBySubscription(executionContext, subscriptionId)
             .stream()
             .filter(apiKey -> !apiKey.isRevoked() && !apiKey.isExpired());
+    }
+
+    @Override
+    public Optional<String> buildSubscriptionConsoleUrl(ExecutionContext executionContext, SubscriptionEntity subscription) {
+        if (subscription == null) {
+            return Optional.empty();
+        }
+        boolean isApiProduct = SubscriptionReferenceType.API_PRODUCT.name().equals(subscription.getReferenceType());
+        String referenceId = subscription.getReferenceId() != null ? subscription.getReferenceId() : subscription.getApi();
+        GenericApiModel api = null;
+        if (!isApiProduct && subscription.getApi() != null) {
+            api = apiTemplateService.findByIdForTemplates(executionContext, subscription.getApi());
+        }
+        String managementURL = installationAccessQueryService.getConsoleUrl(executionContext.getOrganizationId());
+        if (StringUtils.isEmpty(managementURL)) {
+            return Optional.empty();
+        }
+        if (managementURL.endsWith("/")) {
+            managementURL = managementURL.substring(0, managementURL.length() - 1);
+        }
+        String resourceType = isApiProduct ? "api-products" : "apis";
+        String resourceId = isApiProduct ? referenceId : (api != null ? api.getId() : null);
+        if (resourceId == null) {
+            return Optional.empty();
+        }
+        return Optional.of(
+            String.format(
+                "%s/#!/%s/%s/%s/subscriptions/%s",
+                managementURL,
+                executionContext.getEnvironmentId(),
+                resourceType,
+                resourceId,
+                subscription.getId()
+            )
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -782,6 +782,7 @@ public class ApiKeyServiceTest {
 
         SubscriptionEntity subscription = new SubscriptionEntity();
         subscription.setId("subscription-id");
+        subscription.setPlan(PLAN_ID);
         subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT.name());
         subscription.setReferenceId(productId);
 
@@ -795,7 +796,12 @@ public class ApiKeyServiceTest {
 
         when(subscriptionService.findById(any())).thenReturn(subscription);
         when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), anyString())).thenReturn(application);
+        when(application.getId()).thenReturn(APPLICATION_ID);
         when(subscriptionService.findByIdIn(any())).thenReturn(Set.of(subscription));
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), eq(PLAN_ID))).thenReturn(plan);
+        when(subscriptionService.buildSubscriptionConsoleUrl(eq(GraviteeContext.getExecutionContext()), eq(subscription))).thenReturn(
+            Optional.empty()
+        );
 
         apiKeyService.update(GraviteeContext.getExecutionContext(), apiKeyEntity);
 
@@ -804,6 +810,19 @@ public class ApiKeyServiceTest {
         assertTrue("isPaused", existingApiKey.isPaused());
 
         verify(notifierService, never()).trigger(eq(GraviteeContext.getExecutionContext()), eq(ApiHook.APIKEY_EXPIRED), any(), any());
+        verify(subscriptionService, times(1)).triggerSubscriptionNotificationsForApiProduct(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(productId),
+            eq(APPLICATION_ID),
+            eq(application),
+            eq(plan),
+            eq(subscription),
+            any(),
+            eq(false),
+            eq(ApiHook.APIKEY_EXPIRED),
+            eq(existingApiKey),
+            any()
+        );
         verify(auditService, times(1)).createApiProductAuditLog(eq(GraviteeContext.getExecutionContext()), any(), eq(productId));
         verify(auditService, never()).createApiAuditLog(any(), any(), any());
     }
@@ -983,11 +1002,41 @@ public class ApiKeyServiceTest {
         when(apiKeyRepository.findBySubscription(SUBSCRIPTION_ID)).thenReturn(Collections.singleton(apiKey));
         when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID))).thenReturn(application);
         when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(plan);
+        when(subscriptionService.buildSubscriptionConsoleUrl(eq(GraviteeContext.getExecutionContext()), eq(subscription))).thenReturn(
+            Optional.empty()
+        );
 
         apiKeyService.renew(GraviteeContext.getExecutionContext(), subscription);
 
         verify(apiKeyRepository, times(1)).create(any());
         verify(notifierService, never()).trigger(eq(GraviteeContext.getExecutionContext()), eq(ApiHook.APIKEY_RENEWED), any(), any());
+        // Expiring the previous key triggers APIKEY_EXPIRED; the new key triggers APIKEY_RENEWED (API Product pipeline).
+        verify(subscriptionService).triggerSubscriptionNotificationsForApiProduct(
+            eq(GraviteeContext.getExecutionContext()),
+            eq("product-1"),
+            eq(APPLICATION_ID),
+            eq(application),
+            eq(plan),
+            eq(subscription),
+            any(),
+            eq(false),
+            eq(ApiHook.APIKEY_EXPIRED),
+            any(),
+            any()
+        );
+        verify(subscriptionService).triggerSubscriptionNotificationsForApiProduct(
+            eq(GraviteeContext.getExecutionContext()),
+            eq("product-1"),
+            eq(APPLICATION_ID),
+            eq(application),
+            eq(plan),
+            eq(subscription),
+            any(),
+            eq(false),
+            eq(ApiHook.APIKEY_RENEWED),
+            any(),
+            any()
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -143,6 +143,7 @@ public class ApiKeyServiceTest {
         // Prepare subscription
         when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
         when(subscription.getApplication()).thenReturn(APPLICATION_ID);
+        when(subscription.getApi()).thenReturn(API_ID);
         when(subscription.getEndingAt()).thenReturn(Date.from(new Date().toInstant().plus(1, ChronoUnit.DAYS)));
         when(subscriptionService.findByIdIn(List.of(SUBSCRIPTION_ID))).thenReturn(Set.of(subscription));
         // Stub API Key creation
@@ -219,6 +220,7 @@ public class ApiKeyServiceTest {
         when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
         when(subscription.getEndingAt()).thenReturn(Date.from(new Date().toInstant().plus(1, ChronoUnit.DAYS)));
         when(subscription.getApplication()).thenReturn(APPLICATION_ID);
+        when(subscription.getApi()).thenReturn(API_ID);
         when(subscriptionService.findByIdIn(List.of(SUBSCRIPTION_ID))).thenReturn(Set.of(subscription));
         // Stub API Key creation
         when(apiKeyRepository.create(any())).thenAnswer(returnsFirstArg());
@@ -737,6 +739,7 @@ public class ApiKeyServiceTest {
 
         SubscriptionEntity subscription = new SubscriptionEntity();
         subscription.setId("subscription-id");
+        subscription.setApi(API_ID);
 
         ApiKeyEntity apiKeyEntity = new ApiKeyEntity();
         apiKeyEntity.setId("api-key-id");
@@ -767,6 +770,42 @@ public class ApiKeyServiceTest {
             argThat(auditLogData -> auditLogData.getEvent().equals(APIKEY_EXPIRED)),
             any()
         );
+    }
+
+    @Test
+    public void shouldAuditApiProductWhenUpdatingExpirationForApiProductSubscription() throws TechnicalException {
+        final String productId = "api-product-id";
+
+        ApiKey existingApiKey = new ApiKey();
+        existingApiKey.setApplication(APPLICATION_ID);
+        when(apiKeyRepository.findById("api-key-id")).thenReturn(Optional.of(existingApiKey));
+
+        SubscriptionEntity subscription = new SubscriptionEntity();
+        subscription.setId("subscription-id");
+        subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT.name());
+        subscription.setReferenceId(productId);
+
+        ApiKeyEntity apiKeyEntity = new ApiKeyEntity();
+        apiKeyEntity.setId("api-key-id");
+        apiKeyEntity.setApplication(application);
+        apiKeyEntity.setKey("ABC");
+        apiKeyEntity.setPaused(true);
+        apiKeyEntity.setSubscriptions(Set.of(subscription));
+        apiKeyEntity.setExpireAt(new Date());
+
+        when(subscriptionService.findById(any())).thenReturn(subscription);
+        when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), anyString())).thenReturn(application);
+        when(subscriptionService.findByIdIn(any())).thenReturn(Set.of(subscription));
+
+        apiKeyService.update(GraviteeContext.getExecutionContext(), apiKeyEntity);
+
+        verify(apiKeyRepository, times(1)).update(existingApiKey);
+        assertFalse("isRevoked", existingApiKey.isRevoked());
+        assertTrue("isPaused", existingApiKey.isPaused());
+
+        verify(notifierService, never()).trigger(eq(GraviteeContext.getExecutionContext()), eq(ApiHook.APIKEY_EXPIRED), any(), any());
+        verify(auditService, times(1)).createApiProductAuditLog(eq(GraviteeContext.getExecutionContext()), any(), eq(productId));
+        verify(auditService, never()).createApiAuditLog(any(), any(), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -79,6 +79,7 @@ import io.gravitee.rest.api.model.ApiModel;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.NewSubscriptionEntity;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PlanEntity;
@@ -104,6 +105,7 @@ import io.gravitee.rest.api.model.subscription.ReferenceDisplayInfo;
 import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.model.v4.api.GenericApiModel;
 import io.gravitee.rest.api.model.v4.plan.BasePlanEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.ApiKeyService;
@@ -115,6 +117,7 @@ import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.NotifierService;
 import io.gravitee.rest.api.service.PageService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyClosedException;
 import io.gravitee.rest.api.service.exceptions.PlanGeneralConditionAcceptedException;
@@ -3198,6 +3201,194 @@ public class SubscriptionServiceTest {
         assertThat(result.get().getName()).isEqualTo("My Product");
         assertThat(result.get().getOwnerId()).isEqualTo(USER_ID);
         assertThat(result.get().getOwnerDisplayName()).isEmpty();
+    }
+
+    @Test
+    public void buildSubscriptionConsoleUrl_returns_empty_when_subscription_is_null() {
+        assertThat(subscriptionService.buildSubscriptionConsoleUrl(GraviteeContext.getExecutionContext(), null)).isEmpty();
+    }
+
+    @Test
+    public void buildSubscriptionConsoleUrl_returns_empty_when_console_url_is_blank() {
+        when(installationAccessQueryService.getConsoleUrl(anyString())).thenReturn(null);
+        SubscriptionEntity subscription = buildSubscriptionEntityForConsoleUrlApiProduct();
+        assertThat(subscriptionService.buildSubscriptionConsoleUrl(GraviteeContext.getExecutionContext(), subscription)).isEmpty();
+    }
+
+    @Test
+    public void buildSubscriptionConsoleUrl_api_product_contains_expected_path() {
+        when(installationAccessQueryService.getConsoleUrl(anyString())).thenReturn("https://console.example.com");
+        SubscriptionEntity subscription = buildSubscriptionEntityForConsoleUrlApiProduct();
+        assertThat(
+            subscriptionService.buildSubscriptionConsoleUrl(GraviteeContext.getExecutionContext(), subscription).orElseThrow()
+        ).isEqualTo("https://console.example.com/#!/DEFAULT/api-products/console-product-id/subscriptions/console-sub-id");
+    }
+
+    @Test
+    public void buildSubscriptionConsoleUrl_strips_trailing_slash_on_console_base_url() {
+        when(installationAccessQueryService.getConsoleUrl(anyString())).thenReturn("https://console.example.com/");
+        SubscriptionEntity subscription = buildSubscriptionEntityForConsoleUrlApiProduct();
+        assertThat(
+            subscriptionService.buildSubscriptionConsoleUrl(GraviteeContext.getExecutionContext(), subscription).orElseThrow()
+        ).startsWith("https://console.example.com/#!");
+    }
+
+    @Test
+    public void buildSubscriptionConsoleUrl_api_subscription_uses_resolved_api_template_id() throws TechnicalException {
+        when(installationAccessQueryService.getConsoleUrl(anyString())).thenReturn("https://console.example.com");
+        String resolvedApiId = "resolved-api-id";
+        GenericApiModel apiModel = mock(GenericApiModel.class);
+        when(apiModel.getId()).thenReturn(resolvedApiId);
+        when(apiTemplateService.findByIdForTemplates(eq(GraviteeContext.getExecutionContext()), eq(API_ID))).thenReturn(apiModel);
+
+        SubscriptionEntity subscription = new SubscriptionEntity();
+        subscription.setId("console-sub-api");
+        subscription.setReferenceType(SubscriptionReferenceType.API.name());
+        subscription.setApi(API_ID);
+
+        assertThat(
+            subscriptionService.buildSubscriptionConsoleUrl(GraviteeContext.getExecutionContext(), subscription).orElseThrow()
+        ).contains("/apis/" + resolvedApiId + "/subscriptions/console-sub-api");
+    }
+
+    @Test
+    public void triggerSubscriptionNotificationsForApiProduct_notifies_with_api_product_reference() throws TechnicalException {
+        String productId = "notification-product-id";
+        ApiProduct apiProduct = ApiProduct.builder().id(productId).name("Product").version("1.0").build();
+        when(apiProductsRepository.findById(productId)).thenReturn(Optional.of(apiProduct));
+        when(
+            membershipService.getPrimaryOwnerUserId(
+                eq(GraviteeContext.getExecutionContext().getOrganizationId()),
+                eq(MembershipReferenceType.API_PRODUCT),
+                eq(productId)
+            )
+        ).thenReturn(null);
+
+        ApplicationEntity app = new ApplicationEntity();
+        app.setId("notification-app-id");
+
+        io.gravitee.rest.api.model.v4.plan.PlanEntity plan = new io.gravitee.rest.api.model.v4.plan.PlanEntity();
+        plan.setId("notification-plan-id");
+
+        SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setId("notification-sub-id");
+
+        ExecutionContext ctx = GraviteeContext.getExecutionContext();
+        subscriptionService.triggerSubscriptionNotificationsForApiProduct(
+            ctx,
+            productId,
+            app.getId(),
+            app,
+            plan,
+            subscriptionEntity,
+            Optional.empty(),
+            false,
+            ApiHook.SUBSCRIPTION_PAUSED,
+            null,
+            null
+        );
+
+        verify(notifierService).trigger(
+            eq(ctx),
+            eq(ApiHook.SUBSCRIPTION_PAUSED),
+            eq(NotificationReferenceType.API_PRODUCT),
+            eq(productId),
+            argThat((Map<String, Object> m) -> m != null && m.containsKey(NotificationParamsBuilder.PARAM_API_PRODUCT))
+        );
+        verify(notifierService).trigger(eq(ctx), eq(ApplicationHook.SUBSCRIPTION_PAUSED), eq(app.getId()), anyMap());
+    }
+
+    /**
+     * Ensures {@code additionalParams} are merged into notifier params. Uses {@link ApiHook#SUBSCRIPTION_PAUSED} so both
+     * reference and application notifier hooks exist ({@link ApplicationHook}); API-key-only hooks are covered by production
+     * usage from {@code ApiKeyServiceImpl}, not this merge contract.
+     */
+    @Test
+    public void triggerSubscriptionNotificationsForApiProduct_merges_additional_params() throws TechnicalException {
+        String productId = "notification-product-id-2";
+        ApiProduct apiProduct = ApiProduct.builder().id(productId).name("Product").version("1.0").build();
+        when(apiProductsRepository.findById(productId)).thenReturn(Optional.of(apiProduct));
+        when(
+            membershipService.getPrimaryOwnerUserId(
+                eq(GraviteeContext.getExecutionContext().getOrganizationId()),
+                eq(MembershipReferenceType.API_PRODUCT),
+                eq(productId)
+            )
+        ).thenReturn(null);
+
+        ApplicationEntity app = new ApplicationEntity();
+        app.setId("notification-app-id-2");
+        io.gravitee.rest.api.model.v4.plan.PlanEntity plan = new io.gravitee.rest.api.model.v4.plan.PlanEntity();
+        plan.setId("notification-plan-id-2");
+        SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setId("notification-sub-id-2");
+
+        Date expiration = new Date();
+        ExecutionContext ctx = GraviteeContext.getExecutionContext();
+        subscriptionService.triggerSubscriptionNotificationsForApiProduct(
+            ctx,
+            productId,
+            app.getId(),
+            app,
+            plan,
+            subscriptionEntity,
+            Optional.empty(),
+            false,
+            ApiHook.SUBSCRIPTION_PAUSED,
+            null,
+            Map.of(NotificationParamsBuilder.PARAM_EXPIRATION_DATE, expiration)
+        );
+
+        verify(notifierService).trigger(
+            eq(ctx),
+            eq(ApiHook.SUBSCRIPTION_PAUSED),
+            eq(NotificationReferenceType.API_PRODUCT),
+            eq(productId),
+            argThat((Map<String, Object> m) -> m != null && expiration.equals(m.get(NotificationParamsBuilder.PARAM_EXPIRATION_DATE)))
+        );
+        verify(notifierService).trigger(
+            eq(ctx),
+            eq(ApplicationHook.SUBSCRIPTION_PAUSED),
+            eq(app.getId()),
+            argThat((Map<String, Object> m) -> m != null && expiration.equals(m.get(NotificationParamsBuilder.PARAM_EXPIRATION_DATE)))
+        );
+    }
+
+    @Test
+    public void triggerSubscriptionNotificationsForApiProduct_does_not_notify_when_product_missing() throws TechnicalException {
+        String productId = "missing-notification-product";
+        when(apiProductsRepository.findById(productId)).thenReturn(Optional.empty());
+
+        ApplicationEntity app = new ApplicationEntity();
+        app.setId("app-missing-product");
+        io.gravitee.rest.api.model.v4.plan.PlanEntity plan = new io.gravitee.rest.api.model.v4.plan.PlanEntity();
+        plan.setId(PLAN_ID);
+        SubscriptionEntity subscriptionEntity = new SubscriptionEntity();
+        subscriptionEntity.setId(SUBSCRIPTION_ID);
+
+        subscriptionService.triggerSubscriptionNotificationsForApiProduct(
+            GraviteeContext.getExecutionContext(),
+            productId,
+            app.getId(),
+            app,
+            plan,
+            subscriptionEntity,
+            Optional.empty(),
+            false,
+            ApiHook.SUBSCRIPTION_PAUSED,
+            null,
+            null
+        );
+
+        verifyNoInteractions(notifierService);
+    }
+
+    private SubscriptionEntity buildSubscriptionEntityForConsoleUrlApiProduct() {
+        SubscriptionEntity subscription = new SubscriptionEntity();
+        subscription.setId("console-sub-id");
+        subscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT.name());
+        subscription.setReferenceId("console-product-id");
+        return subscription;
     }
 
     private Map<String, Map<String, Object>> prepareMetadata() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13319

## Description

Pausing an API Product subscription updates API keys and writes an audit entry. ApiKeyServiceImpl.createAuditLog always stored AuditProperties.API from subscription.getApi(), which is null for API Product subscriptions. That produced a NULL in audit_properties.value and failed the JDBC insert (NOT NULL).

Change

Resolve referenceId from referenceId with fallback to api.
For referenceType == API_PRODUCT, use API_PRODUCT in audit properties and createApiProductAuditLog; otherwise keep API and createApiAuditLog.

