### PR TITLE
feat(helm): improve JDBC driver handling

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1004,6 +1004,24 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${postgresql.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>${mariadb-java-client.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>${mssql-jdbc.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>io.gravitee.apim.repository</groupId>
             <artifactId>gravitee-apim-repository-mongodb</artifactId>
             <version>${project.version}</version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -129,12 +129,27 @@
             <excludes>
                 <exclude>io.gravitee.*:*:*</exclude>
                 <exclude>com.graviteesource.*:*:*</exclude>
+                <exclude>org.postgresql:postgresql:*</exclude>
+                <exclude>org.mariadb.jdbc:mariadb-java-client:*</exclude>
+                <exclude>com.microsoft.sqlserver:mssql-jdbc:*</exclude>
                 <exclude>org.projectlombok:*:*</exclude>
                 <exclude>org.mapstruct:mapstruct-processor:*</exclude>
                 <exclude>org.junit.jupiter:*:*</exclude>
                 <exclude>*:*:*:windows-x86_64</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>
+            <fileMode>644</fileMode>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>plugins/ext/repository-jdbc</outputDirectory>
+            <unpack>false</unpack>
+            <includes>
+                <include>org.postgresql:postgresql:jar</include>
+                <include>org.mariadb.jdbc:mariadb-java-client:jar</include>
+                <include>com.microsoft.sqlserver:mssql-jdbc:jar</include>
+            </includes>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>false</useTransitiveDependencies>
             <fileMode>644</fileMode>
         </dependencySet>
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -35,10 +35,7 @@
         <HikariCP.version>6.2.1</HikariCP.version>
         <liquibase.version>4.27.0</liquibase.version>
         <liquibase-slf4j.version>5.1.0</liquibase-slf4j.version>
-        <mariaDB.version>3.5.6</mariaDB.version>
-        <mssql-jdbc.version>12.10.2.jre11</mssql-jdbc.version>
         <mysql-connector-j.version>9.2.0</mysql-connector-j.version>
-        <postgresql.version>42.7.7</postgresql.version>
 
         <!-- Plugin configuration -->
         <default-database.jdbcType>postgresql</default-database.jdbcType>
@@ -187,7 +184,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>${mariaDB.version}</version>
+            <version>${mariadb-java-client.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -149,11 +149,26 @@
                 <exclude>com.graviteesource.*:*:*</exclude>
                 <exclude>commons-logging:commons-logging:*</exclude>
                 <exclude>com.sun.mail:mailapi:*</exclude>
+                <exclude>org.postgresql:postgresql:*</exclude>
+                <exclude>org.mariadb.jdbc:mariadb-java-client:*</exclude>
+                <exclude>com.microsoft.sqlserver:mssql-jdbc:*</exclude>
                 <exclude>org.projectlombok:*:*</exclude>
                 <exclude>org.mapstruct:mapstruct-processor:*</exclude>
                 <exclude>org.junit.jupiter:*:*</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>
+            <fileMode>644</fileMode>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>plugins/ext/repository-jdbc</outputDirectory>
+            <unpack>false</unpack>
+            <includes>
+                <include>org.postgresql:postgresql:jar</include>
+                <include>org.mariadb.jdbc:mariadb-java-client:jar</include>
+                <include>com.microsoft.sqlserver:mssql-jdbc:jar</include>
+            </includes>
+            <useProjectArtifact>false</useProjectArtifact>
+            <useTransitiveDependencies>false</useTransitiveDependencies>
             <fileMode>644</fileMode>
         </dependencySet>
 

--- a/helm/README.adoc
+++ b/helm/README.adoc
@@ -264,14 +264,68 @@ postgres-apim-postgresql-0                1/1     Running      0           98s
 ----
 
 
-For PostgrestSQL, use the information below in `values.yml` and replace the `username`, `password`,
+Official APIM images bundle the PostgreSQL, MariaDB, and Microsoft SQL Server JDBC drivers.
+MySQL is intentionally not bundled and is still downloaded at pod startup from `jdbc.driver`.
+
+The startup behavior is derived from the scheme in `jdbc.url`:
+
+* `jdbc:postgresql:`, `jdbc:mariadb:`, `jdbc:sqlserver:` use the bundled driver and do not download anything at startup
+* `jdbc:mysql:` downloads the driver from `jdbc.driver` at startup
+* any other `jdbc:*` scheme also uses `jdbc.driver` as a startup download fallback
+
+For PostgreSQL, use the information below in `values.yml` and replace the `username`, `password`,
 `URL` and `database name` with details for your specific instance.
 
 ----
 jdbc:
-  driver: https://jdbc.postgresql.org/download/postgresql-42.2.23.jar
   url: jdbc:postgresql://postgres-apim-postgresql:5432/graviteeapim
   username: postgres
+  password: P@ssw0rd
+management:
+  type: jdbc
+----
+
+For MariaDB:
+
+----
+jdbc:
+  url: jdbc:mariadb://mariadb-apim-mariadb:3306/graviteeapim
+  username: gravitee
+  password: P@ssw0rd
+management:
+  type: jdbc
+----
+
+For Microsoft SQL Server:
+
+----
+jdbc:
+  url: jdbc:sqlserver://sqlserver-apim-mssql:1433;databaseName=graviteeapim
+  username: sa
+  password: P@ssw0rd
+management:
+  type: jdbc
+----
+
+For MySQL:
+
+----
+jdbc:
+  url: jdbc:mysql://mysql-apim-mysql:3306/graviteeapim
+  driver: https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.3.0/mysql-connector-j-9.3.0.jar
+  username: gravitee
+  password: P@ssw0rd
+management:
+  type: jdbc
+----
+
+For any other JDBC driver, keep `jdbc.driver` set to a URL that can be downloaded at startup:
+
+----
+jdbc:
+  url: jdbc:customdb://customdb:1234/graviteeapim
+  driver: https://artifacts.example.com/jdbc/customdb-driver.jar
+  username: gravitee
   password: P@ssw0rd
 management:
   type: jdbc

--- a/helm/README.adoc
+++ b/helm/README.adoc
@@ -265,19 +265,39 @@ postgres-apim-postgresql-0                1/1     Running      0           98s
 
 
 Official APIM images bundle the PostgreSQL, MariaDB, and Microsoft SQL Server JDBC drivers.
-MySQL is intentionally not bundled and is still downloaded at pod startup from `jdbc.driver`.
+MySQL is intentionally not bundled in official images.
 
-The startup behavior is derived from the scheme in `jdbc.url`:
+The startup behavior is derived from `jdbc.url` and `jdbc.driverSource`:
 
-* `jdbc:postgresql:`, `jdbc:mariadb:`, `jdbc:sqlserver:` use the bundled driver and do not download anything at startup
-* `jdbc:mysql:` downloads the driver from `jdbc.driver` at startup
-* any other `jdbc:*` scheme also uses `jdbc.driver` as a startup download fallback
+* `jdbc.driverSource=auto` uses bundled PostgreSQL, MariaDB, and SQL Server drivers, and uses startup download for MySQL and any other custom JDBC family
+* `jdbc.driverSource=download` always downloads the driver from `jdbc.driver` at startup
+* `jdbc.driverSource=image` copies the driver at startup from a dedicated customer-provided JDBC image
+
+When `jdbc.driverSource=auto`:
+
+* MySQL still requires `jdbc.driver`
+* PostgreSQL, MariaDB, and SQL Server do not use `jdbc.driver`
+
+For MySQL, the recommended path is a minimal JDBC image.
+This avoids outbound downloads at startup without requiring custom API or Gateway application images.
+The dedicated image must contain the MySQL driver at `/drivers/mysql-connector-j.jar`.
+
+Minimal MySQL JDBC image example:
+
+----
+FROM busybox:1.36
+COPY mysql-connector-j-<version>.jar /drivers/mysql-connector-j.jar
+----
+
+The copied file must be readable by UID `1001`.
+Pod image pull secrets already apply to initContainers, so private registries for this JDBC image use the existing API and Gateway image pull secret configuration.
 
 For PostgreSQL, use the information below in `values.yml` and replace the `username`, `password`,
 `URL` and `database name` with details for your specific instance.
 
 ----
 jdbc:
+  driverSource: auto
   url: jdbc:postgresql://postgres-apim-postgresql:5432/graviteeapim
   username: postgres
   password: P@ssw0rd
@@ -289,6 +309,7 @@ For MariaDB:
 
 ----
 jdbc:
+  driverSource: auto
   url: jdbc:mariadb://mariadb-apim-mariadb:3306/graviteeapim
   username: gravitee
   password: P@ssw0rd
@@ -300,6 +321,7 @@ For Microsoft SQL Server:
 
 ----
 jdbc:
+  driverSource: auto
   url: jdbc:sqlserver://sqlserver-apim-mssql:1433;databaseName=graviteeapim
   username: sa
   password: P@ssw0rd
@@ -307,10 +329,29 @@ management:
   type: jdbc
 ----
 
-For MySQL:
+For MySQL, the recommended path is a minimal JDBC image:
 
 ----
 jdbc:
+  driverSource: image
+  url: jdbc:mysql://mysql-apim-mysql:3306/graviteeapim
+  username: gravitee
+  password: P@ssw0rd
+  image:
+    repository: customer/mysql-jdbc
+    tag: 9.3.0
+    pullPolicy: IfNotPresent
+management:
+  type: jdbc
+----
+
+The API upgrader follows the same JDBC behavior automatically.
+
+For MySQL fallback mode, keep the current startup download path:
+
+----
+jdbc:
+  driverSource: download
   url: jdbc:mysql://mysql-apim-mysql:3306/graviteeapim
   driver: https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.3.0/mysql-connector-j-9.3.0.jar
   username: gravitee
@@ -323,6 +364,7 @@ For any other JDBC driver, keep `jdbc.driver` set to a URL that can be downloade
 
 ----
 jdbc:
+  driverSource: auto
   url: jdbc:customdb://customdb:1234/graviteeapim
   driver: https://artifacts.example.com/jdbc/customdb-driver.jar
   username: gravitee

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -162,11 +162,42 @@ other
 {{- end -}}
 
 {{/*
+Configured JDBC driver source.
+*/}}
+{{- define "apim.jdbcDriverSource" -}}
+{{- lower (default "auto" .Values.jdbc.driverSource) -}}
+{{- end -}}
+
+{{/*
 Whether the JDBC driver should be downloaded at startup.
 */}}
 {{- define "apim.shouldDownloadJdbcDriver" -}}
 {{- $family := include "apim.jdbcDriverFamily" . -}}
-{{- if and (eq .Values.management.type "jdbc") .Values.jdbc.driver (not (or (eq $family "postgresql") (eq $family "mariadb") (eq $family "sqlserver"))) -}}
+{{- $source := include "apim.jdbcDriverSource" . -}}
+{{- if eq .Values.management.type "jdbc" -}}
+{{- if and (eq $source "download") .Values.jdbc.driver -}}
+true
+{{- else if and (eq $source "auto") .Values.jdbc.driver (not (or (eq $family "postgresql") (eq $family "mariadb") (eq $family "sqlserver"))) -}}
+true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the JDBC driver should be copied from a dedicated image.
+*/}}
+{{- define "apim.shouldCopyJdbcDriverFromImage" -}}
+{{- $source := include "apim.jdbcDriverSource" . -}}
+{{- if and (eq .Values.management.type "jdbc") (eq $source "image") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the JDBC volume and mount should be provisioned.
+*/}}
+{{- define "apim.shouldProvisionJdbcDriver" -}}
+{{- if or (eq (include "apim.shouldDownloadJdbcDriver" .) "true") (eq (include "apim.shouldCopyJdbcDriverFromImage" .) "true") -}}
 true
 {{- end -}}
 {{- end -}}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -144,6 +144,34 @@ Create volumes for plugins
 {{- end -}}
 
 {{/*
+Classify the configured JDBC URL family.
+*/}}
+{{- define "apim.jdbcDriverFamily" -}}
+{{- $url := lower (default "" .Values.jdbc.url) -}}
+{{- if hasPrefix "jdbc:postgresql:" $url -}}
+postgresql
+{{- else if hasPrefix "jdbc:mariadb:" $url -}}
+mariadb
+{{- else if hasPrefix "jdbc:sqlserver:" $url -}}
+sqlserver
+{{- else if hasPrefix "jdbc:mysql:" $url -}}
+mysql
+{{- else -}}
+other
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the JDBC driver should be downloaded at startup.
+*/}}
+{{- define "apim.shouldDownloadJdbcDriver" -}}
+{{- $family := include "apim.jdbcDriverFamily" . -}}
+{{- if and (eq .Values.management.type "jdbc") .Values.jdbc.driver (not (or (eq $family "postgresql") (eq $family "mariadb") (eq $family "sqlserver"))) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
 Use the fullname if the serviceAccount value is not set
 */}}
 {{- define "apim.serviceAccount" -}}

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -115,9 +115,10 @@ spec:
       {{- end -}}
 
       {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers -}}
