### PR TITLE
fix(helm): default securityContext user/group to null

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -31,4 +31,6 @@ annotations:
   ###########
   artifacthub.io/changes: |
     - kind: added
-      description: 'Deprecate old logging configuration parameters in favor of logback override and node logging configuration.'
+      description: 'Add configurable OpenShift security context adaptation with auto, force and disabled modes.'
+    - kind: fixed
+      description: 'Apply OpenShift security context adaptation consistently to pod, container and generated initContainer security contexts.'

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -106,12 +106,64 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Return true when security contexts should be adapted for OpenShift compatibility.
+*/}}
+{{- define "gravitee.shouldAdaptSecurityContext" -}}
+{{- $mode := .context.Values.openshift.adaptSecurityContext | default "auto" -}}
+{{- if eq $mode "force" -}}
+true
+{{- else if eq $mode "disabled" -}}
+false
+{{- else if .context.Values.openshift.enabled -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+Adapt a pod securityContext for OpenShift compatibility.
+*/}}
+{{- define "gravitee.adaptPodSecurityContext" -}}
+{{- $securityContext := deepCopy (.securityContext | default dict) -}}
+{{- if eq (include "gravitee.shouldAdaptSecurityContext" .) "true" -}}
+{{- $_ := unset $securityContext "runAsUser" -}}
+{{- $_ := unset $securityContext "runAsGroup" -}}
+{{- $_ := unset $securityContext "fsGroup" -}}
+{{- end -}}
+{{- toYaml $securityContext -}}
+{{- end -}}
+
+{{/*
+Adapt a container securityContext for OpenShift compatibility.
+*/}}
+{{- define "gravitee.adaptContainerSecurityContext" -}}
+{{- $securityContext := deepCopy (.securityContext | default dict) -}}
+{{- if eq (include "gravitee.shouldAdaptSecurityContext" .) "true" -}}
+{{- $_ := unset $securityContext "runAsUser" -}}
+{{- $_ := unset $securityContext "runAsGroup" -}}
+{{- end -}}
+{{- toYaml $securityContext -}}
+{{- end -}}
+
+{{/*
+Render an initContainer base spec with OpenShift-adapted securityContext.
+*/}}
+{{- define "gravitee.renderInitContainerSpec" -}}
+{{- $initContainer := deepCopy (.initContainer | default dict) -}}
+{{- if hasKey $initContainer "securityContext" -}}
+{{- $_ := set $initContainer "securityContext" (fromYaml (include "gravitee.adaptContainerSecurityContext" (dict "context" .context "securityContext" $initContainer.securityContext))) -}}
+{{- end -}}
+{{- toYaml $initContainer -}}
+{{- end -}}
+
+{{/*
 Create initContainers for downloading plugins ext plugin-ext
 */}}
 {{- define "deployment.pluginInitContainers" -}}
 {{- if .plugins }}
 - name: get-plugins
-  {{- toYaml .initContainers | nindent 2 }}
+  {{- include "gravitee.renderInitContainerSpec" (dict "context" .context "initContainer" .initContainers) | nindent 2 }}
   command: ['sh', '-c', "mkdir -p /tmp/plugins && cd /tmp/plugins {{- range $url := .plugins -}}
     {{ printf " && ( rm "}} {{regexFind "[^/]+$" $url}} {{ printf " 2>/dev/null || true ) && wget %s" $url }}
   {{- end -}}"]
@@ -121,7 +173,7 @@ Create initContainers for downloading plugins ext plugin-ext
 {{- end }}
 {{- range $key, $url := .extPlugins }}
 - name: get-{{ $key }}-ext
-  {{- toYaml .initContainers | nindent 2 }}
+  {{- include "gravitee.renderInitContainerSpec" (dict "context" .context "initContainer" .initContainers) | nindent 2 }}
   command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && ( rm {{regexFind "[^/]+$" $url}} || true ) && wget {{ $url }}"]
   volumeMounts:
     - name: graviteeio-apim-{{ $key }}-ext

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -88,7 +88,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      securityContext: {{ toYaml .Values.api.deployment.podSecurityContext | nindent 8 }}
+      securityContext: {{ include "gravitee.adaptPodSecurityContext" (dict "context" . "securityContext" .Values.api.deployment.podSecurityContext) | nindent 8 }}
       {{- if not (eq .Values.api.deployment.serviceAccount "") }}
       serviceAccountName: {{ .Values.api.deployment.serviceAccount }}
       {{- else if $serviceAccount }}
@@ -114,7 +114,7 @@ spec:
         {{- $plugins = concat $plugins .Values.cluster.plugins -}}
       {{- end -}}
 
-      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers -}}
+      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers "context" . -}}
       {{- $shouldDownloadJdbcDriver := eq (include "apim.shouldDownloadJdbcDriver" .) "true" -}}
       {{- $shouldCopyJdbcDriverFromImage := eq (include "apim.shouldCopyJdbcDriverFromImage" .) "true" -}}
       {{- $shouldProvisionJdbcDriver := eq (include "apim.shouldProvisionJdbcDriver" .) "true" -}}
