### PR TITLE
fix(page-source): close fetcher input stream on read

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/documentation/PageSourceDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/documentation/PageSourceDomainServiceImpl.java
@@ -133,8 +133,9 @@ public class PageSourceDomainServiceImpl implements PageSourceDomainService {
     private String readContent(Fetcher fetcher, PageSource source) {
         try {
             var resource = fetcher.fetch();
-            var content = resource.getContent();
-            return new String(content.readAllBytes(), Charset.defaultCharset());
+            try (var content = resource.getContent()) {
+                return new String(content.readAllBytes(), Charset.defaultCharset());
+            }
         } catch (FetcherException | IOException e) {
             throw new TechnicalDomainException("unable to fetch content with configuration " + source.getConfiguration());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/DummyFetcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/DummyFetcher.java
@@ -19,8 +19,13 @@ import io.gravitee.fetcher.api.Fetcher;
 import io.gravitee.fetcher.api.FetcherConfiguration;
 import io.gravitee.fetcher.api.FetcherException;
 import io.gravitee.fetcher.api.Resource;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 
 public class DummyFetcher implements Fetcher {
+
+    /** Allow tests to inject a specific InputStream to track stream lifecycle. Thread-safe: one value per thread. */
+    public static final ThreadLocal<InputStream> nextStream = new ThreadLocal<>();
 
     DummyFetcherConfiguration fetcherConfiguration;
 
@@ -30,7 +35,11 @@ public class DummyFetcher implements Fetcher {
 
     @Override
     public Resource fetch() throws FetcherException {
-        return null;
+        var resource = new Resource();
+        InputStream stream = nextStream.get() != null ? nextStream.get() : new ByteArrayInputStream("dummy content".getBytes());
+        nextStream.remove(); // consume once
+        resource.setContent(stream);
+        return resource;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/PageSourceDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/PageSourceDomainServiceImplTest.java
@@ -28,6 +28,9 @@ import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.plugin.core.api.PluginManager;
 import io.gravitee.plugin.fetcher.FetcherPlugin;
 import io.gravitee.rest.api.fetcher.FetcherConfigurationFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,6 +82,28 @@ class PageSourceDomainServiceImplTest {
             cut.setContentFromSource(Page.builder().source(dummySource()).build());
         });
         assertThat(error).hasMessage("unable to build fetcher instance");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void should_read_content_and_close_stream() throws Exception {
+        when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(
+            mock(org.springframework.beans.factory.config.AutowireCapableBeanFactory.class)
+        );
+        when(fetcherPlugin.fetcher()).thenReturn(DummyFetcher.class);
+        when(fetcherPlugin.configuration()).thenReturn(DummyFetcherConfiguration.class);
+        when(fetcherPlugin.clazz()).thenReturn("io.gravitee.apim.infra.domain_service.documentation.DummyFetcher");
+        when(pluginManager.get("dummy-fetcher")).thenReturn(fetcherPlugin);
+        when(fetcherConfigurationFactory.create(any(), any())).thenReturn(new DummyFetcherConfiguration("data", "secret"));
+
+        var trackingStream = new TrackingInputStream(new ByteArrayInputStream("dummy content".getBytes()));
+        DummyFetcher.nextStream.set(trackingStream);
+
+        Page page = Page.builder().source(dummySource()).build();
+        cut.setContentFromSource(page);
+
+        assertThat(page.getContent()).isEqualTo("dummy content");
+        assertThat(trackingStream.closed).isTrue();
     }
 
     @Test
@@ -213,5 +238,32 @@ class PageSourceDomainServiceImplTest {
                 )
             )
             .build();
+    }
+
+    /** Wraps an InputStream and tracks whether close() was called. */
+    static class TrackingInputStream extends InputStream {
+
+        private final InputStream delegate;
+        boolean closed = false;
+
+        TrackingInputStream(InputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return delegate.read();
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            return delegate.read(b, off, len);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            delegate.close();
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <!-- Management API Only -->
         <gravitee-cockpit-connectors-ws.version>5.1.65</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>2.1.1</gravitee-fetcher-bitbucket.version>
-        <gravitee-fetcher-git.version>2.1.1</gravitee-fetcher-git.version>
+        <gravitee-fetcher-git.version>2.1.3</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>2.2.1</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>2.1.2</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>2.1.1</gravitee-fetcher-http.version>

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
         <!-- Management API Only -->
         <gravitee-cockpit-connectors-ws.version>5.1.65</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>2.1.1</gravitee-fetcher-bitbucket.version>
-        <gravitee-fetcher-git.version>2.1.3</gravitee-fetcher-git.version>
+        <gravitee-fetcher-git.version>3.0.0</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>2.2.1</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>2.1.2</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>2.1.1</gravitee-fetcher-http.version>


### PR DESCRIPTION
## Summary

- `PageSourceDomainServiceImpl.readContent()` called `resource.getContent().readAllBytes()` without closing the stream — resource leak on every page-source fetch.
- Wraps the `getContent()` call in try-with-resources so the stream (and, for git-fetcher, the tmp clone dir) is always closed after reading.
- Bumps `gravitee-fetcher-git` to 3.0.0 which contains the tmp-dir cleanup fix.

Depends on gravitee-io/gravitee-fetcher-git#55 being merged and released as 2.1.3.

Fixes APIM-13361