### PR TITLE
feat: add EL resolution for dynamic subscription form options - domai…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactory.java
@@ -18,14 +18,16 @@ package io.gravitee.apim.core.subscription_form.domain_service;
 import io.gravitee.apim.core.subscription_form.model.Constraint;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
-import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxField;
-import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxGroupField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.Field;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.InputField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.MinLengthAttribute;
-import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.OptionsAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.MultiValueOptionsField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.PatternAttribute;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.ReadOnlyValueAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.RequiredSelectionAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.RequiredTrueAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.RequiredValueAttribute;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.SingleValueOptionsField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.TextareaField;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -61,17 +63,27 @@ public final class SubscriptionFormConstraintsFactory {
         }
 
         var out = new ArrayList<Constraint>();
+        addRequiredConstraint(field, out);
+        addLengthConstraints(field, out);
+        addPatternConstraint(field, out);
+        addOptionsConstraint(field, out);
+        return out;
+    }
 
-        if (field.required()) {
-            if (field instanceof CheckboxField) {
-                out.add(new Constraint.MustBeTrue());
-            } else if (field instanceof CheckboxGroupField) {
-                out.add(new Constraint.NonEmptySelection());
-            } else {
-                out.add(new Constraint.Required());
-            }
+    private static void addRequiredConstraint(Field field, List<Constraint> out) {
+        if (!field.required()) {
+            return;
         }
+        if (field instanceof RequiredTrueAttribute) {
+            out.add(new Constraint.MustBeTrue());
+        } else if (field instanceof RequiredSelectionAttribute) {
+            out.add(new Constraint.NonEmptySelection());
+        } else if (field instanceof RequiredValueAttribute) {
+            out.add(new Constraint.Required());
+        }
+    }
 
+    private static void addLengthConstraints(Field field, List<Constraint> out) {
         if (field instanceof MinLengthAttribute min && min.minLength() != null) {
             out.add(new Constraint.MinLength(min.minLength()));
         }
@@ -82,19 +94,42 @@ public final class SubscriptionFormConstraintsFactory {
                 textarea.maxLength() != null ? Constraint.MaxLength.forTextarea(textarea.maxLength()) : Constraint.MaxLength.forTextarea()
             );
         }
+    }
+
+    private static void addPatternConstraint(Field field, List<Constraint> out) {
         if (field instanceof PatternAttribute pat && pat.pattern() != null) {
             out.add(new Constraint.MatchesPattern(pat.pattern()));
         }
+    }
 
