### PR TITLE
feat: introduce API Product primary owner mode setting

### DIFF
--- a/gravitee-apim-console-webui/src/entities/Constants.ts
+++ b/gravitee-apim-console-webui/src/entities/Constants.ts
@@ -58,6 +58,9 @@ export interface EnvSettings {
     labelsDictionary: string[];
     primaryOwnerMode: string;
   };
+  apiProduct: {
+    primaryOwnerMode: string;
+  };
   apiScore: {
     enabled: boolean;
   };

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -121,6 +121,9 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
       labelsDictionary: ['test'],
       primaryOwnerMode: 'USER',
     },
+    apiProduct: {
+      primaryOwnerMode: 'HYBRID',
+    },
     apiQualityMetrics: {
       enabled: false,
       functionalDocumentationWeight: 1041,

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -31,6 +31,7 @@ export interface PortalConfiguration {
   company?: PortalSettingsCompany;
   plan?: PortalSettingsPlan;
   api?: PortalSettingsApi;
+  apiProduct?: PortalSettingsApiProduct;
   dashboards?: PortalSettingsDashboards;
   scheduler?: PortalSettingsScheduler;
   documentation?: PortalSettingsDocumentation;
@@ -185,6 +186,10 @@ export interface PortalSettingsPlan {
 export interface PortalSettingsApi {
   labelsDictionary: string[];
   primaryOwnerMode: string;
+}
+
+export interface PortalSettingsApiProduct {
+  primaryOwnerMode?: string;
 }
 
 export interface PortalSettingsDashboards {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -166,6 +166,15 @@
           </mat-radio-button>
         </mat-radio-group>
       </mat-card-content>
+
+      <mat-card-content formGroupName="apiProduct">
+        <h3 class="portal__form__card__title">API Product Primary Owner mode</h3>
+        <mat-radio-group formControlName="primaryOwnerMode" class="portal__form__card__radio-group">
+          <mat-radio-button *ngFor="let mode of apiProductPrimaryOwnerModeList" [value]="mode.id">
+            {{ mode.label }}
+          </mat-radio-button>
+        </mat-radio-group>
+      </mat-card-content>
     </mat-card>
 
     <h2>Portal</h2>

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -63,6 +63,9 @@ interface PortalForm {
     labelsDictionary: FormControl<string[]>;
     primaryOwnerMode: FormControl<string>;
   }>;
+  apiProduct: FormGroup<{
+    primaryOwnerMode: FormControl<string>;
+  }>;
   dashboards: FormGroup<{
     apiStatus: FormGroup<{
       enabled: FormControl<boolean>;
@@ -180,6 +183,20 @@ export class PortalSettingsComponent implements OnInit {
       label: 'GROUP: an API primary owner can only be a group',
     },
   ];
+  apiProductPrimaryOwnerModeList = [
+    {
+      id: 'HYBRID',
+      label: 'HYBRID: an API Product primary owner can be either a user or a group (Default)',
+    },
+    {
+      id: 'USER',
+      label: 'USER: an API Product primary owner can only be a user',
+    },
+    {
+      id: 'GROUP',
+      label: 'GROUP: an API Product primary owner can only be a group',
+    },
+  ];
   hasEnterpriseLicense$: Observable<boolean> = of(false);
   portalUrl: string = undefined;
   environmentRootRouterLink: string;
@@ -291,6 +308,12 @@ export class PortalSettingsComponent implements OnInit {
         primaryOwnerMode: new FormControl({
           value: this.settings.api.primaryOwnerMode,
           disabled: this.isReadonly('api.primaryOwnerMode'),
+        }),
+      }),
+      apiProduct: new FormGroup({
+        primaryOwnerMode: new FormControl({
+          value: this.settings.apiProduct?.primaryOwnerMode ?? 'HYBRID',
+          disabled: this.isReadonly('apiProduct.primaryOwnerMode'),
         }),
       }),
       dashboards: new FormGroup({
@@ -588,6 +611,10 @@ export class PortalSettingsComponent implements OnInit {
       api: {
         ...this.settings.api,
         ...this.portalForm.get('api').value,
+      },
+      apiProduct: {
+        ...this.settings.apiProduct,
+        ...this.portalForm.get('apiProduct').value,
       },
       dashboards: {
         ...this.settings.dashboards,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -374,6 +374,11 @@ public enum Key {
         ApiPrimaryOwnerMode.HYBRID.name(),
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
+    API_PRODUCT_PRIMARY_OWNER_MODE(
+        "api.product.primary.owner.mode",
+        ApiPrimaryOwnerMode.HYBRID.name(),
+        new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
+    ),
 
     CONSOLE_AUTHENTICATION_LOCALLOGIN_ENABLED(
         "console.authentication.localLogin.enabled",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ApiProduct.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.gravitee.rest.api.model.annotations.ParameterKey;
+import io.gravitee.rest.api.model.parameters.Key;
+
+/**
+ * @author GraviteeSource Team
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiProduct {
+
+    @ParameterKey(Key.API_PRODUCT_PRIMARY_OWNER_MODE)
+    private String primaryOwnerMode;
+
+    public String getPrimaryOwnerMode() {
+        return primaryOwnerMode;
+    }
+
+    public void setPrimaryOwnerMode(String primaryOwnerMode) {
+        this.primaryOwnerMode = primaryOwnerMode;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalConfigEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalConfigEntity.java
@@ -28,6 +28,7 @@ public class PortalConfigEntity {
 
     private Analytics analytics;
     private Api api;
+    private ApiProduct apiProduct;
     private ApiScore apiScore;
     private ApiQualityMetrics apiQualityMetrics;
     private ApiReview apiReview;
@@ -49,6 +50,7 @@ public class PortalConfigEntity {
         super();
         analytics = new Analytics();
         api = new Api();
+        apiProduct = new ApiProduct();
         apiScore = new ApiScore();
         apiQualityMetrics = new ApiQualityMetrics();
         apiReview = new ApiReview();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalSettingsEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalSettingsEntity.java
@@ -33,6 +33,7 @@ public class PortalSettingsEntity extends AbstractCommonSettingsEntity {
 
     private Analytics analytics;
     private Api api;
+    private ApiProduct apiProduct;
     private ApiScore apiScore;
     private ApiQualityMetrics apiQualityMetrics;
     private ApiReview apiReview;
@@ -59,6 +60,7 @@ public class PortalSettingsEntity extends AbstractCommonSettingsEntity {
         super();
         analytics = new Analytics();
         api = new Api();
+        apiProduct = new ApiProduct();
         apiScore = new ApiScore();
         apiQualityMetrics = new ApiQualityMetrics();
         apiReview = new ApiReview();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerFactory.java
@@ -23,8 +23,13 @@ import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.membership.query_service.RoleQueryService;
+import io.gravitee.apim.core.parameters.model.ParameterContext;
+import io.gravitee.apim.core.parameters.query_service.ParametersQueryService;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.service.common.ReferenceContext;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -34,13 +39,22 @@ import lombok.AllArgsConstructor;
 public class ApiProductPrimaryOwnerFactory {
 
     private final MembershipQueryService membershipQueryService;
+    private final ParametersQueryService parametersQueryService;
     private final RoleQueryService roleQueryService;
     private final UserCrudService userCrudService;
     private final GroupQueryService groupQueryService;
 
     public PrimaryOwnerEntity createForNewApiProduct(String organizationId, String environmentId, String userId) {
-        // TODO: Introduce Key.API_PRODUCT_PRIMARY_OWNER_MODE with HYBRID, USER, GROUP support
-        return initUserPrimaryOwner(userId);
+        var mode = ApiPrimaryOwnerMode.valueOf(
+            parametersQueryService.findAsString(
+                Key.API_PRODUCT_PRIMARY_OWNER_MODE,
+                new ParameterContext(environmentId, organizationId, ParameterReferenceType.ENVIRONMENT)
+            )
+        );
+        return switch (mode) {
+            case HYBRID, USER -> initUserPrimaryOwner(userId);
+            case GROUP -> initWithFirstGroupWhereUserIsPrimaryOwner(userId, organizationId);
+        };
     }
 
     private PrimaryOwnerEntity initUserPrimaryOwner(String userId) {
@@ -63,7 +77,11 @@ public class ApiProductPrimaryOwnerFactory {
         return group
             .flatMap(g ->
                 membershipQueryService
-                    .findByReferenceAndRoleId(Membership.ReferenceType.GROUP, g.getId(), getApiPrimaryOwnerRole(organizationId).getId())
+                    .findByReferenceAndRoleId(
+                        Membership.ReferenceType.GROUP,
+                        g.getId(),
+                        getApiProductPrimaryOwnerRole(organizationId).getId()
+                    )
                     .stream()
                     .findFirst()
                     .map(membership -> userCrudService.getBaseUser(membership.getMemberId()))
@@ -72,8 +90,8 @@ public class ApiProductPrimaryOwnerFactory {
             .orElseThrow(() -> new NoPrimaryOwnerGroupForUserException(userId));
     }
 
-    private Role getApiPrimaryOwnerRole(String organizationId) {
-        return roleQueryService.getApiRole(
+    private Role getApiProductPrimaryOwnerRole(String organizationId) {
+        return roleQueryService.getApiProductRole(
             SystemRole.PRIMARY_OWNER.name(),
             ReferenceContext.builder().referenceType(ReferenceContext.Type.ORGANIZATION).referenceId(organizationId).build()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/query_service/RoleQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/query_service/RoleQueryService.java
@@ -33,4 +33,8 @@ public interface RoleQueryService {
     default Role getApiRole(String name, ReferenceContext referenceContext) {
         return findApiRole(name, referenceContext).orElseThrow(() -> new RoleNotFoundException(name, referenceContext));
     }
+
+    default Role getApiProductRole(String name, ReferenceContext referenceContext) {
+        return findApiProductRole(name, referenceContext).orElseThrow(() -> new RoleNotFoundException(name, referenceContext));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -439,6 +439,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             // Portal Config
             portalConfigEntity.getAnalytics(),
             portalConfigEntity.getApi(),
+            portalConfigEntity.getApiProduct(),
             portalConfigEntity.getApiScore(),
             portalConfigEntity.getApiQualityMetrics(),
             portalConfigEntity.getApiReview(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -104,13 +104,19 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
 
         parametersQueryService.initWith(
             List.of(
-                new Parameter(Key.API_PRIMARY_OWNER_MODE.key(), ENV_ID, ParameterReferenceType.ENVIRONMENT, ApiPrimaryOwnerMode.USER.name())
+                new Parameter(
+                    Key.API_PRODUCT_PRIMARY_OWNER_MODE.key(),
+                    ENV_ID,
+                    ParameterReferenceType.ENVIRONMENT,
+                    ApiPrimaryOwnerMode.USER.name()
+                )
             )
         );
 
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
         var apiProductPrimaryOwnerFactory = new ApiProductPrimaryOwnerFactory(
             membershipQueryService,
+            parametersQueryService,
             roleQueryService,
             userCrudService,
             groupQueryService

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerFactoryTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.membership.domain_service;
+
+import static fixtures.core.model.RoleFixtures.apiProductPrimaryOwnerRoleId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.core.membership.exception.NoPrimaryOwnerGroupForUserException;
+import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.repository.management.model.Parameter;
+import io.gravitee.repository.management.model.ParameterReferenceType;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ApiProductPrimaryOwnerFactoryTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String MEMBER_ID = "member-id";
+    private static final String USER_ID = "user-id";
+    private static final String GROUP_ID = "group-id";
+
+    GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
+    MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
+    ParametersQueryServiceInMemory parametersQueryService = new ParametersQueryServiceInMemory();
+    RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
+    UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+
+    ApiProductPrimaryOwnerFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        factory = new ApiProductPrimaryOwnerFactory(
+            membershipQueryService,
+            parametersQueryService,
+            roleQueryService,
+            userCrudService,
+            groupQueryService
+        );
+    }
+
+    @Nested
+    class UserMode {
+
+        @BeforeEach
+        void setUp() {
+            parametersQueryService.initWith(
+                List.of(
+                    new Parameter(
+                        Key.API_PRODUCT_PRIMARY_OWNER_MODE.key(),
+                        ENVIRONMENT_ID,
+                        ParameterReferenceType.ENVIRONMENT,
+                        ApiPrimaryOwnerMode.USER.name()
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_build_a_user_primary_owner() {
+            givenExistingUsers(
+                List.of(BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+            );
+
+            var primaryOwner = factory.createForNewApiProduct(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+            assertThat(primaryOwner).isEqualTo(
+                new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER)
+            );
+        }
+    }
+
+    @Nested
+    class GroupMode {
+
+        @BeforeEach
+        void setUp() {
+            parametersQueryService.initWith(
+                List.of(
+                    new Parameter(
+                        Key.API_PRODUCT_PRIMARY_OWNER_MODE.key(),
+                        ENVIRONMENT_ID,
+                        ParameterReferenceType.ENVIRONMENT,
+                        ApiPrimaryOwnerMode.GROUP.name()
+                    )
+                )
+            );
+            roleQueryService.resetSystemRoles(ORGANIZATION_ID);
+            givenExistingUsers(
+                List.of(
+                    BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build(),
+                    BaseUserEntity.builder().id(MEMBER_ID).firstname("John").lastname("Doe").email("john.doe@gravitee.io").build()
+                )
+            );
+        }
+
+        @Test
+        void should_build_a_group_primary_owner_with_the_1st_group_having_primary_owner() {
+            // Given
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("My Group").apiPrimaryOwner(MEMBER_ID).build()));
+            givenExistingMemberships(
+                List.of(
+                    // PO role for member-id
+                    Membership.builder()
+                        .referenceType(Membership.ReferenceType.GROUP)
+                        .referenceId(GROUP_ID)
+                        .memberType(Membership.Type.USER)
+                        .memberId(MEMBER_ID)
+                        .roleId(apiProductPrimaryOwnerRoleId(ORGANIZATION_ID))
+                        .build(),
+                    // Regular role for user-id
+                    Membership.builder()
+                        .referenceType(Membership.ReferenceType.GROUP)
+                        .referenceId(GROUP_ID)
+                        .memberType(Membership.Type.USER)
+                        .memberId(USER_ID)
+                        .roleId("role-id")
+                        .build()
+                )
+            );
+
+            // When
+            var primaryOwner = factory.createForNewApiProduct(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+            // Then
+            assertThat(primaryOwner).isEqualTo(
+                new PrimaryOwnerEntity(GROUP_ID, "john.doe@gravitee.io", "My Group", PrimaryOwnerEntity.Type.GROUP)
+            );
+        }
+
+        @Test
+        void should_throw_when_user_does_not_belong_to_a_group_having_primary_owner() {
+            // Given
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("My Group").build()));
+            givenExistingMemberships(
+                List.of(
+                    Membership.builder()
+                        .referenceType(Membership.ReferenceType.GROUP)
+                        .referenceId(GROUP_ID)
+                        .memberType(Membership.Type.USER)
+                        .memberId(USER_ID)
+                        .roleId("role-id")
+                        .build()
+                )
+            );
+
+            // When
+            Throwable throwable = catchThrowable(() -> factory.createForNewApiProduct(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+            // Then
+            assertThat(throwable).isInstanceOf(NoPrimaryOwnerGroupForUserException.class);
+        }
+
+        @Test
+        void should_throw_when_primary_owner_role_does_not_exist_for_organization() {
+            // Given
+            roleQueryService.reset();
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("My Group").apiPrimaryOwner(MEMBER_ID).build()));
+            givenExistingMemberships(
+                List.of(
+                    // PO role for member-id
+                    Membership.builder()
+                        .referenceType(Membership.ReferenceType.GROUP)
+                        .referenceId(GROUP_ID)
+                        .memberType(Membership.Type.USER)
+                        .memberId(MEMBER_ID)
+                        .roleId(apiProductPrimaryOwnerRoleId(ORGANIZATION_ID))
+                        .build(),
+                    // Regular role for user-id
+                    Membership.builder()
+                        .referenceType(Membership.ReferenceType.GROUP)
+                        .referenceId(GROUP_ID)
+                        .memberType(Membership.Type.USER)
+                        .memberId(USER_ID)
+                        .roleId("role-id")
+                        .build()
+                )
+            );
+
+            // When
+            Throwable throwable = catchThrowable(() -> factory.createForNewApiProduct(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+            // Then
+            assertThat(throwable).isInstanceOf(RoleNotFoundException.class);
+        }
+    }
+
+    @Nested
+    class HybridMode {
+
+        @BeforeEach
+        void setUp() {
+            parametersQueryService.initWith(
+                List.of(
+                    new Parameter(
+                        Key.API_PRODUCT_PRIMARY_OWNER_MODE.key(),
+                        ENVIRONMENT_ID,
+                        ParameterReferenceType.ENVIRONMENT,
+                        ApiPrimaryOwnerMode.HYBRID.name()
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_build_a_user_primary_owner() {
+            givenExistingUsers(
+                List.of(BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane.doe@gravitee.io").build())
+            );
+
+            var primaryOwner = factory.createForNewApiProduct(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+            assertThat(primaryOwner).isEqualTo(
+                new PrimaryOwnerEntity(USER_ID, "jane.doe@gravitee.io", "Jane Doe", PrimaryOwnerEntity.Type.USER)
+            );
+        }
+    }
+
+    private void givenExistingUsers(List<BaseUserEntity> users) {
+        userCrudService.initWith(users);
+    }
+
+    private void givenExistingMemberships(List<Membership> memberships) {
+        membershipQueryService.initWith(memberships);
+    }
+
+    private void givenExistingGroup(List<Group> groups) {
+        groupQueryService.initWith(groups);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl;
 
 import static io.gravitee.rest.api.model.parameters.Key.ALERT_ENABLED;
 import static io.gravitee.rest.api.model.parameters.Key.API_LABELS_DICTIONARY;
+import static io.gravitee.rest.api.model.parameters.Key.API_PRODUCT_PRIMARY_OWNER_MODE;
 import static io.gravitee.rest.api.model.parameters.Key.COMPANY_NAME;
 import static io.gravitee.rest.api.model.parameters.Key.CONSOLE_AUTHENTICATION_LOCALLOGIN_ENABLED;
 import static io.gravitee.rest.api.model.parameters.Key.CONSOLE_SCHEDULER_NOTIFICATIONS;
@@ -143,6 +144,7 @@ class ConfigServiceTest {
         params.put(Key.PORTAL_ANALYTICS_ENABLED.key(), singletonList("true"));
         params.put(Key.OPEN_API_DOC_TYPE_SWAGGER_ENABLED.key(), singletonList("true"));
         params.put(Key.API_LABELS_DICTIONARY.key(), Arrays.asList("label1", "label2"));
+        params.put(Key.API_PRODUCT_PRIMARY_OWNER_MODE.key(), singletonList("GROUP"));
         params.put(Key.LOGGING_MESSAGE_SAMPLING_COUNT_LIMIT.key(), singletonList("100"));
         params.put(LOGGING_MESSAGE_SAMPLING_COUNT_DEFAULT.key(), singletonList("10"));
         params.put(Key.LOGGING_MESSAGE_SAMPLING_PROBABILISTIC_LIMIT.key(), singletonList("0.5"));
@@ -177,6 +179,7 @@ class ConfigServiceTest {
             .as("open api swagger default")
             .isEqualTo("Swagger");
         assertThat(portalSettings.getApi().getLabelsDictionary().size()).as("api labels").isEqualTo(2);
+        assertThat(portalSettings.getApiProduct().getPrimaryOwnerMode()).as("api product primary owner mode").isEqualTo("GROUP");
         assertThat(portalSettings.getCors().getExposedHeaders().size()).as("cors exposed headers").isEqualTo(2);
         assertThat(portalSettings.getApi().getLabelsDictionary()).as("api labels").hasSize(2);
         assertThat(portalSettings.getCors().getExposedHeaders()).as("cors exposed headers").hasSize(2);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13382

## Description

This PR introduces a new `primaryOwnerMode` setting for **API Products**, similar to the existing setting for APIs. The new setting allows administrators to configure how the primary owner is determined when an API Product is created.

A new `apiProduct.primaryOwnerMode` configuration key is added (e.g., `USER`, `GROUP`, or `HYBRID`), which controls whether the primary owner of an API Product is the creating user, a group, or a hybrid combination. This mirrors the existing behavior for regular APIs.

### Changes

**Backend:**
- Added `API_PRODUCT_PRIMARY_OWNER_MODE` key in `Key.java` (parameter enum)
- - Introduced a new `ApiProduct` settings model class with a `primaryOwnerMode` field
- - Extended `PortalConfigEntity` and `PortalSettingsEntity` to include the `apiProduct` settings block
- - Updated `ApiProductPrimaryOwnerFactory` to read and apply the new setting when determining primary ownership
- - Updated `ConfigServiceImpl` to handle the new configuration key
- - Added/updated tests in `ApiProductPrimaryOwnerFactoryTest`, `CreateApiProductUseCaseTest`, and `ConfigServiceTest`
**Frontend (Console UI):**
- Extended `PortalConfiguration` and `PortalSettings` interfaces to include the `apiProduct.primaryOwnerMode` field
- - Added UI controls in `portal-settings.component.html` and `portal-settings.component.ts` to display and manage the new setting under the API Primary Owner mode section
- - Updated fixture for testing
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->