### PR TITLE
feat: add per-environment mTLS feature toggle to portal-next configuration

### DIFF
--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
@@ -18,6 +18,9 @@ export class ConfigurationPortalNext {
   access?: {
     enabled?: boolean;
   };
+  mtls?: {
+    enabled?: boolean;
+  };
   banner?: {
     enabled?: boolean;
     title?: string;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -144,6 +144,7 @@ public enum Key {
     PORTAL_NEXT_THEME_CUSTOM_CSS("portal.next.theme.customCss", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_THEME_FONT_FAMILY("portal.next.theme.font.family", "\"Roboto\", sans-serif", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_CATALOG_VIEW_MODE("portal.next.catalog.viewMode", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_MTLS_ENABLED("portal.next.feature.mtlsEnabled", Boolean.FALSE.toString(), new HashSet<>(singletonList(ENVIRONMENT))),
 
     MANAGEMENT_TITLE("management.title", "Gravitee.io Management", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     MANAGEMENT_URL("management.url", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -144,7 +144,7 @@ public enum Key {
     PORTAL_NEXT_THEME_CUSTOM_CSS("portal.next.theme.customCss", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_THEME_FONT_FAMILY("portal.next.theme.font.family", "\"Roboto\", sans-serif", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_CATALOG_VIEW_MODE("portal.next.catalog.viewMode", new HashSet<>(singletonList(ENVIRONMENT))),
-    PORTAL_NEXT_MTLS_ENABLED("portal.next.feature.mtlsEnabled", Boolean.FALSE.toString(), new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_MTLS_ENABLED("portal.next.feature.mtlsEnabled", new HashSet<>(singletonList(ENVIRONMENT))),
 
     MANAGEMENT_TITLE("management.title", "Gravitee.io Management", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     MANAGEMENT_URL("management.url", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
@@ -37,6 +37,9 @@ public class PortalNext {
     @ParameterKey(Key.PORTAL_NEXT_ACCESS_ENABLED)
     private Enabled access;
 
+    @ParameterKey(Key.PORTAL_NEXT_MTLS_ENABLED)
+    private Boolean mtlsEnabled;
+
     private Banner banner;
 
     private Catalog catalog;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
@@ -38,7 +38,7 @@ public class PortalNext {
     private Enabled access;
 
     @ParameterKey(Key.PORTAL_NEXT_MTLS_ENABLED)
-    private Boolean mtlsEnabled;
+    private Enabled mtls;
 
     private Banner banner;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -53,8 +53,8 @@ public class ConfigurationMapper {
         configuration.setAccess(convert(portalNext.getAccess()));
         configuration.setBanner(convert(portalNext.getBanner()));
         configuration.setCatalog(convert(portalNext.getCatalog()));
-        if (portalNext.getMtlsEnabled() != null) {
-            configuration.setMtls(convert(portalNext.getMtlsEnabled()));
+        if (portalNext.getMtls() != null) {
+            configuration.setMtls(convert(portalNext.getMtls()));
         }
         return configuration;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -53,6 +53,9 @@ public class ConfigurationMapper {
         configuration.setAccess(convert(portalNext.getAccess()));
         configuration.setBanner(convert(portalNext.getBanner()));
         configuration.setCatalog(convert(portalNext.getCatalog()));
+        if (portalNext.getMtlsEnabled() != null) {
+            configuration.setMtls(convert(portalNext.getMtlsEnabled()));
+        }
         return configuration;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -5583,6 +5583,8 @@ components:
                     $ref: "#/components/schemas/Enabled"
                 catalog:
                     $ref: "#/components/schemas/ConfigurationPortalNextCatalog"
+                mtls:
+                    $ref: "#/components/schemas/Enabled"
         ConfigurationPortalNextBanner:
             type: object
             description: Configuration of the banner for Portal Next

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
@@ -196,17 +196,17 @@ public class ConfigurationMapperTest {
         PortalNext portalNext = new PortalNext();
         portalNext.setAccess(new Enabled(false));
 
-        portalNext.setMtlsEnabled(true);
+        portalNext.setMtls(new Enabled(true));
         ConfigurationPortalNext result = configurationMapper.convert(portalNext);
         Assertions.assertNotNull(result.getMtls());
         Assertions.assertEquals(Boolean.TRUE, result.getMtls().getEnabled());
 
-        portalNext.setMtlsEnabled(false);
+        portalNext.setMtls(new Enabled(false));
         result = configurationMapper.convert(portalNext);
         Assertions.assertNotNull(result.getMtls());
         Assertions.assertEquals(Boolean.FALSE, result.getMtls().getEnabled());
 
-        portalNext.setMtlsEnabled(null);
+        portalNext.setMtls(null);
         result = configurationMapper.convert(portalNext);
         Assertions.assertNull(result.getMtls());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
@@ -190,4 +190,24 @@ public class ConfigurationMapperTest {
         String configurationAsJSON = mapper.writeValueAsString(configuration);
         assertEquals(mapper.readTree(expected), mapper.readTree(configurationAsJSON));
     }
+
+    @Test
+    public void convertPortalNextShouldMapMtlsEnabled() {
+        PortalNext portalNext = new PortalNext();
+        portalNext.setAccess(new Enabled(false));
+
+        portalNext.setMtlsEnabled(true);
+        ConfigurationPortalNext result = configurationMapper.convert(portalNext);
+        Assertions.assertNotNull(result.getMtls());
+        Assertions.assertEquals(Boolean.TRUE, result.getMtls().getEnabled());
+
+        portalNext.setMtlsEnabled(false);
+        result = configurationMapper.convert(portalNext);
+        Assertions.assertNotNull(result.getMtls());
+        Assertions.assertEquals(Boolean.FALSE, result.getMtls().getEnabled());
+
+        portalNext.setMtlsEnabled(null);
+        result = configurationMapper.convert(portalNext);
+        Assertions.assertNull(result.getMtls());
+    }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13258

## Description

- Added `PORTAL_NEXT_MTLS_ENABLED` parameter key (scoped to `ENVIRONMENT`, default `false`) to `Key.java`
- Added `mtlsEnabled` field with `@ParameterKey` annotation to `PortalNext.java` domain model — persisted per-environment via the existing `ConfigService` reflection-based parameter mechanism
- Extended `portal-openapi.yaml` (`ConfigurationPortalNext` schema) and `ConfigurationMapper` to expose `mtls.enabled` in the `GET /configuration` papi response; null-guarded to avoid emitting `"mtls": {}` when the toggle has never been set
- Added `mtls?: { enabled?: boolean }` to `ConfigurationPortalNext` TypeScript model in portal-next so the flag flows through to `ConfigService`
- Added unit test covering enabled, disabled, and null cases in `ConfigurationMapperTest`

## Additional context

- Toggle defaults to `false` (opt-in). Environments that have never set the key will receive no `mtls` field in the configuration response.
- Write path (management console settings page) and portal-next conditional tab visibility (certificate presence check via `GET /applications/{id}/certificates?size=1`) are part of this story but stashed — to be committed separately after review.    