### PR TITLE
chore: bump llm reactor to 2.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
         <gravitee-reactor-message.version>10.0.0</gravitee-reactor-message.version>
         <gravitee-reactor-native-kafka.version>6.0.0</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.0</gravitee-reactor-mcp-proxy.version>
-        <gravitee-reactor-llm-proxy.version>2.3.0</gravitee-reactor-llm-proxy.version>
+        <gravitee-reactor-llm-proxy.version>2.4.0</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>
         <gravitee-resource-ai-vector-store-redis.version>1.0.0</gravitee-resource-ai-vector-store-redis.version>
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13229

**Description**

Bump gravitee-reactor-llm-proxy from 2.3.0 to 2.4.0.