### PR TITLE
fix(migration): v2 to v4 migration issue

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/ApiMigration.java
@@ -174,9 +174,9 @@ class ApiMigration {
         MigrationResult<EndpointGroup> endpointGroupMigrationResult = MigrationResult.value(
             EndpointGroup.builder().name(source.getName()).type(HTTP_PROXY).loadBalancer(mapLoadBalancer(source.getLoadBalancer())).build()
         );
-        String sharedConfiguration = null;
+        MigrationResult<String> sharedConfigResult = MigrationResult.value(null);
         try {
-            sharedConfiguration = sharedConfigurationMigration.convert(source);
+            sharedConfigResult = sharedConfigurationMigration.convert(source);
             endpoints = stream(source.getEndpoints()).map(this::mapEndpoint).collect(MigrationResult.collectList());
         } catch (JsonProcessingException e) {
             log.error("Unable to map configuration for endpoint group {}", source.getName(), e);
@@ -201,7 +201,7 @@ class ApiMigration {
                 }
                 return egp;
             })
-            .foldLeft(MigrationResult.value(sharedConfiguration), (egp, b) -> {
+            .foldLeft(sharedConfigResult, (egp, b) -> {
                 if (egp != null) {
                     egp.setSharedConfiguration(b);
                 }
@@ -346,35 +346,59 @@ class ApiMigration {
             if (root == null || root.isNull() || root.isMissingNode()) {
                 return MigrationResult.value(config);
             }
-            JsonNode healthcheckNode = root.path("healthcheck");
-            if (healthcheckNode == null || healthcheckNode.isNull() || healthcheckNode.isMissingNode()) {
-                return MigrationResult.value(config);
-            }
-            ArrayNode steps = root.path("healthcheck").path("steps").isArray()
-                ? (ArrayNode) root.path("healthcheck").path("steps")
-                : JsonNodeFactory.instance.arrayNode();
-            for (JsonNode step : steps) {
-                ObjectNode response = (ObjectNode) step.path("response");
-                JsonNode assertionsNode = response.get("assertions");
-                response.remove("assertions");
-                if (assertionsNode != null && assertionsNode.isArray() && assertionsNode.size() == 1) {
-                    response.put("assertion", StringUtils.appendCurlyBraces(assertionsNode.get(0).asText()));
-                }
-            }
-            JsonNode httpProxyNode = root.path("proxy");
-            if (httpProxyNode.isObject()) {
-                ObjectNode proxyObject = (ObjectNode) httpProxyNode;
-                boolean enabled = proxyObject.path("enabled").asBoolean(false);
-                boolean useSystemProxy = proxyObject.path("useSystemProxy").asBoolean(false);
-                if (enabled && useSystemProxy) {
-                    proxyObject.remove("port");
-                    proxyObject.remove("type");
-                }
-            }
-            return MigrationResult.value(jsonMapper.writeValueAsString(root));
+            migrateHealthCheckNode(root);
+            List<MigrationResult.Issue> proxyIssues = migrateProxyNode(root);
+            migrateHttpNode(root);
+            return MigrationResult.<String>value(jsonMapper.writeValueAsString(root)).addIssues(proxyIssues);
         } catch (JsonProcessingException e) {
             log.error("Unable to map configuration for endpoint", e);
             return MigrationResult.issue(MigrationWarnings.ENDPOINT_PARSE_ERROR, MigrationResult.State.IMPOSSIBLE);
+        }
+    }
+
+    private void migrateHealthCheckNode(ObjectNode root) {
+        JsonNode healthcheckNode = root.path("healthcheck");
+        if (healthcheckNode.isNull() || healthcheckNode.isMissingNode()) {
+            return;
+        }
+        ArrayNode steps = healthcheckNode.path("steps").isArray()
+            ? (ArrayNode) healthcheckNode.path("steps")
+            : JsonNodeFactory.instance.arrayNode();
+        for (JsonNode step : steps) {
+            JsonNode responseNode = step.path("response");
+            if (responseNode.isObject()) {
+                migrateHealthCheckStepResponse((ObjectNode) responseNode);
+            }
+        }
+    }
+
+    private void migrateHealthCheckStepResponse(ObjectNode response) {
+        JsonNode assertionsNode = response.get("assertions");
+        response.remove("assertions");
+        if (assertionsNode != null && assertionsNode.isArray() && assertionsNode.size() == 1) {
+            response.put("assertion", StringUtils.appendCurlyBraces(assertionsNode.get(0).asText()));
+        }
+    }
+
+    private List<MigrationResult.Issue> migrateProxyNode(ObjectNode root) {
+        JsonNode httpProxyNode = root.path("proxy");
+        if (!httpProxyNode.isObject()) {
+            return List.of();
+        }
+        return SharedConfigurationMigration.sanitizeProxyObjectNode((ObjectNode) httpProxyNode);
+    }
+
+    private void migrateHttpNode(ObjectNode root) {
+        JsonNode httpNode = root.path("http");
+        if (!httpNode.isObject()) {
+            return;
+        }
+        ObjectNode httpObject = (ObjectNode) httpNode;
+        String version = httpObject.path("version").asText("HTTP_1_1");
+        if ("HTTP_2".equals(version)) {
+            httpObject.retain(SharedConfigurationMigration.HTTP2_ALLOWED);
+        } else {
+            httpObject.retain(SharedConfigurationMigration.HTTP11_ALLOWED);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMigration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMigration.java
@@ -21,16 +21,22 @@ import static io.gravitee.plugin.configurations.http.ProtocolVersion.HTTP_2;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.apim.core.api.model.utils.MigrationResult;
+import io.gravitee.apim.core.api.model.utils.MigrationWarnings;
 import io.gravitee.definition.model.HttpClientSslOptions;
 import io.gravitee.plugin.configurations.http.HttpClientOptions;
 import io.gravitee.plugin.configurations.ssl.SslOptions;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class SharedConfigurationMigration {
 
-    private static final Set<String> HTTP11_ALLOWED = Set.of(
+    static final int DEFAULT_PROXY_PORT = 3128;
+
+    static final Set<String> HTTP11_ALLOWED = Set.of(
         "version",
         "keepAlive",
         "keepAliveTimeout",
@@ -45,7 +51,7 @@ public class SharedConfigurationMigration {
         "maxConcurrentConnections"
     );
 
-    private static final Set<String> HTTP2_ALLOWED = Set.of(
+    static final Set<String> HTTP2_ALLOWED = Set.of(
         "version",
         "clearTextUpgrade",
         "keepAlive",
@@ -64,7 +70,51 @@ public class SharedConfigurationMigration {
 
     private final ObjectMapper objectMapper;
 
-    public String convert(io.gravitee.definition.model.EndpointGroup source) throws JsonProcessingException {
+    /**
+     * Sanitizes a proxy ObjectNode from a V2 config to comply with the V4 schema.
+     * <p>
+     * When proxy is disabled or uses the system proxy, V4 only allows {@code enabled} and
+     * {@code useSystemProxy} (strict {@code additionalProperties: false}). For a custom proxy,
+     * {@code host} and {@code port} are required; missing values are replaced with safe defaults
+     * and a {@link MigrationResult.Issue} at {@code CAN_BE_FORCED} is returned for each.
+     *
+     * @param proxyNode the proxy JSON node to sanitize in-place
+     * @return list of issues describing any defaults that were applied
+     */
+    static List<MigrationResult.Issue> sanitizeProxyObjectNode(ObjectNode proxyNode) {
+        List<MigrationResult.Issue> issues = new ArrayList<>();
+        boolean enabled = proxyNode.path("enabled").asBoolean(false);
+        boolean useSystemProxy = proxyNode.path("useSystemProxy").asBoolean(false);
+        if (!enabled || useSystemProxy) {
+            // No proxy or system proxy: V4 schema allows only enabled and useSystemProxy (additionalProperties: false)
+            proxyNode.remove("type");
+            proxyNode.remove("host");
+            proxyNode.remove("port");
+            proxyNode.remove("username");
+            proxyNode.remove("password");
+        } else {
+            // Custom proxy: host and port are required by V4 schema
+            String host = proxyNode.path("host").asText(null);
+            if (host == null || host.isEmpty()) {
+                proxyNode.put("host", "localhost");
+                issues.add(new MigrationResult.Issue(MigrationWarnings.PROXY_HOST_MISSING, MigrationResult.State.CAN_BE_FORCED));
+            }
+            int port = proxyNode.path("port").asInt(0);
+            if (port <= 0) {
+                proxyNode.put("port", DEFAULT_PROXY_PORT);
+                issues.add(
+                    new MigrationResult.Issue(
+                        MigrationWarnings.PROXY_PORT_DEFAULTED.formatted(DEFAULT_PROXY_PORT),
+                        MigrationResult.State.CAN_BE_FORCED
+                    )
+                );
+            }
+        }
+        return issues;
+    }
+
+    public MigrationResult<String> convert(io.gravitee.definition.model.EndpointGroup source) throws JsonProcessingException {
+        List<MigrationResult.Issue> issues = new ArrayList<>();
         ObjectNode httpClientOptions = mapHttpClientOptions(source.getHttpClientOptions());
         ObjectNode httpClientSslOptionsNode = mapHttpClientSslOptions(source.getHttpClientSslOptions());
         ObjectNode sharedConfiguration = objectMapper.createObjectNode();
@@ -79,21 +129,10 @@ public class SharedConfigurationMigration {
         }
         if (source.getHttpProxy() != null) {
             ObjectNode proxyNode = (ObjectNode) objectMapper.valueToTree(source.getHttpProxy());
-            if (source.getHttpProxy().isEnabled() && source.getHttpProxy().isUseSystemProxy()) {
-                proxyNode.remove("host");
-                proxyNode.remove("port");
-                proxyNode.remove("type");
-                proxyNode.put("useSystemProxy", true);
-                proxyNode.remove("enabled");
-            } else {
-                String host = source.getHttpProxy().getHost();
-                if (host == null || host.isEmpty()) {
-                    proxyNode.put("host", "/");
-                }
-            }
+            issues.addAll(sanitizeProxyObjectNode(proxyNode));
             sharedConfiguration.set("proxy", proxyNode);
         }
-        return objectMapper.writeValueAsString(sharedConfiguration);
+        return new MigrationResult<>(objectMapper.writeValueAsString(sharedConfiguration), issues);
     }
 
     private ObjectNode mapHttpClientOptions(io.gravitee.definition.model.HttpClientOptions httpClientOptions) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/utils/MigrationResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/utils/MigrationResult.java
@@ -89,6 +89,11 @@ public class MigrationResult<T> {
         return state() != State.IMPOSSIBLE ? value : null;
     }
 
+    @Nullable
+    public T getValue() {
+        return value();
+    }
+
     public Collection<Issue> issues() {
         return List.copyOf(issues);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/utils/MigrationWarnings.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/utils/MigrationWarnings.java
@@ -66,6 +66,12 @@ public final class MigrationWarnings {
     public static final String DYNAMIC_PROPERTY_HTTP_ONLY =
         "Unable to migrate the API as Dynamic properties configuration only supports HTTP provider";
 
+    public static final String PROXY_HOST_MISSING =
+        "The endpoint proxy is configured as a custom proxy but has no host. The host has been set to a placeholder value. Please review your proxy configuration after migration";
+
+    public static final String PROXY_PORT_DEFAULTED =
+        "The endpoint proxy is configured as a custom proxy but has no valid port. The port has been set to the default value %d. Please review your proxy configuration after migration";
+
     public static final String POLICY_NOT_COMPATIBLE = "Unable to migrate the API as Policy %s is not compatible with V4 APIs";
 
     public static final String NON_GRAVITEE_POLICY =

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMigrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/SharedConfigurationMigrationTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api.model.utils.MigrationResult;
+import io.gravitee.apim.core.api.model.utils.MigrationWarnings;
 import io.gravitee.common.http.HttpHeader;
 import io.gravitee.definition.model.EndpointGroup;
 import io.gravitee.definition.model.HttpClientOptions;
@@ -54,8 +56,8 @@ class SharedConfigurationMigrationTest {
         group.setHeaders(headers);
         group.setHttpProxy(new HttpProxy());
 
-        var result = sharedConfigurationMigration.convert(group);
-        JsonNode json = objectMapper.readTree(result);
+        var migrationResult = sharedConfigurationMigration.convert(group);
+        JsonNode json = objectMapper.readTree(migrationResult.getValue());
 
         JsonNode httpNode = json.get("http");
         assertThat(httpNode).isNotNull();
@@ -67,6 +69,7 @@ class SharedConfigurationMigrationTest {
         assertThat(firstHeader.get("name").asText()).isEqualTo("X-Any-Header");
         assertThat(firstHeader.get("value").asText()).isEqualTo("any header");
         assertThat(json.get("proxy")).isNotNull();
+        assertThat(migrationResult.issues()).isEmpty();
     }
 
     @Test
@@ -78,13 +81,14 @@ class SharedConfigurationMigrationTest {
         group.setHttpClientSslOptions(null);
         group.setHttpProxy(null);
 
-        var result = sharedConfigurationMigration.convert(group);
-        JsonNode json = objectMapper.readTree(result);
+        var migrationResult = sharedConfigurationMigration.convert(group);
+        JsonNode json = objectMapper.readTree(migrationResult.getValue());
 
         assertThat(json.has("http")).isTrue();
         assertThat(json.has("ssl")).isFalse();
         assertThat(json.has("headers")).isFalse();
         assertThat(json.has("proxy")).isFalse();
+        assertThat(migrationResult.issues()).isEmpty();
     }
 
     @Test
@@ -95,14 +99,15 @@ class SharedConfigurationMigrationTest {
         group.setHeaders(null);
         group.setHttpProxy(null);
 
-        var result = sharedConfigurationMigration.convert(group);
-        JsonNode json = objectMapper.readTree(result);
+        var migrationResult = sharedConfigurationMigration.convert(group);
+        JsonNode json = objectMapper.readTree(migrationResult.getValue());
 
         assertThat(json.has("http")).isFalse();
         assertThat(json.has("ssl")).isFalse();
         assertThat(json.has("headers")).isFalse();
         assertThat(json.has("proxy")).isFalse();
         assertThat(json.isEmpty()).isTrue();
+        assertThat(migrationResult.issues()).isEmpty();
     }
 
     @Test
@@ -113,14 +118,15 @@ class SharedConfigurationMigrationTest {
         options.setClearTextUpgrade(true);
         group.setHttpClientOptions(options);
 
-        var result = sharedConfigurationMigration.convert(group);
-        JsonNode json = objectMapper.readTree(result);
+        var migrationResult = sharedConfigurationMigration.convert(group);
+        JsonNode json = objectMapper.readTree(migrationResult.getValue());
 
         JsonNode httpNode = json.get("http");
         assertThat(httpNode).isNotNull();
         assertThat(httpNode.get("version").asText()).isEqualTo(ProtocolVersion.HTTP_2.name());
         assertThat(httpNode.has("clearTextUpgrade")).isTrue();
         assertThat(httpNode.get("clearTextUpgrade").asBoolean()).isTrue();
+        assertThat(migrationResult.issues()).isEmpty();
     }
 
     @Test
@@ -131,13 +137,14 @@ class SharedConfigurationMigrationTest {
         options.setClearTextUpgrade(true); // should be ignored for HTTP_1_1
         group.setHttpClientOptions(options);
 
-        var result = sharedConfigurationMigration.convert(group);
-        JsonNode json = objectMapper.readTree(result);
+        var migrationResult = sharedConfigurationMigration.convert(group);
+        JsonNode json = objectMapper.readTree(migrationResult.getValue());
 
         JsonNode httpNode = json.get("http");
         assertThat(httpNode).isNotNull();
         assertThat(httpNode.get("version").asText()).isEqualTo(ProtocolVersion.HTTP_1_1.name());
         assertThat(httpNode.has("clearTextUpgrade")).isFalse();
+        assertThat(migrationResult.issues()).isEmpty();
     }
 
     @Nested
@@ -157,16 +164,19 @@ class SharedConfigurationMigrationTest {
             proxy.setPort(8080);
             group.setHttpProxy(proxy);
 
-            var result = sharedConfigurationMigration.convert(group);
-            JsonNode json = objectMapper.readTree(result);
+            var migrationResult = sharedConfigurationMigration.convert(group);
+            JsonNode json = objectMapper.readTree(migrationResult.getValue());
 
             JsonNode proxyNode = json.get("proxy");
             assertThat(proxyNode).isNotNull();
             assertThat(proxyNode.has("host")).isFalse();
             assertThat(proxyNode.has("port")).isFalse();
             assertThat(proxyNode.has("type")).isFalse();
-            assertThat(proxyNode.has("enabled")).isFalse();
+            assertThat(proxyNode.has("username")).isFalse();
+            assertThat(proxyNode.has("password")).isFalse();
+            assertThat(proxyNode.get("enabled").asBoolean()).isTrue();
             assertThat(proxyNode.get("useSystemProxy").asBoolean()).isTrue();
+            assertThat(migrationResult.issues()).isEmpty();
         }
 
         @Test
@@ -183,38 +193,17 @@ class SharedConfigurationMigrationTest {
             proxy.setPort(3128);
             group.setHttpProxy(proxy);
 
-            var result = sharedConfigurationMigration.convert(group);
-            JsonNode json = objectMapper.readTree(result);
+            var migrationResult = sharedConfigurationMigration.convert(group);
+            JsonNode json = objectMapper.readTree(migrationResult.getValue());
 
             JsonNode proxyNode = json.get("proxy");
             assertThat(proxyNode).isNotNull();
             assertThat(proxyNode.get("host").asText()).isEqualTo("proxy.example.com");
-        }
-
-        @ParameterizedTest
-        @ValueSource(strings = { "" })
-        void should_set_host_to_slash_when_host_is_blank(String host) throws JsonProcessingException {
-            var group = new EndpointGroup();
-            var options = new HttpClientOptions();
-            options.setVersion(ProtocolVersion.HTTP_1_1);
-            group.setHttpClientOptions(options);
-
-            var proxy = new HttpProxy();
-            proxy.setEnabled(false);
-            proxy.setUseSystemProxy(false);
-            proxy.setHost(host);
-            group.setHttpProxy(proxy);
-
-            var result = sharedConfigurationMigration.convert(group);
-            JsonNode json = objectMapper.readTree(result);
-
-            JsonNode proxyNode = json.get("proxy");
-            assertThat(proxyNode).isNotNull();
-            assertThat(proxyNode.get("host").asText()).isEqualTo("/");
+            assertThat(migrationResult.issues()).isEmpty();
         }
 
         @Test
-        void should_set_host_to_slash_when_host_is_null() throws JsonProcessingException {
+        void should_not_include_host_port_type_when_proxy_is_disabled() throws JsonProcessingException {
             var group = new EndpointGroup();
             var options = new HttpClientOptions();
             options.setVersion(ProtocolVersion.HTTP_1_1);
@@ -223,15 +212,101 @@ class SharedConfigurationMigrationTest {
             var proxy = new HttpProxy();
             proxy.setEnabled(false);
             proxy.setUseSystemProxy(false);
-            proxy.setHost(null);
+            proxy.setHost("proxy.example.com");
+            proxy.setPort(8080);
             group.setHttpProxy(proxy);
 
-            var result = sharedConfigurationMigration.convert(group);
-            JsonNode json = objectMapper.readTree(result);
+            var migrationResult = sharedConfigurationMigration.convert(group);
+            JsonNode json = objectMapper.readTree(migrationResult.getValue());
 
             JsonNode proxyNode = json.get("proxy");
             assertThat(proxyNode).isNotNull();
-            assertThat(proxyNode.get("host").asText()).isEqualTo("/");
+            assertThat(proxyNode.get("enabled").asBoolean()).isFalse();
+            assertThat(proxyNode.get("useSystemProxy").asBoolean()).isFalse();
+            assertThat(proxyNode.has("host")).isFalse();
+            assertThat(proxyNode.has("port")).isFalse();
+            assertThat(proxyNode.has("type")).isFalse();
+            assertThat(proxyNode.has("username")).isFalse();
+            assertThat(proxyNode.has("password")).isFalse();
+            assertThat(migrationResult.issues()).isEmpty();
+        }
+
+        @Test
+        void should_set_host_to_localhost_and_warn_when_custom_proxy_has_blank_host() throws JsonProcessingException {
+            var group = new EndpointGroup();
+            var options = new HttpClientOptions();
+            options.setVersion(ProtocolVersion.HTTP_1_1);
+            group.setHttpClientOptions(options);
+
+            var proxy = new HttpProxy();
+            proxy.setEnabled(true);
+            proxy.setUseSystemProxy(false);
+            proxy.setHost("");
+            proxy.setPort(3128);
+            group.setHttpProxy(proxy);
+
+            var migrationResult = sharedConfigurationMigration.convert(group);
+            JsonNode json = objectMapper.readTree(migrationResult.getValue());
+
+            JsonNode proxyNode = json.get("proxy");
+            assertThat(proxyNode).isNotNull();
+            assertThat(proxyNode.get("host").asText()).isEqualTo("localhost");
+            assertThat(migrationResult.issues()).hasSize(1);
+            assertThat(migrationResult.issues().iterator().next().state()).isEqualTo(MigrationResult.State.CAN_BE_FORCED);
+            assertThat(migrationResult.issues().iterator().next().message()).isEqualTo(MigrationWarnings.PROXY_HOST_MISSING);
+        }
+
+        @Test
+        void should_set_host_to_localhost_and_warn_when_custom_proxy_has_null_host() throws JsonProcessingException {
+            var group = new EndpointGroup();
+            var options = new HttpClientOptions();
+            options.setVersion(ProtocolVersion.HTTP_1_1);
+            group.setHttpClientOptions(options);
+
+            var proxy = new HttpProxy();
+            proxy.setEnabled(true);
+            proxy.setUseSystemProxy(false);
+            proxy.setHost(null);
+            proxy.setPort(3128);
+            group.setHttpProxy(proxy);
+
+            var migrationResult = sharedConfigurationMigration.convert(group);
+            JsonNode json = objectMapper.readTree(migrationResult.getValue());
+
+            JsonNode proxyNode = json.get("proxy");
+            assertThat(proxyNode).isNotNull();
+            assertThat(proxyNode.get("host").asText()).isEqualTo("localhost");
+            assertThat(migrationResult.issues()).hasSize(1);
+            assertThat(migrationResult.issues().iterator().next().state()).isEqualTo(MigrationResult.State.CAN_BE_FORCED);
+            assertThat(migrationResult.issues().iterator().next().message()).isEqualTo(MigrationWarnings.PROXY_HOST_MISSING);
+        }
+
+        @Test
+        void should_set_port_to_default_and_warn_when_custom_proxy_has_zero_port() throws JsonProcessingException {
+            var group = new EndpointGroup();
+            var options = new HttpClientOptions();
+            options.setVersion(ProtocolVersion.HTTP_1_1);
+            group.setHttpClientOptions(options);
+
+            var proxy = new HttpProxy();
+            proxy.setEnabled(true);
+            proxy.setUseSystemProxy(false);
+            proxy.setHost("proxy.example.com");
+            proxy.setPort(0);
+            group.setHttpProxy(proxy);
+
+            var migrationResult = sharedConfigurationMigration.convert(group);
+            JsonNode json = objectMapper.readTree(migrationResult.getValue());
+
+            JsonNode proxyNode = json.get("proxy");
+            assertThat(proxyNode).isNotNull();
+            assertThat(proxyNode.get("host").asText()).isEqualTo("proxy.example.com");
+            assertThat(proxyNode.get("port").asInt()).isEqualTo(SharedConfigurationMigration.DEFAULT_PROXY_PORT);
+            assertThat(migrationResult.issues()).hasSize(1);
+            assertThat(migrationResult.issues().iterator().next().state()).isEqualTo(MigrationResult.State.CAN_BE_FORCED);
+            assertThat(migrationResult.issues().iterator().next().message()).isEqualTo(
+                MigrationWarnings.PROXY_PORT_DEFAULTED.formatted(SharedConfigurationMigration.DEFAULT_PROXY_PORT)
+            );
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/MigrateApiUseCaseTest.java
@@ -1800,6 +1800,65 @@ class MigrateApiUseCaseTest {
         });
     }
 
+    @Test
+    void should_migrate_endpoint_shared_configuration_override_filtering_extraneous_http_fields() {
+        // Given
+        var v2Api = ApiFixtures.aProxyApiV2().toBuilder().id(API_ID).build();
+        v2Api.getApiDefinition().setExecutionMode(ExecutionMode.V4_EMULATION_ENGINE);
+        v2Api
+            .getApiDefinition()
+            .getProxy()
+            .getGroups()
+            .forEach(group ->
+                group
+                    .getEndpoints()
+                    .forEach(e -> {
+                        e.setInherit(false);
+                        // Simulate V2 endpoint configuration with extraneous http fields (clearTextUpgrade, maxHeaderSize, maxChunkSize)
+                        // and proxy with type field not allowed by the V4 schema
+                        e.setConfiguration(
+                            "{\"target\":\"https://api.gravitee.io/echo\",\"http\":{\"version\":\"HTTP_1_1\",\"clearTextUpgrade\":true,\"maxHeaderSize\":8192,\"maxChunkSize\":8192,\"readTimeout\":10000},\"proxy\":{\"enabled\":false,\"useSystemProxy\":false,\"type\":\"HTTP\"}}"
+                        );
+                    })
+            );
+        apiCrudService.initWith(List.of(v2Api));
+
+        var plan = PlanFixtures.aPlanV2()
+            .toBuilder()
+            .id("plan-id")
+            .apiId(API_ID)
+            .referenceType(GenericPlanEntity.ReferenceType.API)
+            .referenceId(API_ID)
+            .build();
+        planCrudService.initWith(List.of(plan));
+
+        // When
+        var result = useCase.execute(new MigrateApiUseCase.Input(API_ID, null, AUDIT_INFO));
+
+        // Then
+        assertThat(result.state()).isEqualTo(MigrationResult.State.MIGRATED);
+
+        var migratedApi = apiCrudService.findById(API_ID);
+        assertThat(migratedApi).hasValueSatisfying(api -> {
+            var endpoints = api
+                .getApiDefinitionHttpV4()
+                .getEndpointGroups()
+                .stream()
+                .flatMap(g -> g.getEndpoints().stream())
+                .toList();
+            assertThat(endpoints)
+                .singleElement()
+                .satisfies(endpoint -> {
+                    assertThat(endpoint.isInheritConfiguration()).isFalse();
+                    var override = endpoint.getSharedConfigurationOverride();
+                    assertThat(override).isNotNull();
+                    assertThat(override).contains("\"readTimeout\":10000");
+                    assertThat(override).doesNotContain("clearTextUpgrade", "maxHeaderSize", "maxChunkSize");
+                    assertThat(override).doesNotContain("\"type\"");
+                });
+        });
+    }
+
     @Nested
     class FlowSpecific {
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13288

## Description

When migrating a V2 API to V4, endpoints with "Inherit Configuration" disabled store their V2 config as sharedConfigurationOverride. This JSON was not sanitized before being stored, causing V4 schema validation errors when trying to save the migrated API.                                                                                      
                                                                                                                                                                                                                                                                                                                                                       
Root causes fixed:                                                                                                                                                                                                                                                                                                                                   
  - proxy node: V2 fields (type, host, port, username, password) were not stripped for disabled/system-proxy cases, which the V4 schema rejects (additionalProperties: false)                                                                                                                                                                          
  - http node: V2-only fields (clearTextUpgrade, maxHeaderSize, maxChunkSize) were not stripped for HTTP_1_1, also rejected by V4 schema                                                                                                                                                                                                               
  - Early return in mapSharedConfigurationOverride was skipping all sanitization when no healthcheck node was present (i.e. most endpoints)
  
**_Before fix:_**

https://github.com/user-attachments/assets/af417b3b-a655-45d9-8fa3-114ff7a3887c


**_After fix:_**


https://github.com/user-attachments/assets/1b3bb8ac-ef6d-4d3b-916a-6a9fed51d9a2