-        if (field instanceof OptionsAttribute opt && hasOptions(opt.options())) {
-            if (field instanceof CheckboxGroupField) {
-                out.add(new Constraint.EachOf(opt.options()));
-            } else {
-                out.add(new Constraint.OneOf(opt.options()));
-            }
+    private static void addOptionsConstraint(Field field, List<Constraint> out) {
+        if (field instanceof SingleValueOptionsField single) {
+            addSingleValueOptionsConstraint(single, out);
+        } else if (field instanceof MultiValueOptionsField multi) {
+            addMultiValueOptionsConstraint(multi, out);
         }
+    }
 
-        return out;
+    private static void addSingleValueOptionsConstraint(SingleValueOptionsField field, List<Constraint> out) {
+        var dynamic = field.dynamicOptions();
+        if (dynamic != null) {
+            out.add(Constraint.OneOf.dynamic(dynamic.expression(), dynamic.fallback()));
+            return;
+        }
+        if (hasOptions(field.options())) {
+            out.add(new Constraint.OneOf(field.options()));
+        }
+    }
+
+    private static void addMultiValueOptionsConstraint(MultiValueOptionsField field, List<Constraint> out) {
+        var dynamic = field.dynamicOptions();
+        if (dynamic != null) {
+            out.add(Constraint.EachOf.dynamic(dynamic.expression(), dynamic.fallback()));
+            return;
+        }
+        if (hasOptions(field.options())) {
+            out.add(new Constraint.EachOf(field.options()));
+        }
     }
 
     private static boolean hasOptions(List<String> options) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormElResolverDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormElResolverDomainService.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.domain_service;
+
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves EL expressions embedded in subscription form option fields.
+ *
+ * <p>Used in two contexts:</p>
+ * <ul>
+ *   <li><b>Form retrieval</b> — resolves {@link SubscriptionFormSchema.DynamicOptions} expressions for
+ *       option-bearing fields and returns a {@code fieldKey → resolved options} map to the frontend.</li>
+ *   <li><b>Subscription validation</b> — resolves dynamic option constraints ({@link io.gravitee.apim.core.subscription_form.model.Constraint.OneOf}
+ *       and {@link io.gravitee.apim.core.subscription_form.model.Constraint.EachOf} with expression/fallback metadata)
+ *       before the validator runs.</li>
+ * </ul>
+ *
+ * <p>Each method has two variants: one that accepts an API context (environment + API id) for full metadata
+ * resolution, and one without — for situations where no API context is available (e.g. Console Form Builder).
+ * The no-context variants use the configured fallback values directly.</p>
+ *
+ * @author Gravitee.io Team
+ */
+public interface SubscriptionFormElResolverDomainService {
+    /**
+     * Resolves EL expressions for all dynamic-option fields in the schema against API + environment metadata.
+     *
+     * @param schema        the subscription form schema
+     * @param environmentId the environment identifier
+     * @param apiId         the API identifier
+     * @return a map of {@code fieldKey → effective option list} for every field that has dynamic options
+     */
+    Map<String, List<String>> resolveSchemaOptions(SubscriptionFormSchema schema, String environmentId, String apiId);
+
+    /**
+     * No-context variant — resolves expressions without API/environment metadata and falls back when resolution fails.
+     */
+    Map<String, List<String>> resolveSchemaOptions(SubscriptionFormSchema schema);
+
+    /**
+     * Resolves dynamic option constraints (OneOf/EachOf with expression/fallback metadata)
+     * to effective options using API + environment metadata.
+     *
+     * @param constraints   the stored constraints (some OneOf/EachOf constraints may carry expression/fallback metadata)
+     * @param environmentId the environment identifier
+     * @param apiId         the API identifier
+     * @return a new {@link SubscriptionFormFieldConstraints} with all dynamic options resolved
+     */
+    SubscriptionFormFieldConstraints resolveConstraints(
+        @Nonnull SubscriptionFormFieldConstraints constraints,
+        String environmentId,
+        String apiId
+    );
+
+    /**
+     * No-context variant — resolves dynamic options using configured fallback values when context-based resolution is not possible.
+     */
+    SubscriptionFormFieldConstraints resolveConstraints(@Nonnull SubscriptionFormFieldConstraints constraints);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormExpressionResolverDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormExpressionResolverDomainService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.domain_service;
+
+import java.util.List;
+import java.util.Map;
+
+public interface SubscriptionFormExpressionResolverDomainService {
+    List<String> resolveToOptions(String expression, Map<String, Object> templateParams);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/exception/SubscriptionFormDefinitionValidationException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/exception/SubscriptionFormDefinitionValidationException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription_form.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import java.util.List;
+import lombok.Getter;
+
+/**
+ * Thrown when a subscription form definition (GMD template itself) is invalid.
+ *
+ * <p>This is distinct from {@link SubscriptionFormValidationException}, which is used for validating
+ * submitted subscription metadata values against an already valid schema.</p>
+ *
+ * @author Gravitee.io Team
+ */
+@Getter
+public class SubscriptionFormDefinitionValidationException extends ValidationDomainException {
+
+    private final List<String> errors;
+
+    public SubscriptionFormDefinitionValidationException(List<String> errors) {
+        this(errors, null);
+    }
+
+    public SubscriptionFormDefinitionValidationException(List<String> errors, Throwable cause) {
+        super("Subscription form definition is invalid: " + String.join(", ", errors), cause);
+        this.getParameters().put("errors", String.join(", ", errors));
+        this.errors = List.copyOf(errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/exception/SubscriptionFormDefinitionValidationException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/exception/SubscriptionFormDefinitionValidationException.java
@@ -27,10 +27,14 @@ import lombok.Getter;
  *
  * @author Gravitee.io Team
  */
-@Getter
 public class SubscriptionFormDefinitionValidationException extends ValidationDomainException {
 
+    @Getter
     private final List<String> errors;
+
+    public SubscriptionFormDefinitionValidationException(String error) {
+        this(List.of(error));
+    }
 
     public SubscriptionFormDefinitionValidationException(List<String> errors) {
         this(errors, null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/Constraint.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/Constraint.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 
@@ -50,6 +51,8 @@ import java.util.stream.Stream;
         @JsonSubTypes.Type(value = Constraint.MatchesPattern.class, name = "matchesPattern"),
         @JsonSubTypes.Type(value = Constraint.OneOf.class, name = "oneOf"),
         @JsonSubTypes.Type(value = Constraint.EachOf.class, name = "eachOf"),
+        @JsonSubTypes.Type(value = Constraint.OneOf.class, name = "dynamicOneOf"),
+        @JsonSubTypes.Type(value = Constraint.EachOf.class, name = "dynamicEachOf"),
     }
 )
 public sealed interface Constraint
@@ -61,8 +64,7 @@ public sealed interface Constraint
         Constraint.MinLength,
         Constraint.MaxLength,
         Constraint.MatchesPattern,
-        Constraint.OneOf,
-        Constraint.EachOf {
+        Constraint.ResolvableOptions {
     /**
      * Whether the submitted value satisfies this constraint. The value is already trimmed; an empty string means absent.
      */
@@ -211,22 +213,52 @@ public sealed interface Constraint
     }
 
     /** Single value must be one of the allowed options (skipped when empty). */
-    record OneOf(List<String> options) implements Constraint {
+    record OneOf(List<String> options, String expression, List<String> fallback) implements ResolvableOptions {
+        public OneOf(List<String> options) {
+            this(options, null, null);
+        }
+
+        public static OneOf dynamic(String expression, List<String> fallback) {
+            return new OneOf(null, expression, fallback);
+        }
+
         @Override
         public boolean check(String value) {
+            if (isDynamic() && options == null) {
+                throw unresolvedConstraintException();
+            }
             return options == null || options.isEmpty() || value.isEmpty() || options.contains(value);
         }
 
         @Override
         public String formatErrorMessage(String fieldKey, String value) {
+            if (isDynamic() && options == null) {
+                throw unresolvedConstraintException();
+            }
             return String.format("Field '%s': value '%s' is not among the allowed options", fieldKey, value);
+        }
+
+        @Override
+        public Constraint withResolvedOptions(List<String> resolvedOptions) {
+            return new OneOf(resolvedOptions);
         }
     }
 
     /** Every value in a comma-separated string must be one of the allowed options (skipped when empty). */
-    record EachOf(List<String> options) implements Constraint {
+    record EachOf(List<String> options, String expression, List<String> fallback) implements ResolvableOptions {
+        public EachOf(List<String> options) {
+            this(options, null, null);
+        }
+
+        public static EachOf dynamic(String expression, List<String> fallback) {
+            return new EachOf(null, expression, fallback);
+        }
+
         @Override
         public boolean check(String value) {
+            if (isDynamic() && options == null) {
+                throw unresolvedConstraintException();
+            }
             if (options == null || options.isEmpty() || value.isEmpty()) {
                 return true;
             }
@@ -236,6 +268,9 @@ public sealed interface Constraint
 
         @Override
         public String formatErrorMessage(String fieldKey, String value) {
+            if (isDynamic() && options == null) {
+                throw unresolvedConstraintException();
+            }
             if (options == null || options.isEmpty() || value.isEmpty()) {
                 return "";
             }
@@ -245,6 +280,42 @@ public sealed interface Constraint
                 .map(item -> String.format("Field '%s': value '%s' is not among the allowed options", fieldKey, item))
                 .toList();
             return String.join("\n", lines);
+        }
+
+        @Override
+        public Constraint withResolvedOptions(List<String> resolvedOptions) {
+            return new EachOf(resolvedOptions);
+        }
+    }
+
+    /**
+     * Contract for option constraints that are resolved at runtime.
+     *
+     * <p>Implementations may store an expression and fallback options.
+     * They must be resolved to effective options via {@link #resolve(BiFunction)} before validation.</p>
+     */
+    non-sealed interface ResolvableOptions extends Constraint {
+        String expression();
+
+        List<String> fallback();
+
+        Constraint withResolvedOptions(List<String> resolvedOptions);
+
+        default boolean isDynamic() {
+            return expression() != null;
+        }
+
+        default Constraint resolve(BiFunction<String, List<String>, List<String>> resolver) {
+            if (!isDynamic()) {
+                return this;
+            }
+            return withResolvedOptions(resolver.apply(expression(), fallback()));
+        }
+
+        default UnsupportedOperationException unresolvedConstraintException() {
+            return new UnsupportedOperationException(
+                getClass().getSimpleName() + " must be resolved before validation — call resolve() first"
+            );
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/Constraint.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/Constraint.java
@@ -15,13 +15,16 @@
  */
 package io.gravitee.apim.core.subscription_form.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Stream;
 
@@ -51,8 +54,8 @@ import java.util.stream.Stream;
         @JsonSubTypes.Type(value = Constraint.MatchesPattern.class, name = "matchesPattern"),
         @JsonSubTypes.Type(value = Constraint.OneOf.class, name = "oneOf"),
         @JsonSubTypes.Type(value = Constraint.EachOf.class, name = "eachOf"),
-        @JsonSubTypes.Type(value = Constraint.OneOf.class, name = "dynamicOneOf"),
-        @JsonSubTypes.Type(value = Constraint.EachOf.class, name = "dynamicEachOf"),
+        @JsonSubTypes.Type(value = Constraint.DynamicOneOf.class, name = "dynamicOneOf"),
+        @JsonSubTypes.Type(value = Constraint.DynamicEachOf.class, name = "dynamicEachOf"),
     }
 )
 public sealed interface Constraint
@@ -64,6 +67,8 @@ public sealed interface Constraint
         Constraint.MinLength,
         Constraint.MaxLength,
         Constraint.MatchesPattern,
+        Constraint.OneOf,
+        Constraint.EachOf,
         Constraint.ResolvableOptions {
     /**
      * Whether the submitted value satisfies this constraint. The value is already trimmed; an empty string means absent.
@@ -213,110 +218,188 @@ public sealed interface Constraint
     }
 
     /** Single value must be one of the allowed options (skipped when empty). */
-    record OneOf(List<String> options, String expression, List<String> fallback) implements ResolvableOptions {
-        public OneOf(List<String> options) {
-            this(options, null, null);
-        }
-
-        public static OneOf dynamic(String expression, List<String> fallback) {
-            return new OneOf(null, expression, fallback);
+    record OneOf(List<String> options) implements Constraint {
+        public static DynamicOneOf dynamic(String expression, List<String> fallback) {
+            return new DynamicOneOf(expression, fallback);
         }
 
         @Override
         public boolean check(String value) {
-            if (isDynamic() && options == null) {
-                throw unresolvedConstraintException();
-            }
-            return options == null || options.isEmpty() || value.isEmpty() || options.contains(value);
+            return oneOfCheck(options, value);
         }
 
         @Override
         public String formatErrorMessage(String fieldKey, String value) {
-            if (isDynamic() && options == null) {
-                throw unresolvedConstraintException();
-            }
             return String.format("Field '%s': value '%s' is not among the allowed options", fieldKey, value);
-        }
-
-        @Override
-        public Constraint withResolvedOptions(List<String> resolvedOptions) {
-            return new OneOf(resolvedOptions);
         }
     }
 
     /** Every value in a comma-separated string must be one of the allowed options (skipped when empty). */
-    record EachOf(List<String> options, String expression, List<String> fallback) implements ResolvableOptions {
-        public EachOf(List<String> options) {
-            this(options, null, null);
-        }
-
-        public static EachOf dynamic(String expression, List<String> fallback) {
-            return new EachOf(null, expression, fallback);
+    record EachOf(List<String> options) implements Constraint {
+        public static DynamicEachOf dynamic(String expression, List<String> fallback) {
+            return new DynamicEachOf(expression, fallback);
         }
 
         @Override
         public boolean check(String value) {
-            if (isDynamic() && options == null) {
-                throw unresolvedConstraintException();
-            }
-            if (options == null || options.isEmpty() || value.isEmpty()) {
-                return true;
-            }
-            Set<String> allowed = new HashSet<>(options);
-            return splitCsv(value).allMatch(allowed::contains);
+            return eachOfCheck(options, value);
         }
 
         @Override
         public String formatErrorMessage(String fieldKey, String value) {
-            if (isDynamic() && options == null) {
-                throw unresolvedConstraintException();
-            }
-            if (options == null || options.isEmpty() || value.isEmpty()) {
-                return "";
-            }
-            Set<String> allowed = new HashSet<>(options);
-            var lines = splitCsv(value)
-                .filter(item -> !allowed.contains(item))
-                .map(item -> String.format("Field '%s': value '%s' is not among the allowed options", fieldKey, item))
-                .toList();
-            return String.join("\n", lines);
+            return eachOfErrorMessage(options, fieldKey, value);
+        }
+    }
+
+    /** Dynamic single-value options constraint resolved from an EL expression. */
+    final class DynamicOneOf extends ResolvableOptions {
+
+        @JsonCreator
+        public DynamicOneOf(@JsonProperty("expression") String expression, @JsonProperty("fallback") List<String> fallback) {
+            super(expression, fallback, false, List.of());
         }
 
         @Override
-        public Constraint withResolvedOptions(List<String> resolvedOptions) {
-            return new EachOf(resolvedOptions);
+        public boolean check(String value) {
+            return oneOfCheck(this.options, value);
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            return String.format("Field '%s': value '%s' is not among the allowed options", fieldKey, value);
+        }
+    }
+
+    /** Dynamic multi-value options constraint resolved from an EL expression. */
+    final class DynamicEachOf extends ResolvableOptions {
+
+        @JsonCreator
+        public DynamicEachOf(@JsonProperty("expression") String expression, @JsonProperty("fallback") List<String> fallback) {
+            super(expression, fallback, false, List.of());
+        }
+
+        @Override
+        public boolean check(String value) {
+            return eachOfCheck(this.options, value);
+        }
+
+        @Override
+        public String formatErrorMessage(String fieldKey, String value) {
+            return eachOfErrorMessage(this.options, fieldKey, value);
         }
     }
 
     /**
-     * Contract for option constraints that are resolved at runtime.
+     * Base type for option constraints that are resolved at runtime.
      *
-     * <p>Implementations may store an expression and fallback options.
-     * They must be resolved to effective options via {@link #resolve(BiFunction)} before validation.</p>
+     * <p>Fallback values are used as effective options when expression resolution returns no values.</p>
      */
-    non-sealed interface ResolvableOptions extends Constraint {
-        String expression();
+    abstract sealed class ResolvableOptions implements Constraint permits DynamicOneOf, DynamicEachOf {
 
-        List<String> fallback();
+        private final String expression;
+        private final List<String> fallback;
+        private boolean resolved;
+        protected List<String> options;
 
-        Constraint withResolvedOptions(List<String> resolvedOptions);
-
-        default boolean isDynamic() {
-            return expression() != null;
+        protected ResolvableOptions(String expression, List<String> fallback, boolean resolved, List<String> options) {
+            this.expression = expression;
+            this.fallback = normalizeOptions(fallback);
+            this.resolved = resolved;
+            this.options = options != null ? normalizeOptions(options) : this.fallback;
         }
 
-        default Constraint resolve(BiFunction<String, List<String>, List<String>> resolver) {
-            if (!isDynamic()) {
-                return this;
+        @JsonProperty("expression")
+        public String expression() {
+            return expression;
+        }
+
+        @JsonProperty("fallback")
+        public List<String> fallback() {
+            return fallback;
+        }
+
+        public boolean resolved() {
+            return resolved;
+        }
+
+        public List<String> options() {
+            return options;
+        }
+
+        public final void resolve(Function<String, List<String>> resolver) {
+            if (resolved) {
+                throw new IllegalStateException("Dynamic constraint already resolved");
             }
-            return withResolvedOptions(resolver.apply(expression(), fallback()));
+            var resolvedOptions = resolver.apply(expression);
+            this.options = normalizeOptions(resolvedOptions == null || resolvedOptions.isEmpty() ? fallback : resolvedOptions);
+            this.resolved = true;
         }
 
-        default UnsupportedOperationException unresolvedConstraintException() {
-            return new UnsupportedOperationException(
-                getClass().getSimpleName() + " must be resolved before validation — call resolve() first"
+        @Override
+        public final boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ResolvableOptions that = (ResolvableOptions) o;
+            return (
+                resolved == that.resolved &&
+                Objects.equals(expression, that.expression) &&
+                Objects.equals(fallback, that.fallback) &&
+                Objects.equals(options, that.options)
             );
         }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hash(getClass(), expression, fallback, resolved, options);
+        }
+
+        @Override
+        public String toString() {
+            return (
+                getClass().getSimpleName() +
+                "[expression=" +
+                expression +
+                ", fallback=" +
+                fallback +
+                ", resolved=" +
+                resolved +
+                ", options=" +
+                options +
+                "]"
+            );
+        }
+
+        private static List<String> normalizeOptions(List<String> options) {
+            return options == null ? List.of() : List.copyOf(options);
+        }
+    }
+
+    private static boolean oneOfCheck(List<String> options, String value) {
+        return options == null || options.isEmpty() || value.isEmpty() || options.contains(value);
+    }
+
+    private static boolean eachOfCheck(List<String> options, String value) {
+        if (options == null || options.isEmpty() || value.isEmpty()) {
+            return true;
+        }
+        Set<String> allowed = new HashSet<>(options);
+        return splitCsv(value).allMatch(allowed::contains);
+    }
+
+    private static String eachOfErrorMessage(List<String> options, String fieldKey, String value) {
+        if (options == null || options.isEmpty() || value.isEmpty()) {
+            return "";
+        }
+        Set<String> allowed = new HashSet<>(options);
+        var lines = splitCsv(value)
+            .filter(item -> !allowed.contains(item))
+            .map(item -> String.format("Field '%s': value '%s' is not among the allowed options", fieldKey, item))
+            .toList();
+        return String.join("\n", lines);
     }
 
     private static Stream<String> splitCsv(String value) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/SubscriptionFormSchema.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/model/SubscriptionFormSchema.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.subscription_form.model;
 
 import java.util.List;
+import lombok.Builder;
 
 /**
  * Represents the validation schema extracted from a subscription form's GMD content.
@@ -38,6 +39,12 @@ public record SubscriptionFormSchema(List<Field> fields) {
         boolean required();
     }
 
+    public interface RequiredValueAttribute extends RequiredAttribute {}
+
+    public interface RequiredTrueAttribute extends RequiredAttribute {}
+
+    public interface RequiredSelectionAttribute extends RequiredAttribute {}
+
     public interface ReadOnlyValueAttribute {
         String readonlyValue();
     }
@@ -58,6 +65,23 @@ public record SubscriptionFormSchema(List<Field> fields) {
         List<String> options();
     }
 
+    public interface DynamicOptionsAttribute {
+        DynamicOptions dynamicOptions();
+    }
+
+    public interface SingleValueOptionsField extends OptionsAttribute, DynamicOptionsAttribute {}
+
+    public interface MultiValueOptionsField extends OptionsAttribute, DynamicOptionsAttribute {}
+
+    /**
+     * Holds a Gravitee EL expression and its fallback option list for option-bearing fields.
+     *
+     * <p>GMD syntax: {@code options="{#expression}:fallback1,fallback2"}</p>
+     * <p>When present on a field, the expression is resolved at retrieval time against the
+     * target API's metadata. If resolution fails, {@code fallback} is used instead.</p>
+     */
+    public record DynamicOptions(String expression, List<String> fallback) {}
+
     /**
      * Marker interface for all field types in a subscription form schema.
      * Each implementation captures only the validation attributes relevant to its component type.
@@ -69,6 +93,7 @@ public record SubscriptionFormSchema(List<Field> fields) {
     }
 
     /** Text input — supports required, readonly, minLength, maxLength, pattern. */
+    @Builder
     public record InputField(
         String fieldKey,
         boolean required,
@@ -76,22 +101,53 @@ public record SubscriptionFormSchema(List<Field> fields) {
         Integer minLength,
         Integer maxLength,
         String pattern
-    ) implements Field, ReadOnlyValueAttribute, MinLengthAttribute, MaxLengthAttribute, PatternAttribute {}
+    ) implements Field, RequiredValueAttribute, ReadOnlyValueAttribute, MinLengthAttribute, MaxLengthAttribute, PatternAttribute {}
 
     /** Multi-line textarea — supports required, readonly, minLength, maxLength. */
+    @Builder
     public record TextareaField(String fieldKey, boolean required, String readonlyValue, Integer minLength, Integer maxLength) implements
-        Field, ReadOnlyValueAttribute, MinLengthAttribute, MaxLengthAttribute {}
+        Field, RequiredValueAttribute, ReadOnlyValueAttribute, MinLengthAttribute, MaxLengthAttribute {}
 
-    /** Single-value dropdown — supports required, options. No readonly (not supported by the GMD component). */
-    public record SelectField(String fieldKey, boolean required, List<String> options) implements Field, OptionsAttribute {}
+    /** Single-value dropdown — supports required, static options, or dynamic EL options. No readonly (not supported by the GMD component). */
+    @Builder
+    public record SelectField(String fieldKey, boolean required, List<String> options, DynamicOptions dynamicOptions) implements
+        Field, RequiredValueAttribute, SingleValueOptionsField {
+        public SelectField {
+            if (options != null && dynamicOptions != null) {
+                throw new IllegalArgumentException("SelectField cannot define both static options and dynamic options");
+            }
+        }
+    }
 
-    /** Single-value radio group — supports required, readonly, options. */
-    public record RadioField(String fieldKey, boolean required, String readonlyValue, List<String> options) implements
-        Field, ReadOnlyValueAttribute, OptionsAttribute {}
+    /** Single-value radio group — supports required, readonly, static options, or dynamic EL options. */
+    @Builder
+    public record RadioField(
+        String fieldKey,
+        boolean required,
+        String readonlyValue,
+        List<String> options,
+        DynamicOptions dynamicOptions
+    ) implements Field, RequiredValueAttribute, ReadOnlyValueAttribute, SingleValueOptionsField {
+        public RadioField {
+            if (options != null && dynamicOptions != null) {
+                throw new IllegalArgumentException("RadioField cannot define both static options and dynamic options");
+            }
+        }
+    }
 
     /** Boolean checkbox — supports required, readonly. Value is "true"/"false". */
-    public record CheckboxField(String fieldKey, boolean required, String readonlyValue) implements Field, ReadOnlyValueAttribute {}
+    @Builder
+    public record CheckboxField(String fieldKey, boolean required, String readonlyValue) implements
+        Field, RequiredTrueAttribute, ReadOnlyValueAttribute {}
 
-    /** Multi-value checkbox group — supports required, options. No readonly (not supported by the GMD component). */
-    public record CheckboxGroupField(String fieldKey, boolean required, List<String> options) implements Field, OptionsAttribute {}
+    /** Multi-value checkbox group — supports required, static options, or dynamic EL options. No readonly (not supported by the GMD component). */
+    @Builder
+    public record CheckboxGroupField(String fieldKey, boolean required, List<String> options, DynamicOptions dynamicOptions) implements
+        Field, RequiredSelectionAttribute, MultiValueOptionsField {
+        public CheckboxGroupField {
+            if (options != null && dynamicOptions != null) {
+                throw new IllegalArgumentException("CheckboxGroupField cannot define both static options and dynamic options");
+            }
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/GetSubscriptionFormForEnvironmentUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/GetSubscriptionFormForEnvironmentUseCase.java
@@ -16,13 +16,23 @@
 package io.gravitee.apim.core.subscription_form.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormElResolverDomainService;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormNotFoundException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
 import io.gravitee.apim.core.subscription_form.query_service.SubscriptionFormQueryService;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Use case for getting the subscription form for an environment (the default form for that environment).
+ * Use case for getting the subscription form for an environment.
+ *
+ * <p>When {@link Input#apiId()} is non-null, EL expressions in option-bearing fields are resolved
+ * against the target API's metadata and returned in {@link Output#resolvedOptions()}.
+ * When null (e.g. Console Form Builder), resolution is attempted without API/environment metadata,
+ * then falls back to configured options on failure.</p>
  *
  * @author Gravitee.io Team
  */
@@ -31,6 +41,8 @@ import lombok.RequiredArgsConstructor;
 public class GetSubscriptionFormForEnvironmentUseCase {
 
     private final SubscriptionFormQueryService subscriptionFormQueryService;
+    private final SubscriptionFormSchemaGenerator schemaGenerator;
+    private final SubscriptionFormElResolverDomainService elResolver;
 
     public Output execute(Input input) {
         var subscriptionForm = subscriptionFormQueryService
@@ -41,10 +53,25 @@ public class GetSubscriptionFormForEnvironmentUseCase {
             throw new SubscriptionFormNotFoundException(input.environmentId());
         }
 
-        return new Output(subscriptionForm);
+        var schema = schemaGenerator.generate(subscriptionForm.getGmdContent());
+        var resolvedOptions = input.apiId() != null
+            ? elResolver.resolveSchemaOptions(schema, input.environmentId(), input.apiId())
+            : elResolver.resolveSchemaOptions(schema);
+
+        return new Output(subscriptionForm, resolvedOptions);
     }
 
-    public record Input(String environmentId, boolean onlyEnabled) {}
+    @Builder
+    public record Input(String environmentId, boolean onlyEnabled, String apiId) {
+        /**
+         * Backward-compatible constructor for callers that don't provide an API context.
+         * TODO: remove once the resource layer is wired (APIM-12990 resource PR).
+         */
+        @Deprecated
+        public Input(String environmentId, boolean onlyEnabled) {
+            this(environmentId, onlyEnabled, null);
+        }
+    }
 
-    public record Output(SubscriptionForm subscriptionForm) {}
+    public record Output(SubscriptionForm subscriptionForm, Map<String, List<String>> resolvedOptions) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCase.java
@@ -28,7 +28,6 @@ import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
 import io.gravitee.apim.core.subscription_form.query_service.SubscriptionFormQueryService;
-import java.util.List;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -76,7 +75,7 @@ public class UpdateSubscriptionFormUseCase {
     private void validateFieldCount(SubscriptionFormSchema schema) {
         if (schema != null && schema.fields().size() > SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT) {
             throw new SubscriptionFormDefinitionValidationException(
-                List.of("Subscription form must not exceed " + SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT + " fields")
+                "Subscription form must not exceed " + SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT + " fields"
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCase.java
@@ -22,8 +22,8 @@ import io.gravitee.apim.core.subscription_form.crud_service.SubscriptionFormCrud
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormConstraintsFactory;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSubmissionValidator;
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormDefinitionValidationException;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormNotFoundException;
-import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
@@ -62,7 +62,7 @@ public class UpdateSubscriptionFormUseCase {
             );
 
         var gmd = GraviteeMarkdown.of(input.gmdContent());
-        var schema = schemaGenerator.generate(gmd);
+        SubscriptionFormSchema schema = schemaGenerator.generate(gmd);
         validateFieldCount(schema);
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         existingForm.update(gmd, constraints);
@@ -75,7 +75,7 @@ public class UpdateSubscriptionFormUseCase {
 
     private void validateFieldCount(SubscriptionFormSchema schema) {
         if (schema != null && schema.fields().size() > SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT) {
-            throw new SubscriptionFormValidationException(
+            throw new SubscriptionFormDefinitionValidationException(
                 List.of("Subscription form must not exceed " + SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT + " fields")
             );
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription_form/GraviteeElSubscriptionFormExpressionResolverDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription_form/GraviteeElSubscriptionFormExpressionResolverDomainServiceImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.subscription_form;
+
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormExpressionResolverDomainService;
+import io.gravitee.el.TemplateEngine;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import lombok.CustomLog;
+import org.springframework.stereotype.Service;
+
+@Service
+@CustomLog
+public class GraviteeElSubscriptionFormExpressionResolverDomainServiceImpl implements SubscriptionFormExpressionResolverDomainService {
+
+    @Override
+    public List<String> resolveToOptions(String expression, Map<String, Object> templateParams) {
+        try {
+            var templateEngine = TemplateEngine.templateEngine();
+            templateParams.forEach((key, value) -> templateEngine.getTemplateContext().setVariable(key, value));
+
+            String resolved = templateEngine.evalNow(expression, String.class);
+            if (resolved == null || resolved.isBlank()) {
+                return List.of();
+            }
+
+            return Arrays.stream(resolved.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+        } catch (Exception e) {
+            log.warn("Failed to resolve EL expression '{}' for subscription form options", expression, e);
+            return List.of();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormElResolverDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormElResolverDomainServiceImpl.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.subscription_form;
+
+import io.gravitee.apim.core.api.model.ApiMetadata;
+import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
+import io.gravitee.apim.core.documentation.domain_service.TemplateResolverDomainService;
+import io.gravitee.apim.core.documentation.exception.InvalidPageContentException;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormElResolverDomainService;
+import io.gravitee.apim.core.subscription_form.model.Constraint;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.DynamicOptionsAttribute;
+import jakarta.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Resolves EL expressions in subscription form option fields using template resolution.
+ *
+ * <p>Expressions are stored and passed around as a Gravitee EL snippet (for example {@code {#api.metadata['envs']}})
+ * and are evaluated against the target API's metadata. On resolution failure the configured fallback list is used transparently.</p>
+ *
+ * @author Gravitee.io Team
+ */
+@Service
+@RequiredArgsConstructor
+@CustomLog
+public class SubscriptionFormElResolverDomainServiceImpl implements SubscriptionFormElResolverDomainService {
+
+    private final TemplateResolverDomainService templateResolver;
+    private final ApiMetadataQueryService apiMetadataQueryService;
+
+    @Override
+    public Map<String, List<String>> resolveSchemaOptions(SubscriptionFormSchema schema, String environmentId, String apiId) {
+        return resolveSchemaOptionsWithParams(schema, buildTemplateParams(environmentId, apiId));
+    }
+
+    @Override
+    public Map<String, List<String>> resolveSchemaOptions(SubscriptionFormSchema schema) {
+        return resolveSchemaOptionsWithParams(schema, Map.of());
+    }
+
+    @Override
+    public SubscriptionFormFieldConstraints resolveConstraints(
+        @Nonnull SubscriptionFormFieldConstraints constraints,
+        String environmentId,
+        String apiId
+    ) {
+        return resolveConstraintsWithParams(constraints, buildTemplateParams(environmentId, apiId));
+    }
+
+    @Override
+    public SubscriptionFormFieldConstraints resolveConstraints(@Nonnull SubscriptionFormFieldConstraints constraints) {
+        return resolveConstraintsWithParams(constraints, Map.of());
+    }
+
+    private Map<String, List<String>> resolveSchemaOptionsWithParams(SubscriptionFormSchema schema, Map<String, Object> templateParams) {
+        if (schema == null || schema.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, List<String>> result = new LinkedHashMap<>();
+        for (SubscriptionFormSchema.Field field : schema.fields()) {
+            if (field instanceof DynamicOptionsAttribute dyn && dyn.dynamicOptions() != null) {
+                var dynamic = dyn.dynamicOptions();
+                result.put(field.fieldKey(), resolve(dynamic.expression(), dynamic.fallback(), templateParams));
+            }
+        }
+        return result;
+    }
+
+    private SubscriptionFormFieldConstraints resolveConstraintsWithParams(
+        SubscriptionFormFieldConstraints constraints,
+        Map<String, Object> templateParams
+    ) {
+        if (constraints.isEmpty()) {
+            return constraints;
+        }
+
+        Map<String, List<Constraint>> resolved = new LinkedHashMap<>();
+        for (Map.Entry<String, List<Constraint>> entry : constraints.byFieldKey().entrySet()) {
+            resolved.put(entry.getKey(), resolveConstraintList(entry.getValue(), templateParams));
+        }
+        return new SubscriptionFormFieldConstraints(resolved);
+    }
+
+    private List<Constraint> resolveConstraintList(List<Constraint> constraints, Map<String, Object> templateParams) {
+        return constraints
+            .stream()
+            .map(constraint -> resolveConstraint(constraint, templateParams))
+            .toList();
+    }
+
+    private Constraint resolveConstraint(Constraint constraint, Map<String, Object> templateParams) {
+        if (constraint instanceof Constraint.ResolvableOptions resolvableOptions) {
+            return resolvableOptions.resolve((expression, fallback) -> resolve(expression, fallback, templateParams));
+        }
+        return constraint;
+    }
+
+    private List<String> resolve(String expression, List<String> fallback, Map<String, Object> templateParams) {
+        try {
+            String resolved = templateResolver.resolveTemplate(expression, templateParams);
+            String trimmedResolved = resolved != null ? resolved.trim() : null;
+            if (trimmedResolved == null || trimmedResolved.isEmpty()) {
+                return fallback;
+            }
+            List<String> options = Arrays.stream(trimmedResolved.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+            return options.isEmpty() ? fallback : options;
+        } catch (InvalidPageContentException e) {
+            log.warn("Failed to resolve EL expression '{}' for subscription form options, using fallback: {}", expression, e.getMessage());
+            return fallback;
+        }
+    }
+
+    private Map<String, Object> buildTemplateParams(String environmentId, String apiId) {
+        Map<String, Object> metadata = apiMetadataQueryService
+            .findApiMetadata(environmentId, apiId)
+            .entrySet()
+            .stream()
+            .filter(e -> effectiveValue(e.getValue()) != null)
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> (Object) effectiveValue(e.getValue())));
+
+        Map<String, Object> api = new HashMap<>();
+        api.put("metadata", metadata);
+        return Map.of("api", api);
+    }
+
+    private static String effectiveValue(ApiMetadata m) {
+        return m.getValue() != null ? m.getValue() : m.getDefaultValue();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormElResolverDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormElResolverDomainServiceImpl.java
@@ -17,21 +17,18 @@ package io.gravitee.apim.infra.domain_service.subscription_form;
 
 import io.gravitee.apim.core.api.model.ApiMetadata;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
-import io.gravitee.apim.core.documentation.domain_service.TemplateResolverDomainService;
-import io.gravitee.apim.core.documentation.exception.InvalidPageContentException;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormElResolverDomainService;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormExpressionResolverDomainService;
 import io.gravitee.apim.core.subscription_form.model.Constraint;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.DynamicOptionsAttribute;
 import jakarta.annotation.Nonnull;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -45,10 +42,9 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor
-@CustomLog
 public class SubscriptionFormElResolverDomainServiceImpl implements SubscriptionFormElResolverDomainService {
 
-    private final TemplateResolverDomainService templateResolver;
+    private final SubscriptionFormExpressionResolverDomainService expressionResolver;
     private final ApiMetadataQueryService apiMetadataQueryService;
 
     @Override
@@ -84,7 +80,10 @@ public class SubscriptionFormElResolverDomainServiceImpl implements Subscription
         for (SubscriptionFormSchema.Field field : schema.fields()) {
             if (field instanceof DynamicOptionsAttribute dyn && dyn.dynamicOptions() != null) {
                 var dynamic = dyn.dynamicOptions();
-                result.put(field.fieldKey(), resolve(dynamic.expression(), dynamic.fallback(), templateParams));
+                result.put(
+                    field.fieldKey(),
+                    resolveExpressionToOptionsWithFallback(dynamic.expression(), dynamic.fallback(), templateParams)
+                );
             }
         }
         return result;
@@ -98,43 +97,31 @@ public class SubscriptionFormElResolverDomainServiceImpl implements Subscription
             return constraints;
         }
 
-        Map<String, List<Constraint>> resolved = new LinkedHashMap<>();
         for (Map.Entry<String, List<Constraint>> entry : constraints.byFieldKey().entrySet()) {
-            resolved.put(entry.getKey(), resolveConstraintList(entry.getValue(), templateParams));
+            resolveConstraintList(entry.getValue(), templateParams);
         }
-        return new SubscriptionFormFieldConstraints(resolved);
+        return constraints;
     }
 
-    private List<Constraint> resolveConstraintList(List<Constraint> constraints, Map<String, Object> templateParams) {
-        return constraints
+    private void resolveConstraintList(List<Constraint> constraints, Map<String, Object> templateParams) {
+        constraints
             .stream()
-            .map(constraint -> resolveConstraint(constraint, templateParams))
-            .toList();
+            .filter(Constraint.ResolvableOptions.class::isInstance)
+            .map(Constraint.ResolvableOptions.class::cast)
+            .forEach(resolvable -> resolvable.resolve(expression -> resolveExpressionToOptions(expression, templateParams)));
     }
 
-    private Constraint resolveConstraint(Constraint constraint, Map<String, Object> templateParams) {
-        if (constraint instanceof Constraint.ResolvableOptions resolvableOptions) {
-            return resolvableOptions.resolve((expression, fallback) -> resolve(expression, fallback, templateParams));
-        }
-        return constraint;
+    private List<String> resolveExpressionToOptionsWithFallback(
+        String expression,
+        List<String> fallback,
+        Map<String, Object> templateParams
+    ) {
+        var resolvedOptions = resolveExpressionToOptions(expression, templateParams);
+        return resolvedOptions == null || resolvedOptions.isEmpty() ? fallback : resolvedOptions;
     }
 
-    private List<String> resolve(String expression, List<String> fallback, Map<String, Object> templateParams) {
-        try {
-            String resolved = templateResolver.resolveTemplate(expression, templateParams);
-            String trimmedResolved = resolved != null ? resolved.trim() : null;
-            if (trimmedResolved == null || trimmedResolved.isEmpty()) {
-                return fallback;
-            }
-            List<String> options = Arrays.stream(trimmedResolved.split(","))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .toList();
-            return options.isEmpty() ? fallback : options;
-        } catch (InvalidPageContentException e) {
-            log.warn("Failed to resolve EL expression '{}' for subscription form options, using fallback: {}", expression, e.getMessage());
-            return fallback;
-        }
+    private List<String> resolveExpressionToOptions(String expression, Map<String, Object> templateParams) {
+        return expressionResolver.resolveToOptions(expression, templateParams);
     }
 
     private Map<String, Object> buildTemplateParams(String environmentId, String apiId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormSchemaGeneratorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormSchemaGeneratorImpl.java
@@ -17,9 +17,11 @@ package io.gravitee.apim.infra.domain_service.subscription_form;
 
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormDefinitionValidationException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxGroupField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.DynamicOptions;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.Field;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.InputField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.RadioField;
@@ -28,6 +30,8 @@ import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.Text
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.springframework.stereotype.Service;
@@ -47,6 +51,13 @@ import org.springframework.stereotype.Service;
  */
 @Service
 public class SubscriptionFormSchemaGeneratorImpl implements SubscriptionFormSchemaGenerator {
+
+    /**
+     * Matches options values that contain a Gravitee EL expression: {@code {#expression}:fallback1,fallback2}
+     * Group 1 = the Gravitee EL snippet (for example {@code {#api.metadata['envs']}}),
+     * group 2 = the fallback list (may be empty).
+     */
+    private static final Pattern EL_OPTIONS_PATTERN = Pattern.compile("^(\\{#.+}):(.*)$", Pattern.DOTALL);
 
     private static final Set<String> FORM_FIELD_TAGS = Set.of(
         "gmd-input",
@@ -78,44 +89,134 @@ public class SubscriptionFormSchemaGeneratorImpl implements SubscriptionFormSche
     private Field toFieldSchema(Element el) {
         String fieldKey = el.attr("fieldkey").trim();
         if (fieldKey.isEmpty()) {
-            throw new IllegalArgumentException("GMD form field is missing required 'fieldkey' attribute for element: " + el.tagName());
+            throw invalidDefinition("GMD form field is missing required 'fieldkey' attribute for element: " + el.tagName());
         }
         boolean required = Boolean.parseBoolean(el.attr("required"));
 
         return switch (el.tagName()) {
-            case "gmd-input" -> new InputField(
-                fieldKey,
-                required,
-                parseReadonlyValue(el, fieldKey),
-                parseNullableInt(el, "minlength"),
-                parseNullableInt(el, "maxlength"),
-                el.hasAttr("pattern") ? el.attr("pattern").trim() : null
-            );
-            case "gmd-textarea" -> new TextareaField(
-                fieldKey,
-                required,
-                parseReadonlyValue(el, fieldKey),
-                parseNullableInt(el, "minlength"),
-                parseNullableInt(el, "maxlength")
-            );
-            case "gmd-select" -> new SelectField(fieldKey, required, parseOptions(el));
-            case "gmd-radio" -> new RadioField(fieldKey, required, parseReadonlyValue(el, fieldKey), parseOptions(el));
-            case "gmd-checkbox" -> new CheckboxField(fieldKey, required, parseReadonlyValue(el, fieldKey));
-            case "gmd-checkbox-group" -> new CheckboxGroupField(fieldKey, required, parseOptions(el));
-            default -> throw new IllegalArgumentException("Unknown GMD form field tag: " + el.tagName());
+            case "gmd-input" -> InputField.builder()
+                .fieldKey(fieldKey)
+                .required(required)
+                .readonlyValue(parseReadonlyValue(el, fieldKey))
+                .minLength(parseNullableInt(el, "minlength"))
+                .maxLength(parseNullableInt(el, "maxlength"))
+                .pattern(el.hasAttr("pattern") ? el.attr("pattern").trim() : null)
+                .build();
+            case "gmd-textarea" -> TextareaField.builder()
+                .fieldKey(fieldKey)
+                .required(required)
+                .readonlyValue(parseReadonlyValue(el, fieldKey))
+                .minLength(parseNullableInt(el, "minlength"))
+                .maxLength(parseNullableInt(el, "maxlength"))
+                .build();
+            case "gmd-select" -> {
+                var parsed = parseOptions(el, fieldKey);
+                yield switch (parsed) {
+                    case ParsedOptions.NoOptions ignored -> SelectField.builder().fieldKey(fieldKey).required(required).build();
+                    case ParsedOptions.StaticOptions(var values) -> SelectField.builder()
+                        .fieldKey(fieldKey)
+                        .required(required)
+                        .options(values)
+                        .build();
+                    case ParsedOptions.DynamicOptionsParsed(var dynamicOptions) -> SelectField.builder()
+                        .fieldKey(fieldKey)
+                        .required(required)
+                        .dynamicOptions(dynamicOptions)
+                        .build();
+                };
+            }
+            case "gmd-radio" -> {
+                var parsed = parseOptions(el, fieldKey);
+                var readonlyValue = parseReadonlyValue(el, fieldKey);
+                yield switch (parsed) {
+                    case ParsedOptions.NoOptions ignored -> RadioField.builder()
+                        .fieldKey(fieldKey)
+                        .required(required)
+                        .readonlyValue(readonlyValue)
+                        .build();
+                    case ParsedOptions.StaticOptions(var values) -> RadioField.builder()
+                        .fieldKey(fieldKey)
+                        .required(required)
+                        .readonlyValue(readonlyValue)
+                        .options(values)
+                        .build();
+                    case ParsedOptions.DynamicOptionsParsed(var dynamicOptions) -> RadioField.builder()
+                        .fieldKey(fieldKey)
+                        .required(required)
+                        .readonlyValue(readonlyValue)
+                        .dynamicOptions(dynamicOptions)
+                        .build();
+                };
+            }
+            case "gmd-checkbox" -> CheckboxField.builder()
+                .fieldKey(fieldKey)
+                .required(required)
+                .readonlyValue(parseReadonlyValue(el, fieldKey))
+                .build();
+            case "gmd-checkbox-group" -> {
+                var parsed = parseOptions(el, fieldKey);
+                yield switch (parsed) {
+                    case ParsedOptions.NoOptions ignored -> CheckboxGroupField.builder().fieldKey(fieldKey).required(required).build();
+                    case ParsedOptions.StaticOptions(var values) -> CheckboxGroupField.builder()
+                        .fieldKey(fieldKey)
+                        .required(required)
+                        .options(values)
+                        .build();
+                    case ParsedOptions.DynamicOptionsParsed(var dynamicOptions) -> CheckboxGroupField.builder()
+                        .fieldKey(fieldKey)
+                        .required(required)
+                        .dynamicOptions(dynamicOptions)
+                        .build();
+                };
+            }
+            default -> throw invalidDefinition("Unknown GMD form field tag: " + el.tagName());
         };
     }
 
     private String parseReadonlyValue(Element el, String fieldKey) {
         boolean readonly = Boolean.parseBoolean(el.attr("readonly"));
         if (readonly && !el.hasAttr("value")) {
-            throw new IllegalArgumentException("Readonly field '" + fieldKey + "' (" + el.tagName() + ") must have a 'value' attribute");
+            throw invalidDefinition("Readonly field '" + fieldKey + "' (" + el.tagName() + ") must have a 'value' attribute");
         }
         return readonly ? el.attr("value").trim() : null;
     }
 
-    private List<String> parseOptions(Element el) {
-        return el.hasAttr("options") ? parseCommaList(el.attr("options")) : null;
+    private sealed interface ParsedOptions
+        permits ParsedOptions.NoOptions, ParsedOptions.StaticOptions, ParsedOptions.DynamicOptionsParsed {
+        record NoOptions() implements ParsedOptions {}
+
+        record StaticOptions(List<String> values) implements ParsedOptions {}
+
+        record DynamicOptionsParsed(DynamicOptions value) implements ParsedOptions {}
+    }
+
+    private ParsedOptions parseOptions(Element el, String fieldKey) {
+        if (!el.hasAttr("options")) {
+            return new ParsedOptions.NoOptions();
+        }
+        String raw = el.attr("options").trim();
+
+        // Check if the whole value starts with {# — could be EL or a misconfigured EL without fallback.
+        if (raw.startsWith("{#")) {
+            Matcher m = EL_OPTIONS_PATTERN.matcher(raw);
+            if (!m.matches()) {
+                throw invalidDefinition(
+                    "Field '" +
+                        fieldKey +
+                        "': EL expression in 'options' requires a fallback list. " +
+                        "Use the format: {#expression}:fallback1,fallback2"
+                );
+            }
+            String expression = m.group(1).trim();
+            List<String> fallback = parseCommaList(m.group(2));
+            return new ParsedOptions.DynamicOptionsParsed(new DynamicOptions(expression, fallback));
+        }
+
+        return new ParsedOptions.StaticOptions(parseCommaList(raw));
+    }
+
+    private SubscriptionFormDefinitionValidationException invalidDefinition(String message) {
+        return new SubscriptionFormDefinitionValidationException(List.of(message));
     }
 
     private Integer parseNullableInt(Element el, String attrName) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImpl.java
@@ -23,8 +23,6 @@ import io.gravitee.apim.core.metadata.model.Metadata;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.MetadataRepository;
 import io.gravitee.repository.management.model.MetadataReferenceType;
-import io.gravitee.rest.api.model.MetadataFormat;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.*;
 import java.util.function.Function;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.rest.api.service.v4.impl.validation;
 
+import static java.util.Optional.ofNullable;
+
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormElResolverDomainService;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSubmissionValidator;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
 import io.gravitee.apim.core.subscription_form.query_service.SubscriptionFormQueryService;
@@ -53,6 +56,7 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
     private final EntrypointConnectorPluginService entrypointService;
     private final SubscriptionMetadataSanitizer subscriptionMetadataSanitizer;
     private final SubscriptionFormQueryService subscriptionFormQueryService;
+    private final SubscriptionFormElResolverDomainService subscriptionFormElResolver;
 
     private final ClientCertificateCrudService clientCertificateCrudService;
 
@@ -69,15 +73,24 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
         final GenericPlanEntity genericPlanEntity,
         final Map<String, String> metadata
     ) {
+        var submitted = ofNullable(metadata).orElseGet(Map::of);
+
         subscriptionFormQueryService
             .findDefaultForEnvironmentId(genericPlanEntity.getEnvironmentId())
             .filter(SubscriptionForm::isEnabled)
             .map(SubscriptionForm::getValidationConstraints)
             .filter(constraints -> !constraints.isEmpty())
-            .ifPresent(constraints -> {
-                var submitted = metadata != null ? metadata : Map.<String, String>of();
-                new SubscriptionFormSubmissionValidator(constraints).validate(submitted);
-            });
+            .map(constraints ->
+                GenericPlanEntity.ReferenceType.API.equals(genericPlanEntity.getReferenceType())
+                    ? subscriptionFormElResolver.resolveConstraints(
+                        constraints,
+                        genericPlanEntity.getEnvironmentId(),
+                        genericPlanEntity.getReferenceId()
+                    )
+                    : subscriptionFormElResolver.resolveConstraints(constraints)
+            )
+            .map(SubscriptionFormSubmissionValidator::new)
+            .ifPresent(validator -> validator.validate(submitted));
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/SubscriptionFormSchemaFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/SubscriptionFormSchemaFixtures.java
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.api.query_service;
+package fixtures.core.model;
 
-import io.gravitee.apim.core.api.model.ApiMetadata;
-import java.util.Map;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import java.util.List;
 
-public interface ApiMetadataQueryService {
-    /**
-     * Find all metadata for an API, merging environment-level defaults with API-level overrides.
-     * @param environmentId The environment id.
-     * @param apiId The API id.
-     * @return A map of metadata key to metadata (API value takes precedence over env default).
-     */
-    Map<String, ApiMetadata> findApiMetadata(String environmentId, String apiId);
+public final class SubscriptionFormSchemaFixtures {
+
+    private SubscriptionFormSchemaFixtures() {}
+
+    public static SubscriptionFormSchema schema(SubscriptionFormSchema.Field... fields) {
+        return new SubscriptionFormSchema(List.of(fields));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiMetadataQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiMetadataQueryServiceInMemory.java
@@ -21,8 +21,6 @@ import io.gravitee.apim.core.api.model.ApiMetadata;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.metadata.model.Metadata;
 import io.gravitee.apim.infra.adapter.MetadataAdapter;
-import io.gravitee.repository.management.model.MetadataReferenceType;
-import io.gravitee.rest.api.model.MetadataFormat;
 import java.util.*;
 import java.util.function.Function;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionFormElResolverInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionFormElResolverInMemory.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormElResolverDomainService;
+import io.gravitee.apim.core.subscription_form.model.Constraint;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.DynamicOptionsAttribute;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * In-memory test double for {@link SubscriptionFormElResolverDomainService}.
+ *
+ * <p>Pre-configured with a map of {@code expression → resolved options} via {@link #withResolved(Map)}.
+ * If an expression is not in the map, the fallback values are returned.</p>
+ */
+public class SubscriptionFormElResolverInMemory implements SubscriptionFormElResolverDomainService {
+
+    private Map<String, List<String>> resolvedByExpression = Map.of();
+
+    public SubscriptionFormElResolverInMemory withResolved(Map<String, List<String>> resolvedByExpression) {
+        this.resolvedByExpression = Map.copyOf(resolvedByExpression);
+        return this;
+    }
+
+    public void reset() {
+        this.resolvedByExpression = Map.of();
+    }
+
+    @Override
+    public Map<String, List<String>> resolveSchemaOptions(SubscriptionFormSchema schema) {
+        return resolveSchemaOptions(schema, null, null);
+    }
+
+    @Override
+    public SubscriptionFormFieldConstraints resolveConstraints(SubscriptionFormFieldConstraints constraints) {
+        return resolveConstraints(constraints, null, null);
+    }
+
+    @Override
+    public Map<String, List<String>> resolveSchemaOptions(SubscriptionFormSchema schema, String environmentId, String apiId) {
+        if (schema == null || schema.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<String, List<String>> result = new LinkedHashMap<>();
+        for (SubscriptionFormSchema.Field field : schema.fields()) {
+            if (field instanceof DynamicOptionsAttribute dyn && dyn.dynamicOptions() != null) {
+                var dynamic = dyn.dynamicOptions();
+                result.put(field.fieldKey(), resolvedByExpression.getOrDefault(dynamic.expression(), dynamic.fallback()));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public SubscriptionFormFieldConstraints resolveConstraints(
+        SubscriptionFormFieldConstraints constraints,
+        String environmentId,
+        String apiId
+    ) {
+        if (constraints == null || constraints.isEmpty()) {
+            return constraints;
+        }
+
+        Map<String, List<Constraint>> resolved = new LinkedHashMap<>();
+        for (Map.Entry<String, List<Constraint>> entry : constraints.byFieldKey().entrySet()) {
+            resolved.put(entry.getKey(), resolveConstraintList(entry.getValue()));
+        }
+        return new SubscriptionFormFieldConstraints(resolved);
+    }
+
+    private List<Constraint> resolveConstraintList(List<Constraint> constraints) {
+        return constraints.stream().map(this::resolveConstraint).collect(Collectors.toList());
+    }
+
+    private Constraint resolveConstraint(Constraint constraint) {
+        if (constraint instanceof Constraint.ResolvableOptions resolvableOptions) {
+            return resolvableOptions.resolve((expression, fallback) -> resolvedByExpression.getOrDefault(expression, fallback));
+        }
+        return constraint;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionFormElResolverInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionFormElResolverInMemory.java
@@ -23,7 +23,6 @@ import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.Dyna
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * In-memory test double for {@link SubscriptionFormElResolverDomainService}.
@@ -80,21 +79,19 @@ public class SubscriptionFormElResolverInMemory implements SubscriptionFormElRes
             return constraints;
         }
 
-        Map<String, List<Constraint>> resolved = new LinkedHashMap<>();
         for (Map.Entry<String, List<Constraint>> entry : constraints.byFieldKey().entrySet()) {
-            resolved.put(entry.getKey(), resolveConstraintList(entry.getValue()));
+            resolveConstraintList(entry.getValue());
         }
-        return new SubscriptionFormFieldConstraints(resolved);
+        return constraints;
     }
 
-    private List<Constraint> resolveConstraintList(List<Constraint> constraints) {
-        return constraints.stream().map(this::resolveConstraint).collect(Collectors.toList());
+    private void resolveConstraintList(List<Constraint> constraints) {
+        constraints.forEach(this::resolveConstraint);
     }
 
-    private Constraint resolveConstraint(Constraint constraint) {
+    private void resolveConstraint(Constraint constraint) {
         if (constraint instanceof Constraint.ResolvableOptions resolvableOptions) {
-            return resolvableOptions.resolve((expression, fallback) -> resolvedByExpression.getOrDefault(expression, fallback));
+            resolvableOptions.resolve(resolvedByExpression::get);
         }
-        return constraint;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -567,4 +567,9 @@ public class InMemoryConfiguration {
     public SubscriptionFormQueryServiceInMemory subscriptionFormQueryService() {
         return new SubscriptionFormQueryServiceInMemory();
     }
+
+    @Bean
+    public SubscriptionFormElResolverInMemory subscriptionFormElResolver() {
+        return new SubscriptionFormElResolverInMemory();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormConstraintsFactoryTest.java
@@ -15,14 +15,15 @@
  */
 package io.gravitee.apim.core.subscription_form.domain_service;
 
+import static fixtures.core.model.SubscriptionFormSchemaFixtures.schema;
 import static io.gravitee.apim.core.subscription_form.model.Constraint.MaxLength.INPUT_MAX_LENGTH;
 import static io.gravitee.apim.core.subscription_form.model.Constraint.MaxLength.TEXTAREA_MAX_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.core.subscription_form.model.Constraint;
-import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxGroupField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.DynamicOptions;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.InputField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.RadioField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.SelectField;
@@ -39,27 +40,31 @@ class SubscriptionFormConstraintsFactoryTest {
 
     @Test
     void should_return_empty_when_schema_has_no_fields() {
-        var schema = new SubscriptionFormSchema(List.of());
+        var schema = schema();
         assertThat(SubscriptionFormConstraintsFactory.fromSchema(schema).isEmpty()).isTrue();
     }
 
     @Test
     void should_map_readonly_input_to_single_read_only_constraint() {
-        var schema = new SubscriptionFormSchema(List.of(new InputField("ref", false, "REF-1", 1, 9, ".*")));
+        var schema = schema(
+            InputField.builder().fieldKey("ref").required(false).readonlyValue("REF-1").minLength(1).maxLength(9).pattern(".*").build()
+        );
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("ref")).containsExactly(new Constraint.ReadOnly("REF-1"));
     }
 
     @Test
     void should_ignore_required_and_options_when_radio_is_readonly() {
-        var schema = new SubscriptionFormSchema(List.of(new RadioField("plan", true, "Free", List.of("Free", "Pro"))));
+        var schema = schema(
+            RadioField.builder().fieldKey("plan").required(true).readonlyValue("Free").options(List.of("Free", "Pro")).build()
+        );
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("plan")).containsExactly(new Constraint.ReadOnly("Free"));
     }
 
     @Test
     void should_stack_input_constraints_in_defined_order() {
-        var schema = new SubscriptionFormSchema(List.of(new InputField("code", true, null, 2, 10, "[A-Z]+")));
+        var schema = schema(InputField.builder().fieldKey("code").required(true).minLength(2).maxLength(10).pattern("[A-Z]+").build());
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("code")).containsExactly(
             new Constraint.Required(),
@@ -71,7 +76,7 @@ class SubscriptionFormConstraintsFactoryTest {
 
     @Test
     void should_map_textarea_without_pattern() {
-        var schema = new SubscriptionFormSchema(List.of(new TextareaField("bio", true, null, 1, 500)));
+        var schema = schema(TextareaField.builder().fieldKey("bio").required(true).minLength(1).maxLength(500).build());
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("bio")).containsExactly(
             new Constraint.Required(),
@@ -82,60 +87,92 @@ class SubscriptionFormConstraintsFactoryTest {
 
     @Test
     void should_map_select_optional_with_one_of_only() {
-        var schema = new SubscriptionFormSchema(List.of(new SelectField("plan", false, List.of("Free", "Pro"))));
+        var schema = schema(SelectField.builder().fieldKey("plan").required(false).options(List.of("Free", "Pro")).build());
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("plan")).containsExactly(new Constraint.OneOf(List.of("Free", "Pro")));
     }
 
     @Test
     void should_map_required_checkbox_to_must_be_true() {
-        var schema = new SubscriptionFormSchema(List.of(new CheckboxField("terms", true, null)));
+        var schema = schema(CheckboxField.builder().fieldKey("terms").required(true).build());
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("terms")).containsExactly(new Constraint.MustBeTrue());
     }
 
     @Test
     void should_apply_system_max_length_to_input_when_no_user_max_defined() {
-        var schema = new SubscriptionFormSchema(List.of(new InputField("name", false, null, null, null, null)));
+        var schema = schema(InputField.builder().fieldKey("name").required(false).build());
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("name")).containsExactly(new Constraint.MaxLength(INPUT_MAX_LENGTH));
     }
 
     @Test
     void should_apply_system_max_length_to_textarea_when_no_user_max_defined() {
-        var schema = new SubscriptionFormSchema(List.of(new TextareaField("bio", false, null, null, null)));
+        var schema = schema(TextareaField.builder().fieldKey("bio").required(false).build());
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("bio")).containsExactly(new Constraint.MaxLength(TEXTAREA_MAX_LENGTH));
     }
 
     @Test
     void should_cap_input_max_length_at_system_limit_when_user_exceeds_it() {
-        var schema = new SubscriptionFormSchema(List.of(new InputField("name", false, null, null, 1000, null)));
+        var schema = schema(InputField.builder().fieldKey("name").required(false).maxLength(1000).build());
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("name")).containsExactly(new Constraint.MaxLength(INPUT_MAX_LENGTH));
     }
 
     @Test
     void should_cap_textarea_max_length_at_system_limit_when_user_exceeds_it() {
-        var schema = new SubscriptionFormSchema(List.of(new TextareaField("notes", false, null, null, 9999)));
+        var schema = schema(TextareaField.builder().fieldKey("notes").required(false).maxLength(9999).build());
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("notes")).containsExactly(new Constraint.MaxLength(TEXTAREA_MAX_LENGTH));
     }
 
     @Test
     void should_preserve_user_max_length_when_within_system_limit() {
-        var schema = new SubscriptionFormSchema(List.of(new InputField("code", false, null, null, 50, null)));
+        var schema = schema(InputField.builder().fieldKey("code").required(false).maxLength(50).build());
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("code")).containsExactly(new Constraint.MaxLength(50));
     }
 
     @Test
     void should_map_checkbox_group_required_with_each_of() {
-        var schema = new SubscriptionFormSchema(List.of(new CheckboxGroupField("tags", true, List.of("A", "B"))));
+        var schema = schema(CheckboxGroupField.builder().fieldKey("tags").required(true).options(List.of("A", "B")).build());
         var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
         assertThat(constraints.byFieldKey().get("tags")).containsExactly(
             new Constraint.NonEmptySelection(),
             new Constraint.EachOf(List.of("A", "B"))
+        );
+    }
+
+    @Test
+    void should_emit_dynamic_one_of_for_select_with_dynamic_options() {
+        var dynamic = new DynamicOptions("{#api.metadata['envs']}", List.of("Prod", "Test"));
+        var schema = schema(SelectField.builder().fieldKey("env").required(false).dynamicOptions(dynamic).build());
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("env")).containsExactly(
+            Constraint.OneOf.dynamic("{#api.metadata['envs']}", List.of("Prod", "Test"))
+        );
+    }
+
+    @Test
+    void should_emit_dynamic_one_of_for_radio_with_dynamic_options() {
+        var dynamic = new DynamicOptions("{#api.metadata['plans']}", List.of("Free"));
+        var schema = schema(RadioField.builder().fieldKey("plan").required(true).dynamicOptions(dynamic).build());
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("plan")).containsExactly(
+            new Constraint.Required(),
+            Constraint.OneOf.dynamic("{#api.metadata['plans']}", List.of("Free"))
+        );
+    }
+
+    @Test
+    void should_emit_dynamic_each_of_for_checkbox_group_with_dynamic_options() {
+        var dynamic = new DynamicOptions("{#api.metadata['tags']}", List.of("Alpha", "Beta"));
+        var schema = schema(CheckboxGroupField.builder().fieldKey("tags").required(true).dynamicOptions(dynamic).build());
+        var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
+        assertThat(constraints.byFieldKey().get("tags")).containsExactly(
+            new Constraint.NonEmptySelection(),
+            Constraint.EachOf.dynamic("{#api.metadata['tags']}", List.of("Alpha", "Beta"))
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSubmissionValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/domain_service/SubscriptionFormSubmissionValidatorTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.subscription_form.domain_service;
 
+import static fixtures.core.model.SubscriptionFormSchemaFixtures.schema;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,7 +40,7 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_skip_validation_when_schema_has_no_fields() {
-            var schema = new SubscriptionFormSchema(List.of());
+            var schema = schema();
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, Map.of()));
         }
     }
@@ -49,7 +50,7 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_throw_when_required_field_is_missing() {
-            var schema = schema(requiredInput("company"));
+            var schema = schema(InputField.builder().fieldKey("company").required(true).build());
             assertThatThrownBy(() -> validateSubmission(schema, Map.of()))
                 .isInstanceOf(SubscriptionFormValidationException.class)
                 .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
@@ -58,7 +59,7 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_throw_when_required_field_is_blank() {
-            var schema = schema(requiredInput("company"));
+            var schema = schema(InputField.builder().fieldKey("company").required(true).build());
             var values = Map.of("company", "  ");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -68,20 +69,20 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_not_throw_when_required_field_has_value() {
-            var schema = schema(requiredInput("company"));
+            var schema = schema(InputField.builder().fieldKey("company").required(true).build());
             var values = Map.of("company", "Acme");
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
         }
 
         @Test
         void should_not_throw_when_optional_field_is_missing() {
-            var schema = schema(optionalInput("notes"));
+            var schema = schema(InputField.builder().fieldKey("notes").required(false).build());
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, Map.of()));
         }
 
         @Test
         void should_throw_when_required_checkbox_is_unchecked() {
-            var schema = schema(new CheckboxField("terms", true, null));
+            var schema = schema(CheckboxField.builder().fieldKey("terms").required(true).build());
             var values = Map.of("terms", "false");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -91,14 +92,14 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_not_throw_when_required_checkbox_is_checked() {
-            var schema = schema(new CheckboxField("terms", true, null));
+            var schema = schema(CheckboxField.builder().fieldKey("terms").required(true).build());
             var values = Map.of("terms", "true");
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
         }
 
         @Test
         void should_throw_when_required_checkbox_group_has_only_separators() {
-            var schema = schema(new CheckboxGroupField("tags", true, List.of("A", "B")));
+            var schema = schema(CheckboxGroupField.builder().fieldKey("tags").required(true).options(List.of("A", "B")).build());
             var values = Map.of("tags", " , , ");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -112,7 +113,9 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_throw_when_value_not_in_allowed_options() {
-            var schema = schema(new SelectField("plan", true, List.of("Free", "Pro", "Enterprise")));
+            var schema = schema(
+                SelectField.builder().fieldKey("plan").required(true).options(List.of("Free", "Pro", "Enterprise")).build()
+            );
             var values = Map.of("plan", "Premium");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -122,14 +125,16 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_not_throw_when_value_is_in_allowed_options() {
-            var schema = schema(new SelectField("plan", true, List.of("Free", "Pro", "Enterprise")));
+            var schema = schema(
+                SelectField.builder().fieldKey("plan").required(true).options(List.of("Free", "Pro", "Enterprise")).build()
+            );
             var values = Map.of("plan", "Pro");
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
         }
 
         @Test
         void should_not_throw_when_optional_select_is_missing() {
-            var schema = schema(new SelectField("plan", false, List.of("Free", "Pro")));
+            var schema = schema(SelectField.builder().fieldKey("plan").required(false).options(List.of("Free", "Pro")).build());
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, Map.of()));
         }
     }
@@ -139,7 +144,9 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_throw_when_one_value_not_in_options() {
-            var schema = schema(new CheckboxGroupField("tags", false, List.of("Alpha", "Beta", "Gamma")));
+            var schema = schema(
+                CheckboxGroupField.builder().fieldKey("tags").required(false).options(List.of("Alpha", "Beta", "Gamma")).build()
+            );
             var values = Map.of("tags", "Alpha,Delta");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -149,14 +156,16 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_not_throw_when_all_values_are_valid() {
-            var schema = schema(new CheckboxGroupField("tags", false, List.of("Alpha", "Beta", "Gamma")));
+            var schema = schema(
+                CheckboxGroupField.builder().fieldKey("tags").required(false).options(List.of("Alpha", "Beta", "Gamma")).build()
+            );
             var values = Map.of("tags", "Alpha,Gamma");
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
         }
 
         @Test
         void should_report_one_error_per_invalid_value() {
-            var schema = schema(new CheckboxGroupField("tags", false, List.of("Alpha", "Beta")));
+            var schema = schema(CheckboxGroupField.builder().fieldKey("tags").required(false).options(List.of("Alpha", "Beta")).build());
             var values = Map.of("tags", "Alpha,Delta,Omega");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -176,7 +185,7 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_throw_when_value_is_shorter_than_minLength() {
-            var schema = schema(new InputField("company", false, null, 5, null, null));
+            var schema = schema(InputField.builder().fieldKey("company").required(false).minLength(5).build());
             var values = Map.of("company", "Acm");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -186,7 +195,7 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_throw_when_value_is_longer_than_maxLength() {
-            var schema = schema(new InputField("company", false, null, null, 10, null));
+            var schema = schema(InputField.builder().fieldKey("company").required(false).maxLength(10).build());
             var values = Map.of("company", "A very long company name indeed");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -196,7 +205,7 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_not_throw_when_value_is_within_boundaries() {
-            var schema = schema(new InputField("company", false, null, 3, 10, null));
+            var schema = schema(InputField.builder().fieldKey("company").required(false).minLength(3).maxLength(10).build());
             var values = Map.of("company", "Acme");
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
         }
@@ -207,7 +216,7 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_throw_when_value_does_not_match_pattern() {
-            var schema = schema(new InputField("code", false, null, null, null, "[A-Z]{3}-\\d{4}"));
+            var schema = schema(InputField.builder().fieldKey("code").required(false).pattern("[A-Z]{3}-\\d{4}").build());
             var values = Map.of("code", "invalid-code");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -217,14 +226,14 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_not_throw_when_value_matches_pattern() {
-            var schema = schema(new InputField("code", false, null, null, null, "[A-Z]{3}-\\d{4}"));
+            var schema = schema(InputField.builder().fieldKey("code").required(false).pattern("[A-Z]{3}-\\d{4}").build());
             var values = Map.of("code", "ABC-1234");
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
         }
 
         @Test
         void should_add_error_when_pattern_is_invalid_regex() {
-            var schema = schema(new InputField("code", false, null, null, null, "[invalid(regex"));
+            var schema = schema(InputField.builder().fieldKey("code").required(false).pattern("[invalid(regex").build());
             var values = Map.of("code", "anything");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -239,9 +248,9 @@ class SubscriptionFormSubmissionValidatorTest {
         @Test
         void should_collect_errors_from_all_fields_before_throwing() {
             var schema = schema(
-                requiredInput("company"),
-                new SelectField("plan", true, List.of("Free", "Pro")),
-                new InputField("code", false, null, null, null, "[A-Z]+")
+                InputField.builder().fieldKey("company").required(true).build(),
+                SelectField.builder().fieldKey("plan").required(true).options(List.of("Free", "Pro")).build(),
+                InputField.builder().fieldKey("code").required(false).pattern("[A-Z]+").build()
             );
             var values = Map.of("company", "", "plan", "Enterprise", "code", "123");
             assertThatThrownBy(() -> validateSubmission(schema, values))
@@ -253,9 +262,9 @@ class SubscriptionFormSubmissionValidatorTest {
         @Test
         void should_not_throw_for_valid_full_submission() {
             var schema = schema(
-                requiredInput("company"),
-                new SelectField("plan", true, List.of("Free", "Pro")),
-                new CheckboxGroupField("tags", false, List.of("A", "B", "C"))
+                InputField.builder().fieldKey("company").required(true).build(),
+                SelectField.builder().fieldKey("plan").required(true).options(List.of("Free", "Pro")).build(),
+                CheckboxGroupField.builder().fieldKey("tags").required(false).options(List.of("A", "B", "C")).build()
             );
             var values = Map.of("company", "Acme Corp", "plan", "Pro", "tags", "A,C");
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, values));
@@ -267,13 +276,13 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_not_throw_when_readonly_value_matches_preset() {
-            var schema = schema(new InputField("ref", false, "REF-123", null, null, null));
+            var schema = schema(InputField.builder().fieldKey("ref").required(false).readonlyValue("REF-123").build());
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, Map.of("ref", "REF-123")));
         }
 
         @Test
         void should_throw_when_readonly_value_does_not_match_preset() {
-            var schema = schema(new InputField("ref", false, "REF-123", null, null, null));
+            var schema = schema(InputField.builder().fieldKey("ref").required(false).readonlyValue("REF-123").build());
             var values = Map.of("ref", "REF-999");
             assertThatThrownBy(() -> validateSubmission(schema, values))
                 .isInstanceOf(SubscriptionFormValidationException.class)
@@ -284,7 +293,9 @@ class SubscriptionFormSubmissionValidatorTest {
         @Test
         void should_not_apply_other_validations_to_readonly_fields() {
             // readonly RadioField has required=true and options, but readonly check takes precedence
-            var schema = schema(new RadioField("plan", true, "Free", List.of("Free", "Pro")));
+            var schema = schema(
+                RadioField.builder().fieldKey("plan").required(true).readonlyValue("Free").options(List.of("Free", "Pro")).build()
+            );
             assertThatNoException().isThrownBy(() -> validateSubmission(schema, Map.of("plan", "Free")));
         }
     }
@@ -294,7 +305,7 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_throw_when_submission_exceeds_max_metadata_count() {
-            var schema = schema(requiredInput("company"));
+            var schema = schema(InputField.builder().fieldKey("company").required(true).build());
             Map<String, String> tooMany = new java.util.HashMap<>();
             for (int i = 0; i < SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT + 1; i++) {
                 tooMany.put("key_" + i, "value");
@@ -311,7 +322,7 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_not_throw_when_submission_is_at_max_metadata_count() {
-            var schema = schema(optionalInput("notes"));
+            var schema = schema(InputField.builder().fieldKey("notes").required(false).build());
             Map<String, String> exactlyMax = new java.util.HashMap<>();
             for (int i = 0; i < SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT; i++) {
                 exactlyMax.put("key_" + i, "value");
@@ -325,7 +336,7 @@ class SubscriptionFormSubmissionValidatorTest {
 
         @Test
         void should_validate_submission_from_field_constraints_without_schema() {
-            var schema = schema(requiredInput("company"));
+            var schema = schema(InputField.builder().fieldKey("company").required(true).build());
             var constraints = SubscriptionFormConstraintsFactory.fromSchema(schema);
             assertThatNoException().isThrownBy(() -> validateSubmission(constraints, Map.of("company", "Acme")));
         }
@@ -339,17 +350,5 @@ class SubscriptionFormSubmissionValidatorTest {
 
     private void validateSubmission(SubscriptionFormFieldConstraints constraints, Map<String, String> values) {
         new SubscriptionFormSubmissionValidator(constraints).validate(values);
-    }
-
-    private SubscriptionFormSchema schema(SubscriptionFormSchema.Field... fields) {
-        return new SubscriptionFormSchema(List.of(fields));
-    }
-
-    private InputField requiredInput(String fieldKey) {
-        return new InputField(fieldKey, true, null, null, null, null);
-    }
-
-    private InputField optionalInput(String fieldKey) {
-        return new InputField(fieldKey, false, null, null, null, null);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/GetSubscriptionFormForEnvironmentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/GetSubscriptionFormForEnvironmentUseCaseTest.java
@@ -19,22 +19,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.core.model.SubscriptionFormFixtures;
+import inmemory.SubscriptionFormElResolverInMemory;
 import inmemory.SubscriptionFormQueryServiceInMemory;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormNotFoundException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
+import io.gravitee.apim.infra.domain_service.subscription_form.SubscriptionFormSchemaGeneratorImpl;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class GetSubscriptionFormForEnvironmentUseCaseTest {
 
     private final SubscriptionFormQueryServiceInMemory queryService = new SubscriptionFormQueryServiceInMemory();
+    private final SubscriptionFormElResolverInMemory elResolver = new SubscriptionFormElResolverInMemory();
+    private final SubscriptionFormSchemaGeneratorImpl schemaGenerator = new SubscriptionFormSchemaGeneratorImpl();
     private GetSubscriptionFormForEnvironmentUseCase useCase;
 
     @BeforeEach
     void setUp() {
         queryService.reset();
-        useCase = new GetSubscriptionFormForEnvironmentUseCase(queryService);
+        elResolver.reset();
+        useCase = new GetSubscriptionFormForEnvironmentUseCase(queryService, schemaGenerator, elResolver);
     }
 
     @Test
@@ -44,10 +50,16 @@ class GetSubscriptionFormForEnvironmentUseCaseTest {
         queryService.initWith(List.of(expectedForm));
 
         // When
-        var result = useCase.execute(new GetSubscriptionFormForEnvironmentUseCase.Input(expectedForm.getEnvironmentId(), false));
+        var result = useCase.execute(
+            GetSubscriptionFormForEnvironmentUseCase.Input.builder()
+                .environmentId(expectedForm.getEnvironmentId())
+                .onlyEnabled(false)
+                .build()
+        );
 
         // Then
         assertThat(result.subscriptionForm()).isEqualTo(expectedForm);
+        assertThat(result.resolvedOptions()).isEmpty();
     }
 
     @Test
@@ -55,7 +67,12 @@ class GetSubscriptionFormForEnvironmentUseCaseTest {
         SubscriptionForm disabledForm = SubscriptionFormFixtures.aSubscriptionForm();
         queryService.initWith(List.of(disabledForm));
 
-        var result = useCase.execute(new GetSubscriptionFormForEnvironmentUseCase.Input(disabledForm.getEnvironmentId(), false));
+        var result = useCase.execute(
+            GetSubscriptionFormForEnvironmentUseCase.Input.builder()
+                .environmentId(disabledForm.getEnvironmentId())
+                .onlyEnabled(false)
+                .build()
+        );
 
         assertThat(result.subscriptionForm()).isEqualTo(disabledForm);
     }
@@ -65,7 +82,10 @@ class GetSubscriptionFormForEnvironmentUseCaseTest {
         SubscriptionForm disabledForm = SubscriptionFormFixtures.aSubscriptionForm();
         queryService.initWith(List.of(disabledForm));
 
-        var input = new GetSubscriptionFormForEnvironmentUseCase.Input(disabledForm.getEnvironmentId(), true);
+        var input = GetSubscriptionFormForEnvironmentUseCase.Input.builder()
+            .environmentId(disabledForm.getEnvironmentId())
+            .onlyEnabled(true)
+            .build();
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(SubscriptionFormNotFoundException.class)
             .hasMessageContaining(disabledForm.getEnvironmentId());
@@ -73,9 +93,59 @@ class GetSubscriptionFormForEnvironmentUseCaseTest {
 
     @Test
     void should_throw_exception_when_subscription_form_not_found() {
-        var input = new GetSubscriptionFormForEnvironmentUseCase.Input("unknown-environment", false);
+        var input = GetSubscriptionFormForEnvironmentUseCase.Input.builder()
+            .environmentId("unknown-environment")
+            .onlyEnabled(false)
+            .build();
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(SubscriptionFormNotFoundException.class)
             .hasMessageContaining("unknown-environment");
+    }
+
+    @Test
+    void should_return_resolved_options_when_apiId_is_present() {
+        // Given a form with an EL select field
+        var form = SubscriptionFormFixtures.aSubscriptionFormBuilder()
+            .gmdContent(
+                io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown.of(
+                    "<gmd-select fieldKey=\"env\" options=\"{#api.metadata['envs']}:Prod,Test\"/>"
+                )
+            )
+            .build();
+        queryService.initWith(List.of(form));
+        elResolver.withResolved(Map.of("{#api.metadata['envs']}", List.of("Dev", "Staging", "Prod")));
+
+        // When retrieving with apiId
+        var result = useCase.execute(
+            GetSubscriptionFormForEnvironmentUseCase.Input.builder()
+                .environmentId(form.getEnvironmentId())
+                .onlyEnabled(false)
+                .apiId("my-api-id")
+                .build()
+        );
+
+        // Then resolved options are returned
+        assertThat(result.resolvedOptions()).containsEntry("env", List.of("Dev", "Staging", "Prod"));
+    }
+
+    @Test
+    void should_return_fallback_options_when_no_resolved_options_configured() {
+        // Given a form with an EL select field
+        var form = SubscriptionFormFixtures.aSubscriptionFormBuilder()
+            .gmdContent(
+                io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown.of(
+                    "<gmd-select fieldKey=\"env\" options=\"{#api.metadata['envs']}:Prod,Test\"/>"
+                )
+            )
+            .build();
+        queryService.initWith(List.of(form));
+
+        // When retrieving without apiId
+        var result = useCase.execute(
+            GetSubscriptionFormForEnvironmentUseCase.Input.builder().environmentId(form.getEnvironmentId()).onlyEnabled(false).build()
+        );
+
+        // Then fallback options from the expression are returned
+        assertThat(result.resolvedOptions()).containsEntry("env", List.of("Prod", "Test"));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCaseTest.java
@@ -26,8 +26,8 @@ import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.gravitee_markdown.exception.GraviteeMarkdownContentEmptyException;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSubmissionValidator;
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormDefinitionValidationException;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormNotFoundException;
-import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
 import io.gravitee.apim.infra.domain_service.subscription_form.SubscriptionFormSchemaGeneratorImpl;
@@ -115,12 +115,32 @@ class UpdateSubscriptionFormUseCaseTest {
         var input = new UpdateSubscriptionFormUseCase.Input(existingForm.getEnvironmentId(), existingForm.getId(), gmd.toString());
 
         assertThatThrownBy(() -> useCase.execute(input))
-            .isInstanceOf(SubscriptionFormValidationException.class)
-            .extracting(e -> ((SubscriptionFormValidationException) e).getErrors())
+            .isInstanceOf(SubscriptionFormDefinitionValidationException.class)
+            .extracting(e -> ((SubscriptionFormDefinitionValidationException) e).getErrors())
             .satisfies(errors ->
                 assertThat(errors).containsExactly(
                     "Subscription form must not exceed " + SubscriptionFormSubmissionValidator.MAX_METADATA_COUNT + " fields"
                 )
+            );
+    }
+
+    @Test
+    void should_throw_definition_validation_exception_when_schema_generation_fails() {
+        SubscriptionForm existingForm = SubscriptionFormFixtures.aSubscriptionForm();
+        crudService.initWith(List.of(existingForm));
+        queryService.initWith(List.of(existingForm));
+
+        var input = new UpdateSubscriptionFormUseCase.Input(
+            existingForm.getEnvironmentId(),
+            existingForm.getId(),
+            "<gmd-input required=\"true\"/>"
+        );
+
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(SubscriptionFormDefinitionValidationException.class)
+            .extracting(e -> ((SubscriptionFormDefinitionValidationException) e).getErrors())
+            .satisfies(errors ->
+                assertThat(errors).containsExactly("GMD form field is missing required 'fieldkey' attribute for element: gmd-input")
             );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription_form/GraviteeElSubscriptionFormExpressionResolverDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription_form/GraviteeElSubscriptionFormExpressionResolverDomainServiceImplTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.subscription_form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class GraviteeElSubscriptionFormExpressionResolverDomainServiceImplTest {
+
+    private final GraviteeElSubscriptionFormExpressionResolverDomainServiceImpl cut =
+        new GraviteeElSubscriptionFormExpressionResolverDomainServiceImpl();
+
+    @ParameterizedTest
+    @MethodSource("should_resolve_to_expected_options_cases")
+    void should_resolve_to_expected_options(String expression, Map<String, Object> templateParams, List<String> expected) {
+        var options = cut.resolveToOptions(expression, templateParams);
+
+        assertThat(options).containsExactlyElementsOf(expected);
+    }
+
+    private static Stream<Arguments> should_resolve_to_expected_options_cases() {
+        return Stream.of(
+            Arguments.of("{#api.metadata['envs']}", metadataParams("envs", "Dev,Staging,Prod"), List.of("Dev", "Staging", "Prod")),
+            Arguments.of("{#api.metadata['env']}", metadataParams("env", "Production"), List.of("Production")),
+            Arguments.of("{#api.metadata['envs']}", metadataParams("envs", " Dev , Staging , Prod "), List.of("Dev", "Staging", "Prod")),
+            Arguments.of("{#api.metadata['envs']}", metadataParams("envs", ",Dev,,Staging,"), List.of("Dev", "Staging")),
+            Arguments.of("{#'   '}", Map.of(), List.of()),
+            Arguments.of("{#api.metadata['nonexistent']}", metadataParams("envs", "Dev"), List.of()),
+            Arguments.of("{#api.metadata['envs']}", Map.of(), List.of()),
+            Arguments.of("{#null}", Map.of(), List.of()),
+            Arguments.of("{#api.metadata['envs']", metadataParams("envs", "Dev"), List.of())
+        );
+    }
+
+    private static Map<String, Object> metadataParams(String key, String value) {
+        return Map.of("api", Map.of("metadata", Map.of(key, value)));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormElResolverDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormElResolverDomainServiceImplTest.java
@@ -24,8 +24,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.api.model.ApiMetadata;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
-import io.gravitee.apim.core.documentation.domain_service.TemplateResolverDomainService;
-import io.gravitee.apim.core.documentation.exception.InvalidPageContentException;
+import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormExpressionResolverDomainService;
 import io.gravitee.apim.core.subscription_form.model.Constraint;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
@@ -39,13 +38,15 @@ import org.junit.jupiter.api.Test;
 
 class SubscriptionFormElResolverDomainServiceImplTest {
 
-    private final TemplateResolverDomainService templateResolver = mock(TemplateResolverDomainService.class);
+    private final SubscriptionFormExpressionResolverDomainService expressionResolver = mock(
+        SubscriptionFormExpressionResolverDomainService.class
+    );
     private final ApiMetadataQueryService metadataQueryService = mock(ApiMetadataQueryService.class);
     private SubscriptionFormElResolverDomainServiceImpl service;
 
     @BeforeEach
     void setUp() {
-        service = new SubscriptionFormElResolverDomainServiceImpl(templateResolver, metadataQueryService);
+        service = new SubscriptionFormElResolverDomainServiceImpl(expressionResolver, metadataQueryService);
         when(metadataQueryService.findApiMetadata(anyString(), anyString())).thenReturn(
             Map.of("envs", ApiMetadata.builder().key("envs").value("Dev,Staging,Prod").build())
         );
@@ -75,7 +76,7 @@ class SubscriptionFormElResolverDomainServiceImplTest {
 
         @Test
         void should_resolve_expression_when_apiId_is_present() {
-            when(templateResolver.resolveTemplate(eq("{#api.metadata['envs']}"), any())).thenReturn("Dev,Staging,Prod");
+            when(expressionResolver.resolveToOptions(eq("{#api.metadata['envs']}"), any())).thenReturn(List.of("Dev", "Staging", "Prod"));
 
             var schema = new SubscriptionFormSchema(
                 List.of(
@@ -111,7 +112,7 @@ class SubscriptionFormElResolverDomainServiceImplTest {
 
         @Test
         void should_resolve_expression_without_api_context_when_expression_is_self_contained() {
-            when(templateResolver.resolveTemplate(eq("{#'Dev,Staging,Prod'}"), eq(Map.of()))).thenReturn("Dev,Staging,Prod");
+            when(expressionResolver.resolveToOptions("{#'Dev,Staging,Prod'}", Map.of())).thenReturn(List.of("Dev", "Staging", "Prod"));
 
             var schema = new SubscriptionFormSchema(
                 List.of(
@@ -130,28 +131,7 @@ class SubscriptionFormElResolverDomainServiceImplTest {
 
         @Test
         void should_use_fallback_when_resolution_fails() {
-            when(templateResolver.resolveTemplate(anyString(), any())).thenThrow(
-                new InvalidPageContentException("template error", new RuntimeException())
-            );
-
-            var schema = new SubscriptionFormSchema(
-                List.of(
-                    SelectField.builder()
-                        .fieldKey("env")
-                        .required(false)
-                        .dynamicOptions(new DynamicOptions("{#api.metadata['envs']}", List.of("Prod")))
-                        .build()
-                )
-            );
-
-            var result = service.resolveSchemaOptions(schema, "env-1", "api-1");
-
-            assertThat(result).containsEntry("env", List.of("Prod"));
-        }
-
-        @Test
-        void should_use_fallback_when_resolved_value_is_blank() {
-            when(templateResolver.resolveTemplate(anyString(), any())).thenReturn("   ");
+            when(expressionResolver.resolveToOptions(anyString(), any())).thenReturn(List.of());
 
             var schema = new SubscriptionFormSchema(
                 List.of(
@@ -170,9 +150,7 @@ class SubscriptionFormElResolverDomainServiceImplTest {
 
         @Test
         void should_use_fallback_without_api_context_when_resolution_fails() {
-            when(templateResolver.resolveTemplate(eq("{#api.metadata['envs']}"), eq(Map.of()))).thenThrow(
-                new InvalidPageContentException("template error", new RuntimeException())
-            );
+            when(expressionResolver.resolveToOptions("{#api.metadata['envs']}", Map.of())).thenReturn(List.of());
 
             var schema = new SubscriptionFormSchema(
                 List.of(
@@ -200,29 +178,33 @@ class SubscriptionFormElResolverDomainServiceImplTest {
         }
 
         @Test
-        void should_resolve_dynamic_one_of_to_one_of() {
-            when(templateResolver.resolveTemplate(eq("{#api.metadata['plans']}"), any())).thenReturn("Free,Pro");
+        void should_resolve_dynamic_one_of_in_place() {
+            when(expressionResolver.resolveToOptions(eq("{#api.metadata['plans']}"), any())).thenReturn(List.of("Free", "Pro"));
+            var dynamicConstraint = Constraint.OneOf.dynamic("{#api.metadata['plans']}", List.of("Free"));
 
-            var constraints = new SubscriptionFormFieldConstraints(
-                Map.of("plan", List.of(Constraint.OneOf.dynamic("{#api.metadata['plans']}", List.of("Free"))))
-            );
+            var constraints = new SubscriptionFormFieldConstraints(Map.of("plan", List.of(dynamicConstraint)));
 
             var resolved = service.resolveConstraints(constraints, "env-1", "api-1");
 
-            assertThat(resolved.byFieldKey().get("plan")).containsExactly(new Constraint.OneOf(List.of("Free", "Pro")));
+            assertThat(resolved).isSameAs(constraints);
+            assertThat(resolved.byFieldKey().get("plan")).containsExactly(dynamicConstraint);
+            assertThat(dynamicConstraint.options()).containsExactly("Free", "Pro");
+            assertThat(dynamicConstraint.resolved()).isTrue();
         }
 
         @Test
-        void should_resolve_dynamic_each_of_to_each_of() {
-            when(templateResolver.resolveTemplate(eq("{#api.metadata['tags']}"), any())).thenReturn("Alpha,Beta");
+        void should_resolve_dynamic_each_of_in_place() {
+            when(expressionResolver.resolveToOptions(eq("{#api.metadata['tags']}"), any())).thenReturn(List.of("Alpha", "Beta"));
+            var dynamicConstraint = Constraint.EachOf.dynamic("{#api.metadata['tags']}", List.of("Fallback"));
 
-            var constraints = new SubscriptionFormFieldConstraints(
-                Map.of("tags", List.of(Constraint.EachOf.dynamic("{#api.metadata['tags']}", List.of("Fallback"))))
-            );
+            var constraints = new SubscriptionFormFieldConstraints(Map.of("tags", List.of(dynamicConstraint)));
 
             var resolved = service.resolveConstraints(constraints, "env-1", "api-1");
 
-            assertThat(resolved.byFieldKey().get("tags")).containsExactly(new Constraint.EachOf(List.of("Alpha", "Beta")));
+            assertThat(resolved).isSameAs(constraints);
+            assertThat(resolved.byFieldKey().get("tags")).containsExactly(dynamicConstraint);
+            assertThat(dynamicConstraint.options()).containsExactly("Alpha", "Beta");
+            assertThat(dynamicConstraint.resolved()).isTrue();
         }
 
         @Test
@@ -238,17 +220,16 @@ class SubscriptionFormElResolverDomainServiceImplTest {
 
         @Test
         void should_use_fallback_when_resolution_fails() {
-            when(templateResolver.resolveTemplate(anyString(), any())).thenThrow(
-                new InvalidPageContentException("template error", new RuntimeException())
-            );
+            when(expressionResolver.resolveToOptions(anyString(), any())).thenReturn(List.of());
+            var dynamicConstraint = Constraint.OneOf.dynamic("{#api.metadata['plans']}", List.of("Free"));
 
-            var constraints = new SubscriptionFormFieldConstraints(
-                Map.of("plan", List.of(Constraint.OneOf.dynamic("{#api.metadata['plans']}", List.of("Free"))))
-            );
+            var constraints = new SubscriptionFormFieldConstraints(Map.of("plan", List.of(dynamicConstraint)));
 
             var resolved = service.resolveConstraints(constraints, "env-1", "api-1");
 
-            assertThat(resolved.byFieldKey().get("plan")).containsExactly(new Constraint.OneOf(List.of("Free")));
+            assertThat(resolved.byFieldKey().get("plan")).containsExactly(dynamicConstraint);
+            assertThat(dynamicConstraint.options()).containsExactly("Free");
+            assertThat(dynamicConstraint.resolved()).isTrue();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormElResolverDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormElResolverDomainServiceImplTest.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.subscription_form;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.api.model.ApiMetadata;
+import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
+import io.gravitee.apim.core.documentation.domain_service.TemplateResolverDomainService;
+import io.gravitee.apim.core.documentation.exception.InvalidPageContentException;
+import io.gravitee.apim.core.subscription_form.model.Constraint;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormFieldConstraints;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.DynamicOptions;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.SelectField;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionFormElResolverDomainServiceImplTest {
+
+    private final TemplateResolverDomainService templateResolver = mock(TemplateResolverDomainService.class);
+    private final ApiMetadataQueryService metadataQueryService = mock(ApiMetadataQueryService.class);
+    private SubscriptionFormElResolverDomainServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SubscriptionFormElResolverDomainServiceImpl(templateResolver, metadataQueryService);
+        when(metadataQueryService.findApiMetadata(anyString(), anyString())).thenReturn(
+            Map.of("envs", ApiMetadata.builder().key("envs").value("Dev,Staging,Prod").build())
+        );
+    }
+
+    @Nested
+    class ResolveSchemaOptions {
+
+        @Test
+        void should_return_empty_map_when_schema_is_null() {
+            assertThat(service.resolveSchemaOptions(null, "env-1", "api-1")).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_map_when_schema_has_no_fields() {
+            var schema = new SubscriptionFormSchema(List.of());
+            assertThat(service.resolveSchemaOptions(schema, "env-1", "api-1")).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_map_when_no_dynamic_fields() {
+            var schema = new SubscriptionFormSchema(
+                List.of(SelectField.builder().fieldKey("plan").required(true).options(List.of("Free", "Pro")).build())
+            );
+            assertThat(service.resolveSchemaOptions(schema, "env-1", "api-1")).isEmpty();
+        }
+
+        @Test
+        void should_resolve_expression_when_apiId_is_present() {
+            when(templateResolver.resolveTemplate(eq("{#api.metadata['envs']}"), any())).thenReturn("Dev,Staging,Prod");
+
+            var schema = new SubscriptionFormSchema(
+                List.of(
+                    SelectField.builder()
+                        .fieldKey("env")
+                        .required(false)
+                        .dynamicOptions(new DynamicOptions("{#api.metadata['envs']}", List.of("Prod")))
+                        .build()
+                )
+            );
+
+            var result = service.resolveSchemaOptions(schema, "env-1", "api-1");
+
+            assertThat(result).containsEntry("env", List.of("Dev", "Staging", "Prod"));
+        }
+
+        @Test
+        void should_return_fallback_when_no_api_context_and_expression_cannot_be_resolved() {
+            var schema = new SubscriptionFormSchema(
+                List.of(
+                    SelectField.builder()
+                        .fieldKey("env")
+                        .required(false)
+                        .dynamicOptions(new DynamicOptions("{#api.metadata['envs']}", List.of("Prod", "Test")))
+                        .build()
+                )
+            );
+
+            var result = service.resolveSchemaOptions(schema);
+
+            assertThat(result).containsEntry("env", List.of("Prod", "Test"));
+        }
+
+        @Test
+        void should_resolve_expression_without_api_context_when_expression_is_self_contained() {
+            when(templateResolver.resolveTemplate(eq("{#'Dev,Staging,Prod'}"), eq(Map.of()))).thenReturn("Dev,Staging,Prod");
+
+            var schema = new SubscriptionFormSchema(
+                List.of(
+                    SelectField.builder()
+                        .fieldKey("env")
+                        .required(false)
+                        .dynamicOptions(new DynamicOptions("{#'Dev,Staging,Prod'}", List.of("Prod", "Test")))
+                        .build()
+                )
+            );
+
+            var result = service.resolveSchemaOptions(schema);
+
+            assertThat(result).containsEntry("env", List.of("Dev", "Staging", "Prod"));
+        }
+
+        @Test
+        void should_use_fallback_when_resolution_fails() {
+            when(templateResolver.resolveTemplate(anyString(), any())).thenThrow(
+                new InvalidPageContentException("template error", new RuntimeException())
+            );
+
+            var schema = new SubscriptionFormSchema(
+                List.of(
+                    SelectField.builder()
+                        .fieldKey("env")
+                        .required(false)
+                        .dynamicOptions(new DynamicOptions("{#api.metadata['envs']}", List.of("Prod")))
+                        .build()
+                )
+            );
+
+            var result = service.resolveSchemaOptions(schema, "env-1", "api-1");
+
+            assertThat(result).containsEntry("env", List.of("Prod"));
+        }
+
+        @Test
+        void should_use_fallback_when_resolved_value_is_blank() {
+            when(templateResolver.resolveTemplate(anyString(), any())).thenReturn("   ");
+
+            var schema = new SubscriptionFormSchema(
+                List.of(
+                    SelectField.builder()
+                        .fieldKey("env")
+                        .required(false)
+                        .dynamicOptions(new DynamicOptions("{#api.metadata['envs']}", List.of("Prod")))
+                        .build()
+                )
+            );
+
+            var result = service.resolveSchemaOptions(schema, "env-1", "api-1");
+
+            assertThat(result).containsEntry("env", List.of("Prod"));
+        }
+
+        @Test
+        void should_use_fallback_without_api_context_when_resolution_fails() {
+            when(templateResolver.resolveTemplate(eq("{#api.metadata['envs']}"), eq(Map.of()))).thenThrow(
+                new InvalidPageContentException("template error", new RuntimeException())
+            );
+
+            var schema = new SubscriptionFormSchema(
+                List.of(
+                    SelectField.builder()
+                        .fieldKey("env")
+                        .required(false)
+                        .dynamicOptions(new DynamicOptions("{#api.metadata['envs']}", List.of("Prod", "Test")))
+                        .build()
+                )
+            );
+
+            var result = service.resolveSchemaOptions(schema);
+
+            assertThat(result).containsEntry("env", List.of("Prod", "Test"));
+        }
+    }
+
+    @Nested
+    class ResolveConstraints {
+
+        @Test
+        void should_return_same_constraints_when_empty() {
+            var empty = new SubscriptionFormFieldConstraints(Map.of());
+            assertThat(service.resolveConstraints(empty, "env-1", "api-1")).isSameAs(empty);
+        }
+
+        @Test
+        void should_resolve_dynamic_one_of_to_one_of() {
+            when(templateResolver.resolveTemplate(eq("{#api.metadata['plans']}"), any())).thenReturn("Free,Pro");
+
+            var constraints = new SubscriptionFormFieldConstraints(
+                Map.of("plan", List.of(Constraint.OneOf.dynamic("{#api.metadata['plans']}", List.of("Free"))))
+            );
+
+            var resolved = service.resolveConstraints(constraints, "env-1", "api-1");
+
+            assertThat(resolved.byFieldKey().get("plan")).containsExactly(new Constraint.OneOf(List.of("Free", "Pro")));
+        }
+
+        @Test
+        void should_resolve_dynamic_each_of_to_each_of() {
+            when(templateResolver.resolveTemplate(eq("{#api.metadata['tags']}"), any())).thenReturn("Alpha,Beta");
+
+            var constraints = new SubscriptionFormFieldConstraints(
+                Map.of("tags", List.of(Constraint.EachOf.dynamic("{#api.metadata['tags']}", List.of("Fallback"))))
+            );
+
+            var resolved = service.resolveConstraints(constraints, "env-1", "api-1");
+
+            assertThat(resolved.byFieldKey().get("tags")).containsExactly(new Constraint.EachOf(List.of("Alpha", "Beta")));
+        }
+
+        @Test
+        void should_leave_non_dynamic_constraints_unchanged() {
+            var constraints = new SubscriptionFormFieldConstraints(
+                Map.of("company", List.of(new Constraint.Required(), new Constraint.MaxLength(100)))
+            );
+
+            var resolved = service.resolveConstraints(constraints, "env-1", "api-1");
+
+            assertThat(resolved.byFieldKey().get("company")).containsExactly(new Constraint.Required(), new Constraint.MaxLength(100));
+        }
+
+        @Test
+        void should_use_fallback_when_resolution_fails() {
+            when(templateResolver.resolveTemplate(anyString(), any())).thenThrow(
+                new InvalidPageContentException("template error", new RuntimeException())
+            );
+
+            var constraints = new SubscriptionFormFieldConstraints(
+                Map.of("plan", List.of(Constraint.OneOf.dynamic("{#api.metadata['plans']}", List.of("Free"))))
+            );
+
+            var resolved = service.resolveConstraints(constraints, "env-1", "api-1");
+
+            assertThat(resolved.byFieldKey().get("plan")).containsExactly(new Constraint.OneOf(List.of("Free")));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormSchemaGeneratorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription_form/SubscriptionFormSchemaGeneratorImplTest.java
@@ -19,9 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormDefinitionValidationException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.CheckboxGroupField;
+import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.DynamicOptions;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.InputField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.RadioField;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema.SelectField;
@@ -173,7 +175,7 @@ class SubscriptionFormSchemaGeneratorImplTest {
     @Test
     void should_throw_when_readonly_field_has_no_value_attribute() {
         assertThatThrownBy(() -> generator.generate(GraviteeMarkdown.of("<gmd-input fieldKey=\"ref\" readonly=\"true\"/>")))
-            .isInstanceOf(IllegalArgumentException.class)
+            .isInstanceOf(SubscriptionFormDefinitionValidationException.class)
             .hasMessageContaining("ref")
             .hasMessageContaining("value");
     }
@@ -181,7 +183,7 @@ class SubscriptionFormSchemaGeneratorImplTest {
     @Test
     void should_throw_when_fieldkey_attribute_is_absent() {
         assertThatThrownBy(() -> generator.generate(GraviteeMarkdown.of("<gmd-input required=\"true\"/>")))
-            .isInstanceOf(IllegalArgumentException.class)
+            .isInstanceOf(SubscriptionFormDefinitionValidationException.class)
             .hasMessageContaining("fieldkey")
             .hasMessageContaining("gmd-input");
     }
@@ -189,7 +191,7 @@ class SubscriptionFormSchemaGeneratorImplTest {
     @Test
     void should_throw_when_fieldkey_attribute_is_blank() {
         assertThatThrownBy(() -> generator.generate(GraviteeMarkdown.of("<gmd-input fieldKey=\"   \" required=\"true\"/>")))
-            .isInstanceOf(IllegalArgumentException.class)
+            .isInstanceOf(SubscriptionFormDefinitionValidationException.class)
             .hasMessageContaining("fieldkey")
             .hasMessageContaining("gmd-input");
     }
@@ -222,6 +224,43 @@ class SubscriptionFormSchemaGeneratorImplTest {
         assertThat(fields.getFirst().fieldKey()).isEqualTo("name");
     }
 
+    @ParameterizedTest(name = "<{0}> → dynamic options")
+    @MethodSource("optionsBearingComponents")
+    void should_parse_el_expression_with_fallback_as_dynamic_options(
+        String tagName,
+        Class<? extends SubscriptionFormSchema.Field> expectedType
+    ) {
+        String gmd = "<" + tagName + " fieldKey=\"env\" options=\"{#api.metadata['envs']}:Prod,Test\"/>";
+
+        SubscriptionFormSchema.Field field = generator.generate(GraviteeMarkdown.of(gmd)).fields().getFirst();
+
+        assertThat(field).isInstanceOf(expectedType);
+        assertThat(dynamicOptionsOf(field)).isNotNull();
+        assertThat(dynamicOptionsOf(field).expression()).isEqualTo("{#api.metadata['envs']}");
+        assertThat(dynamicOptionsOf(field).fallback()).containsExactly("Prod", "Test");
+        assertThat(optionsOf(field)).isNull();
+    }
+
+    @ParameterizedTest(name = "<{0}> → EL without fallback throws")
+    @MethodSource("optionsBearingComponents")
+    void should_throw_when_el_expression_has_no_fallback_separator(
+        String tagName,
+        Class<? extends SubscriptionFormSchema.Field> expectedType
+    ) {
+        String gmd = "<" + tagName + " fieldKey=\"env\" options=\"{#api.metadata['envs']}\"/>";
+        assertThatThrownBy(() -> generator.generate(GraviteeMarkdown.of(gmd)))
+            .isInstanceOf(SubscriptionFormDefinitionValidationException.class)
+            .hasMessageContaining("env")
+            .hasMessageContaining("fallback");
+    }
+
+    @Test
+    void should_parse_el_expression_with_empty_fallback() {
+        String gmd = "<gmd-select fieldKey=\"env\" options=\"{#api.metadata['envs']}:\"/>";
+        SubscriptionFormSchema.Field field = generator.generate(GraviteeMarkdown.of(gmd)).fields().getFirst();
+        assertThat(dynamicOptionsOf(field).fallback()).isEmpty();
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────────
 
     private List<String> optionsOf(SubscriptionFormSchema.Field field) {
@@ -230,6 +269,15 @@ class SubscriptionFormSchemaGeneratorImplTest {
             case RadioField f -> f.options();
             case CheckboxGroupField f -> f.options();
             default -> throw new IllegalArgumentException("Field type has no options: " + field.getClass().getSimpleName());
+        };
+    }
+
+    private DynamicOptions dynamicOptionsOf(SubscriptionFormSchema.Field field) {
+        return switch (field) {
+            case SelectField f -> f.dynamicOptions();
+            case RadioField f -> f.dynamicOptions();
+            case CheckboxGroupField f -> f.dynamicOptions();
+            default -> throw new IllegalArgumentException("Field type has no dynamicOptions: " + field.getClass().getSimpleName());
         };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.SubscriptionFormFixtures;
+import inmemory.SubscriptionFormElResolverInMemory;
 import inmemory.SubscriptionFormQueryServiceInMemory;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
@@ -91,6 +92,7 @@ public class SubscriptionValidationServiceImplTest {
             entrypointConnectorPluginService,
             subscriptionMetadataSanitizer,
             subscriptionFormQueryService,
+            new SubscriptionFormElResolverInMemory(),
             clientCertificateCrudService
         );
         lenient()


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-12990

## Description
**PR 1/2** — Domain & infrastructure layer for EL-based resolution of dynamic subscription form options.

This PR adds:
- `SubscriptionFormElResolverDomainService` interface with `resolveSchemaOptions` and `resolveConstraints` methods
- `SubscriptionFormElResolverDomainServiceImpl` — resolves EL expressions (e.g. `{#api.metadata['key']}:fallback`) against API and environment metadata; falls back gracefully on resolution failure
- `Constraint` model extended with `DynamicOneOf` / `DynamicEachOf` variants for EL-driven constraints
- `SubscriptionFormSchema` extended with `DynamicOptionsAttribute` carrying the raw EL expression and parsed fallback values
- `SubscriptionFormConstraintsFactory` — `constraintsFor` broken into focused private helpers to reduce cyclomatic complexity (Sonar)
- `GetSubscriptionFormForEnvironmentUseCase.Input` migrated to Lombok `@Builder`
- `ApiMetadataQueryService#findEnvironmentMetadata` — returns global/environment-level metadata without API overrides, used to populate EL template context when no API context is available
- In-memory doubles: `SubscriptionFormElResolverInMemory`, updated `ApiMetadataQueryServiceInMemory`

**Not in this PR** (coming in PR 2/2):
- REST resource changes (management v2 and portal endpoints)
- OAS spec updates
- Portal endpoint moved from env-level to API-level (`/apis/{apiId}/subscription-form`)

## Additional context
[Previous in chain: #15918 (apim-12990-validation-resource — validation constraints at resource layer)](https://github.com/gravitee-io/gravitee-api-management/pull/15918)
