### PR TITLE
fix: apply NG portal visibility rules to /apis/_search when view=documentation

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.spec.ts
@@ -326,6 +326,16 @@ describe('SubscriptionsComponent', () => {
     c.verify();
   });
 
+  it('should send view=documentation when loading API filter options', async () => {
+    await setup();
+
+    fixture.componentInstance.apiResultsLoader({ searchTerm: 'payment', page: 1 }).subscribe();
+
+    const req = http.expectOne(req => req.url.includes('/apis/_search'));
+    expect(req.request.params.get('view')).toBe('documentation');
+    req.flush({ data: [], metadata: {} });
+  });
+
   it('hasSubscriptions is false when no data and no filters', async () => {
     await setup();
     expect(fixture.componentInstance.hasSubscriptions()).toBe(false);

--- a/gravitee-apim-portal-webui-next/src/services/api.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api.service.spec.ts
@@ -47,7 +47,11 @@ describe('ApiService', () => {
         done();
       });
 
-      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/_search?page=1&category=ALL&size=9&q=`);
+      const req = httpTestingController.expectOne(
+        r =>
+          r.url === `${TESTING_BASE_URL}/apis/_search` &&
+          r.params.get(PortalApiViewParam.QUERY_PARAM_NAME) === PortalApiViewParam.DOCUMENTATION,
+      );
       expect(req.request.method).toEqual('POST');
 
       req.flush(apisResponse);
@@ -61,7 +65,11 @@ describe('ApiService', () => {
         done();
       });
 
-      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/apis/_search?page=2&category=ALL&size=99&q=`);
+      const req = httpTestingController.expectOne(
+        r =>
+          r.url === `${TESTING_BASE_URL}/apis/_search` &&
+          r.params.get(PortalApiViewParam.QUERY_PARAM_NAME) === PortalApiViewParam.DOCUMENTATION,
+      );
       expect(req.request.method).toEqual('POST');
 
       req.flush(apisResponse);

--- a/gravitee-apim-portal-webui-next/src/services/api.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/api.service.ts
@@ -38,6 +38,7 @@ export class ApiService {
         category: category !== 'all' && category !== undefined ? category : '',
         size,
         q: q,
+        [PortalApiViewParam.QUERY_PARAM_NAME]: PortalApiViewParam.DOCUMENTATION,
       },
     });
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
@@ -15,11 +15,13 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.apim.core.api.use_case.SearchApisForPortalUseCase;
 import io.gravitee.apim.core.category.use_case.GetCategoryApisUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
+import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
@@ -30,6 +32,7 @@ import io.gravitee.rest.api.portal.rest.model.Category;
 import io.gravitee.rest.api.portal.rest.model.FilterApiQuery;
 import io.gravitee.rest.api.portal.rest.resource.param.ApisParam;
 import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
+import io.gravitee.rest.api.portal.rest.resource.param.PortalApiViewParam;
 import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
 import io.gravitee.rest.api.service.CategoryService;
