### PR TITLE
feat: add skeletons in portal documentation.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/animations/keyframes.scss
+++ b/gravitee-apim-portal-webui-next/src/animations/keyframes.scss
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateX(100%);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-out {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(100%);
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.harness.ts
@@ -19,9 +19,12 @@ import { MatButtonHarness } from '@angular/material/button/testing';
 import { GraviteeMarkdownViewerHarness } from '@gravitee/gravitee-markdown';
 
 import { TreeComponentHarness } from './tree/tree.component.harness';
+import { BreadcrumbSkeletonComponentHarness } from '../../../../components/breadcrumb-skeleton/breadcrumb-skeleton.component.harness';
 import { BreadcrumbsComponentHarness } from '../../../../components/breadcrumbs/breadcrumbs.component.harness';
+import { DocumentationSkeletonComponentHarness } from '../../../../components/documentation-skeleton/documentation-skeleton.component.harness';
 import { NavigationItemContentViewerHarness } from '../../../../components/navigation-item-content-viewer/navigation-item-content-viewer.harness';
 import { SidenavLayoutComponentHarness } from '../../../../components/sidenav-layout/sidenav-layout.component.harness';
+import { SidenavSkeletonComponentHarness } from '../../../../components/sidenav-skeleton/sidenav-skeleton.component.harness';
 import { SidenavToggleButtonComponentHarness } from '../../../../components/sidenav-toggle-button/sidenav-toggle-button.component.harness';
 import { DivHarness } from '../../../../testing/div.harness';
 import { ApiTabToolsComponentHarness } from '../../../api/api-details/api-tab-tools/api-tab-tools.component.harness';
@@ -31,6 +34,8 @@ export class DocumentationFolderComponentHarness extends ComponentHarness {
 
   private readonly getSidenavLayoutHarness = this.locatorFor(SidenavLayoutComponentHarness);
   private readonly getTree = this.locatorForOptional(TreeComponentHarness);
+  private readonly getSidenavSkeletonHarness = this.locatorForOptional(SidenavSkeletonComponentHarness);
+  private readonly getDocumentationSkeletonHarness = this.locatorForOptional(DocumentationSkeletonComponentHarness);
   private readonly getBreadcrumbsHarness = this.locatorForOptional(BreadcrumbsComponentHarness);
   private readonly getSidenavEmptyStateHarness = this.locatorForOptional(
     DivHarness.with({ selector: '.documentation-folder__sidenav__empty-state' }),
@@ -56,6 +61,19 @@ export class DocumentationFolderComponentHarness extends ComponentHarness {
 
   async getBreadcrumbs(): Promise<BreadcrumbsComponentHarness | null> {
     return this.getBreadcrumbsHarness();
+  }
+
+  async getBreadcrumbSkeleton(): Promise<BreadcrumbSkeletonComponentHarness | null> {
+    const layout = await this.getSidenavLayoutHarness();
+    return layout.getBreadcrumbSkeleton();
+  }
+
+  async getSidenavSkeleton(): Promise<SidenavSkeletonComponentHarness | null> {
+    return this.getSidenavSkeletonHarness();
+  }
+
+  async getDocumentationSkeleton(): Promise<DocumentationSkeletonComponentHarness | null> {
+    return this.getDocumentationSkeletonHarness();
   }
 
   async getContentEmptyState(): Promise<DivHarness | null> {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<app-sidenav-layout [breadcrumbs]="breadcrumbs()">
+<app-sidenav-layout [breadcrumbs]="breadcrumbs()" [breadcrumbsLoading]="folderLoading()">
   @if (apiId()) {
     <div breadcrumbActions class="documentation-folder__breadcrumb-actions">
       @if (apiHasMcp()) {
@@ -33,8 +33,17 @@
     </div>
   }
   <div sidenavContent class="documentation-folder__sidenav__content">
-    @if (tree() && tree()!.length > 0) {
+    @if (folderLoading()) {
+      <app-sidenav-skeleton
+        animate.leave="documentation-folder__sidenav__skeleton--leave"
+        class="documentation-folder__sidenav__skeleton"
+        aria-busy="true"
+        i18n-aria-label="@@documentationTreeLoadingAria"
+        aria-label="Loading navigation"
+      />
+    } @else if (tree() && tree()!.length > 0) {
       <app-tree-component
+        animate.enter="documentation-folder__sidenav__tree-enter"
         class="documentation-folder__sidenav__tree"
         [tree]="tree()"
         [selectedId]="selectedId$ | async"
@@ -45,7 +54,20 @@
     }
   </div>
   <div class="documentation-folder__main-content" mainContent>
-    <app-navigation-item-content-viewer [pageContent]="folderData()?.selectedPageContent ?? null" />
+    @if (contentLoading()) {
+      <app-documentation-skeleton
+        class="documentation-folder__main-content__skeleton"
+        animate.leave="documentation-folder__main-content__skeleton--leave"
+        aria-busy="true"
+        i18n-aria-label="@@documentationContentLoadingAria"
+        aria-label="Loading content"
+      />
+    } @else {
+      <app-navigation-item-content-viewer
+        animate.enter="documentation-folder__main-content-enter"
+        [pageContent]="folderData()?.selectedPageContent ?? null"
+      />
+    }
   </div>
 </app-sidenav-layout>
 

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.scss
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@use '../../../../scss/skeletons' as skeleton;
 @use '../../../../scss/theme' as app-theme;
 
 $mcp-overlay-duration: 400ms;
@@ -31,6 +32,18 @@ app-sidenav-layout {
 .documentation-folder {
   &__main-content {
     flex: 1 1 100%;
+
+    &-enter {
+      @include skeleton.content-reveal-fade-in;
+    }
+
+    &__skeleton {
+      position: absolute;
+
+      &--leave {
+        @include skeleton.skeleton-fade-out;
+      }
+    }
   }
 
   &__sidenav {
@@ -38,6 +51,18 @@ app-sidenav-layout {
     &__empty-state {
       min-width: 250px;
       height: 100%;
+
+      &-enter {
+        @include skeleton.content-reveal-fade-in;
+      }
+    }
+
+    &__skeleton {
+      position: absolute;
+
+      &--leave {
+        @include skeleton.skeleton-fade-out;
+      }
     }
   }
 
@@ -94,45 +119,5 @@ app-sidenav-layout {
       top: 20px;
       right: 20px;
     }
-  }
-}
-
-@keyframes fade-in {
-  from {
-    opacity: 0;
-  }
-
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes fade-out {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes slide-in {
-  from {
-    transform: translateX(100%);
-  }
-
-  to {
-    transform: translateX(0);
-  }
-}
-
-@keyframes slide-out {
-  from {
-    transform: translateX(0);
-  }
-
-  to {
-    transform: translateX(100%);
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.spec.ts
@@ -18,7 +18,7 @@ import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { ActivatedRoute, Router } from '@angular/router';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
 
 import { DocumentationFolderComponent } from './documentation-folder.component';
@@ -90,6 +90,7 @@ describe('DocumentationFolderComponent', () => {
     } as unknown as ApiService;
 
     await TestBed.configureTestingModule({
+      animationsEnabled: true,
       imports: [DocumentationFolderComponent, MatIconTestingModule, AppTestingModule],
       providers: [
         { provide: ActivatedRoute, useValue: { queryParams: queryParamsSubject.asObservable() } },
@@ -104,6 +105,91 @@ describe('DocumentationFolderComponent', () => {
     fixture.componentRef.setInput('navItem', MOCK_ITEM);
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, DocumentationFolderComponentHarness);
   };
+
+  const initDeferredNavigationItems = async () => {
+    const itemsSubject = new Subject<PortalNavigationItem[]>();
+    queryParamsSubject = new BehaviorSubject<{ selectedId?: string }>({ selectedId: 'p1' });
+    routerSpy = {
+      navigate: jest.fn().mockImplementation((_, options) => {
+        if (options?.queryParams) queryParamsSubject.next(options.queryParams);
+        return Promise.resolve(true);
+      }),
+    } as unknown as jest.Mocked<Router>;
+
+    navigationServiceSpy = {
+      getNavigationItems: jest.fn().mockReturnValue(itemsSubject.asObservable()),
+      getNavigationItemContent: jest.fn().mockReturnValue(of({ content: MOCK_CONTENT, type: 'GRAVITEE_MARKDOWN' })),
+    } as unknown as PortalNavigationItemsService;
+
+    await TestBed.configureTestingModule({
+      animationsEnabled: true,
+      imports: [DocumentationFolderComponent, MatIconTestingModule, AppTestingModule],
+      providers: [
+        { provide: ActivatedRoute, useValue: { queryParams: queryParamsSubject.asObservable() } },
+        { provide: Router, useValue: routerSpy },
+        { provide: PortalNavigationItemsService, useValue: navigationServiceSpy },
+        { provide: CurrentUserService, useValue: { isUserAuthenticated: signal(true) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DocumentationFolderComponent);
+    fixture.componentRef.setInput('navItem', MOCK_ITEM);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, DocumentationFolderComponentHarness);
+    return itemsSubject;
+  };
+
+  describe('loading skeletons', () => {
+    it('should show sidenav, main content and breadcrumb skeletons while folder navigation items load', async () => {
+      const itemsSubject = await initDeferredNavigationItems();
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+      const sidenavSkeleton = await harness.getSidenavSkeleton();
+      const documentationSkeleton = await harness.getDocumentationSkeleton();
+      const breadcrumbSkeleton = await harness.getBreadcrumbSkeleton();
+
+      expect(sidenavSkeleton).not.toBeNull();
+      expect(documentationSkeleton).not.toBeNull();
+      expect(breadcrumbSkeleton).not.toBeNull();
+
+      expect(await harness.getTreeHarness()).toBeNull();
+      expect(await harness.getBreadcrumbs()).toBeNull();
+
+      itemsSubject.next(MOCK_CHILDREN);
+      itemsSubject.complete();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(await harness.getTreeHarness()).not.toBeNull();
+      expect(await harness.getBreadcrumbs()).not.toBeNull();
+      const viewer = await harness.getGmdViewer();
+      expect(viewer).not.toBeNull();
+      expect(await viewer!.getRenderedHtml()).toEqual(gmdViewerContent(MOCK_CONTENT));
+    });
+
+    it('should show documentation skeleton while page content loads after selecting another page', async () => {
+      await init();
+
+      const contentSubject = new Subject<{ content: string; type: string }>();
+      navigationServiceSpy.getNavigationItemContent = jest.fn().mockReturnValue(contentSubject.asObservable());
+
+      const tree = await harness.getTreeHarness();
+      await tree!.clickItemByTitle('Page 2');
+      await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+      expect(await harness.getDocumentationSkeleton()).not.toBeNull();
+      expect(await harness.getSidenavSkeleton()).toBeNull();
+      expect(await harness.getBreadcrumbSkeleton()).toBeNull();
+
+      contentSubject.next({ content: 'Content of Page 2', type: 'GRAVITEE_MARKDOWN' });
+      contentSubject.complete();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const viewer = await harness.getGmdViewer();
+      expect(viewer).not.toBeNull();
+      expect(await viewer!.getRenderedHtml()).toEqual(gmdViewerContent('Content of Page 2'));
+    });
+  });
 
   describe('initial load', () => {
     describe('with content', () => {

--- a/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/documentation/components/documentation-folder/documentation-folder.component.ts
@@ -20,7 +20,7 @@ import { rxResource, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { ActivatedRoute, Router } from '@angular/router';
-import { catchError, debounceTime, map, merge, Observable, switchMap, tap, withLatestFrom } from 'rxjs';
+import { catchError, debounceTime, finalize, map, merge, Observable, switchMap, tap, withLatestFrom } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
 
 import { GraviteeMarkdownViewerModule } from '@gravitee/gravitee-markdown';
@@ -28,8 +28,10 @@ import { Api } from 'src/entities/api/api';
 
 import { TreeComponent } from './tree/tree.component';
 import { Breadcrumb } from '../../../../components/breadcrumbs/breadcrumbs.component';
+import { DocumentationSkeletonComponent } from '../../../../components/documentation-skeleton/documentation-skeleton.component';
 import { NavigationItemContentViewerComponent } from '../../../../components/navigation-item-content-viewer/navigation-item-content-viewer.component';
 import { SidenavLayoutComponent } from '../../../../components/sidenav-layout/sidenav-layout.component';
+import { SidenavSkeletonComponent } from '../../../../components/sidenav-skeleton/sidenav-skeleton.component';
 import { MobileClassDirective } from '../../../../directives/mobile-class.directive';
 import { PortalNavigationItem } from '../../../../entities/portal-navigation/portal-navigation-item';
 import { PortalPageContent } from '../../../../entities/portal-navigation/portal-page-content';
@@ -55,6 +57,8 @@ enum NavParamsChange {
     CdkTrapFocus,
     MobileClassDirective,
     SidenavLayoutComponent,
+    SidenavSkeletonComponent,
+    DocumentationSkeletonComponent,
     TreeComponent,
     GraviteeMarkdownViewerModule,
     NavigationItemContentViewerComponent,
@@ -75,6 +79,9 @@ export class DocumentationFolderComponent {
   selectedId$ = this.activatedRoute.queryParams.pipe(map(({ selectedId }) => selectedId));
 
   folderData = toSignal<FolderData | undefined>(this.loadFolderData());
+  folderLoading = signal(false);
+  contentLoading = signal(false);
+
   tree = signal<TreeNode[]>([]);
   breadcrumbs = signal<Breadcrumb[]>([]);
 
@@ -114,9 +121,17 @@ export class DocumentationFolderComponent {
       switchMap(([changedData, navId, selectedId]) => {
         switch (changedData) {
           case NavParamsChange.NAV_ID:
-            return this.loadChildrenAndContent(navId, selectedId);
+            this.folderLoading.set(true);
+            this.contentLoading.set(true);
+            return this.loadChildrenAndContent(navId, selectedId).pipe(
+              finalize(() => {
+                this.contentLoading.set(false);
+                this.folderLoading.set(false);
+              }),
+            );
           case NavParamsChange.PAGE_ID:
-            return this.loadContentOrRedirect(selectedId);
+            this.contentLoading.set(true);
+            return this.loadContentOrRedirect(selectedId).pipe(finalize(() => this.contentLoading.set(false)));
           default:
             return of(this.folderData());
         }

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumb-skeleton/breadcrumb-skeleton.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumb-skeleton/breadcrumb-skeleton.component.harness.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class BreadcrumbSkeletonComponentHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-breadcrumb-skeleton';
+
+  async getSegmentElements() {
+    return this.locatorForAll('.breadcrumb-skeleton__segment')();
+  }
+
+  async getSeparatorElements() {
+    return this.locatorForAll('.breadcrumb-skeleton__separator')();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumb-skeleton/breadcrumb-skeleton.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumb-skeleton/breadcrumb-skeleton.component.html
@@ -1,0 +1,23 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@for (segment of segments(); track $index; let isLast = $last) {
+  <span class="breadcrumb-skeleton__segment" [attr.data-size]="segment.size" [style.animation-delay.ms]="$index * barStaggerMs()"></span>
+  @if (!isLast) {
+    <span class="breadcrumb-skeleton__separator" aria-hidden="true"></span>
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumb-skeleton/breadcrumb-skeleton.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumb-skeleton/breadcrumb-skeleton.component.scss
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/skeletons' as skeleton;
+@use '../../scss/theme' as app-theme;
+
+$breadcrumb-skeleton-segment-default-width: 96px;
+$breadcrumb-skeleton-segment-short-width: 72px;
+$breadcrumb-skeleton-segment-medium-width: 120px;
+
+:host {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  opacity: 1;
+}
+
+.breadcrumb-skeleton__segment {
+  height: 12px;
+  flex-shrink: 0;
+
+  @include skeleton.skeleton-pulse;
+
+  &[data-size='default'] {
+    width: $breadcrumb-skeleton-segment-default-width;
+  }
+
+  &[data-size='short'] {
+    width: $breadcrumb-skeleton-segment-short-width;
+  }
+
+  &[data-size='medium'] {
+    width: $breadcrumb-skeleton-segment-medium-width;
+  }
+}
+
+.breadcrumb-skeleton__separator {
+  flex-shrink: 0;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  opacity: 0.35;
+  background: app-theme.$paragraph-color;
+}

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumb-skeleton/breadcrumb-skeleton.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumb-skeleton/breadcrumb-skeleton.component.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BreadcrumbSkeletonComponent, DEFAULT_BREADCRUMB_SKELETON_SEGMENTS } from './breadcrumb-skeleton.component';
+import { BreadcrumbSkeletonComponentHarness } from './breadcrumb-skeleton.component.harness';
+
+describe('BreadcrumbSkeletonComponent', () => {
+  let fixture: ComponentFixture<BreadcrumbSkeletonComponent>;
+  let harness: BreadcrumbSkeletonComponentHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BreadcrumbSkeletonComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BreadcrumbSkeletonComponent);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, BreadcrumbSkeletonComponentHarness);
+  });
+
+  it('should render default segments and separators', async () => {
+    const segments = await harness.getSegmentElements();
+    expect(segments.length).toEqual(DEFAULT_BREADCRUMB_SKELETON_SEGMENTS.length);
+
+    const separators = await harness.getSeparatorElements();
+    expect(separators.length).toEqual(DEFAULT_BREADCRUMB_SKELETON_SEGMENTS.length - 1);
+  });
+
+  it('should set data-size from segment input', async () => {
+    const segments = await harness.getSegmentElements();
+    const sizes = await Promise.all(segments.map(el => el.getAttribute('data-size')));
+    expect(sizes).toEqual(DEFAULT_BREADCRUMB_SKELETON_SEGMENTS.map(s => s.size));
+  });
+
+  it('should render custom segments without trailing separator', async () => {
+    fixture.componentRef.setInput('segments', [{ size: 'short' }]);
+    fixture.detectChanges();
+
+    const segments = await harness.getSegmentElements();
+    const separators = await harness.getSeparatorElements();
+    expect(segments.length).toEqual(1);
+    expect(separators.length).toEqual(0);
+    expect(await segments[0].getAttribute('data-size')).toEqual('short');
+  });
+
+  it('should stagger animation delay by barStaggerMs', async () => {
+    fixture.componentRef.setInput('barStaggerMs', 50);
+    fixture.detectChanges();
+
+    const segments = await harness.getSegmentElements();
+    const delays = await Promise.all(segments.map(el => el.getCssValue('animation-delay')));
+    expect(delays[0].trim()).toMatch(/^0m?s$/);
+    expect(delays[1]).toMatch(/50ms|0\.05s/);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumb-skeleton/breadcrumb-skeleton.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumb-skeleton/breadcrumb-skeleton.component.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input } from '@angular/core';
+
+export type BreadcrumbSkeletonSegmentSize = 'default' | 'short' | 'medium';
+
+export interface BreadcrumbSkeletonSegment {
+  size: BreadcrumbSkeletonSegmentSize;
+}
+
+export const DEFAULT_BREADCRUMB_SKELETON_SEGMENTS: readonly BreadcrumbSkeletonSegment[] = [
+  { size: 'default' },
+  { size: 'short' },
+  { size: 'medium' },
+];
+
+@Component({
+  selector: 'app-breadcrumb-skeleton',
+  templateUrl: './breadcrumb-skeleton.component.html',
+  styleUrl: './breadcrumb-skeleton.component.scss',
+  host: { class: 'breadcrumb-skeleton' },
+})
+export class BreadcrumbSkeletonComponent {
+  segments = input<readonly BreadcrumbSkeletonSegment[]>(DEFAULT_BREADCRUMB_SKELETON_SEGMENTS);
+  barStaggerMs = input(100);
+}

--- a/gravitee-apim-portal-webui-next/src/components/breadcrumbs/breadcrumbs.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/breadcrumbs/breadcrumbs.component.ts
@@ -43,7 +43,7 @@ export interface Breadcrumb {
         align-items: center;
         flex-wrap: wrap;
         gap: 15px;
-        padding: 20px 0;
+        padding: 18px 0;
       }
 
       .breadcrumb-item {

--- a/gravitee-apim-portal-webui-next/src/components/documentation-skeleton/documentation-skeleton.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/documentation-skeleton/documentation-skeleton.component.harness.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class DocumentationSkeletonComponentHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-documentation-skeleton';
+
+  async getRowElements() {
+    return this.locatorForAll('.documentation-skeleton__row')();
+  }
+
+  async getBarElements() {
+    return this.locatorForAll('.documentation-skeleton__bar')();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/documentation-skeleton/documentation-skeleton.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/documentation-skeleton/documentation-skeleton.component.html
@@ -1,0 +1,26 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@for (row of rows(); track $index) {
+  <div class="documentation-skeleton__row" [attr.data-type]="row.type">
+    <span
+      class="documentation-skeleton__bar"
+      [style.width.%]="row.widthPercent"
+      [style.animation-delay.ms]="$index * barStaggerMs()"
+    ></span>
+  </div>
+}

--- a/gravitee-apim-portal-webui-next/src/components/documentation-skeleton/documentation-skeleton.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/documentation-skeleton/documentation-skeleton.component.scss
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/skeletons' as skeleton;
+@use '../../scss/theme' as app-theme;
+
+:host {
+  display: flex;
+  width: 100%;
+  max-width: app-theme.$inner-content-width;
+  flex-direction: column;
+  gap: 14px;
+  padding: 32px 32px 32px;
+  opacity: 1;
+}
+
+.documentation-skeleton__row {
+  display: flex;
+  align-items: center;
+
+  &[data-type='h1'] {
+    margin-bottom: 30px;
+  }
+
+  &[data-type='h2'] {
+    margin-top: 30px;
+    margin-bottom: 20px;
+  }
+}
+
+.documentation-skeleton__bar {
+  display: block;
+  max-width: 100%;
+
+  @include skeleton.skeleton-pulse;
+
+  .documentation-skeleton__row[data-type='h1'] & {
+    height: 32px;
+  }
+
+  .documentation-skeleton__row[data-type='h2'] & {
+    height: 26px;
+  }
+
+  .documentation-skeleton__row[data-type='body'] & {
+    height: 14px;
+    margin-left: 16px;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/documentation-skeleton/documentation-skeleton.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/documentation-skeleton/documentation-skeleton.component.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DEFAULT_DOCUMENTATION_SKELETON_ROWS, DocumentationSkeletonComponent } from './documentation-skeleton.component';
+import { DocumentationSkeletonComponentHarness } from './documentation-skeleton.component.harness';
+
+describe('DocumentationSkeletonComponent', () => {
+  let fixture: ComponentFixture<DocumentationSkeletonComponent>;
+  let harness: DocumentationSkeletonComponentHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DocumentationSkeletonComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DocumentationSkeletonComponent);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, DocumentationSkeletonComponentHarness);
+  });
+
+  it('should render default rows and bars', async () => {
+    const rows = await harness.getRowElements();
+    const bars = await harness.getBarElements();
+    expect(rows.length).toEqual(DEFAULT_DOCUMENTATION_SKELETON_ROWS.length);
+    expect(bars.length).toEqual(DEFAULT_DOCUMENTATION_SKELETON_ROWS.length);
+  });
+
+  it('should set data-type from row input', async () => {
+    const rows = await harness.getRowElements();
+    const types = await Promise.all(rows.map(el => el.getAttribute('data-type')));
+    expect(types).toEqual(DEFAULT_DOCUMENTATION_SKELETON_ROWS.map(r => r.type));
+  });
+
+  it('should render custom rows', async () => {
+    const custom = [
+      { type: 'h1' as const, widthPercent: 50 },
+      { type: 'body' as const, widthPercent: 90 },
+    ];
+    fixture.componentRef.setInput('rows', custom);
+    fixture.detectChanges();
+
+    const rowEls = await harness.getRowElements();
+    const barEls = await harness.getBarElements();
+    expect(rowEls.length).toEqual(2);
+    expect(barEls.length).toEqual(2);
+    expect(await rowEls[0].getAttribute('data-type')).toEqual('h1');
+    expect(await rowEls[1].getAttribute('data-type')).toEqual('body');
+    expect((await barEls[0].getCssValue('width')).trim()).toContain('50');
+  });
+
+  it('should stagger bar animation delay by barStaggerMs', async () => {
+    fixture.componentRef.setInput('barStaggerMs', 30);
+    fixture.detectChanges();
+
+    const bars = await harness.getBarElements();
+    const delays = await Promise.all(bars.map(el => el.getCssValue('animation-delay')));
+    expect(delays[0].trim()).toMatch(/^0m?s$/);
+    expect(delays[1]).toMatch(/30ms|0\.03s/);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/documentation-skeleton/documentation-skeleton.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/documentation-skeleton/documentation-skeleton.component.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input } from '@angular/core';
+
+export type DocumentationSkeletonLineType = 'h1' | 'h2' | 'body';
+
+export interface DocumentationSkeletonRow {
+  type: DocumentationSkeletonLineType;
+  widthPercent: number;
+}
+
+export const DEFAULT_DOCUMENTATION_SKELETON_ROWS: readonly DocumentationSkeletonRow[] = [
+  { type: 'h1', widthPercent: 60 },
+  { type: 'body', widthPercent: 65 },
+  { type: 'h2', widthPercent: 55 },
+  { type: 'body', widthPercent: 60 },
+  { type: 'body', widthPercent: 55 },
+  { type: 'body', widthPercent: 55 },
+  { type: 'h2', widthPercent: 38 },
+  { type: 'body', widthPercent: 55 },
+  { type: 'body', widthPercent: 42 },
+  { type: 'body', widthPercent: 50 },
+];
+
+@Component({
+  selector: 'app-documentation-skeleton',
+  templateUrl: './documentation-skeleton.component.html',
+  styleUrl: './documentation-skeleton.component.scss',
+  host: { class: 'documentation-skeleton' },
+})
+export class DocumentationSkeletonComponent {
+  rows = input<readonly DocumentationSkeletonRow[]>(DEFAULT_DOCUMENTATION_SKELETON_ROWS);
+  barStaggerMs = input(60);
+}

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.harness.ts
@@ -16,6 +16,7 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 
 import { DivHarness } from '../../testing/div.harness';
+import { BreadcrumbSkeletonComponentHarness } from '../breadcrumb-skeleton/breadcrumb-skeleton.component.harness';
 import { BreadcrumbsComponentHarness } from '../breadcrumbs/breadcrumbs.component.harness';
 import { SidenavToggleButtonComponentHarness } from '../sidenav-toggle-button/sidenav-toggle-button.component.harness';
 
@@ -24,6 +25,7 @@ export class SidenavLayoutComponentHarness extends ComponentHarness {
 
   private readonly getSidenavHarness = this.locatorFor(DivHarness.with({ selector: '.sidenav-layout__sidenav' }));
   private readonly getSidenavToggleButtonHarness = this.locatorFor(SidenavToggleButtonComponentHarness);
+  private readonly getBreadcrumbSkeletonHarness = this.locatorForOptional(BreadcrumbSkeletonComponentHarness);
   private readonly getBreadcrumbsHarness = this.locatorForOptional(BreadcrumbsComponentHarness);
   private readonly getBreadcrumbActionsHarness = this.locatorForOptional(
     DivHarness.with({ selector: '.sidenav-layout__container__breadcrumbs__actions' }),
@@ -31,6 +33,10 @@ export class SidenavLayoutComponentHarness extends ComponentHarness {
 
   public async getBreadcrumbs(): Promise<BreadcrumbsComponentHarness | null> {
     return this.getBreadcrumbsHarness();
+  }
+
+  public async getBreadcrumbSkeleton(): Promise<BreadcrumbSkeletonComponentHarness | null> {
+    return this.getBreadcrumbSkeletonHarness();
   }
 
   public async getSidenav(): Promise<DivHarness | null> {

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.html
@@ -29,7 +29,23 @@
 <div class="sidenav-layout__container">
   <div class="sidenav-layout__container__breadcrumbs">
     <app-sidenav-toggle-button-component [collapsed]="sidenavCollapsed()" (toggleState)="onToggleSidenav()" />
-    <app-breadcrumbs-component [breadcrumbs]="breadcrumbs()" />
+    <div class="sidenav-layout__container__breadcrumbs__content">
+      @if (breadcrumbsLoading()) {
+        <app-breadcrumb-skeleton
+          animate.leave="sidenav-layout__container__breadcrumbs__skeleton--leave"
+          class="sidenav-layout__container__breadcrumbs__skeleton"
+          aria-busy="true"
+          i18n-aria-label="@@documentationBreadcrumbsLoadingAria"
+          aria-label="Loading breadcrumbs"
+        />
+      } @else {
+        <app-breadcrumbs-component
+          animate.enter="sidenav-layout__container__breadcrumbs__content--enter"
+          class="sidenav-layout__container__breadcrumbs__content"
+          [breadcrumbs]="breadcrumbs()"
+        />
+      }
+    </div>
     <div class="sidenav-layout__container__breadcrumbs__actions">
       <ng-content select="[breadcrumbActions]" />
     </div>

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.scss
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use '../../scss/skeletons' as skeleton;
 @use '../../scss/theme' as app-theme;
 
 $sidenav-min-width: 275px;
@@ -90,6 +91,26 @@ $transition-base: 300ms cubic-bezier(0.4, 0, 0.2, 1);
       padding: 0 16px;
       border-bottom: 1px solid app-theme.$border-color;
       gap: 10px;
+
+      &__content {
+        position: relative;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        width: fit-content;
+
+        &--enter {
+          @include skeleton.content-reveal-fade-in;
+        }
+      }
+
+      &__skeleton {
+        position: absolute;
+
+        &--leave {
+          @include skeleton.skeleton-fade-out;
+        }
+      }
 
       &__actions {
         display: flex;

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.spec.ts
@@ -28,7 +28,7 @@ import { Breadcrumb } from '../breadcrumbs/breadcrumbs.component';
   standalone: true,
   imports: [SidenavLayoutComponent],
   template: `
-    <app-sidenav-layout [breadcrumbs]="breadcrumbs">
+    <app-sidenav-layout [breadcrumbs]="breadcrumbs" [breadcrumbsLoading]="breadcrumbsLoading">
       <div sidenavContent>Sidenav Content</div>
       <div breadcrumbActions>Breadcrumb Actions</div>
       <div mainContent>Main Content</div>
@@ -41,6 +41,7 @@ class TestHostComponent {
     { id: 'level2', label: 'Child' },
     { id: 'level3', label: 'Grandchild' },
   ];
+  breadcrumbsLoading = false;
 }
 
 describe('SidenavLayoutComponent', () => {
@@ -69,6 +70,16 @@ describe('SidenavLayoutComponent', () => {
   it('should display breadcrumbs', async () => {
     const breadcrumbs = await harness.getBreadcrumbs();
     expect(await breadcrumbs?.getText()).toContain('Parent/Child/Grandchild');
+  });
+
+  it('should show breadcrumb skeleton while breadcrumbs are loading', async () => {
+    fixture.componentInstance.breadcrumbsLoading = true;
+    fixture.detectChanges();
+
+    expect(await harness.getBreadcrumbs()).toBeNull();
+
+    const skeleton = await harness.getBreadcrumbSkeleton();
+    expect(skeleton).not.toBeNull();
   });
 
   it('should display breadcrumb actions', async () => {

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.ts
@@ -16,18 +16,20 @@
 import { Component, input, signal } from '@angular/core';
 
 import { MobileClassDirective } from '../../directives/mobile-class.directive';
+import { BreadcrumbSkeletonComponent } from '../breadcrumb-skeleton/breadcrumb-skeleton.component';
 import { Breadcrumb, BreadcrumbsComponent } from '../breadcrumbs/breadcrumbs.component';
 import { SidenavToggleButtonComponent } from '../sidenav-toggle-button/sidenav-toggle-button.component';
 
 @Component({
   selector: 'app-sidenav-layout',
-  imports: [MobileClassDirective, SidenavToggleButtonComponent, BreadcrumbsComponent],
+  imports: [MobileClassDirective, SidenavToggleButtonComponent, BreadcrumbsComponent, BreadcrumbSkeletonComponent],
   standalone: true,
   templateUrl: './sidenav-layout.component.html',
   styleUrl: './sidenav-layout.component.scss',
 })
 export class SidenavLayoutComponent {
   breadcrumbs = input<Breadcrumb[]>([]);
+  breadcrumbsLoading = input(false);
   sidenavCollapsed = signal(false);
 
   onToggleSidenav() {

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-skeleton/sidenav-skeleton.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-skeleton/sidenav-skeleton.component.harness.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class SidenavSkeletonComponentHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-sidenav-skeleton';
+
+  async getRowElements() {
+    return this.locatorForAll('.sidenav-skeleton__row')();
+  }
+
+  async getBarElements() {
+    return this.locatorForAll('.sidenav-skeleton__bar')();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-skeleton/sidenav-skeleton.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-skeleton/sidenav-skeleton.component.html
@@ -1,0 +1,22 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@for (row of rows(); track $index) {
+  <div class="sidenav-skeleton__row" [attr.data-depth]="row.depth">
+    <span class="sidenav-skeleton__bar" [style.width.%]="row.widthPercent" [style.animation-delay.ms]="$index * barStaggerMs()"></span>
+  </div>
+}

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-skeleton/sidenav-skeleton.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-skeleton/sidenav-skeleton.component.scss
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/skeletons' as skeleton;
+
+$tree-skeleton-depth-count: 3;
+$tree-skeleton-row-padding-y: 1px;
+$tree-skeleton-row-padding-x: 20px;
+$tree-skeleton-indent-per-level: 12px;
+
+:host {
+  display: flex;
+  min-width: 250px;
+  flex-direction: column;
+  opacity: 1;
+  position: absolute;
+}
+
+.sidenav-skeleton__row {
+  display: flex;
+  align-items: center;
+  padding: $tree-skeleton-row-padding-y $tree-skeleton-row-padding-x;
+  height: 40px;
+
+  @for $d from 0 through $tree-skeleton-depth-count - 1 {
+    &[data-depth='#{$d}'] {
+      padding-left: $tree-skeleton-row-padding-x + $d * $tree-skeleton-indent-per-level;
+    }
+  }
+}
+
+.sidenav-skeleton__bar {
+  display: block;
+  height: 12px;
+  max-width: 100%;
+
+  @include skeleton.skeleton-pulse;
+}

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-skeleton/sidenav-skeleton.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-skeleton/sidenav-skeleton.component.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DEFAULT_SIDENAV_SKELETON_ROWS, SidenavSkeletonComponent } from './sidenav-skeleton.component';
+import { SidenavSkeletonComponentHarness } from './sidenav-skeleton.component.harness';
+
+describe('SidenavSkeletonComponent', () => {
+  let fixture: ComponentFixture<SidenavSkeletonComponent>;
+  let harness: SidenavSkeletonComponentHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SidenavSkeletonComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SidenavSkeletonComponent);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SidenavSkeletonComponentHarness);
+  });
+
+  it('should render default rows and bars', async () => {
+    const rows = await harness.getRowElements();
+    const bars = await harness.getBarElements();
+    expect(rows.length).toEqual(DEFAULT_SIDENAV_SKELETON_ROWS.length);
+    expect(bars.length).toEqual(DEFAULT_SIDENAV_SKELETON_ROWS.length);
+  });
+
+  it('should set data-depth from row input', async () => {
+    const rows = await harness.getRowElements();
+    const depths = await Promise.all(rows.map(el => el.getAttribute('data-depth')));
+    expect(depths).toEqual(DEFAULT_SIDENAV_SKELETON_ROWS.map(r => String(r.depth)));
+  });
+
+  it('should render custom rows', async () => {
+    const custom = [
+      { depth: 0, widthPercent: 40 },
+      { depth: 1, widthPercent: 55 },
+    ];
+    fixture.componentRef.setInput('rows', custom);
+    fixture.detectChanges();
+
+    const rowEls = await harness.getRowElements();
+    const barEls = await harness.getBarElements();
+    expect(rowEls.length).toEqual(2);
+    expect(barEls.length).toEqual(2);
+    expect(await rowEls[0].getAttribute('data-depth')).toEqual('0');
+    expect(await rowEls[1].getAttribute('data-depth')).toEqual('1');
+    expect((await barEls[0].getCssValue('width')).trim()).toContain('40');
+  });
+
+  it('should stagger bar animation delay by barStaggerMs', async () => {
+    fixture.componentRef.setInput('barStaggerMs', 40);
+    fixture.detectChanges();
+
+    const bars = await harness.getBarElements();
+    const delays = await Promise.all(bars.map(el => el.getCssValue('animation-delay')));
+    expect(delays[0].trim()).toMatch(/^0m?s$/);
+    expect(delays[1]).toMatch(/40ms|0\.04s/);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-skeleton/sidenav-skeleton.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-skeleton/sidenav-skeleton.component.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input } from '@angular/core';
+
+export interface SidenavSkeletonRow {
+  depth: number;
+  widthPercent: number;
+}
+
+export const DEFAULT_SIDENAV_SKELETON_ROWS: readonly SidenavSkeletonRow[] = [
+  { depth: 0, widthPercent: 75 },
+  { depth: 1, widthPercent: 76 },
+  { depth: 1, widthPercent: 85 },
+  { depth: 0, widthPercent: 75 },
+  { depth: 1, widthPercent: 80 },
+  { depth: 2, widthPercent: 65 },
+  { depth: 2, widthPercent: 60 },
+  { depth: 1, widthPercent: 72 },
+  { depth: 1, widthPercent: 68 },
+  { depth: 0, widthPercent: 60 },
+];
+
+@Component({
+  selector: 'app-sidenav-skeleton',
+  templateUrl: './sidenav-skeleton.component.html',
+  styleUrl: './sidenav-skeleton.component.scss',
+  host: { class: 'sidenav-skeleton' },
+})
+export class SidenavSkeletonComponent {
+  rows = input<readonly SidenavSkeletonRow[]>(DEFAULT_SIDENAV_SKELETON_ROWS);
+  barStaggerMs = input(80);
+}

--- a/gravitee-apim-portal-webui-next/src/scss/skeletons.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/skeletons.scss
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../animations/keyframes';
+@use './theme' as app-theme;
+
+$content-reveal-duration: 500ms;
+$content-reveal-delay: 150ms;
+$skeleton-leave-opacity-duration: 220ms;
+$skeleton-leave-easing: ease-in;
+
+@mixin content-reveal-fade-in {
+  animation: fade-in $content-reveal-duration $content-reveal-delay both;
+}
+
+@mixin skeleton-fade-out {
+  animation: none;
+  opacity: 0;
+  transition: opacity $skeleton-leave-opacity-duration $skeleton-leave-easing;
+}
+
+@keyframes gio-skeleton-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@mixin skeleton-pulse {
+  opacity: 0.55;
+  animation: gio-skeleton-pulse 1.2s ease-in-out infinite backwards;
+  background: color-mix(in srgb, app-theme.$default-text-color 12%, app-theme.$background-color);
+  border-radius: app-theme.$element-shape;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13138

## Description

### Display skeletons in Developer Portal documentation.

Included in this PR:
- New skeleton components (documentation content, sidebar, breadcrumbs)
- Changes to existing components to use skeletons inside folder based documentation pages with sidebar (folders or APIs)
- Fix of a layout shift in breadcrumbs due to excessive padding

https://github.com/user-attachments/assets/0604807b-0118-4680-a586-5232730fa45a