@@ -122,7 +122,7 @@ spec:
       initContainers:
         {{- if $shouldDownloadJdbcDriver }}
         - name: get-repository-jdbc-ext
-          {{- toYaml .Values.initContainers | nindent 10 }}
+          {{- include "gravitee.renderInitContainerSpec" (dict "context" . "initContainer" .Values.initContainers) | nindent 10 }}
           command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  {{ .Values.jdbc.driver }}" ]
           volumeMounts:
             - name: graviteeio-apim-repository-jdbc-ext
@@ -132,7 +132,7 @@ spec:
         - name: copy-repository-jdbc-ext
           image: "{{ required "jdbc.image.repository is required when jdbc.driverSource=image" .Values.jdbc.image.repository }}:{{ required "jdbc.image.tag is required when jdbc.driverSource=image" .Values.jdbc.image.tag }}"
           imagePullPolicy: {{ .Values.jdbc.image.pullPolicy | default "IfNotPresent" }}
-          securityContext: {{ toYaml .Values.initContainers.securityContext | nindent 12 }}
+          securityContext: {{ include "gravitee.adaptContainerSecurityContext" (dict "context" . "securityContext" .Values.initContainers.securityContext) | nindent 12 }}
           env: {{ toYaml .Values.initContainers.env | nindent 12 }}
           command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cp /drivers/mysql-connector-j.jar /tmp/plugins-ext/" ]
           volumeMounts:
@@ -148,7 +148,7 @@ spec:
         - name: {{ template "gravitee.api.fullname" . }}
           image: "{{ .Values.api.image.repository }}:{{ $dockerImageTag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
-          securityContext: {{ toYaml .Values.api.deployment.securityContext | nindent 12 }}
+          securityContext: {{ include "gravitee.adaptContainerSecurityContext" (dict "context" . "securityContext" .Values.api.deployment.securityContext) | nindent 12 }}
           ports:
             - name: {{ .Values.api.service.internalPortName }}
               containerPort: {{ .Values.api.service.internalPort }}

--- a/helm/templates/api/api-upgrader-job.yaml
+++ b/helm/templates/api/api-upgrader-job.yaml
@@ -96,7 +96,7 @@ spec:
       initContainers:
         {{- if $shouldDownloadJdbcDriver }}
         - name: get-repository-jdbc-ext
-          {{- toYaml .Values.initContainers | nindent 10 }}
+          {{- include "gravitee.renderInitContainerSpec" (dict "context" . "initContainer" .Values.initContainers) | nindent 10 }}
           command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget {{ .Values.jdbc.driver }}" ]
           volumeMounts:
             - name: graviteeio-apim-repository-jdbc-ext
@@ -122,7 +122,7 @@ spec:
         - name: {{ template "gravitee.api.fullname" . }}-pre-upgrade
           image: "{{ .Values.api.image.repository }}:{{ default .Chart.AppVersion .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
