### PR TITLE
fix(gateway): handle org-level flow interruptions

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -279,6 +279,7 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
             .compose(upstream -> timeout(upstream, ctx))
             // Platform post flows must always be executed
             .andThen(executeFlowChain(ctx, organizationFlowChain, RESPONSE).compose(upstream -> timeout(upstream, ctx)))
+            .onErrorResumeNext(error -> processOrganizationFlowError(ctx, error))
             // Catch all possible unexpected errors.
             .onErrorResumeNext(t -> handleUnexpectedError(ctx, t))
             .andThen(executeProcessorChain(ctx, afterHandleProcessors, RESPONSE))
@@ -415,6 +416,15 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
             ctx.withLogger(log).error("Unexpected error while handling request", throwable);
             return executeProcessorChain(ctx, onErrorProcessors, RESPONSE);
         }
+    }
+
+    private Completable processOrganizationFlowError(final MutableExecutionContext ctx, final Throwable throwable) {
+        if (InterruptionHelper.isInterruptionWithFailure(throwable)) {
+            return executeProcessorChain(ctx, onErrorProcessors, RESPONSE);
+        } else if (InterruptionHelper.isInterruption(throwable)) {
+            return Completable.complete();
+        }
+        return Completable.error(throwable);
     }
 
     private Completable handleUnexpectedError(final HttpExecutionContext ctx, final Throwable throwable) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -378,6 +378,7 @@ public class DefaultApiReactor extends AbstractApiReactor {
             .chainWith(
                 new CompletableReactorChain(organizationFlowChain.execute(ctx, RESPONSE)).chainWith(upstream -> timeout(upstream, ctx))
             )
+            .chainWithOnError(error -> processOrganizationFlowError(ctx, error))
             // Before entrypoint response
             // Handle entrypoint response.
             .chainWith(handleEntrypointResponse(ctx))
@@ -536,6 +537,15 @@ public class DefaultApiReactor extends AbstractApiReactor {
             ctx.withLogger(log).error("Unexpected error while handling request", throwable);
             return executeProcessorChain(ctx, onErrorProcessors, RESPONSE);
         }
+    }
+
+    private Completable processOrganizationFlowError(final MutableExecutionContext ctx, final Throwable throwable) {
+        if (InterruptionHelper.isInterruptionWithFailure(throwable)) {
+            return executeProcessorChain(ctx, onErrorProcessors, RESPONSE);
+        } else if (InterruptionHelper.isInterruption(throwable)) {
+            return Completable.complete();
+        }
+        return Completable.error(throwable);
     }
 
     protected Completable handleUnexpectedError(final ExecutionContext ctx, final Throwable throwable) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
@@ -72,6 +72,7 @@ import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.CompletableObserver;
 import io.reactivex.rxjava3.core.Observable;
@@ -739,6 +740,60 @@ class SyncApiReactorTest {
         orderedChain.verify(spyOnErrorProcessors).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyResponsePlatformFlowChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyAfterHandleProcessors).subscribe(any(CompletableObserver.class));