@@ -54,6 +57,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -88,6 +92,9 @@ public class ApisResource extends AbstractResource<Api, String> {
 
     @Inject
     private CategoryMapper categoryMapper;
+
+    @Inject
+    private SearchApisForPortalUseCase searchApisForPortalUseCase;
 
     @GET
     @Path("categories")
@@ -160,10 +167,30 @@ public class ApisResource extends AbstractResource<Api, String> {
     public Response searchApis(
         @QueryParam("q") String query,
         @QueryParam("category") String category,
+        @QueryParam(PortalApiViewParam.QUERY_PARAM_NAME) String view,
         @BeanParam PaginationParam paginationParam
     ) {
         try {
             final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+
+            if (PortalApiViewParam.isDocumentationView(view)) {
+                var output = searchApisForPortalUseCase.execute(
+                    new SearchApisForPortalUseCase.Input(
+                        executionContext.getEnvironmentId(),
+                        executionContext.getOrganizationId(),
+                        getAuthenticatedUserOrNull(),
+                        query,
+                        new PageableImpl(paginationParam.getPage(), paginationParam.getSize()),
+                        null
+                    )
+                );
+                List<String> apiIds = output.apis().getContent().stream().map(io.gravitee.apim.core.api.model.Api::getId).toList();
+                Map<String, Map<String, Object>> metadata = new HashMap<>(
+                    Map.of("paginateMetaData", new HashMap<>(Map.of("totalElements", output.apis().getTotalElements())))
+                );
+                return createListResponse(executionContext, apiIds, paginationParam, metadata);
+            }
+
             Collection<String> apisList;
             if (category == null || category.isEmpty()) {
                 apisList = filteringService.searchApis(executionContext, getAuthenticatedUserOrNull(), query);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -26,12 +27,18 @@ import static org.mockito.Mockito.when;
 
 import inmemory.ApiAuthorizationDomainServiceInMemory;
 import inmemory.ApiCategoryOrderQueryServiceInMemory;
+import inmemory.ApiPortalSearchQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.CategoryQueryServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.ValidateResourceDomainServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.category.model.ApiCategoryOrder;
 import io.gravitee.apim.core.category.model.Category;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.CategoryEntity;
@@ -82,6 +89,12 @@ public class ApisResourceTest extends AbstractResourceTest {
 
     @Autowired
     private ValidateResourceDomainServiceInMemory validateResourceDomainServiceInMemory;
+
+    @Autowired
+    private ApiPortalSearchQueryServiceInMemory apiPortalSearchQueryServiceInMemory;
+
+    @Autowired
+    private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryServiceInMemory;
 
     @Override
     protected String contextPath() {
@@ -196,6 +209,8 @@ public class ApisResourceTest extends AbstractResourceTest {
         apiCategoryOrderQueryServiceInMemory.reset();
         apiAuthorizationDomainServiceInMemory.reset();
         apiQueryServiceInMemory.reset();
+        apiPortalSearchQueryServiceInMemory.reset();
+        portalNavigationItemsQueryServiceInMemory.reset();
 
         final Category myCat = Category.builder().id("myCat").build();
         categoryQueryServiceInMemory.initWith(List.of(myCat));
@@ -722,6 +737,47 @@ public class ApisResourceTest extends AbstractResourceTest {
         ApisResponse apiResponse = response.readEntity(ApisResponse.class);
         assertEquals(1, apiResponse.getData().size());
         assertTrue(getmaxLabelsListSize(apiResponse) > 0);
+    }
+
+    @Test
+    void shouldSearchApisWithDocumentationViewUsingNgPortalRules() {
+        String envId = GraviteeContext.getExecutionContext().getEnvironmentId();
+        String orgId = GraviteeContext.getExecutionContext().getOrganizationId();
+
+        portalNavigationItemsQueryServiceInMemory.initWith(
+            List.of(
+                PortalNavigationApi.builder()
+                    .id(PortalNavigationItemId.random())
+                    .organizationId(orgId)
+                    .environmentId(envId)
+                    .title("Nav for ng-api")
+                    .area(PortalArea.TOP_NAVBAR)
+                    .order(0)
+                    .apiId("ng-api")
+                    .published(true)
+                    .visibility(PortalVisibility.PUBLIC)
+                    .build()
+            )
+        );
+        apiPortalSearchQueryServiceInMemory.initWith(List.of(Api.builder().id("ng-api").name("ng-api").environmentId(envId).build()));
+
+        ApiEntity ngApiEntity = new ApiEntity();
+        ngApiEntity.setId("ng-api");
+        ngApiEntity.setName("ng-api");
+        ngApiEntity.setLifecycleState(ApiLifecycleState.UNPUBLISHED);
+
+        doReturn(List.of(ngApiEntity)).when(apiSearchService).search(eq(GraviteeContext.getExecutionContext()), any());
+
+        // When
+        final Response response = target("/_search")
+            .queryParam("q", "ng-api")
+            .queryParam("view", "documentation")
+            .request()
+            .post(Entity.json(null));
+
+        ApisResponse apiResponse = response.readEntity(ApisResponse.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        assertThat(apiResponse.getData()).hasSize(1).extracting("id").containsExactly("ng-api");
     }
 
     private int getmaxLabelsListSize(ApisResponse apiResponse) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/SearchApisForPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/SearchApisForPortalUseCase.java
@@ -30,6 +30,10 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Searches APIs visible in the ng portal documentation context.
+ * Visibility rules in this use case must stay aligned with {@code GetVisiblePortalNavigationApisUseCase}.
+ */
 @UseCase
 @RequiredArgsConstructor
 public class SearchApisForPortalUseCase {


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-13315

## Description
The subscriptions page API filter dropdown was using classic portal visibility rules
(`lifecycle=PUBLISHED`) instead of NG portal rules (published navigation item).

- `POST /apis/_search` now accepts `view=documentation` query parameter — when set,
  delegates to `SearchApisForPortalUseCase` which filters by published portal navigation
  items instead of API lifecycle state
- `ApiService.search()` in portal-next always sends `view=documentation` (hardcoded —
  the service lives exclusively in the NG portal context)


## Additional context

First part of the video shows that none of my APIs are published for the classic portal :) 

https://github.com/user-attachments/assets/0f81c23c-1af3-436a-a208-a51772d48cf9

