### PR TITLE
chore: revert entrypoint webhook bump to 4.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
         <gravitee-entrypoint-http-get.version>2.1.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>2.1.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>5.0.1</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>4.2.1</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>4.0.5</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>2.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-endpoint-kafka.version>4.0.9</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>4.0.1</gravitee-endpoint-mqtt5.version>


### PR DESCRIPTION
## Issue

Revert entrypoint webhook bump due to Integ tests failures.

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

