### PR TITLE
fix: capture request body for failover replay without triggering log interceptors

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/BufferFlow.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/BufferFlow.java
@@ -67,6 +67,14 @@ public class BufferFlow implements OnBuffersInterceptor {
         );
     }
 
+    public Maybe<Buffer> bodyIgnoringInterceptors() {
+        if (Boolean.FALSE.equals(isStreaming.get())) {
+            this.chunks = chunksFromCache(() -> chunksOrEmpty().compose(chunksToCache()));
+            return chunks.firstElement();
+        }
+        return Maybe.empty();
+    }
+
     public void body(Buffer buffer) {
         if (Boolean.FALSE.equals(isStreaming.get())) {
             cachedBuffer = Maybe.just(buffer);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/FailoverRequestAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/FailoverRequestAdapter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.context;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
+import io.reactivex.rxjava3.core.Maybe;
+
+/**
+ * Adapter that provides access to the request body without triggering buffer interceptors.
+ * <p>
+ * This is used by the failover mechanism to capture the original request body for replay on retry,
+ * without prematurely consuming interceptors (e.g. logging) that should only fire when the body
+ * actually flows to the backend endpoint.
+ * <p>
+ * Lives in the {@code context} package to access {@link AbstractRequest#lazyBufferFlow()} (protected).
+ *
+ * @see io.gravitee.gateway.reactive.core.BufferFlow#bodyIgnoringInterceptors()
+ */
+public class FailoverRequestAdapter {
+
+    private final AbstractRequest delegate;
+
+    public static FailoverRequestAdapter forRequest(HttpRequest request) {
+        return new FailoverRequestAdapter((AbstractRequest) request);
+    }
+
+    private FailoverRequestAdapter(AbstractRequest delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * Reads and caches the request body without applying buffer interceptors.
+     * Interceptors remain registered and will be applied on subsequent body access (e.g. by the endpoint connector).
+     */
+    public Maybe<Buffer> body() {
+        return delegate.lazyBufferFlow().bodyIgnoringInterceptors();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/failover/FailoverInvoker.java
@@ -33,6 +33,7 @@ import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.invoker.HttpInvoker;
 import io.gravitee.gateway.reactive.api.invoker.Invoker;
+import io.gravitee.gateway.reactive.core.context.FailoverRequestAdapter;
 import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
 import io.gravitee.gateway.reactive.core.v4.endpoint.EndpointManager;
 import io.gravitee.gateway.reactive.core.v4.endpoint.ManagedEndpoint;
@@ -304,8 +305,7 @@ public class FailoverInvoker implements HttpInvoker, Invoker {
      * Calling {@code body()} also activates internal chunk caching, which is mandatory to replay the request.
      */
     private Completable captureRequestState(HttpExecutionContext ctx, AtomicReference<RequestSnapshot> snapshotRef) {
-        return ctx
-            .request()
+        return FailoverRequestAdapter.forRequest(ctx.request())
             .body()
             // Body present: capture path, headers, and body for full replay
             .doOnSuccess(body -> snapshotRef.compareAndSet(null, RequestSnapshot.withBody(ctx, body)))

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/failover/FailoverInvokerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/failover/FailoverInvokerTest.java
@@ -30,6 +30,7 @@ import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.core.context.AbstractRequest;
 import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.reactive.core.context.MutableRequest;
 import io.gravitee.gateway.reactive.core.context.MutableResponse;
@@ -65,9 +66,6 @@ class FailoverInvokerTest {
     private HttpEndpointInvoker endpointInvoker;
 
     @Mock
-    private MutableRequest request;
-
-    @Mock
     private MutableResponse response;
 
     @Mock
@@ -76,16 +74,27 @@ class FailoverInvokerTest {
     @Mock
     private EndpointManager endpointManager;
 
+    private MutableRequest request;
+
     private HttpExecutionContext executionContext;
 
     private FailoverInvoker cut;
 
+    private static MutableRequest fakeRequest(Buffer body) {
+        var request = new AbstractRequest() {
+            {
+                this.headers = HttpHeaders.create();
+            }
+        };
+        request.body(body);
+        return request;
+    }
+
     @BeforeEach
     void setUp() {
+        request = fakeRequest(Buffer.buffer("body"));
         executionContext = new DefaultExecutionContext(request, response);
         ((DefaultExecutionContext) executionContext).metrics(metrics);
-        lenient().when(request.body()).thenReturn(Maybe.just(Buffer.buffer("body")));
-        lenient().when(request.headers()).thenReturn(HttpHeaders.create());
     }
 
     @Test
@@ -229,7 +238,7 @@ class FailoverInvokerTest {
         @BeforeEach
         void setUpConditionTests() {
             lenient().when(mockCtx.getAttribute(ContextAttributes.ATTR_REQUEST_ENDPOINT)).thenReturn("endpoint-name");
-            lenient().when(mockCtx.request()).thenReturn(request);
+            lenient().when(mockCtx.request()).thenReturn(fakeRequest(Buffer.buffer("body")));
             lenient().when(mockCtx.getTemplateEngine()).thenReturn(templateEngine);
             lenient()
                 .when(mockCtx.interruptWith(any()))

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/MutatingHttpProxyEndpointConnector.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/MutatingHttpProxyEndpointConnector.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.connector.fakes;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.core.context.MutableRequest;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+
+/**
+ * An endpoint connector that mutates the request (body, headers, pathInfo) before forwarding to the backend.
+ * This simulates what connectors like LLM proxy do (transforming the request for a specific provider),
+ * allowing to test that failover correctly restores the original request state on each retry.
+ */
+public class MutatingHttpProxyEndpointConnector extends HttpProxyEndpointConnector {
+
+    public MutatingHttpProxyEndpointConnector(
+        HttpProxyEndpointConnectorConfiguration configuration,
+        HttpProxyEndpointConnectorSharedConfiguration sharedConfiguration
+    ) {
+        super(configuration, sharedConfiguration);
+    }
+
+    @Override
+    public Completable connect(HttpExecutionContext ctx) {
+        return ctx
+            .request()
+            .onBody(body ->
+                body
+                    .defaultIfEmpty(Buffer.buffer())
+                    .flatMapMaybe(b -> {
+                        Buffer transformed = Buffer.buffer("mutated-" + b.toString());
+                        ((MutableRequest) ctx.request()).pathInfo("/mutated-path");
+                        ctx.request().headers().set("X-Mutated", "true");
+                        ctx.request().contentLength(transformed.length());
+                        return Maybe.just(transformed);
+                    })
+            )
+            .andThen(super.connect(ctx));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/MutatingHttpProxyEndpointConnectorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/MutatingHttpProxyEndpointConnectorFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.connector.fakes;
+
+import io.gravitee.gateway.reactive.api.ConnectorMode;
+import io.gravitee.gateway.reactive.api.context.DeploymentContext;
+import io.gravitee.gateway.reactive.api.exception.PluginConfigurationException;
+import io.gravitee.gateway.reactive.api.helper.PluginConfigurationHelper;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
+import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
+import java.util.Set;
+
+/**
+ * Factory for {@link MutatingHttpProxyEndpointConnector}.
+ */
+public class MutatingHttpProxyEndpointConnectorFactory extends HttpProxyEndpointConnectorFactory {
+
+    private final PluginConfigurationHelper pluginConfigurationHelper;
+
+    public MutatingHttpProxyEndpointConnectorFactory(PluginConfigurationHelper pluginConfigurationHelper) {
+        super(pluginConfigurationHelper);
+        this.pluginConfigurationHelper = pluginConfigurationHelper;
+    }
+
+    @Override
+    public Set<ConnectorMode> supportedModes() {
+        return Set.of(ConnectorMode.REQUEST_RESPONSE);
+    }
+
+    @Override
+    public MutatingHttpProxyEndpointConnector createConnector(
+        DeploymentContext deploymentContext,
+        String configuration,
+        String sharedConfiguration
+    ) {
+        try {
+            return new MutatingHttpProxyEndpointConnector(
+                pluginConfigurationHelper.readConfiguration(HttpProxyEndpointConnectorConfiguration.class, configuration),
+                pluginConfigurationHelper.readConfiguration(HttpProxyEndpointConnectorSharedConfiguration.class, sharedConfiguration)
+            );
+        } catch (PluginConfigurationException e) {
+            return null;
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4IntegrationTest.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.apim.integration.tests.http.failover;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_APIKEY_ID;
@@ -48,6 +51,10 @@ import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
 import io.gravitee.apim.plugin.reactor.ReactorPlugin;
 import io.gravitee.definition.model.v4.Api;
 import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.logging.Logging;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingContent;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingPhase;
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.Subscription;
@@ -594,6 +601,11 @@ public class FailoverV4IntegrationTest extends FailoverV4EmulationIntegrationTes
         }
 
         @Override
+        public void configurePlaceHolderVariables(Map<String, String> variables) {
+            variables.put("WIREMOCK_PORT", "" + wiremock.port());
+        }
+
+        @Override
         @DeployApi("/apis/v4/http/failover/api-three-endpoints.json")
         @Test
         void should_retry_and_fail_on_slow_call(HttpClient client) {
@@ -619,6 +631,39 @@ public class FailoverV4IntegrationTest extends FailoverV4EmulationIntegrationTes
         @DeployApi("/apis/v4/http/failover/api-three-endpoints-query-params.json")
         void should_success_on_second_retry_with_endpoint_having_query_params(HttpClient client) {
             super.should_success_on_second_retry_with_endpoint_having_query_params(client);
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-three-endpoints-post.json")
+        void should_success_on_second_retry_posting_payload(HttpClient client) {
+            // Given an API with failover configured with 2 maxRetries, a slowCallDuration of 500ms
+            // and only one group with 3 endpoints (round-robin load balancing)
+            // And Given backend answers in 750ms on first two endpoints, and immediately on the third
+            wiremock.stubFor(post("/endpoint-1").willReturn(ok(RESPONSE_FROM_BACKEND + " - 1").withFixedDelay(750)));
+            wiremock.stubFor(post("/endpoint-2").willReturn(ok(RESPONSE_FROM_BACKEND + " - 2").withFixedDelay(750)));
+            wiremock.stubFor(post("/endpoint-3").willReturn(ok(RESPONSE_FROM_BACKEND + " - 3")));
+
+            // When requesting the API with a body
+            client
+                .rxRequest(HttpMethod.POST, "/test")
+                .flatMap(request -> request.rxSend(Buffer.buffer("request-body")))
+                .flatMap(response -> {
+                    // Then the API response should be 200
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(response -> {
+                    // Then the API response body should be the one from third endpoint
+                    assertThat(response).hasToString(RESPONSE_FROM_BACKEND + " - 3");
+                    return true;
+                });
+            // Then each endpoint should have been called once with the original body
+            wiremock.verify(postRequestedFor(urlPathEqualTo("/endpoint-1")).withRequestBody(equalTo("request-body")));
+            wiremock.verify(postRequestedFor(urlPathEqualTo("/endpoint-2")).withRequestBody(equalTo("request-body")));
+            wiremock.verify(postRequestedFor(urlPathEqualTo("/endpoint-3")).withRequestBody(equalTo("request-body")));
         }
     }
 
@@ -871,8 +916,17 @@ public class FailoverV4IntegrationTest extends FailoverV4EmulationIntegrationTes
         @Override
         public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
             if (api.getDefinition() instanceof Api apiDefinition) {
-                var analytics = new Analytics();
+                var analytics = apiDefinition.getAnalytics() != null ? apiDefinition.getAnalytics() : new Analytics();
                 analytics.setEnabled(true);
+                if (analytics.getLogging() == null) {
+                    analytics.setLogging(
+                        Logging.builder()
+                            .mode(new LoggingMode(true, true))
+                            .phase(new LoggingPhase(true, true))
+                            .content(new LoggingContent(true, false, true, false, false))
+                            .build()
+                    );
+                }
                 apiDefinition.setAnalytics(analytics);
             }
         }
@@ -917,6 +971,51 @@ public class FailoverV4IntegrationTest extends FailoverV4EmulationIntegrationTes
                         .containsEntry("keyword_failover_successful-endpoint", "default");
                     return true;
                 });
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-failure-condition-post.json")
+        void should_record_failover_metrics_when_retry_succeeds_posting_payload(HttpClient client) {
+            // Given a backend that returns 500 on the first call, then 200 on the second
+            wiremock.stubFor(
+                post("/endpoint")
+                    .inScenario("metrics-retry-post")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(serverError().withBody("error"))
+                    .willSetStateTo("recovered")
+            );
+            wiremock.stubFor(
+                post("/endpoint").inScenario("metrics-retry-post").whenScenarioStateIs("recovered").willReturn(ok(RESPONSE_FROM_BACKEND))
+            );
+
+            // When requesting the API with a body
+            client
+                .rxRequest(HttpMethod.POST, "/test")
+                .flatMap(request -> request.rxSend(Buffer.buffer("request-body")))
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete();
+
+            // Then failover metrics should be recorded
+            metricsSubject
+                .take(1)
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertValue(metrics -> {
+                    assertThat(metrics.longAdditionalMetrics()).isNotNull().containsEntry("long_failover_count", 1L);
+                    assertThat(metrics.keywordAdditionalMetrics())
+                        .isNotNull()
+                        .containsKey("keyword_failover_first-failed-endpoint")
+                        .containsEntry("keyword_failover_successful-endpoint", "default");
+                    return true;
+                });
+
+            // Then the backend should have been called twice, each time with the original body
+            wiremock.verify(2, postRequestedFor(urlPathEqualTo("/endpoint")).withRequestBody(equalTo("request-body")));
         }
 
         @Test

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4MutatingEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/failover/FailoverV4MutatingEndpointIntegrationTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.failover;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.fakes.MutatingHttpProxyEndpointConnectorFactory;
+import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.logging.Logging;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingContent;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingPhase;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.reporter.api.v4.log.Log;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests failover behavior when the endpoint connector mutates the request (body, headers, pathInfo).
+ * Uses {@link MutatingHttpProxyEndpointConnectorFactory} to simulate connectors like LLM proxy
+ * that transform the request before forwarding to the backend.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class FailoverV4MutatingEndpointIntegrationTest {
+
+    private static final String RESPONSE_FROM_BACKEND = "response-from-backend";
+
+    @Nested
+    @GatewayTest
+    class MultipleEndpointsWithMutatingConnector extends AbstractGatewayTest {
+
+        BehaviorSubject<Metrics> metricsSubject;
+        BehaviorSubject<Log> logSubject;
+
+        @BeforeEach
+        void setUp() {
+            metricsSubject = BehaviorSubject.create();
+            logSubject = BehaviorSubject.create();
+
+            FakeReporter fakeReporter = getBean(FakeReporter.class);
+            fakeReporter.setReportableHandler(reportable -> {
+                switch (reportable) {
+                    case Log l:
+                        logSubject.onNext(l);
+                        break;
+                    case Metrics metrics:
+                        metricsSubject.onNext(metrics.toBuilder().build());
+                        break;
+                    default:
+                }
+            });
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent(
+                "mutating-http-proxy",
+                EndpointBuilder.build("mutating-http-proxy", MutatingHttpProxyEndpointConnectorFactory.class)
+            );
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (api.getDefinition() instanceof Api apiDefinition) {
+                var analytics = apiDefinition.getAnalytics() != null ? apiDefinition.getAnalytics() : new Analytics();
+                analytics.setEnabled(true);
+                if (analytics.getLogging() == null) {
+                    analytics.setLogging(
+                        Logging.builder()
+                            .mode(LoggingMode.builder().entrypoint(true).endpoint(true).build())
+                            .phase(LoggingPhase.builder().request(true).response(true).build())
+                            .content(LoggingContent.builder().headers(true).payload(true).build())
+                            .build()
+                    );
+                }
+                apiDefinition.setAnalytics(analytics);
+            }
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-mutating-three-endpoints-post.json")
+        void should_success_on_second_retry_with_mutated_body(HttpClient client) {
+            // Given backend answers in 750ms on first two endpoints (slow call), and immediately on the third
+            // The mutating connector transforms the body to "transformed-request-body"
+            // and sets pathInfo to "/mutated-path", so wiremock receives on /endpoint-X/mutated-path
+            wiremock.stubFor(post("/endpoint-1/mutated-path").willReturn(ok(RESPONSE_FROM_BACKEND + " - 1").withFixedDelay(750)));
+            wiremock.stubFor(post("/endpoint-2/mutated-path").willReturn(ok(RESPONSE_FROM_BACKEND + " - 2").withFixedDelay(750)));
+            wiremock.stubFor(post("/endpoint-3/mutated-path").willReturn(ok(RESPONSE_FROM_BACKEND + " - 3")));
+
+            // When requesting the API with a body
+            client
+                .rxRequest(HttpMethod.POST, "/test")
+                .flatMap(request -> request.rxSend(Buffer.buffer("request-body")))
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response).hasToString(RESPONSE_FROM_BACKEND + " - 3");
+                    return true;
+                });
+
+            // Then each endpoint should have been called with the transformed body
+            wiremock.verify(postRequestedFor(urlPathEqualTo("/endpoint-1/mutated-path")).withRequestBody(equalTo("mutated-request-body")));
+            wiremock.verify(postRequestedFor(urlPathEqualTo("/endpoint-2/mutated-path")).withRequestBody(equalTo("mutated-request-body")));
+            wiremock.verify(postRequestedFor(urlPathEqualTo("/endpoint-3/mutated-path")).withRequestBody(equalTo("mutated-request-body")));
+        }
+
+        @Test
+        @DeployApi("/apis/v4/http/failover/api-mutating-failure-condition-post.json")
+        void should_record_failover_metrics_with_mutated_request(HttpClient client) {
+            // Given a backend that returns 500 on the first call, then 200 on the second
+            wiremock.stubFor(
+                post("/endpoint/mutated-path")
+                    .inScenario("metrics-retry-post")
+                    .whenScenarioStateIs(Scenario.STARTED)
+                    .willReturn(serverError().withBody("error"))
+                    .willSetStateTo("recovered")
+            );
+            wiremock.stubFor(
+                post("/endpoint/mutated-path")
+                    .inScenario("metrics-retry-post")
+                    .whenScenarioStateIs("recovered")
+                    .willReturn(ok(RESPONSE_FROM_BACKEND))
+            );
+
+            // When requesting the API with a body
+            client
+                .rxRequest(HttpMethod.POST, "/test")
+                .flatMap(request -> request.rxSend(Buffer.buffer("request-body")))
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.body();
+                })
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertComplete();
+
+            // Then failover metrics should be recorded
+            metricsSubject
+                .take(1)
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertValue(metrics -> {
+                    assertThat(metrics.longAdditionalMetrics()).isNotNull().containsEntry("long_failover_count", 1L);
+                    assertThat(metrics.keywordAdditionalMetrics())
+                        .isNotNull()
+                        .containsKey("keyword_failover_first-failed-endpoint")
+                        .containsEntry("keyword_failover_successful-endpoint", "default");
+                    return true;
+                });
+
+            // Then the backend should have been called twice, each time with the transformed body
+            wiremock.verify(2, postRequestedFor(urlPathEqualTo("/endpoint/mutated-path")).withRequestBody(equalTo("mutated-request-body")));
+
+            // Then the log should contain the transformed body (not the original, not duplicated)
+            logSubject
+                .take(1)
+                .test()
+                .awaitDone(30, TimeUnit.SECONDS)
+                .assertValue(log -> {
+                    assertThat(log.getEntrypointRequest()).isNotNull();
+                    assertThat(log.getEndpointRequest()).isNotNull();
+                    assertThat(log.getEndpointRequest().getBody()).isEqualTo("mutated-request-body");
+                    return true;
+                });
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-failure-condition-post.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-failure-condition-post.json
@@ -1,0 +1,85 @@
+{
+  "id": "my-api-v4-failure-condition-post",
+  "name": "my-api-v4-failure-condition-post",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 5000,
+    "perSubscription": false,
+    "failureCondition": "{#response.status >= 500}"
+  },
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": true,
+    "logging": {
+      "condition": "",
+      "content": {
+        "headers": true,
+        "payload": true
+      },
+      "phase": {
+        "request": true,
+        "response": true
+      },
+      "mode": {
+        "endpoint": true,
+        "entrypoint": true
+      }
+    }
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-mutating-failure-condition-post.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-mutating-failure-condition-post.json
@@ -1,0 +1,85 @@
+{
+  "id": "my-api-v4-mutating-failure-condition-post",
+  "name": "my-api-v4-mutating-failure-condition-post",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 5000,
+    "perSubscription": false,
+    "failureCondition": "{#response.status >= 500}"
+  },
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "mutating-http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mutating-http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": true,
+    "logging": {
+      "condition": "",
+      "content": {
+        "headers": true,
+        "payload": true
+      },
+      "phase": {
+        "request": true,
+        "response": true
+      },
+      "mode": {
+        "endpoint": true,
+        "entrypoint": true
+      }
+    }
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-mutating-three-endpoints-post.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-mutating-three-endpoints-post.json
@@ -1,0 +1,114 @@
+{
+  "id": "my-api-v4-mutating-three-endpoints-post",
+  "name": "my-api-v4-mutating-three-endpoints-post",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 500,
+    "perSubscription": false
+  },
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "mutating-http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mutating-http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-1"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        },
+        {
+          "name": "second",
+          "type": "mutating-http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-2"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        },
+        {
+          "name": "third",
+          "type": "mutating-http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-3"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": true,
+    "logging": {
+      "condition": "",
+      "content": {
+        "headers": true,
+        "payload": true
+      },
+      "phase": {
+        "request": true,
+        "response": true
+      },
+      "mode": {
+        "endpoint": true,
+        "entrypoint": true
+      }
+    }
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-three-endpoints-post.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/failover/api-three-endpoints-post.json
@@ -1,0 +1,114 @@
+{
+  "id": "my-api-v4-three-endpoints-post",
+  "name": "my-api-v4-three-endpoints-post",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "failover": {
+    "enabled": true,
+    "maxRetries": 2,
+    "slowCallDuration": 500,
+    "perSubscription": false
+  },
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-1"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        },
+        {
+          "name": "second",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-2"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        },
+        {
+          "name": "third",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint-3"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": true,
+    "logging": {
+      "condition": "",
+      "content": {
+        "headers": true,
+        "payload": true
+      },
+      "phase": {
+        "request": true,
+        "response": true
+      },
+      "mode": {
+        "endpoint": true,
+        "entrypoint": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13229

## Description

When failover retries a request, the body must be captured upfront so it can be replayed on each attempt. Previously, calling `body()` on the request triggered buffer interceptors (e.g. logging), which caused the body to be logged/consumed prematurely — before the endpoint connector had a chance to transform it (as LLM proxy does).

### Changes

- **`FailoverRequestAdapter`** — new adapter in the `context` package that accesses `lazyBufferFlow()` to read the body *without* firing interceptors. Used by `FailoverInvoker.captureRequestState()`.
- **`BufferFlow.bodyIgnoringInterceptors()`** — new method that reads and caches the body but skips `applyBuffersInterceptors()`, so interceptors remain registered for later.
- **`FailoverInvokerTest`** — replaced mocks with real `AbstractRequest` instances via a `fakeRequest()` helper for more realistic testing.

### Test coverage

- **`FailoverV4IntegrationTest`** — added POST failover tests (failure condition + multi-endpoint) verifying body is correctly forwarded on each retry.
- **`FailoverV4MutatingEndpointIntegrationTest`** — new test class using a custom `MutatingHttpProxyEndpointConnector` that transforms the request body, pathInfo, and headers before forwarding (simulating what LLM proxy does). Tests verify that:
  - On each failover retry, the connector receives the **original** request state (not the mutated one from the previous attempt)
  - Each backend call receives the **transformed** body (not the original, not duplicated)
  - Failover metrics are correctly recorded
  - Endpoint logs contain the transformed body

This avoids depending on the LLM proxy plugin in integration tests while covering the same failover + request mutation scenario.