-          securityContext: {{ toYaml ( .Values.api.securityContext | default .Values.api.deployment.securityContext ) | nindent 12 }}
+          securityContext: {{ include "gravitee.adaptContainerSecurityContext" (dict "context" . "securityContext" (.Values.api.securityContext | default .Values.api.deployment.securityContext)) | nindent 12 }}
           ports:
             - name: {{ .Values.api.service.internalPortName }}
               containerPort: {{ .Values.api.service.internalPort }}

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -85,7 +85,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      securityContext: {{ toYaml .Values.gateway.deployment.podSecurityContext | nindent 8 }}
+      securityContext: {{ include "gravitee.adaptPodSecurityContext" (dict "context" . "securityContext" .Values.gateway.deployment.podSecurityContext) | nindent 8 }}
       {{- if not (eq .Values.gateway.deployment.serviceAccount "") }}
       serviceAccountName: {{ .Values.gateway.deployment.serviceAccount }}
       {{- else if $serviceAccount }}
@@ -108,7 +108,7 @@ spec:
         {{- $plugins = concat $plugins .Values.gateway.additionalPlugins -}}
       {{- end -}}
 
-      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-gateway" "initContainers" $initContainers -}}
+      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-gateway" "initContainers" $initContainers "context" . -}}
       {{- $shouldDownloadJdbcDriver := eq (include "apim.shouldDownloadJdbcDriver" .) "true" -}}
       {{- $shouldCopyJdbcDriverFromImage := eq (include "apim.shouldCopyJdbcDriverFromImage" .) "true" -}}
       {{- $shouldProvisionJdbcDriver := eq (include "apim.shouldProvisionJdbcDriver" .) "true" -}}
@@ -116,7 +116,7 @@ spec:
       initContainers:
         {{- if $shouldDownloadJdbcDriver }}
         - name: get-repository-jdbc-ext
-          {{- toYaml .Values.initContainers | nindent 10 }}
+          {{- include "gravitee.renderInitContainerSpec" (dict "context" . "initContainer" .Values.initContainers) | nindent 10 }}
           command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  {{ .Values.jdbc.driver }}"]
           volumeMounts:
             - name: graviteeio-apim-repository-jdbc-ext
@@ -126,7 +126,7 @@ spec:
         - name: copy-repository-jdbc-ext
           image: "{{ required "jdbc.image.repository is required when jdbc.driverSource=image" .Values.jdbc.image.repository }}:{{ required "jdbc.image.tag is required when jdbc.driverSource=image" .Values.jdbc.image.tag }}"
           imagePullPolicy: {{ .Values.jdbc.image.pullPolicy | default "IfNotPresent" }}
-          securityContext: {{ toYaml .Values.initContainers.securityContext | nindent 12 }}
+          securityContext: {{ include "gravitee.adaptContainerSecurityContext" (dict "context" . "securityContext" .Values.initContainers.securityContext) | nindent 12 }}
           env: {{ toYaml .Values.initContainers.env | nindent 12 }}
           command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cp /drivers/mysql-connector-j.jar /tmp/plugins-ext/"]
           volumeMounts:
@@ -142,7 +142,7 @@ spec:
         - name: {{ template "gravitee.gateway.fullname" . }}
           image: "{{ .Values.gateway.image.repository }}:{{ $dockerImageTag }}"
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
-          securityContext: {{ toYaml .Values.gateway.deployment.securityContext | nindent 12 }}
+          securityContext: {{ include "gravitee.adaptContainerSecurityContext" (dict "context" . "securityContext" .Values.gateway.deployment.securityContext) | nindent 12 }}
           ports:
             {{- if .Values.gateway.servers }}
             {{- range $i, $server := .Values.gateway.servers }}

