### PR TITLE
chore: bump @gravitee/ui-particles-angular from 17.7.2 to 17.7.3

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
@@ -229,6 +229,9 @@ describe('ApiProductPlanEditComponent', () => {
       fixture.detectChanges();
       submitForm();
       tick();
+      httpTestingController
+        .match(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/plans/${PLAN_ID}`)
+        .forEach(req => req.error(new ProgressEvent('error')));
 
       httpTestingController.expectNone({
         method: 'POST',

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -204,6 +204,7 @@ describe('ApiPlanFormComponent', () => {
             },
           ],
         } as CreatePlanV2);
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
       });
     });
     describe('JWT plan', () => {
@@ -357,6 +358,8 @@ describe('ApiPlanFormComponent', () => {
             },
           ],
         } as CreatePlanV2);
+        // Allow pending setTimeout(0) from writeValue in ui-particles 17.7.3 to fire before teardown
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
       });
     });
     describe('API Key plan', () => {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.spec.ts
@@ -151,6 +151,8 @@ describe('ApiProviderComponent', () => {
 
       expect(fakeSnackBarService.success).toHaveBeenCalledWith('Provider Test Provider created!');
       expect(routerNavigateSpy).toHaveBeenCalledWith(['../../'], { relativeTo: expect.anything() });
+      // Allow pending setTimeout(0) from writeValue in ui-particles 17.7.3 to fire before teardown
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
     });
   });
 
@@ -202,6 +204,7 @@ describe('ApiProviderComponent', () => {
 
       expect(fakeSnackBarService.success).toHaveBeenCalledWith('Provider group successfully updated!');
       expect(routerNavigateSpy).toHaveBeenCalledWith(['../../../'], { relativeTo: expect.anything() });
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
     });
   });
 
@@ -258,6 +261,7 @@ describe('ApiProviderComponent', () => {
 
       expect(fakeSnackBarService.success).toHaveBeenCalledWith('Endpoint Endpoint 2 created!');
       expect(routerNavigateSpy).toHaveBeenCalledWith(['../../../'], { relativeTo: expect.anything() });
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
     });
   });
 
@@ -313,7 +317,8 @@ describe('ApiProviderComponent', () => {
       expectApiPutRequest(updatedApi);
 
       expect(fakeSnackBarService.success).toHaveBeenCalledWith('Endpoint successfully updated!');
-      expect(routerNavigateSpy).toHaveBeenCalledWith(['../../../'], { relativeTo: expect.anything() });
+      expect(routerNavigateSpy).toHaveBeenCalledWith(['../../'], { relativeTo: expect.anything() });
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.ts
@@ -158,7 +158,7 @@ export class ApiLlmProviderComponent implements OnInit {
       } else if (params.endpointIndex !== undefined) {
         this.mode = 'edit-endpoint';
         this.endpointIndex = +params.endpointIndex;
-        this.backPath = '../../../';
+        this.backPath = '../../';
       }
     }
   }

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
@@ -192,95 +192,99 @@ describe('ApiPlanEditComponent', () => {
         expectApiGetRequest(fakeApiV2({ id: API_ID }));
       });
 
-      it.each(['STAGING', 'PUBLISHED', 'DEPRECATED'])('should edit plan', async (status: PlanStatus) => {
-        PLAN.status = status;
-        expectPlanGetRequest(API_ID, PLAN);
+      it.each(['STAGING', 'PUBLISHED', 'DEPRECATED'])(
+        'should edit plan',
+        fakeAsync(async (status: PlanStatus) => {
+          PLAN.status = status;
+          expectPlanGetRequest(API_ID, PLAN);
 
-        const saveBar = await loader.getHarness(GioSaveBarHarness);
-        expect(await saveBar.isVisible()).toBe(false);
+          const saveBar = await loader.getHarness(GioSaveBarHarness);
+          expect(await saveBar.isVisible()).toBe(false);
 
-        const planForm = await loader.getHarness(ApiPlanFormHarness);
+          const planForm = await loader.getHarness(ApiPlanFormHarness);
 
-        planForm
-          .httpRequest(httpTestingController)
-          .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
-        planForm.httpRequest(httpTestingController).expectGroupListRequest([
-          fakeGroup({
-            id: 'group-a',
-            name: 'Group A',
-          }),
-        ]);
-        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API_ID, [
-          {
-            id: 'doc-1',
-            name: 'Doc 1',
-          },
-        ]);
-        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
-
-        const nameInput = await planForm.getNameInput();
-        await nameInput.setValue('My plan edited');
-
-        expect(await saveBar.isVisible()).toBe(true);
-        await saveBar.clickSubmit();
-
-        expectPlanGetRequest(API_ID, PLAN);
-        const req = httpTestingController.expectOne({
-          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN.id}`,
-          method: 'PUT',
-        });
-
-        expect(req.request.body).toEqual({
-          apiId: API_ID,
-          name: 'My plan edited',
-          description: 'Default plan',
-          characteristics: [],
-          excludedGroups: undefined,
-          status: PLAN.status,
-          validation: 'MANUAL',
-          tags: ['tag1'],
-          commentMessage: 'comment message',
-          commentRequired: false,
-          generalConditions: 'general conditions',
-          id: PLAN.id,
-          security: {
-            type: 'KEY_LESS',
-            configuration: undefined,
-          },
-          selectionRule: undefined,
-          definitionVersion: 'V2',
-          flows: [
+          planForm
+            .httpRequest(httpTestingController)
+            .expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+          planForm.httpRequest(httpTestingController).expectGroupListRequest([
+            fakeGroup({
+              id: 'group-a',
+              name: 'Group A',
+            }),
+          ]);
+          planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API_ID, [
             {
-              name: '',
-              pathOperator: {
-                path: '/',
-                operator: 'STARTS_WITH',
-              },
-              condition: '',
-              consumers: [],
-              methods: [],
-              pre: [
-                {
-                  name: 'Mock',
-                  description: 'Saying hello to the world',
-                  enabled: true,
-                  policy: 'mock',
-                  configuration: { content: 'Hello world', status: '200' },
-                },
-              ],
-              post: [],
-              enabled: true,
+              id: 'doc-1',
+              name: 'Doc 1',
             },
-          ],
-        } as PlanV2);
-        req.flush({});
-        expect(routerNavigationSpy).toHaveBeenCalledWith(['../'], {
-          queryParams: {
+          ]);
+          planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
+
+          const nameInput = await planForm.getNameInput();
+          await nameInput.setValue('My plan edited');
+
+          expect(await saveBar.isVisible()).toBe(true);
+          await saveBar.clickSubmit();
+
+          expectPlanGetRequest(API_ID, PLAN);
+          const req = httpTestingController.expectOne({
+            url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN.id}`,
+            method: 'PUT',
+          });
+
+          expect(req.request.body).toEqual({
+            apiId: API_ID,
+            name: 'My plan edited',
+            description: 'Default plan',
+            characteristics: [],
+            excludedGroups: undefined,
             status: PLAN.status,
-          },
-          relativeTo: expect.anything(),
-        });
-      });
+            validation: 'MANUAL',
+            tags: ['tag1'],
+            commentMessage: 'comment message',
+            commentRequired: false,
+            generalConditions: 'general conditions',
+            id: PLAN.id,
+            security: {
+              type: 'KEY_LESS',
+              configuration: undefined,
+            },
+            selectionRule: undefined,
+            definitionVersion: 'V2',
+            flows: [
+              {
+                name: '',
+                pathOperator: {
+                  path: '/',
+                  operator: 'STARTS_WITH',
+                },
+                condition: '',
+                consumers: [],
+                methods: [],
+                pre: [
+                  {
+                    name: 'Mock',
+                    description: 'Saying hello to the world',
+                    enabled: true,
+                    policy: 'mock',
+                    configuration: { content: 'Hello world', status: '200' },
+                  },
+                ],
+                post: [],
+                enabled: true,
+              },
+            ],
+          } as PlanV2);
+          req.flush({});
+          expect(routerNavigationSpy).toHaveBeenCalledWith(['../'], {
+            queryParams: {
+              status: PLAN.status,
+            },
+            relativeTo: expect.anything(),
+          });
+          flush();
+        }),
+      );
     });
 
     describe('Edit Kubernetes API', () => {

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
@@ -639,7 +639,8 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
               name: 'Test policy',
               policy: 'test-policy',
               condition: undefined,
-              configuration: undefined,
+              messageCondition: undefined,
+              configuration: {},
             },
           ],
           selectors: [

--- a/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-studio/shared-policy-group-studio.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/shared-policy-groups/shared-policy-group/shared-policy-group-studio/shared-policy-group-studio.component.spec.ts
@@ -173,7 +173,7 @@ describe('SharedPolicyGroupStudioComponent', () => {
             description: 'What does the 🦊 say?',
             condition: undefined,
             messageCondition: undefined,
-            configuration: undefined,
+            configuration: {},
             enabled: true,
           },
         ],

--- a/gravitee-apim-e2e/api-test/src/apis/plans/mapi-v1/api-product-deletion-scenarios.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/plans/mapi-v1/api-product-deletion-scenarios.spec.ts
@@ -344,6 +344,8 @@ describeIfClientGatewaySupportingApiProduct(
         await noContent(v2ApisResourceAsApiPublisher.deleteApiRaw({ envId, apiId: api1.id, closePlans: true }));
         // Mark as deleted so afterAll skips a second delete attempt.
         api1 = { ...api1, id: '' };
+
+        // Allow the gateway time to process the undeploy event.
         await new Promise((resolve) => setTimeout(resolve, 6000));
       });
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "@gravitee/graphene": "1.0.0-alpha.23",
         "@gravitee/ui-analytics": "17.7.2",
         "@gravitee/ui-components": "4.4.0",
-        "@gravitee/ui-particles-angular": "17.7.2",
+        "@gravitee/ui-particles-angular": "17.7.3",
         "@gravitee/ui-policy-studio-angular": "17.7.2",
         "@highcharts/map-collection": "1.1.4",
         "@ngx-formly/core": "6.3.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4603,9 +4603,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/ui-particles-angular@npm:17.7.2":
-  version: 17.7.2
-  resolution: "@gravitee/ui-particles-angular@npm:17.7.2"
+"@gravitee/ui-particles-angular@npm:17.7.3":
+  version: 17.7.3
+  resolution: "@gravitee/ui-particles-angular@npm:17.7.3"
   dependencies:
     "@fontsource/fira-mono": "npm:5.0.14"
     "@fontsource/kanit": "npm:^5.2.6"
@@ -4634,7 +4634,7 @@ __metadata:
       optional: true
     prismjs:
       optional: true
-  checksum: 10c0/097642b504e98d52c73e1a077a9e8ee1db5d607ebb019b7167090eef2846f435e235f9361e002801d7782ee72104bda9f794823822b6bf650bb5620f8dae555a
+  checksum: 10c0/3842d2c3a0285a1a069a91474cd88c3714c427694f9bdc9f0f6dd0b385f9f2fb97bc1059624a82273f131405cdbc9a7574309ed9ec744862b46e031692f4b4b2
   languageName: node
   linkType: hard
 
@@ -20486,7 +20486,7 @@ __metadata:
     "@gravitee/graphene": "npm:1.0.0-alpha.23"
     "@gravitee/ui-analytics": "npm:17.7.2"
     "@gravitee/ui-components": "npm:4.4.0"
-    "@gravitee/ui-particles-angular": "npm:17.7.2"
+    "@gravitee/ui-particles-angular": "npm:17.7.3"
     "@gravitee/ui-policy-studio-angular": "npm:17.7.2"
     "@gravitee/ui-schematics": "npm:17.7.2"
     "@highcharts/map-collection": "npm:1.1.4"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12804

## Description

 Fixes a back-navigation issue in the LLM provider endpoint configuration screen.
                                                                                                                                                                                                                                                                                                                                                       
When editing an endpoint (edit-endpoint mode), the back path was set one level too deep, causing the user to be navigated away from the endpoint configuration context. 

This resulted in configuration settings (e.g. sharedConfiguration.http) appearing to be lost or not reflected in the UI after interaction.     
                                                                                                                                                                                                                                                                                                                                                       
+ bumps @gravitee/ui-particles-angular from 17.7.2 to 17.7.3 with the related test adjustments. 


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

