### PR TITLE
fix: handle API product refs in key audit logs & notification changes

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
@@ -81,9 +81,9 @@ public class EmailNotificationBuilder {
     }
 
     public enum EmailTemplate {
-        API_APIKEY_REVOKED(ApiHook.APIKEY_REVOKED, "apiKeyRevoked.html", "API Key revoked for API ${api.name}"),
-        API_APIKEY_RENEWED(ApiHook.APIKEY_RENEWED, "apiKeyRenewed.html", "API Key renewed"),
-        API_APIKEY_EXPIRED(ApiHook.APIKEY_EXPIRED, "apiKeyExpired.html", "API Key expiration!"),
+        API_APIKEY_REVOKED(ApiHook.APIKEY_REVOKED, "apiKeyRevoked.html", "API Key revoked for ${(api.name)!(apiProduct.name)!''}"),
+        API_APIKEY_RENEWED(ApiHook.APIKEY_RENEWED, "apiKeyRenewed.html", "API Key renewed for ${(api.name)!(apiProduct.name)!''}"),
+        API_APIKEY_EXPIRED(ApiHook.APIKEY_EXPIRED, "apiKeyExpired.html", "API Key expiration for ${(api.name)!(apiProduct.name)!''}"),
         API_SUBSCRIPTION_NEW(
             ApiHook.SUBSCRIPTION_NEW,
             "subscriptionReceived.html",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -21,6 +21,7 @@ import static io.gravitee.repository.management.model.ApiKey.AuditEvent.APIKEY_R
 import static io.gravitee.repository.management.model.ApiKey.AuditEvent.APIKEY_RENEWED;
 import static io.gravitee.repository.management.model.Audit.AuditProperties.API;
 import static io.gravitee.repository.management.model.Audit.AuditProperties.API_KEY;
+import static io.gravitee.repository.management.model.Audit.AuditProperties.API_PRODUCT;
 import static io.gravitee.repository.management.model.Audit.AuditProperties.APPLICATION;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
@@ -31,9 +32,12 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
+import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.model.ApiKey;
+import io.gravitee.repository.management.model.ApiProduct;
 import io.gravitee.repository.management.model.Audit;
+import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.ApplicationEntity;
@@ -61,6 +65,7 @@ import io.gravitee.rest.api.service.exceptions.SubscriptionClosedException;
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotActiveException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductTemplateModel;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
@@ -73,6 +78,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -113,6 +119,10 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
 
     @Autowired
     private ApiTemplateService apiTemplateService;
+
+    @Lazy
+    @Autowired
+    private ApiProductsRepository apiProductsRepository;
 
     @Override
     public ApiKeyEntity generate(
@@ -707,21 +717,28 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
         key
             .getSubscriptions()
             .forEach(subscription -> {
+                boolean isApiProduct = isApiProductSubscription(subscription);
+                String referenceId = subscription.getReferenceId() != null ? subscription.getReferenceId() : subscription.getApi();
+                String applicationId = key.getApplication() != null ? key.getApplication().getId() : null;
+
                 Map<Audit.AuditProperties, String> properties = new LinkedHashMap<>();
                 properties.put(API_KEY, key.getKey());
-                properties.put(API, subscription.getApi());
-                properties.put(APPLICATION, key.getApplication().getId());
-                auditService.createApiAuditLog(
-                    executionContext,
-                    AuditService.AuditLogData.builder()
-                        .properties(properties)
-                        .event(event)
-                        .createdAt(eventDate)
-                        .oldValue(previousApiKey)
-                        .newValue(key)
-                        .build(),
-                    subscription.getApi()
-                );
+                properties.put(isApiProduct ? API_PRODUCT : API, referenceId);
+                properties.put(APPLICATION, applicationId);
+
+                AuditService.AuditLogData auditLogData = AuditService.AuditLogData.builder()
+                    .properties(properties)
+                    .event(event)
+                    .createdAt(eventDate)
+                    .oldValue(previousApiKey)
+                    .newValue(key)
+                    .build();
+
+                if (isApiProduct) {
+                    auditService.createApiProductAuditLog(executionContext, auditLogData, referenceId);
+                } else {
+                    auditService.createApiAuditLog(executionContext, auditLogData, referenceId);
+                }
             });
     }
 
@@ -755,8 +772,8 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
         NotificationParamsBuilder paramsBuilder
     ) {
         subscriptions.forEach(subscription -> {
-            // Notifications are not applicable for API Product subscriptions (TODO: implement notifications for API Product subscriptions)
             if (isApiProductSubscription(subscription)) {
+                triggerNotifierServiceForApiProductSubscription(executionContext, apiHook, key, application, subscription);
                 return;
             }
             GenericPlanEntity genericPlanEntity = planSearchService.findById(executionContext, subscription.getPlan());
@@ -771,6 +788,49 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 .build();
             notifierService.trigger(executionContext, apiHook, genericApiModel.getId(), params);
         });
+    }
+
+    private void triggerNotifierServiceForApiProductSubscription(
+        ExecutionContext executionContext,
+        ApiHook apiHook,
+        ApiKey key,
+        ApplicationEntity application,
+        SubscriptionEntity subscription
+    ) {
+        String apiProductId = subscription.getReferenceId();
+        try {
+            GenericPlanEntity genericPlanEntity = planSearchService.findById(executionContext, subscription.getPlan());
+            Optional<ApiProduct> apiProductOpt = apiProductsRepository.findById(apiProductId);
+            if (apiProductOpt.isEmpty()) {
+                log.debug("API Product [{}] not found, skipping API key notification", apiProductId);
+                return;
+            }
+            ApiProduct apiProduct = apiProductOpt.get();
+            PrimaryOwnerEntity applicationOwner = application.getPrimaryOwner();
+            ApiProductTemplateModel apiProductModel = ApiProductTemplateModel.builder()
+                .id(apiProduct.getId())
+                .name(apiProduct.getName())
+                .version(apiProduct.getVersion() != null ? apiProduct.getVersion() : "")
+                .primaryOwner(applicationOwner)
+                .build();
+            NotificationParamsBuilder freshBuilder = new NotificationParamsBuilder()
+                .apiProduct(apiProductModel)
+                .plan(genericPlanEntity)
+                .application(application)
+                .owner(applicationOwner)
+                .apikey(key);
+
+            // Only include expirationDate when the key expires in the future.
+            // The email template renders "will expire on <date>" when present,
+            // and "has expired" when absent.
+            final Date now = new Date();
+            if (key.getExpireAt() != null && now.before(key.getExpireAt())) {
+                freshBuilder.expirationDate(key.getExpireAt());
+            }
+            notifierService.trigger(executionContext, apiHook, NotificationReferenceType.API_PRODUCT, apiProductId, freshBuilder.build());
+        } catch (TechnicalException e) {
+            log.error("Error triggering API key notification for API Product subscription {}", subscription.getId(), e);
+        }
     }
 
     private boolean isApiProductSubscription(SubscriptionEntity subscription) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -35,8 +35,11 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
+import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.model.ApiKey;
+import io.gravitee.repository.management.model.ApiProduct;
 import io.gravitee.repository.management.model.Audit;
+import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.ApiKeyMode;
@@ -47,6 +50,7 @@ import io.gravitee.rest.api.model.PlanSecurityType;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.ApiKeyGenerator;
 import io.gravitee.rest.api.service.ApiKeyService;
 import io.gravitee.rest.api.service.ApiService;
@@ -63,6 +67,7 @@ import io.gravitee.rest.api.service.exceptions.InvalidApplicationApiKeyModeExcep
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotActiveException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.time.Instant;
@@ -134,6 +139,9 @@ public class ApiKeyServiceTest {
 
     @Mock
     private NotifierService notifierService;
+
+    @Mock
+    private ApiProductsRepository apiProductsRepository;
 
     @Test
     public void shouldGenerate() throws TechnicalException {
@@ -1225,6 +1233,158 @@ public class ApiKeyServiceTest {
         assertEquals("Subscription count should remain unchanged", 2, updatedSubscriptions.size());
 
         assertTrue("updatedAt should be updated to a later time", resultApiKey.getUpdatedAt().after(existingApiKey.getUpdatedAt()));
+    }
+
+    @Test
+    public void shouldIncludeExpirationDateInNotificationParamsForApiProductSubscriptionWithFutureExpiry() throws TechnicalException {
+        String apiProductId = "my-api-product";
+        Date futureExpiry = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+
+        ApiKey existingApiKey = new ApiKey();
+        existingApiKey.setApplication(APPLICATION_ID);
+        when(apiKeyRepository.findById("api-key-id")).thenReturn(Optional.of(existingApiKey));
+
+        SubscriptionEntity apiProductSubscription = new SubscriptionEntity();
+        apiProductSubscription.setId(SUBSCRIPTION_ID);
+        apiProductSubscription.setPlan(PLAN_ID);
+        apiProductSubscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT.name());
+        apiProductSubscription.setReferenceId(apiProductId);
+
+        ApiKeyEntity apiKeyEntity = new ApiKeyEntity();
+        apiKeyEntity.setId("api-key-id");
+        apiKeyEntity.setKey("test-key");
+        apiKeyEntity.setExpireAt(futureExpiry);
+        apiKeyEntity.setApplication(application);
+        apiKeyEntity.setSubscriptions(Set.of(apiProductSubscription));
+
+        when(subscriptionService.findById(any())).thenReturn(apiProductSubscription);
+        when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID))).thenReturn(application);
+        when(subscriptionService.findByIdIn(any())).thenReturn(Set.of(apiProductSubscription));
+
+        GenericPlanEntity mockedPlan = mock(GenericPlanEntity.class);
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mockedPlan);
+
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId(apiProductId);
+        apiProduct.setName("My API Product");
+        when(apiProductsRepository.findById(apiProductId)).thenReturn(Optional.of(apiProduct));
+
+        apiKeyService.update(GraviteeContext.getExecutionContext(), apiKeyEntity);
+
+        ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApiHook.APIKEY_EXPIRED),
+            eq(NotificationReferenceType.API_PRODUCT),
+            eq(apiProductId),
+            paramsCaptor.capture()
+        );
+        assertTrue(
+            "expirationDate must be present so template renders 'will expire on <date>'",
+            paramsCaptor.getValue().containsKey(NotificationParamsBuilder.PARAM_EXPIRATION_DATE)
+        );
+        assertEquals(futureExpiry, paramsCaptor.getValue().get(NotificationParamsBuilder.PARAM_EXPIRATION_DATE));
+    }
+
+    /**
+     * When an API key whose expiry is already in the past is updated, 'expirationDate' must NOT
+     * be present in the notification params. The template should render "has expired" in that case.
+     */
+    @Test
+    public void shouldNotIncludeExpirationDateInNotificationParamsForApiProductSubscriptionWhenKeyAlreadyExpired()
+        throws TechnicalException {
+        String apiProductId = "my-api-product";
+        Date pastExpiry = Date.from(Instant.now().minus(1, ChronoUnit.HOURS));
+
+        ApiKey existingApiKey = new ApiKey();
+        existingApiKey.setApplication(APPLICATION_ID);
+        when(apiKeyRepository.findById("api-key-id")).thenReturn(Optional.of(existingApiKey));
+
+        SubscriptionEntity apiProductSubscription = new SubscriptionEntity();
+        apiProductSubscription.setId(SUBSCRIPTION_ID);
+        apiProductSubscription.setPlan(PLAN_ID);
+        apiProductSubscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT.name());
+        apiProductSubscription.setReferenceId(apiProductId);
+
+        ApiKeyEntity apiKeyEntity = new ApiKeyEntity();
+        apiKeyEntity.setId("api-key-id");
+        apiKeyEntity.setKey("test-key");
+        apiKeyEntity.setExpireAt(pastExpiry);
+        apiKeyEntity.setApplication(application);
+        apiKeyEntity.setSubscriptions(Set.of(apiProductSubscription));
+
+        when(subscriptionService.findById(any())).thenReturn(apiProductSubscription);
+        when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID))).thenReturn(application);
+        when(subscriptionService.findByIdIn(any())).thenReturn(Set.of(apiProductSubscription));
+
+        GenericPlanEntity mockedPlan = mock(GenericPlanEntity.class);
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mockedPlan);
+
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId(apiProductId);
+        apiProduct.setName("My API Product");
+        when(apiProductsRepository.findById(apiProductId)).thenReturn(Optional.of(apiProduct));
+
+        apiKeyService.update(GraviteeContext.getExecutionContext(), apiKeyEntity);
+
+        ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApiHook.APIKEY_EXPIRED),
+            eq(NotificationReferenceType.API_PRODUCT),
+            eq(apiProductId),
+            paramsCaptor.capture()
+        );
+        assertFalse(
+            "expirationDate must be absent so template renders 'has expired'",
+            paramsCaptor.getValue().containsKey(NotificationParamsBuilder.PARAM_EXPIRATION_DATE)
+        );
+    }
+
+    /**
+     * When the API product referenced by the subscription cannot be found in the repository,
+     * no notification should be sent.
+     */
+    @Test
+    public void shouldNotTriggerNotificationForApiProductSubscriptionWhenApiProductNotFound() throws TechnicalException {
+        String apiProductId = "non-existent-product";
+        Date futureExpiry = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+
+        ApiKey existingApiKey = new ApiKey();
+        existingApiKey.setApplication(APPLICATION_ID);
+        when(apiKeyRepository.findById("api-key-id")).thenReturn(Optional.of(existingApiKey));
+
+        SubscriptionEntity apiProductSubscription = new SubscriptionEntity();
+        apiProductSubscription.setId(SUBSCRIPTION_ID);
+        apiProductSubscription.setPlan(PLAN_ID);
+        apiProductSubscription.setReferenceType(SubscriptionReferenceType.API_PRODUCT.name());
+        apiProductSubscription.setReferenceId(apiProductId);
+
+        ApiKeyEntity apiKeyEntity = new ApiKeyEntity();
+        apiKeyEntity.setId("api-key-id");
+        apiKeyEntity.setKey("test-key");
+        apiKeyEntity.setExpireAt(futureExpiry);
+        apiKeyEntity.setApplication(application);
+        apiKeyEntity.setSubscriptions(Set.of(apiProductSubscription));
+
+        when(subscriptionService.findById(any())).thenReturn(apiProductSubscription);
+        when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID))).thenReturn(application);
+        when(subscriptionService.findByIdIn(any())).thenReturn(Set.of(apiProductSubscription));
+
+        GenericPlanEntity mockedPlan = mock(GenericPlanEntity.class);
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mockedPlan);
+
+        when(apiProductsRepository.findById(apiProductId)).thenReturn(Optional.empty());
+
+        apiKeyService.update(GraviteeContext.getExecutionContext(), apiKeyEntity);
+
+        verify(notifierService, never()).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApiHook.APIKEY_EXPIRED),
+            eq(NotificationReferenceType.API_PRODUCT),
+            eq(apiProductId),
+            any()
+        );
     }
 
     private ApiKey buildTestApiKey(String id) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiKeyExpired.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiKeyExpired.html
