### PR TITLE
fix: align health check tenant filtering with endpoint manager logic

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/helper/HttpHealthCheckHelper.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/helper/HttpHealthCheckHelper.java
@@ -64,12 +64,12 @@ public class HttpHealthCheckHelper {
             !endpoint.isSecondary() &&
             !isNull(endpoint.getServices()) &&
             isServiceEnabled(endpoint.getServices().getHealthCheck()) &&
-            hasTenant(endpoint, tenant)
+            isTenantApplicable(endpoint, tenant)
         );
     }
 
-    private static boolean hasTenant(final Endpoint endpoint, final String tenant) {
-        return tenant == null || (endpoint.getTenants() != null && endpoint.getTenants().contains(tenant));
+    private static boolean isTenantApplicable(final Endpoint endpoint, final String tenant) {
+        return tenant == null || endpoint.getTenants() == null || endpoint.getTenants().isEmpty() || endpoint.getTenants().contains(tenant);
     }
 
     private static boolean isServiceEnabled(final Service healthCheckService) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/test/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/helper/HttpHealthCheckHelperTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/test/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/helper/HttpHealthCheckHelperTest.java
@@ -146,7 +146,7 @@ public class HttpHealthCheckHelperTest {
 
             when(endpointGroup.getEndpoints()).thenReturn(List.of(endpoint));
             when(endpoint.getServices()).thenReturn(services);
-            assertFalse(HttpHealthCheckHelper.canHandle(api, TENANT_ID));
+            assertTrue(HttpHealthCheckHelper.canHandle(api, TENANT_ID));
         }
 
         @Test


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-13134
https://gravitee.atlassian.net/browse/APIM-13326

## Description

Endpoints without tenants configured were excluded from health checks when the gateway had a tenant defined. Align isTenantApplicable logic with DefaultEndpointManager so tenant-less endpoints are applicable to all tenants.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

