### PR TITLE
chore: bump gravitee-policy-oas-validation from 1.2.0 to 1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <gravitee-policy-mock.version>1.15.0</gravitee-policy-mock.version>
         <gravitee-policy-mtls.version>3.0.0</gravitee-policy-mtls.version>
         <gravitee-policy-oauth2.version>5.1.4</gravitee-policy-oauth2.version>
-        <gravitee-policy-oas-validation.version>1.2.0</gravitee-policy-oas-validation.version>
+        <gravitee-policy-oas-validation.version>1.2.1</gravitee-policy-oas-validation.version>
         <gravitee-policy-openid-connect-userinfo.version>1.7.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>2.2.1</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13032

## Description

Update OAS policy version 
