### PR TITLE
feat: add certificate upload dialog to portal-next certificates tab

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.harness.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+export class AddCertificateDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-add-certificate-dialog';
+
+  private readonly getNameInput = this.locatorFor(MatInputHarness.with({ selector: '[data-testid="certificate-name-input"]' }));
+  private readonly getPemInput = this.locatorFor(MatInputHarness.with({ selector: '[data-testid="certificate-pem-input"]' }));
+  private readonly getContinueUploadButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="certificate-continue-upload-button"]' }),
+  );
+  private readonly getContinueConfigureButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="certificate-continue-configure-button"]' }),
+  );
+  private readonly getSubmitButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="certificate-submit-button"]' }));
+  private readonly getCancelButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="certificate-cancel-button"]' }));
+  private readonly getPreviousButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="certificate-previous-button"]' }),
+  );
+  private readonly getGracePeriodInput = this.locatorForOptional(
+    MatInputHarness.with({ selector: '[data-testid="certificate-grace-period-input"]' }),
+  );
+  private readonly getSubmitErrorEl = this.locatorForOptional('[data-testid="certificate-submit-error"]');
+
+  async nameInput(): Promise<MatInputHarness> {
+    return this.getNameInput();
+  }
+
+  async pemInput(): Promise<MatInputHarness> {
+    return this.getPemInput();
+  }
+
+  async clickContinueUpload(): Promise<void> {
+    return (await this.getContinueUploadButton()).click();
+  }
+
+  async clickContinueConfigure(): Promise<void> {
+    return (await this.getContinueConfigureButton()).click();
+  }
+
+  async clickSubmit(): Promise<void> {
+    return (await this.getSubmitButton()).click();
+  }
+
+  async clickCancel(): Promise<void> {
+    return (await this.getCancelButton()).click();
+  }
+
+  async previousButton(): Promise<MatButtonHarness | null> {
+    return this.getPreviousButton();
+  }
+
+  async gracePeriodInput(): Promise<MatInputHarness | null> {
+    return this.getGracePeriodInput();
+  }
+
+  async submitErrorText(): Promise<string | null> {
+    const el = await this.getSubmitErrorEl();
+    return el ? el.text() : null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.html
@@ -1,0 +1,231 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<span mat-dialog-title i18n="@@addCertificateDialogTitle">Add certificate</span>
+
+<mat-dialog-content class="add-certificate-dialog__content">
+  <mat-stepper [linear]="false" animationDuration="0" #stepper>
+    <!-- Step 1: Upload -->
+    <mat-step>
+      <ng-template matStepLabel>
+        <span i18n="@@addCertificateStepUpload">Upload</span>
+      </ng-template>
+      <form [formGroup]="uploadForm" class="add-certificate-dialog__step">
+        <mat-form-field class="add-certificate-dialog__field">
+          <mat-label i18n="@@addCertificateNameLabel">Certificate Name</mat-label>
+          <input matInput formControlName="name" type="text" maxlength="256" data-testid="certificate-name-input" />
+          @if (uploadForm.controls.name.hasError('required') && uploadForm.controls.name.touched) {
+            <mat-error i18n="@@addCertificateNameRequired">Certificate name is required.</mat-error>
+          }
+        </mat-form-field>
+
+        <div class="add-certificate-dialog__certificate-input">
+          <div class="add-certificate-dialog__section">
+            <span class="next-gen-h4" i18n="@@addCertificatePasteLabel">Paste certificate</span>
+            <mat-form-field class="add-certificate-dialog__field">
+              <mat-label i18n="@@addCertificatePemLabel">Certificate (PEM)</mat-label>
+              <textarea
+                matInput
+                formControlName="certificate"
+                rows="6"
+                placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+                aria-label="PEM certificate"
+                i18n-aria-label="@@addCertificatePemAriaLabel"
+                data-testid="certificate-pem-input"
+              ></textarea>
+              @if (uploadForm.controls.certificate.hasError('required') && uploadForm.controls.certificate.touched) {
+                <mat-error i18n="@@addCertificatePemRequired">Certificate is required.</mat-error>
+              }
+            </mat-form-field>
+          </div>
+
+          <div class="add-certificate-dialog__section">
+            <span class="next-gen-h4" i18n="@@addCertificateUploadFileLabel">Upload file</span>
+            <label class="add-certificate-dialog__file-label">
+              <input
+                type="file"
+                accept=".pem,.crt,.cer"
+                class="add-certificate-dialog__file-input"
+                (change)="onFileSelected($event)"
+                aria-label="Upload certificate file"
+                i18n-aria-label="@@addCertificateFileInputAriaLabel"
+                data-testid="certificate-file-input"
+              />
+              <mat-icon aria-hidden="true">upload_file</mat-icon>
+              <span i18n="@@addCertificateChooseFile">Choose file (.pem, .crt, .cer)</span>
+            </label>
+          </div>
+        </div>
+      </form>
+    </mat-step>
+
+    <!-- Step 2: Configure -->
+    <mat-step>
+      <ng-template matStepLabel>
+        <span i18n="@@addCertificateStepConfigure">Configure</span>
+      </ng-template>
+      <form [formGroup]="configureForm" class="add-certificate-dialog__step">
+        <mat-form-field class="add-certificate-dialog__field">
+          <mat-label i18n="@@addCertificateEndsAtLabel">Active until (optional)</mat-label>
+          <input matInput [matDatepicker]="endsAtPicker" [min]="minDate" formControlName="endsAt" data-testid="certificate-ends-at-input" />
+          <mat-datepicker-toggle
+            matIconSuffix
+            [for]="endsAtPicker"
+            aria-label="Open calendar"
+            i18n-aria-label="@@addCertificateEndsAtCalendarAriaLabel"
+          />
+          <mat-datepicker #endsAtPicker />
+          <mat-hint i18n="@@addCertificateEndsAtHint">When this certificate should stop being active</mat-hint>
+        </mat-form-field>
+
+        @if (data.hasActiveCertificates) {
+          <div class="add-certificate-dialog__grace-period-info">
+            <mat-icon aria-hidden="true">info_outline</mat-icon>
+            <span class="next-gen-small" i18n="@@addCertificateGracePeriodInfo">
+              Both certificates will remain active during the grace period to avoid downtime.
+            </span>
+          </div>
+
+          <mat-form-field class="add-certificate-dialog__field">
+            <mat-label i18n="@@addCertificateGracePeriodLabel">Grace period end for current certificate</mat-label>
+            <input
+              matInput
+              [matDatepicker]="gracePicker"
+              [min]="minDate"
+              [max]="maxGracePeriodDate"
+              formControlName="gracePeriodEnd"
+              data-testid="certificate-grace-period-input"
+            />
+            <mat-datepicker-toggle
+              matIconSuffix
+              [for]="gracePicker"
+              aria-label="Open calendar"
+              i18n-aria-label="@@addCertificateGracePeriodCalendarAriaLabel"
+            />
+            <mat-datepicker #gracePicker />
+            <mat-hint i18n="@@addCertificateGracePeriodHint">When the currently active certificate should be revoked</mat-hint>
+            @if (configureForm.controls.gracePeriodEnd?.hasError('required') && configureForm.controls.gracePeriodEnd?.touched) {
+              <mat-error i18n="@@addCertificateGracePeriodRequired"
+                >Grace period end date is required when rotating certificates.</mat-error
+              >
+            }
+          </mat-form-field>
+        }
+      </form>
+    </mat-step>
+
+    <!-- Step 3: Confirm -->
+    <mat-step>
+      <ng-template matStepLabel>
+        <span i18n="@@addCertificateStepConfirm">Confirm</span>
+      </ng-template>
+      <div class="add-certificate-dialog__step">
+        <div class="add-certificate-dialog__summary" data-testid="certificate-summary">
+          <span class="next-gen-h5" i18n="@@addCertificateSummaryTitle">Certificate Summary</span>
+          <div class="add-certificate-dialog__summary-row">
+            <span class="next-gen-small add-certificate-dialog__summary-label" i18n="@@addCertificateSummaryNameLabel">Name:</span>
+            <span class="next-gen-small add-certificate-dialog__summary-value" data-testid="certificate-summary-name">{{
+              uploadForm.controls.name.value
+            }}</span>
+          </div>
+          @if (configureForm.controls.endsAt.value) {
+            <div class="add-certificate-dialog__summary-row">
+              <span class="next-gen-small add-certificate-dialog__summary-label" i18n="@@addCertificateSummaryEndsAtLabel"
+                >Active until:</span
+              >
+              <span class="next-gen-small add-certificate-dialog__summary-value" data-testid="certificate-summary-ends-at">{{
+                configureForm.controls.endsAt.value | date
+              }}</span>
+            </div>
+          }
+          @if (configureForm.controls.gracePeriodEnd?.value) {
+            <div class="add-certificate-dialog__summary-row">
+              <span class="next-gen-small add-certificate-dialog__summary-label" i18n="@@addCertificateSummaryGracePeriodLabel"
+                >Grace period ends:</span
+              >
+              <span class="next-gen-small add-certificate-dialog__summary-value" data-testid="certificate-summary-grace-period">{{
+                configureForm.controls.gracePeriodEnd.value | date
+              }}</span>
+            </div>
+          }
+        </div>
+
+        @if (submitError) {
+          <p class="add-certificate-dialog__error next-gen-small" data-testid="certificate-submit-error" role="alert">{{ submitError }}</p>
+        }
+      </div>
+    </mat-step>
+  </mat-stepper>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  @if (stepper.selectedIndex > 0) {
+    <button
+      mat-stroked-button
+      type="button"
+      (click)="stepper.previous()"
+      data-testid="certificate-previous-button"
+      i18n="@@addCertificatePreviousButton"
+    >
+      Previous
+    </button>
+  }
+  <button
+    mat-stroked-button
+    [mat-dialog-close]="undefined"
+    type="button"
+    data-testid="certificate-cancel-button"
+    i18n="@@addCertificateCancelButton"
+  >
+    Cancel
+  </button>
+  @if (stepper.selectedIndex === 0) {
+    <button
+      mat-flat-button
+      color="primary"
+      type="button"
+      (click)="onContinueUpload()"
+      data-testid="certificate-continue-upload-button"
+      i18n="@@addCertificateContinueButton"
+    >
+      Continue
+    </button>
+  } @else if (stepper.selectedIndex === 1) {
+    <button
+      mat-flat-button
+      color="primary"
+      type="button"
+      (click)="onContinueConfigure()"
+      data-testid="certificate-continue-configure-button"
+      i18n="@@addCertificateContinueButton"
+    >
+      Continue
+    </button>
+  } @else {
+    <button
+      mat-flat-button
+      color="primary"
+      type="button"
+      [disabled]="isSubmitting"
+      (click)="onSubmit()"
+      data-testid="certificate-submit-button"
+      i18n="@@addCertificateSubmitButton"
+    >
+      Add Certificate
+    </button>
+  }
+</mat-dialog-actions>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<span mat-dialog-title i18n="@@addCertificateDialogTitle">Add certificate</span>
+<h2 mat-dialog-title i18n="@@addCertificateDialogTitle">Add certificate</h2>
 
 <mat-dialog-content class="add-certificate-dialog__content">
   <mat-stepper [linear]="false" animationDuration="0" #stepper>
@@ -164,8 +164,10 @@
           }
         </div>
 
