### PR TITLE
feat: wire certificate use cases through ClientCertificateDomainService

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
@@ -20,6 +20,9 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClientCertificateCrudServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import inmemory.SubscriptionCrudServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
@@ -173,7 +176,13 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     protected CategoryService categoryService;
 
     @Autowired
-    protected ClientCertificateCrudService clientCertificateService;
+    protected ClientCertificateCrudServiceInMemory clientCertificateService;
+
+    @Autowired
+    protected SubscriptionCrudServiceInMemory subscriptionCrudService;
+
+    @Autowired
+    protected PlanCrudServiceInMemory planCrudService;
 
     @Autowired
     protected GetClientCertificateUseCase getClientCertificateUseCase;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationClientCertificateResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationClientCertificateResourceTest.java
@@ -17,22 +17,27 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
-import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
-import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertificateUseCase;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.rest.api.model.clientcertificate.UpdateClientCertificate;
+import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +46,8 @@ public class ApplicationClientCertificateResourceTest extends AbstractResourceTe
 
     private static final String APPLICATION_ID = "my-application";
     private static final String CERT_ID = "my-cert-id";
+    private static final String PLAN_ID = "plan-id";
+    private static final String API_ID = "api-id";
 
     @Override
     protected String contextPath() {
@@ -51,26 +58,25 @@ public class ApplicationClientCertificateResourceTest extends AbstractResourceTe
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        reset(getClientCertificateUseCase, updateClientCertificateUseCase, deleteClientCertificateUseCase);
+        reset(getClientCertificateUseCase);
+        clientCertificateService.reset();
+        subscriptionCrudService.reset();
+        planCrudService.reset();
     }
 
     @Test
     public void should_get_client_certificate() {
-        var certificate = createClientCertificate(CERT_ID, "My Certificate");
-
+        var certificate = buildCertificate(CERT_ID, "My Certificate");
         when(getClientCertificateUseCase.execute(any(GetClientCertificateUseCase.Input.class))).thenReturn(
             new GetClientCertificateUseCase.Output(certificate)
         );
-
         final Response response = envTarget().request().get();
-
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
             var result = response.readEntity(io.gravitee.rest.api.model.clientcertificate.ClientCertificate.class);
             soft.assertThat(result.id()).isEqualTo(CERT_ID);
             soft.assertThat(result.name()).isEqualTo("My Certificate");
         });
-        verify(getClientCertificateUseCase).execute(any(GetClientCertificateUseCase.Input.class));
     }
 
     @Test
@@ -78,80 +84,78 @@ public class ApplicationClientCertificateResourceTest extends AbstractResourceTe
         when(getClientCertificateUseCase.execute(any(GetClientCertificateUseCase.Input.class))).thenThrow(
             new ClientCertificateNotFoundException(CERT_ID)
         );
-
         final Response response = envTarget().request().get();
-
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
     }
 
     @Test
     public void should_update_client_certificate() {
+        clientCertificateService.initWith(List.of(buildCertificate(CERT_ID, "Original Name")));
         UpdateClientCertificate updateRequest = new UpdateClientCertificate(
             "Updated Certificate Name",
-            new Date(),
-            new Date(System.currentTimeMillis() + 86400000)
+            Date.from(Instant.now()),
+            Date.from(Instant.now().plus(1, ChronoUnit.DAYS))
         );
-
-        ClientCertificate updated = createClientCertificate(CERT_ID, "Updated Certificate Name");
-
-        when(updateClientCertificateUseCase.execute(any(UpdateClientCertificateUseCase.Input.class))).thenReturn(
-            new UpdateClientCertificateUseCase.Output(updated)
-        );
-
         final Response response = envTarget().request().put(Entity.json(updateRequest));
-
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
             var result = response.readEntity(io.gravitee.rest.api.model.clientcertificate.ClientCertificate.class);
             soft.assertThat(result.name()).isEqualTo("Updated Certificate Name");
         });
-        verify(updateClientCertificateUseCase).execute(any(UpdateClientCertificateUseCase.Input.class));
+        assertThat(clientCertificateService.storage().getFirst().name()).isEqualTo("Updated Certificate Name");
     }
 
     @Test
     public void should_not_update_client_certificate_without_name() {
         UpdateClientCertificate updateRequest = new UpdateClientCertificate(null, new Date(), null);
-
         final Response response = envTarget().request().put(Entity.json(updateRequest));
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+    }
 
+    @Test
+    public void should_return_400_when_updating_certificate_with_invalid_dates() {
+        clientCertificateService.initWith(List.of(buildCertificate(CERT_ID, "My Certificate")));
+        UpdateClientCertificate updateRequest = new UpdateClientCertificate(
+            "My Certificate",
+            Date.from(Instant.now().plus(2, ChronoUnit.DAYS)),
+            Date.from(Instant.now().plus(1, ChronoUnit.DAYS))
+        );
+        final Response response = envTarget().request().put(Entity.json(updateRequest));
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
     }
 
     @Test
     public void should_return_404_when_updating_non_existent_certificate() {
         UpdateClientCertificate updateRequest = new UpdateClientCertificate("Updated Certificate Name", null, null);
-
-        when(updateClientCertificateUseCase.execute(any(UpdateClientCertificateUseCase.Input.class))).thenThrow(
-            new ClientCertificateNotFoundException(CERT_ID)
-        );
-
         final Response response = envTarget().request().put(Entity.json(updateRequest));
-
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
     }
 
     @Test
     public void should_delete_client_certificate() {
-        doNothing().when(deleteClientCertificateUseCase).execute(any(DeleteClientCertificateUseCase.Input.class));
-
+        clientCertificateService.initWith(List.of(buildCertificate(CERT_ID, "My Certificate")));
         final Response response = envTarget().request().delete();
-
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NO_CONTENT_204);
-        verify(deleteClientCertificateUseCase).execute(any(DeleteClientCertificateUseCase.Input.class));
+        assertThat(clientCertificateService.storage()).isEmpty();
+    }
+
+    @Test
+    public void should_return_400_when_deleting_last_active_certificate_with_mtls_subscriptions() {
+        clientCertificateService.initWith(List.of(buildCertificate(CERT_ID, "My Certificate")));
+        planCrudService.initWith(List.of(buildMtlsPlan()));
+        subscriptionCrudService.initWith(List.of(buildAcceptedSubscription()));
+        final Response response = envTarget().request().delete();
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        assertThat(clientCertificateService.storage()).hasSize(1);
     }
 
     @Test
     public void should_return_404_when_deleting_non_existent_certificate() {
-        doThrow(new ClientCertificateNotFoundException(CERT_ID))
-            .when(deleteClientCertificateUseCase)
-            .execute(any(DeleteClientCertificateUseCase.Input.class));
-
         final Response response = envTarget().request().delete();
-
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
     }
 
