### PR TITLE
fix: add missing ENVIRONMENT_API READ permission on API read endpoints

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -317,6 +317,7 @@ public class ApiResource extends AbstractResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Response getApiById(@PathParam("apiId") String apiId) {
         final GenericApiEntity apiEntity = getGenericApiEntityById(apiId, true);
         return apiResponse(apiEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/scoring/ApiScoringResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/scoring/ApiScoringResource.java
@@ -22,6 +22,10 @@ import io.gravitee.rest.api.management.v2.rest.mapper.ScoringReportMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ApiScoringTriggerResponse;
 import io.gravitee.rest.api.management.v2.rest.model.ScoringStatus;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -57,6 +61,7 @@ public class ApiScoringResource extends AbstractResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Response getApiScoring() {
         var report = getLatestReportUseCase.execute(new GetLatestReportUseCase.Input(apiId)).report();
         if (report == null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMediaResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMediaResource.java
@@ -105,6 +105,7 @@ public class ApiMediaResource extends AbstractResource {
     @GET
     @Path("/{hash}")
     @Operation(summary = "Retrieve a media for an API")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Response getApiMediaImage(@Context Request request, @PathParam("hash") String hash) {
         MediaEntity mediaEntity = mediaService.findByHashAndApiId(hash, api);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResource.java
@@ -98,6 +98,7 @@ public class ApiMembersResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Response getApiMembersPermissions() {
         final GenericApiEntity genericApiEntity = apiSearchService.findGenericById(
             GraviteeContext.getExecutionContext(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResource.java
@@ -85,6 +85,7 @@ public class ApiPagesResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public List<PageEntity> getApiPages(
         @HeaderParam("Accept-Language") String acceptLang,
         @QueryParam("homepage") Boolean homepage,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResource.java
@@ -92,6 +92,7 @@ public class ApiPlansResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public List<PlanEntity> getApiPlans(
         @QueryParam("status") @DefaultValue("PUBLISHED") @Parameter(
             explode = Explode.FALSE,
@@ -191,6 +192,7 @@ public class ApiPlansResource extends AbstractResource {
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PlanEntity.class))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Response getApiPlan(@PathParam("plan") String plan) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiRatingResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiRatingResource.java
@@ -72,6 +72,7 @@ public class ApiRatingResource extends AbstractResource {
     @GET
     @Operation(summary = "List ratings for an API")
     @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Page<RatingEntity> getApiRating(@Min(1) @QueryParam("pageNumber") int pageNumber, @QueryParam("pageSize") int pageSize) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, api, false, false, false);
@@ -94,6 +95,7 @@ public class ApiRatingResource extends AbstractResource {
     @GET
     @Operation(summary = "Retrieve current rating for an API provided by the authenticated user")
     @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public RatingEntity getApiRatingByApiAndUser() {
         if (!isAuthenticated()) {
             return null;
@@ -114,6 +116,7 @@ public class ApiRatingResource extends AbstractResource {
     @Operation(summary = "Get the rating summary for an API")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public RatingSummaryEntity getApiRatingSummaryByApi() {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, api, false, false, false);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -173,6 +173,7 @@ public class ApiResource extends AbstractResource {
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ApiEntity.class))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Response getApi() {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         ApiEntity apiEntity = apiService.findById(executionContext, api);
@@ -212,6 +213,7 @@ public class ApiResource extends AbstractResource {
         content = @Content(mediaType = "*/*", schema = @Schema(type = "string", format = "binary"))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Response getApiPicture(@Context Request request) throws ApiNotFoundException {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         return getImageResponse(executionContext, request, apiService.getPicture(executionContext, api));
@@ -226,6 +228,7 @@ public class ApiResource extends AbstractResource {
         content = @Content(mediaType = "*/*", schema = @Schema(type = "string", format = "binary"))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Response getApiBackground(@Context Request request) throws ApiNotFoundException {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         return getImageResponse(executionContext, request, apiService.getBackground(executionContext, api));
@@ -428,6 +431,7 @@ public class ApiResource extends AbstractResource {
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ApiStateEntity.class))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public ApiStateEntity isApiSynchronized() {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         canReadApi(executionContext, api);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
@@ -30,6 +30,8 @@ import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -95,6 +97,7 @@ public class ApiSubscribersResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Collection<ApplicationListItem> getApiSubscribers(
         @QueryParam("query") final String query,
         @QueryParam("exclude") final List<ApplicationExcludeFilter> exclude,
@@ -157,6 +160,7 @@ public class ApiSubscribersResource extends AbstractResource {
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ApplicationListItemPagedResult.class))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public ApplicationListItemPagedResult getApiSubscribersPaged(
         @QueryParam("query") final String query,
         @QueryParam("exclude") final List<ApplicationExcludeFilter> exclude,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -153,6 +153,7 @@ public class ApisResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Collection<ApiListItem> getApis(@BeanParam final ApisParam apisParam, @QueryParam("ids") final List<String> ids) {
         return getApis(apisParam, ids, null).getData();
     }
@@ -171,6 +172,7 @@ public class ApisResource extends AbstractResource {
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ApiListItemPagedResult.class))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public ApiListItemPagedResult getApis(
         @BeanParam final ApisParam apisParam,
         @QueryParam("ids") final List<String> ids,
@@ -513,6 +515,7 @@ public class ApisResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public Response searchApis(@Parameter(name = "q", required = true) @NotNull @QueryParam("q") String query) {
         try {
             return Response.ok().entity(this.searchPagedApis(query, new ApisOrderParam("name"), true, null).getData()).build();
@@ -531,6 +534,7 @@ public class ApisResource extends AbstractResource {
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ApiListItem.class))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })
     public PagedResult<ApiListItem> searchPagedApis(
         @Parameter(name = "q", required = true) @NotNull @QueryParam("q") String query,
         @Parameter(


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13347

## Summary
- Add `@Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = { RolePermissionAction.READ }) })` annotation on 19 API read endpoints missing it across v1 (`management-rest`) and v2 (`management-v2-rest`) modules
- Prevents unauthorized users from accessing API data through unprotected GET/search endpoints

## Affected endpoints

### V2 (`management-v2-rest`)

| Resource | Path | Method |
|---|---|---|
| `ApiResource` | `GET /apis/{apiId}` | `getApiById()` |
| `ApiScoringResource` | `GET /apis/{apiId}/scoring` | `getApiScoring()` |

### V1 (`management-rest`)

| Resource | Path | Method |
|---|---|---|
| `ApisResource` | `GET /apis` | `getApis()` |
| `ApisResource` | `GET /apis/_paged` | `getApis()` (paged) |
| `ApisResource` | `POST /apis/_search` | `searchApis()` |
| `ApisResource` | `POST /apis/_search/_paged` | `searchPagedApis()` |
| `ApiResource` | `GET /apis/{api}` | `getApi()` |
| `ApiResource` | `GET /apis/{api}/picture` | `getApiPicture()` |
| `ApiResource` | `GET /apis/{api}/background` | `getApiBackground()` |
| `ApiResource` | `GET /apis/{api}/state` | `isApiSynchronized()` |
| `ApiPlansResource` | `GET /apis/{api}/plans` | `getApiPlans()` |
| `ApiPlansResource` | `GET /apis/{api}/plans/{plan}` | `getApiPlan()` |
| `ApiPagesResource` | `GET /apis/{api}/pages` | `getApiPages()` |
| `ApiRatingResource` | `GET /apis/{api}/ratings` | `getApiRating()` |
| `ApiRatingResource` | `GET /apis/{api}/ratings/current` | `getApiRatingByApiAndUser()` |
| `ApiRatingResource` | `GET /apis/{api}/ratings/summary` | `getApiRatingSummaryByApi()` |
| `ApiMembersResource` | `GET /apis/{api}/members/permissions` | `getApiMembersPermissions()` |
| `ApiMediaResource` | `GET /apis/{api}/media/{hash}` | `getApiMediaImage()` |
| `ApiSubscribersResource` | `GET /apis/{api}/subscribers` | `getApiSubscribers()` |
| `ApiSubscribersResource` | `GET /apis/{api}/subscribers/_paged` | `getApiSubscribersPaged()` |

## Test plan
- [ ] Verify that users without `ENVIRONMENT_API READ` permission get a 403 on the affected endpoints
- [ ] Verify that users with the permission can still access all endpoints normally
- [ ] Run existing integration tests to ensure no regression