### PR TITLE
fix(config): default node.logging overrideLogbackXml to false and restore [%thread] in patterns

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -525,10 +525,10 @@ node:
     # Configure the patterns for the most common appenders
     # Nothing prevents the user from modifying logback.xml
     pattern:
-      overrideLogbackXml: true # when enabled, use the following patterns instead of those from logback.xml
+      overrideLogbackXml: false # when enabled, use the following patterns instead of those from logback.xml
       # Use a custom keyword to use MDC formatting and filtering: %mdcList. This list is built from the previous 'mdc.include' list
-      console: "%d{HH:mm:ss.SSS} %-5level %logger{36} [%mdcList] - %msg%n" # Override default STDOUT appender pattern
-      file: "%d{HH:mm:ss.SSS} %-5level %logger{36} [%mdcList] - %msg%n" # Override default FILE appender pattern
+      console: "%d{HH:mm:ss.SSS} [%thread] [%mdcList] %-5level %logger{36} - %msg%n" # Override default STDOUT appender pattern
+      file: "%d{HH:mm:ss.SSS} [%thread] [%mdcList] %-5level %logger{36} - %msg%n%n" # Override default FILE appender pattern
 
 # Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
 # All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/logback.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/logback.xml
@@ -21,7 +21,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- Classical STDOUT logger -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{api}] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
 
 <!--       Uncomment to enable Json Encoder -->
@@ -52,7 +52,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{api}] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -343,10 +343,10 @@ node:
     # Configure the patterns for the most common appenders
     # Nothing prevents the user from modifying logback.xml
     pattern:
-      overrideLogbackXml: true # when enabled, use the following patterns instead of those from logback.xml
+      overrideLogbackXml: false # when enabled, use the following patterns instead of those from logback.xml
       # Use a custom keyword to use MDC formatting and filtering: %mdcList. This list is built from the previous 'mdc.include' list
-      console: "%d{HH:mm:ss.SSS} %-5level %logger{36} [%mdcList] - %msg%n" # Override default STDOUT appender pattern
-      file: "%d{HH:mm:ss.SSS} %-5level %logger{36} [%mdcList] - %msg%n" # Override default FILE appender pattern
+      console: "%d{HH:mm:ss.SSS} [%thread] [%mdcList] %-5level %logger{36} - %msg%n" # Override default STDOUT appender pattern
+      file: "%d{HH:mm:ss.SSS} [%thread] [%mdcList] %-5level %logger{36} - %msg%n%n" # Override default FILE appender pattern
 
 ## Logging settings
 #logging:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/logback.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/logback.xml
@@ -20,7 +20,7 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{orgId} %X{envId}] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
 
         <!--       Uncomment to enable Json Encoder -->
@@ -51,7 +51,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] [%X{orgId} %X{envId}] %-5level %logger{36} - %msg%n%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
## Summary

- `node.logging.pattern.overrideLogbackXml` was shipped with `true` as the default in 4.11.x, silently changing the log format for all upgrading users without any opt-in.
- The override patterns were also missing `[%thread]`, diverging from the historical Gravitee log format.

## Changes

- Set `overrideLogbackXml: false` (opt-in, not opt-out) in both gateway and management API `gravitee.yml`
- Restore `[%thread]` in the `console` and `file` example patterns so the opt-in format is consistent with 4.10.x

## Breaking change prevented

Without this fix, any user upgrading from 4.10.x to 4.11.x would silently get a changed log format, breaking log-parsing pipelines (Logstash, Splunk, regex-based forwarders) tuned to the standard Gravitee format.

## Test plan

- [ ] Start gateway with default config — verify log format is unchanged from 4.10.x (`[%thread]` present, no `[%mdcList]`)
- [ ] Set `overrideLogbackXml: true` — verify new `[%mdcList]` pattern is applied (including `[%thread]`)
- [ ] Repeat for management API