### PR TITLE
feat(repository): add repository support for retrieving mTLS certificates by multiple applications

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ClientCertificateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ClientCertificateRepository.java
@@ -63,6 +63,16 @@ public interface ClientCertificateRepository extends CrudRepository<ClientCertif
         throws TechnicalException;
 
     /**
+     * Find all client certificates for a given set of applications with pagination.
+     *
+     * @param applicationIds the collection of application IDs
+     * @param pageable pagination information
+     * @return a page of client certificates
+     * @throws TechnicalException if an error occurs
+     */
+    Page<ClientCertificate> findByApplicationIds(Collection<String> applicationIds, Pageable pageable) throws TechnicalException;
+
+    /**
      * Find all client certificates matching the given statuses, regardless of application.
      * Returns an empty set if {@code statuses} is null or empty.
      *

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClientCertificateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClientCertificateRepository.java
@@ -89,6 +89,28 @@ public class JdbcClientCertificateRepository
     }
 
     @Override
+    public Page<ClientCertificate> findByApplicationIds(Collection<String> applicationIds, Pageable pageable) throws TechnicalException {
+        log.debug("JdbcClientCertificateRepository.findByApplicationIds({})", applicationIds);
+
+        if (applicationIds == null || applicationIds.isEmpty()) {
+            return getResultAsPage(pageable, List.of());
+        }
+
+        try {
+            List<String> applicationIdList = new ArrayList<>(applicationIds);
+            String sql = getOrm().getSelectAllSql() + " WHERE application_id IN (" + getOrm().buildInClause(applicationIdList) + ")";
+            List<ClientCertificate> clientCertificates = jdbcTemplate.query(
+                sql,
+                ps -> getOrm().setArguments(ps, applicationIdList, 1),
+                getOrm().getRowMapper()
+            );
+            return getResultAsPage(pageable, clientCertificates);
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to find client certificates by application ids", ex);
+        }
+    }
+
+    @Override
     public List<ClientCertificate> findByApplicationIdAndStatuses(String applicationId, ClientCertificateStatus... statuses)
         throws TechnicalException {
         log.debug("JdbcClientCertificateRepository.findByApplicationIdAndStatuses({}, {})", applicationId, Arrays.toString(statuses));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClientCertificateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClientCertificateRepository.java
@@ -125,6 +125,20 @@ public class MongoClientCertificateRepository implements ClientCertificateReposi
     }
 
     @Override
+    public Page<ClientCertificate> findByApplicationIds(Collection<String> applicationIds, Pageable pageable) throws TechnicalException {
+        log.debug("Find client certificates by application IDs [{}]", applicationIds);
+
+        org.springframework.data.domain.Page<ClientCertificateMongo> mongoPage = internalRepository.findByApplicationIds(
+            applicationIds,
+            PageRequest.of(pageable.pageNumber(), pageable.pageSize())
+        );
+
+        List<ClientCertificate> content = mongoPage.getContent().stream().map(mapper::map).toList();
+
+        return new Page<>(content, pageable.pageNumber(), pageable.pageSize(), mongoPage.getTotalElements());
+    }
+
+    @Override
     public List<ClientCertificate> findByApplicationIdAndStatuses(String applicationId, ClientCertificateStatus... statuses)
         throws TechnicalException {
         log.debug("Find client certificates by application ID [{}] and statuses [{}]", applicationId, statuses);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clientcertificate/ClientCertificateMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clientcertificate/ClientCertificateMongoRepository.java
@@ -34,6 +34,9 @@ public interface ClientCertificateMongoRepository extends MongoRepository<Client
     @Query("{ applicationId: ?0 }")
     Page<ClientCertificateMongo> findByApplicationId(String applicationId, Pageable pageable);
 
+    @Query("{ applicationId: { $in: ?0 } }")
+    Page<ClientCertificateMongo> findByApplicationIds(Collection<String> applicationIds, Pageable pageable);
+
     @Query("{ applicationId: ?0, status: { $in: ?1 } }")
     List<ClientCertificateMongo> findByApplicationIdAndStatuses(String applicationId, Collection<String> statuses);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClientCertificateRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClientCertificateRepositoryTest.java
@@ -159,6 +159,42 @@ public class ClientCertificateRepositoryTest extends AbstractManagementRepositor
     }
 
     @Test
+    public void should_find_by_application_ids_with_pagination() throws Exception {
+        Page<ClientCertificate> page = clientCertificateRepository.findByApplicationIds(
+            List.of("app-1", "app-2"),
+            new PageableBuilder().pageNumber(0).pageSize(10).build()
+        );
+
+        assertThat(page).isNotNull();
+        assertThat(page.getTotalElements()).isEqualTo(3);
+        assertThat(page.getContent()).extracting(ClientCertificate::getId).containsExactlyInAnyOrder("cert-1", "cert-2", "cert-3");
+    }
+
+    @Test
+    public void should_find_by_application_ids_with_pagination_page_size() throws Exception {
+        Page<ClientCertificate> page = clientCertificateRepository.findByApplicationIds(
+            List.of("app-1", "app-2"),
+            new PageableBuilder().pageNumber(0).pageSize(2).build()
+        );
+
+        assertThat(page).isNotNull();
+        assertThat(page.getTotalElements()).isEqualTo(3);
+        assertThat(page.getContent()).hasSize(2);
+    }
+
+    @Test
+    public void should_return_empty_page_when_no_matching_application_ids() throws Exception {
+        Page<ClientCertificate> page = clientCertificateRepository.findByApplicationIds(
+            List.of("non-existent-app"),
+            new PageableBuilder().pageNumber(0).pageSize(10).build()
+        );
+
+        assertThat(page).isNotNull();
+        assertThat(page.getTotalElements()).isZero();
+        assertThat(page.getContent()).isEmpty();
+    }
+
+    @Test
     public void should_find_by_application_id_and_statuses() throws Exception {
         List<ClientCertificate> certificates = clientCertificateRepository.findByApplicationIdAndStatuses(
             "app-1",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/crud_service/ClientCertificateCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/crud_service/ClientCertificateCrudService.java
@@ -90,6 +90,15 @@ public interface ClientCertificateCrudService {
     List<ClientCertificate> findByApplicationIdsAndStatuses(Collection<String> applicationIds, ClientCertificateStatus... statuses);
 
     /**
+     * Find all client certificates for a given set of applications with pagination.
+     *
+     * @param applicationIds application IDs
+     * @param pageable pagination information
+     * @return a page of client certificates
+     */
+    Page<ClientCertificate> findByApplicationIds(Collection<String> applicationIds, Pageable pageable);
+
+    /**
      * Find all client certificates matching the given statuses, regardless of application.
      * Returns an empty set if {@code statuses} is null or empty.
      *

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
@@ -168,6 +168,26 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
     }
 
     @Override
+    public Page<ClientCertificate> findByApplicationIds(Collection<String> applicationIds, Pageable pageable) {
+        try {
+            log.debug("Find client certificates by application IDs: {}", applicationIds);
+
+            var repoPageable = new PageableBuilder().pageNumber(pageable.getPageNumber() - 1).pageSize(pageable.getPageSize()).build();
+
+            var page = clientCertificateRepository.findByApplicationIds(applicationIds, repoPageable);
+
+            return new Page<>(
+                page.getContent().stream().map(ClientCertificateAdapter.INSTANCE::toDomain).toList(),
+                page.getPageNumber(),
+                (int) page.getPageElements(),
+                page.getTotalElements()
+            );
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurs while trying to find client certificates by application IDs", e);
+        }
+    }
+
+    @Override
     public List<ClientCertificate> findByApplicationIdAndStatuses(String applicationId, ClientCertificateStatus... statuses) {
         try {
             log.debug("Find client certificates by application ID {} and statuses {}", applicationId, Arrays.toString(statuses));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClientCertificateCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClientCertificateCrudServiceInMemory.java
@@ -152,6 +152,25 @@ public class ClientCertificateCrudServiceInMemory implements ClientCertificateCr
     }
 
     @Override
+    public Page<ClientCertificate> findByApplicationIds(Collection<String> applicationIds, Pageable pageable) {
+        List<ClientCertificate> filtered = storage
+            .stream()
+            .filter(cert -> applicationIds.contains(cert.applicationId()))
+            .toList();
+
+        int pageNumber = pageable.getPageNumber();
+        int pageSize = pageable.getPageSize();
+        int fromIndex = Math.max(0, (pageNumber - 1) * pageSize);
+        int toIndex = Math.min(fromIndex + pageSize, filtered.size());
+
+        List<ClientCertificate> pageContent = fromIndex < filtered.size()
+            ? filtered.subList(fromIndex, toIndex).stream().map(ClientCertificate::new).toList()
+            : Collections.emptyList();
+
+        return new Page<>(pageContent, pageNumber, pageSize, filtered.size());
+    }
+
+    @Override
     public List<ClientCertificate> findByApplicationIdsAndStatuses(Collection<String> applicationIds, ClientCertificateStatus... statuses) {
         if (statuses == null || statuses.length == 0) {
             return List.of();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImplTest.java
@@ -366,6 +366,76 @@ class ClientCertificateCrudServiceImplTest {
     }
 
     @Test
+    void should_find_by_application_ids() throws TechnicalException {
+        String applicationId2 = "app-id-2";
+        String certificateId2 = "cert-id-2";
+        io.gravitee.repository.management.model.ClientCertificate repositoryCertificate1 = buildRepositoryClientCertificate(
+            CERTIFICATE_ID,
+            APPLICATION_ID,
+            io.gravitee.repository.management.model.ClientCertificateStatus.ACTIVE
+        );
+        io.gravitee.repository.management.model.ClientCertificate repositoryCertificate2 = buildRepositoryClientCertificate(
+            certificateId2,
+            applicationId2,
+            io.gravitee.repository.management.model.ClientCertificateStatus.ACTIVE
+        );
+        Page<io.gravitee.repository.management.model.ClientCertificate> repositoryPage = new Page<>(
+            List.of(repositoryCertificate1, repositoryCertificate2),
+            0,
+            2,
+            2
+        );
+        when(clientCertificateRepository.findByApplicationIds(eq(List.of(APPLICATION_ID, applicationId2)), any(Pageable.class))).thenReturn(
+            repositoryPage
+        );
+
+        io.gravitee.rest.api.model.common.Pageable pageable = new io.gravitee.rest.api.model.common.Pageable() {
+            @Override
+            public int getPageNumber() {
+                return 1;
+            }
+
+            @Override
+            public int getPageSize() {
+                return 10;
+            }
+        };
+
+        Page<ClientCertificate> result = clientCertificateCrudService.findByApplicationIds(
+            List.of(APPLICATION_ID, applicationId2),
+            pageable
+        );
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(2).extracting("id").containsExactlyInAnyOrder(CERTIFICATE_ID, certificateId2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    void should_throw_technical_management_exception_when_find_by_application_ids_fails() throws TechnicalException {
+        when(clientCertificateRepository.findByApplicationIds(any(), any(Pageable.class))).thenThrow(
+            new TechnicalException("Database error")
+        );
+
+        io.gravitee.rest.api.model.common.Pageable pageable = new io.gravitee.rest.api.model.common.Pageable() {
+            @Override
+            public int getPageNumber() {
+                return 1;
+            }
+
+            @Override
+            public int getPageSize() {
+                return 10;
+            }
+        };
+
+        List<String> applicationIds = List.of(APPLICATION_ID);
+        assertThatThrownBy(() -> clientCertificateCrudService.findByApplicationIds(applicationIds, pageable))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("An error occurs while trying to find client certificates by application IDs");
+    }
+
+    @Test
     void should_find_by_application_id_and_statuses() throws TechnicalException {
         io.gravitee.repository.management.model.ClientCertificate repositoryCertificate = buildRepositoryClientCertificate(
             CERTIFICATE_ID,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13261

## Description

- Added `ClientCertificateRepository#findByApplicationIds(Collection, Pageable)` to the repository API with MongoDB and JDBC implementations, enabling paginated multi-application certificate queries
- Added `ClientCertificateCrudService#findByApplicationIds` as a proper abstract method (no default) with implementation in `ClientCertificateCrudServiceImpl` and the in-memory test double

## Additional context

- This PR covers Tasks 1a from the story breakdown (repository) — backend core domain to be implemented in Task 1. Task 2 (papi resource) and Tasks 3–4 (portal-next frontend) follow in subsequent PRs.
- The `UserApplicationDomainService` extraction also benefits `PortalNavigationApiVisibilityDomainService` (subscription-based API visibility), whose tests were updated to wire the new service.
