### PR TITLE
fix: Migration to v4 engine : flows on deprecated plans not visible anymore

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
@@ -844,7 +844,7 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
     };
     httpTestingController
       .expectOne({
-        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/plans?page=1&perPage=9999&statuses=PUBLISHED`,
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/plans?page=1&perPage=9999&statuses=PUBLISHED,DEPRECATED`,
         method: 'GET',
       })
       .flush(fakeApiPlansResponse);

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
@@ -103,7 +103,7 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
             this.connectorPluginsV2Service.listEntrypointPlugins(),
             this.connectorPluginsV2Service.listEndpointPlugins(),
             this.apiPlanV2Service
-              .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED'], undefined, undefined, 1, 9999)
+              .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED'], undefined, undefined, 1, 9999)
               .pipe(map((apiPlansResponse) => apiPlansResponse.data)),
             this.policyV2Service.list(),
             this.sharedPolicyGroupsService.getSharedPolicyGroupPolicyPlugin(),


### PR DESCRIPTION
Migration to v4 engine : flows on deprecated plans not visible anymore





https://gravitee.atlassian.net/browse/APIM-13302

