### PR TITLE
[DO NOT MERGE] Introduce UpdateApplicationUseCase for portal application PUT

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.apim.core.application.use_case.UpdateApplicationUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.ApplicationEntity;
@@ -56,6 +57,9 @@ public class ApplicationResource extends AbstractResource {
 
     @Inject
     private ApplicationService applicationService;
+
+    @Inject
+    private UpdateApplicationUseCase updateApplicationUseCase;
 
     @Inject
     private ApplicationMapper applicationMapper;
@@ -142,7 +146,9 @@ public class ApplicationResource extends AbstractResource {
 
         Application updatedApp = applicationMapper.convert(
             GraviteeContext.getExecutionContext(),
-            applicationService.update(GraviteeContext.getExecutionContext(), applicationId, updateApplicationEntity),
+            updateApplicationUseCase
+                .execute(new UpdateApplicationUseCase.Input(getAuditInfo(), applicationId, updateApplicationEntity))
+                .application(),
             uriInfo
         );
         return Response.ok(addApplicationLinks(updatedApp))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.mockito.Mockito.reset;
 
+import io.gravitee.apim.core.application.use_case.UpdateApplicationUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
@@ -137,6 +138,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected DeleteClientCertificateUseCase deleteClientCertificateUseCase;
+
+    @Autowired
+    protected UpdateApplicationUseCase updateApplicationUseCase;
 
     @Autowired
     protected CustomUserFieldService customUserFieldService;
@@ -371,6 +375,7 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
             createClientCertificateUseCase,
             updateClientCertificateUseCase,
             deleteClientCertificateUseCase,
+            updateApplicationUseCase,
             apiService,
             apiSearchService,
             apiAuthorizationService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResourceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.apim.core.application.use_case.UpdateApplicationUseCase;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.application.TlsSettings;
@@ -143,7 +144,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         ApplicationEntity updatedEntity = new ApplicationEntity();
         updatedEntity.setId(APPLICATION_ID);
-        doReturn(updatedEntity).when(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), any());
+        doReturn(new UpdateApplicationUseCase.Output(updatedEntity))
+            .when(updateApplicationUseCase)
+            .execute(any(UpdateApplicationUseCase.Input.class));
 
         Instant now = Instant.now();
         Date nowDate = Date.from(now);
@@ -167,9 +170,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         Mockito.verify(applicationService).findById(GraviteeContext.getExecutionContext(), APPLICATION_ID);
 
-        ArgumentCaptor<UpdateApplicationEntity> captor = ArgumentCaptor.forClass(UpdateApplicationEntity.class);
-        Mockito.verify(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), captor.capture());
-        UpdateApplicationEntity updateAppEntity = captor.getValue();
+        ArgumentCaptor<UpdateApplicationUseCase.Input> captor = ArgumentCaptor.forClass(UpdateApplicationUseCase.Input.class);
+        Mockito.verify(updateApplicationUseCase).execute(captor.capture());
+        UpdateApplicationEntity updateAppEntity = captor.getValue().updateApplicationEntity();
         assertEquals(APPLICATION_ID, updateAppEntity.getName());
         assertEquals(APPLICATION_ID, updateAppEntity.getDescription());
         assertEquals(scaledPicture, updateAppEntity.getPicture());
@@ -202,7 +205,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         ApplicationEntity updatedEntity = new ApplicationEntity();
         updatedEntity.setId(APPLICATION_ID);
-        doReturn(updatedEntity).when(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), any());
+        doReturn(new UpdateApplicationUseCase.Output(updatedEntity))
+            .when(updateApplicationUseCase)
+            .execute(any(UpdateApplicationUseCase.Input.class));
 
         Instant now = Instant.now();
         Application updatedApp = new Application();
@@ -217,9 +222,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         Mockito.verify(applicationService).findById(GraviteeContext.getExecutionContext(), APPLICATION_ID);
 
-        ArgumentCaptor<UpdateApplicationEntity> captor = ArgumentCaptor.forClass(UpdateApplicationEntity.class);
-        Mockito.verify(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), captor.capture());
-        UpdateApplicationEntity updateAppEntity = captor.getValue();
+        ArgumentCaptor<UpdateApplicationUseCase.Input> captor = ArgumentCaptor.forClass(UpdateApplicationUseCase.Input.class);
+        Mockito.verify(updateApplicationUseCase).execute(captor.capture());
+        UpdateApplicationEntity updateAppEntity = captor.getValue().updateApplicationEntity();
         assertEquals(APPLICATION_ID, updateAppEntity.getName());
         assertEquals(APPLICATION_ID, updateAppEntity.getDescription());
         final io.gravitee.rest.api.model.application.ApplicationSettings settings = updateAppEntity.getSettings();
@@ -251,7 +256,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         ApplicationEntity updatedEntity = new ApplicationEntity();
         updatedEntity.setId(APPLICATION_ID);
