### PR TITLE
Fix/gko 2780 toaster custom colors are ignored

### DIFF
--- a/gravitee-apim-console-webui/src/scss/gio-global-style.scss
+++ b/gravitee-apim-console-webui/src/scss/gio-global-style.scss
@@ -15,16 +15,24 @@ $success-color: mat.m2-get-color-from-palette(gio.$mat-success-palette, default-
 $snackbar-button: mat.m2-get-color-from-palette(gio.$mat-basic-palette, white);
 
 .gio-snack-bar-success {
-  --mat-snackbar-container-color: #{$success-background-color};
-  --mat-snackbar-supporting-text-color: #{$success-color};
-  --mat-snack-bar-button-color: #{$snackbar-button};
+  @include mat.snack-bar-overrides(
+    (
+      container-color: $success-background-color,
+      supporting-text-color: $success-color,
+      button-color: $snackbar-button,
+    )
+  );
   white-space: pre-wrap;
 }
 
 .gio-snack-bar-error {
-  --mat-snackbar-container-color: #{$error-background-color};
-  --mat-snackbar-supporting-text-color: #{$error-color};
-  --mat-snack-bar-button-color: #{$snackbar-button};
+  @include mat.snack-bar-overrides(
+    (
+      container-color: $error-background-color,
+      supporting-text-color: $error-color,
+      button-color: $snackbar-button,
+    )
+  );
   white-space: pre-wrap;
 }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2780

## Description

Fix color of the toaster.

## Additional context

<img width="361" height="68" alt="Screenshot 2026-03-30 at 11 15 13" src="https://github.com/user-attachments/assets/a88d05e3-d39d-49d5-96c9-66b4c3cd2407" />
<img width="406" height="103" alt="Screenshot 2026-03-30 at 11 14 51" src="https://github.com/user-attachments/assets/21a3ae95-6497-4438-b2bb-4edad7a77e5f" />

