### PR TITLE
feat: include API Products in user-related resources

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.html
@@ -204,6 +204,63 @@
           }
         </div>
 
+        <!-- API Products section -->
+        <div class="memberships__section">
+          <h3>API Products</h3>
+
+          @if (membershipApiProductsLoaded()) {
+            <gio-table-wrapper [length]="apiProductsUnpaginatedLength()" (filtersChange)="onApiProductsFiltersChanged($event)">
+              <table mat-table [dataSource]="membershipApiProducts()" aria-label="API Products table">
+                <!-- Name Column -->
+                <ng-container matColumnDef="name">
+                  <th mat-header-cell *matHeaderCellDef id="api-product-name">Name</th>
+                  <td mat-cell *matCellDef="let membershipApiProduct">
+                    @if (membershipApiProduct.environmentId && membershipApiProduct.id) {
+                      <a [routerLink]="['/', membershipApiProduct.environmentId, 'api-products', membershipApiProduct.id]">
+                        {{ membershipApiProduct.name }}
+                      </a>
+                    } @else {
+                      {{ membershipApiProduct.name }}
+                    }
+                  </td>
+                </ng-container>
+
+                <!-- Version Column -->
+                <ng-container matColumnDef="version">
+                  <th mat-header-cell *matHeaderCellDef id="api-product-version">Version</th>
+                  <td mat-cell *matCellDef="let membershipApiProduct">
+                    {{ membershipApiProduct.version }}
+                  </td>
+                </ng-container>
+
+                <!-- Visibility Column -->
+                <ng-container matColumnDef="visibility">
+                  <th mat-header-cell *matHeaderCellDef id="api-product-visibility">Visibility</th>
+                  <td mat-cell *matCellDef="let membershipApiProduct">
+                    @if (membershipApiProduct.visibility) {
+                      <span class="gio-badge">
+                        <mat-icon class="gio-left">{{ membershipApiProduct.visibility === 'PUBLIC' ? 'public' : 'lock' }}</mat-icon>
+                        {{ membershipApiProduct.visibility | titlecase }}
+                      </span>
+                    } @else {
+                      —
+                    }
+                  </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="apiProductsTableDisplayedColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: apiProductsTableDisplayedColumns"></tr>
+
+                <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+                  <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="apiProductsTableDisplayedColumns.length">No API Product</td>
+                </tr>
+              </table>
+            </gio-table-wrapper>
+          } @else {
+            <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+          }
+        </div>
+
         <!-- Applications section -->
         <div class="memberships__section">
           <h3>Applications</h3>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.ts
@@ -58,11 +58,21 @@ export interface MembershipApiDS {
   environmentId: string;
 }
 
+export interface MembershipApiProductDS {
+  id: string;
+  name: string;
+  version: string;
+  visibility?: string;
+  environmentId: string;
+}
+
 export interface MembershipApplicationDS {
   id: string;
   name: string;
   environmentId: string;
 }