-        doReturn(updatedEntity).when(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), any());
+        doReturn(new UpdateApplicationUseCase.Output(updatedEntity))
+            .when(updateApplicationUseCase)
+            .execute(any(UpdateApplicationUseCase.Input.class));
 
         Instant now = Instant.now();
         Application updatedApp = new Application();
@@ -269,9 +276,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         Mockito.verify(applicationService).findById(GraviteeContext.getExecutionContext(), APPLICATION_ID);
 
-        ArgumentCaptor<UpdateApplicationEntity> captor = ArgumentCaptor.forClass(UpdateApplicationEntity.class);
-        Mockito.verify(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), captor.capture());
-        UpdateApplicationEntity updateAppEntity = captor.getValue();
+        ArgumentCaptor<UpdateApplicationUseCase.Input> captor = ArgumentCaptor.forClass(UpdateApplicationUseCase.Input.class);
+        Mockito.verify(updateApplicationUseCase).execute(captor.capture());
+        UpdateApplicationEntity updateAppEntity = captor.getValue().updateApplicationEntity();
         assertEquals(APPLICATION_ID, updateAppEntity.getName());
         assertEquals(APPLICATION_ID, updateAppEntity.getDescription());
         final io.gravitee.rest.api.model.application.ApplicationSettings settings = updateAppEntity.getSettings();
@@ -305,7 +312,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         ApplicationEntity updatedEntity = new ApplicationEntity();
         updatedEntity.setId(APPLICATION_ID);
-        doReturn(updatedEntity).when(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), any());
+        doReturn(new UpdateApplicationUseCase.Output(updatedEntity))
+            .when(updateApplicationUseCase)
+            .execute(any(UpdateApplicationUseCase.Input.class));
 
         Instant now = Instant.now();
         Application updatedApp = new Application();
@@ -323,9 +332,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         Mockito.verify(applicationService).findById(GraviteeContext.getExecutionContext(), APPLICATION_ID);
 
-        ArgumentCaptor<UpdateApplicationEntity> captor = ArgumentCaptor.forClass(UpdateApplicationEntity.class);
-        Mockito.verify(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), captor.capture());
-        UpdateApplicationEntity updateAppEntity = captor.getValue();
+        ArgumentCaptor<UpdateApplicationUseCase.Input> captor = ArgumentCaptor.forClass(UpdateApplicationUseCase.Input.class);
+        Mockito.verify(updateApplicationUseCase).execute(captor.capture());
+        UpdateApplicationEntity updateAppEntity = captor.getValue().updateApplicationEntity();
         assertEquals(APPLICATION_ID, updateAppEntity.getName());
         assertEquals(APPLICATION_ID, updateAppEntity.getDescription());
         final io.gravitee.rest.api.model.application.ApplicationSettings settings = updateAppEntity.getSettings();
@@ -360,7 +369,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         ApplicationEntity updatedEntity = new ApplicationEntity();
         updatedEntity.setId(APPLICATION_ID);
-        doReturn(updatedEntity).when(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), any());
+        doReturn(new UpdateApplicationUseCase.Output(updatedEntity))
+            .when(updateApplicationUseCase)
+            .execute(any(UpdateApplicationUseCase.Input.class));
 
         Instant now = Instant.now();
         Application updatedApp = new Application();
@@ -392,9 +403,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         Mockito.verify(applicationService).findById(GraviteeContext.getExecutionContext(), APPLICATION_ID);
 
-        ArgumentCaptor<UpdateApplicationEntity> captor = ArgumentCaptor.forClass(UpdateApplicationEntity.class);
-        Mockito.verify(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), captor.capture());
-        UpdateApplicationEntity updateAppEntity = captor.getValue();
+        ArgumentCaptor<UpdateApplicationUseCase.Input> captor = ArgumentCaptor.forClass(UpdateApplicationUseCase.Input.class);
+        Mockito.verify(updateApplicationUseCase).execute(captor.capture());
+        UpdateApplicationEntity updateAppEntity = captor.getValue().updateApplicationEntity();
         assertEquals(APPLICATION_ID, updateAppEntity.getName());
         assertEquals(APPLICATION_ID, updateAppEntity.getDescription());
         final io.gravitee.rest.api.model.application.ApplicationSettings settings = updateAppEntity.getSettings();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -62,6 +62,7 @@ import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
