### PR TITLE
fix: resolve execution context from dictionary environment in updateProperties

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/dictionary/DictionaryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/dictionary/DictionaryService.java
@@ -30,7 +30,7 @@ public interface DictionaryService {
     DictionaryEntity create(ExecutionContext executionContext, NewDictionaryEntity dictionary);
 
     DictionaryEntity update(ExecutionContext executionContext, String id, UpdateDictionaryEntity dictionary);
-    DictionaryEntity updateProperties(ExecutionContext executionContext, String id, Map<String, String> properties);
+    DictionaryEntity updateProperties(String id, Map<String, String> properties);
 
     DictionaryEntity findById(ExecutionContext executionContext, String id);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
@@ -28,6 +28,7 @@ import io.gravitee.repository.management.model.DictionaryProvider;
 import io.gravitee.repository.management.model.DictionaryTrigger;
 import io.gravitee.repository.management.model.DictionaryType;
 import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryProviderEntity;
@@ -35,6 +36,7 @@ import io.gravitee.rest.api.model.configuration.dictionary.DictionaryTriggerEnti
 import io.gravitee.rest.api.model.configuration.dictionary.NewDictionaryEntity;
 import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntity;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
@@ -69,6 +71,9 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
 
     @Autowired
     private AuditService auditService;
+
+    @Autowired
+    private EnvironmentService environmentService;
 
     @Autowired
     private EventService eventService;
@@ -318,7 +323,7 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
     }
 
     @Override
