### PR TITLE
fix(portal): "cancel" and "back to API" buttons navigation bugfix for ng portal subscribe flow

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.html
@@ -18,7 +18,7 @@
 <div class="container">
   <a
     [routerLink]="['/documentation', navId()]"
-    [queryParams]="{ pageId: pageId() }"
+    [queryParams]="{ selectedId: selectedId() }"
     class="documentation-subscribe__back-link internal-link"
   >
     <mat-icon>arrow_backward</mat-icon>

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.scss
@@ -15,6 +15,7 @@
 }
 
 .documentation-subscribe__back-link {
+  align-self: flex-start;
   display: inline-flex;
   align-items: center;
   gap: 4px;

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.spec.ts
@@ -29,7 +29,7 @@ describe('DocumentationSubscribeComponent', () => {
 
   const MOCK_API = fakeApi({ id: 'api-1', name: 'Test API' });
 
-  const init = async () => {
+  const init = async (selectedId?: string) => {
     routerSpy = { navigate: jest.fn().mockReturnValue(Promise.resolve(true)) } as unknown as jest.Mocked<Router>;
 
     await TestBed.configureTestingModule({
@@ -46,11 +46,37 @@ describe('DocumentationSubscribeComponent', () => {
     component = fixture.componentInstance;
     fixture.componentRef.setInput('api', MOCK_API);
     fixture.componentRef.setInput('navId', 'nav-1');
+    if (selectedId) {
+      fixture.componentRef.setInput('selectedId', selectedId);
+    }
     fixture.detectChanges();
   };
 
   it('should create', async () => {
     await init();
     expect(component).toBeTruthy();
+  });
+
+  describe('cancel()', () => {
+    it('navigates to the documentation folder with selectedId', async () => {
+      await init('page-42');
+
+      component.cancel();
+
+      expect(routerSpy.navigate).toHaveBeenCalledWith(['/documentation', 'nav-1'], {
+        queryParams: { selectedId: 'page-42' },
+      });
+    });
+
+    it('navigates to the documentation folder without a concrete selectedId when not provided', async () => {
+      await init();
+
+      component.cancel();
+
+      expect(routerSpy.navigate).toHaveBeenCalledTimes(1);
+      expect(routerSpy.navigate.mock.calls[0][0]).toEqual(['/documentation', 'nav-1']);
+      const extras = routerSpy.navigate.mock.calls[0][1] as { queryParams?: { selectedId?: string } };
+      expect(extras?.queryParams?.selectedId).toBeUndefined();
+    });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-subscribe/documentation-subscribe.component.ts
@@ -29,9 +29,9 @@ import { SubscribeToApiComponent } from '../../../api/subscribe-to-api/subscribe
 export class DocumentationSubscribeComponent {
   api = input.required<Api>();
   navId = input.required<string>();
-  pageId = input<string>();
+  selectedId = input<string>();
 
   private router = inject(Router);
 
-  cancel = () => this.router.navigate(['/documentation', this.navId(), 'api', this.api().id]);
+  cancel = () => this.router.navigate(['/documentation', this.navId()], { queryParams: { selectedId: this.selectedId() } });
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13346

## Description

Fixed two navigation bugs in `DocumentationSubscribeComponent`:

- **"Back to API"** was navigating to the first item in the sidenav instead of the API the user came from — `pageId` input was bound to a non-existent query param; renamed to `selectedId` and fixed the back link `queryParams` accordingly
- **"Cancel"** was always resulting in a 404 — it was navigating to `/documentation/:navId/api/:apiId` which has no matching route; now it navigates back to `/documentation/:navId?selectedId=...`

## Additional context

### 1️⃣🐛 "Back to API" button 

Every time you click on the "Back to API" button, you're redirected to the first element on the left navbar

https://github.com/user-attachments/assets/d5034974-c704-49cc-950a-b13967fa97ba

### 2️⃣🐛 "Cancel" button

Every time you click on the "Cancel" button, you're seeing 404 instead of being redirected to the doc items list 

https://github.com/user-attachments/assets/89e3a14a-1a00-4569-bc62-b98c4f87540d

### 🔨 Fix video

In the video below, you can see that now both bugs are not present anymore

https://github.com/user-attachments/assets/cbfca67a-f456-4e1e-b63d-84c13ba9ffe6

### Bonus bugfix

Now "Back to API" button clickable area is the same size as the button size

https://github.com/user-attachments/assets/c9e11fdb-deee-4e9e-b49f-0b42750d0110