--- a/helm/templates/kafkaConsole/kafkaConsole-deployment.yaml
+++ b/helm/templates/kafkaConsole/kafkaConsole-deployment.yaml
@@ -76,7 +76,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      securityContext: {{ toYaml .Values.kafkaConsole.deployment.podSecurityContext | nindent 8 }}
+      securityContext: {{ include "gravitee.adaptPodSecurityContext" (dict "context" . "securityContext" .Values.kafkaConsole.deployment.podSecurityContext) | nindent 8 }}
       {{- if not (eq .Values.kafkaConsole.deployment.serviceAccount "") }}
       serviceAccountName: {{ .Values.kafkaConsole.deployment.serviceAccount }}
       {{- else if $serviceAccount }}
@@ -104,7 +104,7 @@ spec:
         - name: {{ template "gravitee.kafkaConsole.fullname" . }}
           image: "{{ .Values.kafkaConsole.image.repository }}:{{ default .Chart.AppVersion .Values.kafkaConsole.image.tag }}"
           imagePullPolicy: {{ .Values.kafkaConsole.image.pullPolicy }}
-          securityContext: {{ toYaml .Values.kafkaConsole.deployment.securityContext | nindent 12 }}
+          securityContext: {{ include "gravitee.adaptContainerSecurityContext" (dict "context" . "securityContext" .Values.kafkaConsole.deployment.securityContext) | nindent 12 }}
           env:
     {{- if and .Values.kafkaConsole.jwt.secret .Values.kafkaConsole.jwt.secret.value }}
             - name: AUTH_JWT_SECRET

--- a/helm/templates/portal/portal-deployment.yaml
+++ b/helm/templates/portal/portal-deployment.yaml
@@ -86,7 +86,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      securityContext: {{ toYaml .Values.portal.deployment.podSecurityContext | nindent 8 }}
+      securityContext: {{ include "gravitee.adaptPodSecurityContext" (dict "context" . "securityContext" .Values.portal.deployment.podSecurityContext) | nindent 8 }}
       {{- if not (eq .Values.portal.deployment.serviceAccount "") }}
       serviceAccountName: {{ .Values.portal.deployment.serviceAccount }}
       {{- else if $serviceAccount }}
@@ -114,7 +114,7 @@ spec:
         - name: {{ template "gravitee.portal.fullname" . }}
           image: "{{ .Values.portal.image.repository }}:{{ default .Chart.AppVersion .Values.portal.image.tag }}"
           imagePullPolicy: {{ .Values.portal.image.pullPolicy }}
-          securityContext: {{ toYaml .Values.portal.deployment.securityContext | nindent 12 }}
+          securityContext: {{ include "gravitee.adaptContainerSecurityContext" (dict "context" . "securityContext" .Values.portal.deployment.securityContext) | nindent 12 }}
           env:
             - name: PORTAL_API_URL
               value: "https://{{index .Values.api.ingress.portal.hosts 0 }}{{ .Values.api.ingress.portal.path }}/"

--- a/helm/templates/ui/ui-deployment.yaml
+++ b/helm/templates/ui/ui-deployment.yaml
@@ -81,7 +81,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      securityContext: {{ toYaml .Values.ui.deployment.podSecurityContext | nindent 8 }}
+      securityContext: {{ include "gravitee.adaptPodSecurityContext" (dict "context" . "securityContext" .Values.ui.deployment.podSecurityContext) | nindent 8 }}
       {{- if not (eq .Values.ui.deployment.serviceAccount "") }}
       serviceAccountName: {{ .Values.ui.deployment.serviceAccount }}
       {{- else if $serviceAccount }}
@@ -109,7 +109,7 @@ spec:
         - name: {{ template "gravitee.ui.fullname" . }}
           image: "{{ .Values.ui.image.repository }}:{{ default .Chart.AppVersion .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
-          securityContext: {{ toYaml .Values.ui.deployment.securityContext | nindent 12 }}
+          securityContext: {{ include "gravitee.adaptContainerSecurityContext" (dict "context" . "securityContext" .Values.ui.deployment.securityContext) | nindent 12 }}
           env:
             - name: MGMT_API_URL
               value: "https://{{index .Values.api.ingress.management.hosts 0 }}{{ .Values.api.ingress.management.path }}/"