+
+const DEFAULT_RESOURCE_TABLE_COLUMNS = ['name', 'version', 'visibility'];
 
 @Component({
   selector: 'org-settings-user-detail-memberships',
@@ -94,27 +104,32 @@ export class OrgSettingsUserDetailMembershipsComponent {
 
   groupsRolesFormGroup: UntypedFormGroup;
   groupsTableDisplayedColumns = ['name', 'groupAdmin', 'apiRoles', 'applicationRole', 'integrationRole', 'delete'];
-  apisTableDisplayedColumns = ['name', 'version', 'visibility'];
+  apisTableDisplayedColumns = [...DEFAULT_RESOURCE_TABLE_COLUMNS];
+  apiProductsTableDisplayedColumns = [...DEFAULT_RESOURCE_TABLE_COLUMNS];
   applicationsTableDisplayedColumns = ['name'];
 
   selectedEnvironmentId: string;
 
   // Filtered (paginated/searched) data for display
   membershipApis = signal<MembershipApiDS[]>([]);
+  membershipApiProducts = signal<MembershipApiProductDS[]>([]);
   membershipApplications = signal<MembershipApplicationDS[]>([]);
   membershipGroups = signal<MembershipGroupDS[]>([]);
 
   membershipApisLoaded = signal(false);
+  membershipApiProductsLoaded = signal(false);
   membershipApplicationsLoaded = signal(false);
   membershipGroupsLoaded = signal(false);
 
   // Unpaginated lengths for gio-table-wrapper
   apisUnpaginatedLength = signal(0);
+  apiProductsUnpaginatedLength = signal(0);
   applicationsUnpaginatedLength = signal(0);
   groupsUnpaginatedLength = signal(0);
 
   // Store initial (unfiltered) data for client-side filtering
   private initialApis: MembershipApiDS[] = [];
+  private initialApiProducts: MembershipApiProductDS[] = [];
   private initialApplications: MembershipApplicationDS[] = [];
   private initialGroups: MembershipGroupDS[] = [];
 
@@ -159,6 +174,14 @@ export class OrgSettingsUserDetailMembershipsComponent {
     });
     this.membershipApis.set(filtered.filteredCollection as MembershipApiDS[]);
     this.apisUnpaginatedLength.set(filtered.unpaginatedLength);
+  }
+
+  onApiProductsFiltersChanged(filters: GioTableWrapperFilters) {
+    const filtered = gioTableFilterCollection(this.initialApiProducts, filters, {
+      searchTermIgnoreKeys: ['id', 'visibility'],
+    });
+    this.membershipApiProducts.set(filtered.filteredCollection as MembershipApiProductDS[]);
+    this.apiProductsUnpaginatedLength.set(filtered.unpaginatedLength);
   }
 
   onApplicationsFiltersChanged(filters: GioTableWrapperFilters) {
@@ -301,6 +324,27 @@ export class OrgSettingsUserDetailMembershipsComponent {
         this.membershipApis.set(this.initialApis);
         this.apisUnpaginatedLength.set(this.initialApis.length);
         this.membershipApisLoaded.set(true);
+      });
+
+    // Load API Products via v2 endpoint
+    this.membershipApiProductsLoaded.set(false);
+    this.usersV2Service
+      .getUserApiProducts(this.userId(), environmentId, 1, 9999)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        catchError(() => of({ data: [], pagination: { page: 1, perPage: 9999, pageCount: 0, pageItemsCount: 0, totalCount: 0 } })),
+      )
+      .subscribe(response => {
+        this.initialApiProducts = response.data.map(userApiProduct => ({
+          id: userApiProduct.id,
+          name: userApiProduct.name,
+          version: userApiProduct.version,
+          visibility: userApiProduct.visibility,
+          environmentId: userApiProduct.environmentId,
+        }));
+        this.membershipApiProducts.set(this.initialApiProducts);
+        this.apiProductsUnpaginatedLength.set(this.initialApiProducts.length);
+        this.membershipApiProductsLoaded.set(true);
       });
 
     // Load Applications via v2 endpoint

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -394,6 +394,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       },
     ]);
     expectUserApplicationsV2Request('userId', 'envBetaId', []);
+    expectUserApiProductsV2Request('userId', 'envBetaId', []);
 
     fixture.detectChanges();
 
@@ -556,6 +557,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     ]);
     expectUserApisV2Request(user.id, 'envAlphaId');
     expectUserApplicationsV2Request(user.id, 'envAlphaId');
