### PR TITLE
fix(services): move primary node check to run() to fix startup race in cluster mode

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/main/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/main/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerService.java
@@ -68,19 +68,21 @@ public class ScheduledAuditCleanerService extends AbstractService implements Run
 
     @Override
     protected void doStart() throws Exception {
-        if (clusterManager.self().primary()) {
-            if (enabled) {
-                super.doStart();
-                log.info("Audit cleaner service has been initialized with cron [{}]", cronTrigger);
-                scheduler.schedule(this, new CronTrigger(cronTrigger));
-            } else {
-                log.warn("Audit cleaner service has been disabled");
-            }
+        if (enabled) {
+            super.doStart();
+            log.info("Audit cleaner service has been initialized with cron [{}]", cronTrigger);
+            scheduler.schedule(this, new CronTrigger(cronTrigger));
+        } else {
+            log.warn("Audit cleaner service has been disabled");
         }
     }
 
     @Override
     public void run() {
+        if (!clusterManager.self().primary()) {
+            log.debug("Audit cleaner service is not the primary node, skipping execution");
+            return;
+        }
         var environments = stream(organizationService.findAll())
             .flatMap(o -> stream(environmentService.findByOrganization(o.getId())))
             .toList();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/test/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/test/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerServiceTest.java
@@ -17,8 +17,11 @@ package io.gravitee.rest.api.services.audit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.audit.use_case.RemoveOldAuditDataUseCase;
@@ -38,6 +41,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
 
 @ExtendWith(MockitoExtension.class)
 class ScheduledAuditCleanerServiceTest {
@@ -79,6 +83,9 @@ class ScheduledAuditCleanerServiceTest {
     @Test
     void run_cleaning_on_all_environments() {
         // given
+        Member mockMember = mock(Member.class);
+        when(mockMember.primary()).thenReturn(true);
+        when(clusterManager.self()).thenReturn(mockMember);
         OrganizationEntity org = new OrganizationEntity();
         org.setId("oId");
         when(organizationService.findAll()).thenReturn(List.of(org));
@@ -97,5 +104,40 @@ class ScheduledAuditCleanerServiceTest {
         assertThat(inputArgumentCaptor.getAllValues())
             .map(RemoveOldAuditDataUseCase.Input::maxAge)
             .containsOnly(Duration.ofDays(1), Duration.ofDays(1));
+    }
+
+    @Test
+    void should_schedule_even_when_not_primary_at_startup() throws Exception {
+        // Given - simulate the cluster race: primary not yet elected at doStart() time
+        var service = new ScheduledAuditCleanerService(
+            scheduler,
+            "@daily",
+            true,
+            1,
+            removeOldAuditDataUseCase,
+            organizationService,
+            environmentService,
+            clusterManager
+        );
+
+        // When
+        service.doStart();
+
+        // Then - scheduler is registered regardless; primary check happens in run()
+        verify(scheduler).schedule(eq(service), any(CronTrigger.class));
+    }
+
+    @Test
+    void should_skip_cleanup_when_not_primary() {
+        // Given
+        Member mockMember = mock(Member.class);
+        when(mockMember.primary()).thenReturn(false);
+        when(clusterManager.self()).thenReturn(mockMember);
+
+        // When
+        sut.run();
+
+        // Then
+        verifyNoInteractions(organizationService);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-events/src/main/java/io/gravitee/rest/api/services/events/ScheduledEventsCleaningService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-events/src/main/java/io/gravitee/rest/api/services/events/ScheduledEventsCleaningService.java
@@ -71,19 +71,21 @@ public class ScheduledEventsCleaningService extends AbstractService implements R
 
     @Override
     protected void doStart() throws Exception {
-        if (clusterManager.self().primary()) {
-            if (enabled) {
-                super.doStart();
-                logger.info("Event cleaner service has been initialized with cron [{}]", cronTrigger);
-                scheduler.schedule(this, new CronTrigger(cronTrigger));
-            } else {
-                logger.warn("Event cleaner Refresher service has been disabled");
-            }
+        if (enabled) {
+            super.doStart();
+            logger.info("Event cleaner service has been initialized with cron [{}]", cronTrigger);
+            scheduler.schedule(this, new CronTrigger(cronTrigger));
+        } else {
+            logger.warn("Event cleaner Refresher service has been disabled");
         }
     }
 
     @Override
     public void run() {
+        if (!clusterManager.self().primary()) {
+            logger.debug("Event cleaner service is not the primary node, skipping execution");
+            return;
+        }
         var environments = stream(organizationService.findAll())
             .flatMap(o -> stream(environmentService.findByOrganization(o.getId())))
             .toList();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-events/src/test/java/io/gravitee/rest/api/services/events/ScheduledEventsCleaningServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-events/src/test/java/io/gravitee/rest/api/services/events/ScheduledEventsCleaningServiceTest.java
@@ -18,7 +18,9 @@ package io.gravitee.rest.api.services.events;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.event.use_case.CleanupEventsUseCase;
@@ -73,23 +75,6 @@ class ScheduledEventsCleaningServiceTest {
 
     @Test
     void should_be_enabled_by_default() throws Exception {
-        // Given
-        Member mockMember = org.mockito.Mockito.mock(Member.class);
-        when(mockMember.primary()).thenReturn(true);
-        when(clusterManager.self()).thenReturn(mockMember);
-
-        scheduledEventsCleaningService = new ScheduledEventsCleaningService(
-            cleanupEventsUseCase,
-            organizationService,
-            environmentService,
-            scheduler,
-            clusterManager,
-            "@daily",
-            5,
-            true, // enabled = true
-            30
-        );
-
         // When
         scheduledEventsCleaningService.doStart();
 
@@ -100,17 +85,13 @@ class ScheduledEventsCleaningServiceTest {
     @Test
     void should_schedule_task_when_enabled() throws Exception {
         // Given
-        Member mockMember = org.mockito.Mockito.mock(Member.class);
-        when(mockMember.primary()).thenReturn(true);
-        when(clusterManager.self()).thenReturn(mockMember);
-        String cronExpression = "@hourly";
         scheduledEventsCleaningService = new ScheduledEventsCleaningService(
             cleanupEventsUseCase,
             organizationService,
             environmentService,
             scheduler,
             clusterManager,
-            cronExpression,
+            "@hourly",
             5,
             true,
             30
@@ -126,17 +107,13 @@ class ScheduledEventsCleaningServiceTest {
     @Test
     void should_use_correct_cron_expression() throws Exception {
         // Given
-        Member mockMember = org.mockito.Mockito.mock(Member.class);
-        when(mockMember.primary()).thenReturn(true);
-        when(clusterManager.self()).thenReturn(mockMember);
-        String cronExpression = "0 0 2 * * ?"; // Daily at 2 AM
         scheduledEventsCleaningService = new ScheduledEventsCleaningService(
             cleanupEventsUseCase,
             organizationService,
             environmentService,
             scheduler,
             clusterManager,
-            cronExpression,
+            "0 0 2 * * ?",
             5,
             true,
             30
@@ -290,55 +267,45 @@ class ScheduledEventsCleaningServiceTest {
 
     @Test
     void should_log_info_message_when_starting() throws Exception {
-        // Given
-        Member mockMember = org.mockito.Mockito.mock(Member.class);
-        when(mockMember.primary()).thenReturn(true);
-        when(clusterManager.self()).thenReturn(mockMember);
-        scheduledEventsCleaningService = new ScheduledEventsCleaningService(
-            cleanupEventsUseCase,
-            organizationService,
-            environmentService,
-            scheduler,
-            clusterManager,
-            "@daily",
-            5,
-            true,
-            30
-        );
-
         // When
         scheduledEventsCleaningService.doStart();
 
         // Then
-        // The service should log an info message about initialization
-        // This is verified by the fact that the service starts without throwing exceptions
-        assertThat(scheduledEventsCleaningService).isNotNull();
+        verify(scheduler).schedule(eq(scheduledEventsCleaningService), any(CronTrigger.class));
     }
 
     @Test
     void should_not_log_warning_when_enabled() throws Exception {
-        // Given
-        Member mockMember = org.mockito.Mockito.mock(Member.class);
-        when(mockMember.primary()).thenReturn(true);
-        when(clusterManager.self()).thenReturn(mockMember);
-        scheduledEventsCleaningService = new ScheduledEventsCleaningService(
-            cleanupEventsUseCase,
-            organizationService,
-            environmentService,
-            scheduler,
-            clusterManager,
-            "@daily",
-            5,
-            true, // enabled = true
-            30
-        );
-
         // When
         scheduledEventsCleaningService.doStart();
 
         // Then
-        // No warning should be logged when the service is enabled
-        // This is verified by the fact that the service starts without throwing exceptions
-        assertThat(scheduledEventsCleaningService).isNotNull();
+        verify(scheduler).schedule(eq(scheduledEventsCleaningService), any(CronTrigger.class));
+    }
+
+    @Test
+    void should_schedule_even_when_not_primary_at_startup() throws Exception {
+        // Given - no primary mock needed: doStart() no longer checks cluster state
+        // (this would have failed before the fix, when primary()=false prevented scheduling)
+
+        // When
+        scheduledEventsCleaningService.doStart();
+
+        // Then - scheduler is registered regardless; primary check happens in run()
+        verify(scheduler).schedule(eq(scheduledEventsCleaningService), any(CronTrigger.class));
+    }
+
+    @Test
+    void should_skip_cleanup_when_not_primary() {
+        // Given
+        Member mockMember = mock(Member.class);
+        when(mockMember.primary()).thenReturn(false);
+        when(clusterManager.self()).thenReturn(mockMember);
+
+        // When
+        scheduledEventsCleaningService.run();
+
+        // Then
+        verifyNoInteractions(organizationService);
     }
 }

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -188,6 +188,14 @@ data:
       subscription:
         {{- toYaml .Values.api.services.subscription | nindent 8 }}
       {{- end }}
+      {{- if .Values.api.services.events.enabled }}
+      events:
+        {{- toYaml .Values.api.services.events | nindent 8 }}
+      {{- end }}
+      {{- if .Values.api.services.audit.enabled }}
+      audit:
+        {{- toYaml .Values.api.services.audit | nindent 8 }}
+      {{- end }}
 
     {{- if and .Values.api.http .Values.api.http.client }}
     httpClient:

--- a/helm/tests/api/configmap_services_test.yaml
+++ b/helm/tests/api/configmap_services_test.yaml
@@ -17,3 +17,67 @@ tests:
             \s subscription:
             \s   enabled: true
             \s   pre-expiration-notification-schedule: 15,10,5
+
+  - it: Enable events cleaner service with custom settings
+    template: api/api-configmap.yaml
+    set:
+      api:
+        services:
+          events:
+            enabled: true
+            cron: "0 0 12 * * *"
+            keep: 10
+            timeToLive: 15
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s events:
+            \s   cron: 0 0 12 \* \* \*
+            \s   enabled: true
+            \s   keep: 10
+            \s   timeToLive: 15
+
+  - it: Does not render events section when disabled
+    template: api/api-configmap.yaml
+    set:
+      api:
+        services:
+          events:
+            enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "events:"
+
+  - it: Enable audit cleaner service with custom retention
+    template: api/api-configmap.yaml
+    set:
+      api:
+        services:
+          audit:
+            enabled: true
+            cron: "0 1 * * * *"
+            retention:
+              days: 90
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s audit:
+            \s   cron: 0 1 \* \* \* \*
+            \s   enabled: true
+            \s   retention:
+            \s     days: 90
+
+  - it: Does not render audit section when disabled
+    template: api/api-configmap.yaml
+    set:
+      api:
+        services:
+          audit:
+            enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "audit:"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -703,6 +703,16 @@ api:
     subscription:
       enabled: false
 #      pre-expiration-notification-schedule: 15,10,5
+    events:
+      enabled: false
+#      cron: "0 0 12 * * *"
+#      keep: 5
+#      timeToLive: 30
+    audit:
+      enabled: false
+#      cron: "0 1 * * * *"
+#      retention:
+#        days: 365
   http:
     services:
       core:


### PR DESCRIPTION
## Summary

- Fixes APIM-13404
- `ScheduledEventsCleaningService` and `ScheduledAuditCleanerService` both checked `clusterManager.self().primary()` in `doStart()` — a one-shot evaluation at startup
- In Kubernetes, if the Hazelcast cluster has not yet elected a primary when `doStart()` fires, `primary()` returns `false` on every pod and the scheduler is never registered — the service silently never runs
- Fix: always register the scheduler in `doStart()` (when enabled), and guard with `primary()` in `run()` instead — matching the pattern already used by `ScheduledCommandsRefresherServiceImpl`

## Test plan

- [ ] Start two mapi instances in cluster mode — verify both log the "initialized with cron" message
- [ ] Verify cleanup only executes on the primary (single "Start cleanup environment" log per tick)
- [ ] Verify non-primary instances skip execution silently on each tick
- [ ] Verify behavior is unchanged in standalone (single instance) mode