### PR TITLE
docs(ipfiltering): APIM-13213 add note for X-Forwarded-For

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <gravitee-policy-html-json.version>1.6.3</gravitee-policy-html-json.version>
         <gravitee-policy-http-signature.version>1.7.0</gravitee-policy-http-signature.version>
         <gravitee-policy-interrupt.version>2.0.0</gravitee-policy-interrupt.version>
-        <gravitee-policy-ipfiltering.version>2.1.0</gravitee-policy-ipfiltering.version>
+        <gravitee-policy-ipfiltering.version>2.1.1</gravitee-policy-ipfiltering.version>
         <gravitee-policy-javascript.version>2.0.0</gravitee-policy-javascript.version>
         <gravitee-policy-json-threat-protection.version>2.1.0</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>3.0.1</gravitee-policy-json-to-json.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13213

**Description**

Added a note in overview: `The X-Forwarded-For header verification is only applicable to self-hosted gateways. On SaaS-based gateways (Gravitee Cloud), the X-Forwarded-For header isn't available for IP filtering because the SaaS infrastructure manages traffic routing differently.`

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