-    private ClientCertificate createClientCertificate(String id, String name) {
+    private ClientCertificate buildCertificate(String id, String name) {
         return new ClientCertificate(
             id,
             null,
@@ -167,7 +171,33 @@ public class ApplicationClientCertificateResourceTest extends AbstractResourceTe
             null,
             null,
             null,
-            null
+            ClientCertificateStatus.ACTIVE
         );
+    }
+
+    private Plan buildMtlsPlan() {
+        var planDefinition = io.gravitee.definition.model.v4.plan.Plan.builder()
+            .id(PLAN_ID)
+            .security(PlanSecurity.builder().type(PlanSecurityType.MTLS.name()).build())
+            .build();
+        return Plan.builder()
+            .id(PLAN_ID)
+            .apiId(API_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .planDefinitionHttpV4(planDefinition)
+            .build();
+    }
+
+    private SubscriptionEntity buildAcceptedSubscription() {
+        var now = ZonedDateTime.now();
+        return SubscriptionEntity.builder()
+            .id("sub-1")
+            .applicationId(APPLICATION_ID)
+            .planId(PLAN_ID)
+            .apiId(API_ID)
+            .status(SubscriptionEntity.Status.ACCEPTED)
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -24,13 +24,17 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiExposedEntrypointDomainServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
+import inmemory.ClientCertificateCrudServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
+import inmemory.SubscriptionCrudServiceInMemory;
 import inmemory.SubscriptionFormQueryServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
 import inmemory.SubscriptionSearchQueryServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
@@ -142,6 +146,7 @@ import io.gravitee.apim.core.shared_policy_group.use_case.UpdateSharedPolicyGrou
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDSpecDomainService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
 import io.gravitee.apim.core.subscription.use_case.AcceptSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
@@ -159,6 +164,8 @@ import io.gravitee.apim.infra.domain_service.analytics_engine.definition.Analyti
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.UnitEnrichmentPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.api.ApiHostValidatorDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.application_certificates.ClientCertificateDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.application_certificates.ClientCertificateValidationDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
@@ -431,8 +438,16 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ClientCertificateCrudService clientCertificateService() {
-        return mock(ClientCertificateCrudService.class);
+    public ClientCertificateCrudServiceInMemory clientCertificateService() {
+        return new ClientCertificateCrudServiceInMemory();
+    }
+
+    @Bean
+    public SubscriptionQueryServiceInMemory subscriptionQueryService(
+        SubscriptionCrudServiceInMemory subscriptionCrudService,
+        PlanCrudServiceInMemory planCrudService
+    ) {
+        return new SubscriptionQueryServiceInMemory(subscriptionCrudService, planCrudService);
     }
 
     @Bean
@@ -451,13 +466,16 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public UpdateClientCertificateUseCase updateClientCertificateUseCase() {
-        return mock(UpdateClientCertificateUseCase.class);
+    public UpdateClientCertificateUseCase updateClientCertificateUseCase(
+        ClientCertificateDomainService clientCertificateDomainService,
+        ClientCertificateValidationDomainService clientCertificateValidationDomainService
+    ) {
+        return new UpdateClientCertificateUseCase(clientCertificateDomainService, clientCertificateValidationDomainService);
     }
 
     @Bean
-    public DeleteClientCertificateUseCase deleteClientCertificateUseCase() {
-        return mock(DeleteClientCertificateUseCase.class);
+    public DeleteClientCertificateUseCase deleteClientCertificateUseCase(ClientCertificateDomainService clientCertificateDomainService) {
+        return new DeleteClientCertificateUseCase(clientCertificateDomainService);
     }
 
     @Bean
@@ -1265,8 +1283,16 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ClientCertificateDomainService clientCertificateDomainService() {
-        return mock(ClientCertificateDomainService.class);
+    public ClientCertificateDomainService clientCertificateDomainService(
+        ClientCertificateCrudService clientCertificateService,
+        MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService,
+        SubscriptionQueryService subscriptionQueryService
+    ) {
+        return new ClientCertificateDomainServiceImpl(
+            clientCertificateService,
+            mtlsSubscriptionSyncDomainService,
+            subscriptionQueryService
+        );
     }
 
     @Bean
@@ -1280,7 +1306,9 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ClientCertificateValidationDomainService clientCertificateValidationDomainService() {
-        return mock(ClientCertificateValidationDomainService.class);
+    public ClientCertificateValidationDomainService clientCertificateValidationDomainService(
+        ClientCertificateCrudService clientCertificateService
+    ) {
+        return new ClientCertificateValidationDomainServiceImpl(clientCertificateService);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
@@ -17,6 +17,9 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.mockito.Mockito.reset;
 
+import inmemory.ClientCertificateCrudServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import inmemory.SubscriptionCrudServiceInMemory;
 import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
@@ -119,6 +122,15 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ContextConfiguration(classes = { ResourceContextConfiguration.class })
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AbstractResourceTest extends JerseySpringTest {
+
+    @Autowired
+    protected ClientCertificateCrudServiceInMemory clientCertificateService;
+
+    @Autowired
+    protected SubscriptionCrudServiceInMemory subscriptionCrudService;
+
+    @Autowired
+    protected PlanCrudServiceInMemory planCrudService;
 
     @Autowired
     protected CreateSubscriptionUseCase createSubscriptionUseCase;
@@ -369,8 +381,6 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
             getClientCertificatesUseCase,
             getClientCertificateUseCase,
             createClientCertificateUseCase,
-            updateClientCertificateUseCase,
-            deleteClientCertificateUseCase,
             apiService,
             apiSearchService,
             apiAuthorizationService,
@@ -439,6 +449,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
             themeMapper,
             endpointConnectorPluginService
         );
+        clientCertificateService.reset();
+        subscriptionCrudService.reset();
+        planCrudService.reset();
     }
 
     @Priority(50)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificateResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificateResourceTest.java
@@ -17,23 +17,28 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
-import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
-import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertificateUseCase;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.portal.rest.model.PortalClientCertificate;
 import io.gravitee.rest.api.portal.rest.model.UpdatePortalClientCertificateInput;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.List;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +47,8 @@ public class PortalApplicationClientCertificateResourceTest extends AbstractReso
 
     private static final String APPLICATION_ID = "my-application";
     private static final String CERT_ID = "my-cert-id";
+    private static final String PLAN_ID = "plan-id";
+    private static final String API_ID = "api-id";
 
     @Override
     protected String contextPath() {
@@ -56,21 +63,17 @@ public class PortalApplicationClientCertificateResourceTest extends AbstractReso
 
     @Test
     public void should_get_client_certificate() {
-        var certificate = createClientCertificate(CERT_ID, "My Certificate");
-
+        var certificate = buildCertificate(CERT_ID, "My Certificate");
         when(getClientCertificateUseCase.execute(any(GetClientCertificateUseCase.Input.class))).thenReturn(
             new GetClientCertificateUseCase.Output(certificate)
         );
-
         final Response response = target().request().get();
-
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
             var result = response.readEntity(PortalClientCertificate.class);
             soft.assertThat(result.getId()).isEqualTo(CERT_ID);
             soft.assertThat(result.getName()).isEqualTo("My Certificate");
         });
-        verify(getClientCertificateUseCase).execute(any(GetClientCertificateUseCase.Input.class));
     }
 
     @Test
@@ -78,69 +81,68 @@ public class PortalApplicationClientCertificateResourceTest extends AbstractReso
         when(getClientCertificateUseCase.execute(any(GetClientCertificateUseCase.Input.class))).thenThrow(
             new ClientCertificateNotFoundException(CERT_ID)
         );
-
         final Response response = target().request().get();
-
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
     }
 
     @Test
     public void should_update_client_certificate() {
+        clientCertificateService.initWith(List.of(buildCertificate(CERT_ID, "Original Name")));
         var updateRequest = new UpdatePortalClientCertificateInput();
         updateRequest.setName("Updated Certificate Name");
-
-        ClientCertificate updated = createClientCertificate(CERT_ID, "Updated Certificate Name");
-
-        when(updateClientCertificateUseCase.execute(any(UpdateClientCertificateUseCase.Input.class))).thenReturn(
-            new UpdateClientCertificateUseCase.Output(updated)
-        );
-
         final Response response = target().request().put(Entity.json(updateRequest));
-
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
             var result = response.readEntity(PortalClientCertificate.class);
             soft.assertThat(result.getName()).isEqualTo("Updated Certificate Name");
         });
-        verify(updateClientCertificateUseCase).execute(any(UpdateClientCertificateUseCase.Input.class));
+        assertThat(clientCertificateService.storage().getFirst().name()).isEqualTo("Updated Certificate Name");
+    }
+
+    @Test
+    public void should_return_400_when_updating_certificate_with_invalid_dates() {
+        clientCertificateService.initWith(List.of(buildCertificate(CERT_ID, "My Certificate")));
+        var updateRequest = new UpdatePortalClientCertificateInput();
+        updateRequest.setName("My Certificate");
+        updateRequest.setStartsAt(OffsetDateTime.now().plus(2, ChronoUnit.DAYS));
+        updateRequest.setEndsAt(OffsetDateTime.now().plus(1, ChronoUnit.DAYS));
+        final Response response = target().request().put(Entity.json(updateRequest));
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
     }
 
     @Test
     public void should_return_404_when_updating_non_existent_certificate() {
         var updateRequest = new UpdatePortalClientCertificateInput();
         updateRequest.setName("Updated Certificate Name");
-
-        when(updateClientCertificateUseCase.execute(any(UpdateClientCertificateUseCase.Input.class))).thenThrow(
-            new ClientCertificateNotFoundException(CERT_ID)
-        );
-
         final Response response = target().request().put(Entity.json(updateRequest));
-
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
     }
 
     @Test
     public void should_delete_client_certificate() {
-        doNothing().when(deleteClientCertificateUseCase).execute(any(DeleteClientCertificateUseCase.Input.class));
-
+        clientCertificateService.initWith(List.of(buildCertificate(CERT_ID, "My Certificate")));
         final Response response = target().request().delete();
-
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NO_CONTENT_204);
-        verify(deleteClientCertificateUseCase).execute(any(DeleteClientCertificateUseCase.Input.class));
+        assertThat(clientCertificateService.storage()).isEmpty();
+    }
+
+    @Test
+    public void should_return_400_when_deleting_last_active_certificate_with_mtls_subscriptions() {
+        clientCertificateService.initWith(List.of(buildCertificate(CERT_ID, "My Certificate")));
+        planCrudService.initWith(List.of(buildMtlsPlan()));
+        subscriptionCrudService.initWith(List.of(buildAcceptedSubscription()));
+        final Response response = target().request().delete();
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        assertThat(clientCertificateService.storage()).hasSize(1);
     }
 
     @Test
     public void should_return_404_when_deleting_non_existent_certificate() {
-        doThrow(new ClientCertificateNotFoundException(CERT_ID))
-            .when(deleteClientCertificateUseCase)
-            .execute(any(DeleteClientCertificateUseCase.Input.class));
-
         final Response response = target().request().delete();
-
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
     }
 
-    private ClientCertificate createClientCertificate(String id, String name) {
+    private ClientCertificate buildCertificate(String id, String name) {
         return new ClientCertificate(
             id,
             null,
@@ -158,5 +160,31 @@ public class PortalApplicationClientCertificateResourceTest extends AbstractReso
             null,
             ClientCertificateStatus.ACTIVE
         );
+    }
+
+    private Plan buildMtlsPlan() {
+        var planDefinition = io.gravitee.definition.model.v4.plan.Plan.builder()
+            .id(PLAN_ID)
+            .security(PlanSecurity.builder().type(PlanSecurityType.MTLS.name()).build())
+            .build();
+        return Plan.builder()
+            .id(PLAN_ID)
+            .apiId(API_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .planDefinitionHttpV4(planDefinition)
+            .build();
+    }
+
+    private SubscriptionEntity buildAcceptedSubscription() {
+        var now = ZonedDateTime.now();
+        return SubscriptionEntity.builder()
+            .id("sub-1")
+            .applicationId(APPLICATION_ID)
+            .planId(PLAN_ID)
+            .apiId(API_ID)
+            .status(SubscriptionEntity.Status.ACCEPTED)
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -24,12 +24,15 @@ import inmemory.ApiExposedEntrypointDomainServiceInMemory;
 import inmemory.ApiPortalSearchQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
+import inmemory.ClientCertificateCrudServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
+import inmemory.SubscriptionCrudServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
 import inmemory.SubscriptionSearchQueryServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
@@ -62,6 +65,7 @@ import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
@@ -144,6 +148,7 @@ import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomai
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDSpecDomainService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionSearchQueryService;
 import io.gravitee.apim.core.subscription.use_case.CloseSubscriptionUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
@@ -159,6 +164,8 @@ import io.gravitee.apim.infra.domain_service.analytics_engine.definition.Analyti
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.UnitEnrichmentPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.api.ApiHostValidatorDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.application_certificates.ClientCertificateDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.application_certificates.ClientCertificateValidationDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.logs_engine.LogNamesPostProcessorImpl;
@@ -1092,8 +1099,16 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public SubscriptionQueryServiceInMemory subscriptionQueryService() {
-        return new SubscriptionQueryServiceInMemory();
+    public ClientCertificateCrudServiceInMemory clientCertificateService() {
+        return new ClientCertificateCrudServiceInMemory();
+    }
+
+    @Bean
+    public SubscriptionQueryServiceInMemory subscriptionQueryService(
+        SubscriptionCrudServiceInMemory subscriptionCrudService,
+        PlanCrudServiceInMemory planCrudService
+    ) {
+        return new SubscriptionQueryServiceInMemory(subscriptionCrudService, planCrudService);
     }
 
     @Bean
@@ -1221,13 +1236,23 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    ClientCertificateDomainService clientCertificateDomainService() {
-        return mock(ClientCertificateDomainService.class);
+    ClientCertificateDomainService clientCertificateDomainService(
+        ClientCertificateCrudService clientCertificateService,
+        MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService,
+        SubscriptionQueryService subscriptionQueryService
+    ) {
+        return new ClientCertificateDomainServiceImpl(
+            clientCertificateService,
+            mtlsSubscriptionSyncDomainService,
+            subscriptionQueryService
+        );
     }
 
     @Bean
-    public ClientCertificateValidationDomainService clientCertificateValidationDomainService() {
-        return mock(ClientCertificateValidationDomainService.class);
+    public ClientCertificateValidationDomainService clientCertificateValidationDomainService(
+        ClientCertificateCrudService clientCertificateService
+    ) {
+        return new ClientCertificateValidationDomainServiceImpl(clientCertificateService);
     }
 
     @Bean
@@ -1246,13 +1271,16 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public UpdateClientCertificateUseCase updateClientCertificateUseCase() {
-        return mock(UpdateClientCertificateUseCase.class);
+    public UpdateClientCertificateUseCase updateClientCertificateUseCase(
+        ClientCertificateDomainService clientCertificateDomainService,
+        ClientCertificateValidationDomainService clientCertificateValidationDomainService
+    ) {
+        return new UpdateClientCertificateUseCase(clientCertificateDomainService, clientCertificateValidationDomainService);
     }
 
     @Bean
-    public DeleteClientCertificateUseCase deleteClientCertificateUseCase() {
-        return mock(DeleteClientCertificateUseCase.class);
+    public DeleteClientCertificateUseCase deleteClientCertificateUseCase(ClientCertificateDomainService clientCertificateDomainService) {
+        return new DeleteClientCertificateUseCase(clientCertificateDomainService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/ClientCertificateDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/ClientCertificateDomainService.java
@@ -34,17 +34,19 @@ public interface ClientCertificateDomainService {
 
     /**
      * Updates an existing client certificate and syncs active mTLS subscriptions.
+     * Performs an ownership check when applicationId is non-null.
      *
+     * @param applicationId the application ID for ownership verification (may be null to skip)
      * @param certificateId the certificate ID to update
      * @param certificate the certificate data to apply
      * @return the updated certificate
      */
-    ClientCertificate update(String certificateId, ClientCertificate certificate);
+    ClientCertificate update(String applicationId, String certificateId, ClientCertificate certificate);
 
     /**
      * Deletes a client certificate and syncs active mTLS subscriptions.
      *
-     * @param applicationId the application ID (used for validation and sync)
+     * @param applicationId the application ID for ownership verification (may be null to skip; resolved from the certificate)
      * @param certificateId the certificate ID to delete
      */
     void delete(String applicationId, String certificateId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/ClientCertificateValidationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/ClientCertificateValidationDomainService.java
@@ -42,5 +42,13 @@ public interface ClientCertificateValidationDomainService {
      */
     CertificateInfo validateForCreation(ClientCertificate clientCertificate, String environmentId);
 
+    /**
+     * Validates a certificate for update: date bounds check.
+     *
+     * @param clientCertificate the certificate data to validate
+     * @throws ClientCertificateDateBoundsInvalidException if startsAt is not before endsAt
+     */
+    void validateForUpdate(ClientCertificate clientCertificate);
+
     record CertificateInfo(Date certificateExpiration, String subject, String issuer, String fingerprint) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/MtlsSubscriptionSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/domain_service/MtlsSubscriptionSyncDomainService.java
@@ -38,15 +38,4 @@ public interface MtlsSubscriptionSyncDomainService {
      * @param applicationId the application ID
      */
     void updateActiveMTLSSubscriptions(String applicationId);
-
-    /**
-     * Validates that the given certificate can be safely removed from the application.
-     * <p>
-     * Throws {@link io.gravitee.rest.api.service.exceptions.ClientCertificateLastRemovalException}
-     * if the certificate is the last active one and the application has active mTLS subscriptions.
-     *
-     * @param applicationId the application ID
-     * @param certificateId the certificate ID being removed
-     */
-    void validateCertificateRemoval(String applicationId, String certificateId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCase.java
@@ -16,10 +16,7 @@
 package io.gravitee.apim.core.application_certificate.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
-import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
-import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
@@ -27,15 +24,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DeleteClientCertificateUseCase {
 
-    private final ClientCertificateCrudService clientCertificateCrudService;
     private final ClientCertificateDomainService clientCertificateDomainService;
 
     public void execute(Input input) {
-        ClientCertificate certificate = clientCertificateCrudService.findById(input.clientCertificateId());
-        if (input.applicationId().isPresent() && !input.applicationId().get().equals(certificate.applicationId())) {
-            throw new ClientCertificateNotFoundException(input.clientCertificateId());
-        }
-        clientCertificateDomainService.delete(certificate.applicationId(), input.clientCertificateId());
+        clientCertificateDomainService.delete(input.applicationId().orElse(null), input.clientCertificateId());
     }
 
     public record Input(Optional<String> applicationId, String clientCertificateId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCase.java
@@ -16,10 +16,9 @@
 package io.gravitee.apim.core.application_certificate.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
-import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
@@ -27,17 +26,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UpdateClientCertificateUseCase {
 
-    private final ClientCertificateCrudService clientCertificateCrudService;
     private final ClientCertificateDomainService clientCertificateDomainService;
+    private final ClientCertificateValidationDomainService clientCertificateValidationDomainService;
 
     public Output execute(Input input) {
-        if (input.applicationId().isPresent()) {
-            ClientCertificate existing = clientCertificateCrudService.findById(input.clientCertificateId());
-            if (!input.applicationId().get().equals(existing.applicationId())) {
-                throw new ClientCertificateNotFoundException(input.clientCertificateId());
-            }
-        }
-        var certificate = clientCertificateDomainService.update(input.clientCertificateId(), input.toUpdate());
+        clientCertificateValidationDomainService.validateForUpdate(input.toUpdate());
+        var certificate = clientCertificateDomainService.update(
+            input.applicationId().orElse(null),
+            input.clientCertificateId(),
+            input.toUpdate()
+        );
         return new Output(certificate);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImpl.java
@@ -26,12 +26,9 @@ import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
-import io.gravitee.rest.api.service.exceptions.ClientCertificateDateBoundsInvalidException;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.TransactionalService;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -95,17 +92,6 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
         }
     }
 
-    private void validateDateBounds(ClientCertificate clientCertificate) {
-        if (
-            !Duration.between(
-                Optional.ofNullable(clientCertificate.startsAt()).map(Date::toInstant).orElse(Instant.ofEpochMilli(Long.MIN_VALUE)),
-                Optional.ofNullable(clientCertificate.endsAt()).map(Date::toInstant).orElse(Instant.ofEpochMilli(Long.MAX_VALUE))
-            ).isPositive()
-        ) {
-            throw new ClientCertificateDateBoundsInvalidException();
-        }
-    }
-
     @Override
     public ClientCertificate update(String clientCertificateId, ClientCertificate update) {
         try {
@@ -114,8 +100,6 @@ public class ClientCertificateCrudServiceImpl extends TransactionalService imple
             var existingCertificate = clientCertificateRepository
                 .findById(clientCertificateId)
                 .orElseThrow(() -> new ClientCertificateNotFoundException(clientCertificateId));
-
-            validateDateBounds(update);
 
             existingCertificate.setName(update.name());
             existingCertificate.setStartsAt(update.startsAt());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateDomainServiceImpl.java
@@ -19,6 +19,13 @@ import io.gravitee.apim.core.application_certificate.crud_service.ClientCertific
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
+import io.gravitee.rest.api.model.PlanSecurityType;
+import io.gravitee.rest.api.service.exceptions.ClientCertificateLastRemovalException;
+import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
+import java.util.List;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,6 +42,7 @@ public class ClientCertificateDomainServiceImpl implements ClientCertificateDoma
 
     private final ClientCertificateCrudService clientCertificateCrudService;
     private final MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
+    private final SubscriptionQueryService subscriptionQueryService;
 
     @Override
     public ClientCertificate create(String applicationId, ClientCertificate certificate) {
@@ -45,8 +53,9 @@ public class ClientCertificateDomainServiceImpl implements ClientCertificateDoma
     }
 
     @Override
-    public ClientCertificate update(String certificateId, ClientCertificate certificate) {
+    public ClientCertificate update(String applicationId, String certificateId, ClientCertificate certificate) {
         log.debug("Updating client certificate [{}]", certificateId);
+        resolveAndVerifyOwnership(certificateId, applicationId);
         var updated = clientCertificateCrudService.update(certificateId, certificate);
         mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(updated.applicationId());
         return updated;
@@ -55,8 +64,41 @@ public class ClientCertificateDomainServiceImpl implements ClientCertificateDoma
     @Override
     public void delete(String applicationId, String certificateId) {
         log.debug("Deleting client certificate [{}] for application [{}]", certificateId, applicationId);
-        mtlsSubscriptionSyncDomainService.validateCertificateRemoval(applicationId, certificateId);
+        var existing = resolveAndVerifyOwnership(certificateId, applicationId);
+        var resolvedAppId = existing.applicationId();
+        validateCertificateRemoval(resolvedAppId, certificateId);
         clientCertificateCrudService.delete(certificateId);
-        mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(applicationId);
+        mtlsSubscriptionSyncDomainService.updateActiveMTLSSubscriptions(resolvedAppId);
+    }
+
+    private ClientCertificate resolveAndVerifyOwnership(String certificateId, String applicationId) {
+        var existing = clientCertificateCrudService.findById(certificateId);
+        if (applicationId != null && !applicationId.equals(existing.applicationId())) {
+            throw new ClientCertificateNotFoundException(certificateId);
+        }
+        return existing;
+    }
+
+    private void validateCertificateRemoval(String applicationId, String certificateId) {
+        List<SubscriptionEntity> mtlsSubscriptions = subscriptionQueryService.findActiveByApplicationIdAndPlanSecurityTypes(
+            applicationId,
+            List.of(PlanSecurityType.MTLS.name())
+        );
+
+        if (mtlsSubscriptions.isEmpty()) {
+            return;
+        }
+
+        var activeCertificates = clientCertificateCrudService.findByApplicationIdAndStatuses(
+            applicationId,
+            ClientCertificateStatus.ACTIVE,
+            ClientCertificateStatus.ACTIVE_WITH_END
+        );
+
+        boolean noneRemaining = activeCertificates.stream().noneMatch(c -> !c.id().equals(certificateId));
+
+        if (noneRemaining) {
+            throw new ClientCertificateLastRemovalException(applicationId);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateValidationDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateValidationDomainServiceImpl.java
@@ -75,6 +75,11 @@ public class ClientCertificateValidationDomainServiceImpl implements ClientCerti
         return info;
     }
 
+    @Override
+    public void validateForUpdate(ClientCertificate clientCertificate) {
+        validateDateBounds(clientCertificate);
+    }
+
     private X509Certificate parseCertificate(String pemCertificate) {
         Certificate[] certificates;
         try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/MtlsSubscriptionSyncDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application_certificates/MtlsSubscriptionSyncDomainServiceImpl.java
@@ -24,7 +24,6 @@ import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.common.security.PKCS7Utils;
 import io.gravitee.rest.api.model.PlanSecurityType;
-import io.gravitee.rest.api.service.exceptions.ClientCertificateLastRemovalException;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Base64;
@@ -48,33 +47,6 @@ public class MtlsSubscriptionSyncDomainServiceImpl implements MtlsSubscriptionSy
     private final SubscriptionQueryService subscriptionQueryService;
     private final SubscriptionCrudService subscriptionCrudService;
     private final ClientCertificateCrudService clientCertificateCrudService;
-
-    @Override
-    public void validateCertificateRemoval(String applicationId, String certificateId) {
-        List<SubscriptionEntity> mtlsSubscriptions = subscriptionQueryService.findActiveByApplicationIdAndPlanSecurityTypes(
-            applicationId,
-            List.of(PlanSecurityType.MTLS.name())
-        );
-
-        if (mtlsSubscriptions.isEmpty()) {
-            return;
-        }
-
-        var activeCertificates = clientCertificateCrudService.findByApplicationIdAndStatuses(
-            applicationId,
-            ClientCertificateStatus.ACTIVE,
-            ClientCertificateStatus.ACTIVE_WITH_END
-        );
-
-        long remainingAfterRemoval = activeCertificates
-            .stream()
-            .filter(c -> !c.id().equals(certificateId))
-            .count();
-
-        if (remainingAfterRemoval == 0) {
-            throw new ClientCertificateLastRemovalException(applicationId);
-        }
-    }
 
     @Override
     public void updateActiveMTLSSubscriptions(String applicationId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCaseTest.java
@@ -15,19 +15,13 @@
  */
 package io.gravitee.apim.core.application_certificate.use_case;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
-import inmemory.ClientCertificateCrudServiceInMemory;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
-import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
-import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateLastRemovalException;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
-import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -41,8 +35,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class DeleteClientCertificateUseCaseTest {
 
-    private final ClientCertificateCrudServiceInMemory clientCertificateCrudService = new ClientCertificateCrudServiceInMemory();
-
     @Mock
     private ClientCertificateDomainService clientCertificateDomainService;
 
@@ -50,34 +42,24 @@ class DeleteClientCertificateUseCaseTest {
 
     @BeforeEach
     void setUp() {
-        clientCertificateCrudService.reset();
-        deleteClientCertificateUseCase = new DeleteClientCertificateUseCase(clientCertificateCrudService, clientCertificateDomainService);
+        deleteClientCertificateUseCase = new DeleteClientCertificateUseCase(clientCertificateDomainService);
     }
 
     @Test
     void should_delete_client_certificate() {
         var certId = "cert-id";
-        var appId = "app-id";
-        var certificate = new ClientCertificate(
-            certId,
-            "cross-id",
-            appId,
-            "Test Certificate",
-            new Date(),
-            new Date(),
-            new Date(),
-            new Date(),
-            "PEM_CONTENT",
-            new Date(),
-            "CN=Test",
-            "CN=Issuer",
-            "fingerprint",
-            "env-id",
-            ClientCertificateStatus.ACTIVE
-        );
-        clientCertificateCrudService.initWith(List.of(certificate));
 
         deleteClientCertificateUseCase.execute(new DeleteClientCertificateUseCase.Input(certId));
+
+        verify(clientCertificateDomainService).delete(null, certId);
+    }
+
+    @Test
+    void should_delete_client_certificate_with_application_id() {
+        var certId = "cert-id";
+        var appId = "app-id";
+
+        deleteClientCertificateUseCase.execute(new DeleteClientCertificateUseCase.Input(Optional.of(appId), certId));
 
         verify(clientCertificateDomainService).delete(appId, certId);
     }
@@ -85,27 +67,7 @@ class DeleteClientCertificateUseCaseTest {
     @Test
     void should_not_delete_when_last_active_certificate_with_mtls_subscriptions() {
         var certId = "cert-id";
-        var appId = "app-id";
-        var certificate = new ClientCertificate(
-            certId,
-            "cross-id",
-            appId,
-            "Test Certificate",
-            new Date(),
-            new Date(),
-            new Date(),
-            new Date(),
-            "PEM_CONTENT",
-            new Date(),
-            "CN=Test",
-            "CN=Issuer",
-            "fingerprint",
-            "env-id",
-            ClientCertificateStatus.ACTIVE
-        );
-        clientCertificateCrudService.initWith(List.of(certificate));
-
-        doThrow(new ClientCertificateLastRemovalException(appId)).when(clientCertificateDomainService).delete(appId, certId);
+        doThrow(new ClientCertificateLastRemovalException("app-id")).when(clientCertificateDomainService).delete(null, certId);
 
         var input = new DeleteClientCertificateUseCase.Input(certId);
 
@@ -114,6 +76,10 @@ class DeleteClientCertificateUseCaseTest {
 
     @Test
     void should_throw_exception_when_certificate_not_found() {
+        doThrow(new ClientCertificateNotFoundException("non-existent-id"))
+            .when(clientCertificateDomainService)
+            .delete(null, "non-existent-id");
+
         var input = new DeleteClientCertificateUseCase.Input("non-existent-id");
 
         assertThatThrownBy(() -> deleteClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateNotFoundException.class);
@@ -121,28 +87,9 @@ class DeleteClientCertificateUseCaseTest {
 
     @Test
     void should_throw_exception_when_applicationId_does_not_match() {
-        var certId = "cert-id";
-        var appId = "app-id";
-        var certificate = new ClientCertificate(
-            certId,
-            "cross-id",
-            appId,
-            "Test Certificate",
-            new Date(),
-            new Date(),
-            new Date(),
-            new Date(),
-            "PEM_CONTENT",
-            new Date(),
-            "CN=Test",
-            "CN=Issuer",
-            "fingerprint",
-            "env-id",
-            ClientCertificateStatus.ACTIVE
-        );
-        clientCertificateCrudService.initWith(List.of(certificate));
+        doThrow(new ClientCertificateNotFoundException("cert-id")).when(clientCertificateDomainService).delete("other-app-id", "cert-id");
 
-        var input = new DeleteClientCertificateUseCase.Input(Optional.of("other-app-id"), certId);
+        var input = new DeleteClientCertificateUseCase.Input(Optional.of("other-app-id"), "cert-id");
 
         assertThatThrownBy(() -> deleteClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateNotFoundException.class);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCaseTest.java
@@ -19,62 +19,55 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import inmemory.ClientCertificateCrudServiceInMemory;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.rest.api.service.exceptions.ClientCertificateDateBoundsInvalidException;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class UpdateClientCertificateUseCaseTest {
-
-    private final ClientCertificateCrudServiceInMemory clientCertificateCrudService = new ClientCertificateCrudServiceInMemory();
 
     @Mock
     private ClientCertificateDomainService clientCertificateDomainService;
+
+    @Mock
+    private ClientCertificateValidationDomainService clientCertificateValidationDomainService;
 
     private UpdateClientCertificateUseCase updateClientCertificateUseCase;
 
     @BeforeEach
     void setUp() {
-        clientCertificateCrudService.reset();
-        updateClientCertificateUseCase = new UpdateClientCertificateUseCase(clientCertificateCrudService, clientCertificateDomainService);
+        updateClientCertificateUseCase = new UpdateClientCertificateUseCase(
+            clientCertificateDomainService,
+            clientCertificateValidationDomainService
+        );
     }
 
     @Test
     void should_update_client_certificate() {
         var certId = "cert-id";
         var appId = "app-id";
-        var certificate = new ClientCertificate(
-            certId,
-            "cross-id",
-            appId,
-            "Original Name",
-            new Date(),
-            new Date(),
-            new Date(),
-            new Date(),
-            "PEM_CONTENT",
-            new Date(),
-            "CN=Test",
-            "CN=Issuer",
-            "fingerprint",
-            "env-id",
-            ClientCertificateStatus.ACTIVE
-        );
-        clientCertificateCrudService.initWith(List.of(certificate));
-
         var updatedCertificate = new ClientCertificate(
             certId,
             "cross-id",
@@ -93,7 +86,7 @@ class UpdateClientCertificateUseCaseTest {
             ClientCertificateStatus.ACTIVE
         );
         var updateRequest = new ClientCertificate("Updated Name", new Date(), new Date());
-        when(clientCertificateDomainService.update(eq(certId), any(ClientCertificate.class))).thenReturn(updatedCertificate);
+        when(clientCertificateDomainService.update(isNull(), eq(certId), any(ClientCertificate.class))).thenReturn(updatedCertificate);
 
         var result = updateClientCertificateUseCase.execute(new UpdateClientCertificateUseCase.Input(certId, updateRequest));
 
@@ -101,13 +94,15 @@ class UpdateClientCertificateUseCaseTest {
         assertThat(result.clientCertificate().id()).isEqualTo(certId);
         assertThat(result.clientCertificate().name()).isEqualTo("Updated Name");
 
-        verify(clientCertificateDomainService).update(eq(certId), any(ClientCertificate.class));
+        InOrder inOrder = inOrder(clientCertificateValidationDomainService, clientCertificateDomainService);
+        inOrder.verify(clientCertificateValidationDomainService).validateForUpdate(any(ClientCertificate.class));
+        inOrder.verify(clientCertificateDomainService).update(isNull(), eq(certId), any(ClientCertificate.class));
     }
 
     @Test
     void should_throw_exception_when_certificate_not_found() {
         var updateRequest = new ClientCertificate("Updated Name", new Date(), new Date());
-        when(clientCertificateDomainService.update(eq("non-existent-id"), any(ClientCertificate.class))).thenThrow(
+        when(clientCertificateDomainService.update(isNull(), eq("non-existent-id"), any(ClientCertificate.class))).thenThrow(
             new ClientCertificateNotFoundException("non-existent-id")
         );
 
@@ -119,28 +114,29 @@ class UpdateClientCertificateUseCaseTest {
     @Test
     void should_throw_exception_when_applicationId_does_not_match() {
         var certId = "cert-id";
-        var certificate = new ClientCertificate(
-            certId,
-            "cross-id",
-            "app-id",
-            "Original Name",
-            new Date(),
-            new Date(),
-            new Date(),
-            new Date(),
-            "PEM_CONTENT",
-            new Date(),
-            "CN=Test",
-            "CN=Issuer",
-            "fingerprint",
-            "env-id",
-            ClientCertificateStatus.ACTIVE
-        );
-        clientCertificateCrudService.initWith(List.of(certificate));
-
         var updateRequest = new ClientCertificate("Updated Name", new Date(), new Date());
+        when(clientCertificateDomainService.update(eq("other-app-id"), eq(certId), any(ClientCertificate.class))).thenThrow(
+            new ClientCertificateNotFoundException(certId)
+        );
+
         var input = new UpdateClientCertificateUseCase.Input(Optional.of("other-app-id"), certId, updateRequest);
 
         assertThatThrownBy(() -> updateClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_exception_when_date_bounds_are_invalid() {
+        var startsAt = Date.from(Instant.now().plus(2, ChronoUnit.DAYS));
+        var endsAt = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+        var updateRequest = new ClientCertificate("Bad Dates", startsAt, endsAt);
+        doThrow(new ClientCertificateDateBoundsInvalidException())
+            .when(clientCertificateValidationDomainService)
+            .validateForUpdate(any(ClientCertificate.class));
+
+        var input = new UpdateClientCertificateUseCase.Input("cert-id", updateRequest);
+
+        assertThatThrownBy(() -> updateClientCertificateUseCase.execute(input)).isInstanceOf(
+            ClientCertificateDateBoundsInvalidException.class
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/application_certificates/ClientCertificateCrudServiceImplTest.java
@@ -18,7 +18,6 @@ package io.gravitee.apim.infra.crud_service.application_certificates;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -31,7 +30,6 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ClientCertificateRepository;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.exceptions.ClientCertificateDateBoundsInvalidException;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.time.Instant;
@@ -39,16 +37,12 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -537,34 +531,17 @@ class ClientCertificateCrudServiceImplTest {
         assertThat(result).isEmpty();
     }
 
-    public static Stream<Arguments> datesBounds() {
-        return Stream.of(
-            arguments(null, null, true),
-            arguments(null, new Date(), true),
-            arguments(new Date(), null, true),
-            arguments(new Date(), Date.from(Instant.now().plus(1, ChronoUnit.MILLIS)), true),
-            arguments(new Date(), Date.from(Instant.now().plus(1, ChronoUnit.DAYS)), true),
-            arguments(Date.from(Instant.now().minus(1, ChronoUnit.DAYS)), new Date(), true),
-            arguments(Date.from(Instant.now().minus(1, ChronoUnit.DAYS)), Date.from(Instant.now().plus(1, ChronoUnit.DAYS)), true),
-            arguments(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)), new Date(), false),
-            arguments(new Date(), Date.from(Instant.now().minus(1, ChronoUnit.DAYS)), false)
-        );
-    }
-
-    @MethodSource("datesBounds")
-    @ParameterizedTest
-    void should_validate_date_boundaries_on_update(Date startDate, Date endDate, boolean valid) throws TechnicalException {
+    @Test
+    void should_update_certificate_without_date_validation() throws TechnicalException {
+        // Date-bounds validation is now the responsibility of ClientCertificateValidationDomainService,
+        // not the crud service. The crud service should accept any date combination.
         when(clientCertificateRepository.findById(any())).thenReturn(
             Optional.of(io.gravitee.repository.management.model.ClientCertificate.builder().build())
         );
-        ClientCertificate clientCertificate = new ClientCertificate("With dates", startDate, endDate);
-        if (valid) {
-            assertThatCode(() -> clientCertificateCrudService.update(CERTIFICATE_ID, clientCertificate)).doesNotThrowAnyException();
-        } else {
-            assertThatThrownBy(() -> clientCertificateCrudService.update(CERTIFICATE_ID, clientCertificate)).isInstanceOf(
-                ClientCertificateDateBoundsInvalidException.class
-            );
-        }
+        when(clientCertificateRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var startsAtAfterEndsAt = new ClientCertificate("With dates", Date.from(Instant.now().plus(1, ChronoUnit.DAYS)), new Date());
+        assertThatCode(() -> clientCertificateCrudService.update(CERTIFICATE_ID, startsAtAfterEndsAt)).doesNotThrowAnyException();
     }
 
     private io.gravitee.repository.management.model.ClientCertificate buildRepositoryClientCertificate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateDomainServiceImplTest.java
@@ -26,12 +26,22 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import inmemory.ClientCertificateCrudServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import inmemory.SubscriptionCrudServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.domain_service.MtlsSubscriptionSyncDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateLastRemovalException;
+import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
@@ -39,6 +49,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -53,8 +64,16 @@ class ClientCertificateDomainServiceImplTest {
 
     private static final String APPLICATION_ID = "app-id";
     private static final String ENVIRONMENT_ID = "env-id";
+    private static final String PLAN_ID = "plan-id";
+    private static final String API_ID = "api-id";
 
     private final ClientCertificateCrudServiceInMemory clientCertificateCrudService = new ClientCertificateCrudServiceInMemory();
+    private final SubscriptionCrudServiceInMemory subscriptionCrudService = new SubscriptionCrudServiceInMemory();
+    private final PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
+    private final SubscriptionQueryServiceInMemory subscriptionQueryService = new SubscriptionQueryServiceInMemory(
+        subscriptionCrudService,
+        planCrudService
+    );
 
     @Mock
     private MtlsSubscriptionSyncDomainService mtlsSubscriptionSyncDomainService;
@@ -63,12 +82,18 @@ class ClientCertificateDomainServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new ClientCertificateDomainServiceImpl(clientCertificateCrudService, mtlsSubscriptionSyncDomainService);
+        service = new ClientCertificateDomainServiceImpl(
+            clientCertificateCrudService,
+            mtlsSubscriptionSyncDomainService,
+            subscriptionQueryService
+        );
     }
 
     @AfterEach
     void tearDown() {
         clientCertificateCrudService.reset();
+        subscriptionCrudService.reset();
+        planCrudService.reset();
     }
 
     @Test
@@ -101,56 +126,182 @@ class ClientCertificateDomainServiceImplTest {
         verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APPLICATION_ID);
     }
 
-    @Test
-    void should_update_certificate_and_sync_subscriptions() {
-        var certId = "cert-id";
-        var existing = buildClientCertificate(certId, "Original Name", ClientCertificateStatus.ACTIVE);
-        clientCertificateCrudService.initWith(List.of(existing));
+    @Nested
+    class Update {
 
-        var updateRequest = new ClientCertificate("Updated Name", new Date(), Date.from(Instant.now().plus(365, ChronoUnit.DAYS)));
+        @Test
+        void should_update_certificate_and_sync_subscriptions() {
+            var certId = "cert-id";
+            var existing = buildClientCertificate(certId, "Original Name", ClientCertificateStatus.ACTIVE);
+            clientCertificateCrudService.initWith(List.of(existing));
 
-        var result = service.update(certId, updateRequest);
+            var updateRequest = new ClientCertificate("Updated Name", new Date(), Date.from(Instant.now().plus(365, ChronoUnit.DAYS)));
 
-        assertThat(result).isNotNull();
-        assertThat(result.id()).isEqualTo(certId);
-        assertThat(result.name()).isEqualTo("Updated Name");
-        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APPLICATION_ID);
+            var result = service.update(null, certId, updateRequest);
+
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(certId);
+            assertThat(result.name()).isEqualTo("Updated Name");
+            verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APPLICATION_ID);
+        }
+
+        @Test
+        void should_update_certificate_when_applicationId_matches() {
+            var certId = "cert-id";
+            var existing = buildClientCertificate(certId, "Original Name", ClientCertificateStatus.ACTIVE);
+            clientCertificateCrudService.initWith(List.of(existing));
+
+            var updateRequest = new ClientCertificate("Updated Name", new Date(), Date.from(Instant.now().plus(365, ChronoUnit.DAYS)));
+
+            var result = service.update(APPLICATION_ID, certId, updateRequest);
+
+            assertThat(result).isNotNull();
+            assertThat(result.name()).isEqualTo("Updated Name");
+        }
+
+        @Test
+        void should_throw_when_applicationId_does_not_match() {
+            var certId = "cert-id";
+            var existing = buildClientCertificate(certId, "Original Name", ClientCertificateStatus.ACTIVE);
+            clientCertificateCrudService.initWith(List.of(existing));
+
+            var updateRequest = new ClientCertificate("Updated Name", new Date(), Date.from(Instant.now().plus(365, ChronoUnit.DAYS)));
+
+            assertThatThrownBy(() -> service.update("other-app-id", certId, updateRequest)).isInstanceOf(
+                ClientCertificateNotFoundException.class
+            );
+        }
     }
 
-    @Test
-    void should_delete_certificate_and_sync_subscriptions() {
-        var certId = "cert-id";
-        var existing = buildClientCertificate(certId, "Test Certificate", ClientCertificateStatus.ACTIVE);
-        clientCertificateCrudService.initWith(List.of(existing));
+    @Nested
+    class Delete {
 
-        service.delete(APPLICATION_ID, certId);
+        @Test
+        void should_delete_certificate_and_sync_subscriptions() {
+            var certId = "cert-id";
+            var existing = buildClientCertificate(certId, "Test Certificate", ClientCertificateStatus.ACTIVE);
+            clientCertificateCrudService.initWith(List.of(existing));
 
-        assertThat(clientCertificateCrudService.storage()).isEmpty();
-        verify(mtlsSubscriptionSyncDomainService).validateCertificateRemoval(APPLICATION_ID, certId);
-        verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APPLICATION_ID);
-    }
+            service.delete(APPLICATION_ID, certId);
 
-    @Test
-    void should_not_delete_when_validation_fails() {
-        var certId = "cert-id";
-        var existing = buildClientCertificate(certId, "Test Certificate", ClientCertificateStatus.ACTIVE);
-        clientCertificateCrudService.initWith(List.of(existing));
+            assertThat(clientCertificateCrudService.storage()).isEmpty();
+            verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APPLICATION_ID);
+        }
 
-        doThrow(new ClientCertificateLastRemovalException(APPLICATION_ID))
-            .when(mtlsSubscriptionSyncDomainService)
-            .validateCertificateRemoval(APPLICATION_ID, certId);
+        @Test
+        void should_delete_when_no_mtls_subscriptions() {
+            var certId = "cert-id";
+            var existing = buildClientCertificate(certId, "Test Certificate", ClientCertificateStatus.ACTIVE);
+            clientCertificateCrudService.initWith(List.of(existing));
 
-        assertThatThrownBy(() -> service.delete(APPLICATION_ID, certId)).isInstanceOf(ClientCertificateLastRemovalException.class);
+            // No subscriptions at all
+            service.delete(APPLICATION_ID, certId);
 
-        assertThat(clientCertificateCrudService.storage()).hasSize(1);
-        verify(mtlsSubscriptionSyncDomainService, never()).updateActiveMTLSSubscriptions(anyString());
+            assertThat(clientCertificateCrudService.storage()).isEmpty();
+        }
+
+        @Test
+        void should_delete_when_other_active_certs_remain() {
+            var certId = "cert-1";
+            var cert1 = buildClientCertificate(certId, "Cert 1", ClientCertificateStatus.ACTIVE);
+            var cert2 = buildClientCertificate("cert-2", "Cert 2", ClientCertificateStatus.ACTIVE);
+            clientCertificateCrudService.initWith(List.of(cert1, cert2));
+
+            var mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
+            planCrudService.initWith(List.of(mtlsPlan));
+            var subscription = buildSubscription("sub-1", APPLICATION_ID, PLAN_ID);
+            subscriptionCrudService.initWith(List.of(subscription));
+
+            service.delete(APPLICATION_ID, certId);
+
+            assertThat(clientCertificateCrudService.storage()).hasSize(1);
+            assertThat(clientCertificateCrudService.storage().getFirst().id()).isEqualTo("cert-2");
+        }
+
+        @Test
+        void should_reject_deletion_when_last_active_cert_and_mtls_subscriptions_exist() {
+            var certId = "cert-id";
+            var existing = buildClientCertificate(certId, "Test Certificate", ClientCertificateStatus.ACTIVE);
+            clientCertificateCrudService.initWith(List.of(existing));
+
+            var mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
+            planCrudService.initWith(List.of(mtlsPlan));
+            var subscription = buildSubscription("sub-1", APPLICATION_ID, PLAN_ID);
+            subscriptionCrudService.initWith(List.of(subscription));
+
+            assertThatThrownBy(() -> service.delete(APPLICATION_ID, certId)).isInstanceOf(ClientCertificateLastRemovalException.class);
+
+            assertThat(clientCertificateCrudService.storage()).hasSize(1);
+        }
+
+        @Test
+        void should_delete_when_remaining_cert_is_active_with_end() {
+            var certId = "cert-1";
+            var cert1 = buildClientCertificate(certId, "Cert 1", ClientCertificateStatus.ACTIVE);
+            var cert2 = buildClientCertificate("cert-2", "Cert 2", ClientCertificateStatus.ACTIVE_WITH_END);
+            clientCertificateCrudService.initWith(List.of(cert1, cert2));
+
+            var mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
+            planCrudService.initWith(List.of(mtlsPlan));
+            var subscription = buildSubscription("sub-1", APPLICATION_ID, PLAN_ID);
+            subscriptionCrudService.initWith(List.of(subscription));
+
+            service.delete(APPLICATION_ID, certId);
+
+            assertThat(clientCertificateCrudService.storage()).hasSize(1);
+            assertThat(clientCertificateCrudService.storage().getFirst().id()).isEqualTo("cert-2");
+        }
+
+        @Test
+        void should_reject_deletion_when_only_revoked_certs_remain() {
+            var certId = "cert-1";
+            var cert1 = buildClientCertificate(certId, "Cert 1", ClientCertificateStatus.ACTIVE);
+            var cert2 = buildClientCertificate("cert-2", "Cert 2", ClientCertificateStatus.REVOKED);
+            clientCertificateCrudService.initWith(List.of(cert1, cert2));
+
+            var mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
+            planCrudService.initWith(List.of(mtlsPlan));
+            var subscription = buildSubscription("sub-1", APPLICATION_ID, PLAN_ID);
+            subscriptionCrudService.initWith(List.of(subscription));
+
+            assertThatThrownBy(() -> service.delete(APPLICATION_ID, certId)).isInstanceOf(ClientCertificateLastRemovalException.class);
+
+            assertThat(clientCertificateCrudService.storage()).hasSize(2);
+        }
+
+        @Test
+        void should_throw_when_applicationId_does_not_match() {
+            var certId = "cert-id";
+            var existing = buildClientCertificate(certId, "Test Certificate", ClientCertificateStatus.ACTIVE);
+            clientCertificateCrudService.initWith(List.of(existing));
+
+            assertThatThrownBy(() -> service.delete("other-app-id", certId)).isInstanceOf(ClientCertificateNotFoundException.class);
+
+            assertThat(clientCertificateCrudService.storage()).hasSize(1);
+        }
+
+        @Test
+        void should_resolve_applicationId_from_certificate_when_null() {
+            var certId = "cert-id";
+            var existing = buildClientCertificate(certId, "Test Certificate", ClientCertificateStatus.ACTIVE);
+            clientCertificateCrudService.initWith(List.of(existing));
+
+            service.delete(null, certId);
+
+            assertThat(clientCertificateCrudService.storage()).isEmpty();
+            verify(mtlsSubscriptionSyncDomainService).updateActiveMTLSSubscriptions(APPLICATION_ID);
+        }
     }
 
     @Test
     void should_not_sync_subscriptions_when_create_fails() {
         var crudService = mock(ClientCertificateCrudService.class);
         when(crudService.create(anyString(), any())).thenThrow(new RuntimeException("DB error"));
-        var failingService = new ClientCertificateDomainServiceImpl(crudService, mtlsSubscriptionSyncDomainService);
+        var failingService = new ClientCertificateDomainServiceImpl(
+            crudService,
+            mtlsSubscriptionSyncDomainService,
+            subscriptionQueryService
+        );
 
         var toCreate = buildClientCertificate(null, "Test Certificate", null);
         assertThatThrownBy(() -> failingService.create(APPLICATION_ID, toCreate)).isInstanceOf(RuntimeException.class);
@@ -162,10 +313,14 @@ class ClientCertificateDomainServiceImplTest {
     void should_not_sync_subscriptions_when_update_fails() {
         var crudService = mock(ClientCertificateCrudService.class);
         when(crudService.update(anyString(), any())).thenThrow(new RuntimeException("DB error"));
-        var failingService = new ClientCertificateDomainServiceImpl(crudService, mtlsSubscriptionSyncDomainService);
+        var failingService = new ClientCertificateDomainServiceImpl(
+            crudService,
+            mtlsSubscriptionSyncDomainService,
+            subscriptionQueryService
+        );
 
         var updateRequest = new ClientCertificate("Updated Name", new Date(), Date.from(Instant.now().plus(365, ChronoUnit.DAYS)));
-        assertThatThrownBy(() -> failingService.update("cert-id", updateRequest)).isInstanceOf(RuntimeException.class);
+        assertThatThrownBy(() -> failingService.update(null, "cert-id", updateRequest)).isInstanceOf(RuntimeException.class);
 
         verify(mtlsSubscriptionSyncDomainService, never()).updateActiveMTLSSubscriptions(anyString());
     }
@@ -173,12 +328,17 @@ class ClientCertificateDomainServiceImplTest {
     @Test
     void should_not_sync_subscriptions_when_crud_delete_fails() {
         var crudService = mock(ClientCertificateCrudService.class);
+        var cert = buildClientCertificate("cert-id", "Test Certificate", ClientCertificateStatus.ACTIVE);
+        when(crudService.findById("cert-id")).thenReturn(cert);
         doThrow(new RuntimeException("DB error")).when(crudService).delete(anyString());
-        var failingService = new ClientCertificateDomainServiceImpl(crudService, mtlsSubscriptionSyncDomainService);
+        var failingService = new ClientCertificateDomainServiceImpl(
+            crudService,
+            mtlsSubscriptionSyncDomainService,
+            subscriptionQueryService
+        );
 
         assertThatThrownBy(() -> failingService.delete(APPLICATION_ID, "cert-id")).isInstanceOf(RuntimeException.class);
 
-        verify(mtlsSubscriptionSyncDomainService).validateCertificateRemoval(APPLICATION_ID, "cert-id");
         verify(mtlsSubscriptionSyncDomainService, never()).updateActiveMTLSSubscriptions(anyString());
     }
 
@@ -200,5 +360,33 @@ class ClientCertificateDomainServiceImplTest {
             ENVIRONMENT_ID,
             status
         );
+    }
+
+    private Plan buildPlan(String securityType) {
+        var planDefinition = io.gravitee.definition.model.v4.plan.Plan.builder()
+            .id(PLAN_ID)
+            .security(PlanSecurity.builder().type(securityType).build())
+            .build();
+
+        return Plan.builder()
+            .id(PLAN_ID)
+            .apiId(API_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .planDefinitionHttpV4(planDefinition)
+            .build();
+    }
+
+    private SubscriptionEntity buildSubscription(String subscriptionId, String applicationId, String planId) {
+        var now = ZonedDateTime.now();
+        return SubscriptionEntity.builder()
+            .id(subscriptionId)
+            .applicationId(applicationId)
+            .planId(planId)
+            .apiId(API_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .status(SubscriptionEntity.Status.ACCEPTED)
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateValidationDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ClientCertificateValidationDomainServiceImplTest.java
@@ -209,4 +209,57 @@ class ClientCertificateValidationDomainServiceImplTest {
             assertThat(result).isNotNull();
         }
     }
+
+    @Nested
+    class ValidateForUpdate {
+
+        @Test
+        void should_pass_when_date_bounds_are_valid() {
+            var startsAt = Date.from(Instant.now());
+            var endsAt = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+            var cert = new ClientCertificate("Good Dates", startsAt, endsAt);
+
+            service.validateForUpdate(cert);
+        }
+
+        @Test
+        void should_pass_when_dates_are_null() {
+            var cert = new ClientCertificate("No Dates", null, null);
+
+            service.validateForUpdate(cert);
+        }
+
+        @Test
+        void should_throw_when_starts_at_is_after_ends_at() {
+            var startsAt = Date.from(Instant.now().plus(2, ChronoUnit.DAYS));
+            var endsAt = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+            var cert = new ClientCertificate("Bad Dates", startsAt, endsAt);
+
+            assertThatThrownBy(() -> service.validateForUpdate(cert)).isInstanceOf(ClientCertificateDateBoundsInvalidException.class);
+        }
+
+        @Test
+        void should_pass_when_starts_at_is_null_and_ends_at_is_set() {
+            var endsAt = Date.from(Instant.now().plus(1, ChronoUnit.DAYS));
+            var cert = new ClientCertificate("Only EndsAt", null, endsAt);
+
+            service.validateForUpdate(cert);
+        }
+
+        @Test
+        void should_pass_when_starts_at_is_set_and_ends_at_is_null() {
+            var startsAt = Date.from(Instant.now());
+            var cert = new ClientCertificate("Only StartsAt", startsAt, null);
+
+            service.validateForUpdate(cert);
+        }
+
+        @Test
+        void should_throw_when_starts_at_equals_ends_at() {
+            var now = Date.from(Instant.now());
+            var cert = new ClientCertificate("Same Dates", now, now);
+
+            assertThatThrownBy(() -> service.validateForUpdate(cert)).isInstanceOf(ClientCertificateDateBoundsInvalidException.class);
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/MtlsSubscriptionSyncDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/MtlsSubscriptionSyncDomainServiceImplTest.java
@@ -16,7 +16,6 @@
 package io.gravitee.apim.infra.domain_service.application_certificates;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import inmemory.ClientCertificateCrudServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
@@ -31,7 +30,6 @@ import io.gravitee.common.util.KeyStoreUtils;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
-import io.gravitee.rest.api.service.exceptions.ClientCertificateLastRemovalException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.time.Instant;
@@ -351,83 +349,6 @@ class MtlsSubscriptionSyncDomainServiceImplTest {
         SubscriptionEntity result = subscriptionCrudService.get(SUBSCRIPTION_ID);
         String decodedCertificate = new String(Base64.getDecoder().decode(result.getClientCertificate()), StandardCharsets.UTF_8);
         assertThat(decodedCertificate).isEqualTo(PEM_CERTIFICATE_1);
-    }
-
-    @Test
-    void should_allow_certificate_removal_when_no_mtls_subscriptions() {
-        Plan apiKeyPlan = buildPlan(PlanSecurityType.API_KEY.getLabel());
-        planCrudService.initWith(List.of(apiKeyPlan));
-
-        SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, null);
-        subscriptionCrudService.initWith(List.of(subscription));
-
-        ClientCertificate certificate = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
-        clientCertificateCrudService.initWith(List.of(certificate));
-
-        service.validateCertificateRemoval(APPLICATION_ID, "cert-1");
-    }
-
-    @Test
-    void should_allow_certificate_removal_when_other_active_certs_remain() {
-        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
-        planCrudService.initWith(List.of(mtlsPlan));
-
-        SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, null);
-        subscriptionCrudService.initWith(List.of(subscription));
-
-        ClientCertificate cert1 = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
-        ClientCertificate cert2 = buildClientCertificate("cert-2", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_2);
-        clientCertificateCrudService.initWith(List.of(cert1, cert2));
-
-        service.validateCertificateRemoval(APPLICATION_ID, "cert-1");
-    }
-
-    @Test
-    void should_allow_certificate_removal_when_active_with_end_cert_remains() {
-        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
-        planCrudService.initWith(List.of(mtlsPlan));
-
-        SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, null);
-        subscriptionCrudService.initWith(List.of(subscription));
-
-        ClientCertificate cert1 = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
-        ClientCertificate cert2 = buildClientCertificate("cert-2", ClientCertificateStatus.ACTIVE_WITH_END, PEM_CERTIFICATE_2);
-        clientCertificateCrudService.initWith(List.of(cert1, cert2));
-
-        service.validateCertificateRemoval(APPLICATION_ID, "cert-1");
-    }
-
-    @Test
-    void should_reject_certificate_removal_when_last_active_cert_and_mtls_subscriptions_exist() {
-        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
-        planCrudService.initWith(List.of(mtlsPlan));
-
-        SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, null);
-        subscriptionCrudService.initWith(List.of(subscription));
-
-        ClientCertificate certificate = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
-        clientCertificateCrudService.initWith(List.of(certificate));
-
-        assertThatThrownBy(() -> service.validateCertificateRemoval(APPLICATION_ID, "cert-1"))
-            .isInstanceOf(ClientCertificateLastRemovalException.class)
-            .hasMessageContaining(APPLICATION_ID);
-    }
-
-    @Test
-    void should_reject_certificate_removal_when_only_non_active_certs_remain_and_mtls_subscriptions_exist() {
-        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
-        planCrudService.initWith(List.of(mtlsPlan));
-
-        SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, null);
-        subscriptionCrudService.initWith(List.of(subscription));
-
-        ClientCertificate activeCert = buildClientCertificate("cert-1", ClientCertificateStatus.ACTIVE, PEM_CERTIFICATE_1);
-        ClientCertificate revokedCert = buildClientCertificate("cert-2", ClientCertificateStatus.REVOKED, PEM_CERTIFICATE_2);
-        clientCertificateCrudService.initWith(List.of(activeCert, revokedCert));
-
-        assertThatThrownBy(() -> service.validateCertificateRemoval(APPLICATION_ID, "cert-1"))
-            .isInstanceOf(ClientCertificateLastRemovalException.class)
-            .hasMessageContaining(APPLICATION_ID);
     }
 
     private Plan buildPlan(String securityType) {


### PR DESCRIPTION
## Issue

[GKO-2784](https://gravitee.atlassian.net/browse/GKO-2784)

## Why

The use cases for updating and deleting client certificates called `ClientCertificateCrudService`
directly, bypassing the domain service layer. This scattered validation logic across the wrong
layers: date-bounds checks lived in the CRUD service implementation, and the removal guard was
in the subscription sync service. This PR consolidates all certificate lifecycle logic —
ownership verification, validation, and removal guards — in `ClientCertificateDomainService`,
restoring the intended layering and closing a validation gap that could arise if the CRUD
service were called without going through the use case.

## What changed

- **Use case rewiring** — `UpdateClientCertificateUseCase` and `DeleteClientCertificateUseCase`
  no longer depend on `ClientCertificateCrudService` directly; all operations now go through
  `ClientCertificateDomainService`.
- **Validation moved to domain layer** — `validateForUpdate()` added to
  `ClientCertificateValidationDomainService` (date-bounds check); `validateDateBounds()` removed
  from `ClientCertificateCrudServiceImpl.update()` so validation and mutation can't diverge.
- **Removal guard relocated** — `validateCertificateRemoval` moved from
  `MtlsSubscriptionSyncDomainService` into `ClientCertificateDomainServiceImpl.delete()`.
  Certificate lifecycle logic belongs in the certificate domain service, not subscription sync.
- **Shared ownership check** — `resolveAndVerifyOwnership()` extracted as a private helper in
  `ClientCertificateDomainServiceImpl`, reused by both `update` and `delete`.
- `ClientCertificateDomainService.update` now accepts `applicationId` for ownership
  verification — all internal callers updated in this PR.

## User-facing impact

No user-facing effect. This is a pure internal refactoring; no HTTP API signatures, config
keys, or observable behaviors changed.

## How to test

No behavior change — confirm existing tests pass:

108 certificate-related tests cover:
- Ownership mismatch, null `applicationId`, certificate-not-found paths
- `ACTIVE_WITH_END` counts as remaining; `REVOKED` does not
- Date-bounds validation (valid, invalid, partial nulls, equal bounds)
- `InOrder` verification that validation runs before mutation


[GKO-2784]: https://gravitee.atlassian.net/browse/GKO-2784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