### PR TITLE
feat(gateway): support Private Network Access (PNA) in CORS preflight

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/cors.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/cors.ts
@@ -22,5 +22,6 @@ export interface Cors {
   enabled?: boolean;
   exposeHeaders?: string[];
   maxAge?: number;
+  allowPrivateNetwork?: boolean;
   runPolicies?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.html
+++ b/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.html
@@ -144,6 +144,22 @@
         </mat-form-field>
       </div>
 
+      <!-- Allow Private Network -->
+      <div class="cors-card__allow-private-network" [class.disabled]="!corsForm.get('enabled').value">
+        <gio-form-slide-toggle class="cors-card__allow-private-network__enable-toggle">
+          <gio-form-label>Access-Control-Allow-Private-Network</gio-form-label>
+          When enabled, the gateway responds with <code>Access-Control-Allow-Private-Network: true</code> to preflight requests that include
+          <code>Access-Control-Request-Private-Network: true</code>. This is required for public websites to access private network
+          resources.
+          <mat-slide-toggle
+            gioFormSlideToggle
+            formControlName="allowPrivateNetwork"
+            aria-label="CORS allow private network toggle"
+            name="allowPrivateNetwork"
+          ></mat-slide-toggle>
+        </gio-form-slide-toggle>
+      </div>
+
       <!-- Run policies -->
       <div class="cors-card__run-policies" [class.disabled]="!corsForm.get('enabled').value">
         <gio-form-slide-toggle class="cors-card__run-policies__enable-toggle">

--- a/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.spec.ts
@@ -127,6 +127,7 @@ describe('ApiCorsComponent', () => {
         allowCredentials: false,
         exposeHeaders: [],
         maxAge: -1,
+        allowPrivateNetwork: false,
         runPolicies: false,
       });
     });
@@ -143,6 +144,7 @@ describe('ApiCorsComponent', () => {
             allowCredentials: true,
             maxAge: 10,
             exposeHeaders: ['exposeHeaders'],
+            allowPrivateNetwork: true,
             runPolicies: true,
           },
         },
@@ -179,6 +181,12 @@ describe('ApiCorsComponent', () => {
       expect(await exposeHeadersInput.getTags()).toEqual(['exposeHeaders']);
       await exposeHeadersInput.addTag('exposeHeaders2');
 
+      const allowPrivateNetworkInput = await loader.getHarness(
+        MatSlideToggleHarness.with({ selector: '[formControlName="allowPrivateNetwork"]' }),
+      );
+      expect(await allowPrivateNetworkInput.isChecked()).toEqual(true);
+      await allowPrivateNetworkInput.toggle();
+
       const runPoliciesInput = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="runPolicies"]' }));
       expect(await runPoliciesInput.isChecked()).toEqual(true);
       await runPoliciesInput.toggle();
@@ -197,6 +205,7 @@ describe('ApiCorsComponent', () => {
         allowCredentials: false,
         maxAge: 20,
         exposeHeaders: ['exposeHeaders', 'exposeHeaders2'],
+        allowPrivateNetwork: false,
         runPolicies: false,
       });
     });
@@ -238,6 +247,7 @@ describe('ApiCorsComponent', () => {
         allowCredentials: false,
         exposeHeaders: [],
         maxAge: -1,
+        allowPrivateNetwork: false,
         runPolicies: false,
       });
     });
@@ -310,6 +320,7 @@ describe('ApiCorsComponent', () => {
         allowCredentials: false,
         exposeHeaders: [],
         maxAge: -1,
+        allowPrivateNetwork: false,
         runPolicies: false,
       });
     });
@@ -361,6 +372,7 @@ describe('ApiCorsComponent', () => {
         allowCredentials: false,
         exposeHeaders: [],
         maxAge: -1,
+        allowPrivateNetwork: false,
         runPolicies: false,
       });
     });
@@ -382,6 +394,7 @@ describe('ApiCorsComponent', () => {
               allowCredentials: true,
               maxAge: 10,
               exposeHeaders: ['exposeHeaders'],
+              allowPrivateNetwork: true,
               runPolicies: true,
             },
           },
