### PR TITLE
feat: add mTLS toggle to portal-next settings page in management console

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -216,6 +216,9 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
       access: {
         enabled: true,
       },
+      mtls: {
+        enabled: false,
+      },
       banner: {
         enabled: true,
         title: 'testTitle',

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -242,6 +242,9 @@ export interface PortalSettingsPortalNext {
   access: {
     enabled: boolean;
   };
+  mtls?: {
+    enabled?: boolean;
+  };
   banner?: {
     title?: string;
     subtitle?: string;

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -447,6 +447,15 @@
                 aria-label="New Portal Enabled"
               ></mat-slide-toggle>
             </gio-form-slide-toggle>
+            <gio-form-slide-toggle formGroupName="mtls" class="portal__form__card__form-field">
+              <gio-form-label>Enable mTLS Certificate Management</gio-form-label>
+              <mat-slide-toggle
+                id="enable-portal-next-mtls"
+                formControlName="enabled"
+                gioFormSlideToggle
+                aria-label="mTLS Certificate Management Enabled"
+              ></mat-slide-toggle>
+            </gio-form-slide-toggle>
             @if (!!settings.portalNext?.access?.enabled) {
               <div class="new-developer-portal-actions">
                 @if (portalUrl) {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -198,6 +198,9 @@ describe('PortalSettingsComponent', () => {
           access: {
             enabled: false,
           },
+          mtls: {
+            enabled: false,
+          },
           banner: {
             ...portalSettingsMock.portalNext.banner,
             enabled: true,

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -107,6 +107,7 @@ interface PortalForm {
   }>;
   portalNext: FormGroup<{
     access: FormGroup<{ enabled: FormControl<boolean> }>;
+    mtls: FormGroup<{ enabled: FormControl<boolean> }>;
   }>;
   scheduler: FormGroup<{
     tasks: FormControl<number>;
@@ -387,6 +388,12 @@ export class PortalSettingsComponent implements OnInit {
             disabled: this.isReadonly('portalNext.access.enabled'),
           }),
         }),
+        mtls: new FormGroup({
+          enabled: new FormControl({
+            value: !!this.settings.portalNext?.mtls?.enabled,
+            disabled: this.isReadonly('portalNext.feature.mtlsEnabled'),
+          }),
+        }),
       }),
       scheduler: new FormGroup({
         tasks: new FormControl({
@@ -636,6 +643,7 @@ export class PortalSettingsComponent implements OnInit {
           ...this.settings.portalNext.access,
           ...this.portalForm.get('portalNext.access').value,
         },
+        mtls: this.portalForm.get('portalNext.mtls').value,
       },
     };
 

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -391,7 +391,7 @@ export class PortalSettingsComponent implements OnInit {
         mtls: new FormGroup({
           enabled: new FormControl({
             value: !!this.settings.portalNext?.mtls?.enabled,
-            disabled: this.isReadonly('portalNext.feature.mtlsEnabled'),
+            disabled: this.isReadonly('portalNext.mtls.enabled'),
           }),
         }),
       }),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import lombok.AccessLevel;
 import lombok.Getter;
 
 /**
@@ -144,7 +143,7 @@ public enum Key {
     PORTAL_NEXT_THEME_CUSTOM_CSS("portal.next.theme.customCss", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_THEME_FONT_FAMILY("portal.next.theme.font.family", "\"Roboto\", sans-serif", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_CATALOG_VIEW_MODE("portal.next.catalog.viewMode", new HashSet<>(singletonList(ENVIRONMENT))),
-    PORTAL_NEXT_MTLS_ENABLED("portal.next.feature.mtlsEnabled", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_MTLS_ENABLED("portal.next.mtls.enabled", new HashSet<>(singletonList(ENVIRONMENT))),
 
     MANAGEMENT_TITLE("management.title", "Gravitee.io Management", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     MANAGEMENT_URL("management.url", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13258

## Description

- Added "Enable mTLS Certificate Management" slide-toggle to the portal-next settings card in management console (`portal-settings.component.html`)
- Wired `mtlsEnabled` FormControl (guarded by `portalNext.feature.mtlsEnabled` read-only check) into the form group and save path (`portal-settings.component.ts`)
- Added `mtlsEnabled?: boolean` to `PortalSettingsPortalNext` interface and `fakePortalSettings` fixture; updated spec expected bodies accordingly     