+    expectUserApiProductsV2Request(user.id, 'envAlphaId');
 
     const membershipsCardAfterAdd = await loader.getHarness(
       MatCardHarness.with({ selector: '.org-settings-user-detail__memberships-card' }),
@@ -717,7 +719,7 @@ describe('OrgSettingsUserDetailComponent', () => {
   function expectInitRequests(
     user: User = fakeUser({ id: 'userId' }),
     environments: Environment[] = defaultEnvironments,
-    v2MembershipsPerEnv: Record<string, { groups?: any[]; apis?: any[]; applications?: any[] }> = {},
+    v2MembershipsPerEnv: Record<string, { groups?: any[]; apis?: any[]; applications?: any[]; apiProducts?: any[] }> = {},
     tokens: Token[] = [],
     roles: {
       organization?: Role[];
@@ -738,6 +740,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       expectUserGroupsV2Request(user.id, firstEnvId, firstEnvData.groups || []);
       expectUserApisV2Request(user.id, firstEnvId, firstEnvData.apis || []);
       expectUserApplicationsV2Request(user.id, firstEnvId, firstEnvData.applications || []);
+      expectUserApiProductsV2Request(user.id, firstEnvId, firstEnvData.apiProducts || []);
     }
 
     // Flush role requests always fired by toSignal() in memberships component and parent template
@@ -858,6 +861,26 @@ describe('OrgSettingsUserDetailComponent', () => {
         totalCount: applications.length,
         pageCount: applications.length > 0 ? 1 : 0,
         pageItemsCount: applications.length,
+      },
+    });
+    fixture.detectChanges();
+  }
+
+  function expectUserApiProductsV2Request(userId: string, environmentId: string, apiProducts: any[] = []) {
+    const req = httpTestingController.expectOne(
+      request =>
+        request.method === 'GET' &&
+        request.url === `${CONSTANTS_TESTING.org.v2BaseURL}/users/${userId}/api-products` &&
+        request.params.get('environmentId') === environmentId,
+    );
+    req.flush({
+      data: apiProducts,
+      pagination: {
+        page: 1,
+        perPage: 9999,
+        totalCount: apiProducts.length,
+        pageCount: apiProducts.length > 0 ? 1 : 0,
+        pageItemsCount: apiProducts.length,
       },
     });
     fixture.detectChanges();

--- a/gravitee-apim-console-webui/src/services-ngx/users-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/users-v2.service.spec.ts
@@ -95,6 +95,35 @@ describe('UsersV2Service', () => {
     });
   });
 
+  describe('getUserApiProducts', () => {
+    it('should call API with default pagination', done => {
+      const fakeResponse = {
+        data: [{ id: 'ap1', name: 'Product 1', version: '1.0', environmentId: 'env1', environmentName: 'Env 1' }],
+        pagination: { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 1, totalCount: 1 },
+      };
+
+      service.getUserApiProducts('userId', 'envId').subscribe(response => {
+        expect(response).toEqual(fakeResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.org.v2BaseURL}/users/userId/api-products?environmentId=envId&page=1&perPage=10`,
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(fakeResponse);
+    });
+
+    it('should allow custom pagination', done => {
+      service.getUserApiProducts('userId', 'envId', 2, 20).subscribe(() => done());
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.org.v2BaseURL}/users/userId/api-products?environmentId=envId&page=2&perPage=20`,
+      );
+      req.flush({ data: [], pagination: { page: 2, perPage: 20, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+    });
+  });
+
   describe('getUserGroups', () => {
     it('should call API with default pagination', done => {
       const fakeResponse = {

--- a/gravitee-apim-console-webui/src/services-ngx/users-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/users-v2.service.ts
@@ -28,6 +28,15 @@ export interface UserApi {
   environmentName: string;
 }
 
+export interface UserApiProduct {
+  id: string;
+  name: string;
+  version: string;
+  visibility?: string;
+  environmentId: string;
+  environmentName: string;
+}
+
 export interface UserApplication {
   id: string;
   name: string;
@@ -66,6 +75,12 @@ export class UsersV2Service {
 
   getUserApis(userId: string, environmentId: string, page = 1, perPage = 10): Observable<PaginatedResponse<UserApi>> {
     return this.http.get<PaginatedResponse<UserApi>>(`${this.constants.org.v2BaseURL}/users/${userId}/apis`, {
+      params: { environmentId, page: page.toString(), perPage: perPage.toString() },
+    });
+  }
+
+  getUserApiProducts(userId: string, environmentId: string, page = 1, perPage = 10): Observable<PaginatedResponse<UserApiProduct>> {
+    return this.http.get<PaginatedResponse<UserApiProduct>>(`${this.constants.org.v2BaseURL}/users/${userId}/api-products`, {
       params: { environmentId, page: page.toString(), perPage: perPage.toString() },
     });
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/user/UserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/user/UserResource.java
@@ -15,11 +15,14 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.user;
 
+import io.gravitee.apim.core.user.use_case.GetUserApiProductsUseCase;
 import io.gravitee.apim.core.user.use_case.GetUserApisUseCase;
 import io.gravitee.apim.core.user.use_case.GetUserApplicationsUseCase;
 import io.gravitee.apim.core.user.use_case.GetUserGroupsUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.model.UserApi;
+import io.gravitee.rest.api.management.v2.rest.model.UserApiProduct;
+import io.gravitee.rest.api.management.v2.rest.model.UserApiProductsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.UserApisResponse;
 import io.gravitee.rest.api.management.v2.rest.model.UserApplication;
 import io.gravitee.rest.api.management.v2.rest.model.UserApplicationsResponse;
@@ -46,6 +49,9 @@ public class UserResource extends AbstractResource {
 
     @Inject
     private GetUserApisUseCase getUserApisUseCase;
+
+    @Inject
+    private GetUserApiProductsUseCase getUserApiProductsUseCase;
 
     @Inject
     private GetUserApplicationsUseCase getUserApplicationsUseCase;
@@ -82,6 +88,41 @@ public class UserResource extends AbstractResource {
 
         return Response.ok(
             new UserApisResponse()
+                .data(data)
+                .pagination(PaginationInfo.computePaginationInfo(output.totalCount(), data.size(), paginationParam))
+                .links(computePaginationLinks(output.totalCount(), paginationParam))
+        ).build();
+    }
+
+    @GET
+    @Path("/api-products")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ORGANIZATION_USERS, acls = RolePermissionAction.READ) })
+    public Response getUserApiProducts(
+        @PathParam("userId") String userId,
+        @BeanParam PaginationParam paginationParam,
+        @QueryParam("environmentId") String environmentId
+    ) {
+        var output = getUserApiProductsUseCase.execute(
+            new GetUserApiProductsUseCase.Input(userId, environmentId, paginationParam.getPage(), paginationParam.getPerPage())
+        );
+
+        List<UserApiProduct> data = output
+            .data()
+            .stream()
+            .map(userApiProduct ->
+                new UserApiProduct()
+                    .id(userApiProduct.getId())
+                    .name(userApiProduct.getName())
+                    .version(userApiProduct.getVersion())
+                    .visibility(userApiProduct.getVisibility())
+                    .environmentId(userApiProduct.getEnvironmentId())
+                    .environmentName(userApiProduct.getEnvironmentName())
+            )
+            .toList();
+
+        return Response.ok(
+            new UserApiProductsResponse()
                 .data(data)
                 .pagination(PaginationInfo.computePaginationInfo(output.totalCount(), data.size(), paginationParam))
                 .links(computePaginationLinks(output.totalCount(), paginationParam))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-users.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-users.yaml
@@ -53,6 +53,32 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
+    /users/{userId}/api-products:
+        parameters:
+            - $ref: "#/components/parameters/userIdParam"
+        get:
+            tags:
+                - Users
+            summary: Get API Products the user is a member of
+            description: |
+                Get the list of API Products the user is a member of.
+
+                User must have the ORGANIZATION_USERS[READ] permission.
+            operationId: getUserApiProducts
+            parameters:
+                - $ref: "#/components/parameters/pageParam"
+                - $ref: "#/components/parameters/perPageParam"
+                - $ref: "#/components/parameters/environmentIdParam"
+            responses:
+                "200":
+                    description: Paginated list of API Products the user is a member of.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/UserApiProductsResponse"
+                default:
+                    $ref: "#/components/responses/Error"
+
     /users/{userId}/applications:
         parameters:
             - $ref: "#/components/parameters/userIdParam"
@@ -135,6 +161,39 @@ components:
                     type: array
                     items:
                         $ref: "#/components/schemas/UserApi"
+                pagination:
+                    $ref: "#/components/schemas/Pagination"
+                links:
+                    $ref: "#/components/schemas/Links"
+
+        UserApiProduct:
+            type: object
+            properties:
+                id:
+                    type: string
+                    description: The API Product's unique identifier.
+                name:
+                    type: string
+                    description: The API Product's name.
+                version:
+                    type: string
+                    description: The API Product's version.
+                visibility:
+                    type: string
+                    description: Reserved for parity with User API listing; may be unset for API Products.
+                environmentId:
+                    type: string
+                    description: The ID of the environment the API Product belongs to.
+                environmentName:
+                    type: string
+                    description: The name of the environment the API Product belongs to.
+        UserApiProductsResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/UserApiProduct"
                 pagination:
                     $ref: "#/components/schemas/Pagination"
                 links:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -44,6 +44,7 @@ import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.specgen.use_case.SpecGenRequestUseCase;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.use_case.GetUserApiProductsUseCase;
 import io.gravitee.apim.core.user.use_case.GetUserApisUseCase;
 import io.gravitee.apim.core.user.use_case.GetUserApplicationsUseCase;
 import io.gravitee.apim.core.user.use_case.GetUserGroupsUseCase;
@@ -232,6 +233,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected GetUserApisUseCase getUserApisUseCase;
+
+    @Autowired
+    protected GetUserApiProductsUseCase getUserApiProductsUseCase;
 
     @Autowired
     protected GetUserApplicationsUseCase getUserApplicationsUseCase;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/user/UsersResourceApiProductsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/user/UsersResourceApiProductsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.user.model.UserApiProduct;
+import io.gravitee.apim.core.user.use_case.GetUserApiProductsUseCase;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.management.v2.rest.model.UserApiProductsResponse;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class UsersResourceApiProductsTest extends AbstractResourceTest {
+
+    private static final String USER_ID = "user-1";
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/users/" + USER_ID + "/api-products";
+    }
+
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        reset(getUserApiProductsUseCase);
+    }
+
+    @Test
+    void should_return_403_when_missing_permission() {
+        when(
+            permissionService.hasPermission(any(), eq(RolePermission.ORGANIZATION_USERS), eq(ORGANIZATION), eq(RolePermissionAction.READ))
+        ).thenReturn(false);
+
+        final Response response = rootTarget().request().get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+    }
+
+    @Test
+    void should_return_200_with_paginated_response() {
+        var products = List.of(
+            UserApiProduct.builder()
+                .id("ap-1")
+                .name("My Product")
+                .version("1.0")
+                .environmentId("env-1")
+                .environmentName("Development")
+                .build()
+        );
+
+        when(getUserApiProductsUseCase.execute(any())).thenReturn(new GetUserApiProductsUseCase.Output(products, 1));
+
+        final Response response = rootTarget().request().get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+
+        var body = response.readEntity(UserApiProductsResponse.class);
+        assertThat(body.getData()).hasSize(1);
+        assertThat(body.getData().get(0).getId()).isEqualTo("ap-1");
+        assertThat(body.getData().get(0).getName()).isEqualTo("My Product");
+        assertThat(body.getData().get(0).getVersion()).isEqualTo("1.0");
+        assertThat(body.getData().get(0).getEnvironmentId()).isEqualTo("env-1");
+        assertThat(body.getData().get(0).getEnvironmentName()).isEqualTo("Development");
+        assertThat(body.getPagination()).isNotNull();
+        assertThat(body.getLinks()).isNotNull();
+    }
+
+    @Test
+    void should_pass_environment_id_query_param() {
+        when(getUserApiProductsUseCase.execute(any())).thenReturn(new GetUserApiProductsUseCase.Output(List.of(), 0));
+
+        final Response response = rootTarget().queryParam("environmentId", "env-1").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+    }
+
+    @Test
+    void should_return_empty_list_when_no_results() {
+        when(getUserApiProductsUseCase.execute(any())).thenReturn(new GetUserApiProductsUseCase.Output(List.of(), 0));
+
+        final Response response = rootTarget().request().get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+
+        var body = response.readEntity(UserApiProductsResponse.class);
+        assertThat(body.getData()).isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -192,6 +192,7 @@ import io.gravitee.apim.core.subscription.use_case.UpdateSubscriptionUseCase;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.apim.core.user.domain_service.UserDomainService;
+import io.gravitee.apim.core.user.use_case.GetUserApiProductsUseCase;
 import io.gravitee.apim.core.user.use_case.GetUserApisUseCase;
 import io.gravitee.apim.core.user.use_case.GetUserApplicationsUseCase;
 import io.gravitee.apim.core.user.use_case.GetUserGroupsUseCase;
@@ -1257,6 +1258,11 @@ public class ResourceContextConfiguration {
     @Bean
     public GetUserApisUseCase getUserApisUseCase() {
         return mock(GetUserApisUseCase.class);
+    }
+
+    @Bean
+    public GetUserApiProductsUseCase getUserApiProductsUseCase() {
+        return mock(GetUserApiProductsUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductQueryService.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.core.api_product.query_service;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -26,6 +28,6 @@ public interface ApiProductQueryService {
     Set<ApiProduct> findByEnvironmentIdAndIdIn(String environmentId, Set<String> ids);
     Optional<ApiProduct> findById(String apiProductId);
     Set<ApiProduct> findByApiId(String apiId);
-
     Map<String, Set<ApiProduct>> findProductsByApiIds(Set<String> apiIds);
+    Page<ApiProduct> searchByIds(Set<String> ids, String environmentId, Pageable pageable);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/UserApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/UserApiProduct.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.user.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class UserApiProduct {
+
+    private String id;
+    private String name;
+    private String version;
+    private String visibility;
+    private String environmentId;
+    private String environmentName;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/use_case/GetUserApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/use_case/GetUserApiProductsUseCase.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.user.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.environment.crud_service.EnvironmentCrudService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import io.gravitee.apim.core.user.model.UserApiProduct;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetUserApiProductsUseCase {
+
+    private final MembershipQueryService membershipQueryService;
+    private final ApiProductQueryService apiProductQueryService;
+    private final EnvironmentCrudService environmentCrudService;
+
+    public Output execute(Input input) {
+        var memberships = membershipQueryService.findByMemberIdAndMemberTypeAndReferenceType(
+            input.userId,
+            Membership.Type.USER,
+            Membership.ReferenceType.API_PRODUCT
+        );
+
+        Set<String> apiProductIds = memberships.stream().map(Membership::getReferenceId).collect(Collectors.toSet());
+
+        if (apiProductIds.isEmpty()) {
+            return new Output(List.of(), 0);
+        }
+
+        var page = apiProductQueryService.searchByIds(apiProductIds, input.environmentId, new PageableImpl(input.page, input.perPage));
+
+        Set<String> environmentIds = page
+            .getContent()
+            .stream()
+            .map(ApiProduct::getEnvironmentId)
+            .filter(envId -> envId != null)
+            .collect(Collectors.toSet());
+        Map<String, String> environmentNames = resolveEnvironmentNames(environmentIds);
+
+        List<UserApiProduct> data = page
+            .getContent()
+            .stream()
+            .map(apiProduct -> {
+                String envId = apiProduct.getEnvironmentId();
+                return UserApiProduct.builder()
+                    .id(apiProduct.getId())
+                    .name(apiProduct.getName())
+                    .version(apiProduct.getVersion())
+                    .environmentId(envId)
+                    .environmentName(envId != null ? environmentNames.get(envId) : null)
+                    .build();
+            })
+            .toList();
+
+        return new Output(data, page.getTotalElements());
+    }
+
+    private Map<String, String> resolveEnvironmentNames(Set<String> environmentIds) {
+        Map<String, String> result = new HashMap<>();
+        for (String envId : environmentIds) {
+            try {
+                result.put(envId, environmentCrudService.get(envId).getName());
+            } catch (Exception e) {
+                // Skip environments that cannot be resolved
+            }
+        }
+        return result;
+    }
+
+    public record Input(String userId, String environmentId, int page, int perPage) {}
+
+    public record Output(List<UserApiProduct> data, long totalCount) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImpl.java
@@ -19,11 +19,18 @@ import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.infra.adapter.ApiProductAdapter;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiProductsRepository;
+import io.gravitee.repository.management.api.search.ApiProductCriteria;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
+import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.impl.AbstractService;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -35,7 +42,7 @@ import org.springframework.util.CollectionUtils;
 
 @Service
 @CustomLog
-public class ApiProductQueryServiceImpl implements ApiProductQueryService {
+public class ApiProductQueryServiceImpl extends AbstractService implements ApiProductQueryService {
 
     private final ApiProductsRepository apiProductRepository;
 
@@ -116,6 +123,38 @@ public class ApiProductQueryServiceImpl implements ApiProductQueryService {
             return repoApiProducts.stream().map(ApiProductAdapter.INSTANCE::toModel).collect(Collectors.toSet());
         } catch (TechnicalException e) {
             throw new TechnicalManagementException("Failed to find API Products by API ID", e);
+        }
+    }
+
+    @Override
+    public Page<ApiProduct> searchByIds(Set<String> ids, String environmentId, Pageable pageable) {
+        if (ids == null || ids.isEmpty()) {
+            return new Page<>(List.of(), pageable.getPageNumber(), pageable.getPageSize(), 0);
+        }
+        try {
+            log.debug("Searching API Products by ids: {} and environmentId: {}", ids, environmentId);
+            var criteria = new ApiProductCriteria.Builder().ids(ids).environmentId(environmentId).build();
+            var sortable = new SortableBuilder().field("name").setAsc(true).build();
+
+            Page<String> idPage = apiProductRepository.searchIds(List.of(criteria), convert(pageable), sortable);
+            if (idPage.getContent().isEmpty()) {
+                return new Page<>(List.of(), pageable.getPageNumber(), pageable.getPageSize(), idPage.getTotalElements());
+            }
+
+            Map<String, io.gravitee.repository.management.model.ApiProduct> apiProductsById = new LinkedHashMap<>();
+            apiProductRepository
+                .findByIds(idPage.getContent())
+                .forEach(repoApiProduct -> apiProductsById.put(repoApiProduct.getId(), repoApiProduct));
+            List<ApiProduct> pageContent = idPage
+                .getContent()
+                .stream()
+                .filter(apiProductsById::containsKey)
+                .map(apiProductId -> ApiProductAdapter.INSTANCE.toModel(apiProductsById.get(apiProductId)))
+                .toList();
+
+            return new Page<>(pageContent, pageable.getPageNumber(), pageContent.size(), idPage.getTotalElements());
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Failed to search API Products by ids", e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductQueryServiceInMemory.java
@@ -17,8 +17,12 @@ package inmemory;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -72,6 +76,23 @@ public class ApiProductQueryServiceInMemory extends AbstractQueryServiceInMemory
             }
         }
         return result;
+    }
+
+    @Override
+    public Page<ApiProduct> searchByIds(Set<String> ids, String environmentId, Pageable pageable) {
+        var matches = storage
+            .stream()
+            .filter(p -> ids.contains(p.getId()))
+            .filter(p -> environmentId == null || Objects.equals(environmentId, p.getEnvironmentId()))
+            .sorted(Comparator.comparing(ApiProduct::getName, Comparator.nullsLast(String::compareToIgnoreCase)))
+            .toList();
+
+        int pageNumber = pageable.getPageNumber();
+        int pageSize = pageable.getPageSize();
+        int startIndex = (pageNumber - 1) * pageSize;
+        int endIndex = Math.min(startIndex + pageSize, matches.size());
+        List<ApiProduct> pageContent = startIndex >= matches.size() ? List.of() : matches.subList(startIndex, endIndex);
+        return new Page<>(pageContent, pageNumber, pageSize, matches.size());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/user/use_case/GetUserApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/user/use_case/GetUserApiProductsUseCaseTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.user.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.EnvironmentCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.MembershipQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.environment.model.Environment;
+import io.gravitee.apim.core.membership.model.Membership;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetUserApiProductsUseCaseTest {
+
+    private static final String USER_ID = "user-1";
+
+    MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
+    ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    EnvironmentCrudServiceInMemory environmentCrudService = new EnvironmentCrudServiceInMemory();
+    GetUserApiProductsUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetUserApiProductsUseCase(membershipQueryService, apiProductQueryService, environmentCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(membershipQueryService, apiProductQueryService, environmentCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_return_user_api_products_with_correct_fields() {
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("m1")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("ap-1")
+                    .build()
+            )
+        );
+        apiProductQueryService.initWith(
+            List.of(ApiProduct.builder().id("ap-1").name("My Product").version("1.0").environmentId("env-1").build())
+        );
+        environmentCrudService.initWith(List.of(Environment.builder().id("env-1").name("Development").build()));
+
+        var output = useCase.execute(new GetUserApiProductsUseCase.Input(USER_ID, null, 1, 10));
+
+        assertThat(output.data()).hasSize(1);
+        assertThat(output.totalCount()).isEqualTo(1);
+
+        var result = output.data().get(0);
+        assertThat(result.getId()).isEqualTo("ap-1");
+        assertThat(result.getName()).isEqualTo("My Product");
+        assertThat(result.getVersion()).isEqualTo("1.0");
+        assertThat(result.getVisibility()).isNull();
+        assertThat(result.getEnvironmentId()).isEqualTo("env-1");
+        assertThat(result.getEnvironmentName()).isEqualTo("Development");
+    }
+
+    @Test
+    void should_filter_by_environment_id() {
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("m1")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("ap-1")
+                    .build(),
+                Membership.builder()
+                    .id("m2")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("ap-2")
+                    .build()
+            )
+        );
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder().id("ap-1").name("Product 1").environmentId("env-1").build(),
+                ApiProduct.builder().id("ap-2").name("Product 2").environmentId("env-2").build()
+            )
+        );
+        environmentCrudService.initWith(
+            List.of(Environment.builder().id("env-1").name("Dev").build(), Environment.builder().id("env-2").name("Prod").build())
+        );
+
+        var output = useCase.execute(new GetUserApiProductsUseCase.Input(USER_ID, "env-1", 1, 10));
+
+        assertThat(output.data()).hasSize(1);
+        assertThat(output.totalCount()).isEqualTo(1);
+        assertThat(output.data().get(0).getId()).isEqualTo("ap-1");
+    }
+
+    @Test
+    void should_return_empty_page_when_user_has_no_memberships() {
+        var output = useCase.execute(new GetUserApiProductsUseCase.Input(USER_ID, null, 1, 10));
+
+        assertThat(output.data()).isEmpty();
+        assertThat(output.totalCount()).isZero();
+    }
+
+    @Test
+    void should_paginate_correctly() {
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("m1")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("ap-1")
+                    .build(),
+                Membership.builder()
+                    .id("m2")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("ap-2")
+                    .build(),
+                Membership.builder()
+                    .id("m3")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("ap-3")
+                    .build()
+            )
+        );
+        apiProductQueryService.initWith(
+            List.of(
+                ApiProduct.builder().id("ap-1").name("Product 1").environmentId("env-1").build(),
+                ApiProduct.builder().id("ap-2").name("Product 2").environmentId("env-1").build(),
+                ApiProduct.builder().id("ap-3").name("Product 3").environmentId("env-1").build()
+            )
+        );
+        environmentCrudService.initWith(List.of(Environment.builder().id("env-1").name("Dev").build()));
+
+        var output = useCase.execute(new GetUserApiProductsUseCase.Input(USER_ID, "env-1", 2, 2));
+
+        assertThat(output.data()).hasSize(1);
+        assertThat(output.totalCount()).isEqualTo(3);
+        assertThat(output.data().get(0).getId()).isEqualTo("ap-3");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImplTest.java
@@ -18,14 +18,17 @@ package io.gravitee.apim.infra.query_service.api_product;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiProductsRepository;
+import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Date;
@@ -282,6 +285,110 @@ class ApiProductQueryServiceImplTest {
         void should_throw_technical_exception_when_repository_fails() throws TechnicalException {
             when(apiProductRepository.findApiProductsByApiIds(Set.of(API_ID))).thenThrow(new TechnicalException("Database error"));
             var throwable = catchThrowable(() -> service.findProductsByApiIds(Set.of(API_ID)));
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
+        }
+    }
+
+    @Nested
+    class SearchByIds {
+
+        @Test
+        void should_return_empty_page_when_ids_null() {
+            var result = service.searchByIds(null, ENV_ID, new PageableImpl(1, 10));
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getTotalElements()).isZero();
+        }
+
+        @Test
+        void should_return_empty_page_when_ids_empty() {
+            var result = service.searchByIds(Set.of(), ENV_ID, new PageableImpl(1, 10));
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getTotalElements()).isZero();
+        }
+
+        @Test
+        void should_return_empty_page_when_searchIds_returns_no_results() throws TechnicalException {
+            when(apiProductRepository.searchIds(any(), any(), any())).thenReturn(new Page<>(List.of(), 1, 0, 0));
+
+            Page<ApiProduct> result = service.searchByIds(Set.of(API_PRODUCT_ID), ENV_ID, new PageableImpl(1, 10));
+
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getTotalElements()).isZero();
+        }
+
+        @Test
+        void should_return_products_for_current_page() throws TechnicalException {
+            var repoApiProduct = buildRepositoryApiProduct();
+            when(apiProductRepository.searchIds(any(), any(), any())).thenReturn(new Page<>(List.of(API_PRODUCT_ID), 1, 1, 1));
+            when(apiProductRepository.findByIds(List.of(API_PRODUCT_ID))).thenReturn(Set.of(repoApiProduct));
+
+            Page<ApiProduct> result = service.searchByIds(Set.of(API_PRODUCT_ID), ENV_ID, new PageableImpl(1, 10));
+
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).getId()).isEqualTo(API_PRODUCT_ID);
+            assertThat(result.getTotalElements()).isEqualTo(1);
+        }
+
+        @Test
+        void should_respect_db_sort_order_from_searchIds() throws TechnicalException {
+            var productA = io.gravitee.repository.management.model.ApiProduct.builder()
+                .id("p-a")
+                .environmentId(ENV_ID)
+                .name("Alpha Product")
+                .version("1.0.0")
+                .createdAt(new Date())
+                .updatedAt(new Date())
+                .build();
+            var productZ = io.gravitee.repository.management.model.ApiProduct.builder()
+                .id("p-z")
+                .environmentId(ENV_ID)
+                .name("Zebra Product")
+                .version("1.0.0")
+                .createdAt(new Date())
+                .updatedAt(new Date())
+                .build();
+            // DB returns IDs already sorted by name ASC
+            when(apiProductRepository.searchIds(any(), any(), any())).thenReturn(new Page<>(List.of("p-a", "p-z"), 1, 2, 2));
+            when(apiProductRepository.findByIds(List.of("p-a", "p-z"))).thenReturn(Set.of(productA, productZ));
+
+            Page<ApiProduct> result = service.searchByIds(Set.of("p-a", "p-z"), ENV_ID, new PageableImpl(1, 10));
+
+            assertThat(result.getContent()).extracting(ApiProduct::getName).containsExactly("Alpha Product", "Zebra Product");
+        }
+
+        @Test
+        void should_return_only_current_page_with_correct_total() throws TechnicalException {
+            var product3 = io.gravitee.repository.management.model.ApiProduct.builder()
+                .id("p-3")
+                .environmentId(ENV_ID)
+                .name("Product C")
+                .version("1.0.0")
+                .createdAt(new Date())
+                .updatedAt(new Date())
+                .build();
+            // DB handles pagination: page 2, size 2 → only "p-3", total 3
+            when(apiProductRepository.searchIds(any(), any(), any())).thenReturn(new Page<>(List.of("p-3"), 2, 1, 3));
+            when(apiProductRepository.findByIds(List.of("p-3"))).thenReturn(Set.of(product3));
+
+            Page<ApiProduct> result = service.searchByIds(Set.of("p-1", "p-2", "p-3"), ENV_ID, new PageableImpl(2, 2));
+
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).getName()).isEqualTo("Product C");
+            assertThat(result.getTotalElements()).isEqualTo(3);
+        }
+
+        @Test
+        void should_throw_technical_exception_when_searchIds_fails() throws TechnicalException {
+            when(apiProductRepository.searchIds(any(), any(), any())).thenThrow(new TechnicalException("Database error"));
+            var throwable = catchThrowable(() -> service.searchByIds(Set.of(API_PRODUCT_ID), ENV_ID, new PageableImpl(1, 10)));
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
+        }
+
+        @Test
+        void should_throw_technical_exception_when_findByIds_fails() throws TechnicalException {
+            when(apiProductRepository.searchIds(any(), any(), any())).thenReturn(new Page<>(List.of(API_PRODUCT_ID), 1, 1, 1));
+            when(apiProductRepository.findByIds(List.of(API_PRODUCT_ID))).thenThrow(new TechnicalException("Database error"));
+            var throwable = catchThrowable(() -> service.searchByIds(Set.of(API_PRODUCT_ID), ENV_ID, new PageableImpl(1, 10)));
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
         }
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13366

## Description

This PR introduces the API Products section in the User Details page (Organization → Users).

**Context / Problem**

Currently, the User Details page provides visibility into:

- > Organization role
- > Environments
- > Groups
- > APIs
- > Applications
- > Tokens

However, there is no visibility into API Products, making it difficult to understand:

> User association with API Products
> Ownership or access scope at the product level
> Overall access footprint of a user

Since API Products are a key abstraction for grouping APIs and managing access in Gravitee, this visibility is essential for better governance and user management.

_Changes Introduced_
🔹 **_Console (UI)_**
```
Added a new “API Products” section in the User Details page
Displays:
API Product Name
Version
Visibility
Added:
Search functionality
Pagination (aligned with existing sections like APIs and Applications)
Empty state handling:
Displays “No API Product” when no data is available
Ensured UI consistency with existing tables and layouts
```
**_🔹 Management API (mAPI)_**
```
Added/extended API to fetch API Products associated with a user
Supports:
Pagination
Search (by name)
Applies permission-based filtering:
Returns only API Products visible to the user (based on roles, ownership, or admin access)
```

<img width="1706" height="872" alt="Screenshot 2026-03-30 at 10 10 16 AM" src="https://github.com/user-attachments/assets/51b52f1d-4423-4326-8076-ad693aab6971" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

