### PR TITLE
fix: analytics error responses

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/JsonMappingExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/JsonMappingExceptionMapper.java
@@ -16,14 +16,15 @@
 package io.gravitee.rest.api.management.v2.rest.exceptionMapper;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
-import io.gravitee.common.http.HttpStatusCode;
-import io.gravitee.rest.api.management.v2.rest.exceptionMapper.AbstractExceptionMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.ErrorDetailsInner;
 import jakarta.annotation.Priority;
-import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.Provider;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Provider
 @Priority(1)
@@ -31,9 +32,44 @@ public class JsonMappingExceptionMapper extends AbstractExceptionMapper<JsonMapp
 
     @Override
     public Response toResponse(JsonMappingException exception) {
-        return Response.status(Response.Status.BAD_REQUEST)
-            .type(MediaType.APPLICATION_JSON_TYPE)
-            .entity(new Error().httpStatus(Response.Status.BAD_REQUEST.getStatusCode()).message(exception.getOriginalMessage()))
-            .build();
+        return Response.status(Response.Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON_TYPE).entity(buildError(exception)).build();
+    }
+
+    private Error buildError(JsonMappingException exception) {
+        var error = new Error()
+            .httpStatus(Response.Status.BAD_REQUEST.getStatusCode())
+            .technicalCode("invalidValue")
+            .message(sanitizeMessage(exception));
+
+        var location = buildFieldLocation(exception);
+        if (location != null) {
+            error.details(List.of(new ErrorDetailsInner().message(sanitizeMessage(exception)).location(location)));
+        }
+
+        return error;
+    }
+
+    /**
+     * When JSON deserialization fails on an invalid enum value, the exception message
+     * includes the fully-qualified Java class name. We extract just the cause's message
+     * to avoid exposing internal implementation details in API responses.
+     */
+    private String sanitizeMessage(JsonMappingException exception) {
+        if (exception instanceof ValueInstantiationException && exception.getCause() != null) {
+            return exception.getCause().getMessage();
+        }
+        return exception.getOriginalMessage();
+    }
+
+    private String buildFieldLocation(JsonMappingException exception) {
+        var path = exception.getPath();
+        if (path == null || path.isEmpty()) {
+            return null;
+        }
+        return path
+            .stream()
+            .map(ref -> ref.getFieldName() != null ? ref.getFieldName() : "[" + ref.getIndex() + "]")
+            .collect(Collectors.joining("."))
+            .replace(".[", "[");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/ValidationDomainExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/ValidationDomainExceptionMapper.java
@@ -31,6 +31,7 @@ public class ValidationDomainExceptionMapper extends AbstractDomainExceptionMapp
         return new Error()
             .httpStatus(Response.Status.BAD_REQUEST.getStatusCode())
             .message(vde.getMessage())
+            .technicalCode(vde.getTechnicalCode())
             .parameters(vde.getParameters());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/JsonMappingExceptionMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/JsonMappingExceptionMapperTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.exceptionMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class JsonMappingExceptionMapperTest {
+
+    private JsonMappingExceptionMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new JsonMappingExceptionMapper();
+    }
+
+    @Test
+    void should_sanitize_class_name_from_value_instantiation_exception() {
+        var cause = new IllegalArgumentException("Unexpected value 'UNSUPPORTED_METRIC'");
+        var exception = ValueInstantiationException.from(
+            null,
+            "Cannot construct instance of io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricName, problem: Unexpected value 'UNSUPPORTED_METRIC'",
+            (JavaType) null,
+            cause
+        );
+
+        try (Response response = mapper.toResponse(exception)) {
+            assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+            assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+            assertThat(response.getEntity()).isInstanceOf(Error.class);
+
+            Error error = (Error) response.getEntity();
+            assertThat(error.getHttpStatus()).isEqualTo(400);
+            assertThat(error.getMessage()).isEqualTo("Unexpected value 'UNSUPPORTED_METRIC'");
+            assertThat(error.getMessage()).doesNotContain("io.gravitee");
+            assertThat(error.getTechnicalCode()).isEqualTo("invalidValue");
+        }
+    }
+
+    @Test
+    void should_use_original_message_for_regular_json_mapping_exception() {
+        var exception = JsonMappingException.from(
+            (com.fasterxml.jackson.core.JsonParser) null,
+            "Cannot deserialize value of type `String` from Array value"
+        );
+
+        try (Response response = mapper.toResponse(exception)) {
+            assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+
+            Error error = (Error) response.getEntity();
+            assertThat(error.getMessage()).isEqualTo("Cannot deserialize value of type `String` from Array value");
+            assertThat(error.getTechnicalCode()).isEqualTo("invalidValue");
+        }
+    }
+
+    @Test
+    void should_include_field_location_in_details() {
+        var cause = new IllegalArgumentException("Unexpected value 'INVALID'");
+        var exception = ValueInstantiationException.from(null, "problem", (JavaType) null, cause);
+        exception.prependPath(null, "name");
+        exception.prependPath(null, "metrics");
+
+        try (Response response = mapper.toResponse(exception)) {
+            Error error = (Error) response.getEntity();
+            assertThat(error.getDetails()).hasSize(1);
+            assertThat(error.getDetails().getFirst().getLocation()).isEqualTo("metrics.name");
+            assertThat(error.getDetails().getFirst().getMessage()).isEqualTo("Unexpected value 'INVALID'");
+        }
+    }
+
+    @Test
+    void should_format_array_index_in_field_location() {
+        var cause = new IllegalArgumentException("Unexpected value 'INVALID'");
+        var exception = ValueInstantiationException.from(null, "problem", (JavaType) null, cause);
+        exception.prependPath(null, "name");
+        exception.prependPath(new Object(), 0);
+        exception.prependPath(null, "metrics");
+
+        try (Response response = mapper.toResponse(exception)) {
+            Error error = (Error) response.getEntity();
+            assertThat(error.getDetails()).hasSize(1);
+            assertThat(error.getDetails().getFirst().getLocation()).isEqualTo("metrics[0].name");
+        }
+    }
+
+    @Test
+    void should_not_include_details_when_no_path() {
+        var exception = JsonMappingException.from((com.fasterxml.jackson.core.JsonParser) null, "Some error");
+
+        try (Response response = mapper.toResponse(exception)) {
+            Error error = (Error) response.getEntity();
+            assertThat(error.getDetails()).isNullOrEmpty();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/ValidationDomainExceptionMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/domain/ValidationDomainExceptionMapperTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.exceptionMapper.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.analytics_engine.exception.InvalidQueryException;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ValidationDomainExceptionMapperTest {
+
+    private ValidationDomainExceptionMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ValidationDomainExceptionMapper();
+    }
+
+    @Test
+    void should_include_technical_code_when_present() {
+        var exception = InvalidQueryException.forUnknownAPIType("INVALID_TYPE");
+
+        try (Response response = mapper.toResponse(exception)) {
+            assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+            assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+            assertThat(response.getEntity()).isInstanceOf(Error.class);
+
+            Error error = (Error) response.getEntity();
+            assertThat(error.getHttpStatus()).isEqualTo(400);
+            assertThat(error.getMessage()).isEqualTo("Unknown API type 'INVALID_TYPE'");
+            assertThat(error.getTechnicalCode()).isEqualTo("analytics.filter.invalidValue");
+        }
+    }
+
+    @Test
+    void should_handle_null_technical_code() {
+        var exception = new ValidationDomainException("Some validation error");
+
+        try (Response response = mapper.toResponse(exception)) {
+            assertThat(response.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+
+            Error error = (Error) response.getEntity();
+            assertThat(error.getHttpStatus()).isEqualTo(400);
+            assertThat(error.getMessage()).isEqualTo("Some validation error");
+            assertThat(error.getTechnicalCode()).isNull();
+        }
+    }
+
+    @Test
+    void should_include_parameters_when_present() {
+        var params = Map.of("field", "apiType");
+        var exception = new ValidationDomainException("Invalid value", params, "analytics.filter.invalidValue");
+
+        try (Response response = mapper.toResponse(exception)) {
+            Error error = (Error) response.getEntity();
+            assertThat(error.getParameters()).containsEntry("field", "apiType");
+            assertThat(error.getTechnicalCode()).isEqualTo("analytics.filter.invalidValue");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/exception/InvalidQueryException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/exception/InvalidQueryException.java
@@ -27,6 +27,10 @@ public class InvalidQueryException extends ValidationDomainException {
         super(message);
     }
 
+    public InvalidQueryException(String message, String technicalCode) {
+        super(message, technicalCode);
+    }
+
     public static InvalidQueryException forMaximumFacetsExceeded(int allowed, int actual) {
         return new InvalidQueryException("Cannot query for more than " + allowed + " facets, got " + actual);
     }
@@ -64,6 +68,6 @@ public class InvalidQueryException extends ValidationDomainException {
     }
 
     public static InvalidQueryException forUnknownAPIType(String apiType) {
-        return new InvalidQueryException("Unknown API type '" + apiType + "'");
+        return new InvalidQueryException("Unknown API type '" + apiType + "'", "analytics.filter.invalidValue");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/exception/ValidationDomainException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/exception/ValidationDomainException.java
@@ -23,17 +23,29 @@ import lombok.Getter;
 public class ValidationDomainException extends AbstractDomainException {
 
     private final Map<String, String> parameters = new HashMap<>();
+    private final String technicalCode;
 
     public ValidationDomainException(String message) {
+        this(message, (String) null);
+    }
+
+    public ValidationDomainException(String message, String technicalCode) {
         super(message);
+        this.technicalCode = technicalCode;
     }
 
     public ValidationDomainException(String message, Map<String, String> parameters) {
+        this(message, parameters, null);
+    }
+
+    public ValidationDomainException(String message, Map<String, String> parameters, String technicalCode) {
         super(message);
         this.parameters.putAll(parameters);
+        this.technicalCode = technicalCode;
     }
 
     public ValidationDomainException(String message, Throwable cause) {
         super(message, cause);
+        this.technicalCode = null;
     }
 }


### PR DESCRIPTION
## Issue

Fixes [GKO-2603](https://gravitee.atlassian.net/browse/GKO-2603)

**Problem:**

Analytics API error responses leaked internal Java class names (e.g. Cannot construct instance of io.gravitee...MetricName)
technicalCode field was never populated, breaking compliance with the OpenAPI Error schema

**Changes:**

- JsonMappingExceptionMapper: extract cause message instead of raw exception message to prevent class name leaks; populate technicalCode and details with field location (e.g. metrics[0].name)

- ValidationDomainExceptionMapper: forward technicalCode from the domain exception to the Error response

- ValidationDomainException: add optional technicalCode field

- InvalidQueryException: set technicalCode to analytics.filter.invalidValue for unknown API type errors

Tests: 8 new unit tests covering both mappers (message sanitization, technicalCode, field location with array indices, backward compatibility)

```
 ~ curl -s -u admin:admin -X POST \
  http://localhost:8083/management/v2/environments/DEFAULT/analytics/measures \
  -H 'Content-Type: application/json' \
  -d '{
    "timeRange": { "from": 1711900800000, "to": 1711987200000 },
    "metrics": [
      { "name": "UNSUPPORTED_METRIC", "measures": ["COUNT"] }
    ]
  }' | jq .
```
gets response
```
{
  "httpStatus": 400,
  "message": "Unexpected value 'UNSUPPORTED_METRIC'",
  "technicalCode": "invalidValue",
  "parameters": {},
  "details": [
    {
      "message": "Unexpected value 'UNSUPPORTED_METRIC'",
      "location": "metrics[0].name"
    }
  ]
}
```

```
➜  ~ curl -s -u admin:admin -X POST \
  http://localhost:8083/management/v2/environments/DEFAULT/analytics/measures \
  -H 'Content-Type: application/json' \
  -d '{
    "timeRange": { "from": 1711900800000, "to": 1711987200000 },
    "metrics": [
      { "name": "HTTP_REQUESTS", "measures": ["COUNT"] }
    ],
    "filters": [
      { "name": "API_TYPE", "operator": "EQ", "value": "INVALID_API_TYPE" }
    ]
  }' | jq .
```
gets response
```
{
  "httpStatus": 400,
  "message": "Unknown API type 'INVALID_API_TYPE'",
  "technicalCode": "analytics.filter.invalidValue",
  "parameters": {},
  "details": []
}
```

[GKO-2603]: https://gravitee.atlassian.net/browse/GKO-2603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