### PR TITLE
fix(portal-next): APIM-13336 decouple subscription details from API documentation

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
@@ -30,6 +30,7 @@
         [subscription]="detailsVM.result.subscription"
         [planUsageConfiguration]="detailsVM.result.planUsageConfiguration"
         [api]="detailsVM.result.api"
+        [apiName]="detailsVM.result.apiName"
         [consumerStatus]="detailsVM.result.consumerStatus"
         [failureCause]="detailsVM.result.failureCause"
         [createdAt]="detailsVM.result.createdAt"
@@ -38,16 +39,18 @@
         (resumeConsumerStatus)="resumeConsumerStatus()"
         (closeSubscription)="closeSubscription()"
       />
-      <app-api-access
-        [planSecurity]="detailsVM.result.planSecurity"
-        [subscription]="detailsVM.result.subscription"
-        [entrypointUrls]="detailsVM.result.entrypointUrls"
-        [apiKey]="detailsVM.result.apiKey"
-        [clientId]="detailsVM.result.clientId"
-        [clientSecret]="detailsVM.result.clientSecret"
-        [apiType]="detailsVM.result.api?.type"
-        [apiKeyConfigUsername]="detailsVM.result.apiKeyConfigUsername"
-      />
+      @if (detailsVM.result.api) {
+        <app-api-access
+          [planSecurity]="detailsVM.result.planSecurity"
+          [subscription]="detailsVM.result.subscription"
+          [entrypointUrls]="detailsVM.result.entrypointUrls"
+          [apiKey]="detailsVM.result.apiKey"
+          [clientId]="detailsVM.result.clientId"
+          [clientSecret]="detailsVM.result.clientSecret"
+          [apiType]="detailsVM.result.api.type"
+          [apiKeyConfigUsername]="detailsVM.result.apiKeyConfigUsername"
+        />
+      }
     </div>
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
@@ -175,6 +175,9 @@ describe('SubscriptionsDetailsComponent', () => {
       expectPlansList(fakePlansResponse({ data: [fakePlan({ id: PLAN_ID, security: 'API_KEY' })] }));
       fixture.detectChanges();
 
+      const apiLink = fixture.nativeElement.querySelector('[data-testid="subscription-api-link"]');
+      expect(apiLink).not.toBeNull();
+
       const apiAccess = await harnessLoader.getHarness(ApiAccessHarness);
       expect(await apiAccess.getApiKey()).toStrictEqual(API_KEY);
       expect(await apiAccess.getBaseURL()).toStrictEqual('https://gw/entrypoint');
@@ -393,8 +396,30 @@ describe('SubscriptionsDetailsComponent', () => {
     httpTestingController.expectOne(`${TESTING_BASE_URL}/subscriptions?apiIds=${apiId}`).flush(subscriptionResponse);
   }
 
-  function expectPlansList(plansResponse: PlansResponse = fakePlansResponse()) {
-    httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/testApiId/plans?size=-1`).flush(plansResponse);
+  function expectPlansList(plansResponse: PlansResponse = fakePlansResponse(), apiName = 'API name from metadata') {
+    const firstPlan = plansResponse.data?.[0];
+    const metadata = {
+      [fakeSubscription().plan]: {
+        name: firstPlan?.name,
+        securityType: firstPlan?.security,
+        planMode: firstPlan?.mode,
+        usageConfiguration: firstPlan?.usage_configuration,
+      },
+      [API_ID]: {
+        name: apiName,
+      },
+      ...(firstPlan?.id
+        ? {
+            [firstPlan.id]: {
+              name: firstPlan.name,
+              securityType: firstPlan.security,
+              planMode: firstPlan.mode,
+              usageConfiguration: firstPlan.usage_configuration,
+            },
+          }
+        : {}),
+    };
+    expectSubscriptionList(fakeSubscriptionResponse({ metadata }), API_ID);
   }
 
   function expectApplicationsList(applicationsResponse: Application = fakeApplication()) {
@@ -403,23 +428,67 @@ describe('SubscriptionsDetailsComponent', () => {
 
   function expectGetApi(api: Api = fakeApi()) {
     httpTestingController
-      .expectOne(
-        request =>
+      .expectOne(request => {
+        return (
           request.url === `${TESTING_BASE_URL}/apis/${api.id}` &&
-          request.params.get(PortalApiViewParam.QUERY_PARAM_NAME) === PortalApiViewParam.DOCUMENTATION,
-      )
+          request.params.get(PortalApiViewParam.QUERY_PARAM_NAME) === PortalApiViewParam.DOCUMENTATION
+        );
+      })
       .flush(api);
   }
 
-  function expectGetApiPermissions(permissions = fakeUserApiPermissions({ PLAN: ['R'] })) {
+  function expectGetApiPermissions(permissions = fakeUserApiPermissions({ PLAN: ['R'] }), hasDocumentationAccess = true) {
     const req = httpTestingController.expectOne(
       request =>
         request.url === `${TESTING_BASE_URL}/permissions` &&
         request.params.get('apiId') === API_ID &&
         request.params.get(PortalApiViewParam.QUERY_PARAM_NAME) === PortalApiViewParam.DOCUMENTATION,
     );
-    req.flush(permissions);
+    if (hasDocumentationAccess) {
+      req.flush(permissions);
+    } else {
+      req.flush(null, { status: 404, statusText: 'Not Found' });
+    }
   }
+
+  describe('when documentation view is unavailable', () => {
+    beforeEach(() => {
+      expectSubscriptionWithKeys(fakeSubscription({ status: 'ACCEPTED' }));
+      expectGetApiPermissions(undefined, false);
+      expectPlansList(fakePlansResponse());
+      expectApplicationsList(fakeApplication());
+    });
+
+    it('should still render subscription details instead of generic error state', async () => {
+      fixture.detectChanges();
+
+      const errorMessage = fixture.nativeElement.querySelector('.subscriptions-details__error');
+      expect(errorMessage).toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="subscription-api-link"]')).toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="subscription-api-label"]')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('app-api-access')).toBeNull();
+    });
+  });
+
+  describe('when documentation and api details are unavailable', () => {
+    const metadataApiName = 'API from subscription metadata';
+
+    beforeEach(() => {
+      expectSubscriptionWithKeys(fakeSubscription({ status: 'ACCEPTED' }));
+      expectGetApiPermissions(undefined, false);
+      expectPlansList(fakePlansResponse(), metadataApiName);
+      expectApplicationsList(fakeApplication());
+    });
+
+    it('should render API name from subscription metadata as plain text', async () => {
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('[data-testid="subscription-api-link"]')).toBeNull();
+      const apiLabel = fixture.nativeElement.querySelector('[data-testid="subscription-api-label"]');
+      expect(apiLabel).not.toBeNull();
+      expect(apiLabel.textContent?.trim()).toStrictEqual(metadataApiName);
+    });
+  });
 
   function expectPostChangeConsumerStatus() {
     const url = `${TESTING_BASE_URL}/subscriptions/testSubscriptionId/_resumeFailure`;

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
@@ -15,6 +15,7 @@
  */
 
 import { AsyncPipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component, DestroyRef, Input, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -22,7 +23,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { BehaviorSubject, catchError, filter, forkJoin, map, Observable, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, filter, forkJoin, map, Observable, switchMap, tap, throwError } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
 
 import { SubscriptionConsumerConfigurationComponent } from './subscription-consumer-configuration';
@@ -32,7 +33,6 @@ import { LoaderComponent } from '../../../../../components/loader/loader.compone
 import { SubscriptionInfoComponent } from '../../../../../components/subscription-info/subscription-info.component';
 import { Api } from '../../../../../entities/api/api';
 import { Application } from '../../../../../entities/application/application';
-import { UserApiPermissions } from '../../../../../entities/permission/permission';
 import { PlanMode, PlanSecurityEnum, PlanUsageConfiguration } from '../../../../../entities/plan/plan';
 import {
   SubscriptionConsumerStatusEnum,
@@ -68,6 +68,8 @@ interface SubscriptionDetailsData {
   clientId?: string;
   clientSecret?: string;
   api?: Api;
+  apiName?: string;
+  hasDocumentationAccess: boolean;
   consumerConfiguration?: SubscriptionConsumerConfiguration;
 }
 
@@ -158,27 +160,42 @@ export class SubscriptionsDetailsComponent implements OnInit {
       });
   }
 
+  private getDocumentationAccess$(): Observable<boolean> {
+    return this.permissionsService.getApiPermissions(this.apiId).pipe(
+      map(() => true),
+      catchError(error => {
+        if (error instanceof HttpErrorResponse && error.status === 404) {
+          return of(false);
+        }
+
+        return throwError(() => error);
+      }),
+    );
+  }
+
   private loadDetails() {
     return this._subscriptionDetails.pipe(
       switchMap(() =>
         forkJoin({
           subscription: this.subscriptionService.get(this.subscriptionId),
-          permissions: this.permissionsService.getApiPermissions(this.apiId),
+          hasDocumentationAccess: this.getDocumentationAccess$(),
         }),
       ),
-      switchMap(({ subscription, permissions }) =>
+      switchMap(({ subscription, hasDocumentationAccess }) =>
         forkJoin({
           subscription: of(subscription),
-          plan: this.getPlanData$(subscription.plan, permissions),
-          api: this.apiService.details(this.apiId),
+          plan: this.getPlanData$(subscription.plan),
+          api: hasDocumentationAccess ? this.apiService.details(this.apiId).pipe(catchError(() => of(null))) : of(null),
           application: this.applicationService.get(subscription.application),
+          hasDocumentationAccess: of(hasDocumentationAccess),
         }),
       ),
-      map(({ subscription, plan, api, application }) => {
+      map(({ subscription, plan, api, application, hasDocumentationAccess }) => {
         const subscriptionDetails: SubscriptionDetailsData = {
           application,
           subscription,
-          api,
+          api: api ?? undefined,
+          apiName: plan.apiName,
           planName: plan.name,
           planSecurity: plan.securityType,
           planUsageConfiguration: plan.usageConfiguration,
@@ -186,7 +203,8 @@ export class SubscriptionsDetailsComponent implements OnInit {
           failureCause: subscription.failureCause,
           createdAt: subscription.created_at,
           updatedAt: subscription.updated_at,
-          entrypointUrls: api?.entrypoints,
+          entrypointUrls: api?.entrypoints ?? [],
+          hasDocumentationAccess,
         };
 
         if (subscription.status === 'ACCEPTED') {
@@ -237,31 +255,31 @@ export class SubscriptionsDetailsComponent implements OnInit {
     );
   }
 
-  private getPlanData$(
-    planId: string,
-    permissions: UserApiPermissions,
-  ): Observable<{
+  private getPlanData$(planId: string): Observable<{
     name: string;
     securityType: PlanSecurityEnum;
     usageConfiguration: PlanUsageConfiguration;
     planMode: PlanMode;
+    apiName?: string;
   }> {
-    return of(permissions.PLAN?.includes('R') === true).pipe(
-      switchMap(hasPermission => (hasPermission ? this.getPlanDataFromList$(planId) : this.getPlanDataFromMetadata$(planId))),
+    return this.getPlanDataFromMetadata$(planId).pipe(
       map(plan => ({
         name: plan.name ?? '',
         securityType: plan.securityType ?? 'KEY_LESS',
         usageConfiguration: plan.usageConfiguration ?? {},
         planMode: plan.planMode ?? 'STANDARD',
+        apiName: plan.apiName,
       })),
     );
   }
 
+  // TODO check if this is still relevant
   private getPlanDataFromList$(planId: string): Observable<{
     name?: string;
     securityType?: PlanSecurityEnum;
     usageConfiguration?: PlanUsageConfiguration;
     planMode?: PlanMode;
+    apiName?: string;
   }> {
     return this.planService.list(this.apiId).pipe(
       map(({ data }) => {
@@ -285,12 +303,19 @@ export class SubscriptionsDetailsComponent implements OnInit {
     securityType?: PlanSecurityEnum;
     usageConfiguration?: PlanUsageConfiguration;
     planMode?: PlanMode;
+    apiName?: string;
   }> {
     return this.subscriptionService.list({ apiIds: [this.apiId], statuses: [] }).pipe(
       catchError(_ => of({ data: [], metadata: {}, links: {} } as SubscriptionsResponse)),
       map(({ metadata }) => {
         const planMetadata = metadata[planId];
-        return { name: planMetadata?.name, securityType: planMetadata?.securityType, planMode: planMetadata?.planMode };
+        const apiMetadata = metadata[this.apiId];
+        return {
+          name: planMetadata?.name,
+          securityType: planMetadata?.securityType,
+          planMode: planMetadata?.planMode,
+          apiName: apiMetadata?.name,
+        };
       }),
     );
   }

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.html
@@ -48,14 +48,26 @@
             }
           </div>
         }
-
-        @if (api) {
+        @if (resolvedApiName) {
           <div class="subscription-info__content-row">
             <span class="next-gen-body">
               <span class="material-icons icon-small">api</span>
               <span i18n="@@subscriptionDetailsHeaderApi">Subscribed API:</span>
             </span>
-            <a class="internal-link next-gen-body" [routerLink]="['/catalog/api/' + api.id]">{{ api.name }}</a>
+            @if (api && api.id) {
+              <a data-testid="subscription-api-link" class="internal-link next-gen-body" [routerLink]="['/catalog/api/' + api.id]">
+                {{ resolvedApiName }}
+              </a>
+            } @else {
+              <span
+                data-testid="subscription-api-label"
+                class="next-gen-body"
+                i18n-matTooltip="@@subscriptionApiUnpublishedTooltip"
+                matTooltip="The API has been unpublished from the Developer Portal"
+                matTooltipPosition="above"
+                >{{ resolvedApiName }}</span
+              >
+            }
           </div>
         }
 
@@ -105,27 +117,29 @@
           </span>
           <span class="next-gen-body">{{ planName }}</span>
         </div>
-        <div class="subscription-info__content-row">
-          <span class="next-gen-body">
-            <span class="material-icons icon-small">lock</span>
-            <span i18n="@@subscriptionDetailsHeaderAuthentication">Authentication:</span>
-          </span>
-          @if (api?.type === 'NATIVE') {
-            @if (planSecurity === 'API_KEY') {
-              <span class="next-gen-body" i18n="@@subscriptionDetailsAuthenticationSaslApiKey"
-                >SASL/SSL with SASL mechanisms PLAIN, SCRAM-256, and SCRAM-512</span
-              >
-            } @else if (planSecurity === 'OAUTH2' || planSecurity === 'JWT') {
-              <span class="next-gen-body" i18n="@@subscriptionDetailsAuthenticationSaslOauthbearer"
-                >SASL/SSL with SASL mechanism OAUTHBEARER</span
-              >
-            } @else if (planSecurity === 'KEY_LESS') {
-              <span class="next-gen-body" i18n="@@subscriptionDetailsAuthenticationKeyless">SSL</span>
+        @if (api) {
+          <div class="subscription-info__content-row">
+            <span class="next-gen-body">
+              <span class="material-icons icon-small">lock</span>
+              <span i18n="@@subscriptionDetailsHeaderAuthentication">Authentication:</span>
+            </span>
+            @if (api.type === 'NATIVE') {
+              @if (planSecurity === 'API_KEY') {
+                <span class="next-gen-body" i18n="@@subscriptionDetailsAuthenticationSaslApiKey"
+                  >SASL/SSL with SASL mechanisms PLAIN, SCRAM-256, and SCRAM-512</span
+                >
+              } @else if (planSecurity === 'OAUTH2' || planSecurity === 'JWT') {
+                <span class="next-gen-body" i18n="@@subscriptionDetailsAuthenticationSaslOauthbearer"
+                  >SASL/SSL with SASL mechanism OAUTHBEARER</span
+                >
+              } @else if (planSecurity === 'KEY_LESS') {
+                <span class="next-gen-body" i18n="@@subscriptionDetailsAuthenticationKeyless">SSL</span>
+              }
+            } @else {
+              <span class="next-gen-body">{{ authentication }}</span>
             }
-          } @else {
-            <span class="next-gen-body">{{ authentication }}</span>
-          }
-        </div>
+          </div>
+        }
         @if (!!planUsageConfiguration?.quota?.limit) {
           <div class="subscription-info__content-row">
             <span class="next-gen-body">

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.spec.ts
@@ -15,9 +15,11 @@
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { SubscriptionInfoComponent } from './subscription-info.component';
 import { SubscriptionInfoHarness } from './subscription-info.harness';
+import { Api } from '../../entities/api/api';
 import { Subscription } from '../../entities/subscription';
 
 describe('SubscriptionInfoComponent', () => {
@@ -25,17 +27,29 @@ describe('SubscriptionInfoComponent', () => {
   let fixture: ComponentFixture<SubscriptionInfoComponent>;
   let harness: SubscriptionInfoHarness;
 
-  const init = async (subscription: Subscription) => {
+  const init = async (
+    subscription: Subscription,
+    options?: {
+      api?: Api;
+      apiName?: string;
+    },
+  ) => {
     await TestBed.configureTestingModule({
       imports: [SubscriptionInfoComponent],
+      providers: [provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SubscriptionInfoComponent);
     component = fixture.componentInstance;
     component.subscription = subscription;
+    component.api = options?.api;
+    component.apiName = options?.apiName;
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionInfoHarness);
     fixture.detectChanges();
   };
+
+  const getApiLink = (): HTMLAnchorElement | null => fixture.nativeElement.querySelector('[data-testid="subscription-api-link"]');
+  const getApiLabel = (): HTMLSpanElement | null => fixture.nativeElement.querySelector('[data-testid="subscription-api-label"]');
 
   it('should create', async () => {
     await init({ status: 'ACCEPTED' } as Subscription);
@@ -80,6 +94,34 @@ describe('SubscriptionInfoComponent', () => {
       await init({ status: 'CLOSED' } as Subscription);
 
       expect(await harness.getCloseButton()).toBeFalsy();
+    });
+  });
+
+  describe('api link visibility', () => {
+    const api: Api = { id: 'api-id', name: 'My API' } as Api;
+
+    it('should render API as clickable link when API details are available', async () => {
+      await init({ status: 'ACCEPTED' } as Subscription, { api });
+
+      expect(getApiLink()).toBeTruthy();
+      expect(getApiLink()?.textContent?.trim()).toStrictEqual('My API');
+      expect(getApiLabel()).toBeNull();
+    });
+
+    it('should render API metadata name as plain text when api details are missing', async () => {
+      await init({ status: 'ACCEPTED' } as Subscription, { apiName: 'API from metadata' });
+
+      expect(getApiLink()).toBeNull();
+      expect(getApiLabel()).toBeTruthy();
+      expect(getApiLabel()?.textContent?.trim()).toStrictEqual('API from metadata');
+    });
+
+    it('should prefer api.name over apiName fallback', async () => {
+      await init({ status: 'ACCEPTED' } as Subscription, { api, apiName: 'API from metadata' });
+
+      expect(getApiLink()).toBeTruthy();
+      expect(getApiLink()?.textContent?.trim()).toStrictEqual('My API');
+      expect(getApiLabel()).toBeNull();
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/subscription-info/subscription-info.component.ts
@@ -16,6 +16,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
 
 import { Api } from '../../entities/api/api';
@@ -29,7 +30,16 @@ import { LoaderComponent } from '../loader/loader.component';
 
 @Component({
   selector: 'app-subscription-info',
-  imports: [CapitalizeFirstPipe, ToPeriodTimeUnitLabelPipe, BannerComponent, MatIcon, MatButton, LoaderComponent, RouterLink],
+  imports: [
+    CapitalizeFirstPipe,
+    ToPeriodTimeUnitLabelPipe,
+    BannerComponent,
+    MatIcon,
+    MatButton,
+    MatTooltipModule,
+    LoaderComponent,
+    RouterLink,
+  ],
   templateUrl: './subscription-info.component.html',
   styleUrl: './subscription-info.component.scss',
 })
@@ -51,6 +61,9 @@ export class SubscriptionInfoComponent implements OnInit {
 
   @Input()
   api?: Api;
+
+  @Input()
+  apiName?: string;
 
   @Input()
   subscription?: Subscription;
@@ -82,5 +95,9 @@ export class SubscriptionInfoComponent implements OnInit {
 
   ngOnInit() {
     this.authentication = getPlanSecurityTypeLabel(this.planSecurity);
+  }
+
+  get resolvedApiName(): string | undefined {
+    return this.api?.name ?? this.apiName;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/services/api.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api.service.ts
@@ -44,7 +44,9 @@ export class ApiService {
 
   details(apiId: string): Observable<Api> {
     return this.http.get<Api>(`${this.configService.baseURL}/apis/${apiId}`, {
-      params: { [PortalApiViewParam.QUERY_PARAM_NAME]: PortalApiViewParam.DOCUMENTATION },
+      params: {
+        [PortalApiViewParam.QUERY_PARAM_NAME]: PortalApiViewParam.DOCUMENTATION,
+      },
     });
   }
 }

--- a/gravitee-apim-portal-webui-next/src/services/permissions.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/permissions.service.ts
@@ -32,7 +32,10 @@ export class PermissionsService {
 
   getApiPermissions(apiId: string): Observable<UserApiPermissions> {
     return this.http.get<UserApiPermissions>(`${this.configService.baseURL}/permissions`, {
-      params: { apiId, [PortalApiViewParam.QUERY_PARAM_NAME]: PortalApiViewParam.DOCUMENTATION },
+      params: {
+        apiId,
+        [PortalApiViewParam.QUERY_PARAM_NAME]: PortalApiViewParam.DOCUMENTATION,
+      },
     });
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13336


## Description

This PR makes Subscription Details resilient to missing API documentation in Portal Next by decoupling core data loading from view=documentation checks.
When documentation is unavailable (404), the page still renders subscription data and the “Subscribed API” item is shown as plain text instead of a clickable link 