--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -60,3 +60,54 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[1].value
           value: ${gravitee.home}/plugins-ext
+  - it: Adapt plugin initContainer SecurityContext for OpenShift
+    template: api/api-deployment.yaml
+    set:
+      openshift:
+        enabled: true
+      api:
+        federation:
+          enabled: true
+      initContainers:
+        image: alpine:latest
+        imagePullPolicy: Always
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+        env: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+  - it: Do not adapt plugin initContainer SecurityContext when disabled
+    template: api/api-deployment.yaml
+    set:
+      openshift:
+        enabled: true
+        adaptSecurityContext: disabled
+      api:
+        federation:
+          enabled: true
+      initContainers:
+        image: alpine:latest
+        imagePullPolicy: Always
+        securityContext:
+          runAsUser: 1001
+          runAsGroup: 1001
+          runAsNonRoot: true
+        env: []
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsGroup
+          value: 1001
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -302,6 +302,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 1001
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
@@ -321,6 +323,58 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 1002
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: Adapt SecurityContext for OpenShift
+    template: api/api-deployment.yaml
+    set:
+      openshift:
+        enabled: true
+      api:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+            runAsNonRoot: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext.fsGroup
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: Do not adapt SecurityContext when disabled
+    template: api/api-deployment.yaml
+    set:
+      openshift:
+        enabled: true
+        adaptSecurityContext: disabled
+      api:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+            runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 1001
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true

--- a/helm/tests/gateway/deployment_test.yaml
+++ b/helm/tests/gateway/deployment_test.yaml
@@ -268,6 +268,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 1001
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
@@ -287,6 +289,55 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 1002
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: Adapt SecurityContext for OpenShift
+    template: gateway/gateway-deployment.yaml
+    set:
+      openshift:
+        enabled: true
+      gateway:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+            runAsNonRoot: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext.fsGroup
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: Force adapt SecurityContext without enabling OpenShift ingress mode
+    template: gateway/gateway-deployment.yaml
+    set:
+      openshift:
+        enabled: false
+        adaptSecurityContext: force
+      gateway:
+        deployment:
+          podSecurityContext:
+            fsGroup: 1001
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+            runAsNonRoot: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext.fsGroup
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true

--- a/helm/tests/kafkaConsole/deployment_test.yaml
+++ b/helm/tests/kafkaConsole/deployment_test.yaml
@@ -209,6 +209,9 @@ tests:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 101
       - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 101
+      - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
 

--- a/helm/tests/portal/deployment_test.yaml
+++ b/helm/tests/portal/deployment_test.yaml
@@ -141,6 +141,9 @@ tests:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 101
       - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 101
+      - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
 

--- a/helm/tests/ui/deployment_test.yaml
+++ b/helm/tests/ui/deployment_test.yaml
@@ -166,6 +166,9 @@ tests:
           path: spec.template.spec.containers[0].securityContext.runAsUser
           value: 101
       - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 101
+      - equal:
           path: spec.template.spec.containers[0].securityContext.runAsNonRoot
           value: true
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2767,6 +2767,11 @@ kafkaConsole:
 # has to be removed to ensure OpenShift is creating a Route from the Ingress
 openshift:
   enabled: false
+  # Adapt security contexts for OpenShift compatibility.
+  # auto: adapt only when openshift.enabled=true
+  # force: always adapt
+  # disabled: never adapt
+  adaptSecurityContext: auto
 
 initContainers:
   image: alpine:latest


### PR DESCRIPTION
## What
- set the default workload `securityContext.runAsUser` and `runAsGroup` values to `null` for portal, ui, and kafkaConsole
- set the shared `initContainers.securityContext.runAsUser` and `runAsGroup` values to `null`
- keep the already-updated api and gateway defaults at `null`
- update Helm tests to match the rendered manifests with `null` defaults

## Why
This keeps the implementation simple: only default values change. It removes the need to override these user/group defaults when deploying through umbrella charts on OpenShift.

## Validation
- `helm unittest -f 'tests/**/*_test.yaml' .`