### PR TITLE
fix: register NoOpMetricsRepository and add null-guards for v4 analytics

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpAnalyticsRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpAnalyticsRepositoryConfiguration.java
@@ -18,10 +18,12 @@ package io.gravitee.repository.noop;
 import io.gravitee.repository.analytics.api.AnalyticsRepository;
 import io.gravitee.repository.healthcheck.api.HealthCheckRepository;
 import io.gravitee.repository.log.api.LogRepository;
+import io.gravitee.repository.log.v4.api.MetricsRepository;
 import io.gravitee.repository.monitoring.MonitoringRepository;
 import io.gravitee.repository.noop.analytics.NoOpAnalyticsRepository;
 import io.gravitee.repository.noop.healthcheck.NoOpHealthCheckRepository;
 import io.gravitee.repository.noop.log.NoOpLogRepository;
+import io.gravitee.repository.noop.log.v4.NoOpMetricsRepository;
 import io.gravitee.repository.noop.monitor.NoOpMonitoringRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -61,6 +63,11 @@ public class NoOpAnalyticsRepositoryConfiguration {
     @Bean
     public io.gravitee.repository.log.v4.api.LogRepository logV4Repository() {
         return new io.gravitee.repository.noop.log.v4.NoOpLogRepository();
+    }
+
+    @Bean
+    public MetricsRepository metricsRepository() {
+        return new NoOpMetricsRepository();
     }
 
     @Bean


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13392

## Description

Resolved a regression in v4.10 where the Management API crashed when gravitee_analytics_type was set to none.

## Additional context

Registered the NoOpMetricsRepository bean in NoOpAnalyticsRepositoryConfiguration.java, aligning it with its v4 sibling repositories.