-      {{- if or .Values.api.extraInitContainers $plugins .Values.jdbc.driver }}
+      {{- $shouldDownloadJdbcDriver := eq (include "apim.shouldDownloadJdbcDriver" .) "true" -}}
+      {{- if or .Values.api.extraInitContainers $plugins $shouldDownloadJdbcDriver }}
       initContainers:
-        {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
+        {{- if $shouldDownloadJdbcDriver }}
         - name: get-repository-jdbc-ext
           {{- toYaml .Values.initContainers | nindent 10 }}
           command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  {{ .Values.jdbc.driver }}" ]
@@ -278,7 +279,7 @@ spec:
               mountPath: /opt/graviteeio-management-api/config/logback.xml
               subPath: logback.xml
           {{- end }}
-          {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
+          {{- if $shouldDownloadJdbcDriver }}
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /opt/graviteeio-management-api/plugins/ext/repository-jdbc
           {{- end }}
@@ -338,7 +339,7 @@ spec:
           configMap:
             name: {{ template "gravitee.api.fullname" . }}
         {{- end }}
-        {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
+        {{- if $shouldDownloadJdbcDriver }}
         - name: graviteeio-apim-repository-jdbc-ext
           emptyDir: { }
         {{- end }}

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -116,12 +116,25 @@ spec:
 
       {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers -}}
       {{- $shouldDownloadJdbcDriver := eq (include "apim.shouldDownloadJdbcDriver" .) "true" -}}
-      {{- if or .Values.api.extraInitContainers $plugins $shouldDownloadJdbcDriver }}
+      {{- $shouldCopyJdbcDriverFromImage := eq (include "apim.shouldCopyJdbcDriverFromImage" .) "true" -}}
+      {{- $shouldProvisionJdbcDriver := eq (include "apim.shouldProvisionJdbcDriver" .) "true" -}}
+      {{- if or .Values.api.extraInitContainers $plugins $shouldProvisionJdbcDriver }}
       initContainers:
         {{- if $shouldDownloadJdbcDriver }}
         - name: get-repository-jdbc-ext
           {{- toYaml .Values.initContainers | nindent 10 }}
           command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  {{ .Values.jdbc.driver }}" ]
+          volumeMounts:
+            - name: graviteeio-apim-repository-jdbc-ext
+              mountPath: /tmp/plugins-ext
+        {{- end -}}
+        {{- if $shouldCopyJdbcDriverFromImage }}
+        - name: copy-repository-jdbc-ext
+          image: "{{ required "jdbc.image.repository is required when jdbc.driverSource=image" .Values.jdbc.image.repository }}:{{ required "jdbc.image.tag is required when jdbc.driverSource=image" .Values.jdbc.image.tag }}"
+          imagePullPolicy: {{ .Values.jdbc.image.pullPolicy | default "IfNotPresent" }}
+          securityContext: {{ toYaml .Values.initContainers.securityContext | nindent 12 }}
+          env: {{ toYaml .Values.initContainers.env | nindent 12 }}
+          command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cp /drivers/mysql-connector-j.jar /tmp/plugins-ext/" ]
           volumeMounts:
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /tmp/plugins-ext
@@ -279,7 +292,7 @@ spec:
               mountPath: /opt/graviteeio-management-api/config/logback.xml
               subPath: logback.xml
           {{- end }}
-          {{- if $shouldDownloadJdbcDriver }}
+          {{- if $shouldProvisionJdbcDriver }}
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /opt/graviteeio-management-api/plugins/ext/repository-jdbc
           {{- end }}
@@ -339,7 +352,7 @@ spec:
           configMap:
             name: {{ template "gravitee.api.fullname" . }}
         {{- end }}
-        {{- if $shouldDownloadJdbcDriver }}
+        {{- if $shouldProvisionJdbcDriver }}
         - name: graviteeio-apim-repository-jdbc-ext
           emptyDir: { }
         {{- end }}

--- a/helm/templates/api/api-upgrader-job.yaml
+++ b/helm/templates/api/api-upgrader-job.yaml
@@ -90,12 +90,25 @@ spec:
       {{- end -}}
       {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers -}}
       {{- $shouldDownloadJdbcDriver := eq (include "apim.shouldDownloadJdbcDriver" .) "true" -}}
-      {{- if or .Values.api.extraInitContainers $plugins $shouldDownloadJdbcDriver }}
+      {{- $shouldCopyJdbcDriverFromImage := eq (include "apim.shouldCopyJdbcDriverFromImage" .) "true" -}}
+      {{- $shouldProvisionJdbcDriver := eq (include "apim.shouldProvisionJdbcDriver" .) "true" -}}
+      {{- if or .Values.api.extraInitContainers $plugins $shouldProvisionJdbcDriver }}
       initContainers:
         {{- if $shouldDownloadJdbcDriver }}
         - name: get-repository-jdbc-ext
           {{- toYaml .Values.initContainers | nindent 10 }}
           command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget {{ .Values.jdbc.driver }}" ]
+          volumeMounts:
+            - name: graviteeio-apim-repository-jdbc-ext
+              mountPath: /tmp/plugins-ext
+        {{- end -}}
+        {{- if $shouldCopyJdbcDriverFromImage }}
+        - name: copy-repository-jdbc-ext
+          image: "{{ required "jdbc.image.repository is required when jdbc.driverSource=image" .Values.jdbc.image.repository }}:{{ required "jdbc.image.tag is required when jdbc.driverSource=image" .Values.jdbc.image.tag }}"
+          imagePullPolicy: {{ .Values.jdbc.image.pullPolicy | default "IfNotPresent" }}
+          securityContext: {{ toYaml .Values.initContainers.securityContext | nindent 12 }}
+          env: {{ toYaml .Values.initContainers.env | nindent 12 }}
+          command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cp /drivers/mysql-connector-j.jar /tmp/plugins-ext/" ]
           volumeMounts:
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /tmp/plugins-ext
@@ -168,7 +181,7 @@ spec:
               mountPath: /opt/graviteeio-management-api/config/logback.xml
               subPath: logback.xml
           {{- end }}
-          {{- if $shouldDownloadJdbcDriver }}
+          {{- if $shouldProvisionJdbcDriver }}
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /opt/graviteeio-management-api/plugins/ext/repository-jdbc
           {{- end }}
@@ -189,7 +202,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "gravitee.api.fullname" . }}
-        {{- if $shouldDownloadJdbcDriver }}
+        {{- if $shouldProvisionJdbcDriver }}
         - name: graviteeio-apim-repository-jdbc-ext
           emptyDir: { }
         {{- end }}

