### PR TITLE
fix: prevent auto-deploy API Product when APIs lack valid plans

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
@@ -278,6 +278,7 @@ export class ApiProductApisComponent implements OnInit {
     const newApiIds = selectedApis.map(api => api.id);
     const updatedApiIds = [...currentApiIds, ...newApiIds];
     return this.apiProductV2Service.updateApiProductApis(apiProductId, updatedApiIds).pipe(
+      tap(() => this.apiProductV2Service.notifyApiProductChanged()),
       map(() => selectedApis),
       catchError(this.handleError('An error occurred while adding the APIs', EMPTY)),
     );
@@ -310,6 +311,7 @@ export class ApiProductApisComponent implements OnInit {
       switchMap(apiProduct => {
         const updatedApiIds = (apiProduct.apiIds || []).filter(id => id !== api.id);
         return this.apiProductV2Service.updateApiProductApis(apiProductId, updatedApiIds).pipe(
+          tap(() => this.apiProductV2Service.notifyApiProductChanged()),
           catchError(this.handleError('An error occurred while removing the API', EMPTY)),
           map(() => undefined),
         );

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
@@ -142,6 +142,7 @@ export class ApiProductConfigurationComponent {
       .update(product.id, updateApiProduct)
       .pipe(
         tap(() => {
+          this.apiProductV2Service.notifyApiProductChanged();
           this.initialFormValue.set(this.form.getRawValue());
           this.snackBarService.success('Configuration successfully saved!');
           this.onReloadDetails();
@@ -182,6 +183,7 @@ export class ApiProductConfigurationComponent {
         filter((confirm): confirm is true => confirm === true),
         switchMap(() => this.apiProductV2Service.updateApiProductApis(apiProductId, [])),
         tap(() => {
+          this.apiProductV2Service.notifyApiProductChanged();
           this.snackBarService.success('All APIs have been removed from the API Product.');
           this.onReloadDetails();
         }),

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
@@ -223,7 +223,7 @@ describe('ApiProductNavigationComponent', () => {
 
     expect(fixture.nativeElement.textContent).not.toContain('out of sync');
 
-    TestBed.inject(ApiProductV2Service).notifyPlanStateChanged();
+    TestBed.inject(ApiProductV2Service).notifyApiProductChanged();
     fixture.detectChanges();
 
     flushRequests({ ...fakeApiProduct, deploymentState: 'NEED_REDEPLOY' }, true);

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
@@ -39,7 +39,7 @@ describe('ApiProductPlanEditComponent', () => {
   let harness: ApiProductPlanEditComponentHarness;
   let httpTestingController: HttpTestingController;
   let routerNavigateSpy: jest.SpyInstance;
-  let notifyPlanStateChangedSpy: jest.SpyInstance;
+  let notifyApiProductChangedSpy: jest.SpyInstance;
   const snackBarService = { error: jest.fn(), success: jest.fn() };
 
   async function setup(
@@ -73,7 +73,7 @@ describe('ApiProductPlanEditComponent', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
     const router = TestBed.inject(Router);
     routerNavigateSpy = jest.spyOn(router, 'navigate');
-    notifyPlanStateChangedSpy = jest.spyOn(TestBed.inject(ApiProductV2Service), 'notifyPlanStateChanged');
+    notifyApiProductChangedSpy = jest.spyOn(TestBed.inject(ApiProductV2Service), 'notifyApiProductChanged');
     fixture.detectChanges();
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductPlanEditComponentHarness);
   }
@@ -313,7 +313,7 @@ describe('ApiProductPlanEditComponent', () => {
       tick();
       fixture.detectChanges();
 
-      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+      expect(notifyApiProductChangedSpy).toHaveBeenCalledTimes(1);
     }));
 
     it('notifies plan state changed after updating a plan so deploy banner is triggered', fakeAsync(async () => {
@@ -340,7 +340,7 @@ describe('ApiProductPlanEditComponent', () => {
 
       httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/api-key/schema`).forEach(r => r.flush({}));
 
-      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+      expect(notifyApiProductChangedSpy).toHaveBeenCalledTimes(1);
     }));
 
     it('does not notify plan state changed when save fails', fakeAsync(async () => {
@@ -363,7 +363,7 @@ describe('ApiProductPlanEditComponent', () => {
         .flush({ message: 'Plan creation failed' }, { status: 500, statusText: 'Server Error' });
       tick();
 
-      expect(notifyPlanStateChangedSpy).not.toHaveBeenCalled();
+      expect(notifyApiProductChangedSpy).not.toHaveBeenCalled();
     }));
   });
 });

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.ts
@@ -118,7 +118,7 @@ export class ApiProductPlanEditComponent {
       .pipe(
         tap(() => {
           this.snackBarService.success('Configuration successfully saved!');
-          this.apiProductV2Service.notifyPlanStateChanged();
+          this.apiProductV2Service.notifyApiProductChanged();
         }),
         catchError(err => this.handleError(err, 'An error occurred while saving configuration.')),
         takeUntilDestroyed(this.destroyRef),

--- a/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.spec.ts
@@ -47,7 +47,7 @@ describe('ApiProductPlanListComponent', () => {
   let planListHarness: PlanListComponentHarness;
   let httpTestingController: HttpTestingController;
   let routerNavigateSpy: jest.SpyInstance;
-  let notifyPlanStateChangedSpy: jest.SpyInstance;
+  let notifyApiProductChangedSpy: jest.SpyInstance;
   const snackBarService = { error: jest.fn(), success: jest.fn() };
 
   async function init(permissions: string[] = ['api_product-plan-u', 'api_product-plan-r', 'api_product-plan-c']) {
@@ -89,7 +89,7 @@ describe('ApiProductPlanListComponent', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
     const router = TestBed.inject(Router);
     routerNavigateSpy = jest.spyOn(router, 'navigate');
-    notifyPlanStateChangedSpy = jest.spyOn(TestBed.inject(ApiProductV2Service), 'notifyPlanStateChanged');
+    notifyApiProductChangedSpy = jest.spyOn(TestBed.inject(ApiProductV2Service), 'notifyApiProductChanged');
     loader = TestbedHarnessEnvironment.loader(fixture);
     rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     planListHarness = await loader.getHarness(PlanListComponentHarness);
@@ -424,7 +424,7 @@ describe('ApiProductPlanListComponent', () => {
       fixture.detectChanges();
       flushPlansList([{ ...plan, status: 'PUBLISHED' }]);
 
-      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+      expect(notifyApiProductChangedSpy).toHaveBeenCalledTimes(1);
     }));
 
     it('notifies plan state changed after deprecate so deploy banner is triggered', fakeAsync(async () => {
@@ -446,7 +446,7 @@ describe('ApiProductPlanListComponent', () => {
       fixture.detectChanges();
       flushPlansList([{ ...plan, status: 'DEPRECATED' }]);
 
-      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+      expect(notifyApiProductChangedSpy).toHaveBeenCalledTimes(1);
     }));
 
     it('notifies plan state changed after close so deploy banner is triggered', fakeAsync(async () => {
@@ -468,7 +468,7 @@ describe('ApiProductPlanListComponent', () => {
       fixture.detectChanges();
       flushPlansList([{ ...plan, status: 'CLOSED' }]);
 
-      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+      expect(notifyApiProductChangedSpy).toHaveBeenCalledTimes(1);
     }));
 
     it('notifies plan state changed after reorder so deploy banner is triggered', fakeAsync(async () => {
@@ -498,7 +498,7 @@ describe('ApiProductPlanListComponent', () => {
       listReq.flush({ data: [plan2, { ...plan1, order: 2 }] });
       fixture.detectChanges();
 
-      expect(notifyPlanStateChangedSpy).toHaveBeenCalledTimes(1);
+      expect(notifyApiProductChangedSpy).toHaveBeenCalledTimes(1);
     }));
 
     it('does not notify plan state changed when publish fails', fakeAsync(async () => {
@@ -523,7 +523,7 @@ describe('ApiProductPlanListComponent', () => {
         .flush({ message: 'Publish failed' }, { status: 500, statusText: 'Server Error' });
       fixture.detectChanges();
 
-      expect(notifyPlanStateChangedSpy).not.toHaveBeenCalled();
+      expect(notifyApiProductChangedSpy).not.toHaveBeenCalled();
     }));
   });
 

--- a/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.ts
@@ -119,7 +119,7 @@ export class ApiProductPlanListComponent {
   }
 
   private refreshPlansAfterStateChange(): void {
-    this.apiProductV2Service.notifyPlanStateChanged();
+    this.apiProductV2Service.notifyApiProductChanged();
     this.triggerReload();
   }
 

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
@@ -46,11 +46,12 @@ export class ApiProductV2Service {
   ) {}
 
   /**
-   * Notifies subscribers that plan state has changed. Must be called after any operation that
-   * modifies plans: create, update, publish, deprecate, close, reorder, or delete.
-   * Keeps the navigation banner (e.g. NEED_REDEPLOY) in sync with the latest plan state.
+   * Notifies subscribers to refetch the API Product (deployment state, verify deploy).
+   * Call after plan changes (create, update, publish, deprecate, close, reorder, delete) or after
+   * definition changes that affect gateway sync (e.g. API list on the product). PUT responses may
+   * omit computed deploymentState; this forces a GET so the "Deploy API Product" banner stays in sync.
    */
-  notifyPlanStateChanged(): void {
+  notifyApiProductChanged(): void {
     this._planStateVersion.update(v => v + 1);
   }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
@@ -32,6 +32,7 @@ import io.gravitee.apim.core.audit.model.ApiProductAuditLogEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.ApiProductAuditEvent;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
@@ -109,7 +110,12 @@ public class UpdateApiProductUseCase {
         }
         apiProductIndexerDomainService.index(oneShotIndexation(input.auditInfo()), updated, primaryOwner);
 
-        deployApiProductDomainService.deploy(input.auditInfo(), updated);
+        try {
+            validateApiProductService.validateForDeploy(updated);
+            deployApiProductDomainService.deploy(input.auditInfo(), updated);
+        } catch (ValidationDomainException e) {
+            log.warn("API Product [{}] was updated but not deployed to the gateway. {}", updated.getId(), e.getMessage());
+        }
         createAuditLog(beforeUpdate, updated, input.auditInfo());
         return new Output(updated);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.LicenseFixtures;
+import fixtures.core.model.PlanFixtures;
 import inmemory.AbstractUseCaseTest;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiProductCrudServiceInMemory;
@@ -49,8 +50,11 @@ import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
+import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.node.api.license.LicenseManager;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -77,6 +81,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
 
     @BeforeEach
     void setUp() {
+        planQueryService.reset();
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
         var validateApiProductService = new ValidateApiProductService(
             apiQueryService,
@@ -100,6 +105,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
 
     @Test
     void should_update_api_product() {
+        givenPublishedApiProductPlan();
         ApiProduct existing = ApiProduct.builder()
             .id("api-product-id")
             .name("Old Name")
@@ -208,6 +214,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
 
     @Test
     void should_include_all_allowed_apis() {
+        givenPublishedApiProductPlan();
         ApiProduct existing = ApiProduct.builder()
             .id("api-product-id")
             .name("API Product")
@@ -256,6 +263,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
 
     @Test
     void should_auto_undeploy_removed_deployed_api_without_plans_then_update_product() {
+        givenPublishedApiProductPlan();
         ApiProduct existing = ApiProduct.builder()
             .id("api-product-id")
             .name("API Product")
@@ -283,6 +291,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
 
     @Test
     void should_not_call_stop_when_no_apis_removed() {
+        givenPublishedApiProductPlan();
         ApiProduct existing = ApiProduct.builder()
             .id("api-product-id")
             .name("API Product")
@@ -306,6 +315,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
 
     @Test
     void should_stop_each_removed_deployed_api_without_plan_when_multiple_removed() {
+        givenPublishedApiProductPlan();
         ApiProduct existing = ApiProduct.builder()
             .id("api-product-id")
             .name("API Product")
@@ -418,6 +428,45 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
         Assertions.assertThat(message).contains("api-v2");
         Assertions.assertThat(message).contains("not allowed in API Products");
         Assertions.assertThat(message).contains("api-not-allowed");
+    }
+
+    @Test
+    void should_persist_update_but_not_publish_deploy_when_configuration_is_not_deployable() {
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .apiIds(Set.of("api-1"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        Api api1 = createV4ProxyApi("api-1", true);
+        Api api2 = createV4ProxyApi("api-2", true);
+        apiCrudService.initWith(List.of(api1, api2));
+        // No API plans and no API Product plan — same rules as DeployApiProductUseCase
+
+        var toUpdate = UpdateApiProduct.builder().apiIds(Set.of("api-1", "api-2")).build();
+        var input = new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO);
+
+        var output = updateApiProductUseCase.execute(input);
+
+        assertThat(output.apiProduct().getApiIds()).containsExactlyInAnyOrder("api-1", "api-2");
+        verify(eventCrudService, never()).createEvent(any(), any(), any(), any(), any(), any());
+        verify(eventLatestCrudService, never()).createOrPatchLatestEvent(any(), any(), any());
+    }
+
+    private void givenPublishedApiProductPlan() {
+        Plan productPlan = PlanFixtures.aPlanHttpV4()
+            .toBuilder()
+            .id("api-product-deploy-plan")
+            .referenceId("api-product-id")
+            .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .environmentId(ENV_ID)
+            .planDefinitionHttpV4(PlanFixtures.aPlanHttpV4().getPlanDefinitionHttpV4().toBuilder().status(PlanStatus.PUBLISHED).build())
+            .build();
+        planQueryService.initWith(List.of(productPlan));
     }
 
     private Api createV4ProxyApi(String id, Boolean allowedInApiProducts) {


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-13331

## Description

Prevent unintended auto-deployment of API Products when associated APIs do not meet plan requirements.

Current issue:
When an API Product has no plans, adding a new API with a valid plan (e.g., keyless) triggers auto-deployment,
even if another API in the same product does not have any plan. This leads to a scenario where APIs without plans
get deployed via the API Product, violating deployment constraints.

Fix:
Added validation to ensure that an API Product is not auto-deployed if:
- The API Product has no valid (published/deprecated) plans, AND
- Any associated API does not have its own valid plan.

This guarantees:
- APIs without plans cannot be deployed unless covered by a valid API Product plan.
- API Product deployment remains consistent with plan enforcement rules.

Impact:
- Prevents invalid deployment states
- Ensures strict enforcement of plan dependency rules across APIs and API Products

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

