### PR TITLE
rename ApplicationCertificatesUpdateDomainService to MtlsSubscriptionSyncDomainService

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -71,8 +71,9 @@ import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.application.use_case.ImportApplicationCRDUseCase;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
 import io.gravitee.apim.core.audit.query_service.AuditMetadataQueryService;
@@ -1067,8 +1068,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService() {
-        return mock(ApplicationCertificatesUpdateDomainService.class);
+    public MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService() {
+        return mock(MtlsSubscriptionSyncDomainService.class);
+    }
+
+    @Bean
+    public ClientCertificateDomainService clientCertificateDomainService() {
+        return mock(ClientCertificateDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -81,8 +81,9 @@ import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.application.use_case.ValidateApplicationCRDUseCase;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
 import io.gravitee.apim.core.audit.query_service.AuditMetadataQueryService;
 import io.gravitee.apim.core.audit.query_service.AuditQueryService;
@@ -1240,8 +1241,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService() {
-        return mock(ApplicationCertificatesUpdateDomainService.class);
+    MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService() {
+        return mock(MtlsSubscriptionSyncDomainService.class);
+    }
+
+    @Bean
+    ClientCertificateDomainService clientCertificateDomainService() {
+        return mock(ClientCertificateDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationResource.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.exception.InvalidImageException;
 import io.gravitee.rest.api.model.ApplicationEntity;
@@ -86,7 +86,7 @@ public class ApplicationResource extends AbstractResource {
     private ApplicationTypeService applicationTypeService;
 
     @Inject
-    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
 
     @PathParam("application")
     @Parameter(name = "application", required = true)
@@ -152,7 +152,7 @@ public class ApplicationResource extends AbstractResource {
 
         var result = applicationService.update(GraviteeContext.getExecutionContext(), application, updatedApplication);
         if (updatedApplication.getSettings() != null && updatedApplication.getSettings().getTls() != null) {
-            applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(application);
+            mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(application);
         }
         return result;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.repository.management.model.ApplicationStatus;
@@ -67,7 +67,7 @@ public class ApplicationsResource extends AbstractResource {
     private ApplicationService applicationService;
 
     @Inject
-    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
 
     /**
      * @deprecated must be replaced by /applications/_paged in future major release
@@ -239,7 +239,7 @@ public class ApplicationsResource extends AbstractResource {
         );
         if (newApplication != null) {
             if (newApplication.getSettings() != null && newApplication.getSettings().getTls() != null) {
-                applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(newApplication.getId());
+                mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(newApplication.getId());
             }
             return Response.created(this.getLocationHeader(newApplication.getId())).entity(newApplication).build();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -64,8 +64,9 @@ import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
@@ -1259,8 +1260,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService() {
-        return mock(ApplicationCertificatesUpdateDomainService.class);
+    public MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService() {
+        return mock(MtlsSubscriptionSyncDomainService.class);
+    }
+
+    @Bean
+    public ClientCertificateDomainService clientCertificateDomainService() {
+        return mock(ClientCertificateDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -62,8 +62,9 @@ import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
@@ -1215,8 +1216,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService() {
-        return mock(ApplicationCertificatesUpdateDomainService.class);
+    MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService() {
+        return mock(MtlsSubscriptionSyncDomainService.class);
+    }
+
+    @Bean
+    ClientCertificateDomainService clientCertificateDomainService() {
+        return mock(ClientCertificateDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/use_case/ImportApplicationCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/use_case/ImportApplicationCRDUseCase.java
@@ -22,7 +22,7 @@ import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDo
 import io.gravitee.apim.core.application.model.crd.ApplicationCRDSpec;
 import io.gravitee.apim.core.application.model.crd.ApplicationCRDStatus;
 import io.gravitee.apim.core.application.model.crd.ApplicationMetadataCRD;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.application_metadata.crud_service.ApplicationMetadataCrudService;
 import io.gravitee.apim.core.application_metadata.query_service.ApplicationMetadataQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
@@ -55,7 +55,7 @@ public class ImportApplicationCRDUseCase {
     private final ApplicationMetadataQueryService applicationMetadataQueryService;
     private final CRDMembersDomainService membersDomainService;
     private final ValidateApplicationCRDDomainService crdValidator;
-    private final ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private final MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
 
     public ImportApplicationCRDUseCase(
         ApplicationCrudService applicationCrudService,
@@ -64,7 +64,7 @@ public class ImportApplicationCRDUseCase {
         ApplicationMetadataQueryService applicationMetadataQueryService,
         CRDMembersDomainService membersDomainService,
         ValidateApplicationCRDDomainService crdValidator,
-        ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService
+        MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService
     ) {
         this.applicationCrudService = applicationCrudService;
         this.importApplicationCRDDomainService = importApplicationCRDDomainService;
@@ -72,7 +72,7 @@ public class ImportApplicationCRDUseCase {
         this.applicationMetadataQueryService = applicationMetadataQueryService;
         this.membersDomainService = membersDomainService;
         this.crdValidator = crdValidator;
-        this.applicationCertificatesUpdateDomainService = applicationCertificatesUpdateDomainService;
+        this.mtlsSubscriptionSyncDomainService = mtlsSubscriptionSyncDomainService;
     }
 
     public record Output(ApplicationCRDStatus status) {}
@@ -112,7 +112,7 @@ public class ImportApplicationCRDUseCase {
                 sanitizedInput.crd.getMembers()
             );
 
-            applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(newApplication.getId());
+            mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(newApplication.getId());
 
             return ApplicationCRDStatus.builder()
                 .id(newApplication.getId())
@@ -144,7 +144,7 @@ public class ImportApplicationCRDUseCase {
                 sanitizedInput.crd.getMembers()
             );
 
-            applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(updatedApplication.getId());
+            mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(updatedApplication.getId());
 
             return ApplicationCRDStatus.builder()
                 .id(updatedApplication.getId())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/ClientCertificateDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/ClientCertificateDomainService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application_certificate.domain_service;
+
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+
+/**
+ * Domain service for managing client certificates and syncing mTLS subscriptions.
+ *
+ * @author GraviteeSource Team
+ */
+public interface ClientCertificateDomainService {
+    /**
+     * Creates a new client certificate for the given application and syncs active mTLS subscriptions.
+     *
+     * @param applicationId the application ID
+     * @param certificate the certificate to create (pre-validated and enriched)
+     * @return the persisted certificate
+     */
+    ClientCertificate create(String applicationId, ClientCertificate certificate);
+
+    /**
+     * Updates an existing client certificate and syncs active mTLS subscriptions.
+     *
+     * @param certificateId the certificate ID to update
+     * @param certificate the certificate data to apply
+     * @return the updated certificate
+     */
+    ClientCertificate update(String certificateId, ClientCertificate certificate);
+
+    /**
+     * Deletes a client certificate and syncs active mTLS subscriptions.
+     *
+     * @param applicationId the application ID (used for validation and sync)
+     * @param certificateId the certificate ID to delete
+     */
+    void delete(String applicationId, String certificateId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/MtlsSubscriptionSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/MtlsSubscriptionSyncDomainService.java
@@ -16,12 +16,12 @@
 package io.gravitee.apim.core.application_certificate.domain_service;
 
 /**
- * Domain service for updating application certificates on mTLS subscriptions.
+ * Domain service for syncing mTLS subscriptions with the current active certificate bundle.
  *
  * @author GraviteeSource Team
  */
 
-public interface ApplicationCertificatesUpdateDomainService {
+public interface MtlsSubscriptionSyncDomainService {
     /**
      * Updates the client certificates for all active mTLS subscriptions of the given application.
      * <p>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/CreateClientCertificateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/CreateClientCertificateUseCase.java
@@ -16,8 +16,7 @@
 package io.gravitee.apim.core.application_certificate.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -27,8 +26,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CreateClientCertificateUseCase {
 
-    private final ClientCertificateCrudService clientCertificateCrudService;
-    private final ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private final ClientCertificateDomainService clientCertificateDomainService;
     private final ClientCertificateValidationDomainService clientCertificateValidationDomainService;
 
     public Output execute(Input input) {
@@ -53,8 +51,7 @@ public class CreateClientCertificateUseCase {
             null
         );
 
-        ClientCertificate certificate = clientCertificateCrudService.create(input.applicationId(), enriched);
-        applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(input.applicationId());
+        var certificate = clientCertificateDomainService.create(input.applicationId(), enriched);
         return new Output(certificate);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCase.java
@@ -17,7 +17,7 @@ package io.gravitee.apim.core.application_certificate.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import java.util.Optional;
@@ -28,16 +28,14 @@ import lombok.RequiredArgsConstructor;
 public class DeleteClientCertificateUseCase {
 
     private final ClientCertificateCrudService clientCertificateCrudService;
-    private final ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private final ClientCertificateDomainService clientCertificateDomainService;
 
     public void execute(Input input) {
         ClientCertificate certificate = clientCertificateCrudService.findById(input.clientCertificateId());
         if (input.applicationId().isPresent() && !input.applicationId().get().equals(certificate.applicationId())) {
             throw new ClientCertificateNotFoundException(input.clientCertificateId());
         }
-        applicationCertificatesUpdateDomainService.validateCertificateRemoval(certificate.applicationId(), input.clientCertificateId());
-        clientCertificateCrudService.delete(input.clientCertificateId());
-        applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(certificate.applicationId());
+        clientCertificateDomainService.delete(certificate.applicationId(), input.clientCertificateId());
     }
 
     public record Input(Optional<String> applicationId, String clientCertificateId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/ProcessPendingCertificateTransitionsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/ProcessPendingCertificateTransitionsUseCase.java
@@ -17,7 +17,7 @@ package io.gravitee.apim.core.application_certificate.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -50,18 +50,18 @@ public class ProcessPendingCertificateTransitionsUseCase {
     private final ClientCertificateCrudService clientCertificateCrudService;
     private final EnvironmentCrudService environmentCrudService;
     private final AuditDomainService auditDomainService;
-    private final ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private final MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
 
     public ProcessPendingCertificateTransitionsUseCase(
         ClientCertificateCrudService clientCertificateCrudService,
         EnvironmentCrudService environmentCrudService,
         AuditDomainService auditDomainService,
-        ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService
+        MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService
     ) {
         this.clientCertificateCrudService = clientCertificateCrudService;
         this.environmentCrudService = environmentCrudService;
         this.auditDomainService = auditDomainService;
-        this.applicationCertificatesUpdateDomainService = applicationCertificatesUpdateDomainService;
+        this.mtlsSubscriptionSyncDomainService = mtlsSubscriptionSyncDomainService;
     }
 
     public Output execute(Input input) {
@@ -99,7 +99,7 @@ public class ProcessPendingCertificateTransitionsUseCase {
         int failedMtlsUpdateCount = 0;
         for (var applicationId : affectedApplicationIds) {
             try {
-                applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(applicationId);
+                mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(applicationId);
             } catch (Exception e) {
                 failedMtlsUpdateCount++;
                 log.error("Failed to update mTLS subscriptions for application [{}]: {}", applicationId, e.getMessage(), e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCase.java
@@ -17,7 +17,7 @@ package io.gravitee.apim.core.application_certificate.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import java.util.Optional;
@@ -28,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class UpdateClientCertificateUseCase {
 
     private final ClientCertificateCrudService clientCertificateCrudService;
-    private final ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private final ClientCertificateDomainService clientCertificateDomainService;
 
     public Output execute(Input input) {
         if (input.applicationId().isPresent()) {
@@ -37,8 +37,7 @@ public class UpdateClientCertificateUseCase {
                 throw new ClientCertificateNotFoundException(input.clientCertificateId());
             }
         }
-        ClientCertificate certificate = clientCertificateCrudService.update(input.clientCertificateId(), input.toUpdate());
-        applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(certificate.applicationId());
+        var certificate = clientCertificateDomainService.update(input.clientCertificateId(), input.toUpdate());
         return new Output(certificate);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateDomainServiceImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.application_certificates;
+
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementation of ClientCertificateDomainService.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@RequiredArgsConstructor
+@Service
+public class ClientCertificateDomainServiceImpl implements ClientCertificateDomainService {
+
+    private final ClientCertificateCrudService clientCertificateCrudService;
+    private final MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
+
+    @Override
+    public ClientCertificate create(String applicationId, ClientCertificate certificate) {
+        log.debug("Creating client certificate for application [{}]", applicationId);
+        var created = clientCertificateCrudService.create(applicationId, certificate);
+        mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(applicationId);
+        return created;
+    }
+
+    @Override
+    public ClientCertificate update(String certificateId, ClientCertificate certificate) {
+        log.debug("Updating client certificate [{}]", certificateId);
+        var updated = clientCertificateCrudService.update(certificateId, certificate);
+        mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(updated.applicationId());
+        return updated;
+    }
+
+    @Override
+    public void delete(String applicationId, String certificateId) {
+        log.debug("Deleting client certificate [{}] for application [{}]", certificateId, applicationId);
+        mtlsSubscriptionSyncDomainService.validateCertificateRemoval(applicationId, certificateId);
+        clientCertificateCrudService.delete(certificateId);
+        mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(applicationId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/MtlsSubscriptionSyncDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/MtlsSubscriptionSyncDomainServiceImpl.java
@@ -16,7 +16,7 @@
 package io.gravitee.apim.infra.domain_service.application_certificates;
 
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
@@ -36,14 +36,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 /**
- * Implementation of ApplicationCertificatesUpdateDomainService.
+ * Implementation of MtlsSubscriptionSyncDomainService.
  *
  * @author GraviteeSource Team
  */
 @CustomLog
 @RequiredArgsConstructor
 @Service
-public class ApplicationCertificatesUpdateDomainServiceImpl implements ApplicationCertificatesUpdateDomainService {
+public class MtlsSubscriptionSyncDomainServiceImpl implements MtlsSubscriptionSyncDomainService {
 
     private final SubscriptionQueryService subscriptionQueryService;
     private final SubscriptionCrudService subscriptionCrudService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
@@ -32,7 +32,7 @@ import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDo
 import io.gravitee.apim.core.application.model.crd.ApplicationCRDSpec;
 import io.gravitee.apim.core.application.model.crd.ApplicationMetadataCRD;
 import io.gravitee.apim.core.application.use_case.ImportApplicationCRDUseCase;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
@@ -103,9 +103,7 @@ class ImportApplicationCRDUseCaseTest {
     private final CRDMembersDomainServiceInMemory membersDomainService = new CRDMembersDomainServiceInMemory();
     private final ApplicationRepository applicationRepository = mock(ApplicationRepository.class);
     private final ParameterService parameterService = mock(ParameterService.class);
-    private final ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService = mock(
-        ApplicationCertificatesUpdateDomainService.class
-    );
+    private final MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService = mock(MtlsSubscriptionSyncDomainService.class);
 
     private final GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
     // Validation
@@ -121,7 +119,7 @@ class ImportApplicationCRDUseCaseTest {
     void setUp() {
         importApplicationCRDDomainService.initWith(List.of(anApplicationCRD()));
         userDomainService.initWith(getUsers());
-        Mockito.reset(applicationCertificatesUpdateDomainService);
+        Mockito.reset(mtlsSubscriptionSyncDomainService);
         useCase = new ImportApplicationCRDUseCase(
             applicationCrudService,
             importApplicationCRDDomainService,
@@ -129,7 +127,7 @@ class ImportApplicationCRDUseCaseTest {
             applicationMetadataQueryService,
             membersDomainService,
             crdValidator,
-            applicationCertificatesUpdateDomainService
+            mtlsSubscriptionSyncDomainService
         );
         roleQueryService.initWith(
             List.of(
@@ -202,7 +200,7 @@ class ImportApplicationCRDUseCaseTest {
             crd.setId(UuidString.generateRandom());
             useCase.execute(new ImportApplicationCRDUseCase.Input(AUDIT_INFO, crd));
 
-            verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions(APP_ID);
+            verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APP_ID);
         }
 
         @Test
@@ -272,7 +270,7 @@ class ImportApplicationCRDUseCaseTest {
             crd.setDescription("updated description");
             useCase.execute(new ImportApplicationCRDUseCase.Input(AUDIT_INFO, crd));
 
-            verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions(APP_ID);
+            verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APP_ID);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/CreateClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/CreateClientCertificateUseCaseTest.java
@@ -22,11 +22,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import inmemory.ClientCertificateCrudServiceInMemory;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService.CertificateInfo;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateEmptyException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -40,10 +40,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CreateClientCertificateUseCaseTest {
 
-    private final ClientCertificateCrudServiceInMemory clientCertificateCrudService = new ClientCertificateCrudServiceInMemory();
-
     @Mock
-    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private ClientCertificateDomainService clientCertificateDomainService;
 
     @Mock
     private ClientCertificateValidationDomainService clientCertificateValidationDomainService;
@@ -52,10 +50,8 @@ class CreateClientCertificateUseCaseTest {
 
     @BeforeEach
     void setUp() {
-        clientCertificateCrudService.reset();
         createClientCertificateUseCase = new CreateClientCertificateUseCase(
-            clientCertificateCrudService,
-            applicationCertificatesUpdateDomainService,
+            clientCertificateDomainService,
             clientCertificateValidationDomainService
         );
     }
@@ -68,6 +64,25 @@ class CreateClientCertificateUseCaseTest {
 
         when(clientCertificateValidationDomainService.validateForCreation(any(ClientCertificate.class), any())).thenReturn(certInfo);
 
+        var createdCertificate = new ClientCertificate(
+            "generated-id",
+            "cross-id",
+            appId,
+            "Test Certificate",
+            new Date(),
+            Date.from(Instant.now().plus(1, ChronoUnit.DAYS)),
+            new Date(),
+            new Date(),
+            "pem-content",
+            expiration,
+            "CN=unit-tests",
+            "CN=unit-tests-issuer",
+            "sha256-fingerprint",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
+        when(clientCertificateDomainService.create(eq(appId), any(ClientCertificate.class))).thenReturn(createdCertificate);
+
         var result = createClientCertificateUseCase.execute(
             new CreateClientCertificateUseCase.Input(
                 appId,
@@ -76,15 +91,14 @@ class CreateClientCertificateUseCaseTest {
         );
 
         assertThat(result.clientCertificate()).isNotNull();
-        assertThat(result.clientCertificate().id()).isNotNull();
+        assertThat(result.clientCertificate().id()).isEqualTo("generated-id");
         assertThat(result.clientCertificate().applicationId()).isEqualTo(appId);
         assertThat(result.clientCertificate().name()).isEqualTo("Test Certificate");
         assertThat(result.clientCertificate().fingerprint()).isEqualTo("sha256-fingerprint");
         assertThat(result.clientCertificate().subject()).isEqualTo("CN=unit-tests");
         assertThat(result.clientCertificate().issuer()).isEqualTo("CN=unit-tests-issuer");
         assertThat(result.clientCertificate().certificateExpiration()).isEqualTo(expiration);
-        assertThat(clientCertificateCrudService.storage()).hasSize(1);
-        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions(appId);
+        verify(clientCertificateDomainService).create(eq(appId), any(ClientCertificate.class));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCaseTest.java
@@ -17,13 +17,11 @@ package io.gravitee.apim.core.application_certificate.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import inmemory.ClientCertificateCrudServiceInMemory;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateLastRemovalException;
@@ -46,17 +44,14 @@ class DeleteClientCertificateUseCaseTest {
     private final ClientCertificateCrudServiceInMemory clientCertificateCrudService = new ClientCertificateCrudServiceInMemory();
 
     @Mock
-    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private ClientCertificateDomainService clientCertificateDomainService;
 
     private DeleteClientCertificateUseCase deleteClientCertificateUseCase;
 
     @BeforeEach
     void setUp() {
         clientCertificateCrudService.reset();
-        deleteClientCertificateUseCase = new DeleteClientCertificateUseCase(
-            clientCertificateCrudService,
-            applicationCertificatesUpdateDomainService
-        );
+        deleteClientCertificateUseCase = new DeleteClientCertificateUseCase(clientCertificateCrudService, clientCertificateDomainService);
     }
 
     @Test
@@ -84,10 +79,7 @@ class DeleteClientCertificateUseCaseTest {
 
         deleteClientCertificateUseCase.execute(new DeleteClientCertificateUseCase.Input(certId));
 
-        assertThat(clientCertificateCrudService.storage()).isEmpty();
-
-        verify(applicationCertificatesUpdateDomainService).validateCertificateRemoval(appId, certId);
-        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions(appId);
+        verify(clientCertificateDomainService).delete(appId, certId);
     }
 
     @Test
@@ -113,16 +105,11 @@ class DeleteClientCertificateUseCaseTest {
         );
         clientCertificateCrudService.initWith(List.of(certificate));
 
-        doThrow(new ClientCertificateLastRemovalException(appId))
-            .when(applicationCertificatesUpdateDomainService)
-            .validateCertificateRemoval(appId, certId);
+        doThrow(new ClientCertificateLastRemovalException(appId)).when(clientCertificateDomainService).delete(appId, certId);
 
         var input = new DeleteClientCertificateUseCase.Input(certId);
 
         assertThatThrownBy(() -> deleteClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateLastRemovalException.class);
-
-        assertThat(clientCertificateCrudService.storage()).hasSize(1);
-        verify(applicationCertificatesUpdateDomainService, never()).updateActiveMTLSSubscriptions(anyString());
     }
 
     @Test
@@ -158,7 +145,5 @@ class DeleteClientCertificateUseCaseTest {
         var input = new DeleteClientCertificateUseCase.Input(Optional.of("other-app-id"), certId);
 
         assertThatThrownBy(() -> deleteClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateNotFoundException.class);
-
-        assertThat(clientCertificateCrudService.storage()).hasSize(1);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/ProcessPendingCertificateTransitionsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/ProcessPendingCertificateTransitionsUseCaseTest.java
@@ -29,7 +29,7 @@ import inmemory.AuditCrudServiceInMemory;
 import inmemory.ClientCertificateCrudServiceInMemory;
 import inmemory.EnvironmentCrudServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -68,7 +68,7 @@ class ProcessPendingCertificateTransitionsUseCaseTest {
     private final UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
 
     @Mock
-    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
 
     private ProcessPendingCertificateTransitionsUseCase useCase;
 
@@ -82,7 +82,7 @@ class ProcessPendingCertificateTransitionsUseCaseTest {
             clientCertificateCrudService,
             environmentCrudService,
             auditDomainService,
-            applicationCertificatesUpdateDomainService
+            mtlsSubscriptionSyncDomainService
         );
 
         environmentCrudService.initWith(
@@ -264,7 +264,7 @@ class ProcessPendingCertificateTransitionsUseCaseTest {
         var result = useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
 
         assertThat(result.transitionedCertificates()).isEmpty();
-        verify(applicationCertificatesUpdateDomainService, never()).updateActiveMTLSSubscriptions(org.mockito.ArgumentMatchers.anyString());
+        verify(mtlsSubscriptionSyncDomainService, never()).updateActiveMTLSSubscriptions(org.mockito.ArgumentMatchers.anyString());
     }
 
     @Test
@@ -360,8 +360,8 @@ class ProcessPendingCertificateTransitionsUseCaseTest {
 
         useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
 
-        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions("app1");
-        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions("app2");
+        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions("app1");
+        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions("app2");
     }
 
     @Test
@@ -371,7 +371,7 @@ class ProcessPendingCertificateTransitionsUseCaseTest {
         var result = useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
 
         assertThat(result.transitionedCertificates()).isEmpty();
-        verify(applicationCertificatesUpdateDomainService, never()).updateActiveMTLSSubscriptions(org.mockito.ArgumentMatchers.anyString());
+        verify(mtlsSubscriptionSyncDomainService, never()).updateActiveMTLSSubscriptions(org.mockito.ArgumentMatchers.anyString());
     }
 
     @Test
@@ -449,15 +449,13 @@ class ProcessPendingCertificateTransitionsUseCaseTest {
             )
         );
 
-        doThrow(new RuntimeException("mTLS update failed"))
-            .when(applicationCertificatesUpdateDomainService)
-            .updateActiveMTLSSubscriptions("app1");
+        doThrow(new RuntimeException("mTLS update failed")).when(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions("app1");
 
         var result = useCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
 
         assertThat(result.transitionedCertificates()).hasSize(2);
-        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions("app1");
-        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions("app2");
+        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions("app1");
+        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions("app2");
     }
 
     @Test
@@ -467,7 +465,7 @@ class ProcessPendingCertificateTransitionsUseCaseTest {
             spiedService,
             environmentCrudService,
             new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor()),
-            applicationCertificatesUpdateDomainService
+            mtlsSubscriptionSyncDomainService
         );
 
         var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
@@ -512,8 +510,8 @@ class ProcessPendingCertificateTransitionsUseCaseTest {
 
         spiedUseCase.execute(new ProcessPendingCertificateTransitionsUseCase.Input(AUDIT_ACTOR));
 
-        verify(applicationCertificatesUpdateDomainService, never()).updateActiveMTLSSubscriptions("app1");
-        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions("app2");
+        verify(mtlsSubscriptionSyncDomainService, never()).updateActiveMTLSSubscriptions("app1");
+        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions("app2");
     }
 
     @Test
@@ -523,7 +521,7 @@ class ProcessPendingCertificateTransitionsUseCaseTest {
             spiedService,
             environmentCrudService,
             new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor()),
-            applicationCertificatesUpdateDomainService
+            mtlsSubscriptionSyncDomainService
         );
 
         var pastDate = Date.from(Instant.now().minus(1, ChronoUnit.DAYS));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCaseTest.java
@@ -17,10 +17,13 @@ package io.gravitee.apim.core.application_certificate.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import inmemory.ClientCertificateCrudServiceInMemory;
-import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
@@ -39,17 +42,14 @@ class UpdateClientCertificateUseCaseTest {
     private final ClientCertificateCrudServiceInMemory clientCertificateCrudService = new ClientCertificateCrudServiceInMemory();
 
     @Mock
-    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+    private ClientCertificateDomainService clientCertificateDomainService;
 
     private UpdateClientCertificateUseCase updateClientCertificateUseCase;
 
     @BeforeEach
     void setUp() {
         clientCertificateCrudService.reset();
-        updateClientCertificateUseCase = new UpdateClientCertificateUseCase(
-            clientCertificateCrudService,
-            applicationCertificatesUpdateDomainService
-        );
+        updateClientCertificateUseCase = new UpdateClientCertificateUseCase(clientCertificateCrudService, clientCertificateDomainService);
     }
 
     @Test
@@ -75,7 +75,25 @@ class UpdateClientCertificateUseCaseTest {
         );
         clientCertificateCrudService.initWith(List.of(certificate));
 
+        var updatedCertificate = new ClientCertificate(
+            certId,
+            "cross-id",
+            appId,
+            "Updated Name",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            new Date(),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
         var updateRequest = new ClientCertificate("Updated Name", new Date(), new Date());
+        when(clientCertificateDomainService.update(eq(certId), any(ClientCertificate.class))).thenReturn(updatedCertificate);
 
         var result = updateClientCertificateUseCase.execute(new UpdateClientCertificateUseCase.Input(certId, updateRequest));
 
@@ -83,12 +101,15 @@ class UpdateClientCertificateUseCaseTest {
         assertThat(result.clientCertificate().id()).isEqualTo(certId);
         assertThat(result.clientCertificate().name()).isEqualTo("Updated Name");
 
-        verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions(appId);
+        verify(clientCertificateDomainService).update(eq(certId), any(ClientCertificate.class));
     }
 
     @Test
     void should_throw_exception_when_certificate_not_found() {
         var updateRequest = new ClientCertificate("Updated Name", new Date(), new Date());
+        when(clientCertificateDomainService.update(eq("non-existent-id"), any(ClientCertificate.class))).thenThrow(
+            new ClientCertificateNotFoundException("non-existent-id")
+        );
 
         var input = new UpdateClientCertificateUseCase.Input("non-existent-id", updateRequest);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateDomainServiceImplTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.application_certificates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import inmemory.ClientCertificateCrudServiceInMemory;
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.rest.api.service.exceptions.ClientCertificateLastRemovalException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ClientCertificateDomainServiceImplTest {
+
+    private static final String APPLICATION_ID = "app-id";
+    private static final String ENVIRONMENT_ID = "env-id";
+
+    private final ClientCertificateCrudServiceInMemory clientCertificateCrudService = new ClientCertificateCrudServiceInMemory();
+
+    @Mock
+    private MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
+
+    private ClientCertificateDomainServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ClientCertificateDomainServiceImpl(clientCertificateCrudService, mtlsSubscriptionSyncDomainService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        clientCertificateCrudService.reset();
+    }
+
+    @Test
+    void should_create_certificate_and_sync_subscriptions() {
+        var toCreate = new ClientCertificate(
+            null,
+            null,
+            null,
+            "Test Certificate",
+            new Date(),
+            Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+            null,
+            null,
+            "PEM_CONTENT",
+            Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint",
+            ENVIRONMENT_ID,
+            null
+        );
+
+        var result = service.create(APPLICATION_ID, toCreate);
+
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isNotNull();
+        assertThat(result.applicationId()).isEqualTo(APPLICATION_ID);
+        assertThat(result.name()).isEqualTo("Test Certificate");
+        assertThat(clientCertificateCrudService.storage()).hasSize(1);
+        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APPLICATION_ID);
+    }
+
+    @Test
+    void should_update_certificate_and_sync_subscriptions() {
+        var certId = "cert-id";
+        var existing = buildClientCertificate(certId, "Original Name", ClientCertificateStatus.ACTIVE);
+        clientCertificateCrudService.initWith(List.of(existing));
+
+        var updateRequest = new ClientCertificate("Updated Name", new Date(), Date.from(Instant.now().plus(365, ChronoUnit.DAYS)));
+
+        var result = service.update(certId, updateRequest);
+
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(certId);
+        assertThat(result.name()).isEqualTo("Updated Name");
+        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APPLICATION_ID);
+    }
+
+    @Test
+    void should_delete_certificate_and_sync_subscriptions() {
+        var certId = "cert-id";
+        var existing = buildClientCertificate(certId, "Test Certificate", ClientCertificateStatus.ACTIVE);
+        clientCertificateCrudService.initWith(List.of(existing));
+
+        service.delete(APPLICATION_ID, certId);
+
+        assertThat(clientCertificateCrudService.storage()).isEmpty();
+        verify(mtlsSubscriptionSyncDomainService).validateCertificateRemoval(APPLICATION_ID, certId);
+        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APPLICATION_ID);
+    }
+
+    @Test
+    void should_not_delete_when_validation_fails() {
+        var certId = "cert-id";
+        var existing = buildClientCertificate(certId, "Test Certificate", ClientCertificateStatus.ACTIVE);
+        clientCertificateCrudService.initWith(List.of(existing));
+
+        doThrow(new ClientCertificateLastRemovalException(APPLICATION_ID))
+            .when(mtlsSubscriptionSyncDomainService)
+            .validateCertificateRemoval(APPLICATION_ID, certId);
+
+        assertThatThrownBy(() -> service.delete(APPLICATION_ID, certId)).isInstanceOf(ClientCertificateLastRemovalException.class);
+
+        assertThat(clientCertificateCrudService.storage()).hasSize(1);
+        verify(mtlsSubscriptionSyncDomainService, never()).updateActiveMTLSSubscriptions(anyString());
+    }
+
+    @Test
+    void should_not_sync_subscriptions_when_create_fails() {
+        var crudService = mock(ClientCertificateCrudService.class);
+        when(crudService.create(anyString(), any())).thenThrow(new RuntimeException("DB error"));
+        var failingService = new ClientCertificateDomainServiceImpl(crudService, mtlsSubscriptionSyncDomainService);
+
+        var toCreate = buildClientCertificate(null, "Test Certificate", null);
+        assertThatThrownBy(() -> failingService.create(APPLICATION_ID, toCreate)).isInstanceOf(RuntimeException.class);
+
+        verify(mtlsSubscriptionSyncDomainService, never()).updateActiveMTLSSubscriptions(anyString());
+    }
+
+    @Test
+    void should_not_sync_subscriptions_when_update_fails() {
+        var crudService = mock(ClientCertificateCrudService.class);
+        when(crudService.update(anyString(), any())).thenThrow(new RuntimeException("DB error"));
+        var failingService = new ClientCertificateDomainServiceImpl(crudService, mtlsSubscriptionSyncDomainService);
+
+        var updateRequest = new ClientCertificate("Updated Name", new Date(), Date.from(Instant.now().plus(365, ChronoUnit.DAYS)));
+        assertThatThrownBy(() -> failingService.update("cert-id", updateRequest)).isInstanceOf(RuntimeException.class);
+
+        verify(mtlsSubscriptionSyncDomainService, never()).updateActiveMTLSSubscriptions(anyString());
+    }
+
+    @Test
+    void should_not_sync_subscriptions_when_crud_delete_fails() {
+        var crudService = mock(ClientCertificateCrudService.class);
+        doThrow(new RuntimeException("DB error")).when(crudService).delete(anyString());
+        var failingService = new ClientCertificateDomainServiceImpl(crudService, mtlsSubscriptionSyncDomainService);
+
+        assertThatThrownBy(() -> failingService.delete(APPLICATION_ID, "cert-id")).isInstanceOf(RuntimeException.class);
+
+        verify(mtlsSubscriptionSyncDomainService).validateCertificateRemoval(APPLICATION_ID, "cert-id");
+        verify(mtlsSubscriptionSyncDomainService, never()).updateActiveMTLSSubscriptions(anyString());
+    }
+
+    private ClientCertificate buildClientCertificate(String id, String name, ClientCertificateStatus status) {
+        return new ClientCertificate(
+            id,
+            "cross-id-" + id,
+            APPLICATION_ID,
+            name,
+            new Date(),
+            Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint-" + id,
+            ENVIRONMENT_ID,
+            status
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/MtlsSubscriptionSyncDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/MtlsSubscriptionSyncDomainServiceImplTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class ApplicationCertificatesUpdateDomainServiceImplTest {
+class MtlsSubscriptionSyncDomainServiceImplTest {
 
     private static final String APPLICATION_ID = "app-id";
     private static final String PLAN_ID = "plan-id";
@@ -104,7 +104,7 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
     private SubscriptionCrudServiceInMemory subscriptionCrudService;
     private SubscriptionQueryServiceInMemory subscriptionQueryService;
     private PlanCrudServiceInMemory planCrudService;
-    private ApplicationCertificatesUpdateDomainServiceImpl service;
+    private MtlsSubscriptionSyncDomainServiceImpl service;
 
     @BeforeEach
     void setUp() {
@@ -113,7 +113,7 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
         planCrudService = new PlanCrudServiceInMemory();
         subscriptionQueryService = new SubscriptionQueryServiceInMemory(subscriptionCrudService, planCrudService);
 
-        service = new ApplicationCertificatesUpdateDomainServiceImpl(
+        service = new MtlsSubscriptionSyncDomainServiceImpl(
             subscriptionQueryService,
             subscriptionCrudService,
             clientCertificateCrudService


### PR DESCRIPTION
## Summary

- Renames `ApplicationCertificatesUpdateDomainService` → `MtlsSubscriptionSyncDomainService` (interface + impl + all callers) with no behavior change
- Introduces `ClientCertificateDomainService` to consolidate certificate CRUD + mTLS subscription sync into a single domain service, replacing the pattern where each use case called both separately
- Rewires `CreateClientCertificateUseCase`, `UpdateClientCertificateUseCase`, `DeleteClientCertificateUseCase` through the new domain service
- Adds `ClientCertificateDomainServiceImplTest` covering happy paths and CRUD failure paths (verifying sync is never called when persistence fails)

## Test plan

- [ ] `ClientCertificateDomainServiceImplTest` — create/update/delete happy paths + 3 failure-path tests (CRUD throws → sync not called)
- [ ] `MtlsSubscriptionSyncDomainServiceImplTest` — unchanged; verify rename didn't break existing coverage
- [ ] `DeleteClientCertificateUseCaseTest` / `UpdateClientCertificateUseCaseTest` / `CreateClientCertificateUseCaseTest` — verify delegation to domain service

## Known issues

The following pre-existing behaviors were identified during review and tracked for follow-up:

- **GKO-2789** — Partial failure: if subscription sync throws after cert deletion, subscriptions are left stale
- **GKO-2790** — Non-atomic ownership check + delete in `DeleteClientCertificateUseCase`
- **GKO-2791** — `DeleteClientCertificateUseCase` and `UpdateClientCertificateUseCase` retain a `ClientCertificateCrudService` dependency for ownership checks that should move into the domain service