### PR TITLE
fix: increase flow_selectors path limit to 2048 for JDBC

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/02_change_flow_selectors_path_length.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/02_change_flow_selectors_path_length.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_02_change_flow_selectors_path_length
+      author: GraviteeSource Team
+      changes:
+        - modifyDataType:
+            tableName: ${gravitee_prefix}flow_selectors
+            columnName: path
+            newDataType: nvarchar(2048)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -324,3 +324,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/00_add_tags_key_column.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/01_add_tenants_key_column.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/02_change_flow_selectors_path_length.yml


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12488

## Description

This PR fixes a DataIntegrityViolationException occurring during API imports (Swagger/OData) when using a PostgreSQL/JDBC backend. The issue was caused by a strict VARCHAR(256) limit on the flow_selectors.path column, which is insufficient for complex or nested resource paths.

## Additional context

Database Migration: Added a Liquibase script to increase the flow_selectors.path column size to 2048 characters.

