### PR TITLE
fix(api): decouple group access management from Definition Update permission

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.spec.ts
@@ -72,7 +72,7 @@ describe('ApiGeneralGroupsComponent', () => {
 
   describe('Groups tab for user with writing rights', () => {
     beforeEach(async () => {
-      await init(['api-definition-u', 'api-member-u']);
+      await init(['api-member-u']);
     });
 
     it('should show groups', async () => {
@@ -108,7 +108,7 @@ describe('ApiGeneralGroupsComponent', () => {
         declarations: [ApiGeneralMembersComponent],
         providers: [
           { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId } } } },
-          { provide: GioTestingPermissionProvider, useValue: ['api-definition-u', 'api-member-u'] },
+          { provide: GioTestingPermissionProvider, useValue: ['api-member-u'] },
           { provide: MatDialog, useValue: matDialogSpy },
         ],
       }).compileComponents();
@@ -125,8 +125,7 @@ describe('ApiGeneralGroupsComponent', () => {
 
       [groupId1, groupId2].forEach(id => expectGetGroupMembersRequest(fakeGroup({ id })));
       await harness.manageGroupsClick();
-      expectApiGetRequest({ ...api, groups: mockedReturnedGroups });
-      expectApiPutRequest({ ...api, groups: mockedReturnedGroups });
+      expectApiGroupsPutRequest(apiId, mockedReturnedGroups);
       expectApiGetRequest({ ...api, groups: mockedReturnedGroups });
       expectGetGroupsListRequest(mockedReturnedGroups);
       expectApiMembersGetRequest({ ...api, groups: mockedReturnedGroups });
@@ -158,7 +157,7 @@ describe('ApiGeneralGroupsComponent', () => {
       await init(['api-definition-r', 'api-member-r', 'api-gateway_definition-u']);
     });
 
-    it('should display list of groups', async () => {
+    it('should not show manage groups button', async () => {
       const api = fakeApiV4({ id: apiId, groups: [groupId1, groupId2] });
       await expectGetRequests(api, [groupId1, groupId2]);
       httpTestingController
@@ -176,14 +175,7 @@ describe('ApiGeneralGroupsComponent', () => {
 
       expect(await harness.getGroupsNames()).toEqual(api.groups.map(id => `Group ${id}-name`));
       expect(await harness.getGroupsLength()).toStrictEqual(api.groups.length);
-
-      await harness.manageGroupsClick();
-
-      const groupsHarness = await rootLoader.getHarness(ApiGeneralGroupsHarness);
-      expect(await groupsHarness.isReadOnlyGroupsPresent()).toEqual(true);
-      expect(await groupsHarness.getReadOnlyGroupsText()).toContain(`${groupId1}-name, ${groupId2}-name`);
-      expect(await groupsHarness.isFillFormPresent()).toEqual(false);
-      expect(await groupsHarness.isSaveButtonVisible()).toEqual(false);
+      expect(await harness.isManageGroupsButtonVisible()).toEqual(false);
     });
   });
 
@@ -199,8 +191,8 @@ describe('ApiGeneralGroupsComponent', () => {
     fixture.detectChanges();
   }
 
-  function expectApiPutRequest(api: Api) {
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'PUT' }).flush(api);
+  function expectApiGroupsPutRequest(apiId: string, groups: string[]) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/groups`, method: 'PUT' }).flush(groups);
   }
 
   function expectGetGroupsListRequest(groups: string[]) {

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.ts
@@ -56,7 +56,7 @@ export class ApiGeneralGroupsComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.isReadOnly = this.isKubernetesOrigin || !this.permissionService.hasAnyMatching(['api-definition-u']);
+    this.isReadOnly = this.isKubernetesOrigin || !this.permissionService.hasAnyMatching(['api-member-u']);
 
     const userGroupList: Group[] = this.groups.filter(group => this.api.groups?.includes(group.id));
     this.form = this.formBuilder.group({

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.html
@@ -37,7 +37,7 @@
           <button
             class="card__header__actions__button"
             aria-label="Manage groups"
-            *gioPermission="{ anyOf: ['api-member-r', 'api-member-u', 'api-member-d'] }"
+            *gioPermission="{ anyOf: ['api-member-u'] }"
             mat-raised-button
             (click)="updateGroups()"
             [disabled]="groups?.length === 0"

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Component, OnInit } from '@angular/core';
-import { combineLatest, EMPTY, forkJoin, Observable, of, Subject } from 'rxjs';
+import { combineLatest, EMPTY, forkJoin, Observable, Subject } from 'rxjs';
 import { catchError, filter, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
@@ -244,11 +244,10 @@ export class ApiGeneralMembersComponent implements OnInit {
       .afterClosed()
       .pipe(
         filter((apiDialogResult): apiDialogResult is ApiGroupsDialogResult => !!apiDialogResult && !this.isKubernetesOrigin),
-        switchMap(apiDialogResult => {
-          return combineLatest([of(apiDialogResult), this.apiService.get(this.activatedRoute.snapshot.params.apiId)]);
-        }),
-        switchMap(([apiDialogResult, api]) => {
-          return this.apiService.update(api.id, { ...api, groups: apiDialogResult?.groups });
+        switchMap(apiDialogResult => this.apiService.updateGroups(this.apiId, apiDialogResult.groups)),
+        catchError(({ error }) => {
+          this.snackBarService.error(error.message);
+          return EMPTY;
         }),
         takeUntil(this.unsubscribe$),
       )

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.harness.ts
@@ -37,6 +37,7 @@ export class ApiGeneralMembersHarness extends ComponentHarness {
   private getUsersSelector = this.documentRootLocatorFactory().locatorFor(GioUsersSelectorHarness);
   private groupsSelector = this.locatorForAll(ApiGeneralGroupMembersHarness);
   private manageGroupsButtonSelector = this.locatorFor(MatButtonHarness.with({ text: 'Manage groups' }));
+  private manageGroupsButtonOptionalSelector = this.locatorForOptional(MatButtonHarness.with({ text: 'Manage groups' }));
   private transferOwnershipButtonSelector = this.locatorForOptional(MatButtonHarness.with({ text: 'Transfer ownership' }));
 
   async getTableRows(): Promise<MatRowHarness[]> {
@@ -140,6 +141,10 @@ export class ApiGeneralMembersHarness extends ComponentHarness {
 
   async manageGroupsClick() {
     return this.manageGroupsButtonSelector().then(btn => btn.click());
+  }
+
+  async isManageGroupsButtonVisible(): Promise<boolean> {
+    return (await this.manageGroupsButtonOptionalSelector()) != null;
   }
 
   async isTransferOwnershipVisible() {

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -81,6 +81,10 @@ export class ApiV2Service {
     );
   }
 
+  updateGroups(apiId: string, groups: string[]): Observable<string[]> {
+    return this.http.put<string[]>(`${this.constants.env.v2BaseURL}/apis/${apiId}/groups`, groups);
+  }
+
   delete(apiId: string, closePlans = false): Observable<void> {
     return this.http.delete<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}${closePlans ? '?closePlans=true' : ''}`);
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -17,7 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 
 import static io.gravitee.apim.core.utils.CollectionUtils.isNotEmpty;
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
-import static io.gravitee.rest.api.model.permissions.SystemRole.*;
+import static io.gravitee.rest.api.model.permissions.SystemRole.PRIMARY_OWNER;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
@@ -34,6 +34,7 @@ import io.gravitee.apim.core.api.use_case.MigrateApiUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
+import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateFederatedApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateNativeApiUseCase;
 import io.gravitee.apim.core.audit.model.AuditActor;
@@ -106,7 +107,6 @@ import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
-import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
@@ -258,6 +258,9 @@ public class ApiResource extends AbstractResource {
 
     @Inject
     private OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
+
+    @Inject
+    private UpdateApiGroupsUseCase updateApiGroupsUseCase;
 
     @Context
     protected UriInfo uriInfo;
@@ -435,6 +438,17 @@ public class ApiResource extends AbstractResource {
             }
             default -> throw new ApiDefinitionVersionNotSupportedException(updateApi.getDefinitionVersion().name());
         };
+    }
+
+    @PUT
+    @Path("groups")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_MEMBER, acls = { RolePermissionAction.UPDATE }) })
+    public Response updateApiGroups(@PathParam("apiId") String apiId, @Valid @NotNull final List<@NotNull String> groups) {
+        var groupsSet = Set.copyOf(groups);
+        var output = updateApiGroupsUseCase.execute(new UpdateApiGroupsUseCase.Input(apiId, groupsSet, getAuditInfo()));
+        return Response.ok().entity(output.groups()).build();
     }
 
     private GenericApiEntity updateApiV4(GenericApiEntity currentEntity, UpdateApiV4 updateApiV4) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateGroupsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateGroupsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static assertions.MAPIAssertions.assertThat;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ApiResource_UpdateGroupsTest extends ApiResourceTest {
+
+    @Autowired
+    private UpdateApiGroupsUseCase updateApiGroupsUseCase;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/groups";
+    }
+
+    @Test
+    public void should_return_403_if_incorrect_permissions() {
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_MEMBER),
+                eq(API),
+                eq(RolePermissionAction.UPDATE)
+            )
+        ).thenReturn(false);
+
+        var response = rootTarget().request().put(Entity.json(List.of("group-1")));
+
+        assertThat(response)
+            .hasStatus(FORBIDDEN_403)
+            .asError()
+            .hasHttpStatus(FORBIDDEN_403)
+            .hasMessage("You do not have sufficient rights to access this resource");
+    }
+
+    @Test
+    public void should_update_api_groups() {
+        var groups = List.of("group-1", "group-2");
+        when(updateApiGroupsUseCase.execute(any())).thenReturn(new UpdateApiGroupsUseCase.Output(Set.of("group-1", "group-2")));
+
+        var response = rootTarget().request().put(Entity.json(groups));
+
+        assertThat(response).hasStatus(OK_200);
+        var captor = ArgumentCaptor.forClass(UpdateApiGroupsUseCase.Input.class);
+        verify(updateApiGroupsUseCase).execute(captor.capture());
+        var input = captor.getValue();
+        assertThat(input.apiId()).isEqualTo(API);
+        assertThat(input.groups()).containsExactlyInAnyOrder("group-1", "group-2");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -74,6 +74,7 @@ import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
+import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
@@ -596,6 +597,11 @@ public class ResourceContextConfiguration {
     @Primary
     public UpdateApiDefinitionFromImportUseCase updateApiDefinitionUseCase() {
         return mock(UpdateApiDefinitionFromImportUseCase.class);
+    }
+
+    @Bean
+    public UpdateApiGroupsUseCase updateApiGroupsUseCase() {
+        return mock(UpdateApiGroupsUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateApiGroupsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateApiGroupsUseCase.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.ApiAuditLogEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.AuditProperties;
+import io.gravitee.apim.core.audit.model.event.ApiAuditEvent;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.model.context.OriginContext;
+import java.util.Map;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+@UseCase
+public class UpdateApiGroupsUseCase {
+
+    private final ApiCrudService apiCrudService;
+    private final AuditDomainService auditService;
+    private final ValidateGroupsDomainService validateGroupsDomainService;
+
+    public record Input(String apiId, Set<String> groups, AuditInfo auditInfo) {}
+
+    public record Output(Set<String> groups) {}
+
+    public Output execute(Input input) {
+        Api api = apiCrudService.get(input.apiId());
+
+        if (!api.getEnvironmentId().equals(input.auditInfo().environmentId())) {
+            throw new ApiNotFoundException(input.apiId());
+        }
+
+        if (api.getOriginContext() instanceof OriginContext.Kubernetes) {
+            throw new ValidationDomainException("Cannot update groups of a Kubernetes-managed API");
+        }
+
+        var validationInput = new ValidateGroupsDomainService.Input(
+            input.auditInfo().environmentId(),
+            input.groups(),
+            api.getDefinitionVersion().getLabel(),
+            null,
+            false
+        );
+        var validationResult = validateGroupsDomainService.validateAndSanitize(validationInput);
+        Set<String> sanitizedGroups = validationResult.value().map(ValidateGroupsDomainService.Input::groups).orElse(input.groups());
+
+        Set<String> oldGroups = api.getGroups();
+
+        api.setGroups(sanitizedGroups);
+        Api updated = apiCrudService.update(api);
+
+        createAuditLog(oldGroups, updated.getGroups(), input.apiId(), input.auditInfo());
+
+        return new Output(updated.getGroups());
+    }
+
+    private void createAuditLog(Set<String> groupsBeforeUpdate, Set<String> groupsAfterUpdate, String apiId, AuditInfo auditInfo) {
+        auditService.createApiAuditLog(
+            ApiAuditLogEntity.builder()
+                .apiId(apiId)
+                .organizationId(auditInfo.organizationId())
+                .environmentId(auditInfo.environmentId())
+                .event(ApiAuditEvent.API_UPDATED)
+                .actor(auditInfo.actor())
+                .oldValue(groupsBeforeUpdate)
+                .newValue(groupsAfterUpdate)
+                .createdAt(TimeProvider.now())
+                .properties(Map.of(AuditProperties.API, apiId))
+                .build()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateApiGroupsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateApiGroupsUseCase.java
@@ -59,9 +59,7 @@ public class UpdateApiGroupsUseCase {
         var validationInput = new ValidateGroupsDomainService.Input(
             input.auditInfo().environmentId(),
             input.groups(),
-            api.getDefinitionVersion().getLabel(),
-            null,
-            false
+            api.getDefinitionVersion().getLabel()
         );
         var validationResult = validateGroupsDomainService.validateAndSanitize(validationInput);
         Set<String> sanitizedGroups = validationResult.value().map(ValidateGroupsDomainService.Input::groups).orElse(input.groups());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/domain_service/ValidateGroupsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/domain_service/ValidateGroupsDomainService.java
@@ -48,6 +48,10 @@ public class ValidateGroupsDomainService implements Validator<ValidateGroupsDoma
         Group.GroupEvent groupEvent,
         boolean addDefaultGroups
     ) implements Validator.Input {
+        public Input(String environmentId, Set<String> groups, String definitionVersion) {
+            this(environmentId, groups, definitionVersion, null, false);
+        }
+
         Input sanitized(Set<String> sanitizedGroups) {
             return new Input(environmentId, sanitizedGroups, definitionVersion, groupEvent, addDefaultGroups);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateApiGroupsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateApiGroupsUseCaseTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.ApiFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.audit.model.AuditProperties;
+import io.gravitee.apim.core.audit.model.event.ApiAuditEvent;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.model.context.OriginContext;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UpdateApiGroupsUseCaseTest {
+
+    private static final String API_ID = "api-1";
+    private static final String ENV_ID = "env-1";
+    private static final String ORG_ID = "org-1";
+    private static final String USER_ID = "user-1";
+    private static final Instant INSTANT_NOW = Instant.parse("2026-03-25T10:00:00Z");
+
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    private final AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
+    private final UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    private final GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
+
+    private UpdateApiGroupsUseCase useCase;
+
+    @BeforeAll
+    static void beforeAll() {
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.of("UTC")));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @BeforeEach
+    void setUp() {
+        var auditDomainService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+        var validateGroupsDomainService = new ValidateGroupsDomainService(groupQueryService);
+        useCase = new UpdateApiGroupsUseCase(apiCrudService, auditDomainService, validateGroupsDomainService);
+        apiCrudService.initWith(
+            List.of(ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).environmentId(ENV_ID).groups(Set.of("old-group")).build())
+        );
+        groupQueryService.initWith(
+            List.of(
+                Group.builder().id("group-1").name("Group 1").environmentId(ENV_ID).build(),
+                Group.builder().id("group-2").name("Group 2").environmentId(ENV_ID).build()
+            )
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(apiCrudService, auditCrudService, userCrudService, groupQueryService).forEach(s -> s.reset());
+    }
+
+    @Test
+    void should_update_api_groups_and_create_audit_log() {
+        var auditInfo = anAuditInfo(ENV_ID);
+        var input = new UpdateApiGroupsUseCase.Input(API_ID, Set.of("group-1", "group-2"), auditInfo);
+
+        var output = useCase.execute(input);
+
+        // Groups updated in storage
+        var updatedApi = apiCrudService.get(API_ID);
+        assertThat(updatedApi.getGroups()).containsExactlyInAnyOrder("group-1", "group-2");
+        assertThat(output.groups()).containsExactlyInAnyOrder("group-1", "group-2");
+
+        // Audit log created
+        assertThat(auditCrudService.storage())
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("id", "patch")
+            .contains(
+                new AuditEntity(
+                    "generated-id",
+                    ORG_ID,
+                    ENV_ID,
+                    AuditEntity.AuditReferenceType.API,
+                    API_ID,
+                    USER_ID,
+                    Map.of(AuditProperties.API.name(), API_ID),
+                    ApiAuditEvent.API_UPDATED.name(),
+                    INSTANT_NOW.atZone(ZoneId.of("UTC")),
+                    ""
+                )
+            );
+    }
+
+    @Test
+    void should_throw_when_api_not_found() {
+        var input = new UpdateApiGroupsUseCase.Input("unknown-api", Set.of("group-1"), anAuditInfo(ENV_ID));
+
+        assertThatThrownBy(() -> useCase.execute(input)).isInstanceOf(ApiNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_when_api_belongs_to_different_environment() {
+        var input = new UpdateApiGroupsUseCase.Input(API_ID, Set.of("group-1"), anAuditInfo("other-env"));
+
+        assertThatThrownBy(() -> useCase.execute(input)).isInstanceOf(ApiNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_when_api_is_kubernetes_managed() {
+        apiCrudService.reset();
+        apiCrudService.initWith(
+            List.of(
+                ApiFixtures.aProxyApiV4()
+                    .toBuilder()
+                    .id(API_ID)
+                    .environmentId(ENV_ID)
+                    .groups(Set.of("old-group"))
+                    .originContext(new OriginContext.Kubernetes(OriginContext.Kubernetes.Mode.FULLY_MANAGED))
+                    .build()
+            )
+        );
+
+        var input = new UpdateApiGroupsUseCase.Input(API_ID, Set.of("group-1"), anAuditInfo(ENV_ID));
+
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("Kubernetes-managed API");
+    }
+
+    @Test
+    void should_filter_out_nonexistent_groups() {
+        var auditInfo = anAuditInfo(ENV_ID);
+        var input = new UpdateApiGroupsUseCase.Input(API_ID, Set.of("group-1", "nonexistent-group"), auditInfo);
+
+        var output = useCase.execute(input);
+
+        // Only the valid group should be persisted
+        var updatedApi = apiCrudService.get(API_ID);
+        assertThat(updatedApi.getGroups()).containsExactly("group-1");
+        assertThat(output.groups()).containsExactly("group-1");
+    }
+
+    private static AuditInfo anAuditInfo(String envId) {
+        return AuditInfo.builder().organizationId(ORG_ID).environmentId(envId).actor(AuditActor.builder().userId(USER_ID).build()).build();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13273

## Description

Group management was wrongly gated behind `API_DEFINITION` `UPDATE`. Adds a dedicated `PUT /apis/{apiId}/groups` endpoint with `API_MEMBER` `UPDATE` permission and updates the frontend accordingly.

