### PR TITLE
Chore/gko 2720 renderer remove in ms in widget s title now the unit is correctly handled

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/data-access/templates/http-proxy.template.ts
+++ b/gravitee-apim-console-webui/src/management/observability/data-access/templates/http-proxy.template.ts
@@ -50,7 +50,7 @@ export const HTTP_PROXY_TEMPLATE: DashboardTemplate = {
       },
       {
         id: 'proxy-average-latency',
-        title: 'Average Latency in ms',
+        title: 'Average Latency',
         description: 'Average latency of the Gateway',
         type: 'stats',
         layout: { cols: 1, rows: 1, y: 0, x: 2 },
@@ -61,7 +61,7 @@ export const HTTP_PROXY_TEMPLATE: DashboardTemplate = {
       },
       {
         id: 'proxy-average-response-time',
-        title: 'Average Response Time in ms',
+        title: 'Average Response Time',
         description: 'Average response time of the Gateway',
         type: 'stats',
         layout: { cols: 1, rows: 1, y: 0, x: 3 },

--- a/gravitee-apim-console-webui/src/scss/gio-global-style.scss
+++ b/gravitee-apim-console-webui/src/scss/gio-global-style.scss
@@ -28,6 +28,10 @@ $snackbar-button: mat.m2-get-color-from-palette(gio.$mat-basic-palette, white);
   white-space: pre-wrap;
 }
 
+.gd-widget-description-tooltip {
+  white-space: pre-line;
+}
+
 .mdc-button__label {
   white-space: nowrap;
 }

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/grid/grid.component.html
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/grid/grid.component.html
@@ -20,7 +20,7 @@
   @for (item of items()!; track item.id) {
     <gridster-item [item]="item.layout">
       <gd-widget [isDraggable]="editMode()">
-        <gd-widget-title [matTooltip]="item.description">
+        <gd-widget-title [description]="item.description">
           {{ item.title }}
         </gd-widget-title>
 

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/widget/widget.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/widget/widget.component.ts
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 import { Component, input } from '@angular/core';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'gd-widget-title',
-  template: `<h3><ng-content /></h3>`,
+  imports: [MatTooltipModule],
+  template: `<h3>
+    <span [matTooltip]="description()" matTooltipClass="gd-widget-description-tooltip"><ng-content /></span>
+  </h3>`,
   styleUrl: './widget-title.component.scss',
 })
-export class WidgetTitleComponent {}
+export class WidgetTitleComponent {
+  description = input<string>();
+}
 
 @Component({
   selector: 'gd-widget-body',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2720

## Description

Remove "in ms" in widget title
Improve tooltip info at hover on a widget's title (title + description appear)
Improve template's widget description to avoid redundancy.
Now the tooltip appears under the title of the widget, not under its header.

## Additional context

<img width="1321" height="277" alt="Screenshot 2026-03-27 at 10 26 59" src="https://github.com/user-attachments/assets/ab7b2a19-3bb2-4f3f-a090-8189edb3376f" />