-        @if (submitError) {
-          <p class="add-certificate-dialog__error next-gen-small" data-testid="certificate-submit-error" role="alert">{{ submitError }}</p>
+        @if (submitError(); as submitError) {
+          <p class="add-certificate-dialog__error next-gen-small" data-testid="certificate-submit-error" role="alert">
+            {{ submitError }}
+          </p>
         }
       </div>
     </mat-step>
@@ -198,7 +200,7 @@
       mat-flat-button
       color="primary"
       type="button"
-      (click)="onContinueUpload()"
+      (click)="continueStep(uploadForm)"
       data-testid="certificate-continue-upload-button"
       i18n="@@addCertificateContinueButton"
     >
@@ -209,7 +211,7 @@
       mat-flat-button
       color="primary"
       type="button"
-      (click)="onContinueConfigure()"
+      (click)="continueStep(configureForm)"
       data-testid="certificate-continue-configure-button"
       i18n="@@addCertificateContinueButton"
     >
@@ -220,7 +222,7 @@
       mat-flat-button
       color="primary"
       type="button"
-      [disabled]="isSubmitting"
+      [disabled]="isSubmitting()"
       (click)="onSubmit()"
       data-testid="certificate-submit-button"
       i18n="@@addCertificateSubmitButton"

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.scss
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../../../scss/theme' as app-theme;
+
+.add-certificate-dialog {
+  &__content {
+    min-width: 480px;
+  }
+
+  &__step {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding-top: 16px;
+  }
+
+  &__field {
+    width: 100%;
+  }
+
+  &__certificate-input {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__section-title {
+    color: app-theme.$paragraph-color;
+  }
+
+  &__file-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    color: app-theme.$primary-main-color;
+    padding: 8px 12px;
+    border: app-theme.$border-width solid app-theme.$border-color;
+    border-radius: app-theme.$container-shape;
+    width: fit-content;
+
+    &:hover {
+      background-color: color-mix(in srgb, app-theme.$primary-main-color 8%, transparent);
+    }
+  }
+
+  &__file-input {
+    display: none;
+  }
+
+  &__grace-period-info {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 8px 12px;
+    background-color: color-mix(in srgb, app-theme.$primary-main-color 8%, app-theme.$background-color);
+    border-radius: app-theme.$container-shape;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__summary {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 16px;
+    background-color: app-theme.$background-color;
+    border-radius: app-theme.$container-shape;
+    border: app-theme.$border-width solid app-theme.$border-color;
+  }
+
+  &__summary-row {
+    display: flex;
+    gap: 8px;
+  }
+
+  &__summary-label {
+    color: app-theme.$paragraph-color;
+    min-width: 100px;
+  }
+
+  &__summary-value {
+    color: app-theme.$default-text-color;
+  }
+
+  &__error {
+    color: app-theme.$error-main-color;
+    margin: 0;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { AddCertificateDialogComponent, AddCertificateDialogData } from './add-certificate-dialog.component';
+import { ConfigService } from '../../../../../../services/config.service';
+import { AppTestingModule, TESTING_BASE_URL } from '../../../../../../testing/app-testing.module';
+
+const APPLICATION_ID = 'app-1';
+
+function makeData(overrides: Partial<AddCertificateDialogData> = {}): AddCertificateDialogData {
+  return {
+    applicationId: APPLICATION_ID,
+    hasActiveCertificates: false,
+    ...overrides,
+  };
+}
+
+describe('AddCertificateDialogComponent', () => {
+  let fixture: ComponentFixture<AddCertificateDialogComponent>;
+  let httpTestingController: HttpTestingController;
+  let dialogRef: { close: jest.Mock };
+
+  async function init(data: AddCertificateDialogData = makeData()): Promise<void> {
+    dialogRef = { close: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [AddCertificateDialogComponent, AppTestingModule],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddCertificateDialogComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  afterEach(() => httpTestingController.verify());
+
+  it('should show upload step initially', async () => {
+    await init();
+    expect(fixture.nativeElement.querySelector('[data-testid="certificate-name-input"]')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('[data-testid="certificate-pem-input"]')).toBeTruthy();
+  });
+
+  it('should show validation errors when continuing with empty upload form', async () => {
+    await init();
+    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.uploadForm.touched).toBe(true);
+    expect(fixture.componentInstance.uploadForm.invalid).toBe(true);
+  });
+
+  it('should advance to configure step when upload form is valid', async () => {
+    await init();
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.stepper().selectedIndex).toBe(1);
+  });
+
+  it('should not show grace period field when hasActiveCertificates is false', async () => {
+    await init(makeData({ hasActiveCertificates: false }));
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="certificate-grace-period-input"]')).toBeNull();
+  });
+
+  it('should show grace period field when hasActiveCertificates is true', async () => {
+    await init(makeData({ hasActiveCertificates: true, activeCertificateId: 'old-cert' }));
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="certificate-grace-period-input"]')).toBeTruthy();
+  });
+
+  it('should call create and close dialog on successful submit', async () => {
+    await init();
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('[data-testid="certificate-continue-configure-button"]').click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('[data-testid="certificate-submit-button"]').click();
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toMatchObject({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    req.flush({ id: 'new-cert', name: 'My Cert', status: 'ACTIVE' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should also call update on old cert when gracePeriodEnd is set', async () => {
+    const activeCertificateId = 'old-cert-id';
+    await init(makeData({ hasActiveCertificates: true, activeCertificateId }));
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const graceDate = new Date('2026-12-31');
+    fixture.componentInstance.configureForm.controls.gracePeriodEnd.setValue(graceDate);
+    fixture.nativeElement.querySelector('[data-testid="certificate-continue-configure-button"]').click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('[data-testid="certificate-submit-button"]').click();
+    fixture.detectChanges();
+
+    const createReq = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`);
+    createReq.flush({ id: 'new-cert', name: 'My Cert', status: 'ACTIVE' });
+    fixture.detectChanges();
+
+    const updateReq = httpTestingController.expectOne(
+      `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates/${activeCertificateId}`,
+    );
+    expect(updateReq.request.method).toBe('PUT');
+    expect(updateReq.request.body).toMatchObject({ endsAt: graceDate.toISOString() });
+    updateReq.flush({ id: activeCertificateId, name: 'Old Cert', status: 'ACTIVE_WITH_END' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should show validation error on 400 response', async () => {
+    await init();
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: 'INVALID PEM' });
+    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('[data-testid="certificate-continue-configure-button"]').click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('[data-testid="certificate-submit-button"]').click();
+    fixture.detectChanges();
+
+    httpTestingController
+      .expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`)
+      .flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="certificate-submit-error"]')).toBeTruthy();
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -20,6 +21,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { AddCertificateDialogComponent, AddCertificateDialogData } from './add-certificate-dialog.component';
+import { AddCertificateDialogHarness } from './add-certificate-dialog.component.harness';
 import { ConfigService } from '../../../../../../services/config.service';
 import { AppTestingModule, TESTING_BASE_URL } from '../../../../../../testing/app-testing.module';
 
@@ -35,6 +37,7 @@ function makeData(overrides: Partial<AddCertificateDialogData> = {}): AddCertifi
 
 describe('AddCertificateDialogComponent', () => {
   let fixture: ComponentFixture<AddCertificateDialogComponent>;
+  let harness: AddCertificateDialogHarness;
   let httpTestingController: HttpTestingController;
   let dialogRef: { close: jest.Mock };
 
@@ -54,6 +57,7 @@ describe('AddCertificateDialogComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(AddCertificateDialogComponent);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AddCertificateDialogHarness);
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
     await fixture.whenStable();
@@ -64,13 +68,13 @@ describe('AddCertificateDialogComponent', () => {
 
   it('should show upload step initially', async () => {
     await init();
-    expect(fixture.nativeElement.querySelector('[data-testid="certificate-name-input"]')).toBeTruthy();
-    expect(fixture.nativeElement.querySelector('[data-testid="certificate-pem-input"]')).toBeTruthy();
+    expect(await harness.nameInput()).toBeTruthy();
+    expect(await harness.pemInput()).toBeTruthy();
   });
 
   it('should show validation errors when continuing with empty upload form', async () => {
     await init();
-    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    await harness.clickContinueUpload();
     fixture.detectChanges();
 
     expect(fixture.componentInstance.uploadForm.touched).toBe(true);
@@ -83,7 +87,7 @@ describe('AddCertificateDialogComponent', () => {
     fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
     fixture.detectChanges();
 
-    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    await harness.clickContinueUpload();
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -95,41 +99,41 @@ describe('AddCertificateDialogComponent', () => {
     await init(makeData({ hasActiveCertificates: false }));
 
     fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    await harness.clickContinueUpload();
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.querySelector('[data-testid="certificate-grace-period-input"]')).toBeNull();
+    expect(await harness.gracePeriodInput()).toBeNull();
   });
 
   it('should show grace period field when hasActiveCertificates is true', async () => {
     await init(makeData({ hasActiveCertificates: true, activeCertificateId: 'old-cert' }));
 
     fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    await harness.clickContinueUpload();
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.querySelector('[data-testid="certificate-grace-period-input"]')).toBeTruthy();
+    expect(await harness.gracePeriodInput()).toBeTruthy();
   });
 
   it('should call create and close dialog on successful submit', async () => {
     await init();
 
     fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    await harness.clickContinueUpload();
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
-    fixture.nativeElement.querySelector('[data-testid="certificate-continue-configure-button"]').click();
+    await harness.clickContinueConfigure();
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
-    fixture.nativeElement.querySelector('[data-testid="certificate-submit-button"]').click();
+    await harness.clickSubmit();
     fixture.detectChanges();
 
     const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`);
@@ -147,19 +151,19 @@ describe('AddCertificateDialogComponent', () => {
     await init(makeData({ hasActiveCertificates: true, activeCertificateId }));
 
     fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    await harness.clickContinueUpload();
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
     const graceDate = new Date('2026-12-31');
     fixture.componentInstance.configureForm.controls.gracePeriodEnd.setValue(graceDate);
-    fixture.nativeElement.querySelector('[data-testid="certificate-continue-configure-button"]').click();
+    await harness.clickContinueConfigure();
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
-    fixture.nativeElement.querySelector('[data-testid="certificate-submit-button"]').click();
+    await harness.clickSubmit();
     fixture.detectChanges();
 
     const createReq = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`);
@@ -182,17 +186,17 @@ describe('AddCertificateDialogComponent', () => {
     await init();
 
     fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: 'INVALID PEM' });
-    fixture.nativeElement.querySelector('[data-testid="certificate-continue-upload-button"]').click();
+    await harness.clickContinueUpload();
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
-    fixture.nativeElement.querySelector('[data-testid="certificate-continue-configure-button"]').click();
+    await harness.clickContinueConfigure();
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
-    fixture.nativeElement.querySelector('[data-testid="certificate-submit-button"]').click();
+    await harness.clickSubmit();
     fixture.detectChanges();
 
     httpTestingController
@@ -202,7 +206,7 @@ describe('AddCertificateDialogComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.querySelector('[data-testid="certificate-submit-error"]')).toBeTruthy();
+    expect(await harness.submitErrorText()).toBeTruthy();
     expect(dialogRef.close).not.toHaveBeenCalled();
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
@@ -15,7 +15,7 @@
  */
 import { DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, DestroyRef, inject, viewChild } from '@angular/core';
+import { Component, DestroyRef, inject, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -67,8 +67,8 @@ export class AddCertificateDialogComponent {
     ? new Date(this.data.activeCertificateExpiration)
     : undefined;
 
-  isSubmitting = false;
-  submitError: string | undefined;
+  isSubmitting = signal(false);
+  submitError = signal<string | null>(null);
 
   readonly uploadForm = new FormGroup({
     name: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
@@ -80,15 +80,9 @@ export class AddCertificateDialogComponent {
     gracePeriodEnd: new FormControl<Date | null>(null, this.data.hasActiveCertificates ? [Validators.required] : []),
   });
 
-  onContinueUpload(): void {
-    this.uploadForm.markAllAsTouched();
-    if (this.uploadForm.invalid) return;
-    this.stepper().next();
-  }
-
-  onContinueConfigure(): void {
-    this.configureForm.markAllAsTouched();
-    if (this.configureForm.invalid) return;
+  continueStep(group: FormGroup): void {
+    group.markAllAsTouched();
+    if (group.invalid) return;
     this.stepper().next();
   }
 
@@ -104,16 +98,16 @@ export class AddCertificateDialogComponent {
   onSubmit(): void {
     if (this.uploadForm.invalid || this.configureForm.invalid) return;
 
-    const { name, certificate } = this.uploadForm.getRawValue();
-    const { endsAt, gracePeriodEnd } = this.configureForm.getRawValue();
+    const { name, certificate } = this.uploadForm.value;
+    const { endsAt, gracePeriodEnd } = this.configureForm.value;
 
-    this.isSubmitting = true;
-    this.submitError = undefined;
+    this.isSubmitting.set(true);
+    this.submitError.set(null);
 
     this.certService
       .create(this.data.applicationId, {
-        name,
-        certificate,
+        name: name!,
+        certificate: certificate!,
         ...(endsAt ? { endsAt: endsAt.toISOString() } : {}),
       })
       .pipe(
@@ -129,15 +123,15 @@ export class AddCertificateDialogComponent {
       )
       .subscribe({
         next: () => {
-          this.isSubmitting = false;
+          this.isSubmitting.set(false);
           this.dialogRef.close(true);
         },
         error: (err: HttpErrorResponse) => {
-          this.isSubmitting = false;
+          this.isSubmitting.set(false);
           if (err.status === 400) {
-            this.submitError = $localize`:@@addCertificateValidationError:Validation failed for Certificate uploaded. Please try again`;
+            this.submitError.set($localize`:@@addCertificateValidationError:Validation failed for Certificate uploaded. Please try again`);
           } else {
-            this.submitError = $localize`:@@addCertificateSubmitError:An error occurred. Please try again`;
+            this.submitError.set($localize`:@@addCertificateSubmitError:An error occurred. Please try again`);
           }
         },
       });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, DestroyRef, inject, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DATE_FORMATS, MAT_NATIVE_DATE_FORMATS, provideNativeDateAdapter } from '@angular/material/core';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatStepper, MatStepperModule } from '@angular/material/stepper';
+import { of, switchMap } from 'rxjs';
+
+import { ApplicationCertificateService } from '../../../../../../services/application-certificate.service';
+
+export interface AddCertificateDialogData {
+  applicationId: string;
+  hasActiveCertificates: boolean;
+  activeCertificateId?: string;
+  activeCertificateExpiration?: string;
+}
+
+@Component({
+  selector: 'app-add-certificate-dialog',
+  imports: [
+    DatePipe,
+    MatDialogModule,
+    MatButtonModule,
+    MatStepperModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatDatepickerModule,
+    ReactiveFormsModule,
+  ],
+  providers: [provideNativeDateAdapter(), { provide: MAT_DATE_FORMATS, useValue: MAT_NATIVE_DATE_FORMATS }],
+  templateUrl: './add-certificate-dialog.component.html',
+  styleUrl: './add-certificate-dialog.component.scss',
+})
+export class AddCertificateDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<AddCertificateDialogComponent>);
+  readonly data: AddCertificateDialogData = inject(MAT_DIALOG_DATA);
+  private readonly certService = inject(ApplicationCertificateService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly stepper = viewChild.required<MatStepper>('stepper');
+
+  readonly minDate = new Date();
+  readonly maxGracePeriodDate: Date | undefined = this.data.activeCertificateExpiration
+    ? new Date(this.data.activeCertificateExpiration)
+    : undefined;
+
+  isSubmitting = false;
+  submitError: string | undefined;
+
+  readonly uploadForm = new FormGroup({
+    name: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    certificate: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+  });
+
+  readonly configureForm = new FormGroup({
+    endsAt: new FormControl<Date | null>(null),
+    gracePeriodEnd: new FormControl<Date | null>(null, this.data.hasActiveCertificates ? [Validators.required] : []),
+  });
+
+  onContinueUpload(): void {
+    this.uploadForm.markAllAsTouched();
+    if (this.uploadForm.invalid) return;
+    this.stepper().next();
+  }
+
+  onContinueConfigure(): void {
+    this.configureForm.markAllAsTouched();
+    if (this.configureForm.invalid) return;
+    this.stepper().next();
+  }
+
+  async onFileSelected(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    const content = await this.readFileAsText(file);
+    this.uploadForm.controls.certificate.setValue(content);
+    input.value = '';
+  }
+
+  onSubmit(): void {
+    if (this.uploadForm.invalid || this.configureForm.invalid) return;
+
+    const { name, certificate } = this.uploadForm.getRawValue();
+    const { endsAt, gracePeriodEnd } = this.configureForm.getRawValue();
+
+    this.isSubmitting = true;
+    this.submitError = undefined;
+
+    this.certService
+      .create(this.data.applicationId, {
+        name,
+        certificate,
+        ...(endsAt ? { endsAt: endsAt.toISOString() } : {}),
+      })
+      .pipe(
+        switchMap(() => {
+          if (gracePeriodEnd && this.data.activeCertificateId) {
+            return this.certService.update(this.data.applicationId, this.data.activeCertificateId!, {
+              endsAt: gracePeriodEnd.toISOString(),
+            });
+          }
+          return of(null);
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: () => {
+          this.isSubmitting = false;
+          this.dialogRef.close(true);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isSubmitting = false;
+          if (err.status === 400) {
+            this.submitError = $localize`:@@addCertificateValidationError:Validation failed for Certificate uploaded. Please try again`;
+          } else {
+            this.submitError = $localize`:@@addCertificateSubmitError:An error occurred. Please try again`;
+          }
+        },
+      });
+  }
+
+  private readFileAsText(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsText(file);
+    });
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.html
@@ -23,6 +23,20 @@
         Manage mTLS certificates for this application
       </p>
     </div>
+    @if (canManage()) {
+      <button
+        mat-flat-button
+        color="primary"
+        type="button"
+        (click)="openUploadDialog()"
+        data-testid="upload-certificate-button"
+        aria-label="Upload certificate"
+        i18n-aria-label="@@uploadCertificateAriaLabel"
+      >
+        <mat-icon aria-hidden="true">upload</mat-icon>
+        <span i18n="@@uploadCertificateButton">Upload certificate</span>
+      </button>
+    }
   </div>
 
   @if (loadError()) {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.spec.ts
@@ -17,6 +17,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
@@ -152,5 +153,28 @@ describe('ApplicationTabSettingsCertificatesComponent', () => {
       .forEach(req => req.flush({ data: [], metadata: { paginateMetaData: { totalElements: 0 } } }));
 
     expect(fixture.componentInstance.currentPage()).toBe(2);
+  });
+
+  it('should show upload button when user has UPDATE permission', async () => {
+    const harness = await initWithCertificates([fakeCertificate()]);
+    expect(await harness.getUploadButton()).toBeTruthy();
+  });
+
+  it('should not show upload button when user lacks UPDATE permission', async () => {
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ DEFINITION: ['R'] }));
+    const harness = await initWithCertificates([fakeCertificate()]);
+    expect(await harness.getUploadButton()).toBeNull();
+  });
+
+  it('should open upload dialog when upload button is clicked', async () => {
+    const harness = await initWithCertificates([fakeCertificate()]);
+    const dialog = TestBed.inject(MatDialog);
+    const openSpy = jest
+      .spyOn(dialog, 'open')
+      .mockReturnValue({ afterClosed: () => ({ pipe: () => ({ subscribe: () => ({}) }) }) } as never);
+
+    await harness.clickUploadButton();
+
+    expect(openSpy).toHaveBeenCalled();
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
@@ -15,9 +15,13 @@
  */
 import { Component, computed, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { differenceInCalendarDays } from 'date-fns';
 
+import { AddCertificateDialogComponent, AddCertificateDialogData } from './add-certificate-dialog/add-certificate-dialog.component';
 import { PaginatedTableComponent, TableColumn } from '../../../../../components/paginated-table/paginated-table.component';
 import { ClientCertificate } from '../../../../../entities/application/client-certificate';
 import { UserApplicationPermissions } from '../../../../../entities/permission/permission';
@@ -25,12 +29,13 @@ import { ApplicationCertificateService } from '../../../../../services/applicati
 
 @Component({
   selector: 'app-application-tab-settings-certificates',
-  imports: [MatTabsModule, PaginatedTableComponent],
+  imports: [MatTabsModule, MatButtonModule, MatIconModule, PaginatedTableComponent],
   templateUrl: './application-tab-settings-certificates.component.html',
   styleUrl: './application-tab-settings-certificates.component.scss',
 })
 export class ApplicationTabSettingsCertificatesComponent implements OnInit {
   private readonly certService = inject(ApplicationCertificateService);
+  private readonly dialog = inject(MatDialog);
   private readonly destroyRef = inject(DestroyRef);
 
   applicationId = input.required<string>();
@@ -94,6 +99,23 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
     if (!endsAt) return '—';
     const days = differenceInCalendarDays(new Date(endsAt), new Date());
     return days <= 0 ? 'Expired' : String(days);
+  }
+
+  openUploadDialog(): void {
+    const activeCert = this.activeCertificates()[0];
+    const data: AddCertificateDialogData = {
+      applicationId: this.applicationId(),
+      hasActiveCertificates: this.activeCertificates().length > 0,
+      activeCertificateId: activeCert?.id,
+      activeCertificateExpiration: activeCert?.endsAt,
+    };
+    this.dialog
+      .open(AddCertificateDialogComponent, { data, width: '560px' })
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(needsRefresh => {
+        if (needsRefresh) this.loadCertificates();
+      });
   }
 
   private toRows(certs: ClientCertificate[]) {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
@@ -102,10 +102,11 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
   }
 
   openUploadDialog(): void {
-    const activeCert = this.activeCertificates()[0];
+    const activeCerts = this.activeCertificates();
+    const activeCert = activeCerts[0];
     const data: AddCertificateDialogData = {
       applicationId: this.applicationId(),
-      hasActiveCertificates: this.activeCertificates().length > 0,
+      hasActiveCertificates: activeCerts.length > 0,
       activeCertificateId: activeCert?.id,
       activeCertificateExpiration: activeCert?.endsAt,
     };

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
@@ -23,6 +23,12 @@ export class ApplicationTabSettingsCertificatesHarness extends ComponentHarness 
   getErrorMessage = this.locatorForOptional('.certificates__error');
   getTabButtons = this.locatorForAll('.certificates__tabs__tab');
   getActiveTabButton = this.locatorForOptional('.certificates__tabs__tab--active');
+  getUploadButton = this.locatorForOptional('[data-testid="upload-certificate-button"]');
+
+  async clickUploadButton(): Promise<void> {
+    const btn = await this.getUploadButton();
+    await btn?.click();
+  }
 
   async clickTab(label: 'active' | 'history'): Promise<void> {
     const tabs = await this.getTabButtons();


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-13260

## Description
- Added `AddCertificateDialogComponent` (3-step stepper: Upload → Configure → Confirm) to portal-next, allowing application owners to paste PEM text or upload a `.pem`/`.crt`/`.cer` file
- Upload button added to `ApplicationTabSettingsCertificatesComponent`, visible only to users with `APPLICATION_DEFINITION + UPDATE` permission
- Certificate rotation support: when an active certificate exists, the Configure step exposes a required grace period date; on submit, the new cert is created then the old cert's `endsAt` is updated via a chained `switchMap` call
- 11 new unit tests across the certificates tab component (harness) and the dialog (submit, rotation, validation, permission guard)

## Additional context
- No certificate validate endpoint exists in papi; server-side 400 responses from `POST /applications/{applicationId}/certificates` are surfaced inline on the Confirm step as "Validation failed for Certificate uploaded. Please try again"
- Grace period is modelled as `endsAt` (date) on the existing active certificate — not a day count; the spec's "grace period days" requirement maps to setting an expiry date on the old cert     