-    public DictionaryEntity updateProperties(ExecutionContext executionContext, final String id, final Map<String, String> properties) {
+    public DictionaryEntity updateProperties(final String id, final Map<String, String> properties) {
         try {
             LOGGER.debug("Update dictionary properties {}", id);
 
@@ -331,6 +336,9 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             dictionary.setUpdatedAt(new Date());
             dictionary.setDeployedAt(dictionary.getUpdatedAt());
             Dictionary updatedDictionary = dictionaryRepository.update(dictionary);
+
+            EnvironmentEntity environment = environmentService.findById(dictionary.getEnvironmentId());
+            ExecutionContext executionContext = new ExecutionContext(environment.getOrganizationId(), environment.getId());
 
             // Create publish event
             eventService.createDictionaryEvent(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_StartTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_StartTest.java
@@ -32,6 +32,7 @@ import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Collections;
@@ -56,6 +57,9 @@ public class DictionaryServiceImpl_StartTest {
     private DictionaryRepository dictionaryRepository;
 
     @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
     private EventService eventService;
 
     @Mock
@@ -68,12 +72,13 @@ public class DictionaryServiceImpl_StartTest {
         dictionaryInDb.setCreatedAt(new Date(1486771200000L));
         dictionaryInDb.setUpdatedAt(new Date(1486771200000L));
         dictionaryInDb.setState(LifecycleState.STOPPED);
-        dictionaryInDb.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        dictionaryInDb.setEnvironmentId(ENVIRONMENT_ID);
         when(dictionaryRepository.findById(dictionaryInDb.getId())).thenReturn(Optional.of(dictionaryInDb));
 
         Dictionary updatedDictionary = new Dictionary();
         updatedDictionary.setUpdatedAt(new Date());
         updatedDictionary.setState(LifecycleState.STARTED);
+        updatedDictionary.setEnvironmentId(ENVIRONMENT_ID);
         updatedDictionary.setType(io.gravitee.repository.management.model.DictionaryType.MANUAL);
         when(
             dictionaryRepository.update(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_StopTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_StopTest.java
@@ -32,6 +32,7 @@ import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Collections;
@@ -56,6 +57,9 @@ public class DictionaryServiceImpl_StopTest {
     private DictionaryRepository dictionaryRepository;
 
     @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
     private EventService eventService;
 
     @Mock
@@ -68,12 +72,13 @@ public class DictionaryServiceImpl_StopTest {
         dictionaryInDb.setCreatedAt(new Date(1486771200000L));
         dictionaryInDb.setUpdatedAt(new Date(1486771200000L));
         dictionaryInDb.setState(LifecycleState.STARTED);
-        dictionaryInDb.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        dictionaryInDb.setEnvironmentId(ENVIRONMENT_ID);
         when(dictionaryRepository.findById(dictionaryInDb.getId())).thenReturn(Optional.of(dictionaryInDb));
 
         Dictionary updatedDictionary = new Dictionary();
         updatedDictionary.setUpdatedAt(new Date());
         updatedDictionary.setState(LifecycleState.STOPPED);
+        updatedDictionary.setEnvironmentId(ENVIRONMENT_ID);
         updatedDictionary.setType(io.gravitee.repository.management.model.DictionaryType.MANUAL);
         when(
             dictionaryRepository.update(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdatePropertiesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdatePropertiesTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.configuration.dictionary;
+
+import static io.gravitee.repository.management.model.Dictionary.AuditEvent.DICTIONARY_UPDATED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.DictionaryRepository;
+import io.gravitee.repository.management.model.Dictionary;
+import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.EventType;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.EventService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DictionaryServiceImpl_UpdatePropertiesTest {
+
+    private static final String DICTIONARY_ID = "dictionaryId";
+    private static final String ENVIRONMENT_ID = "my-specific-environment";
+    private static final String ORGANIZATION_ID = "my-specific-organization";
+
+    @InjectMocks
+    private DictionaryServiceImpl dictionaryService = new DictionaryServiceImpl();
+
+    @Mock
+    private DictionaryRepository dictionaryRepository;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private AuditService auditService;
+
+    @Test
+    public void shouldUpdatePropertiesUsingDictionaryEnvironment() throws TechnicalException {
+        Dictionary dictionaryInDb = new Dictionary();
+        dictionaryInDb.setId(DICTIONARY_ID);
+        dictionaryInDb.setCreatedAt(new Date());
+        dictionaryInDb.setUpdatedAt(new Date());
+        dictionaryInDb.setState(LifecycleState.STARTED);
+        dictionaryInDb.setEnvironmentId(ENVIRONMENT_ID);
+        dictionaryInDb.setType(io.gravitee.repository.management.model.DictionaryType.DYNAMIC);
+        when(dictionaryRepository.findById(DICTIONARY_ID)).thenReturn(Optional.of(dictionaryInDb));
+
+        Dictionary updatedDictionary = new Dictionary();
+        updatedDictionary.setId(DICTIONARY_ID);
+        updatedDictionary.setUpdatedAt(new Date());
+        updatedDictionary.setState(LifecycleState.STARTED);
+        updatedDictionary.setEnvironmentId(ENVIRONMENT_ID);
+        updatedDictionary.setType(io.gravitee.repository.management.model.DictionaryType.DYNAMIC);
+        when(dictionaryRepository.update(any(Dictionary.class))).thenReturn(updatedDictionary);
+
+        EnvironmentEntity environment = new EnvironmentEntity();
+        environment.setId(ENVIRONMENT_ID);
+        environment.setOrganizationId(ORGANIZATION_ID);
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(environment);
+
+        Map<String, String> newProperties = Map.of("key1", "value1", "key2", "value2");
+
+        DictionaryEntity result = dictionaryService.updateProperties(DICTIONARY_ID, newProperties);
+        assertNotNull(result);
+
+        verify(environmentService).findById(ENVIRONMENT_ID);
+
+        ExecutionContext expectedContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        verify(eventService).createDictionaryEvent(
+            eq(expectedContext),
+            eq(Collections.singleton(ENVIRONMENT_ID)),
+            eq(ORGANIZATION_ID),
+            eq(EventType.PUBLISH_DICTIONARY),
+            any(Dictionary.class)
+        );
+        verify(auditService).createAuditLog(
+            eq(expectedContext),
+            argThat(auditLogData -> auditLogData.getEvent().equals(DICTIONARY_UPDATED))
+        );
+    }
+
+    @Test(expected = DictionaryNotFoundException.class)
+    public void shouldNotUpdatePropertiesBecauseNotFound() throws TechnicalException {
+        when(dictionaryRepository.findById(DICTIONARY_ID)).thenReturn(Optional.empty());
+
+        dictionaryService.updateProperties(DICTIONARY_ID, Map.of("key", "value"));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdateTest.java
@@ -34,6 +34,7 @@ import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryType;
 import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntity;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Collections;
@@ -57,6 +58,9 @@ public class DictionaryServiceImpl_UpdateTest {
 
     @Mock
     private DictionaryRepository dictionaryRepository;
+
+    @Mock
+    private EnvironmentService environmentService;
 
     @Mock
     private EventService eventService;
@@ -83,6 +87,7 @@ public class DictionaryServiceImpl_UpdateTest {
         updatedDictionary.setId(DICTIONARY_ID);
         updatedDictionary.setUpdatedAt(new Date());
         updatedDictionary.setState(LifecycleState.STARTED);
+        updatedDictionary.setEnvironmentId(ENVIRONMENT_ID);
         updatedDictionary.setType(io.gravitee.repository.management.model.DictionaryType.MANUAL);
         when(
             dictionaryRepository.update(
@@ -144,6 +149,7 @@ public class DictionaryServiceImpl_UpdateTest {
         updatedDictionary.setId(DICTIONARY_ID);
         updatedDictionary.setUpdatedAt(new Date());
         updatedDictionary.setState(LifecycleState.STARTED);
+        updatedDictionary.setEnvironmentId(ENVIRONMENT_ID);
         updatedDictionary.setType(io.gravitee.repository.management.model.DictionaryType.DYNAMIC);
         when(
             dictionaryRepository.update(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/DictionaryRefresher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/DictionaryRefresher.java
@@ -18,7 +18,6 @@ package io.gravitee.rest.api.services.dictionary;
 import io.gravitee.definition.model.Property;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
 import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntity;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.configuration.dictionary.DictionaryNotFoundException;
 import io.gravitee.rest.api.services.dictionary.model.DynamicProperty;
 import io.gravitee.rest.api.services.dictionary.provider.Provider;
@@ -93,7 +92,7 @@ public class DictionaryRefresher implements Handler<Long> {
         if (!properties.equals(dictionary.getProperties())) {
             try {
                 // Get a fresh version of the dictionary before updating its properties.
-                dictionary = dictionaryService.updateProperties(GraviteeContext.getExecutionContext(), dictionary.getId(), properties);
+                dictionary = dictionaryService.updateProperties(dictionary.getId(), properties);
             } catch (DictionaryNotFoundException e) {
                 log.debug("Trying to update a deleted dictionary {} - nothing to do...", dictionary.getId());
             } catch (Exception ex) {


### PR DESCRIPTION
## Summary
Cherry-pick of https://github.com/gravitee-io/gravitee-api-management/pull/16025 onto 4.9.x

Original commit: ec790c50aa561c78243472d5b0976629c74e7a97