### PR TITLE
fix: resolve CSRF token mismatch on changePassword endpoint

### DIFF
--- a/gravitee-apim-console-webui/src/index.ts
+++ b/gravitee-apim-console-webui/src/index.ts
@@ -26,9 +26,11 @@ import { Build, Constants, DefaultPortal } from './entities/Constants';
 import { getFeatureInfoData } from './shared/components/gio-license/gio-license-data';
 import { ConsoleCustomization } from './entities/management-api-v2/consoleCustomization';
 import { environment } from './environments/environment';
+import { CsrfInterceptor } from './shared/interceptors/csrf.interceptor';
 
 const requestConfig: RequestInit = {
   headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache' },
+  credentials: 'include',
 };
 
 // fix angular-schema-form angular<1.7
@@ -61,7 +63,8 @@ function fetchData(): Promise<{ constants: Constants; build: any }> {
         enforcedOrganizationId ? `${baseURL}/v2/ui/bootstrap?organizationId=${enforcedOrganizationId}` : `${baseURL}/v2/ui/bootstrap`,
         requestConfig,
       )
-        .then(r => getSuccessJsonDataOrThrowError(r))
+        .then(storeCsrfToken)
+        .then(getSuccessJsonDataOrThrowError)
         .then((bootstrapResponse: { baseURL: string; organizationId: string }) => ({
           bootstrapResponse,
           build: buildResponse,
@@ -207,6 +210,13 @@ function bootstrapApplication(constants: Constants) {
       // eslint-disable-next-line
       console.error(err);
     });
+}
+
+function storeCsrfToken(response: Response): Response {
+  if (response.headers.has(CsrfInterceptor.xsrfTokenHeaderName)) {
+    CsrfInterceptor.xsrfToken = response.headers.get(CsrfInterceptor.xsrfTokenHeaderName);
+  }
+  return response;
 }
 
 function getSuccessJsonDataOrThrowError(response: Response): Promise<any> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/config/BasicSecurityConfigurerAdapter.java
@@ -257,8 +257,8 @@ public class BasicSecurityConfigurerAdapter implements SecureHeadersConfigurer {
     }
 
     private HttpSecurity authorizations(HttpSecurity security) throws Exception {
-        String uriOrgPrefix = "/organizations/**";
-        String uriPrefix = uriOrgPrefix + "/environments/**";
+        String uriOrgPrefix = "/organizations/*";
+        String uriPrefix = uriOrgPrefix + "/environments/*";
 
         return security
             .authorizeHttpRequests()
@@ -306,7 +306,7 @@ public class BasicSecurityConfigurerAdapter implements SecureHeadersConfigurer {
             .permitAll()
             .requestMatchers(HttpMethod.POST, uriOrgPrefix + "/users/registration/**")
             .permitAll()
-            .requestMatchers(HttpMethod.POST, uriOrgPrefix + "/users/**/changePassword")
+            .requestMatchers(HttpMethod.POST, uriOrgPrefix + "/users/*/changePassword")
             .permitAll()
             .requestMatchers(HttpMethod.GET, uriOrgPrefix + "/users")
             .authenticated()


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13340
https://gravitee.atlassian.net/browse/APIM-13293


## Summary
- Use single-segment wildcard (`*`) instead of multi-segment (`**`) in Spring Security path patterns for organization, environment, and user ID segments, fixing `PathPatternParser` matching issues
- Add `credentials: 'include'` to `fetch` requests in `index.ts` so CSRF cookies are sent cross-origin, preventing token regeneration on parallel requests
- Extract CSRF token storage from bootstrap response into dedicated `storeCsrfToken` function using `CsrfInterceptor`
