### PR TITLE
fix(promotion): use correct bridge op for V4 promotion (APIM-13334)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Promotion.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Promotion.java
@@ -22,6 +22,7 @@ public class Promotion {
 
     public enum AuditEvent implements Audit.ApiAuditEvent {
         PROMOTION_CREATED,
+        PROMOTION_PROCESSED,
     }
 
     private String id;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/ApiAuditEvent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/ApiAuditEvent.java
@@ -32,5 +32,6 @@ public enum ApiAuditEvent implements AuditEvent {
     METADATA_UPDATED,
     PUBLISH_API,
     PROMOTION_CREATED,
+    PROMOTION_PROCESSED,
     AUTOMATION_DETACHED,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/service_provider/CockpitPromotionServiceProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/service_provider/CockpitPromotionServiceProvider.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.promotion.model.PromotionRequest;
 
 public interface CockpitPromotionServiceProvider {
     CockpitReplyStatus requestPromotion(String organizationId, String environmentId, Promotion promotion);
+    CockpitReplyStatus processPromotion(String organizationId, String environmentId, Promotion promotion);
     Promotion createPromotion(String apiId, PromotionRequest promotionRequest, String userId);
     Promotion process(String promotionId, boolean isAccepted);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCase.java
@@ -117,7 +117,7 @@ public class ProcessPromotionUseCase {
                 .organizationId(auditInfo.organizationId())
                 .environmentId(auditInfo.environmentId())
                 .apiId(updatedPromotion.getApiId())
-                .event(ApiAuditEvent.PROMOTION_CREATED)
+                .event(ApiAuditEvent.PROMOTION_PROCESSED)
                 .actor(auditInfo.actor())
                 .oldValue(null)
                 .newValue(updatedPromotion)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCase.java
@@ -100,7 +100,7 @@ public class ProcessPromotionUseCase {
             promotion.setStatus(PromotionStatus.REJECTED);
         }
 
-        var cockpitReplyStatus = cockpitPromotionServiceProvider.requestPromotion(
+        var cockpitReplyStatus = cockpitPromotionServiceProvider.processPromotion(
             auditInfo.organizationId(),
             auditInfo.environmentId(),
             promotion

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/promotion/CockpitPromotionServiceProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/promotion/CockpitPromotionServiceProviderImpl.java
@@ -50,6 +50,17 @@ public class CockpitPromotionServiceProviderImpl implements CockpitPromotionServ
     }
 
     @Override
+    public CockpitReplyStatus processPromotion(String organizationId, String environmentId, Promotion promotion) {
+        var cockpitReply = cockpitPromotionService.processPromotion(
+            new ExecutionContext(organizationId, environmentId),
+            PromotionAdapter.INSTANCE.toRestApiModel(promotion)
+        );
+        return cockpitReply.getStatus() == io.gravitee.rest.api.service.cockpit.services.CockpitReplyStatus.SUCCEEDED
+            ? CockpitReplyStatus.SUCCEEDED
+            : CockpitReplyStatus.ERROR;
+    }
+
+    @Override
     public Promotion createPromotion(String apiId, PromotionRequest promotionRequest, String userId) {
         PromotionEntity created = promotionService.create(
             GraviteeContext.getExecutionContext(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl.promotion;
 
 import static io.gravitee.repository.management.model.Promotion.AuditEvent.PROMOTION_CREATED;
+import static io.gravitee.repository.management.model.Promotion.AuditEvent.PROMOTION_PROCESSED;
 import static io.gravitee.rest.api.model.permissions.RolePermission.ENVIRONMENT_API;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
@@ -327,7 +328,7 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
                 targetExecutionContext,
                 AuditService.AuditLogData.builder()
                     .properties(emptyMap())
-                    .event(PROMOTION_CREATED)
+                    .event(PROMOTION_PROCESSED)
                     .createdAt(updated.getCreatedAt())
                     .oldValue(null)
                     .newValue(updated)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCaseTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -159,7 +160,7 @@ class ProcessPromotionUseCaseTest {
         promotionCrudService.initWith(List.of(PROMOTION));
         environmentCrudService.initWith(List.of(ENVIRONMENT));
 
-        when(cockpitPromotionServiceProvider.requestPromotion(eq(ORGANIZATION_ID), eq(ENVIRONMENT_ID), any())).thenReturn(
+        when(cockpitPromotionServiceProvider.processPromotion(eq(ORGANIZATION_ID), eq(ENVIRONMENT_ID), any())).thenReturn(
             CockpitReplyStatus.SUCCEEDED
         );
 
@@ -177,13 +178,14 @@ class ProcessPromotionUseCaseTest {
         assertThat(result).isNotNull();
         assertThat(result.promotion()).isNotNull();
         assertThat(result.promotion().getStatus()).isEqualTo(PromotionStatus.REJECTED);
+        verify(cockpitPromotionServiceProvider, never()).requestPromotion(any(), any(), any());
     }
 
     @Test
     void should_throw_exception_when_v4_api_promotion_command_fails() {
         environmentCrudService.initWith(List.of(ENVIRONMENT));
 
-        when(cockpitPromotionServiceProvider.requestPromotion(eq(ORGANIZATION_ID), eq(ENVIRONMENT_ID), any())).thenReturn(
+        when(cockpitPromotionServiceProvider.processPromotion(eq(ORGANIZATION_ID), eq(ENVIRONMENT_ID), any())).thenReturn(
             CockpitReplyStatus.ERROR
         );
 
@@ -233,7 +235,7 @@ class ProcessPromotionUseCaseTest {
             .build();
         apiCrudServiceInMemory.initWith(List.of(v4proxyApi, aleadyPromotedApi));
 
-        when(cockpitPromotionServiceProvider.requestPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
+        when(cockpitPromotionServiceProvider.processPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
 
         var result = useCase.execute(
             new ProcessPromotionUseCase.Input(
@@ -256,7 +258,7 @@ class ProcessPromotionUseCaseTest {
         var v4proxyApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).crossId(CROSS_ID).build();
         apiCrudServiceInMemory.initWith(List.of(v4proxyApi));
 
-        when(cockpitPromotionServiceProvider.requestPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
+        when(cockpitPromotionServiceProvider.processPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
 
         importDefinitionCreateDomainService.parametersQueryService.initWith(
             List.of(
@@ -313,7 +315,7 @@ class ProcessPromotionUseCaseTest {
             .build();
         apiCrudServiceInMemory.initWith(List.of(v4proxyApi, existingApi));
 
-        when(cockpitPromotionServiceProvider.requestPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
+        when(cockpitPromotionServiceProvider.processPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
 
         useCase.execute(
             new ProcessPromotionUseCase.Input(
@@ -340,7 +342,7 @@ class ProcessPromotionUseCaseTest {
         promotionCrudService.initWith(List.of(PROMOTION));
         environmentCrudService.initWith(List.of(ENVIRONMENT));
 
-        when(cockpitPromotionServiceProvider.requestPromotion(eq(ORGANIZATION_ID), eq(ENVIRONMENT_ID), any())).thenReturn(
+        when(cockpitPromotionServiceProvider.processPromotion(eq(ORGANIZATION_ID), eq(ENVIRONMENT_ID), any())).thenReturn(
             CockpitReplyStatus.SUCCEEDED
         );
 
@@ -380,8 +382,6 @@ class ProcessPromotionUseCaseTest {
             .environmentId(ENVIRONMENT.getId())
             .build();
         apiCrudServiceInMemory.initWith(List.of(v4proxyApi, aleadyPromotedApi));
-
-        when(cockpitPromotionServiceProvider.requestPromotion(any(), any(), any())).thenReturn(CockpitReplyStatus.SUCCEEDED);
 
         Throwable throwable = catchThrowable(() ->
             useCase.execute(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/promotion/use_case/ProcessPromotionUseCaseTest.java
@@ -330,7 +330,7 @@ class ProcessPromotionUseCaseTest {
 
         assertThat(auditCrudService.storage()).anySatisfy(audit -> {
             assertThat(audit.getReferenceId()).isEqualTo(API_ID);
-            assertThat(audit.getEvent()).isEqualTo(ApiAuditEvent.PROMOTION_CREATED.name());
+            assertThat(audit.getEvent()).isEqualTo(ApiAuditEvent.PROMOTION_PROCESSED.name());
             assertThat(audit.getOrganizationId()).isEqualTo(ORGANIZATION_ID);
             assertThat(audit.getEnvironmentId()).isEqualTo(ENVIRONMENT_ID);
             assertThat(audit.getUser()).isEqualTo(USER_NAME);
@@ -362,7 +362,7 @@ class ProcessPromotionUseCaseTest {
             .first()
             .satisfies(audit -> {
                 assertThat(audit.getReferenceId()).isEqualTo(API_ID);
-                assertThat(audit.getEvent()).isEqualTo(ApiAuditEvent.PROMOTION_CREATED.name());
+                assertThat(audit.getEvent()).isEqualTo(ApiAuditEvent.PROMOTION_PROCESSED.name());
                 assertThat(audit.getOrganizationId()).isEqualTo(ORGANIZATION_ID);
                 assertThat(audit.getEnvironmentId()).isEqualTo(ENVIRONMENT_ID);
                 assertThat(audit.getUser()).isEqualTo(USER_NAME);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/audit/AuditEventQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/audit/AuditEventQueryServiceImplTest.java
@@ -27,7 +27,7 @@ class AuditEventQueryServiceImplTest {
     void should_return_all_audit_events_names_sorted() {
         var result = service.listAllApiAuditEvents();
 
-        Assertions.assertThat(result).hasSize(48).isSortedAccordingTo(Comparator.naturalOrder());
+        Assertions.assertThat(result).hasSize(49).isSortedAccordingTo(Comparator.naturalOrder());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl.promotion;
 
 import static io.gravitee.repository.management.model.Promotion.AuditEvent.PROMOTION_CREATED;
+import static io.gravitee.repository.management.model.Promotion.AuditEvent.PROMOTION_PROCESSED;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -349,7 +350,7 @@ public class PromotionServiceTest {
 
         verify(auditService).createApiAuditLog(
             argThat(context -> targetEnvironment.getId().equals(context.getEnvironmentId())),
-            argThat(auditLogData -> auditLogData.getEvent().equals(PROMOTION_CREATED) && auditLogData.getOldValue() == null),
+            argThat(auditLogData -> auditLogData.getEvent().equals(PROMOTION_PROCESSED) && auditLogData.getOldValue() == null),
             eq(promotion.getApiId())
         );
     }
@@ -381,7 +382,7 @@ public class PromotionServiceTest {
 
         verify(auditService).createApiAuditLog(
             argThat(context -> targetEnvironment.getId().equals(context.getEnvironmentId())),
-            argThat(auditLogData -> auditLogData.getEvent().equals(PROMOTION_CREATED) && auditLogData.getOldValue() == null),
+            argThat(auditLogData -> auditLogData.getEvent().equals(PROMOTION_PROCESSED) && auditLogData.getOldValue() == null),
             eq(promotion.getApiId())
         );
     }


### PR DESCRIPTION
## Summary
- V4 API promotion accept/reject was calling `requestPromotion()` (sends `PROMOTE_API` to target env) instead of `processPromotion()` (sends `PROCESS_API_PROMOTION` to source env)
- Source env never got notified of accept/reject, leaving promotions stuck in `TO_BE_VALIDATED`
- Fix: add `processPromotion()` to `CockpitPromotionServiceProvider` interface + impl, swap the call in `ProcessPromotionUseCase`

Fixes: https://gravitee.atlassian.net/browse/APIM-13334

## Test plan
- [x] 11/11 existing tests pass (6 mocks updated to use new method)
- [x] Negative assertion confirms old `requestPromotion()` is no longer called in reject path