### PR TITLE
feat(core): add use case for retrieving mTLS certificates across user applications

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/domain_service/UserApplicationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/domain_service/UserApplicationDomainService.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application.domain_service;
+
+import static java.util.stream.Collectors.toSet;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class UserApplicationDomainService {
+
+    private final MembershipQueryService membershipQueryService;
+
+    /**
+     * Returns the set of application IDs for which the given user has a direct membership.
+     *
+     * @param userId the user ID
+     * @return a set of application IDs
+     */
+    public Set<String> findApplicationIdsByUserId(String userId) {
+        return membershipQueryService
+            .findByMemberIdAndMemberTypeAndReferenceType(userId, Membership.Type.USER, Membership.ReferenceType.APPLICATION)
+            .stream()
+            .map(Membership::getReferenceId)
+            .collect(toSet());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/GetUserClientCertificatesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/GetUserClientCertificatesUseCase.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application_certificate.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.application.domain_service.UserApplicationDomainService;
+import io.gravitee.apim.core.application.query_service.ApplicationQueryService;
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetUserClientCertificatesUseCase {
+
+    private final ClientCertificateCrudService clientCertificateCrudService;
+    private final UserApplicationDomainService userApplicationDomainService;
+    private final ApplicationQueryService applicationQueryService;
+
+    public Output execute(Input input) {
+        Set<String> appIds = userApplicationDomainService.findApplicationIdsByUserId(input.userId());
+
+        if (appIds.isEmpty()) {
+            return new Output(new Page<>(List.of(), 0, 0, 0), List.of());
+        }
+
+        Page<ClientCertificate> certificates = clientCertificateCrudService.findByApplicationIds(appIds, input.pageable());
+
+        List<BaseApplicationEntity> applications = List.of();
+        if (input.includeApplications()) {
+            applications = applicationQueryService
+                .searchByIds(appIds, input.environmentId(), new PageableImpl(1, appIds.size()))
+                .getContent();
+        }
+
+        return new Output(certificates, applications);
+    }
+
+    public record Input(String userId, String environmentId, Pageable pageable, boolean includeApplications) {}
+
+    public record Output(Page<ClientCertificate> clientCertificates, List<BaseApplicationEntity> applications) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiPortalMembershipDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiPortalMembershipDomainService.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.membership.domain_service;
 import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.application.domain_service.UserApplicationDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
@@ -32,6 +33,7 @@ public class ApiPortalMembershipDomainService {
 
     private final MembershipQueryService membershipQueryService;
     private final SubscriptionQueryService subscriptionQueryService;
+    private final UserApplicationDomainService userApplicationDomainService;
 
     public Set<String> filterApiIdsByUserMembership(String userId, Set<String> candidateApiIds) {
         if (candidateApiIds.isEmpty()) {
@@ -69,11 +71,7 @@ public class ApiPortalMembershipDomainService {
             return Set.of();
         }
 
-        Set<String> userApplicationIds = membershipQueryService
-            .findByMemberIdAndMemberTypeAndReferenceType(userId, Membership.Type.USER, Membership.ReferenceType.APPLICATION)
-            .stream()
-            .map(Membership::getReferenceId)
-            .collect(toSet());
+        Set<String> userApplicationIds = userApplicationDomainService.findApplicationIdsByUserId(userId);
 
         if (userApplicationIds.isEmpty()) {
             return Set.of();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ClientCertificateFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ClientCertificateFixtures.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import java.util.Date;
+import java.util.function.Supplier;
+
+public class ClientCertificateFixtures {
+
+    private ClientCertificateFixtures() {}
+
+    private static final Supplier<ClientCertificate> BASE = () ->
+        new ClientCertificate(
+            "certificate-id",
+            "cross-certificate-id",
+            "application-id",
+            "Certificate",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            new Date(),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint",
+            "environment-id",
+            ClientCertificateStatus.ACTIVE
+        );
+
+    public static ClientCertificate aClientCertificate() {
+        return BASE.get();
+    }
+
+    public static ClientCertificate aClientCertificate(String id, String applicationId, String fingerprint) {
+        return new ClientCertificate(
+            id,
+            "cross-" + id,
+            applicationId,
+            "Certificate " + id,
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            new Date(),
+            "CN=Test",
+            "CN=Issuer",
+            fingerprint,
+            "environment-id",
+            ClientCertificateStatus.ACTIVE
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/MembershipFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/MembershipFixtures.java
@@ -60,4 +60,14 @@ public class MembershipFixtures {
             .roleId(applicationPrimaryOwnerRoleId(organizationId))
             .build();
     }
+
+    public static Membership anApplicationMembership(String userId, String applicationId) {
+        return BASE.get()
+            .id("m-" + userId + "-" + applicationId)
+            .memberId(userId)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.APPLICATION)
+            .referenceId(applicationId)
+            .build();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiForPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiForPortalUseCaseTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.application.domain_service.UserApplicationDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
@@ -49,7 +50,12 @@ class GetApiForPortalUseCaseTest {
 
     @BeforeEach
     void setUp() {
-        var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        var userApplicationDomainService = new UserApplicationDomainService(membershipQueryService);
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            subscriptionQueryService,
+            userApplicationDomainService
+        );
         useCase = new GetApiForPortalUseCase(new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/SearchApisForPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/SearchApisForPortalUseCaseTest.java
@@ -22,6 +22,7 @@ import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.application.domain_service.UserApplicationDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
@@ -57,7 +58,12 @@ class SearchApisForPortalUseCaseTest {
         membershipQueryService = new MembershipQueryServiceInMemory();
         var subscriptionQueryService = new SubscriptionQueryServiceInMemory();
         apiSearchQueryService = new ApiPortalSearchQueryServiceInMemory();
-        var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        var userApplicationDomainService = new UserApplicationDomainService(membershipQueryService);
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            subscriptionQueryService,
+            userApplicationDomainService
+        );
         var visibilityDomainService = new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService);
         useCase = new SearchApisForPortalUseCase(visibilityDomainService, apiSearchQueryService);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/domain_service/UserApplicationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/domain_service/UserApplicationDomainServiceTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application.domain_service;
+
+import static fixtures.core.model.MembershipFixtures.anApiMembership;
+import static fixtures.core.model.MembershipFixtures.anApplicationMembership;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.MembershipQueryServiceInMemory;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UserApplicationDomainServiceTest {
+
+    private static final String USER_ID = "user-1";
+    private static final String OTHER_USER_ID = "user-2";
+
+    private final MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
+
+    private UserApplicationDomainService domainService;
+
+    @BeforeEach
+    void setUp() {
+        domainService = new UserApplicationDomainService(membershipQueryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        membershipQueryService.reset();
+    }
+
+    @Test
+    void should_return_application_ids_for_user() {
+        membershipQueryService.initWith(List.of(anApplicationMembership(USER_ID, "app-1"), anApplicationMembership(USER_ID, "app-2")));
+
+        var result = domainService.findApplicationIdsByUserId(USER_ID);
+
+        assertThat(result).containsExactlyInAnyOrder("app-1", "app-2");
+    }
+
+    @Test
+    void should_return_empty_set_when_user_has_no_application_memberships() {
+        var result = domainService.findApplicationIdsByUserId(USER_ID);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_exclude_application_ids_belonging_to_other_users() {
+        membershipQueryService.initWith(
+            List.of(anApplicationMembership(USER_ID, "app-1"), anApplicationMembership(OTHER_USER_ID, "app-other"))
+        );
+
+        var result = domainService.findApplicationIdsByUserId(USER_ID);
+
+        assertThat(result).containsExactly("app-1");
+    }
+
+    @Test
+    void should_exclude_non_application_memberships() {
+        membershipQueryService.initWith(List.of(anApplicationMembership(USER_ID, "app-1"), anApiMembership("api-1")));
+
+        var result = domainService.findApplicationIdsByUserId(USER_ID);
+
+        assertThat(result).containsExactly("app-1");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/GetUserClientCertificatesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/GetUserClientCertificatesUseCaseTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application_certificate.use_case;
+
+import static fixtures.core.model.ClientCertificateFixtures.aClientCertificate;
+import static fixtures.core.model.MembershipFixtures.anApplicationMembership;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApplicationQueryServiceInMemory;
+import inmemory.ClientCertificateCrudServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.MembershipQueryServiceInMemory;
+import io.gravitee.apim.core.application.domain_service.UserApplicationDomainService;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetUserClientCertificatesUseCaseTest {
+
+    private static final String USER_ID = "user-1";
+    private static final String ENV_ID = "env-1";
+
+    private final ClientCertificateCrudServiceInMemory clientCertificateCrudService = new ClientCertificateCrudServiceInMemory();
+    private final MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
+    private final ApplicationQueryServiceInMemory applicationQueryService = new ApplicationQueryServiceInMemory();
+
+    private GetUserClientCertificatesUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        var userApplicationDomainService = new UserApplicationDomainService(membershipQueryService);
+        useCase = new GetUserClientCertificatesUseCase(clientCertificateCrudService, userApplicationDomainService, applicationQueryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Stream.of(clientCertificateCrudService, membershipQueryService, applicationQueryService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_return_certificates_across_user_applications() {
+        membershipQueryService.initWith(List.of(anApplicationMembership(USER_ID, "app-1"), anApplicationMembership(USER_ID, "app-2")));
+        clientCertificateCrudService.initWith(
+            List.of(aClientCertificate("cert-1", "app-1", "fp1"), aClientCertificate("cert-2", "app-2", "fp2"))
+        );
+
+        var result = useCase.execute(new GetUserClientCertificatesUseCase.Input(USER_ID, ENV_ID, new PageableImpl(1, 10), false));
+
+        assertThat(result.clientCertificates().getContent()).hasSize(2);
+        assertThat(result.clientCertificates().getTotalElements()).isEqualTo(2);
+        assertThat(result.applications()).isEmpty();
+    }
+
+    @Test
+    void should_exclude_certificates_from_other_users_applications() {
+        membershipQueryService.initWith(List.of(anApplicationMembership(USER_ID, "app-1")));
+        clientCertificateCrudService.initWith(
+            List.of(aClientCertificate("cert-1", "app-1", "fp1"), aClientCertificate("cert-other", "app-other", "fp-other"))
+        );
+
+        var result = useCase.execute(new GetUserClientCertificatesUseCase.Input(USER_ID, ENV_ID, new PageableImpl(1, 10), false));
+
+        assertThat(result.clientCertificates().getContent()).hasSize(1);
+        assertThat(result.clientCertificates().getContent().get(0).applicationId()).isEqualTo("app-1");
+    }
+
+    @Test
+    void should_return_empty_when_user_has_no_application_memberships() {
+        clientCertificateCrudService.initWith(List.of(aClientCertificate("cert-1", "app-1", "fp1")));
+
+        var result = useCase.execute(new GetUserClientCertificatesUseCase.Input(USER_ID, ENV_ID, new PageableImpl(1, 10), false));
+
+        assertThat(result.clientCertificates().getContent()).isEmpty();
+        assertThat(result.clientCertificates().getTotalElements()).isZero();
+    }
+
+    @Test
+    void should_paginate_certificates() {
+        membershipQueryService.initWith(List.of(anApplicationMembership(USER_ID, "app-1")));
+        clientCertificateCrudService.initWith(
+            List.of(
+                aClientCertificate("cert-1", "app-1", "fp1"),
+                aClientCertificate("cert-2", "app-1", "fp2"),
+                aClientCertificate("cert-3", "app-1", "fp3")
+            )
+        );
+
+        var result = useCase.execute(new GetUserClientCertificatesUseCase.Input(USER_ID, ENV_ID, new PageableImpl(1, 2), false));
+
+        assertThat(result.clientCertificates().getContent()).hasSize(2);
+        assertThat(result.clientCertificates().getTotalElements()).isEqualTo(3);
+    }
+
+    @Test
+    void should_populate_applications_when_includeApplications_is_true() {
+        membershipQueryService.initWith(List.of(anApplicationMembership(USER_ID, "app-1")));
+        clientCertificateCrudService.initWith(List.of(aClientCertificate("cert-1", "app-1", "fp1")));
+        var app = new BaseApplicationEntity();
+        app.setId("app-1");
+        app.setName("My App");
+        app.setEnvironmentId(ENV_ID);
+        applicationQueryService.initWith(List.of(app));
+
+        var result = useCase.execute(new GetUserClientCertificatesUseCase.Input(USER_ID, ENV_ID, new PageableImpl(1, 10), true));
+
+        assertThat(result.clientCertificates().getContent()).hasSize(1);
+        assertThat(result.applications()).hasSize(1);
+        assertThat(result.applications().get(0).getId()).isEqualTo("app-1");
+        assertThat(result.applications().get(0).getName()).isEqualTo("My App");
+    }
+
+    @Test
+    void should_not_populate_applications_when_includeApplications_is_false() {
+        membershipQueryService.initWith(List.of(anApplicationMembership(USER_ID, "app-1")));
+        clientCertificateCrudService.initWith(List.of(aClientCertificate("cert-1", "app-1", "fp1")));
+        var app = new BaseApplicationEntity();
+        app.setId("app-1");
+        app.setName("My App");
+        app.setEnvironmentId(ENV_ID);
+        applicationQueryService.initWith(List.of(app));
+
+        var result = useCase.execute(new GetUserClientCertificatesUseCase.Input(USER_ID, ENV_ID, new PageableImpl(1, 10), false));
+
+        assertThat(result.applications()).isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainServiceTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.application.domain_service.UserApplicationDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
@@ -54,7 +55,12 @@ class PortalNavigationApiVisibilityDomainServiceTest {
         navQueryService = new PortalNavigationItemsQueryServiceInMemory();
         membershipQueryService = new MembershipQueryServiceInMemory();
         subscriptionQueryService = new SubscriptionQueryServiceInMemory();
-        var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        var userApplicationDomainService = new UserApplicationDomainService(membershipQueryService);
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            subscriptionQueryService,
+            userApplicationDomainService
+        );
         domainService = new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
@@ -22,6 +22,7 @@ import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.application.domain_service.UserApplicationDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
@@ -59,7 +60,12 @@ class GetVisiblePortalNavigationApisUseCaseTest {
         membershipQueryService = new MembershipQueryServiceInMemory();
         apiSearchQueryService = new ApiPortalSearchQueryServiceInMemory();
         var subscriptionQueryService = new SubscriptionQueryServiceInMemory();
-        var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        var userApplicationDomainService = new UserApplicationDomainService(membershipQueryService);
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            subscriptionQueryService,
+            userApplicationDomainService
+        );
         var visibilityDomainService = new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService);
         useCase = new GetVisiblePortalNavigationApisUseCase(visibilityDomainService, apiSearchQueryService);
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13261

## Description

- Added `UserApplicationDomainService` to encapsulate user-application membership resolution; refactored `ApiPortalMembershipDomainService` to delegate to it instead of querying `MembershipQueryService` inline
- Added `GetUserClientCertificatesUseCase` — resolves the user's application memberships, fetches paginated certificates across all of them, and optionally populates application details via `includeApplications` flag
- Added `ClientCertificateFixtures` and `anApplicationMembership` to `MembershipFixtures` for reuse across tests
- Unit tests for `GetUserClientCertificatesUseCase` and `UserApplicationDomainService`; updated wiring in `PortalNavigationApiVisibilityDomainServiceTest`, `GetApiForPortalUseCaseTest`, `SearchApisForPortalUseCaseTest`, and `GetVisiblePortalNavigationApisUseCaseTest`

## Additional context

- This PR targets Task 1 only. Task 2 (papi `GET /certificates` resource) and Tasks 3–4 (portal-next frontend) follow in subsequent PRs.
- Depends on the companion Task 1a PR which adds `ClientCertificateCrudService#findByApplicationIds` and its repository implementations.