@@ -419,6 +432,12 @@ describe('ApiCorsComponent', () => {
       expect(await exposeHeadersInput.getTags()).toEqual(['exposeHeaders']);
       await exposeHeadersInput.addTag('exposeHeaders2');
 
+      const allowPrivateNetworkInput = await loader.getHarness(
+        MatSlideToggleHarness.with({ selector: '[formControlName="allowPrivateNetwork"]' }),
+      );
+      expect(await allowPrivateNetworkInput.isChecked()).toEqual(true);
+      await allowPrivateNetworkInput.toggle();
+
       const runPoliciesInput = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="runPolicies"]' }));
       expect(await runPoliciesInput.isChecked()).toEqual(true);
       await runPoliciesInput.toggle();
@@ -437,6 +456,7 @@ describe('ApiCorsComponent', () => {
         allowCredentials: false,
         maxAge: 20,
         exposeHeaders: ['exposeHeaders', 'exposeHeaders2'],
+        allowPrivateNetwork: false,
         runPolicies: false,
       });
     });
@@ -475,6 +495,7 @@ describe('ApiCorsComponent', () => {
         allowCredentials: false,
         exposeHeaders: [],
         maxAge: -1,
+        allowPrivateNetwork: false,
         runPolicies: false,
       });
     });

--- a/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.ts
@@ -123,6 +123,10 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
               value: cors.exposeHeaders ?? [],
               disabled: isCorsDisabled,
             }),
+            allowPrivateNetwork: new UntypedFormControl({
+              value: cors.allowPrivateNetwork ?? false,
+              disabled: isCorsDisabled,
+            }),
             runPolicies: new UntypedFormControl({
               value: cors.runPolicies ?? false,
               disabled: isCorsDisabled,
@@ -131,7 +135,16 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
           this.initialCorsFormValue = this.corsForm.getRawValue();
 
           // Disable all Control if enabled is not checked
-          const controlKeys = ['allowOrigin', 'allowMethods', 'allowHeaders', 'allowCredentials', 'maxAge', 'exposeHeaders', 'runPolicies'];
+          const controlKeys = [
+            'allowOrigin',
+            'allowMethods',
+            'allowHeaders',
+            'allowCredentials',
+            'maxAge',
+            'exposeHeaders',
+            'allowPrivateNetwork',
+            'runPolicies',
+          ];
           this.corsForm.get('enabled').valueChanges.subscribe(checked => {
             controlKeys.forEach(k => {
               return checked ? this.corsForm.get(k).enable() : this.corsForm.get(k).disable();
@@ -203,6 +216,7 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
                   allowCredentials: corsFormValue.allowCredentials,
                   maxAge: corsFormValue.maxAge,
                   exposeHeaders: corsFormValue.exposeHeaders,
+                  allowPrivateNetwork: corsFormValue.allowPrivateNetwork,
                   runPolicies: corsFormValue.runPolicies,
                 },
               },
@@ -221,6 +235,7 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
                   allowCredentials: corsFormValue.allowCredentials,
                   maxAge: corsFormValue.maxAge,
                   exposeHeaders: corsFormValue.exposeHeaders,
+                  allowPrivateNetwork: corsFormValue.allowPrivateNetwork,
                   runPolicies: corsFormValue.runPolicies,
                 };
               });

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/CorsDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/CorsDeserializer.java
@@ -66,6 +66,7 @@ public class CorsDeserializer extends StdScalarDeserializer<Cors> {
                 cors.setAccessControlMaxAge(-1);
             }
             cors.setRunPolicies(node.path("runPolicies").asBoolean(false));
+            cors.setAllowPrivateNetwork(node.path("allowPrivateNetwork").asBoolean(false));
         }
 
         return cors;

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/CorsSerializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/CorsSerializer.java
@@ -115,6 +115,10 @@ public class CorsSerializer extends StdScalarSerializer<Cors> {
             jgen.writeBooleanField("runPolicies", cors.isRunPolicies());
         }
 
