### PR TITLE
fix: only show tooltips on ellipsis in cards view.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.html
@@ -19,7 +19,9 @@
   <mat-card-content class="api-card__content">
     <div class="api-card__header">
       <div class="api-card__header__content">
-        <div class="api-card__title next-gen-h5" data-testid="api-card-title" [matTooltip]="title">{{ title }}</div>
+        <div class="api-card__title next-gen-h5" data-testid="api-card-title" [matTooltip]="title" appMatTooltipOnEllipsis>
+          {{ title }}
+        </div>
       </div>
       @if (isEnabledMcpServer) {
         <app-badge i18n-label label="MCP" i18n-matTooltip matTooltip="MCP available for this API" />

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.spec.ts
@@ -47,7 +47,7 @@ describe('CardComponent', () => {
   });
 
   it('should display data in card', () => {
-    expect(fixture.nativeElement.querySelector('[data-testid="api-card-title"]').textContent).toEqual('Test title');
+    expect(fixture.nativeElement.querySelector('[data-testid="api-card-title"]').textContent?.trim()).toEqual('Test title');
     expect(fixture.nativeElement.querySelector('.api-card__description').innerHTML).toContain(
       'Get real-time weather updates, forecasts, and historical data to enhance your applications with accurate weather information.',
     );

--- a/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-card/api-card.component.ts
@@ -17,11 +17,12 @@ import { Component, Input, output } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatTooltip } from '@angular/material/tooltip';
 
+import { MatTooltipOnEllipsisDirective } from '../../directives/mat-tooltip-on-ellipsis.directive';
 import { BadgeComponent } from '../badge/badge.component';
 
 @Component({
   selector: 'app-api-card',
-  imports: [MatCardModule, MatTooltip, BadgeComponent],
+  imports: [MatCardModule, MatTooltip, MatTooltipOnEllipsisDirective, BadgeComponent],
   templateUrl: './api-card.component.html',
   styleUrl: './api-card.component.scss',
 })

--- a/gravitee-apim-portal-webui-next/src/directives/mat-tooltip-on-ellipsis.directive.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/directives/mat-tooltip-on-ellipsis.directive.spec.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTooltip } from '@angular/material/tooltip';
+import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { MatTooltipOnEllipsisDirective } from './mat-tooltip-on-ellipsis.directive';
+
+@Component({
+  template: `<div data-testid="host" matTooltip="Help text" appMatTooltipOnEllipsis>
+    {{ label }}
+  </div>`,
+  standalone: true,
+  imports: [MatTooltip, MatTooltipOnEllipsisDirective],
+})
+class TestHostComponent {
+  label = 'Short';
+}
+
+@Component({
+  template: `<div data-testid="host" matTooltip="Help text" [matTooltipDisabled]="tooltipDisabled" appMatTooltipOnEllipsis>
+    {{ label }}
+  </div>`,
+  standalone: true,
+  imports: [MatTooltip, MatTooltipOnEllipsisDirective],
+})
+class TestHostWithTooltipDisabledComponent {
+  label = 'Long label';
+  tooltipDisabled = true;
+}
+
+function mockElementWidths(element: HTMLElement, clientWidth: number, scrollWidth: number): void {
+  Object.defineProperty(element, 'clientWidth', { configurable: true, value: clientWidth });
+  Object.defineProperty(element, 'scrollWidth', { configurable: true, value: scrollWidth });
+}
+
+describe('MatTooltipOnEllipsisDirective', () => {
+  describe('with default tooltip', () => {
+    let fixture: ComponentFixture<TestHostComponent>;
+    let hostEl: HTMLElement;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [TestHostComponent],
+        providers: [provideNoopAnimations()],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(TestHostComponent);
+      hostEl = fixture.nativeElement.querySelector('[data-testid="host"]');
+      fixture.detectChanges();
+    });
+
+    function matTooltip(): MatTooltip {
+      return fixture.debugElement.query(By.css('[data-testid="host"]')).injector.get(MatTooltip);
+    }
+
+    it('should attach to host', () => {
+      const dir = fixture.debugElement.query(By.directive(MatTooltipOnEllipsisDirective));
+      expect(dir).toBeTruthy();
+    });
+
+    it('should disable MatTooltip when text is not truncated on mouseenter and restore after mouseleave', () => {
+      mockElementWidths(hostEl, 200, 200);
+      hostEl.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(true);
+      hostEl.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(false);
+    });
+
+    it('should enable MatTooltip when text is truncated on mouseenter and keep enabled after mouseleave', () => {
+      mockElementWidths(hostEl, 100, 250);
+      hostEl.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(false);
+      hostEl.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(false);
+    });
+
+    it('should enable MatTooltip when text is truncated on focusin and keep enabled after focusout', () => {
+      mockElementWidths(hostEl, 100, 250);
+      hostEl.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(false);
+      hostEl.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(false);
+    });
+
+    it('should disable MatTooltip when text is not truncated on focusin and restore after focusout', () => {
+      mockElementWidths(hostEl, 200, 200);
+      hostEl.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(true);
+      hostEl.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(false);
+    });
+  });
+
+  describe('with an already disabled tooltip', () => {
+    let fixture: ComponentFixture<TestHostWithTooltipDisabledComponent>;
+    let hostEl: HTMLElement;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [TestHostWithTooltipDisabledComponent],
+        providers: [provideNoopAnimations()],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(TestHostWithTooltipDisabledComponent);
+      hostEl = fixture.nativeElement.querySelector('[data-testid="host"]') as HTMLElement;
+      fixture.detectChanges();
+    });
+
+    function matTooltip(): MatTooltip {
+      return fixture.debugElement.query(By.css('[data-testid="host"]')).injector.get(MatTooltip);
+    }
+
+    it('should not enable MatTooltip on mouseenter even if truncated', () => {
+      mockElementWidths(hostEl, 100, 250);
+      hostEl.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(true);
+    });
+
+    it('should leave MatTooltip disabled after mouseleave', () => {
+      mockElementWidths(hostEl, 100, 250);
+      hostEl.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+      hostEl.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(true);
+    });
+
+    it('should not enable MatTooltip on focusin even if truncated and keep disabled after focusout', () => {
+      mockElementWidths(hostEl, 100, 250);
+      hostEl.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(true);
+      hostEl.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+      expect(matTooltip().disabled).toBe(true);
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/directives/mat-tooltip-on-ellipsis.directive.ts
+++ b/gravitee-apim-portal-webui-next/src/directives/mat-tooltip-on-ellipsis.directive.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Directive, ElementRef, HostListener, inject } from '@angular/core';
+import { MatTooltip } from '@angular/material/tooltip';
+
+/**
+ * Enables {@link MatTooltip} only when the host text overflows horizontally (ellipsis),
+ * measured lazily on pointer or keyboard focus. No layout observers — prefer for long lists.
+ *
+ * @usage
+ * <span [matTooltip]="label" appMatTooltipOnEllipsis>{{ label }}</span>
+ */
+@Directive({
+  selector: '[matTooltip][appMatTooltipOnEllipsis]',
+  standalone: true,
+})
+export class MatTooltipOnEllipsisDirective {
+  private readonly matTooltip = inject(MatTooltip);
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+  private originalDisabledState = false;
+
+  @HostListener('mouseenter')
+  @HostListener('focusin')
+  checkOverflow(): void {
+    this.originalDisabledState = this.matTooltip.disabled;
+    if (this.originalDisabledState) {
+      return;
+    }
+    const element = this.elementRef.nativeElement;
+    const isTextTruncated = element.scrollWidth > element.clientWidth;
+    this.matTooltip.disabled = !isTextTruncated;
+  }
+
+  @HostListener('mouseleave')
+  @HostListener('focusout')
+  resetDisabledState(): void {
+    this.matTooltip.disabled = this.originalDisabledState;
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13138

## Description

- Create a new Angular directive to handle the display of mat tooltips only when the label is not entirely visible to avoid intrusive tooltips.
- Apply the new directive to card view in Catalog


https://github.com/user-attachments/assets/66dc76e6-b2ff-4798-9ce9-1777c84ba54a

