### PR TITLE
fix(gateway): restore error fields in legacy engine logs (APIM-12654)

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessor.java
@@ -61,6 +61,15 @@ public class SimpleFailureProcessor extends AbstractProcessor<ExecutionContext> 
         final Response response = context.response();
 
         context.request().metrics().setErrorKey(failure.key());
+        String existingMessage = context.request().metrics().getMessage();
+        if (existingMessage == null) {
+            context.request().metrics().setMessage(failure.message());
+        } else if (failure.message() != null && !failure.message().equals(existingMessage)) {
+            // Combine generic failure message with detailed reason from policy,
+            // e.g. "Unauthorized" + "Signed JWT rejected: Invalid signature"
+            //    -> "Unauthorized (Signed JWT rejected: Invalid signature)"
+            context.request().metrics().setMessage(failure.message() + " (" + existingMessage + ")");
+        }
 
         response.status(failure.statusCode());
         response.reason(HttpResponseStatus.valueOf(response.status()).reasonPhrase());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessorTest.java
@@ -99,6 +99,7 @@ class SimpleFailureProcessorTest {
         cut.handle(executionContext);
 
         assertThat(metrics.getErrorKey()).isEqualTo(FAILURE_KEY);
+        assertThat(metrics.getMessage()).isNull();
         verify(response).status(FAILURE_CODE);
         verify(response).reason("Bad Request");
         verify(responseHeaders).set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
@@ -115,6 +116,7 @@ class SimpleFailureProcessorTest {
         cut.handle(executionContext);
 
         assertThat(metrics.getErrorKey()).isEqualTo(FAILURE_KEY);
+        assertThat(metrics.getMessage()).isEqualTo(failureMessage);
         verify(response).status(FAILURE_CODE);
         verify(response).reason("Bad Request");
         verify(responseHeaders).set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
@@ -168,5 +170,37 @@ class SimpleFailureProcessorTest {
         verify(responseHeaders).set(HttpHeaderNames.CONTENT_LENGTH, "44");
         verify(responseHeaders).set(HttpHeaderNames.CONTENT_TYPE, expectedContentType);
         verify(response).write(any());
+    }
+
+    @Test
+    @DisplayName("Should combine generic failure message with detailed policy message")
+    void shouldCombineGenericAndDetailedMessages() {
+        when(executionContext.getAttribute(ExecutionContext.ATTR_PREFIX + "failure")).thenReturn(processorFailure);
+        final String policyDetailedMessage = "Signed JWT rejected: Invalid signature";
+        final String genericFailureMessage = "Unauthorized";
+        // Simulate JWT policy setting detailed message before SimpleFailureProcessor runs
+        metrics.setMessage(policyDetailedMessage);
+        when(processorFailure.message()).thenReturn(genericFailureMessage);
+
+        cut.handle(executionContext);
+
+        assertThat(metrics.getErrorKey()).isEqualTo(FAILURE_KEY);
+        // Should combine: "Unauthorized (Signed JWT rejected: Invalid signature)"
+        assertThat(metrics.getMessage()).isEqualTo("Unauthorized (Signed JWT rejected: Invalid signature)");
+        verify(processorNext).handle(executionContext);
+    }
+
+    @Test
+    @DisplayName("Should not duplicate message when failure message equals existing message")
+    void shouldNotDuplicateWhenMessagesMatch() {
+        when(executionContext.getAttribute(ExecutionContext.ATTR_PREFIX + "failure")).thenReturn(processorFailure);
+        final String sameMessage = "Unauthorized";
+        metrics.setMessage(sameMessage);
+        when(processorFailure.message()).thenReturn(sameMessage);
+
+        cut.handle(executionContext);
+
+        assertThat(metrics.getMessage()).isEqualTo("Unauthorized");
+        verify(processorNext).handle(executionContext);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/reporter/ReporterProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/reporter/ReporterProcessor.java
@@ -18,6 +18,8 @@ package io.gravitee.gateway.reactor.processor.reporter;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.core.processor.AbstractProcessor;
 import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.reporter.api.http.Metrics;
+import io.gravitee.reporter.api.v4.metric.Diagnostic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +40,7 @@ public class ReporterProcessor extends AbstractProcessor<ExecutionContext> {
     @Override
     public void handle(ExecutionContext context) {
         try {
+            translateErrorToDiagnosticFailure(context.request().metrics());
             reporterService.report(context.request().metrics());
 
             if (context.request().metrics().getLog() != null) {
@@ -50,5 +53,21 @@ public class ReporterProcessor extends AbstractProcessor<ExecutionContext> {
         }
 
         next.handle(context);
+    }
+
+    /**
+     * Translates error key and error message to Diagnostic failure if failure is null and error information exists.
+     * Mirrors the reactive ReporterProcessor's translateErrorToDiagnosticFailure() for the legacy engine path.
+     * Component fields are left null since the legacy engine has no component tracking.
+     */
+    private void translateErrorToDiagnosticFailure(Metrics metrics) {
+        if (metrics != null && metrics.getFailure() == null) {
+            String errorKey = metrics.getErrorKey();
+            String errorMessage = metrics.getMessage();
+
+            if (errorMessage != null && !errorMessage.isBlank()) {
+                metrics.setFailure(new Diagnostic(errorKey != null ? errorKey : "internal_error", errorMessage, null, null));
+            }
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/reporter/ReporterProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/reporter/ReporterProcessorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactor.processor.reporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.core.processor.AbstractProcessor;
+import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.reporter.api.http.Metrics;
+import io.gravitee.reporter.api.v4.metric.Diagnostic;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReporterProcessorTest {
+
+    private ReporterProcessor cut;
+
+    @Mock
+    private ReporterService reporterService;
+
+    @Mock
+    private AbstractProcessor<ExecutionContext> processorNext;
+
+    @Mock
+    private ExecutionContext executionContext;
+
+    @Mock
+    private Request request;
+
+    private Metrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        cut = new ReporterProcessor(reporterService);
+        cut.handler(processorNext);
+        metrics = Metrics.on(System.currentTimeMillis()).build();
+        when(executionContext.request()).thenReturn(request);
+        when(request.metrics()).thenReturn(metrics);
+    }
+
+    @Test
+    @DisplayName("Should create Diagnostic when errorKey and message are present")
+    void shouldCreateDiagnosticWhenErrorKeyAndMessagePresent() {
+        metrics.setErrorKey("GATEWAY_PLAN_UNRESOLVABLE");
+        metrics.setMessage("Unauthorized");
+
+        cut.handle(executionContext);
+
+        assertThat(metrics.getFailure()).isNotNull();
+        assertThat(metrics.getFailure().getKey()).isEqualTo("GATEWAY_PLAN_UNRESOLVABLE");
+        assertThat(metrics.getFailure().getMessage()).isEqualTo("Unauthorized");
+        assertThat(metrics.getFailure().getComponentType()).isNull();
+        assertThat(metrics.getFailure().getComponentName()).isNull();
+        verify(reporterService).report(metrics);
+        verify(processorNext).handle(executionContext);
+    }
+
+    @Test
+    @DisplayName("Should use internal_error as default key when errorKey is null")
+    void shouldUseDefaultKeyWhenErrorKeyNull() {
+        metrics.setMessage("Some error");
+
+        cut.handle(executionContext);
+
+        assertThat(metrics.getFailure()).isNotNull();
+        assertThat(metrics.getFailure().getKey()).isEqualTo("internal_error");
+        assertThat(metrics.getFailure().getMessage()).isEqualTo("Some error");
+        verify(reporterService).report(metrics);
+    }
+
+    @Test
+    @DisplayName("Should not create Diagnostic when message is null")
+    void shouldNotCreateDiagnosticWhenMessageNull() {
+        metrics.setErrorKey("GATEWAY_PLAN_UNRESOLVABLE");
+
+        cut.handle(executionContext);
+
+        assertThat(metrics.getFailure()).isNull();
+        verify(reporterService).report(metrics);
+    }
+
+    @Test
+    @DisplayName("Should not create Diagnostic when message is blank")
+    void shouldNotCreateDiagnosticWhenMessageBlank() {
+        metrics.setErrorKey("GATEWAY_PLAN_UNRESOLVABLE");
+        metrics.setMessage("   ");
+
+        cut.handle(executionContext);
+
+        assertThat(metrics.getFailure()).isNull();
+        verify(reporterService).report(metrics);
+    }
+
+    @Test
+    @DisplayName("Should not override existing Diagnostic failure")
+    void shouldNotOverrideExistingFailure() {
+        Diagnostic existing = new Diagnostic("existing_key", "existing_message", "comp_type", "comp_name");
+        metrics.setFailure(existing);
+        metrics.setErrorKey("GATEWAY_PLAN_UNRESOLVABLE");
+        metrics.setMessage("Unauthorized");
+
+        cut.handle(executionContext);
+
+        assertThat(metrics.getFailure()).isSameAs(existing);
+        verify(reporterService).report(metrics);
+    }
+
+    @Test
+    @DisplayName("Should report metrics even without error information")
+    void shouldReportMetricsWithoutErrors() {
+        cut.handle(executionContext);
+
+        assertThat(metrics.getFailure()).isNull();
+        verify(reporterService).report(metrics);
+        verify(processorNext).handle(executionContext);
+    }
+}


### PR DESCRIPTION
## Summary
- v2 APIs on the legacy (non-reactive) engine had empty error fields in runtime logs: error-key, message, error-component-type, error-component-name all missing. Only status + timestamp present. v4 emulation worked fine. Regression introduced during 4.9.x reporter refactor.
- Root cause: `SimpleFailureProcessor` never set `metrics.setMessage()`, and legacy `ReporterProcessor` had no `translateErrorToDiagnosticFailure()` bridge. The ES FTL template reads error fields from `metrics.getFailure()` (a Diagnostic object), so without that translation the entire error block was skipped.
- Also: `SimpleFailureProcessor` was overwriting detailed policy-set messages (e.g. JWT policy sets "Signed JWT rejected: Invalid signature") with the generic "Unauthorized" from the PolicyResult.

**Fix:**
- `SimpleFailureProcessor`: only sets `metrics.setMessage()` if null; when both a policy message and failure message exist, combines them as "failure (policy-detail)" to match v4 emulation format.
- Legacy `ReporterProcessor`: added `translateErrorToDiagnosticFailure()` mirroring the reactive version, using v2 `getMessage()`. Component fields left null since legacy engine has no component scope tracking (FTL + UI already handle null gracefully).

Fixes APIM-12654

## Test plan
- [x] `SimpleFailureProcessorTest`: 9/9 (7 existing + 2 new: combine message, preserve existing)
- [x] `ReporterProcessorTest`: 6/6 new tests (errorKey+message, null errorKey fallback, null/blank message, existing failure preserved, no-error passthrough)
- [x] Integration: v2 API + JWT + legacy engine, invalid token → 401 with error-key=JWT_INVALID_TOKEN, message="Unauthorized (Signed JWT rejected: Invalid signature)", component fields absent