+        if (cors.isAllowPrivateNetwork()) {
+            jgen.writeBooleanField("allowPrivateNetwork", cors.isAllowPrivateNetwork());
+        }
+
         jgen.writeEndObject();
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Cors.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Cors.java
@@ -77,6 +77,10 @@ public class Cors implements Serializable {
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     private boolean runPolicies;
 
+    @JsonProperty("allowPrivateNetwork")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    private boolean allowPrivateNetwork;
+
     public static int getDefaultErrorStatusCode() {
         return DEFAULT_ERROR_STATUS_CODE;
     }
@@ -163,5 +167,13 @@ public class Cors implements Serializable {
 
     public void setRunPolicies(boolean runPolicies) {
         this.runPolicies = runPolicies;
+    }
+
+    public boolean isAllowPrivateNetwork() {
+        return allowPrivateNetwork;
+    }
+
+    public void setAllowPrivateNetwork(boolean allowPrivateNetwork) {
+        this.allowPrivateNetwork = allowPrivateNetwork;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/cors/CorsPreflightRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/cors/CorsPreflightRequestProcessor.java
@@ -145,6 +145,15 @@ public class CorsPreflightRequestProcessor extends CorsRequestProcessor {
             .headers()
             .set(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS, String.join(JOINER_CHAR_SEQUENCE, cors.getAccessControlAllowHeaders()));
 
+        // 11. Private Network Access: if enabled and request includes Access-Control-Request-Private-Network,
+        // respond with Access-Control-Allow-Private-Network: true
+        if (cors.isAllowPrivateNetwork()) {
+            String pnaRequest = request.headers().getFirst(HttpHeaders.ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK);
+            if ("true".equalsIgnoreCase(pnaRequest)) {
+                response.headers().set(HttpHeaders.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK, "true");
+            }
+        }
+
         response.status(HttpStatusCode.OK_200);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/cors/CorsPreflightRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/cors/CorsPreflightRequestProcessor.java
@@ -177,6 +177,16 @@ public class CorsPreflightRequestProcessor extends AbstractCorsRequestProcessor 
                 .headers()
                 .set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, String.join(JOINER_CHAR_SEQUENCE, cors.getAccessControlAllowHeaders()));
         }
+
+        // 11. Private Network Access: if enabled and request includes Access-Control-Request-Private-Network,
+        // respond with Access-Control-Allow-Private-Network: true
+        if (cors.isAllowPrivateNetwork()) {
+            String pnaRequest = request.headers().get(HttpHeaderNames.ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK);
+            if ("true".equalsIgnoreCase(pnaRequest)) {
+                response.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK, "true");
+            }
+        }
+
         return true;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/cors/CorsPreflightRequestProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/cors/CorsPreflightRequestProcessorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.cors;
+
+import static io.gravitee.common.http.HttpHeaders.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK;
+import static io.gravitee.common.http.HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD;
+import static io.gravitee.common.http.HttpHeaders.ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK;
+import static io.gravitee.common.http.HttpHeaders.ORIGIN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.model.Cors;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.context.SimpleExecutionContext;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.reporter.api.http.Metrics;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CorsPreflightRequestProcessorTest {
+
+    private CorsPreflightRequestProcessor processor;
+    private Cors cors;
+    private HttpHeaders requestHeaders;
+    private HttpHeaders responseHeaders;
+    private ExecutionContext context;
+
+    @BeforeEach
+    void setUp() {
+        cors = new Cors();
+        cors.setEnabled(true);
+        cors.setAccessControlAllowOrigin(Set.of("*"));
+        cors.setAccessControlAllowMethods(Set.of("GET"));
+        cors.setAccessControlAllowHeaders(Set.of());
+        cors.setRunPolicies(false);
+
+        Request request = mock(Request.class);
+        Response response = mock(Response.class);
+        requestHeaders = HttpHeaders.create();
+        responseHeaders = HttpHeaders.create();
+
+        when(request.method()).thenReturn(HttpMethod.OPTIONS);
+        when(request.headers()).thenReturn(requestHeaders);
+        when(request.metrics()).thenReturn(mock(Metrics.class));
+        when(response.headers()).thenReturn(responseHeaders);
+
+        context = new SimpleExecutionContext(request, response);
+
+        processor = new CorsPreflightRequestProcessor(cors);
+        processor.handler(c -> {});
+        processor.exitHandler(v -> {});
+    }
+
+    @Test
+    void shouldSetAllowPrivateNetworkHeaderWhenEnabledAndRequestHasPnaHeader() {
+        cors.setAllowPrivateNetwork(true);
+        requestHeaders.set(ORIGIN, "origin");
+        requestHeaders.set(ACCESS_CONTROL_REQUEST_METHOD, "GET");
+        requestHeaders.set(ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK, "true");
+
+        processor.handle(context);
+
+        assertThat(responseHeaders.getFirst(ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK)).isEqualTo("true");
+    }
+
+    @Test
+    void shouldNotSetAllowPrivateNetworkHeaderWhenEnabledButRequestMissingPnaHeader() {
+        cors.setAllowPrivateNetwork(true);
+        requestHeaders.set(ORIGIN, "origin");
+        requestHeaders.set(ACCESS_CONTROL_REQUEST_METHOD, "GET");
+
+        processor.handle(context);
+
+        assertThat(responseHeaders.getFirst(ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK)).isNull();
+    }
+
+    @Test
+    void shouldNotSetAllowPrivateNetworkHeaderWhenDisabledAndRequestHasPnaHeader() {
+        cors.setAllowPrivateNetwork(false);
+        requestHeaders.set(ORIGIN, "origin");
+        requestHeaders.set(ACCESS_CONTROL_REQUEST_METHOD, "GET");
+        requestHeaders.set(ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK, "true");
+
+        processor.handle(context);
+
+        assertThat(responseHeaders.getFirst(ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK)).isNull();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/cors/CorsPreflightRequestProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/cors/CorsPreflightRequestProcessorTest.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.processor.cors;
 
+import static io.gravitee.gateway.api.http.HttpHeaderNames.ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK;
 import static io.gravitee.gateway.api.http.HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD;
+import static io.gravitee.gateway.api.http.HttpHeaderNames.ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK;
 import static io.gravitee.gateway.api.http.HttpHeaderNames.ORIGIN;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_INVOKER;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_SECURITY_SKIP;
@@ -316,6 +318,35 @@ class CorsPreflightRequestProcessorTest extends AbstractProcessorTest {
 
         assertThat(spyCtx.<Boolean>getInternalAttribute(ATTR_INTERNAL_SECURITY_SKIP)).isNull();
         assertThat(spyCtx.<CorsPreflightInvoker>getInternalAttribute(ATTR_INTERNAL_INVOKER)).isNull();
+    }
+
+    @Test
+    public void shouldSetAllowPrivateNetworkHeaderWhenEnabledAndRequestHasPnaHeader() {
+        api.getProxy().getCors().setAllowPrivateNetwork(true);
+        spyRequestHeaders.set(ORIGIN, "origin");
+        spyRequestHeaders.set(ACCESS_CONTROL_REQUEST_METHOD, "GET");
+        spyRequestHeaders.set(ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK, "true");
+        corsPreflightRequestProcessor.execute(spyCtx).test().assertError(InterruptionException.class);
+        assertThat(spyResponseHeaders.get(ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK)).isEqualTo("true");
+    }
+
+    @Test
+    public void shouldNotSetAllowPrivateNetworkHeaderWhenEnabledButRequestMissingPnaHeader() {
+        api.getProxy().getCors().setAllowPrivateNetwork(true);
+        spyRequestHeaders.set(ORIGIN, "origin");
+        spyRequestHeaders.set(ACCESS_CONTROL_REQUEST_METHOD, "GET");
+        corsPreflightRequestProcessor.execute(spyCtx).test().assertError(InterruptionException.class);
+        assertThat(spyResponseHeaders.get(ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK)).isNull();
+    }
+
+    @Test
+    public void shouldNotSetAllowPrivateNetworkHeaderWhenDisabledAndRequestHasPnaHeader() {
+        api.getProxy().getCors().setAllowPrivateNetwork(false);
+        spyRequestHeaders.set(ORIGIN, "origin");
+        spyRequestHeaders.set(ACCESS_CONTROL_REQUEST_METHOD, "GET");
+        spyRequestHeaders.set(ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK, "true");
+        corsPreflightRequestProcessor.execute(spyCtx).test().assertError(InterruptionException.class);
+        assertThat(spyResponseHeaders.get(ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK)).isNull();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4295,6 +4295,9 @@ components:
                     default: -1
                 runPolicies:
                     type: boolean
+                allowPrivateNetwork:
+                    type: boolean
+                    description: Allow private network access (PNA) requests during CORS preflight
         Dlq:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/CorsFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/CorsFixtures.java
@@ -36,7 +36,8 @@ public class CorsFixtures {
             .enabled(true)
             .exposeHeaders(Set.of("exposeHeader1", "exposeHeader2"))
             .maxAge(10)
-            .runPolicies(true);
+            .runPolicies(true)
+            .allowPrivateNetwork(true);
 
     public static Cors aCors() {
         return BASE_CORS.get();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/CorsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/CorsMapperTest.java
@@ -39,6 +39,7 @@ public class CorsMapperTest {
         assertThat(corsEntity.getAccessControlExposeHeaders()).isEqualTo(cors.getExposeHeaders());
         assertThat(corsEntity.getAccessControlMaxAge()).isEqualTo(cors.getMaxAge());
         assertThat(corsEntity.isRunPolicies()).isEqualTo(cors.getRunPolicies());
+        assertThat(corsEntity.isAllowPrivateNetwork()).isEqualTo(cors.getAllowPrivateNetwork());
     }
 
     @Test
@@ -55,5 +56,6 @@ public class CorsMapperTest {
         assertThat(cors.getExposeHeaders()).isEqualTo(corsEntity.getAccessControlExposeHeaders());
         assertThat(cors.getMaxAge()).isEqualTo(corsEntity.getAccessControlMaxAge());
         assertThat(cors.getRunPolicies()).isEqualTo(corsEntity.isRunPolicies());
+        assertThat(cors.getAllowPrivateNetwork()).isEqualTo(corsEntity.isAllowPrivateNetwork());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/CorsModelFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-test-fixtures/src/main/java/fixtures/CorsModelFixtures.java
@@ -29,7 +29,8 @@ public class CorsModelFixtures {
         .enabled(true)
         .accessControlExposeHeaders(Set.of("exposeHeader1", "exposeHeader2"))
         .accessControlMaxAge(10)
-        .runPolicies(true);
+        .runPolicies(true)
+        .allowPrivateNetwork(true);
 
     public static io.gravitee.definition.model.Cors aModelCors() {
         return BASE_MODEL_CORS.build();


### PR DESCRIPTION
## Summary

- Add `allowPrivateNetwork` boolean to CORS config model (default `false`)
- When enabled, gateway responds with `Access-Control-Allow-Private-Network: true` to preflight requests containing `Access-Control-Request-Private-Network: true`
- Both v3 (legacy) and v4 (reactive) preflight processors updated
- Console UI: new toggle in CORS settings page for both V2 and V4 APIs
- OpenAPI spec, serializer/deserializer, mapper tests, and fixtures updated

Fixes [APIM-13215](https://gravitee.atlassian.net/browse/APIM-13215)

## Test plan

- [ ] Unit tests: 3 new tests (enabled+present, enabled+absent, disabled+present)
- [ ] Mapper round-trip assertions for `allowPrivateNetwork`
- [ ] Console UI: toggle appears, persists on save, disabled when CORS is off
- [ ] Manual gateway test: preflight with PNA header returns correct response

[APIM-13215]: https://gravitee.atlassian.net/browse/APIM-13215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