+    }
+
+    @Test
+    void shouldExecuteErrorChainWhenOrganizationResponseFlowThrowsInterruptionFailureException() throws Exception {
+        ExecutionFailure executionFailure = new ExecutionFailure(500).key("INTERNAL_SYSTEM_ERROR").message("Custom error from org policy");
+        when(onErrorProcessors.execute(ctx, ExecutionPhase.RESPONSE)).thenReturn(spyOnErrorProcessors);
+        setupOrgFlowErrorTest(spy(Completable.error(new InterruptionFailureException(executionFailure))));
+
+        cut.handle(ctx).test().assertComplete();
+
+        // The onErrorProcessors should be invoked to properly handle the failure
+        verify(spyOnErrorProcessors).subscribe(any(CompletableObserver.class));
+
+        // handleUnexpectedError should NOT be reached (onErrorProcessors is mocked, so no status is set here)
+        verify(ctx.response(), never()).status(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+        verify(ctx.response(), never()).reason(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
+    }
+
+    @Test
+    void shouldCompleteNormallyWhenOrganizationResponseFlowThrowsInterruptionException() throws Exception {
+        setupOrgFlowErrorTest(spy(Completable.error(new InterruptionException())));
+
+        cut.handle(ctx).test().assertComplete();
+
+        // Plain interruption from org flow should NOT trigger error processors nor handleUnexpectedError
+        verify(spyOnErrorProcessors, never()).subscribe(any(CompletableObserver.class));
+        verify(ctx.response(), never()).status(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+    }
+
+    @Test
+    void shouldFallbackToUnexpectedErrorWhenOrganizationResponseFlowThrowsRuntimeException() throws Exception {
+        setupOrgFlowErrorTest(spy(Completable.error(new RuntimeException("Unexpected org flow error"))));
+
+        cut.handle(ctx).test().assertComplete();
+
+        // Unexpected errors should fall through to handleUnexpectedError
+        verify(ctx.response()).status(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+    }
+
+    private void setupOrgFlowErrorTest(Completable orgResponseFlowChain) throws Exception {
+        when(api.getDeployedAt()).thenReturn(new Date());
+        when(platformFlowChain.execute(ctx, ExecutionPhase.REQUEST)).thenReturn(spyRequestPlatformFlowChain);
+        when(beforeApiFlowsProcessors.execute(ctx, ExecutionPhase.REQUEST)).thenReturn(spyBeforeApiFlowsProcessors);
+        when(platformFlowChain.execute(ctx, ExecutionPhase.RESPONSE)).thenReturn(orgResponseFlowChain);
+        when(apiPlanFlowChain.execute(ctx, ExecutionPhase.REQUEST)).thenReturn(spyRequestApiPlanFlowChain);
+        when(apiPlanFlowChain.execute(ctx, ExecutionPhase.RESPONSE)).thenReturn(spyResponseApiPlanFlowChain);
+        when(apiFlowChain.execute(ctx, ExecutionPhase.REQUEST)).thenReturn(spyRequestApiFlowChain);
+        when(apiFlowChain.execute(ctx, ExecutionPhase.RESPONSE)).thenReturn(spyResponseApiFlowChain);
+        when(afterApiFlowsProcessors.execute(ctx, ExecutionPhase.RESPONSE)).thenReturn(spyAfterApiFlowsProcessors);
+        fillRequestExecutionContext();
+        when(invokerAdapter.invoke(any(HttpExecutionContext.class))).thenReturn(spyInvokerAdapterChain);
+        cut.doStart();
+        when(httpSecurityChain.execute(any())).thenReturn(spySecurityChain);
+        ReflectionTestUtils.setField(cut, "httpSecurityChain", httpSecurityChain);
     }
 
     private InOrder getInOrder() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
@@ -779,6 +779,18 @@ class SyncApiReactorTest {
         verify(ctx.response()).status(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
     }
 
+    @Test
+    void shouldAlwaysExecuteAfterHandleProcessorsWhenOrganizationResponseFlowFails() throws Exception {
+        ExecutionFailure executionFailure = new ExecutionFailure(502).key("CUSTOM_ERROR");
+        when(onErrorProcessors.execute(ctx, ExecutionPhase.RESPONSE)).thenReturn(spyOnErrorProcessors);
+        setupOrgFlowErrorTest(spy(Completable.error(new InterruptionFailureException(executionFailure))));
+
+        cut.handle(ctx).test().assertComplete();
+
+        // afterHandleProcessors must always execute (metrics, logging, etc.) even after org flow errors
+        verify(spyAfterHandleProcessors).subscribe(any(CompletableObserver.class));
+    }
+
     private void setupOrgFlowErrorTest(Completable orgResponseFlowChain) throws Exception {
         when(api.getDeployedAt()).thenReturn(new Date());
         when(platformFlowChain.execute(ctx, ExecutionPhase.REQUEST)).thenReturn(spyRequestPlatformFlowChain);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -1123,6 +1123,18 @@ class DefaultApiReactorTest {
         verify(response).reason(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
     }
 
+    @Test
+    void shouldAlwaysExecuteAfterHandleProcessorsWhenOrganizationResponseFlowFails() {
+        ExecutionFailure executionFailure = new ExecutionFailure(502).key("CUSTOM_ERROR");
+        spyResponsePlatformFlowChain = spy(Completable.error(new InterruptionFailureException(executionFailure)));
+        when(platformFlowChain.execute(ctx, ExecutionPhase.RESPONSE)).thenReturn(spyResponsePlatformFlowChain);
+
+        cut.handle(ctx).test().assertComplete();
+
+        // afterHandleProcessors must always execute (metrics, logging, etc.) even after org flow errors
+        verify(spyAfterHandleProcessors).subscribe(any(CompletableObserver.class));
+    }
+
     private InOrder getInOrder() {
         return inOrder(
             spyRequestPlatformFlowChain,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -1081,6 +1081,48 @@ class DefaultApiReactorTest {
         verify(apiService).stop();
     }
 
+    @Test
+    void shouldExecuteErrorChainWhenOrganizationResponseFlowThrowsInterruptionFailureException() {
+        // Simulate the organization response flow chain throwing an InterruptionFailureException
+        // (e.g., Groovy policy at ORG level setting State.FAILURE)
+        ExecutionFailure executionFailure = new ExecutionFailure(500).key("INTERNAL_SYSTEM_ERROR").message("Custom error from org policy");
+        spyResponsePlatformFlowChain = spy(Completable.error(new InterruptionFailureException(executionFailure)));
+        when(platformFlowChain.execute(ctx, ExecutionPhase.RESPONSE)).thenReturn(spyResponsePlatformFlowChain);
+
+        cut.handle(ctx).test().assertComplete();
+
+        // The onErrorProcessors should be invoked to properly handle the failure
+        verify(spyOnErrorProcessors, times(1)).subscribe(any(CompletableObserver.class));
+
+        // The response should NOT be set to a generic 500 by handleUnexpectedError
+        verify(response, never()).status(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+        verify(response, never()).reason(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
+    }
+
+    @Test
+    void shouldCompleteNormallyWhenOrganizationResponseFlowThrowsInterruptionException() {
+        spyResponsePlatformFlowChain = spy(Completable.error(new InterruptionException()));
+        when(platformFlowChain.execute(ctx, ExecutionPhase.RESPONSE)).thenReturn(spyResponsePlatformFlowChain);
+
+        cut.handle(ctx).test().assertComplete();
+
+        // Plain interruption from org flow should NOT trigger error processors or generic 500
+        verify(spyOnErrorProcessors, never()).subscribe(any(CompletableObserver.class));
+        verify(response, never()).status(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+    }
+
+    @Test
+    void shouldFallbackToUnexpectedErrorWhenOrganizationResponseFlowThrowsRuntimeException() {
+        spyResponsePlatformFlowChain = spy(Completable.error(new RuntimeException("Unexpected org flow error")));
+        when(platformFlowChain.execute(ctx, ExecutionPhase.RESPONSE)).thenReturn(spyResponsePlatformFlowChain);
+
+        cut.handle(ctx).test().assertComplete();
+
+        // Unexpected errors should fall through to handleUnexpectedError
+        verify(response).status(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
+        verify(response).reason(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase());
+    }
+
     private InOrder getInOrder() {
         return inOrder(
             spyRequestPlatformFlowChain,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13351

## Description

Organization-level policies triggering `State.FAILURE` (e.g., Groovy) returned a generic 500 instead of the custom error code. The `InterruptionFailureException` from org response flows was not caught before `handleUnexpectedError`, which overwrote the failure details. Added a dedicated error handler for org flow chains in both `SyncApiReactor` and `DefaultApiReactor`.