--- a/helm/templates/api/api-upgrader-job.yaml
+++ b/helm/templates/api/api-upgrader-job.yaml
@@ -89,9 +89,10 @@ spec:
         {{- $plugins = concat $plugins .Values.api.additionalPlugins -}}
       {{- end -}}
       {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers -}}
-      {{- if or .Values.api.extraInitContainers $plugins .Values.jdbc.driver }}
+      {{- $shouldDownloadJdbcDriver := eq (include "apim.shouldDownloadJdbcDriver" .) "true" -}}
+      {{- if or .Values.api.extraInitContainers $plugins $shouldDownloadJdbcDriver }}
       initContainers:
-        {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
+        {{- if $shouldDownloadJdbcDriver }}
         - name: get-repository-jdbc-ext
           {{- toYaml .Values.initContainers | nindent 10 }}
           command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget {{ .Values.jdbc.driver }}" ]
@@ -167,7 +168,7 @@ spec:
               mountPath: /opt/graviteeio-management-api/config/logback.xml
               subPath: logback.xml
           {{- end }}
-          {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
+          {{- if $shouldDownloadJdbcDriver }}
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /opt/graviteeio-management-api/plugins/ext/repository-jdbc
           {{- end }}
@@ -188,7 +189,7 @@ spec:
         - name: config
           configMap:
             name: {{ template "gravitee.api.fullname" . }}
-        {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
+        {{- if $shouldDownloadJdbcDriver }}
         - name: graviteeio-apim-repository-jdbc-ext
           emptyDir: { }
         {{- end }}

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -110,12 +110,25 @@ spec:
 
       {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-gateway" "initContainers" $initContainers -}}
       {{- $shouldDownloadJdbcDriver := eq (include "apim.shouldDownloadJdbcDriver" .) "true" -}}
-      {{- if or .Values.gateway.extraInitContainers $plugins $shouldDownloadJdbcDriver }}
+      {{- $shouldCopyJdbcDriverFromImage := eq (include "apim.shouldCopyJdbcDriverFromImage" .) "true" -}}
+      {{- $shouldProvisionJdbcDriver := eq (include "apim.shouldProvisionJdbcDriver" .) "true" -}}
+      {{- if or .Values.gateway.extraInitContainers $plugins $shouldProvisionJdbcDriver }}
       initContainers:
         {{- if $shouldDownloadJdbcDriver }}
         - name: get-repository-jdbc-ext
           {{- toYaml .Values.initContainers | nindent 10 }}
           command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  {{ .Values.jdbc.driver }}"]
+          volumeMounts:
+            - name: graviteeio-apim-repository-jdbc-ext
+              mountPath: /tmp/plugins-ext
+        {{- end -}}
+        {{- if $shouldCopyJdbcDriverFromImage }}
+        - name: copy-repository-jdbc-ext
+          image: "{{ required "jdbc.image.repository is required when jdbc.driverSource=image" .Values.jdbc.image.repository }}:{{ required "jdbc.image.tag is required when jdbc.driverSource=image" .Values.jdbc.image.tag }}"
+          imagePullPolicy: {{ .Values.jdbc.image.pullPolicy | default "IfNotPresent" }}
+          securityContext: {{ toYaml .Values.initContainers.securityContext | nindent 12 }}
+          env: {{ toYaml .Values.initContainers.env | nindent 12 }}
+          command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cp /drivers/mysql-connector-j.jar /tmp/plugins-ext/"]
           volumeMounts:
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /tmp/plugins-ext
@@ -255,7 +268,7 @@ spec:
               mountPath: /opt/graviteeio-gateway/config/logback.xml
               subPath: logback.xml
           {{- end }}
-          {{- if $shouldDownloadJdbcDriver }}
+          {{- if $shouldProvisionJdbcDriver }}
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /opt/graviteeio-gateway/plugins/ext/repository-jdbc
           {{- end }}
@@ -305,7 +318,7 @@ spec:
           configMap:
             name: {{ template "gravitee.gateway.fullname" . }}
         {{- end }}
-        {{- if $shouldDownloadJdbcDriver }}
+        {{- if $shouldProvisionJdbcDriver }}
         - name: graviteeio-apim-repository-jdbc-ext
           emptyDir: {}
         {{- end }}

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -109,9 +109,10 @@ spec:
       {{- end -}}
 
       {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-gateway" "initContainers" $initContainers -}}
-      {{- if or .Values.gateway.extraInitContainers $plugins .Values.jdbc.driver }}
+      {{- $shouldDownloadJdbcDriver := eq (include "apim.shouldDownloadJdbcDriver" .) "true" -}}
+      {{- if or .Values.gateway.extraInitContainers $plugins $shouldDownloadJdbcDriver }}
       initContainers:
-        {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
+        {{- if $shouldDownloadJdbcDriver }}
         - name: get-repository-jdbc-ext
           {{- toYaml .Values.initContainers | nindent 10 }}
           command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  {{ .Values.jdbc.driver }}"]
@@ -254,7 +255,7 @@ spec:
               mountPath: /opt/graviteeio-gateway/config/logback.xml
               subPath: logback.xml
           {{- end }}
-          {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
+          {{- if $shouldDownloadJdbcDriver }}
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /opt/graviteeio-gateway/plugins/ext/repository-jdbc
           {{- end }}
@@ -304,7 +305,7 @@ spec:
           configMap:
             name: {{ template "gravitee.gateway.fullname" . }}
         {{- end }}
-        {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}
+        {{- if $shouldDownloadJdbcDriver }}
         - name: graviteeio-apim-repository-jdbc-ext
           emptyDir: {}
         {{- end }}

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -76,6 +76,33 @@ tests:
       - notExists:
           path: spec.template.spec.volumes[1]
 
+  - it: Check deployment with MySQL JDBC image support
+    template: api/api-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        driverSource: "image"
+        url: "jdbc:mysql://db:3306/gravitee"
+        image:
+          repository: "customer/mysql-jdbc"
+          tag: "9.3.0"
+          pullPolicy: "IfNotPresent"
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: copy-repository-jdbc-ext
+            image: "customer/mysql-jdbc:9.3.0"
+            imagePullPolicy: IfNotPresent
+            command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cp /drivers/mysql-connector-j.jar /tmp/plugins-ext/" ]
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: graviteeio-apim-repository-jdbc-ext
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: graviteeio-apim-repository-jdbc-ext
+
   - it: Set containerPort with custom port if core service is enabled
     template: api/api-deployment.yaml
     set:

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -96,6 +96,13 @@ tests:
             image: "customer/mysql-jdbc:9.3.0"
             imagePullPolicy: IfNotPresent
             command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cp /drivers/mysql-connector-j.jar /tmp/plugins-ext/" ]
+            env: []
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            volumeMounts:
+            - name: graviteeio-apim-repository-jdbc-ext
+              mountPath: /tmp/plugins-ext
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[1].name
           value: graviteeio-apim-repository-jdbc-ext

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -61,6 +61,21 @@ tests:
           path: spec.template.spec.containers[0].volumeMounts[1].mountPath
           value: /opt/graviteeio-management-api/plugins/ext/repository-jdbc
 
+  - it: Check deployment with bundled PostgreSQL JDBC support
+    template: api/api-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        url: "jdbc:postgresql://db:5432/gravitee"
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[1]
+      - notExists:
+          path: spec.template.spec.volumes[1]
+
   - it: Set containerPort with custom port if core service is enabled
     template: api/api-deployment.yaml
     set:

--- a/helm/tests/api/job_upgrader_test.yaml
+++ b/helm/tests/api/job_upgrader_test.yaml
@@ -59,6 +59,23 @@ tests:
             name: GRAVITEE_ALERTS_ALERT-ENGINE_ENABLED
             value: "false"
 
+  - it: Should not download bundled PostgreSQL JDBC driver
+    template: api/api-upgrader-job.yaml
+    set:
+      api:
+        upgrader: true
+      management:
+        type: "jdbc"
+      jdbc:
+        url: "jdbc:postgresql://db:5432/gravitee"
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[1]
+      - notExists:
+          path: spec.template.spec.volumes[1]
+
   - it: Check that cockpit has been disabled
     template: api/api-upgrader-job.yaml
     set:

--- a/helm/tests/api/job_upgrader_test.yaml
+++ b/helm/tests/api/job_upgrader_test.yaml
@@ -76,6 +76,33 @@ tests:
       - notExists:
           path: spec.template.spec.volumes[1]
 
+  - it: Should copy MySQL JDBC driver from dedicated image
+    template: api/api-upgrader-job.yaml
+    set:
+      api:
+        upgrader: true
+      management:
+        type: "jdbc"
+      jdbc:
+        driverSource: "image"
+        url: "jdbc:mysql://db:3306/gravitee"
+        image:
+          repository: "customer/mysql-jdbc"
+          tag: "9.3.0"
+          pullPolicy: "IfNotPresent"
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: copy-repository-jdbc-ext
+            image: "customer/mysql-jdbc:9.3.0"
+            imagePullPolicy: IfNotPresent
+            command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cp /drivers/mysql-connector-j.jar /tmp/plugins-ext/" ]
+      - notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: get-repository-jdbc-ext
+
   - it: Check that cockpit has been disabled
     template: api/api-upgrader-job.yaml
     set:

--- a/helm/tests/api/job_upgrader_test.yaml
+++ b/helm/tests/api/job_upgrader_test.yaml
@@ -26,8 +26,8 @@ tests:
           content:
             name: GRAVITEE_UPGRADE_MODE
             value: "true"
-      - exists:
-          # It need hazelcast plugin
+      - notExists:
+          # It should not contain init containers by default
           path: spec.template.spec.initContainers
 
 
@@ -98,6 +98,13 @@ tests:
             image: "customer/mysql-jdbc:9.3.0"
             imagePullPolicy: IfNotPresent
             command: [ 'sh', '-c', "mkdir -p /tmp/plugins-ext && cp /drivers/mysql-connector-j.jar /tmp/plugins-ext/" ]
+            env: []
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            volumeMounts:
+            - name: graviteeio-apim-repository-jdbc-ext
+              mountPath: /tmp/plugins-ext
       - notContains:
           path: spec.template.spec.initContainers
           content:

--- a/helm/tests/gateway/deployment_jdbc_test.yaml
+++ b/helm/tests/gateway/deployment_jdbc_test.yaml
@@ -71,6 +71,38 @@ tests:
             -  name: graviteeio-apim-repository-jdbc-ext
                mountPath: /tmp/plugins-ext
 
+  - it: Should copy MySQL JDBC driver from dedicated image
+    template: gateway/gateway-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        driverSource: "image"
+        url: "jdbc:mysql://db:3306/gravitee"
+        image:
+          repository: "customer/mysql-jdbc"
+          tag: "9.3.0"
+          pullPolicy: "IfNotPresent"
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: copy-repository-jdbc-ext
+            image: "customer/mysql-jdbc:9.3.0"
+            imagePullPolicy: IfNotPresent
+            command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cp /drivers/mysql-connector-j.jar /tmp/plugins-ext/"]
+            env: []
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            volumeMounts:
+            - name: graviteeio-apim-repository-jdbc-ext
+              mountPath: /tmp/plugins-ext
+      - notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: get-repository-jdbc-ext
+
   - it: Should not download bundled PostgreSQL JDBC driver
     template: gateway/gateway-deployment.yaml
     set:
@@ -127,6 +159,24 @@ tests:
           path: spec.template.spec.volumes
           content:
             name: graviteeio-apim-repository-jdbc-ext
+
+  - it: Should force PostgreSQL JDBC driver download when configured
+    template: gateway/gateway-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        driverSource: "download"
+        url: "jdbc:postgresql://db:5432/gravitee"
+        driver: "https://url/where/to/download/driver"
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: get-repository-jdbc-ext
+            image: "alpine:latest"
+            imagePullPolicy: Always
+            command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  https://url/where/to/download/driver"]
 
   - it: Should keep startup download for custom JDBC drivers
     template: gateway/gateway-deployment.yaml

--- a/helm/tests/gateway/deployment_jdbc_test.yaml
+++ b/helm/tests/gateway/deployment_jdbc_test.yaml
@@ -4,7 +4,7 @@ templates:
   - "gateway/gateway-configmap.yaml"
 
 tests:
-  - it: Check that volumes are defined
+  - it: Check that MySQL volumes are defined
     template: gateway/gateway-deployment.yaml
     chart:
       version: 1.0.0-chart
@@ -47,12 +47,94 @@ tests:
             - name: graviteeio-apim-repository-jdbc-ext
               mountPath: /tmp/plugins-ext
 
-  - it: Should run init container to download JDBC driver
+  - it: Should run init container to download MySQL JDBC driver
     template: gateway/gateway-deployment.yaml
     set:
       management:
         type: "jdbc"
       jdbc:
+        url: "jdbc:mysql://db:3306/gravitee"
+        driver: "https://url/where/to/download/driver"
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: get-repository-jdbc-ext
+            image: "alpine:latest"
+            imagePullPolicy: Always
+            command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  https://url/where/to/download/driver"]
+            env: []
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            volumeMounts:
+            -  name: graviteeio-apim-repository-jdbc-ext
+               mountPath: /tmp/plugins-ext
+
+  - it: Should not download bundled PostgreSQL JDBC driver
+    template: gateway/gateway-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        url: "jdbc:postgresql://db:5432/gravitee"
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: graviteeio-apim-repository-jdbc-ext
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: graviteeio-apim-repository-jdbc-ext
+
+  - it: Should not download bundled MariaDB JDBC driver
+    template: gateway/gateway-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        url: "jdbc:mariadb://db:3306/gravitee"
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: graviteeio-apim-repository-jdbc-ext
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: graviteeio-apim-repository-jdbc-ext
+
+  - it: Should not download bundled SQL Server JDBC driver
+    template: gateway/gateway-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        url: "jdbc:sqlserver://db:1433;databaseName=gravitee"
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: graviteeio-apim-repository-jdbc-ext
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: graviteeio-apim-repository-jdbc-ext
+
+  - it: Should keep startup download for custom JDBC drivers
+    template: gateway/gateway-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        url: "jdbc:customdb://db:4242/gravitee"
         driver: "https://url/where/to/download/driver"
     asserts:
       - contains:
@@ -76,6 +158,7 @@ tests:
       management:
         type: "jdbc"
       jdbc:
+        url: "jdbc:mysql://db:3306/gravitee"
         driver: "https://url/where/to/download/driver"
       initContainers:
         image: "some.harbor.local/dockerhub-cache/library/alpine:latest"

--- a/helm/tests/gateway/deployment_jdbc_test.yaml
+++ b/helm/tests/gateway/deployment_jdbc_test.yaml
@@ -177,6 +177,13 @@ tests:
             image: "alpine:latest"
             imagePullPolicy: Always
             command: ['sh', '-c', "mkdir -p /tmp/plugins-ext && cd /tmp/plugins-ext && wget  https://url/where/to/download/driver"]
+            env: []
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            volumeMounts:
+            -  name: graviteeio-apim-repository-jdbc-ext
+               mountPath: /tmp/plugins-ext
 
   - it: Should keep startup download for custom JDBC drivers
     template: gateway/gateway-deployment.yaml

--- a/helm/tests/gateway/deployment_test.yaml
+++ b/helm/tests/gateway/deployment_test.yaml
@@ -21,7 +21,7 @@ tests:
       - isEmpty:
           # It should not contain environment variable by default
           path: spec.template.spec.containers[0].env
-      - isEmpty:
+      - notExists:
           # It should not contain init containers by default
           path: spec.template.spec.initContainers
       - equal:
@@ -47,7 +47,7 @@ tests:
       - isEmpty:
           # It should not contain environment variable by default
           path: spec.template.spec.containers[0].env
-      - isEmpty:
+      - notExists:
           # It should not contain init containers by default
           path: spec.template.spec.initContainers
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -258,16 +258,29 @@ mongo:
     password:
 
 jdbc:
-  # The jdbc.url scheme decides whether APIM uses a bundled JDBC driver or downloads jdbc.driver at startup.
-  url: jdbc:mysql://localhost:3306/gravitee
+  # The jdbc.url scheme and jdbc.driverSource decide how APIM obtains the JDBC driver.
+  # Supported values for jdbc.driverSource:
+  # - auto: bundled PostgreSQL/MariaDB/SQL Server drivers, download for MySQL and other custom JDBC families
+  # - download: always download the driver from jdbc.driver at startup
+  # - image: copy the driver at startup from a dedicated customer-provided JDBC image
+  # In auto mode, MySQL still requires jdbc.driver and downloads the driver at startup.
+  # PostgreSQL, MariaDB, and SQL Server ignore jdbc.driver in auto mode.
+  driverSource: auto
   # APIM bundles PostgreSQL, MariaDB, and SQL Server JDBC drivers in the official images.
-  # MySQL is intentionally not bundled and is still downloaded at pod startup.
-  # Startup download behavior is derived from the jdbc.url scheme:
-  # - jdbc:postgresql:, jdbc:mariadb:, jdbc:sqlserver: -> bundled driver, no startup download
-  # - jdbc:mysql: -> startup download using jdbc.driver
-  # - any other jdbc:* scheme -> startup download using jdbc.driver
-  # Set this URL for MySQL or any other non-bundled/custom JDBC driver.
+  # MySQL is intentionally not bundled in official images.
+  # For MySQL, the recommended path is jdbc.driverSource=image with a minimal JDBC image
+  # containing /drivers/mysql-connector-j.jar.
+  # The fallback path is jdbc.driverSource=download using jdbc.driver.
+  # mount-based MySQL delivery is not part of the documented recommendation.
+  url: jdbc:mysql://localhost:3306/gravitee
+  # Set this URL for MySQL runtime download mode or any other non-bundled/custom JDBC driver.
   driver: https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.22/mysql-connector-java-8.0.22.jar
+  image:
+    # Required when jdbc.driverSource=image.
+    # The image must contain the MySQL JDBC driver at /drivers/mysql-connector-j.jar.
+    repository:
+    tag:
+    pullPolicy: IfNotPresent
   # the version of the gravitee-repository-jdbc (only required for apim versions < 3.5.0)
 #  repositoryVersion: 3.3.0
   username:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -258,8 +258,15 @@ mongo:
     password:
 
 jdbc:
+  # The jdbc.url scheme decides whether APIM uses a bundled JDBC driver or downloads jdbc.driver at startup.
   url: jdbc:mysql://localhost:3306/gravitee
-  # the URL to download the driver
+  # APIM bundles PostgreSQL, MariaDB, and SQL Server JDBC drivers in the official images.
+  # MySQL is intentionally not bundled and is still downloaded at pod startup.
+  # Startup download behavior is derived from the jdbc.url scheme:
+  # - jdbc:postgresql:, jdbc:mariadb:, jdbc:sqlserver: -> bundled driver, no startup download
+  # - jdbc:mysql: -> startup download using jdbc.driver
+  # - any other jdbc:* scheme -> startup download using jdbc.driver
+  # Set this URL for MySQL or any other non-bundled/custom JDBC driver.
   driver: https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.22/mysql-connector-java-8.0.22.jar
   # the version of the gravitee-repository-jdbc (only required for apim versions < 3.5.0)
 #  repositoryVersion: 3.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -134,10 +134,13 @@
         <lucene.version>10.1.0</lucene.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <mapstruct.version>1.6.3</mapstruct.version>
+        <mariadb-java-client.version>3.5.6</mariadb-java-client.version>
+        <mssql-jdbc.version>12.10.2.jre11</mssql-jdbc.version>
         <netty-tcnative-boringssl-static.version>2.0.70.Final</netty-tcnative-boringssl-static.version>
         <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
         <mongo.version>5.3.1</mongo.version>
         <owasp-java-html-sanitizer.version>20260102.1</owasp-java-html-sanitizer.version>
+        <postgresql.version>42.7.7</postgresql.version>
         <reactor-adapter.version>3.5.2</reactor-adapter.version>
         <reactor-core.version>3.7.4</reactor-core.version>
         <slf4j2-mock.version>2.4.0</slf4j2-mock.version>


### PR DESCRIPTION
## Issue

N/A

## Description

Update the Helm JDBC behavior so PostgreSQL, MariaDB, and SQL Server use bundled drivers by default, while MySQL is supported either through a dedicated minimal JDBC image or the existing runtime download fallback.

## Additional context

This PR also documents the expected JDBC behavior in Helm values and README so users can clearly understand when a driver is bundled, downloaded at startup, or copied from a customer-provided MySQL JDBC image.