### PR TITLE
feat: support EL expressions in option-bearing GMD components

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.html
@@ -30,7 +30,7 @@
             <app-subscribe-to-api-choose-plan
               [plans]="plans"
               [selectedPlan]="currentPlan"
-              [api]="api"
+              [api]="api()"
               (selectPlan)="currentPlan.set($event)"
             />
           }
@@ -83,7 +83,7 @@
         @if (currentPlan(); as plan) {
           @if (checkoutData$ | async; as checkoutData) {
             <app-subscribe-to-api-checkout
-              [api]="api"
+              [api]="api()"
               [application]="currentApplication()"
               [plan]="plan"
               [message]="message"

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.spec.ts
@@ -51,7 +51,6 @@ import { ConfigService } from '../../../services/config.service';
 import { AppTestingModule, TESTING_BASE_URL } from '../../../testing/app-testing.module';
 
 describe('SubscribeToApiComponent', () => {
-  let component: SubscribeToApiComponent;
   let fixture: ComponentFixture<SubscribeToApiComponent>;
   let httpTestingController: HttpTestingController;
   let harnessLoader: HarnessLoader;
@@ -103,8 +102,7 @@ describe('SubscribeToApiComponent', () => {
     harnessLoader = TestbedHarnessEnvironment.loader(fixture);
     rootHarnessLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
 
-    component = fixture.componentInstance;
-    component.api = api;
+    fixture.componentRef.setInput('api', api);
     fixture.detectChanges();
 
     expectGetSubscriptionForm(subscriptionForm);
@@ -515,7 +513,14 @@ describe('SubscribeToApiComponent', () => {
       });
       describe('When a subscription form is enabled', () => {
         const subscriptionForm: SubscriptionForm = {
-          gmdContent: '# Subscription form',
+          gmdContent:
+            '<gmd-select fieldkey="country" options="{#api.metadata[\'countries\']}:Fallback Country"></gmd-select>' +
+            '<gmd-radio fieldkey="color" options="{#api.metadata[\'colors\']}:Fallback Color"></gmd-radio>' +
+            '<gmd-select fieldkey="unchanged" options="{#api.metadata[\'teams\']}:Fallback Team"></gmd-select>',
+          resolvedOptions: {
+            country: ['France', 'Spain'],
+            color: ['Blue', 'Green'],
+          },
         };
         beforeEach(async () => {
           await init(true, API, subscriptionForm);
@@ -543,6 +548,16 @@ describe('SubscribeToApiComponent', () => {
 
           const subscribeButton = await getSubscribeButton();
           expect(await subscribeButton?.isDisabled()).toEqual(true);
+        });
+
+        it('should merge resolved options into gmdContent by fieldkey', async () => {
+          const mergedContent = fixture.componentInstance.subscriptionForm()?.gmdContent;
+
+          expect(mergedContent).toContain('<gmd-select fieldkey="country" options="France,Spain"></gmd-select>');
+          expect(mergedContent).toContain('<gmd-radio fieldkey="color" options="Blue,Green"></gmd-radio>');
+          expect(mergedContent).toContain(
+            '<gmd-select fieldkey="unchanged" options="{#api.metadata[\'teams\']}:Fallback Team"></gmd-select>',
+          );
         });
       });
       describe('API Key Management', () => {
@@ -1226,7 +1241,7 @@ describe('SubscribeToApiComponent', () => {
   }
 
   function expectGetSubscriptionForm(subscriptionForm: SubscriptionForm | null) {
-    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/subscription-form`);
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/${API_ID}/subscription-form`);
     if (subscriptionForm) {
       req.flush(subscriptionForm);
     } else {

--- a/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/subscribe-to-api/subscribe-to-api.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { CommonModule } from '@angular/common';
-import { Component, computed, DestroyRef, inject, input, Input, OnInit, Signal, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, OnInit, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardActions, MatCardContent } from '@angular/material/card';
@@ -46,6 +46,7 @@ import { Api } from '../../../entities/api/api';
 import { Application, ApplicationsResponse } from '../../../entities/application/application';
 import { Page } from '../../../entities/page/page';
 import { Plan } from '../../../entities/plan/plan';
+import { SubscriptionForm } from '../../../entities/portal/subscription-form';
 import { SubscriptionConsumerConfiguration } from '../../../entities/subscription';
 import { CreateSubscription, Subscription } from '../../../entities/subscription/subscription';
 import { SubscriptionsResponse } from '../../../entities/subscription/subscriptions-response';
@@ -113,7 +114,7 @@ export class SubscribeToApiComponent implements OnInit {
   private readonly currentApplicationsPage = new BehaviorSubject(1);
   private readonly currentApplicationsPageSize = new BehaviorSubject(DEFAULT_APPLICATIONS_PAGE_SIZE);
 
-  @Input() api!: Api;
+  api = input.required<Api>();
   cancelFn = input<() => void>();
 
   readonly SubscribeStep = SubscribeStep;
@@ -142,7 +143,9 @@ export class SubscribeToApiComponent implements OnInit {
   subscriptionInProgress = signal<boolean>(false);
   showApiKeyModeSelection = signal<boolean>(false);
   subscriptionForm = toSignal(
-    this.portalService.getSubscriptionForm().pipe(
+    toObservable(this.api).pipe(
+      switchMap(api => this.portalService.getSubscriptionForm(api.id)),
+      map(form => (form ? this.applyResolvedOptions(form) : null)),
       tap(form => {
         if (!form) {
           this.store.reset();
@@ -184,12 +187,12 @@ export class SubscribeToApiComponent implements OnInit {
   });
 
   ngOnInit(): void {
-    this.plans$ = this.planService.list(this.api.id).pipe(
+    this.plans$ = this.planService.list(this.api().id).pipe(
       map(({ data }) => data ?? []),
       catchError(_ => of([])),
     );
 
-    this.applicationsData$ = this.subscriptionService.list({ apiIds: [this.api.id], statuses: ['PENDING', 'ACCEPTED'], size: -1 }).pipe(
+    this.applicationsData$ = this.subscriptionService.list({ apiIds: [this.api().id], statuses: ['PENDING', 'ACCEPTED'], size: -1 }).pipe(
       combineLatestWith(this.currentApplicationsPage, this.currentApplicationsPageSize),
       switchMap(([subscriptions, page, pageSize]) => this.getApplicationsData$(page, pageSize, subscriptions)),
       catchError(_ =>
@@ -197,11 +200,11 @@ export class SubscribeToApiComponent implements OnInit {
       ),
     );
 
-    this.checkoutData$ = this.handleCheckoutData$(this.api).pipe(
+    this.checkoutData$ = this.handleCheckoutData$(this.api()).pipe(
       tap(({ applicationApiKeySubscriptions }) => {
         this.showApiKeyModeSelection.set(
           this.configuration.plan?.security?.sharedApiKey?.enabled === true &&
-            this.api.definitionVersion !== 'FEDERATED' &&
+            this.api().definitionVersion !== 'FEDERATED' &&
             applicationApiKeySubscriptions.length === 1,
         );
       }),
@@ -330,8 +333,8 @@ export class SubscribeToApiComponent implements OnInit {
     const generalConditionsPageId = this.currentPlan()?.general_conditions;
     if (generalConditionsPageId) {
       return this.pageService
-        .getByApiIdAndId(this.api.id, generalConditionsPageId, true)
-        .pipe(switchMap(page => this.handleTermsAndConditionsDialog$(this.api.id, page, createSubscription)));
+        .getByApiIdAndId(this.api().id, generalConditionsPageId, true)
+        .pipe(switchMap(page => this.handleTermsAndConditionsDialog$(this.api().id, page, createSubscription)));
     }
     return of(createSubscription);
   }
@@ -491,5 +494,28 @@ export class SubscribeToApiComponent implements OnInit {
         return { applicationApiKeySubscriptions };
       }),
     );
+  }
+
+  /**
+   * Merges API-resolved option lists into `gmdContent` by parsing HTML and setting
+   * `options` on elements matched by `fieldkey`.
+   *
+   * Security note: this method does not sanitize HTML. The merged content must only
+   * be rendered by `gmd-viewer`, which sanitizes content before display.
+   * Do not bind this output to raw `innerHTML` or other unsanitized sinks.
+   */
+  private applyResolvedOptions(form: SubscriptionForm): SubscriptionForm {
+    const resolved = form.resolvedOptions ?? {};
+    if (Object.keys(resolved).length === 0) return form;
+
+    const doc = new DOMParser().parseFromString(`<body>${form.gmdContent}</body>`, 'text/html');
+    for (const [fieldKey, options] of Object.entries(resolved)) {
+      const optionsValue = options.join(',');
+      const matchingElements = doc.querySelectorAll(`[fieldkey="${fieldKey}"]`);
+      matchingElements.forEach(element => {
+        element.setAttribute('options', optionsValue);
+      });
+    }
+    return { ...form, gmdContent: doc.body.innerHTML };
   }
 }

--- a/gravitee-apim-portal-webui-next/src/entities/portal/subscription-form.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal/subscription-form.ts
@@ -21,4 +21,5 @@
  */
 export interface SubscriptionForm {
   gmdContent: string;
+  resolvedOptions?: Record<string, string[]>;
 }

--- a/gravitee-apim-portal-webui-next/src/services/portal.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal.service.spec.ts
@@ -20,6 +20,7 @@ import { ConfigService } from './config.service';
 import { PortalService } from './portal.service';
 import { ApiInformation } from '../entities/api/api-information';
 import { PortalPage } from '../entities/portal/portal-page';
+import { SubscriptionForm } from '../entities/portal/subscription-form';
 
 describe('PortalService', () => {
   let service: PortalService;
@@ -92,5 +93,35 @@ describe('PortalService', () => {
     const req = httpMock.expectOne(`${baseURL}/portal-pages?type=HOMEPAGE`);
     expect(req.request.method).toBe('GET');
     req.flush({ pages: mockPages });
+  });
+
+  it('should GET subscription form for an API id', () => {
+    const apiId = 'api-123';
+    const mockForm: SubscriptionForm = {
+      gmdContent: '<gmd-select fieldkey="country" options="France,Spain"></gmd-select>',
+      resolvedOptions: {
+        country: ['France', 'Spain'],
+      },
+    };
+
+    service.getSubscriptionForm(apiId).subscribe(form => {
+      expect(form).toEqual(mockForm);
+    });
+
+    const req = httpMock.expectOne(`${baseURL}/apis/${apiId}/subscription-form`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockForm);
+  });
+
+  it('should return null when subscription form endpoint responds 404', () => {
+    const apiId = 'api-404';
+
+    service.getSubscriptionForm(apiId).subscribe(form => {
+      expect(form).toBeNull();
+    });
+
+    const req = httpMock.expectOne(`${baseURL}/apis/${apiId}/subscription-form`);
+    expect(req.request.method).toBe('GET');
+    req.flush(null, { status: 404, statusText: 'Not Found' });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/portal.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/portal.service.ts
@@ -59,8 +59,8 @@ export class PortalService {
       .pipe(map(resp => resp?.pages ?? []));
   }
 
-  public getSubscriptionForm(): Observable<SubscriptionForm | null> {
-    return this.http.get<SubscriptionForm>(`${this.configService.baseURL}/subscription-form`).pipe(
+  public getSubscriptionForm(apiId: string): Observable<SubscriptionForm | null> {
+    return this.http.get<SubscriptionForm>(`${this.configService.baseURL}/apis/${apiId}/subscription-form`).pipe(
       catchError(err => {
         if (err.status === 404) {
           return of(null);

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/README.md
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/README.md
@@ -1,6 +1,6 @@
 # `gmd-checkbox-group`
 
-A checkbox group component that allows users to select multiple options from a list. Structurally modeled after `gmd-radio` — same fieldset/legend layout, same `GmdFormFieldBase` extension. Options are parsed from a comma-separated string. The selected value is serialized as a sorted, comma-separated string.
+A checkbox group component that allows users to select multiple options from a list. Structurally modeled after `gmd-radio` — same fieldset/legend layout, same `GmdFormFieldBase` extension. Options are parsed from a comma-separated string or from EL fallback values. The selected value is serialized as a sorted, comma-separated string.
 
 ## Usage
 
@@ -26,6 +26,14 @@ A checkbox group component that allows users to select multiple options from a l
 | `required` | boolean | `false` | Whether at least one option must be selected                           |
 | `options`  | string  | `''`    | Comma-separated list of options (e.g., `"Option 1,Option 2,Option 3"`) |
 | `disabled` | boolean | `false` | Disables all checkboxes and removes field from form state              |
+
+## Options format
+
+- Comma-separated: `"Option 1,Option 2,Option 3"`
+- EL expression with fallback: `"{#api.metadata['features']}:Authentication,Rate Limiting,Analytics"`
+
+When options use EL, the fallback list is used for preview/editing contexts where runtime values cannot be resolved.
+If no fallback is provided for an EL expression, the component reports a `missingElFallback` config error.
 
 ## Value serialization
 

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.spec.ts
@@ -104,6 +104,14 @@ describe('GmdCheckboxGroupComponent', () => {
   });
 
   describe('Options parsing', () => {
+    it('should parse EL fallback options for preview', () => {
+      fixture.componentRef.setInput('options', "{#api.metadata['countries']}:France,Spain");
+      fixture.detectChanges();
+
+      const options = checkboxGroupComponent.optionsVM();
+      expect(options).toEqual(['France', 'Spain']);
+    });
+
     it('should parse comma-separated options', () => {
       fixture.componentRef.setInput('options', 'option1,option2,option3');
       fixture.detectChanges();
@@ -134,6 +142,22 @@ describe('GmdCheckboxGroupComponent', () => {
 
       const options = await harness.getOptions();
       expect(options).toHaveLength(3);
+    });
+  });
+
+  describe('Config errors', () => {
+    it('should return missingElFallback when EL options have no fallback values', () => {
+      fixture.componentRef.setInput('fieldKey', 'country');
+      fixture.componentRef.setInput('options', "{#api.metadata['countries']}");
+      fixture.detectChanges();
+
+      expect(checkboxGroupComponent.configErrors()).toContainEqual(
+        expect.objectContaining({
+          code: 'missingElFallback',
+          severity: 'error',
+          field: 'options',
+        }),
+      );
     });
   });
 

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.stories.ts
@@ -91,6 +91,28 @@ export const PreSelectedValues: StoryObj<GmdCheckboxGroupComponent> = {
   },
 };
 
+export const WithDynamicOptionsFallback: StoryObj<GmdCheckboxGroupComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-checkbox-group
+          name="dynamic"
+          label="Enabled capabilities (EL fallback preview)"
+          options="{#api.metadata['capabilities']}:Analytics,Rate Limiting,Caching">
+        </gmd-checkbox-group>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Example of EL options with fallback. In preview contexts, fallback values are displayed. Runtime-resolved options are injected separately.',
+      },
+    },
+  },
+};
+
 export const ManyOptions: StoryObj<GmdCheckboxGroupComponent> = {
   render: () => ({
     template: `

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/checkbox-group/gmd-checkbox-group.component.ts
@@ -18,7 +18,7 @@ import { Component, computed, effect, input, signal } from '@angular/core';
 
 import { GmdConfigError, GmdFieldErrorCode, GmdFieldState } from '../../models/formField';
 import { GmdFormFieldBase } from '../form-field-base/gmd-form-field-base.component';
-import { emptyFieldKeyErrors, parseBoolean } from '../form-helpers';
+import { elFallbackErrors, emptyFieldKeyErrors, isElExpression, parseBoolean, parseElFallback } from '../form-helpers';
 
 @Component({
   selector: 'gmd-checkbox-group',
@@ -42,13 +42,7 @@ export class GmdCheckboxGroupComponent extends GmdFormFieldBase {
   protected readonly touched = signal<boolean>(false);
 
   // Computed
-  configErrors = computed<GmdConfigError[]>(() => {
-    const errors: GmdConfigError[] = [];
-
-    errors.push(...emptyFieldKeyErrors(this.fieldKey()));
-
-    return errors;
-  });
+  configErrors = computed<GmdConfigError[]>(() => [...emptyFieldKeyErrors(this.fieldKey()), ...elFallbackErrors(this.options())]);
 
   validationErrors = computed<GmdFieldErrorCode[]>(() => {
     const errs: GmdFieldErrorCode[] = [];
@@ -77,6 +71,11 @@ export class GmdCheckboxGroupComponent extends GmdFormFieldBase {
   optionsVM = computed(() => {
     const opts = this.options();
     if (!opts) return [];
+
+    // EL expression: show only fallback values in form builder preview
+    if (isElExpression(opts)) {
+      return parseElFallback(opts);
+    }
 
     return opts
       .split(',')

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/form-helpers.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/form-helpers.spec.ts
@@ -16,15 +16,69 @@
 import { signal } from '@angular/core';
 
 import {
+  elFallbackErrors,
   emptyFieldKeyErrors,
+  isElExpression,
   normalizedValueWarning,
   normalizeLength,
+  parseElFallback,
   parseBoolean,
   safePattern,
   useLengthValidation,
 } from './form-helpers';
 
 describe('form-helpers', () => {
+  describe('EL options helpers', () => {
+    describe('isElExpression', () => {
+      it('should detect EL expressions with optional leading whitespace', () => {
+        expect(isElExpression("{#api.metadata['key']}:A,B")).toBe(true);
+        expect(isElExpression("   {#api.metadata['key']}:A,B")).toBe(true);
+      });
+
+      it('should return false for static options', () => {
+        expect(isElExpression('A,B,C')).toBe(false);
+        expect(isElExpression("#{api.metadata['key']}:A,B")).toBe(false);
+      });
+    });
+
+    describe('parseElFallback', () => {
+      it('should parse fallback values from EL options', () => {
+        expect(parseElFallback("{#api.metadata['country']}:France,Spain")).toEqual(['France', 'Spain']);
+      });
+
+      it('should return empty array when fallback is missing', () => {
+        expect(parseElFallback("{#api.metadata['country']}")).toEqual([]);
+      });
+    });
+
+    describe('elFallbackErrors', () => {
+      it('should return invalidElSyntax error for malformed EL options syntax', () => {
+        expect(elFallbackErrors("#{api.metadata['country']}:France,Spain")).toEqual([
+          expect.objectContaining({
+            code: 'invalidElSyntax',
+            severity: 'error',
+            field: 'options',
+          }),
+        ]);
+      });
+
+      it('should return missingElFallback error when EL options have no fallback', () => {
+        expect(elFallbackErrors("{#api.metadata['country']}")).toEqual([
+          expect.objectContaining({
+            code: 'missingElFallback',
+            severity: 'error',
+            field: 'options',
+          }),
+        ]);
+      });
+
+      it('should return no errors for EL options with fallback and for static options', () => {
+        expect(elFallbackErrors("{#api.metadata['country']}:France,Spain")).toEqual([]);
+        expect(elFallbackErrors('France,Spain')).toEqual([]);
+      });
+    });
+  });
+
   describe('parseBoolean', () => {
     [
       { input: true, expected: true },

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/form-helpers.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/form-helpers.ts
@@ -17,6 +17,42 @@ import { computed, Signal } from '@angular/core';
 
 import type { GmdConfigError, GmdFieldErrorCode } from '../models/formField';
 
+const EL_SEPARATOR = '}:';
+const EL_OPTIONS_CANDIDATE_PATTERN = /^\s*\{#.+}(?::.*)?$/;
+const INVALID_EL_OPTIONS_PREFIX_PATTERN = /^\s*(?:#\{|\{(?!#))/;
+const INVALID_EL_SYNTAX_MESSAGE = 'Invalid EL syntax in options. Use {#...}:option1,option2.';
+const MISSING_EL_FALLBACK_MESSAGE =
+  "EL expression in options requires fallback options as a comma-separated list (CSV) after ':', e.g. {#api.metadata['key']}:option1,option2";
+
+/**
+ * Returns true if the options string is an EL expression (starts with `{#`).
+ *
+ * @example
+ * isElExpression("{#api.metadata['key']}:A,B") → true
+ * isElExpression("A,B,C") → false
+ */
+export function isElExpression(options: string): boolean {
+  return EL_OPTIONS_CANDIDATE_PATTERN.test(options);
+}
+
+/**
+ * Parses the fallback option list from an EL options string.
+ * Returns the comma-split values after `}:`, or an empty array if no separator is found.
+ *
+ * @example
+ * parseElFallback("{#api.metadata['key']}:A,B,C") → ["A", "B", "C"]
+ * parseElFallback("{#api.metadata['key']}") → []
+ */
+export function parseElFallback(options: string): string[] {
+  const sepIdx = options.indexOf(EL_SEPARATOR);
+  if (sepIdx === -1) return [];
+  return options
+    .slice(sepIdx + EL_SEPARATOR.length)
+    .split(',')
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+}
+
 const DEFAULT_MIN_LENGTH = 0;
 const DEFAULT_MAX_LENGTH = 10000;
 const DEFAULT_ROWS = 4;
@@ -114,6 +150,40 @@ export function normalizedLengthInput(
   const result = computed(() => normalizeLength(value(), min, max, name));
   const normalizedValue = computed(() => result().value);
   return { result, value: normalizedValue };
+}
+
+/**
+ * Builds a config error when an EL expression in options is missing its required fallback list.
+ */
+export function elFallbackErrors(options: string | undefined): GmdConfigError[] {
+  if (!options) {
+    return [];
+  }
+
+  if (INVALID_EL_OPTIONS_PREFIX_PATTERN.test(options)) {
+    return [
+      {
+        code: 'invalidElSyntax',
+        message: INVALID_EL_SYNTAX_MESSAGE,
+        severity: 'error',
+        field: 'options',
+        value: options,
+      },
+    ];
+  }
+
+  if (isElExpression(options) && parseElFallback(options).length === 0) {
+    return [
+      {
+        code: 'missingElFallback',
+        message: MISSING_EL_FALLBACK_MESSAGE,
+        severity: 'error',
+        field: 'options',
+        value: options,
+      },
+    ];
+  }
+  return [];
 }
 
 /**

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/README.md
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/README.md
@@ -45,6 +45,10 @@ Radio group input with label, options, validation, and error display. It is desi
 
 - Comma-separated: `"Basic,Pro,Enterprise"`
 - JSON array: `'["Basic","Pro","Enterprise"]'`
+- EL expression with fallback: `"{#api.metadata['plans']}:Basic,Pro,Enterprise"`
+
+When options use EL, the fallback list is used for preview/editing contexts where runtime values cannot be resolved.
+If no fallback is provided for an EL expression, the component reports a `missingElFallback` config error.
 
 ## Theming
 

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.spec.ts
@@ -107,6 +107,14 @@ describe('GmdRadioComponent', () => {
   });
 
   describe('Options parsing', () => {
+    it('should parse EL fallback options for preview', () => {
+      fixture.componentRef.setInput('options', "{#api.metadata['countries']}:France,Spain");
+      fixture.detectChanges();
+
+      const options = radioComponent.optionsVM();
+      expect(options).toEqual(['France', 'Spain']);
+    });
+
     it('should parse comma-separated options', () => {
       fixture.componentRef.setInput('options', 'option1,option2,option3');
       fixture.detectChanges();
@@ -145,6 +153,22 @@ describe('GmdRadioComponent', () => {
 
       const count = await harness.getOptionCount();
       expect(count).toBe(2);
+    });
+  });
+
+  describe('Config errors', () => {
+    it('should return missingElFallback when EL options have no fallback values', () => {
+      fixture.componentRef.setInput('fieldKey', 'country');
+      fixture.componentRef.setInput('options', "{#api.metadata['countries']}");
+      fixture.detectChanges();
+
+      expect(radioComponent.configErrors()).toContainEqual(
+        expect.objectContaining({
+          code: 'missingElFallback',
+          severity: 'error',
+          field: 'options',
+        }),
+      );
     });
   });
 

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.stories.ts
@@ -69,6 +69,28 @@ export const WithJsonOptions: StoryObj<GmdRadioComponent> = {
   }),
 };
 
+export const WithDynamicOptionsFallback: StoryObj<GmdRadioComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-radio
+          name="dynamic"
+          label="Deployment environment (EL fallback preview)"
+          options="{#api.metadata['environments']}:Dev,Staging,Prod">
+        </gmd-radio>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Example of EL options with fallback. In preview contexts, fallback values are displayed. Runtime-resolved options are injected separately.',
+      },
+    },
+  },
+};
+
 export const ReadonlyAndDisabled: StoryObj<GmdRadioComponent> = {
   render: () => ({
     template: `

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/radio/gmd-radio.component.ts
@@ -18,7 +18,7 @@ import { Component, computed, effect, input, signal } from '@angular/core';
 
 import { GmdConfigError, GmdFieldErrorCode, GmdFieldState } from '../../models/formField';
 import { GmdFormFieldBase } from '../form-field-base/gmd-form-field-base.component';
-import { emptyFieldKeyErrors, parseBoolean } from '../form-helpers';
+import { elFallbackErrors, emptyFieldKeyErrors, isElExpression, parseBoolean, parseElFallback } from '../form-helpers';
 
 @Component({
   selector: 'gmd-radio',
@@ -43,13 +43,7 @@ export class GmdRadioComponent extends GmdFormFieldBase {
   protected readonly touched = signal<boolean>(false);
 
   // Computed
-  configErrors = computed<GmdConfigError[]>(() => {
-    const errors: GmdConfigError[] = [];
-
-    errors.push(...emptyFieldKeyErrors(this.fieldKey()));
-
-    return errors;
-  });
+  configErrors = computed<GmdConfigError[]>(() => [...emptyFieldKeyErrors(this.fieldKey()), ...elFallbackErrors(this.options())]);
 
   validationErrors = computed<GmdFieldErrorCode[]>(() => {
     const v = this.internalValue();
@@ -79,6 +73,11 @@ export class GmdRadioComponent extends GmdFormFieldBase {
   optionsVM = computed(() => {
     const opts = this.options();
     if (!opts) return [];
+
+    // EL expression: show only fallback values in form builder preview
+    if (isElExpression(opts)) {
+      return parseElFallback(opts);
+    }
 
     // Try to parse as JSON array first
     try {

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/README.md
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/README.md
@@ -38,6 +38,10 @@ Dropdown select input with label, validation, and error display. It is designed 
 
 - Comma-separated: `"Basic,Pro,Enterprise"`
 - JSON array: `'["Basic","Pro","Enterprise"]'`
+- EL expression with fallback: `"{#api.metadata['plans']}:Basic,Pro,Enterprise"`
+
+When options use EL, the fallback list is used for preview/editing contexts where runtime values cannot be resolved.
+If no fallback is provided for an EL expression, the component reports a `missingElFallback` config error.
 
 ## Theming
 

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.spec.ts
@@ -104,6 +104,14 @@ describe('GmdSelectComponent', () => {
   });
 
   describe('Options parsing', () => {
+    it('should parse EL fallback options for preview', () => {
+      fixture.componentRef.setInput('options', "{#api.metadata['countries']}:France,Spain");
+      fixture.detectChanges();
+
+      const options = selectComponent.optionsVM();
+      expect(options).toEqual(['France', 'Spain']);
+    });
+
     it('should parse comma-separated options', () => {
       fixture.componentRef.setInput('options', 'option1,option2,option3');
       fixture.detectChanges();
@@ -152,6 +160,22 @@ describe('GmdSelectComponent', () => {
       const count = await harness.getOptionCount();
       // +1 for the default "-- Select --" option
       expect(count).toBe(3);
+    });
+  });
+
+  describe('Config errors', () => {
+    it('should return missingElFallback when EL options have no fallback values', () => {
+      fixture.componentRef.setInput('fieldKey', 'country');
+      fixture.componentRef.setInput('options', "{#api.metadata['countries']}");
+      fixture.detectChanges();
+
+      expect(selectComponent.configErrors()).toContainEqual(
+        expect.objectContaining({
+          code: 'missingElFallback',
+          severity: 'error',
+          field: 'options',
+        }),
+      );
     });
   });
 

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.stories.ts
@@ -69,6 +69,28 @@ export const WithJsonOptions: StoryObj<GmdSelectComponent> = {
   }),
 };
 
+export const WithDynamicOptionsFallback: StoryObj<GmdSelectComponent> = {
+  render: () => ({
+    template: `
+      <div style="width: 400px;">
+        <gmd-select
+          name="dynamic"
+          label="Country (EL fallback preview)"
+          options="{#api.metadata['countries']}:France,Spain,Poland">
+        </gmd-select>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Example of EL options with fallback. In preview contexts, fallback values are displayed. Runtime-resolved options are injected separately.',
+      },
+    },
+  },
+};
+
 export const CommonUseCases: StoryObj<GmdSelectComponent> = {
   render: () => ({
     template: `

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/select/gmd-select.component.ts
@@ -18,7 +18,7 @@ import { Component, computed, effect, input, signal } from '@angular/core';
 
 import { GmdConfigError, GmdFieldErrorCode, GmdFieldState } from '../../models/formField';
 import { GmdFormFieldBase } from '../form-field-base/gmd-form-field-base.component';
-import { emptyFieldKeyErrors, parseBoolean } from '../form-helpers';
+import { elFallbackErrors, emptyFieldKeyErrors, isElExpression, parseBoolean, parseElFallback } from '../form-helpers';
 
 @Component({
   selector: 'gmd-select',
@@ -42,13 +42,7 @@ export class GmdSelectComponent extends GmdFormFieldBase {
   protected readonly touched = signal<boolean>(false);
 
   // Computed
-  configErrors = computed<GmdConfigError[]>(() => {
-    const errors: GmdConfigError[] = [];
-
-    errors.push(...emptyFieldKeyErrors(this.fieldKey()));
-
-    return errors;
-  });
+  configErrors = computed<GmdConfigError[]>(() => [...emptyFieldKeyErrors(this.fieldKey()), ...elFallbackErrors(this.options())]);
 
   validationErrors = computed<GmdFieldErrorCode[]>(() => {
     const v = this.internalValue();
@@ -78,6 +72,11 @@ export class GmdSelectComponent extends GmdFormFieldBase {
   optionsVM = computed(() => {
     const opts = this.options();
     if (!opts) return [];
+
+    // EL expression: show only fallback values in form builder preview
+    if (isElExpression(opts)) {
+      return parseElFallback(opts);
+    }
 
     // Decode HTML entities (Angular should do this automatically, but be safe)
     // The renderer service encodes quotes in options attribute to prevent DOMParser truncation

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/formField.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/formField.ts
@@ -26,7 +26,9 @@ export type GmdConfigErrorCode =
   | 'invalidRegex' // Pattern string is not a valid RegExp
   | 'emptyFieldKey' // fieldKey is empty or whitespace
   | 'duplicateKey' // Multiple fields share the same fieldKey (detected in the editor)
-  | 'normalizedValue'; // Value was auto-adjusted (warning)
+  | 'normalizedValue' // Value was auto-adjusted (warning)
+  | 'invalidElSyntax' // EL-like options use invalid syntax (must be {#...}:fallback)
+  | 'missingElFallback'; // EL expression in options without a fallback list
 
 /**
  * Configuration error with context and severity


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-12990

## Description

- Portal subscribe flow switches to /apis/{apiId}/subscription-form and injects resolved options into gmdContent before rendering (withResolvedOptions)
- gmd-select, gmd-radio, gmd-checkbox-group detect EL syntax in options: show fallback values in form builder preview, raise missingElFallback config error (blocks save) when fallback is absent
- Add isElExpression / parseElFallback / elFallbackErrors helpers to form-helpers
- Convert api @Input to input.required signal in subscribe-to-api component

## Additional context

<put recording>