+import io.gravitee.apim.core.application.use_case.UpdateApplicationUseCase;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
@@ -1253,6 +1254,11 @@ public class ResourceContextConfiguration {
     @Bean
     public DeleteClientCertificateUseCase deleteClientCertificateUseCase() {
         return mock(DeleteClientCertificateUseCase.class);
+    }
+
+    @Bean
+    public UpdateApplicationUseCase updateApplicationUseCase() {
+        return mock(UpdateApplicationUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/use_case/UpdateApplicationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/use_case/UpdateApplicationUseCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.application.domain_service.ImportApplicationCRDDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.model.UpdateApplicationEntity;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@UseCase
+@RequiredArgsConstructor
+public class UpdateApplicationUseCase {
+
+    private final ImportApplicationCRDDomainService importApplicationCRDDomainService;
+    private final MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
+
+    public record Input(AuditInfo auditInfo, String applicationId, UpdateApplicationEntity updateApplicationEntity) {}
+
+    public record Output(ApplicationEntity application) {}
+
+    public Output execute(Input input) {
+        var updated = (ApplicationEntity) importApplicationCRDDomainService.update(
+            input.applicationId(),
+            input.updateApplicationEntity(),
+            input.auditInfo()
+        );
+        mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(input.applicationId());
+        return new Output(updated);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/UpdateApplicationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/UpdateApplicationUseCaseTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application.domain_service.ImportApplicationCRDDomainService;
+import io.gravitee.apim.core.application.use_case.UpdateApplicationUseCase;
+import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.model.UpdateApplicationEntity;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UpdateApplicationUseCaseTest {
+
+    private static final String APPLICATION_ID = "app-id";
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("org-id")
+        .environmentId("env-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    @Mock
+    private ImportApplicationCRDDomainService importApplicationCRDDomainService;
+
+    @Mock
+    private MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
+
+    private UpdateApplicationUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new UpdateApplicationUseCase(importApplicationCRDDomainService, mtlsSubscriptionSyncDomainService);
+    }
+
+    @Test
+    void should_update_application() {
+        var updateEntity = new UpdateApplicationEntity();
+        updateEntity.setName("Updated App");
+
+        var expectedApp = new ApplicationEntity();
+        expectedApp.setId(APPLICATION_ID);
+        expectedApp.setName("Updated App");
+
+        when(importApplicationCRDDomainService.update(eq(APPLICATION_ID), eq(updateEntity), eq(AUDIT_INFO))).thenReturn(expectedApp);
+
+        var output = useCase.execute(new UpdateApplicationUseCase.Input(AUDIT_INFO, APPLICATION_ID, updateEntity));
+
+        assertThat(output.application().getId()).isEqualTo(APPLICATION_ID);
+        assertThat(output.application().getName()).isEqualTo("Updated App");
+    }
+
+    @Test
+    void should_sync_mtls_subscriptions_after_update() {
+        var updateEntity = new UpdateApplicationEntity();
+        var expectedApp = new ApplicationEntity();
+        expectedApp.setId(APPLICATION_ID);
+
+        when(importApplicationCRDDomainService.update(eq(APPLICATION_ID), eq(updateEntity), eq(AUDIT_INFO))).thenReturn(expectedApp);
+
+        useCase.execute(new UpdateApplicationUseCase.Input(AUDIT_INFO, APPLICATION_ID, updateEntity));
+
+        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APPLICATION_ID);
+    }
+
+    @Test
+    void should_propagate_exception_when_application_not_found() {
+        var updateEntity = new UpdateApplicationEntity();
+
+        when(importApplicationCRDDomainService.update(eq(APPLICATION_ID), eq(updateEntity), eq(AUDIT_INFO))).thenThrow(
+            new ApplicationNotFoundException(APPLICATION_ID)
+        );
+
+        assertThatThrownBy(() ->
+            useCase.execute(new UpdateApplicationUseCase.Input(AUDIT_INFO, APPLICATION_ID, updateEntity))
+        ).isInstanceOf(ApplicationNotFoundException.class);
+    }
+}


### PR DESCRIPTION
**Note: Do not merge this until the portal uses the multi-cert API.  Otherwise, mTLS subscriptions will be revoked.**

## Issue

[GKO-2785](https://gravitee.atlassian.net/browse/GKO-2785)

## Description

Introduces `UpdateApplicationUseCase` and wires it into the portal `ApplicationResource.PUT` endpoint, replacing the direct `ApplicationService.update` call.

- `UpdateApplicationUseCase` delegates persistence to `ImportApplicationCRDDomainService` and calls `MtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions` after every save — ensuring mTLS subscriptions are always re-evaluated after an application update.
- The portal `ApplicationResource` still calls `applicationService.findById` for data assembly (groups, settings merge) before passing to the use case.
- `ApplicationServiceImpl` is untouched.

## Additional context

Depends on [GKO-2783](https://gravitee.atlassian.net/browse/GKO-2783) — base branch is `gko-2783-rename-mtls-subscription-sync`.

The sync is now unconditional on every update (previously the management API gated it on `settings.tls != null`). This is consistent with `ImportApplicationCRDUseCase` and intentional.

[GKO-2785]: https://gravitee.atlassian.net/browse/GKO-2785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GKO-2783]: https://gravitee.atlassian.net/browse/GKO-2783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