@@ -6,8 +6,8 @@
 		<div style="margin-top: 50px; color: #424e5a;">
 			<h3>Hi,</h3>
 			<p>
-				Your API Key <b><code>${apiKey}</code></b> used by subscription to plan <b>${plan.name}</b> for API
-				<b>${api.name}</b> and application <b>${application.name}</b> <#if expirationDate??>will expire the ${expirationDate?date} at ${expirationDate?time}.<#else>has expired.</#if>
+			Your API Key <b><code>${apiKey}</code></b> used by subscription to plan <b>${plan.name}</b> for ${(api??)?then("API","API Product")}
+			<b>${(api.name)!(apiProduct.name)!''}</b> and application <b>${application.name}</b> <#if expirationDate??>will expire the ${expirationDate?date} at ${expirationDate?time}.<#else>has expired.</#if>
 			</p>
 		</p>
 	</body>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiKeyRenewed.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiKeyRenewed.html
@@ -6,8 +6,8 @@
 		<div style="margin-top: 50px; color: #424e5a;">
 			<h3>Hi,</h3>
 			<p>
-				A new API Key <b><code>${apiKey}</code></b> used by subscription to plan <b>${plan.name}</b> for API
-				<b>${api.name}</b> and application <b>${application.name}</b> has been generated.
+			A new API Key <b><code>${apiKey}</code></b> used by subscription to plan <b>${plan.name}</b> for ${(api??)?then("API","API Product")}
+			<b>${(api.name)!(apiProduct.name)!''}</b> and application <b>${application.name}</b> has been generated.
 			</p>
 		</div>
 	</body>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiKeyRevoked.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiKeyRevoked.html
