### PR TITLE
fix: Clear response headers between failover attempts

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
@@ -123,7 +123,7 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
                 // On retry, capture the endpoint that failed in the previous attempt and restore the request to its initial state
                 if (attempt > 0) {
                     firstFailedEndpoint.compareAndSet(null, resolveCurrentEndpointName(ctx));
-                    restoreRequestState(ctx, snapshotRef.get());
+                    restoreContextState(ctx, snapshotRef.get());
                 }
 
                 // EndpointInvoker overrides the request endpoint. We need to set it back to original state to retry properly
@@ -316,8 +316,9 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
 
     /**
      * Restores the request to its initial state captured by {@link #captureRequestState}.
+     * Removes response headers to avoid interference with subsequent response processing.
      */
-    private void restoreRequestState(HttpExecutionContext ctx, RequestSnapshot snapshot) {
+    private void restoreContextState(HttpExecutionContext ctx, RequestSnapshot snapshot) {
         if (ctx.request() instanceof HttpRequestInternal httpRequestInternal) {
             httpRequestInternal.pathInfo(snapshot.pathInfo());
         }
@@ -330,6 +331,10 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
 
         if (snapshot.body() != null) {
             ctx.request().body(snapshot.body());
+        }
+
+        if (ctx.response() != null && ctx.response().headers() != null) {
+            ctx.response().headers().clear();
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/failover/FailoverInvokerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/failover/FailoverInvokerTest.java
@@ -151,9 +151,7 @@ class FailoverInvokerTest {
             .test()
             .awaitDone(2, TimeUnit.SECONDS)
             .assertError(
-                t ->
-                    t instanceof InterruptionFailureException &&
-                    ((InterruptionFailureException) t).getExecutionFailure().statusCode() == 502
+                t -> t instanceof InterruptionFailureException interruption && interruption.getExecutionFailure().statusCode() == 502
             );
 
         ArgumentCaptor<HttpExecutionContext> executionContextArgumentCaptor = ArgumentCaptor.forClass(HttpExecutionContext.class);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Clear response headers between attempts.

