### PR TITLE
feat: support multiple endpoints per LLM provider group

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -1174,7 +1174,31 @@ const apisRoutes: Routes = [
         },
       },
       {
-        path: 'v4/endpoints/provider/:providerIndex',
+        path: 'v4/endpoints/provider/:providerIndex/edit',
+        component: ApiLlmProviderComponent,
+        data: {
+          permissions: {
+            anyOf: ['api-definition-r'],
+          },
+          docs: {
+            page: 'management-api-proxy-endpoints',
+          },
+        },
+      },
+      {
+        path: 'v4/endpoints/provider/:providerIndex/new',
+        component: ApiLlmProviderComponent,
+        data: {
+          permissions: {
+            anyOf: ['api-definition-u'],
+          },
+          docs: {
+            page: 'management-api-proxy-endpoints',
+          },
+        },
+      },
+      {
+        path: 'v4/endpoints/provider/:providerIndex/:endpointIndex',
         component: ApiLlmProviderComponent,
         data: {
           permissions: {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.adapter.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.adapter.ts
@@ -17,6 +17,13 @@ import { ApiV4 } from '../../../../../entities/management-api-v2';
 
 export type Provider = {
   name: string;
+  groupIndex: number;
+  endpoints: ProviderEndpoint[];
+};
+
+export type ProviderEndpoint = {
+  name: string;
+  endpointIndex: number;
   providerConfiguration: ProviderConfiguration;
 };
 
@@ -41,12 +48,13 @@ export const toProviders = (api: ApiV4): Provider[] => {
 
   return api.endpointGroups
     .filter(endpointGroup => endpointGroup.endpoints && endpointGroup.endpoints.length > 0)
-    .map(endpointGroup => {
-      const endpoint = endpointGroup.endpoints[0];
-
-      return {
-        name: endpointGroup.name,
+    .map((endpointGroup, groupIndex) => ({
+      name: endpointGroup.name,
+      groupIndex,
+      endpoints: endpointGroup.endpoints.map((endpoint, endpointIndex) => ({
+        name: endpoint.name,
+        endpointIndex,
         providerConfiguration: endpoint.configuration as ProviderConfiguration,
-      };
-    });
+      })),
+    }));
 };

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.html
@@ -16,22 +16,19 @@
 
 -->
 @if (providersTableData().length > 0) {
-  @for (provider of providersTableData(); track provider.name; let i = $index) {
+  @for (provider of providersTableData(); track provider.name) {
     <mat-card class="endpoint-group-card">
       <mat-card-content>
         <div class="endpoint-group-card__header">
           <div class="endpoint-group-card__header__title">
             <h3 class="mat-h3">{{ provider?.name }}</h3>
-            <span class="gio-badge-primary">
-              {{ getProviderTypeDisplayName(provider?.endpoints?.[0]?.providerConfiguration?.provider) }}
-            </span>
           </div>
           <div class="endpoint-group-card__header__actions">
             <button
               *gioPermission="{ anyOf: ['api-definition-u'] }"
               mat-stroked-button
-              [attr.aria-label]="isReadOnly() ? 'View provider' : 'Edit Provider'"
-              [routerLink]="['./provider', i]"
+              [attr.aria-label]="isReadOnly() ? 'View provider group' : 'Edit provider group'"
+              [routerLink]="['./provider', provider.groupIndex, 'edit']"
             >
               <mat-icon [svgIcon]="isReadOnly() ? 'gio:eye-empty' : 'gio:edit-pencil'"></mat-icon>
               {{ isReadOnly() ? 'View' : 'Edit' }}
@@ -46,57 +43,103 @@
             </ng-container>
           </div>
         </div>
-        <table
-          mat-table
-          [dataSource]="provider.endpoints[0]?.providerConfiguration?.models ?? []"
-          [attr.id]="'groupsTable-' + i"
-          aria-label="Endpoint group table"
-          class="gio-table-light"
+        @for (endpoint of provider.endpoints; track endpoint.name; let j = $index) {
+          <div class="endpoint-group-card__endpoint">
+            <div class="endpoint-group-card__endpoint__header">
+              <div class="endpoint-group-card__endpoint__header__title">
+                <h4 class="mat-h4">{{ endpoint.name }}</h4>
+                <span class="gio-badge-primary">
+                  {{ getProviderTypeDisplayName(endpoint.providerConfiguration?.provider) }}
+                </span>
+              </div>
+              <div class="endpoint-group-card__endpoint__header__actions">
+                <button
+                  *gioPermission="{ anyOf: ['api-definition-u'] }"
+                  mat-stroked-button
+                  [attr.aria-label]="isReadOnly() ? 'View endpoint' : 'Edit endpoint'"
+                  [routerLink]="['./provider', provider.groupIndex, endpoint.endpointIndex]"
+                >
+                  <mat-icon [svgIcon]="isReadOnly() ? 'gio:eye-empty' : 'gio:edit-pencil'"></mat-icon>
+                  {{ isReadOnly() ? 'View' : 'Edit' }}
+                </button>
+                <ng-container *gioPermission="{ anyOf: ['api-definition-u'] }">
+                  @if (provider.endpoints.length > 1) {
+                    <button
+                      mat-stroked-button
+                      aria-label="Delete endpoint"
+                      (click)="deleteEndpoint(provider.groupIndex, endpoint.name)"
+                      [disabled]="isReadOnly()"
+                    >
+                      <mat-icon svgIcon="gio:trash"></mat-icon>
+                      Delete
+                    </button>
+                  }
+                </ng-container>
+              </div>
+            </div>
+            <table
+              mat-table
+              [dataSource]="endpoint.providerConfiguration?.models ?? []"
+              [attr.id]="'groupsTable-' + provider.groupIndex + '-' + endpoint.endpointIndex"
+              aria-label="Endpoint models table"
+              class="gio-table-light"
+            >
+              <!-- Model Column -->
+              <ng-container matColumnDef="model">
+                <th mat-header-cell *matHeaderCellDef>Model</th>
+                <td mat-cell *matCellDef="let element">
+                  {{ element.name }}
+                </td>
+              </ng-container>
+
+              <!-- Cost Input Column -->
+              <ng-container matColumnDef="costInput">
+                <th mat-header-cell *matHeaderCellDef>Cost per 1m tokens (input) ($)</th>
+                <td mat-cell *matCellDef="let element">
+                  {{ element.inputPrice | number: '1.2' }}
+                </td>
+              </ng-container>
+
+              <!-- Cost Output Column -->
+              <ng-container matColumnDef="costOutput">
+                <th mat-header-cell *matHeaderCellDef>Cost per 1m tokens (output) ($)</th>
+                <td mat-cell *matCellDef="let element">
+                  {{ element.outputPrice | number: '1.2' }}
+                </td>
+              </ng-container>
+
+              <!-- Alias Column -->
+              <ng-container matColumnDef="aliases">
+                <th mat-header-cell *matHeaderCellDef>Alias</th>
+                <td mat-cell *matCellDef="let element">
+                  <mat-chip-set aria-label="Model aliases">
+                    @for (alias of element.aliases ?? []; track alias) {
+                      <mat-chip>{{ alias }}</mat-chip>
+                    }
+                  </mat-chip-set>
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="llmProxyDisplayedColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: llmProxyDisplayedColumns"></tr>
+
+              <!-- Row shown when there is no data -->
+              <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+                <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="llmProxyDisplayedColumns.length">No Models</td>
+              </tr>
+            </table>
+          </div>
+        }
+        <button
+          *gioPermission="{ anyOf: ['api-definition-u'] }"
+          mat-stroked-button
+          aria-label="Add endpoint"
+          [routerLink]="['./provider', provider.groupIndex, 'new']"
+          [disabled]="isReadOnly()"
         >
-          <!-- Model Column -->
-          <ng-container matColumnDef="model">
-            <th mat-header-cell *matHeaderCellDef [id]="'model-' + i">Model</th>
-            <td mat-cell *matCellDef="let element">
-              {{ element.name }}
-            </td>
-          </ng-container>
-
-          <!-- Options Column -->
-          <ng-container matColumnDef="costInput">
-            <th mat-header-cell *matHeaderCellDef [id]="'costInput-' + i">Cost per 1m tokens (input) ($)</th>
-            <td mat-cell *matCellDef="let element">
-              {{ element.inputPrice | number: '1.2' }}
-            </td>
-          </ng-container>
-
-          <!-- Weight Column -->
-          <ng-container matColumnDef="costOutput">
-            <th mat-header-cell *matHeaderCellDef [id]="'costOutput-' + i">Cost per 1m tokens (output) ($)</th>
-            <td mat-cell *matCellDef="let element">
-              {{ element.outputPrice | number: '1.2' }}
-            </td>
-          </ng-container>
-
-          <!-- Alias Column -->
-          <ng-container matColumnDef="aliases">
-            <th mat-header-cell *matHeaderCellDef [id]="'aliases-' + i">Alias</th>
-            <td mat-cell *matCellDef="let element">
-              <mat-chip-set aria-label="Model aliases">
-                @for (alias of element.aliases ?? []; track alias) {
-                  <mat-chip>{{ alias }}</mat-chip>
-                }
-              </mat-chip-set>
-            </td>
-          </ng-container>
-
-          <tr mat-header-row *matHeaderRowDef="llmProxyDisplayedColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: llmProxyDisplayedColumns"></tr>
-
-          <!-- Row shown when there is no data -->
-          <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-            <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="llmProxyDisplayedColumns.length">No Endpoints</td>
-          </tr>
-        </table>
+          <mat-icon svgIcon="gio:plus"></mat-icon>
+          Add endpoint
+        </button>
       </mat-card-content>
     </mat-card>
   }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.html
@@ -23,7 +23,7 @@
           <div class="endpoint-group-card__header__title">
             <h3 class="mat-h3">{{ provider?.name }}</h3>
             <span class="gio-badge-primary">
-              {{ getProviderTypeDisplayName(provider?.providerConfiguration?.provider) }}
+              {{ getProviderTypeDisplayName(provider?.endpoints?.[0]?.providerConfiguration?.provider) }}
             </span>
           </div>
           <div class="endpoint-group-card__header__actions">
@@ -48,7 +48,7 @@
         </div>
         <table
           mat-table
-          [dataSource]="provider.providerConfiguration.models"
+          [dataSource]="provider.endpoints[0]?.providerConfiguration?.models ?? []"
           [attr.id]="'groupsTable-' + i"
           aria-label="Endpoint group table"
           class="gio-table-light"

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.scss
@@ -45,9 +45,45 @@
     }
   }
 
+  &__endpoint {
+    margin-bottom: 16px;
+    padding: 16px;
+    border: 1px solid #bdbdbd;
+    border-radius: 8px;
+
+    &__header {
+      display: flex;
+      flex-direction: row;
+      margin-bottom: 12px;
+      align-items: center;
+
+      &__title {
+        display: flex;
+        flex-direction: row;
+        flex: 1;
+        align-items: center;
+
+        .mat-h4 {
+          margin: 0 8px 0 0;
+          font-size: 1rem;
+        }
+
+        .gio-badge-primary {
+          text-transform: unset;
+        }
+      }
+
+      &__actions {
+        display: flex;
+        flex-direction: row;
+        gap: 8px;
+      }
+    }
+  }
+
   .gio-table-light {
     width: 100%;
-    margin-bottom: 16px;
+    margin-bottom: 0;
 
     th {
       text-transform: none;

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.spec.ts
@@ -121,7 +121,7 @@ describe('ApiEndpointGroupsLlmComponent', () => {
   });
 
   describe('table display tests', () => {
-    it('should display providers table correctly', async () => {
+    it('should display providers and endpoints correctly', async () => {
       const apiV4 = fakeApiV4({
         id: API_ID,
         endpointGroups: [
@@ -164,11 +164,48 @@ describe('ApiEndpointGroupsLlmComponent', () => {
       expect(await componentHarness.getProviderCards()).toBe(2);
       expect(await componentHarness.getProviderName(0)).toBe('OpenAI Provider');
       expect(await componentHarness.getProviderName(1)).toBe('Anthropic Provider');
-      expect(await componentHarness.getProviderType(0)).toBe('OpenAI Compatible');
-      expect(await componentHarness.getProviderType(1)).toBe('ANTHROPIC');
+      expect(await componentHarness.getEndpointProviderType(0, 0)).toBe('OpenAI Compatible');
+      expect(await componentHarness.getEndpointProviderType(1, 0)).toBe('ANTHROPIC');
     });
 
-    it('should display models table for each provider', async () => {
+    it('should display multiple endpoints per provider', async () => {
+      const apiV4 = fakeApiV4({
+        id: API_ID,
+        endpointGroups: [
+          {
+            name: 'OpenAI Provider',
+            type: 'llm',
+            endpoints: [
+              {
+                name: 'Production',
+                type: 'llm-proxy',
+                configuration: {
+                  provider: 'OPEN_AI',
+                  models: [{ name: 'gpt-4o', inputPrice: 2.5, outputPrice: 10.0 }],
+                },
+              },
+              {
+                name: 'Staging',
+                type: 'llm-proxy',
+                configuration: {
+                  provider: 'OPEN_AI',
+                  models: [{ name: 'gpt-4o-mini', inputPrice: 0.15, outputPrice: 0.6 }],
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      await initComponent(apiV4);
+
+      expect(await componentHarness.getProviderCards()).toBe(1);
+      expect(await componentHarness.getEndpointCount(0)).toBe(2);
+      expect(await componentHarness.getEndpointName(0, 0)).toBe('Production');
+      expect(await componentHarness.getEndpointName(0, 1)).toBe('Staging');
+    });
+
+    it('should display models table for each endpoint', async () => {
       const apiV4 = fakeApiV4({
         id: API_ID,
         endpointGroups: [
@@ -194,10 +231,10 @@ describe('ApiEndpointGroupsLlmComponent', () => {
 
       await initComponent(apiV4);
 
-      const modelsTable = await componentHarness.getModelsTable(0);
+      const modelsTable = await componentHarness.getModelsTable(0, 0);
       expect(modelsTable).toBeTruthy();
 
-      const modelsRows = await componentHarness.getModelsTableRows(0);
+      const modelsRows = await componentHarness.getModelsTableRows(0, 0);
       expect(modelsRows).toHaveLength(2);
       expect(modelsRows[0]).toEqual(['gpt-3.5-turbo', '0.001', '0.002', '']);
       expect(modelsRows[1]).toEqual(['gpt-4', '0.03', '0.06', '']);
@@ -205,7 +242,7 @@ describe('ApiEndpointGroupsLlmComponent', () => {
   });
 
   describe('action buttons tests', () => {
-    it('should show edit button when user has update permission', async () => {
+    it('should show group and endpoint edit buttons when user has update permission', async () => {
       const apiV4 = fakeApiV4({
         id: API_ID,
         endpointGroups: [
@@ -236,8 +273,9 @@ describe('ApiEndpointGroupsLlmComponent', () => {
 
       await initComponent(apiV4, ['api-definition-r', 'api-definition-u']);
 
-      expect(await componentHarness.isEditButtonVisible(0)).toBe(true);
-      expect(await componentHarness.isDeleteButtonVisible(0)).toBe(true);
+      expect(await componentHarness.isGroupEditButtonVisible(0)).toBe(true);
+      expect(await componentHarness.isGroupDeleteButtonVisible(0)).toBe(true);
+      expect(await componentHarness.isEndpointEditButtonVisible(0)).toBe(true);
     });
 
     it('should hide edit and delete buttons when user has no update permission', async () => {
@@ -260,8 +298,9 @@ describe('ApiEndpointGroupsLlmComponent', () => {
 
       await initComponent(apiV4, ['api-definition-r']);
 
-      expect(await componentHarness.isEditButtonVisible(0)).toBe(false);
-      expect(await componentHarness.isDeleteButtonVisible(0)).toBe(false);
+      expect(await componentHarness.isGroupEditButtonVisible(0)).toBe(false);
+      expect(await componentHarness.isGroupDeleteButtonVisible(0)).toBe(false);
+      expect(await componentHarness.isEndpointEditButtonVisible(0)).toBe(false);
     });
 
     it('should show add provider button when user has create permission', async () => {
@@ -288,7 +327,7 @@ describe('ApiEndpointGroupsLlmComponent', () => {
   });
 
   describe('delete flow tests', () => {
-    it('should show delete button when there are multiple providers', async () => {
+    it('should show group delete button when there are multiple providers', async () => {
       const apiV4 = fakeApiV4({
         id: API_ID,
         endpointGroups: [
@@ -319,14 +358,12 @@ describe('ApiEndpointGroupsLlmComponent', () => {
 
       await initComponent(apiV4, ['api-definition-r', 'api-definition-u', 'api-definition-d']);
 
-      // Should have 2 providers
       expect(await componentHarness.getProviderCards()).toBe(2);
-      // Delete button should be visible when there are multiple providers
-      expect(await componentHarness.isDeleteButtonVisible(0)).toBe(true);
-      expect(await componentHarness.isDeleteButtonVisible(1)).toBe(true);
+      expect(await componentHarness.isGroupDeleteButtonVisible(0)).toBe(true);
+      expect(await componentHarness.isGroupDeleteButtonVisible(1)).toBe(true);
     });
 
-    it('should not show delete button when there is only one provider', async () => {
+    it('should not show group delete button when there is only one provider', async () => {
       const apiV4 = fakeApiV4({
         id: API_ID,
         endpointGroups: [
@@ -346,10 +383,60 @@ describe('ApiEndpointGroupsLlmComponent', () => {
 
       await initComponent(apiV4, ['api-definition-r', 'api-definition-u', 'api-definition-d']);
 
-      // Should have 1 provider
       expect(await componentHarness.getProviderCards()).toBe(1);
-      // Delete button should not be visible when there is only one provider
-      expect(await componentHarness.isDeleteButtonVisible(0)).toBe(false);
+      expect(await componentHarness.isGroupDeleteButtonVisible(0)).toBe(false);
+    });
+
+    it('should show endpoint delete button when there are multiple endpoints in a group', async () => {
+      const apiV4 = fakeApiV4({
+        id: API_ID,
+        endpointGroups: [
+          {
+            name: 'OpenAI Provider',
+            type: 'llm',
+            endpoints: [
+              {
+                name: 'Endpoint 1',
+                type: 'llm-proxy',
+                configuration: { provider: 'OPEN_AI', models: [] },
+              },
+              {
+                name: 'Endpoint 2',
+                type: 'llm-proxy',
+                configuration: { provider: 'OPEN_AI', models: [] },
+              },
+            ],
+          },
+        ],
+      });
+
+      await initComponent(apiV4, ['api-definition-r', 'api-definition-u']);
+
+      expect(await componentHarness.isEndpointDeleteButtonVisible(0)).toBe(true);
+      expect(await componentHarness.isEndpointDeleteButtonVisible(1)).toBe(true);
+    });
+
+    it('should not show endpoint delete button when there is only one endpoint', async () => {
+      const apiV4 = fakeApiV4({
+        id: API_ID,
+        endpointGroups: [
+          {
+            name: 'OpenAI Provider',
+            type: 'llm',
+            endpoints: [
+              {
+                name: 'Only Endpoint',
+                type: 'llm-proxy',
+                configuration: { provider: 'OPEN_AI', models: [] },
+              },
+            ],
+          },
+        ],
+      });
+
+      await initComponent(apiV4, ['api-definition-r', 'api-definition-u']);
+
+      expect(await componentHarness.isEndpointDeleteButtonVisible(0)).toBe(false);
     });
   });
 
@@ -365,7 +452,7 @@ describe('ApiEndpointGroupsLlmComponent', () => {
       expect(await componentHarness.isAddProviderButtonVisible()).toBe(true);
     });
 
-    it('should have correct routerLink for edit provider button', async () => {
+    it('should have correct routerLink for edit provider group button', async () => {
       const apiV4 = fakeApiV4({
         id: API_ID,
         endpointGroups: [
@@ -385,7 +472,7 @@ describe('ApiEndpointGroupsLlmComponent', () => {
 
       await initComponent(apiV4, ['api-definition-r', 'api-definition-u']);
 
-      expect(await componentHarness.isEditButtonVisible(0)).toBe(true);
+      expect(await componentHarness.isGroupEditButtonVisible(0)).toBe(true);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.component.ts
@@ -125,6 +125,48 @@ export class ApiEndpointGroupsLlmComponent {
       .subscribe();
   }
 
+  public deleteEndpoint(groupIndex: number, endpointName: string): void {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        width: '500px',
+        data: {
+          title: 'Delete Endpoint',
+          content: `Are you sure you want to delete the endpoint <strong>${endpointName}</strong>?`,
+          confirmButton: 'Delete',
+        },
+        role: 'alertdialog',
+        id: 'deleteEndpointConfirmDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.apiService.get(this.activatedRoute.snapshot.params.apiId)),
+        switchMap(api => {
+          const apiV4 = api as ApiV4;
+          const endpointGroups = apiV4.endpointGroups || [];
+          const group = endpointGroups[groupIndex];
+          if (group?.endpoints) {
+            remove(group.endpoints, e => e.name === endpointName);
+          }
+          return this.apiService.update(apiV4.id, { ...apiV4, endpointGroups } as UpdateApi);
+        }),
+        catchError(({ error }) => {
+          this.snackBarService.error(
+            error.message === 'Validation error' ? `${error.message}: ${error.details[0].message}` : error.message,
+          );
+          return EMPTY;
+        }),
+        switchMap(() => this.apiService.get(this.activatedRoute.snapshot.params.apiId)),
+        map(refreshedApi => {
+          const apiV4 = refreshedApi as ApiV4;
+          this.providersTableData.set(toProviders(apiV4));
+          this.snackBarService.success(`Endpoint ${endpointName} successfully deleted!`);
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
   public onRequestUpgrade() {
     this.licenseService.openDialog(this.apiType === 'LLM_PROXY' ? this.llmProxyLicenseOptions : this.messageLicenseOptions);
   }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/llm/api-endpoint-groups-llm.harness.ts
@@ -23,8 +23,14 @@ export class ApiEndpointGroupsLlmHarness extends ComponentHarness {
 
   private getProviderCardsLocator = this.locatorForAll('.endpoint-group-card');
   private getAddProviderButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Add provider"]' }));
-  private getEditButtons = this.locatorForAll(MatButtonHarness.with({ text: /Edit|View/ }));
-  private getDeleteButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete provider"]' }));
+  private getGroupEditButtons = this.locatorForAll(
+    MatButtonHarness.with({ selector: '[aria-label="Edit provider group"], [aria-label="View provider group"]' }),
+  );
+  private getGroupDeleteButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete provider"]' }));
+  private getEndpointEditButtons = this.locatorForAll(
+    MatButtonHarness.with({ selector: '[aria-label="Edit endpoint"], [aria-label="View endpoint"]' }),
+  );
+  private getEndpointDeleteButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete endpoint"]' }));
 
   public async getProviderCards(): Promise<number> {
     const cards = await this.getProviderCardsLocator();
@@ -38,17 +44,30 @@ export class ApiEndpointGroupsLlmHarness extends ComponentHarness {
     return titleElement ? await titleElement.text() : '';
   }
 
-  public async getProviderType(index: number): Promise<string> {
-    const badgeElement = await this.locatorForOptional(`.endpoint-group-card:nth-child(${index + 1}) .gio-badge-primary`)();
-    return badgeElement ? await badgeElement.text() : '';
+  public async getEndpointName(cardIndex: number, endpointIndex: number): Promise<string> {
+    const selector = `.endpoint-group-card:nth-child(${cardIndex + 1}) .endpoint-group-card__endpoint:nth-child(${endpointIndex + 2}) .endpoint-group-card__endpoint__header__title .mat-h4`;
+    const element = await this.locatorForOptional(selector)();
+    return element ? await element.text() : '';
   }
 
-  public async getModelsTable(index: number): Promise<MatTableHarness | null> {
-    return await this.locatorForOptional(MatTableHarness.with({ selector: `#groupsTable-${index}` }))();
+  public async getEndpointProviderType(cardIndex: number, endpointIndex: number): Promise<string> {
+    const selector = `.endpoint-group-card:nth-child(${cardIndex + 1}) .endpoint-group-card__endpoint:nth-child(${endpointIndex + 2}) .gio-badge-primary`;
+    const element = await this.locatorForOptional(selector)();
+    return element ? await element.text() : '';
   }
 
-  public async getModelsTableRows(index: number): Promise<string[][]> {
-    const table = await this.getModelsTable(index);
+  public async getEndpointCount(cardIndex: number): Promise<number> {
+    const selector = `.endpoint-group-card:nth-child(${cardIndex + 1}) .endpoint-group-card__endpoint`;
+    const elements = await this.locatorForAll(selector)();
+    return elements.length;
+  }
+
+  public async getModelsTable(groupIndex: number, endpointIndex: number): Promise<MatTableHarness | null> {
+    return await this.locatorForOptional(MatTableHarness.with({ selector: `#groupsTable-${groupIndex}-${endpointIndex}` }))();
+  }
+
+  public async getModelsTableRows(groupIndex: number, endpointIndex: number): Promise<string[][]> {
+    const table = await this.getModelsTable(groupIndex, endpointIndex);
     if (!table) return [];
     return await table.getCellTextByIndex();
   }
@@ -62,28 +81,37 @@ export class ApiEndpointGroupsLlmHarness extends ComponentHarness {
     }
   }
 
-  public async clickAddProviderButton(): Promise<void> {
-    const button = await this.getAddProviderButton();
-    return await button.click();
-  }
-
-  public async isEditButtonVisible(index: number): Promise<boolean> {
-    const buttons = await this.getEditButtons();
+  public async isGroupEditButtonVisible(index: number): Promise<boolean> {
+    const buttons = await this.getGroupEditButtons();
     return buttons.length > index;
   }
 
-  public async clickEditButton(index: number): Promise<void> {
-    const buttons = await this.getEditButtons();
-    return await buttons[index].click();
-  }
-
-  public async isDeleteButtonVisible(index: number): Promise<boolean> {
-    const buttons = await this.getDeleteButtons();
+  public async isGroupDeleteButtonVisible(index: number): Promise<boolean> {
+    const buttons = await this.getGroupDeleteButtons();
     return buttons.length > index;
   }
 
-  public async clickDeleteButton(index: number, rootLoader: HarnessLoader): Promise<void> {
-    const buttons = await this.getDeleteButtons();
+  public async isEndpointEditButtonVisible(index: number): Promise<boolean> {
+    const buttons = await this.getEndpointEditButtons();
+    return buttons.length > index;
+  }
+
+  public async isEndpointDeleteButtonVisible(index: number): Promise<boolean> {
+    const buttons = await this.getEndpointDeleteButtons();
+    return buttons.length > index;
+  }
+
+  public async clickGroupDeleteButton(index: number, rootLoader: HarnessLoader): Promise<void> {
+    const buttons = await this.getGroupDeleteButtons();
+    await buttons[index].click();
+
+    const dialog = await rootLoader.getHarness(MatDialogHarness);
+    const confirmButton = await dialog.getHarness(MatButtonHarness.with({ text: /Delete/ }));
+    return await confirmButton.click();
+  }
+
+  public async clickEndpointDeleteButton(index: number, rootLoader: HarnessLoader): Promise<void> {
+    const buttons = await this.getEndpointDeleteButtons();
     await buttons[index].click();
 
     const dialog = await rootLoader.getHarness(MatDialogHarness);

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.html
@@ -44,6 +44,9 @@
 
       @if (showConfiguration && providerSchema?.config) {
         <div class="endpoint-card__form__field">
+          @if (formGroup.errors?.providerMismatch; as mismatch) {
+            <gio-banner-error> All endpoints in this group must use the same provider ({{ mismatch.expected }}). </gio-banner-error>
+          }
           <gio-form-json-schema formControlName="configuration" [jsonSchema]="providerSchema.config"></gio-form-json-schema>
         </div>
       }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.html
@@ -16,55 +16,54 @@
 
 -->
 <div class="back-button">
-  <a mat-button [routerLink]="'../../'">
+  <a mat-button [routerLink]="backPath">
     <mat-icon svgIcon="gio:arrow-left"></mat-icon>
-    <span>{{ 'Go back to your endpoints' }}</span>
+    <span>Go back to your endpoints</span>
   </a>
 </div>
 
-<mat-card class="endpoint-card">
-  <mat-card-content>
-    <div class="endpoint-card__header__group-name">
-      <span class="mat-h3">LLM Proxy</span>
-    </div>
-    @if (formGroup && providerSchema) {
-      <form [formGroup]="formGroup" (ngSubmit)="onSave()">
-        <mat-form-field appearance="outline" class="endpoint-card__form__field">
-          <input id="name" type="text" matInput formControlName="name" required="true" />
-          <mat-label>Name</mat-label>
-          @if (formGroup.controls.name.errors?.required) {
-            <mat-error>
-              {{ 'Provider name is required' }}
-            </mat-error>
-          }
-          @if (formGroup.controls.name.errors?.isUnique) {
-            <mat-error> This name is used by another provider or endpoint group. </mat-error>
-          }
-        </mat-form-field>
-        <div class="endpoint-card__form__field">
-          <gio-form-json-schema formControlName="configuration" [jsonSchema]="providerSchema?.config"></gio-form-json-schema>
-        </div>
-        @if (providerSchema?.sharedConfig) {
-          <div class="endpoint-card__form__field">
-            <gio-form-json-schema
-              formControlName="sharedConfigurationOverride"
-              [jsonSchema]="providerSchema?.sharedConfig"
-            ></gio-form-json-schema>
-          </div>
-        }
+<form *ngIf="formGroup" autocomplete="off" [formGroup]="formGroup">
+  <mat-card class="endpoint-card">
+    <mat-card-content>
+      <div class="endpoint-card__header__group-name">
+        <span class="mat-h3">{{ pageTitle }}</span>
+      </div>
 
-        <button
-          mat-flat-button
-          aria-label="Validate my endpoints"
-          color="primary"
-          type="submit"
-          [disabled]="formGroup.invalid || (isEditMode && !formGroup.dirty) || isReadOnly"
-        >
-          Validate my endpoints
-        </button>
-      </form>
-    } @else {
-      <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-    }
-  </mat-card-content>
-</mat-card>
+      <mat-form-field appearance="outline" class="endpoint-card__form__field">
+        <input id="name" type="text" matInput formControlName="name" required="true" />
+        <mat-label>Name</mat-label>
+        @if (formGroup.controls.name.errors?.required) {
+          <mat-error>
+            {{ mode === 'edit-group' || mode === 'create-group' ? 'Provider name is required' : 'Endpoint name is required' }}
+          </mat-error>
+        }
+        @if (formGroup.controls.name.errors?.isUnique) {
+          <mat-error>This name is used by another provider or endpoint group.</mat-error>
+        }
+      </mat-form-field>
+
+      @if (showConfiguration && providerSchema?.config) {
+        <div class="endpoint-card__form__field">
+          <gio-form-json-schema formControlName="configuration" [jsonSchema]="providerSchema.config"></gio-form-json-schema>
+        </div>
+      }
+
+      @if (showSharedConfiguration && providerSchema?.sharedConfig) {
+        <div class="endpoint-card__form__field">
+          <gio-form-json-schema
+            formControlName="sharedConfigurationOverride"
+            [jsonSchema]="providerSchema.sharedConfig"
+          ></gio-form-json-schema>
+        </div>
+      }
+    </mat-card-content>
+  </mat-card>
+
+  <gio-save-bar
+    class="save-bar"
+    [creationMode]="mode === 'create-group' || mode === 'create-endpoint'"
+    [form]="formGroup"
+    [formInitialValues]="initialFormValue"
+    (submitted)="onSave()"
+  ></gio-save-bar>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.spec.ts
@@ -20,7 +20,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { InteractivityChecker } from '@angular/cdk/a11y';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, UrlSegment } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ApiLlmProviderComponent } from './api-llm-provider.component';
@@ -48,7 +48,8 @@ describe('ApiProviderComponent', () => {
 
   const initComponent = async (
     api: ApiV4,
-    routerParams: unknown = { apiId: API_ID, providerIndex: 'new' },
+    routerParams: Record<string, unknown> = { apiId: API_ID },
+    urlSegments: string[] = ['provider', 'new'],
     permissions: GioTestingPermission = ['api-definition-r', 'api-definition-u', 'api-definition-c'],
   ) => {
     await TestBed.configureTestingModule({
@@ -59,6 +60,7 @@ describe('ApiProviderComponent', () => {
           useValue: {
             snapshot: {
               params: routerParams,
+              url: urlSegments.map(s => new UrlSegment(s, {})),
             },
           },
         },
@@ -90,10 +92,12 @@ describe('ApiProviderComponent', () => {
     routerNavigateSpy = jest.spyOn(router, 'navigate');
 
     fixture.detectChanges();
-
     await fixture.whenStable();
 
+    // API is loaded first, form is created in the subscribe callback
     expectApiGetRequest(api);
+
+    // Schemas are loaded independently
     expectEndpointSchemaGetRequest('llm-proxy');
     expectEndpointsSharedConfigurationSchemaGetRequest('llm-proxy');
   };
@@ -103,16 +107,14 @@ describe('ApiProviderComponent', () => {
     httpTestingController.verify();
   });
 
-  describe('should create new provider', () => {
+  describe('create-group mode', () => {
     it('should add a new provider', async () => {
       const apiV4 = fakeApiV4({
         id: API_ID,
         endpointGroups: [],
       });
 
-      await initComponent(apiV4, { apiId: API_ID });
-
-      expect(await componentHarness.isSaveButtonDisabled()).toBeTruthy();
+      await initComponent(apiV4, { apiId: API_ID }, ['provider', 'new']);
 
       await componentHarness.setProviderName('Test Provider');
       fixture.componentInstance.formGroup.get('configuration')!.setValue({ provider: 'OPEN_AI_COMPATIBLE' });
@@ -122,7 +124,6 @@ describe('ApiProviderComponent', () => {
       fixture.componentInstance.formGroup.get('sharedConfigurationOverride')!.setErrors(null);
       fixture.componentInstance.formGroup.updateValueAndValidity();
 
-      expect(await componentHarness.isSaveButtonDisabled()).toBeFalsy();
       await componentHarness.clickSaveButton();
 
       expectApiGetRequest(apiV4);
@@ -153,14 +154,15 @@ describe('ApiProviderComponent', () => {
     });
   });
 
-  describe('should update existing provider', () => {
-    it('should edit and save an existing provider', async () => {
+  describe('edit-group mode', () => {
+    it('should edit and save a provider group', async () => {
       const existingProvider = {
         name: 'Existing Provider',
         type: 'llm-proxy',
+        sharedConfiguration: { apiKey: 'existing-key' },
         endpoints: [
           {
-            name: 'Existing Provider',
+            name: 'Endpoint 1',
             type: 'llm-proxy',
             configuration: { provider: 'ANTHROPIC' },
             sharedConfigurationOverride: { apiKey: 'existing-key' },
@@ -173,15 +175,12 @@ describe('ApiProviderComponent', () => {
         endpointGroups: [existingProvider],
       });
 
-      await initComponent(apiV4, { apiId: API_ID, providerIndex: 0 });
+      await initComponent(apiV4, { apiId: API_ID, providerIndex: '0' }, ['provider', '0', 'edit']);
 
       expect(await componentHarness.getProviderName()).toBe('Existing Provider');
 
       await componentHarness.setProviderName('Updated Provider');
-      fixture.componentInstance.formGroup.get('configuration')!.setValue({ provider: 'OPEN_AI_COMPATIBLE' });
       fixture.componentInstance.formGroup.get('sharedConfigurationOverride')!.setValue({ apiKey: 'updated-key' });
-
-      fixture.componentInstance.formGroup.get('configuration')!.setErrors(null);
       fixture.componentInstance.formGroup.get('sharedConfigurationOverride')!.setErrors(null);
       fixture.componentInstance.formGroup.updateValueAndValidity();
 
@@ -196,12 +195,60 @@ describe('ApiProviderComponent', () => {
             ...existingProvider,
             name: 'Updated Provider',
             sharedConfiguration: { apiKey: 'updated-key' },
+          },
+        ],
+      };
+      expectApiPutRequest(updatedApi);
+
+      expect(fakeSnackBarService.success).toHaveBeenCalledWith('Provider group successfully updated!');
+      expect(routerNavigateSpy).toHaveBeenCalledWith(['../../../'], { relativeTo: expect.anything() });
+    });
+  });
+
+  describe('create-endpoint mode', () => {
+    it('should add a new endpoint to an existing provider', async () => {
+      const existingProvider = {
+        name: 'OpenAI Provider',
+        type: 'llm-proxy',
+        sharedConfiguration: { apiKey: 'key' },
+        endpoints: [
+          {
+            name: 'Endpoint 1',
+            type: 'llm-proxy',
+            configuration: { provider: 'OPEN_AI' },
+            inheritConfiguration: true,
+          },
+        ],
+      };
+
+      const apiV4 = fakeApiV4({
+        id: API_ID,
+        endpointGroups: [existingProvider],
+      });
+
+      await initComponent(apiV4, { apiId: API_ID, providerIndex: '0' }, ['provider', '0', 'new']);
+
+      await componentHarness.setProviderName('Endpoint 2');
+      fixture.componentInstance.formGroup.get('configuration')!.setValue({ provider: 'OPEN_AI' });
+      fixture.componentInstance.formGroup.get('configuration')!.setErrors(null);
+      fixture.componentInstance.formGroup.updateValueAndValidity();
+
+      await componentHarness.clickSaveButton();
+
+      expectApiGetRequest(apiV4);
+
+      const updatedApi: ApiV4 = {
+        ...apiV4,
+        endpointGroups: [
+          {
+            ...existingProvider,
             endpoints: [
+              ...existingProvider.endpoints,
               {
-                ...existingProvider.endpoints[0],
-                name: 'Updated Provider default endpoint',
-                configuration: { provider: 'OPEN_AI_COMPATIBLE' },
-                sharedConfigurationOverride: { apiKey: 'updated-key' },
+                name: 'Endpoint 2',
+                type: 'llm-proxy',
+                inheritConfiguration: true,
+                configuration: { provider: 'OPEN_AI' },
               },
             ],
           },
@@ -209,8 +256,64 @@ describe('ApiProviderComponent', () => {
       };
       expectApiPutRequest(updatedApi);
 
-      expect(fakeSnackBarService.success).toHaveBeenCalledWith('Provider successfully updated!');
-      expect(routerNavigateSpy).toHaveBeenCalledWith(['../../'], { relativeTo: expect.anything() });
+      expect(fakeSnackBarService.success).toHaveBeenCalledWith('Endpoint Endpoint 2 created!');
+      expect(routerNavigateSpy).toHaveBeenCalledWith(['../../../'], { relativeTo: expect.anything() });
+    });
+  });
+
+  describe('edit-endpoint mode', () => {
+    it('should edit and save an existing endpoint', async () => {
+      const existingProvider = {
+        name: 'OpenAI Provider',
+        type: 'llm-proxy',
+        sharedConfiguration: { apiKey: 'key' },
+        endpoints: [
+          {
+            name: 'Endpoint 1',
+            type: 'llm-proxy',
+            configuration: { provider: 'OPEN_AI' },
+            inheritConfiguration: true,
+          },
+        ],
+      };
+
+      const apiV4 = fakeApiV4({
+        id: API_ID,
+        endpointGroups: [existingProvider],
+      });
+
+      await initComponent(apiV4, { apiId: API_ID, providerIndex: '0', endpointIndex: '0' }, ['provider', '0', '0']);
+
+      expect(await componentHarness.getProviderName()).toBe('Endpoint 1');
+
+      await componentHarness.setProviderName('Updated Endpoint');
+      fixture.componentInstance.formGroup.get('configuration')!.setValue({ provider: 'OPEN_AI', model: 'gpt-4o' });
+      fixture.componentInstance.formGroup.get('configuration')!.setErrors(null);
+      fixture.componentInstance.formGroup.updateValueAndValidity();
+
+      await componentHarness.clickSaveButton();
+
+      expectApiGetRequest(apiV4);
+
+      const updatedApi: ApiV4 = {
+        ...apiV4,
+        endpointGroups: [
+          {
+            ...existingProvider,
+            endpoints: [
+              {
+                ...existingProvider.endpoints[0],
+                name: 'Updated Endpoint',
+                configuration: { provider: 'OPEN_AI', model: 'gpt-4o' },
+              },
+            ],
+          },
+        ],
+      };
+      expectApiPutRequest(updatedApi);
+
+      expect(fakeSnackBarService.success).toHaveBeenCalledWith('Endpoint successfully updated!');
+      expect(routerNavigateSpy).toHaveBeenCalledWith(['../../../'], { relativeTo: expect.anything() });
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.ts
@@ -18,15 +18,7 @@ import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { EMPTY } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GioFormJsonSchemaComponent, GioJsonSchema } from '@gravitee/ui-particles-angular';
-import {
-  AbstractControl,
-  FormControl,
-  FormGroup,
-  UntypedFormControl,
-  UntypedFormGroup,
-  ValidationErrors,
-  Validators,
-} from '@angular/forms';
+import { AbstractControl, UntypedFormControl, UntypedFormGroup, ValidationErrors, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
@@ -37,12 +29,6 @@ import { isEndpointNameUniqueAndDoesNotMatchDefaultValue } from '../api-endpoint
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 
 export type ProviderMode = 'create-group' | 'edit-group' | 'create-endpoint' | 'edit-endpoint';
-
-interface ProviderForm {
-  name: FormControl<string>;
-  configuration: FormControl<any>;
-  sharedConfigurationOverride: FormControl<any>;
-}
 
 @Component({
   selector: 'api-llm-provider',
@@ -82,6 +68,8 @@ export class ApiLlmProviderComponent implements OnInit {
         return 'New Endpoint';
       case 'edit-endpoint':
         return 'Edit Endpoint';
+      default:
+        return 'Provider';
     }
   }
 
@@ -221,15 +209,12 @@ export class ApiLlmProviderComponent implements OnInit {
         break;
     }
 
-    const defaultNameForUnique =
-      this.mode === 'edit-group' ? this.provider?.name || '' : this.mode === 'edit-endpoint' ? this.endpoint?.name || '' : '';
-
     this.formGroup = new UntypedFormGroup(
       {
         name: new UntypedFormControl({ value: nameValue, disabled: this.isReadOnly }, [
           Validators.required,
           Validators.pattern(/^[^:]*$/),
-          isEndpointNameUniqueAndDoesNotMatchDefaultValue(this.api, defaultNameForUnique),
+          isEndpointNameUniqueAndDoesNotMatchDefaultValue(this.api, this.retrieveDisplayName()),
         ]),
         configuration: new UntypedFormControl({ value: configurationValue, disabled: this.isReadOnly }, [Validators.required]),
         sharedConfigurationOverride: new UntypedFormControl({ value: sharedConfigValue, disabled: this.isReadOnly }, [Validators.required]),
@@ -238,6 +223,10 @@ export class ApiLlmProviderComponent implements OnInit {
     );
 
     this.initialFormValue = this.formGroup.getRawValue();
+  }
+
+  private retrieveDisplayName() {
+    return this.mode === 'edit-group' ? this.provider?.name || '' : this.mode === 'edit-endpoint' ? this.endpoint?.name || '' : '';
   }
 
   private loadSchemas(): void {
@@ -369,7 +358,7 @@ export class ApiLlmProviderComponent implements OnInit {
         if (!provider) {
           return null;
         }
-        return provider !== expectedProvider ? { providerMismatch: { expected: expectedProvider, actual: provider } } : null;
+        return provider === expectedProvider ? null : { providerMismatch: { expected: expectedProvider, actual: provider } };
       },
     ];
   }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.ts
@@ -18,7 +18,15 @@ import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { EMPTY } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GioFormJsonSchemaComponent, GioJsonSchema } from '@gravitee/ui-particles-angular';
-import { FormControl, FormGroup, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  UntypedFormControl,
+  UntypedFormGroup,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
@@ -216,15 +224,18 @@ export class ApiLlmProviderComponent implements OnInit {
     const defaultNameForUnique =
       this.mode === 'edit-group' ? this.provider?.name || '' : this.mode === 'edit-endpoint' ? this.endpoint?.name || '' : '';
 
-    this.formGroup = new UntypedFormGroup({
-      name: new UntypedFormControl({ value: nameValue, disabled: this.isReadOnly }, [
-        Validators.required,
-        Validators.pattern(/^[^:]*$/),
-        isEndpointNameUniqueAndDoesNotMatchDefaultValue(this.api, defaultNameForUnique),
-      ]),
-      configuration: new UntypedFormControl({ value: configurationValue, disabled: this.isReadOnly }, [Validators.required]),
-      sharedConfigurationOverride: new UntypedFormControl({ value: sharedConfigValue, disabled: this.isReadOnly }, [Validators.required]),
-    });
+    this.formGroup = new UntypedFormGroup(
+      {
+        name: new UntypedFormControl({ value: nameValue, disabled: this.isReadOnly }, [
+          Validators.required,
+          Validators.pattern(/^[^:]*$/),
+          isEndpointNameUniqueAndDoesNotMatchDefaultValue(this.api, defaultNameForUnique),
+        ]),
+        configuration: new UntypedFormControl({ value: configurationValue, disabled: this.isReadOnly }, [Validators.required]),
+        sharedConfigurationOverride: new UntypedFormControl({ value: sharedConfigValue, disabled: this.isReadOnly }, [Validators.required]),
+      },
+      this.getProviderConsistencyValidators(),
+    );
 
     this.initialFormValue = this.formGroup.getRawValue();
   }
@@ -338,6 +349,29 @@ export class ApiLlmProviderComponent implements OnInit {
       ...api,
       endpointGroups: endpointGroups.map((group, i) => (i === this.providerIndex ? updatedProvider : group)),
     };
+  }
+
+  private getProviderConsistencyValidators(): ((control: AbstractControl) => ValidationErrors | null)[] {
+    if (this.mode !== 'create-endpoint' && this.mode !== 'edit-endpoint') {
+      return [];
+    }
+    const existingEndpoints = this.provider?.endpoints || [];
+    if (existingEndpoints.length === 0) {
+      return [];
+    }
+    const expectedProvider = existingEndpoints[0]?.configuration?.provider;
+    if (!expectedProvider) {
+      return [];
+    }
+    return [
+      (control: AbstractControl): ValidationErrors | null => {
+        const provider = control.value?.configuration?.provider;
+        if (!provider) {
+          return null;
+        }
+        return provider !== expectedProvider ? { providerMismatch: { expected: expectedProvider, actual: provider } } : null;
+      },
+    ];
   }
 
   private getSuccessMessage(name: string): string {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.component.ts
@@ -15,18 +15,20 @@
  */
 import { Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { catchError, map, switchMap, tap } from 'rxjs/operators';
-import { combineLatest, EMPTY } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { GioFormJsonSchemaComponent, GioJsonSchema } from '@gravitee/ui-particles-angular';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FormControl, FormGroup, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
-import { ApiV4, EndpointGroupV4, EndpointV4Default, UpdateApiV4 } from '../../../../entities/management-api-v2';
+import { ApiV4, EndpointGroupV4, EndpointV4, EndpointV4Default, UpdateApiV4 } from '../../../../entities/management-api-v2';
 import { ConnectorPluginsV2Service } from '../../../../services-ngx/connector-plugins-v2.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { isEndpointNameUniqueAndDoesNotMatchDefaultValue } from '../api-endpoint-v4-unique-name';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
+
+export type ProviderMode = 'create-group' | 'edit-group' | 'create-endpoint' | 'edit-endpoint';
 
 interface ProviderForm {
   name: FormControl<string>;
@@ -42,17 +44,17 @@ interface ProviderForm {
 })
 export class ApiLlmProviderComponent implements OnInit {
   private providerIndex: number | null = null;
-  public provider: EndpointGroupV4 | null = null;
-  public isEditMode = false;
-  public isReadOnly = false;
-  public formGroup: FormGroup<ProviderForm> = new FormGroup<ProviderForm>({
-    name: new FormControl<string>('', { validators: [Validators.required, Validators.pattern(/^[^:]*$/)], nonNullable: true }),
-    configuration: new FormControl<any>({}, { validators: [Validators.required], nonNullable: true }),
-    sharedConfigurationOverride: new FormControl<any>({}, { validators: [Validators.required], nonNullable: true }),
-  });
-  public providerSchema: { config: GioJsonSchema | null; sharedConfig: GioJsonSchema | null };
-  public isLoading = false;
+  private endpointIndex: number | null = null;
   private api: ApiV4;
+
+  public provider: EndpointGroupV4 | null = null;
+  public endpoint: EndpointV4 | null = null;
+  public mode: ProviderMode = 'create-group';
+  public isReadOnly = false;
+  public formGroup: UntypedFormGroup;
+  public providerSchema: { config: GioJsonSchema | null; sharedConfig: GioJsonSchema | null };
+  public initialFormValue: any;
+  public backPath = '../../';
 
   private readonly router = inject(Router);
   private readonly activatedRoute = inject(ActivatedRoute);
@@ -62,56 +64,41 @@ export class ApiLlmProviderComponent implements OnInit {
   private readonly permissionService = inject(GioPermissionService);
   private readonly destroyRef: DestroyRef = inject(DestroyRef);
 
-  public ngOnInit(): void {
-    this.isLoading = true;
-    const apiId = this.activatedRoute.snapshot.params.apiId;
-    const providerIndexParam = this.activatedRoute.snapshot.params.providerIndex;
-
-    this.isEditMode = providerIndexParam !== undefined && providerIndexParam !== null;
-    if (this.isEditMode) {
-      this.providerIndex = +providerIndexParam;
+  public get pageTitle(): string {
+    switch (this.mode) {
+      case 'create-group':
+        return 'New Provider';
+      case 'edit-group':
+        return 'Edit Provider Group';
+      case 'create-endpoint':
+        return 'New Endpoint';
+      case 'edit-endpoint':
+        return 'Edit Endpoint';
     }
+  }
+
+  public get showConfiguration(): boolean {
+    return this.mode !== 'edit-group';
+  }
+
+  public get showSharedConfiguration(): boolean {
+    return this.mode === 'create-group' || this.mode === 'edit-group';
+  }
+
+  public ngOnInit(): void {
+    this.detectMode();
+
+    const apiId = this.activatedRoute.snapshot.params.apiId;
 
     this.apiService
       .get(apiId)
-      .pipe(
-        switchMap(api => {
-          this.api = api as ApiV4;
-          const apiV4 = api as ApiV4;
-
-          const isKubernetesOrigin = apiV4.definitionContext?.origin === 'KUBERNETES';
-          const canUpdate = this.permissionService.hasAnyMatching(['api-definition-u']);
-          this.isReadOnly = isKubernetesOrigin || !canUpdate;
-
-          if (this.isEditMode && this.providerIndex !== null) {
-            const endpointGroups = apiV4.endpointGroups || [];
-            this.provider = endpointGroups[this.providerIndex];
-
-            if (!this.provider) {
-              this.snackBarService.error(`Provider at index [ ${this.providerIndex} ] does not exist.`);
-              this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
-              return EMPTY;
-            }
-          }
-
-          return combineLatest([
-            this.connectorPluginsV2Service.getEndpointPluginSchema('llm-proxy'),
-            this.connectorPluginsV2Service.getEndpointPluginSharedConfigurationSchema('llm-proxy'),
-          ]);
-        }),
-        tap(([config, sharedConfig]) => {
-          this.providerSchema = {
-            config: config && GioFormJsonSchemaComponent.isDisplayable(config) ? config : null,
-            sharedConfig: sharedConfig && GioFormJsonSchemaComponent.isDisplayable(sharedConfig) ? sharedConfig : null,
-          };
-          this.setupForm();
-        }),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe(() => (this.isLoading = false));
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (api: ApiV4) => this.initializeComponent(api),
+      });
   }
 
-  public onSave() {
+  public onSave(): void {
     const formValue = this.formGroup.getRawValue();
     const cleanName = formValue.name.trim();
     const configuration = formValue.configuration || {};
@@ -122,10 +109,22 @@ export class ApiLlmProviderComponent implements OnInit {
       .pipe(
         switchMap(api => {
           const apiV4 = api as ApiV4;
-          const updatedApi =
-            this.isEditMode && this.provider && this.providerIndex !== null
-              ? this.updateExistingProvider(apiV4, cleanName, configuration, sharedConfiguration)
-              : this.createNewProvider(apiV4, cleanName, configuration, sharedConfiguration);
+          let updatedApi: UpdateApiV4;
+
+          switch (this.mode) {
+            case 'create-group':
+              updatedApi = this.createNewProvider(apiV4, cleanName, configuration, sharedConfiguration);
+              break;
+            case 'edit-group':
+              updatedApi = this.updateProviderGroup(apiV4, cleanName, sharedConfiguration);
+              break;
+            case 'create-endpoint':
+              updatedApi = this.createEndpoint(apiV4, cleanName, configuration);
+              break;
+            case 'edit-endpoint':
+              updatedApi = this.updateEndpoint(apiV4, cleanName, configuration);
+              break;
+          }
 
           return this.apiService.update(apiV4.id, updatedApi);
         }),
@@ -134,38 +133,128 @@ export class ApiLlmProviderComponent implements OnInit {
           return EMPTY;
         }),
         map(() => {
-          const successMessage = this.isEditMode ? 'Provider successfully updated!' : `Provider ${formValue.name.trim()} created!`;
-          this.snackBarService.success(successMessage);
-          this.router.navigate(['../../'], { relativeTo: this.activatedRoute });
+          this.snackBarService.success(this.getSuccessMessage(cleanName));
+          this.router.navigate([this.backPath], { relativeTo: this.activatedRoute });
         }),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
   }
 
-  private updateExistingProvider(api: ApiV4, cleanName: string, configuration: any, sharedConfiguration: any): UpdateApiV4 {
-    if (!this.provider || this.providerIndex === null) {
-      throw new Error('Cannot update provider: provider or index is null');
+  private detectMode(): void {
+    const params = this.activatedRoute.snapshot.params;
+    const url = this.activatedRoute.snapshot.url;
+    const lastSegment = url?.[url.length - 1]?.path;
+
+    if (params.providerIndex === undefined) {
+      this.mode = 'create-group';
+      this.backPath = '../../';
+    } else {
+      this.providerIndex = +params.providerIndex;
+
+      if (lastSegment === 'edit') {
+        this.mode = 'edit-group';
+        this.backPath = '../../../';
+      } else if (lastSegment === 'new') {
+        this.mode = 'create-endpoint';
+        this.backPath = '../../../';
+      } else if (params.endpointIndex !== undefined) {
+        this.mode = 'edit-endpoint';
+        this.endpointIndex = +params.endpointIndex;
+        this.backPath = '../../../';
+      }
+    }
+  }
+
+  private initializeComponent(api: ApiV4): void {
+    this.api = api;
+
+    const isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
+    const canUpdate = this.permissionService.hasAnyMatching(['api-definition-u']);
+    this.isReadOnly = isKubernetesOrigin || !canUpdate;
+
+    if (this.providerIndex !== null) {
+      const endpointGroups = api.endpointGroups || [];
+      this.provider = endpointGroups[this.providerIndex];
+
+      if (!this.provider) {
+        this.snackBarService.error(`Provider at index [ ${this.providerIndex} ] does not exist.`);
+        this.router.navigate([this.backPath], { relativeTo: this.activatedRoute });
+        return;
+      }
+
+      if (this.mode === 'edit-endpoint' && this.endpointIndex !== null) {
+        this.endpoint = this.provider.endpoints?.[this.endpointIndex] || null;
+        if (!this.endpoint) {
+          this.snackBarService.error(`Endpoint at index [ ${this.endpointIndex} ] does not exist.`);
+          this.router.navigate([this.backPath], { relativeTo: this.activatedRoute });
+          return;
+        }
+      }
     }
 
-    const endpoints = this.provider.endpoints || [];
-    const updatedProvider: EndpointGroupV4 = {
-      ...this.provider,
-      name: cleanName,
-      ...(sharedConfiguration ? { sharedConfiguration } : {}),
-      endpoints: endpoints.map(endpoint => ({
-        ...endpoint,
-        name: `${cleanName} default endpoint`,
-        configuration,
-        sharedConfigurationOverride: sharedConfiguration,
-      })),
-    };
+    this.initForm();
+    this.loadSchemas();
+  }
 
-    const endpointGroups = api.endpointGroups || [];
-    return {
-      ...api,
-      endpointGroups: endpointGroups.map((group, i) => (i === this.providerIndex ? updatedProvider : group)),
-    };
+  private initForm(): void {
+    let nameValue = '';
+    let configurationValue: any = {};
+    let sharedConfigValue: any = {};
+
+    switch (this.mode) {
+      case 'edit-group':
+        nameValue = this.provider?.name || '';
+        sharedConfigValue = this.provider?.sharedConfiguration || {};
+        break;
+      case 'edit-endpoint':
+        nameValue = this.endpoint?.name || '';
+        configurationValue = this.endpoint?.configuration || {};
+        break;
+    }
+
+    const defaultNameForUnique =
+      this.mode === 'edit-group' ? this.provider?.name || '' : this.mode === 'edit-endpoint' ? this.endpoint?.name || '' : '';
+
+    this.formGroup = new UntypedFormGroup({
+      name: new UntypedFormControl({ value: nameValue, disabled: this.isReadOnly }, [
+        Validators.required,
+        Validators.pattern(/^[^:]*$/),
+        isEndpointNameUniqueAndDoesNotMatchDefaultValue(this.api, defaultNameForUnique),
+      ]),
+      configuration: new UntypedFormControl({ value: configurationValue, disabled: this.isReadOnly }, [Validators.required]),
+      sharedConfigurationOverride: new UntypedFormControl({ value: sharedConfigValue, disabled: this.isReadOnly }, [Validators.required]),
+    });
+
+    this.initialFormValue = this.formGroup.getRawValue();
+  }
+
+  private loadSchemas(): void {
+    this.connectorPluginsV2Service
+      .getEndpointPluginSchema('llm-proxy')
+      .pipe(
+        tap(config => {
+          this.providerSchema = {
+            ...this.providerSchema,
+            config: config && GioFormJsonSchemaComponent.isDisplayable(config) ? config : null,
+          };
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+
+    this.connectorPluginsV2Service
+      .getEndpointPluginSharedConfigurationSchema('llm-proxy')
+      .pipe(
+        tap(sharedConfig => {
+          this.providerSchema = {
+            ...this.providerSchema,
+            sharedConfig: sharedConfig && GioFormJsonSchemaComponent.isDisplayable(sharedConfig) ? sharedConfig : null,
+          };
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 
   private createNewProvider(api: ApiV4, cleanName: string, configuration: any, sharedConfiguration: any): UpdateApiV4 {
@@ -189,33 +278,78 @@ export class ApiLlmProviderComponent implements OnInit {
     };
   }
 
-  private setupForm(): void {
-    const nameControl = this.formGroup.get('name');
-    if (nameControl) {
-      const defaultValue = this.provider?.name || '';
-      const uniqueValidator = isEndpointNameUniqueAndDoesNotMatchDefaultValue(this.api, defaultValue);
-
-      if (uniqueValidator) {
-        const existingValidator = nameControl.validator;
-        nameControl.setValidators(
-          existingValidator ? [existingValidator, uniqueValidator] : [Validators.required, Validators.pattern(/^[^:]*$/), uniqueValidator],
-        );
-        nameControl.updateValueAndValidity();
-      }
+  private updateProviderGroup(api: ApiV4, cleanName: string, sharedConfiguration: any): UpdateApiV4 {
+    if (!this.provider || this.providerIndex === null) {
+      throw new Error('Cannot update provider: provider or index is null');
     }
 
-    if (this.isEditMode && this.provider) {
-      const endpoint = this.provider.endpoints?.[0];
-      this.formGroup.patchValue({
-        name: this.provider.name || '',
-        configuration: endpoint?.configuration || {},
-        // LLM don’t have the ability to override shared configuration
-        sharedConfigurationOverride: this.provider?.sharedConfiguration || {},
-      });
+    const updatedProvider: EndpointGroupV4 = {
+      ...this.provider,
+      name: cleanName,
+      ...(sharedConfiguration ? { sharedConfiguration } : {}),
+    };
+
+    const endpointGroups = api.endpointGroups || [];
+    return {
+      ...api,
+      endpointGroups: endpointGroups.map((group, i) => (i === this.providerIndex ? updatedProvider : group)),
+    };
+  }
+
+  private createEndpoint(api: ApiV4, cleanName: string, configuration: any): UpdateApiV4 {
+    if (!this.provider || this.providerIndex === null) {
+      throw new Error('Cannot create endpoint: provider or index is null');
     }
 
-    if (this.isReadOnly) {
-      this.formGroup.disable();
+    const newEndpoint: EndpointV4 = {
+      ...EndpointV4Default.byTypeAndGroupName('llm-proxy', cleanName),
+      name: cleanName,
+      configuration,
+      inheritConfiguration: true,
+    };
+
+    const updatedProvider: EndpointGroupV4 = {
+      ...this.provider,
+      endpoints: [...(this.provider.endpoints || []), newEndpoint],
+    };
+
+    const endpointGroups = api.endpointGroups || [];
+    return {
+      ...api,
+      endpointGroups: endpointGroups.map((group, i) => (i === this.providerIndex ? updatedProvider : group)),
+    };
+  }
+
+  private updateEndpoint(api: ApiV4, cleanName: string, configuration: any): UpdateApiV4 {
+    if (!this.provider || this.providerIndex === null || this.endpointIndex === null) {
+      throw new Error('Cannot update endpoint: provider, provider index, or endpoint index is null');
+    }
+
+    const endpoints = this.provider.endpoints || [];
+    const updatedEndpoints = endpoints.map((ep, j) => (j === this.endpointIndex ? { ...ep, name: cleanName, configuration } : ep));
+
+    const updatedProvider: EndpointGroupV4 = {
+      ...this.provider,
+      endpoints: updatedEndpoints,
+    };
+
+    const endpointGroups = api.endpointGroups || [];
+    return {
+      ...api,
+      endpointGroups: endpointGroups.map((group, i) => (i === this.providerIndex ? updatedProvider : group)),
+    };
+  }
+
+  private getSuccessMessage(name: string): string {
+    switch (this.mode) {
+      case 'create-group':
+        return `Provider ${name} created!`;
+      case 'edit-group':
+        return 'Provider group successfully updated!';
+      case 'create-endpoint':
+        return `Endpoint ${name} created!`;
+      case 'edit-endpoint':
+        return 'Endpoint successfully updated!';
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.harness.ts
@@ -16,8 +16,7 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { MatFormFieldHarness } from '@angular/material/form-field/testing';
-// JSON schema harness not used; interact via component in tests when needed
+import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 
 export class ApiLlmProviderHarness extends ComponentHarness {
   static hostSelector = 'api-provider';
@@ -25,9 +24,8 @@ export class ApiLlmProviderHarness extends ComponentHarness {
   private getTitleElement = this.locatorFor('.mat-h3');
   private getForm = this.locatorFor('form');
   private getProviderNameInput = this.locatorFor(MatInputHarness.with({ selector: '#name' }));
-  private getProviderNameFormField = this.locatorFor(MatFormFieldHarness.with({ selector: '#name' }));
-  private getSaveButton = this.locatorFor(MatButtonHarness.with({ text: 'Validate my endpoints' }));
-  private getBackButton = this.locatorFor(MatButtonHarness.with({ text: 'Go back to your endpoints' }));
+  private getSaveBar = this.locatorFor(GioSaveBarHarness);
+  private getBackButton = this.locatorFor(MatButtonHarness.with({ text: /Go back to your endpoints/ }));
 
   public async getTitle(): Promise<string> {
     const titleElement = await this.getTitleElement();
@@ -63,25 +61,14 @@ export class ApiLlmProviderHarness extends ComponentHarness {
     return await input.blur();
   }
 
-  public async getProviderNameError(): Promise<string> {
-    const errorElement = await this.locatorForOptional('mat-form-field .mat-error')();
-    if (!errorElement) return '';
-    return await errorElement.text();
-  }
-
-  public async isSaveButtonDisabled(): Promise<boolean> {
-    const button = await this.getSaveButton();
-    return await button.isDisabled();
-  }
-
-  public async getSaveButtonText(): Promise<string> {
-    const button = await this.getSaveButton();
-    return await button.getText();
+  public async isSaveButtonInvalid(): Promise<boolean> {
+    const saveBar = await this.getSaveBar();
+    return await saveBar.isSubmitButtonInvalid();
   }
 
   public async clickSaveButton(): Promise<void> {
-    const button = await this.getSaveButton();
-    return await button.click();
+    const saveBar = await this.getSaveBar();
+    return await saveBar.clickSubmit();
   }
 
   public async clickBackButton(): Promise<void> {

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.module.ts
@@ -16,7 +16,7 @@
 
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { GioFormJsonSchemaModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioFormJsonSchemaModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -49,6 +49,7 @@ import { GioGoBackButtonModule } from '../../../../shared/components/gio-go-back
     MatSelectModule,
     MatSnackBarModule,
 
+    GioBannerModule,
     GioFormJsonSchemaModule,
     GioGoBackButtonModule,
     GioSaveBarModule,

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/llm-provider/api-llm-provider.module.ts
@@ -16,7 +16,7 @@
 
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { GioFormJsonSchemaModule } from '@gravitee/ui-particles-angular';
+import { GioFormJsonSchemaModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -51,6 +51,7 @@ import { GioGoBackButtonModule } from '../../../../shared/components/gio-go-back
 
     GioFormJsonSchemaModule,
     GioGoBackButtonModule,
+    GioSaveBarModule,
   ],
 })
 export class ApiLlmProviderModule {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/EndpointGroupLlmProxyProviderMismatchInvalidException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/EndpointGroupLlmProxyProviderMismatchInvalidException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.exception;
+
+import static java.util.Collections.singletonMap;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import java.util.Map;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EndpointGroupLlmProxyProviderMismatchInvalidException extends AbstractManagementException {
+
+    private final String groupName;
+
+    public EndpointGroupLlmProxyProviderMismatchInvalidException(String groupName) {
+        this.groupName = groupName;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return "All endpoints in llm-proxy endpoint group [" + groupName + "] must have the same provider.";
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "api.endpointsGroup.llm-proxy.provider.mismatch";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return singletonMap("api.endpointsGroup[].name", groupName);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
@@ -17,6 +17,9 @@ package io.gravitee.rest.api.service.v4.impl.validation;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.AbstractEndpoint;
 import io.gravitee.definition.model.v4.endpointgroup.AbstractEndpointGroup;
@@ -34,9 +37,11 @@ import io.gravitee.rest.api.service.exceptions.EndpointNameAlreadyExistsExceptio
 import io.gravitee.rest.api.service.exceptions.EndpointNameInvalidException;
 import io.gravitee.rest.api.service.exceptions.HealthcheckInheritanceException;
 import io.gravitee.rest.api.service.exceptions.HealthcheckInvalidException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.TransactionalService;
 import io.gravitee.rest.api.service.v4.ApiServicePluginService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.exception.EndpointGroupLlmProxyProviderMismatchInvalidException;
 import io.gravitee.rest.api.service.v4.exception.EndpointGroupTypeInvalidException;
 import io.gravitee.rest.api.service.v4.exception.EndpointGroupTypeMismatchInvalidException;
 import io.gravitee.rest.api.service.v4.exception.EndpointTypeInvalidException;
@@ -55,15 +60,20 @@ import org.springframework.stereotype.Component;
 @Component
 public class EndpointGroupsValidationServiceImpl extends TransactionalService implements EndpointGroupsValidationService {
 
+    private static final String LLM_PROXY_TYPE = "llm-proxy";
+
     private final EndpointConnectorPluginService endpointService;
     private final ApiServicePluginService apiServicePluginService;
+    private final ObjectMapper objectMapper;
 
     public EndpointGroupsValidationServiceImpl(
         final EndpointConnectorPluginService endpointService,
-        final ApiServicePluginService apiServicePluginService
+        final ApiServicePluginService apiServicePluginService,
+        final ObjectMapper objectMapper
     ) {
         this.endpointService = endpointService;
         this.apiServicePluginService = apiServicePluginService;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -92,6 +102,7 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
             final ConnectorPluginEntity endpointConnector = endpointService.findById(endpointGroup.getType());
             validateEndpointGroupType(apiType, endpointGroup.getType(), endpointConnector);
             validateEndpointsExistence(endpointGroup);
+            validateLlmProxyProviderConsistency(endpointGroup);
             validateServices(apiType, endpointGroup);
 
             if (endpointGroup.getSharedConfiguration() != null) {
@@ -195,6 +206,37 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
     private void validateEndpointMatchType(final AbstractEndpointGroup endpointGroup, final AbstractEndpoint endpoint) {
         if (!endpointGroup.getType().equals(endpoint.getType())) {
             throw new EndpointGroupTypeMismatchInvalidException(endpointGroup.getType());
+        }
+    }
+
+    private void validateLlmProxyProviderConsistency(final AbstractEndpointGroup<? extends AbstractEndpoint> endpointGroup) {
+        if (!LLM_PROXY_TYPE.equals(endpointGroup.getType())) {
+            return;
+        }
+        if (endpointGroup.getEndpoints() == null || endpointGroup.getEndpoints().size() < 2) {
+            return;
+        }
+        String firstProvider = null;
+        for (AbstractEndpoint endpoint : endpointGroup.getEndpoints()) {
+            String provider = extractLlmProxyProvider(endpoint.getConfiguration());
+            if (firstProvider == null) {
+                firstProvider = provider;
+            } else if (!firstProvider.equals(provider)) {
+                throw new EndpointGroupLlmProxyProviderMismatchInvalidException(endpointGroup.getName());
+            }
+        }
+    }
+
+    private String extractLlmProxyProvider(final String configuration) {
+        if (configuration == null) {
+            return null;
+        }
+        try {
+            JsonNode config = objectMapper.readTree(configuration);
+            JsonNode providerNode = config.path("provider");
+            return providerNode.isMissingNode() ? null : providerNode.asText();
+        } catch (JsonProcessingException e) {
+            throw new TechnicalManagementException("Failed to parse llm-proxy endpoint configuration", e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
@@ -90,7 +91,16 @@ public class EndpointGroupsValidationServiceImplTest {
         nativeFriendlyEndpoint.setSupportedApiType(ApiType.NATIVE);
         lenient().when(endpointService.findById(NATIVE_ENDPOINT_TYPE)).thenReturn(nativeFriendlyEndpoint);
 
-        endpointGroupsValidationService = new EndpointGroupsValidationServiceImpl(endpointService, apiServicePluginService);
+        var llmProxyEndpoint = new ConnectorPluginEntity();
+        llmProxyEndpoint.setId("llm-proxy");
+        llmProxyEndpoint.setSupportedApiType(ApiType.LLM_PROXY);
+        lenient().when(endpointService.findById("llm-proxy")).thenReturn(llmProxyEndpoint);
+
+        endpointGroupsValidationService = new EndpointGroupsValidationServiceImpl(
+            endpointService,
+            apiServicePluginService,
+            new ObjectMapper()
+        );
     }
 
     @Test(expected = EndpointMissingException.class)
@@ -881,5 +891,77 @@ public class EndpointGroupsValidationServiceImplTest {
         verify(endpointService).validateSharedConfiguration(any(), eq(endpointGroup.getSharedConfiguration()));
         verify(endpointService, never()).validateSharedConfiguration(any(), eq(endpoint.getSharedConfigurationOverride()));
         verify(endpointService).validateSharedConfiguration(any(), eq("{}"));
+    }
+
+    /**
+     * LLM Proxy provider consistency tests
+     */
+
+    @Test
+    public void should_throw_when_llm_proxy_endpoints_have_different_providers() {
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("llm-group");
+        endpointGroup.setType("llm-proxy");
+
+        Endpoint endpoint1 = new Endpoint();
+        endpoint1.setName("openai-endpoint");
+        endpoint1.setType("llm-proxy");
+        endpoint1.setConfiguration("{\"provider\":\"OPEN_AI\"}");
+
+        Endpoint endpoint2 = new Endpoint();
+        endpoint2.setName("azure-endpoint");
+        endpoint2.setType("llm-proxy");
+        endpoint2.setConfiguration("{\"provider\":\"OPEN_AI_COMPATIBLE\"}");
+
+        endpointGroup.setEndpoints(List.of(endpoint1, endpoint2));
+
+        assertThatExceptionOfType(EndpointGroupLlmProxyProviderMismatchInvalidException.class).isThrownBy(() ->
+            endpointGroupsValidationService.validateAndSanitizeHttpV4(ApiType.LLM_PROXY, List.of(endpointGroup))
+        );
+    }
+
+    @Test
+    public void should_not_throw_when_llm_proxy_endpoints_have_same_provider() {
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("llm-group");
+        endpointGroup.setType("llm-proxy");
+
+        Endpoint endpoint1 = new Endpoint();
+        endpoint1.setName("openai-endpoint-1");
+        endpoint1.setType("llm-proxy");
+        endpoint1.setConfiguration("{\"provider\":\"OPEN_AI\"}");
+
+        Endpoint endpoint2 = new Endpoint();
+        endpoint2.setName("openai-endpoint-2");
+        endpoint2.setType("llm-proxy");
+        endpoint2.setConfiguration("{\"provider\":\"OPEN_AI\"}");
+
+        endpointGroup.setEndpoints(List.of(endpoint1, endpoint2));
+
+        List<EndpointGroup> result = endpointGroupsValidationService.validateAndSanitizeHttpV4(ApiType.LLM_PROXY, List.of(endpointGroup));
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void should_not_validate_provider_for_non_llm_proxy_groups() {
+        // HTTP endpoint group with different configurations should pass without provider validation
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("http-group");
+        endpointGroup.setType("http");
+
+        Endpoint endpoint1 = new Endpoint();
+        endpoint1.setName("endpoint-1");
+        endpoint1.setType("http");
+        endpoint1.setConfiguration("{\"provider\":\"A\"}");
+
+        Endpoint endpoint2 = new Endpoint();
+        endpoint2.setName("endpoint-2");
+        endpoint2.setType("http");
+        endpoint2.setConfiguration("{\"provider\":\"B\"}");
+
+        endpointGroup.setEndpoints(List.of(endpoint1, endpoint2));
+
+        List<EndpointGroup> result = endpointGroupsValidationService.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(endpointGroup));
+        assertThat(result).hasSize(1);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13226

## Description

Support multiple endpoints per LLM provider group in the console UI, allowing users to manage individual endpoints (create, edit, delete) within a provider group independently.

### Backend
- Add validation ensuring all endpoints in an `llm-proxy` group share the same `configuration.provider` (e.g., all `OPEN_AI` or all `OPEN_AI_COMPATIBLE`)
- New exception `EndpointGroupLlmProxyProviderMismatchInvalidException`

### Frontend — List
- Adapter now exposes N endpoints per provider (with `groupIndex` and `endpointIndex`)
- Each provider card shows sub-sections per endpoint (name, provider badge, models table)
- Buttons: Edit Group / Delete Group at group level, Edit / Delete / Add Endpoint at endpoint level

### Frontend — Form
- Provider component refactored into 4 modes: `create-group`, `edit-group`, `create-endpoint`, `edit-endpoint`
- Follows the standard endpoint-group pattern: form created in `initForm()`, schemas loaded independently
- Uses `gio-save-bar` instead of custom disabled button
- Frontend validation with `gio-banner-error` when provider type doesn't match existing endpoints in the group

### Routes
- `provider/:providerIndex/edit` — edit group config
- `provider/:providerIndex/new` — create endpoint in group
- `provider/:providerIndex/:endpointIndex` — edit specific endpoint

## Additional context

The backend validation uses `ObjectMapper` to parse the `endpoint.getConfiguration()` JSON string and extract the `provider` field. This works but is coupled to the internal structure of the LLM proxy plugin configuration. A more robust approach would be to have the plugin expose its provider type as a first-class field in the endpoint model, but this is out of scope for this PR.