@@ -6,9 +6,9 @@
 		<div style="margin-top: 50px; color: #424e5a;">
 			<h3>Hi,</h3>
 			<p>
-				Your API Key <b><code>${apiKey}</code></b> used by subscription to plan <b>${plan.name}</b> for API
-				<b>${api.name}</b> and application <b>${application.name}</b> has been revoked and cannot be used
-				anymore to consume API.
+			Your API Key <b><code>${apiKey}</code></b> used by subscription to plan <b>${plan.name}</b> for ${(api??)?then("API","API Product")}
+			<b>${(api.name)!(apiProduct.name)!''}</b> and application <b>${application.name}</b> has been revoked and cannot be used
+			anymore to consume ${(api??)?then("API","API Product")}.
 			</p>
 		</div>
 	</body>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13319

## Description

## Fixes: API Product Subscription — Audit, Notifications & Email Templates

| # | Bug | Root Cause | Fix |
|---|-----|-----------|-----|
| 1 | **500 on pause/resume (JDBC only)** | `genericPlanEntity.getReferenceId()` is `null` for API product plans → `NULL` inserted into `audit_properties.value` which has a `NOT NULL` constraint in PostgreSQL | Use `subscription.getReferenceId()` with fallback to `subscription.getApi()` |
| 2 | **API key emails never sent for API product subscriptions** (`APIKEY_EXPIRED`, `APIKEY_RENEWED`, `APIKEY_REVOKED`) | An early `return` with a `TODO` comment blocked all API product subscriptions in `ApiKeyServiceImpl` | Route to a new helper `triggerNotifierServiceForApiProductSubscription` that reuses `SubscriptionService.buildApiProductNotificationParams` |
| 3 | **Email shows "has expired" instead of "will expire on \<date\>"** | `updateExpirationDate` sets `expirationDate` on the caller's `NotificationParamsBuilder` before triggering, but the API product path created a fresh internal builder — silently dropping `expirationDate` | `buildSubscriptionNotificationParamsForApiProduct` now accepts and enriches the caller's builder in-place, matching the regular API pattern |
| 4 | **FreeMarker `InvalidReferenceException` in API key email templates** | `apiKey*.html` templates unconditionally access `${api.name}` which is absent in API product context | Added `<#if api??>` guards and `!(apiProduct.name)!''` fallbacks; `EmailNotificationBuilder` subject lines use the same fallback |


**Notifications**: 
<img width="1205" height="462" alt="image" src="https://github.com/user-attachments/assets/98e1fb95-c017-4929-9231-bed693c302af" />


<img width="1205" height="462" alt="image" src="https://github.com/user-attachments/assets/050c185e-43f5-4bdd-90af-c69bd5c425bd" />


<img width="1205" height="462" alt="image" src="https://github.com/user-attachments/assets/dbb51592-b0b1-4617-80d3-d7d545931088" />


<img width="1205" height="462" alt="image" src="https://github.com/user-attachments/assets/7754b9f5-05e0-43dc-b22b-5f30f8e90c83" />
