### PR TITLE
fix(repository): support repositories.* prefix for ES cross-cluster and proxy config

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -271,21 +271,23 @@ secrets:
 
 # Management repository is used to store global configuration such as APIs, applications, apikeys, ...
 # If you use a JDBC repository, we recommend disabling liquibase scripts execution by the Gateway. Let the Management API do it.
-# management:
-#   type: jdbc
-#   jdbc:
-#     liquibase: false
+# repositories:
+#   management:
+#     type: jdbc
+#     jdbc:
+#       liquibase: false
 
 # This is the default configuration using MongoDB (single server)
 # For more information about MongoDB configuration, please have a look to:
 # - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html
-management:
-  type: mongodb                  # repository type
-  mongodb:                       # mongodb repository
-#    prefix:                      # collections prefix
-    dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
-    host: ${ds.mongodb.host}     # mongodb host (default localhost)
-    port: ${ds.mongodb.port}     # mongodb port (default 27017)
+repositories:
+  management:
+    type: mongodb                  # repository type
+    mongodb:                       # mongodb repository
+#      prefix:                      # collections prefix
+      dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
+      host: ${ds.mongodb.host}     # mongodb host (default localhost)
+      port: ${ds.mongodb.port}     # mongodb port (default 27017)
 
 ## Client settings
 #    description:                 # mongodb description (default gravitee.io)
@@ -413,10 +415,10 @@ management:
 
 # When defining rate-limiting policy, the gateway has to store data to share with other gateway instances.
 # In this example, we are using MongoDB to store counters.
-ratelimit:
-  type: mongodb
-  mongodb:
-    uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
+  ratelimit:
+    type: mongodb
+    mongodb:
+      uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
 #  redis:
 #    username: # Optional: Redis username for ACL authentication
 #    password:

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfiguration.java
@@ -264,12 +264,20 @@ public class RepositoryConfiguration {
     private Map<String, String> initializeCrossClusterMapping() {
         crossClusterInitialized = true;
 
+        // Try new prefix first, fall back to legacy prefix
         Map<String, Object> tenantMapping = EnvironmentUtils.getPropertiesStartingWith(
             (ConfigurableEnvironment) environment,
-            "analytics.elasticsearch.cross_cluster.mapping."
+            "repositories.analytics.elasticsearch.cross_cluster.mapping."
         );
 
-        if (tenantMapping != null) {
+        if (tenantMapping == null || tenantMapping.isEmpty()) {
+            tenantMapping = EnvironmentUtils.getPropertiesStartingWith(
+                (ConfigurableEnvironment) environment,
+                "analytics.elasticsearch.cross_cluster.mapping."
+            );
+        }
+
+        if (tenantMapping != null && !tenantMapping.isEmpty()) {
             Map<String, String> mapping = new HashMap<>(tenantMapping.size());
             tenantMapping.forEach((s, o) -> mapping.put(s.substring(s.lastIndexOf('.') + 1), (String) o));
 
@@ -398,10 +406,19 @@ public class RepositoryConfiguration {
     }
 
     public boolean isProxyConfigured() {
-        return !EnvironmentUtils.getPropertiesStartingWith(
+        boolean configured = !EnvironmentUtils.getPropertiesStartingWith(
             (ConfigurableEnvironment) environment,
-            "analytics.elasticsearch.http.proxy"
+            "repositories.analytics.elasticsearch.http.proxy"
         ).isEmpty();
+
+        if (!configured) {
+            configured = !EnvironmentUtils.getPropertiesStartingWith(
+                (ConfigurableEnvironment) environment,
+                "analytics.elasticsearch.http.proxy"
+            ).isEmpty();
+        }
+
+        return configured;
     }
 
     public boolean isCrossClusterInitialized() {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfigurationNewPrefixTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfigurationNewPrefixTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.elasticsearch.config.Endpoint;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+/**
+ * Tests that the Elasticsearch RepositoryConfiguration correctly reads properties
+ * from the new "repositories.analytics.elasticsearch.*" prefix when a
+ * RepositoryAliasPropertySource is registered (simulating the gravitee-plugin behavior).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(loader = AnnotationConfigContextLoader.class)
+public class RepositoryConfigurationNewPrefixTest {
+
+    @Configuration
+    @PropertySource(factory = YamlPropertySourceFactory.class, value = "classpath:configuration/gravitee-repositories-prefix.yml")
+    static class ContextConfiguration {
+
+        @Autowired
+        private Environment environment;
+
+        @Bean
+        public org.springframework.core.env.PropertySource<?> repositoryAliasPropertySource() {
+            org.springframework.core.env.PropertySource<?> aliasSource = new org.springframework.core.env.PropertySource<Object>(
+                "repositoryAlias"
+            ) {
+                @Override
+                public Object getProperty(String name) {
+                    if (name.startsWith("management.") || name.startsWith("analytics.") || name.startsWith("ratelimit.")) {
+                        return environment.getProperty("repositories." + name);
+                    }
+                    return null;
+                }
+            };
+            // Register with highest priority
+            ((ConfigurableEnvironment) environment).getPropertySources().addFirst(aliasSource);
+            return aliasSource;
+        }
+
+        @Bean
+        public RepositoryConfiguration repositoryConfiguration() {
+            return new RepositoryConfiguration();
+        }
+    }
+
+    @Autowired
+    private RepositoryConfiguration configuration;
+
+    @Test
+    public void should_read_endpoints_from_new_prefix() {
+        assertThat(configuration.getEndpoints()).hasSize(1).extracting(Endpoint::getUrl).containsExactly("http://es-remote:9200");
+    }
+
+    @Test
+    public void should_not_fallback_to_localhost_9200() {
+        assertThat(configuration.getEndpoints()).extracting(Endpoint::getUrl).doesNotContain("http://localhost:9200");
+    }
+
+    @Test
+    public void should_read_index_name_from_new_prefix() {
+        assertThat(configuration.getIndexName()).isEqualTo("my-custom-index");
+    }
+
+    @Test
+    public void should_read_index_mode_from_new_prefix() {
+        assertThat(configuration.isILMIndex()).isTrue();
+    }
+
+    @Test
+    public void should_read_security_credentials_from_new_prefix() {
+        assertThat(configuration.getUsername()).isEqualTo("es_user");
+        assertThat(configuration.getPassword()).isEqualTo("es_pass");
+    }
+
+    @Test
+    public void should_read_http_timeout_from_new_prefix() {
+        assertThat(configuration.getRequestTimeout()).isEqualTo(15000L);
+    }
+
+    @Test
+    public void should_read_cross_cluster_mapping_from_new_prefix() {
+        assertThat(configuration.hasCrossClusterMapping()).isTrue();
+        assertThat(configuration.getCrossClusterMapping()).containsEntry("tenantA", "clusterA");
+    }
+
+    @Test
+    public void should_read_ssl_pem_certs_from_new_prefix() {
+        assertThat(configuration.getSslPemCerts()).hasSize(1).containsExactly("new-cert1");
+    }
+
+    @Test
+    public void should_read_ssl_pem_keys_from_new_prefix() {
+        assertThat(configuration.getSslPemKeys()).hasSize(1).containsExactly("new-key1");
+    }
+
+    @Test
+    public void should_detect_proxy_configured_from_new_prefix() {
+        assertThat(configuration.isProxyConfigured()).isTrue();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/configuration/RepositoryConfigurationTest.java
@@ -71,4 +71,9 @@ public class RepositoryConfigurationTest {
     public void shouldHaveKeystoreKeys() {
         Assertions.assertThat(configuration.getSslPemKeys()).hasSize(1).containsExactly("unique-key");
     }
+
+    @Test
+    public void shouldDetectProxyConfiguredFromLegacyPrefix() {
+        assertThat(configuration.isProxyConfigured()).isTrue();
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/configuration/gravitee-repositories-prefix.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/configuration/gravitee-repositories-prefix.yml
@@ -1,0 +1,26 @@
+repositories:
+  analytics:
+    type: elasticsearch
+    elasticsearch:
+      endpoints:
+        - http://es-remote:9200
+      index: my-custom-index
+      index_mode: ilm
+      cross_cluster:
+        mapping:
+          tenantA: clusterA
+      security:
+        username: es_user
+        password: es_pass
+      http:
+        timeout: 15000
+        proxy:
+          type: HTTP
+          http:
+            host: proxy.local
+            port: 3128
+      ssl:
+        keystore:
+          certs:
+            - new-cert1
+          keys: new-key1

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/configuration/gravitee.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/configuration/gravitee.yml
@@ -11,6 +11,11 @@ analytics:
         tenant2: cluster2
     http:
       timeout: 30000
+      proxy:
+        type: HTTP
+        http:
+          host: legacy-proxy.local
+          port: 8080
     ssl:
       keystore:
         certs:

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/common/MongoFactoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/common/MongoFactoryTest.java
@@ -26,11 +26,14 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
 public class MongoFactoryTest {
 
     private static final String PROPERTY_PREFIX = "management.mongodb.";
+    private static final String NEW_PROPERTY_PREFIX = "repositories.management.mongodb.";
 
     private MongoFactory mongoFactory;
     private MockEnvironment environment;
@@ -39,6 +42,27 @@ public class MongoFactoryTest {
     public void setUp() {
         environment = new MockEnvironment();
         mongoFactory = new MongoFactory(environment, "management");
+    }
+
+    /**
+     * Simulates the RepositoryAliasPropertySource from gravitee-plugin-repository.
+     * For any key starting with a known scope (e.g. "management."), it checks
+     * "repositories." + key first.
+     */
+    private void registerAliasPropertySource() {
+        environment
+            .getPropertySources()
+            .addFirst(
+                new PropertySource<Object>("repositoryAlias") {
+                    @Override
+                    public Object getProperty(String name) {
+                        if (name.startsWith("management.") || name.startsWith("analytics.") || name.startsWith("ratelimit.")) {
+                            return environment.getProperty("repositories." + name);
+                        }
+                        return null;
+                    }
+                }
+            );
     }
 
     @Test
@@ -335,5 +359,109 @@ public class MongoFactoryTest {
     @Test
     public void isSingletonShouldReturnTrue() {
         assertThat(mongoFactory.isSingleton()).isTrue();
+    }
+
+    @Test
+    public void should_use_new_prefix_for_cluster_settings_when_alias_property_source_is_registered() {
+        registerAliasPropertySource();
+        environment.setProperty(NEW_PROPERTY_PREFIX + "host", "newhost");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "port", "27117");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "serverSelectionTimeout", "500");
+
+        ClusterSettings clusterSettings = mongoFactory.buildClusterSettings(false);
+
+        assertThat(clusterSettings.getHosts()).isEqualTo(List.of(new ServerAddress("newhost", 27117)));
+        assertThat(clusterSettings.getServerSelectionTimeout(TimeUnit.MILLISECONDS)).isEqualTo(500);
+    }
+
+    @Test
+    public void should_use_new_prefix_for_socket_settings_when_alias_property_source_is_registered() {
+        registerAliasPropertySource();
+        environment.setProperty(NEW_PROPERTY_PREFIX + "connectTimeout", "200");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "socketTimeout", "300");
+
+        SocketSettings socketSettings = mongoFactory.buildSocketSettings();
+
+        assertThat(socketSettings.getConnectTimeout(TimeUnit.MILLISECONDS)).isEqualTo(200);
+        assertThat(socketSettings.getReadTimeout(TimeUnit.MILLISECONDS)).isEqualTo(300);
+    }
+
+    @Test
+    public void should_use_new_prefix_for_client_settings_with_credentials_when_alias_property_source_is_registered() {
+        registerAliasPropertySource();
+        environment.setProperty(NEW_PROPERTY_PREFIX + "username", "newuser");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "password", "newpass");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "authSource", "admin");
+
+        MongoClientSettings settings = mongoFactory.buildClientSettingsFromProperties(false);
+
+        assertThat(settings.getCredential()).isEqualTo(MongoCredential.createCredential("newuser", "admin", "newpass".toCharArray()));
+    }
+
+    @Test
+    public void should_use_new_prefix_for_uri_when_alias_property_source_is_registered() throws Exception {
+        registerAliasPropertySource();
+        environment.setProperty(NEW_PROPERTY_PREFIX + "uri", "mongodb://remotehost:27017/gravitee");
+
+        MongoClient mongoClient = mongoFactory.getObject();
+
+        assertThat(mongoClient).isNotNull();
+        assertThat(mongoClient.getClusterDescription().getClusterSettings().getHosts()).isEqualTo(
+            List.of(new ServerAddress("remotehost", 27017))
+        );
+    }
+
+    @Test
+    public void should_prefer_new_prefix_over_old_prefix_when_alias_property_source_is_registered() {
+        registerAliasPropertySource();
+        // Old prefix values
+        environment.setProperty(PROPERTY_PREFIX + "host", "oldhost");
+        environment.setProperty(PROPERTY_PREFIX + "port", "27017");
+        // New prefix values (should win)
+        environment.setProperty(NEW_PROPERTY_PREFIX + "host", "newhost");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "port", "27117");
+
+        ClusterSettings clusterSettings = mongoFactory.buildClusterSettings(false);
+
+        assertThat(clusterSettings.getHosts()).isEqualTo(List.of(new ServerAddress("newhost", 27117)));
+    }
+
+    @Test
+    public void should_fallback_to_old_prefix_when_new_prefix_not_set_and_alias_property_source_is_registered() {
+        registerAliasPropertySource();
+        // Only old prefix set
+        environment.setProperty(PROPERTY_PREFIX + "host", "oldhost");
+        environment.setProperty(PROPERTY_PREFIX + "port", "27117");
+
+        ClusterSettings clusterSettings = mongoFactory.buildClusterSettings(false);
+
+        assertThat(clusterSettings.getHosts()).isEqualTo(List.of(new ServerAddress("oldhost", 27117)));
+    }
+
+    @Test
+    public void should_use_new_prefix_for_multiple_servers_when_alias_property_source_is_registered() {
+        registerAliasPropertySource();
+        environment.setProperty(NEW_PROPERTY_PREFIX + "servers[0].host", "mongo1");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "servers[0].port", "27017");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "servers[1].host", "mongo2");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "servers[1].port", "27018");
+
+        ClusterSettings clusterSettings = mongoFactory.buildClusterSettings(false);
+
+        assertThat(clusterSettings.getHosts()).isEqualTo(List.of(new ServerAddress("mongo1", 27017), new ServerAddress("mongo2", 27018)));
+    }
+
+    @Test
+    public void should_use_new_prefix_for_connection_pool_settings_when_alias_property_source_is_registered() {
+        registerAliasPropertySource();
+        environment.setProperty(NEW_PROPERTY_PREFIX + "connectionsPerHost", "50");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "minConnectionsPerHost", "5");
+        environment.setProperty(NEW_PROPERTY_PREFIX + "maxWaitTime", "5000");
+
+        ConnectionPoolSettings poolSettings = mongoFactory.buildConnectionPoolSettings(false);
+
+        assertThat(poolSettings.getMaxSize()).isEqualTo(50);
+        assertThat(poolSettings.getMinSize()).isEqualTo(5);
+        assertThat(poolSettings.getMaxWaitTime(TimeUnit.MILLISECONDS)).isEqualTo(5000);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -156,13 +156,14 @@ http:
 # This is the default configuration using MongoDB (single server)
 # For more information about MongoDB configuration, please have a look to:
 # - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html
-management:
-  type: mongodb                  # repository type
-  mongodb:                       # mongodb repository
-#    prefix:                      # collections prefix
-    dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
-    host: ${ds.mongodb.host}     # mongodb host (default localhost)
-    port: ${ds.mongodb.port}     # mongodb port (default 27017)
+repositories:
+  management:
+    type: mongodb                  # repository type
+    mongodb:                       # mongodb repository
+#      prefix:                      # collections prefix
+      dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
+      host: ${ds.mongodb.host}     # mongodb host (default localhost)
+      port: ${ds.mongodb.port}     # mongodb port (default 27017)
 
 ## Client settings
 #    description:                 # mongodb description (default gravitee.io)
@@ -314,11 +315,11 @@ services:
 # Analytics repository is used to store all reporting, metrics, health-checks stored by gateway instances
 # This is the default configuration using Elasticsearch. If you want to disable it completely, you can set
 # the type as "none"
-analytics:
-  type: elasticsearch # or none
-  elasticsearch:
-    endpoints:
-      - http://${ds.elastic.host}:${ds.elastic.port}
+  analytics:
+    type: elasticsearch # or none
+    elasticsearch:
+      endpoints:
+        - http://${ds.elastic.host}:${ds.elastic.port}
 #    index: gravitee
 #    index_per_type: true
 #    index_mode: daily    # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -45,50 +45,51 @@ data:
         {{- end }}
     {{- end }}
 
-    management:
-      type: {{ .Values.management.type | default "mongodb" }}
-      {{- if or (eq .Values.management.type "mongodb") (kindIs "invalid" .Values.management.type) }}
-      mongodb:
-        sslEnabled: {{ .Values.mongo.sslEnabled }}
-        socketKeepAlive: {{ .Values.mongo.socketKeepAlive }}
-        {{- if .Values.mongo.uri }}
-        uri: {{ .Values.mongo.uri }}
-        {{- else if .Values.mongo.servers }}
-        servers:
-          {{- .Values.mongo.servers | nindent 10 }}
-        dbname: {{ .Values.mongo.dbname }}
-        {{- if (eq .Values.mongo.auth.enabled true) }}
-        username: {{ .Values.mongo.auth.username }}
-        password: {{ .Values.mongo.auth.password }}
-        authSource: {{ .Values.mongo.auth.source | default "gravitee" }}
+    repositories:
+      management:
+        type: {{ .Values.management.type | default "mongodb" }}
+        {{- if or (eq .Values.management.type "mongodb") (kindIs "invalid" .Values.management.type) }}
+        mongodb:
+          sslEnabled: {{ .Values.mongo.sslEnabled }}
+          socketKeepAlive: {{ .Values.mongo.socketKeepAlive }}
+          {{- if .Values.mongo.uri }}
+          uri: {{ .Values.mongo.uri }}
+          {{- else if .Values.mongo.servers }}
+          servers:
+            {{- .Values.mongo.servers | nindent 12 }}
+          dbname: {{ .Values.mongo.dbname }}
+          {{- if (eq .Values.mongo.auth.enabled true) }}
+          username: {{ .Values.mongo.auth.username }}
+          password: {{ .Values.mongo.auth.password }}
+          authSource: {{ .Values.mongo.auth.source | default "gravitee" }}
+          {{- end }}
+          {{- else }}
+          uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
+          {{- end }}
+          {{- if .Values.mongo.keystore }}
+          keystore:
+          {{- toYaml .Values.mongo.keystore | nindent 12 }}
+          {{- end }}
+          {{- if .Values.mongo.truststore }}
+          truststore:
+          {{- toYaml .Values.mongo.truststore | nindent 12 }}
+          {{- end }}
+        {{- else if (eq .Values.management.type "jdbc") }}
+        jdbc:
+          url: {{ .Values.jdbc.url }}
+          {{- if .Values.jdbc.username }}
+          username: {{ .Values.jdbc.username }}
+          {{- end }}
+          {{- if .Values.jdbc.password }}
+          password: {{ .Values.jdbc.password }}
+          {{- end }}
+          schema: {{ .Values.jdbc.schema | default "public" }}
+          liquibase: {{ .Values.jdbc.liquibase }}
+          {{- if .Values.jdbc.pool }}
+          pool:
+            {{ toYaml .Values.jdbc.pool | nindent 12 | trim -}}
+          {{- end }}
         {{- end }}
-        {{- else }}
-        uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
-        {{- end }}
-        {{- if .Values.mongo.keystore }}
-        keystore:
-        {{- toYaml .Values.mongo.keystore | nindent 10 }}
-        {{- end }}
-        {{- if .Values.mongo.truststore }}
-        truststore:
-        {{- toYaml .Values.mongo.truststore | nindent 10 }}
-        {{- end }}
-      {{- else if (eq .Values.management.type "jdbc") }}
-      jdbc:
-        url: {{ .Values.jdbc.url }}
-        {{- if .Values.jdbc.username }}
-        username: {{ .Values.jdbc.username }}
-        {{- end }}
-        {{- if .Values.jdbc.password }}
-        password: {{ .Values.jdbc.password }}
-        {{- end }}
-        schema: {{ .Values.jdbc.schema | default "public" }}
-        liquibase: {{ .Values.jdbc.liquibase }}
-        {{- if .Values.jdbc.pool }}
-        pool:
-          {{ toYaml .Values.jdbc.pool | nindent 10 | trim -}}
-        {{- end }}
-      {{- end }}
 
     # Secret Manager configuration
     {{- if .Values.secrets }}
@@ -261,45 +262,45 @@ data:
     {{- end }}
     {{- end }}
 
-    analytics:
-      {{- if (eq .Values.api.analytics.type "elasticsearch") }}
-      type: elasticsearch
-      elasticsearch:
-        {{- with .Values.es.endpoints }}
-        endpoints:
-          {{ toYaml . | nindent 10 | trim -}}
-        {{- end }}
-        {{- if .Values.es.index_mode }}
-        index_mode: {{ .Values.es.index_mode }}
-        {{- end }}
-        {{- if .Values.es.http }}
-        http:
-          {{- if .Values.es.http.timeout }}
-          timeout: {{ .Values.es.http.timeout }}
+      analytics:
+        {{- if (eq .Values.api.analytics.type "elasticsearch") }}
+        type: elasticsearch
+        elasticsearch:
+          {{- with .Values.es.endpoints }}
+          endpoints:
+            {{ toYaml . | nindent 12 | trim -}}
           {{- end }}
-        {{- end }}
-        {{- if (eq .Values.es.security.enabled true) }}
-        security:
-          username: {{ .Values.es.security.username }}
-          password: {{ .Values.es.security.password }}
-        {{- end }}
-        {{- if (eq .Values.es.ssl.enabled true) }}
-        ssl:
-          keystore:
-            type: {{ .Values.es.ssl.keystore.type }}
-            {{- if or .Values.es.ssl.keystore.path .Values.es.ssl.keystore.password }}
-            path: {{ .Values.es.ssl.keystore.path }}
-            password: {{ .Values.es.ssl.keystore.password }}
+          {{- if .Values.es.index_mode }}
+          index_mode: {{ .Values.es.index_mode }}
+          {{- end }}
+          {{- if .Values.es.http }}
+          http:
+            {{- if .Values.es.http.timeout }}
+            timeout: {{ .Values.es.http.timeout }}
             {{- end }}
-            {{- if or .Values.es.ssl.keystore.certs .Values.es.ssl.keystore.keys }}
-            certs: {{ .Values.es.ssl.keystore.certs }}
-            keys: {{ .Values.es.ssl.keystore.keys }}
-            {{- end }}
+          {{- end }}
+          {{- if (eq .Values.es.security.enabled true) }}
+          security:
+            username: {{ .Values.es.security.username }}
+            password: {{ .Values.es.security.password }}
+          {{- end }}
+          {{- if (eq .Values.es.ssl.enabled true) }}
+          ssl:
+            keystore:
+              type: {{ .Values.es.ssl.keystore.type }}
+              {{- if or .Values.es.ssl.keystore.path .Values.es.ssl.keystore.password }}
+              path: {{ .Values.es.ssl.keystore.path }}
+              password: {{ .Values.es.ssl.keystore.password }}
+              {{- end }}
+              {{- if or .Values.es.ssl.keystore.certs .Values.es.ssl.keystore.keys }}
+              certs: {{ .Values.es.ssl.keystore.certs }}
+              keys: {{ .Values.es.ssl.keystore.keys }}
+              {{- end }}
+          {{- end }}
+          index: {{ .Values.es.index }}
+        {{- else if (eq .Values.api.analytics.type "none") }}
+        type: none
         {{- end }}
-        index: {{ .Values.es.index }}
-      {{- else if (eq .Values.api.analytics.type "none") }}
-      type: none
-      {{- end }}
     {{- if .Values.api.configuration.logging }}
     logging: {{- toYaml .Values.api.configuration.logging | nindent 6 }}
     {{- end }}

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -390,215 +390,216 @@ data:
         {{- end}}
       {{- end}}
     {{- end }}
-    management:
-    {{- if .Values.gateway.dbLess }}
-      type: {{ "none" }}
-    {{- else }}
-      type: {{ .Values.management.type | default "mongodb" }}
-      {{- if or (eq .Values.management.type "mongodb") (kindIs "invalid" .Values.management.type) }}
-      mongodb:
-        sslEnabled: {{ .Values.mongo.sslEnabled }}
-        socketKeepAlive: {{ .Values.mongo.socketKeepAlive }}
-        {{- if .Values.mongo.uri }}
-        uri: {{ .Values.mongo.uri }}
-        {{- else if .Values.mongo.servers }}
-        servers:
-          {{- .Values.mongo.servers | nindent 10 }}
-        dbname: {{ .Values.mongo.dbname }}
-        {{- if (eq .Values.mongo.auth.enabled true) }}
-        username: {{ .Values.mongo.auth.username }}
-        password: {{ .Values.mongo.auth.password }}
-        authSource: {{ .Values.mongo.auth.source | default "gravitee" }}
-        {{- end }}
-        {{- else }}
-        uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
-        {{- end }}
-        {{- if .Values.mongo.keystore }}
-        keystore:
-        {{- toYaml .Values.mongo.keystore | nindent 10 }}
-        {{- end }}
-        {{- if .Values.mongo.truststore }}
-        truststore:
-        {{- toYaml .Values.mongo.truststore | nindent 10 }}
-        {{- end }}
-      {{- else if (eq .Values.management.type "jdbc") }}
-      jdbc:
-        url: {{ .Values.jdbc.url }}
-        {{- if .Values.jdbc.username }}
-        username: {{ .Values.jdbc.username }}
-        {{- end }}
-        {{- if .Values.jdbc.password }}
-        password: {{ .Values.jdbc.password }}
-        {{- end }}
-        schema: {{ .Values.jdbc.schema | default "public" }}
-        liquibase: {{ .Values.jdbc.liquibase }}
-        {{- if .Values.jdbc.pool }}
-        pool:
-          {{ toYaml .Values.jdbc.pool | nindent 10 | trim -}}
-        {{- end }}
-      {{- else if (eq .Values.management.type "http") }}
-      http:
-        url: {{ .Values.gateway.management.http.url }}
-        keepAlive: {{ if hasKey .Values.gateway.management.http "keepAlive" }}{{ .Values.gateway.management.http.keepAlive }}{{else}}true{{end}}
-        idleTimeout: {{ .Values.gateway.management.http.idleTimeout | default 60000 }}
-        connectTimeout: {{ .Values.gateway.management.http.connectTimeout | default 5000 }}
-        keepAliveTimeout: {{ .Values.gateway.management.http.keepAliveTimeout | default 10000 }}
-        useCompression: {{ if hasKey .Values.gateway.management.http "useCompression" }}{{ .Values.gateway.management.http.useCompression }}{{else}}true{{end}}
-        followRedirects: {{ .Values.gateway.management.http.followRedirects | default false }}
-        clearTextUpgrade: {{ if hasKey .Values.gateway.management.http "clearTextUpgrade" }}{{ .Values.gateway.management.http.clearTextUpgrade }}{{else}}true{{end}}
-        version: {{ .Values.gateway.management.http.version | default "HTTP_1_1" }}
-        {{- if .Values.gateway.management.http.connectionRetry }}
-        connectionRetry:
-          delaySec: {{ .Values.gateway.management.http.connectionRetry.delaySec | default 2 }}
-          maxDelaySec: {{ .Values.gateway.management.http.connectionRetry.maxDelaySec  | default 60 }}
-          backoffFactor: {{ .Values.gateway.management.http.connectionRetry.backoffFactor  | default 1.5 }}
-        {{- end}}
-        {{- if .Values.gateway.management.http.proxy}}
-        proxy:
-{{ toYaml .Values.gateway.management.http.proxy | indent 10 -}}
-        {{- end }}
-        {{- if .Values.gateway.management.http.username }}
-        authentication:
-          type: basic
-          basic:
-            username: {{ .Values.gateway.management.http.username }}
-            password: {{ .Values.gateway.management.http.password }}
-        {{- else if .Values.gateway.management.http.authentication }}
-        authentication:
-{{ toYaml .Values.gateway.management.http.authentication | indent 10 }}
-        {{- end }}
-        {{- if .Values.gateway.management.http.ssl }}
-        ssl:
-          {{- if hasKey .Values.gateway.management.http.ssl "trustall" }}
-          trustAll: {{ .Values.gateway.management.http.ssl.trustall }}
+    repositories:
+      management:
+      {{- if .Values.gateway.dbLess }}
+        type: {{ "none" }}
+      {{- else }}
+        type: {{ .Values.management.type | default "mongodb" }}
+        {{- if or (eq .Values.management.type "mongodb") (kindIs "invalid" .Values.management.type) }}
+        mongodb:
+          sslEnabled: {{ .Values.mongo.sslEnabled }}
+          socketKeepAlive: {{ .Values.mongo.socketKeepAlive }}
+          {{- if .Values.mongo.uri }}
+          uri: {{ .Values.mongo.uri }}
+          {{- else if .Values.mongo.servers }}
+          servers:
+            {{- .Values.mongo.servers | nindent 12 }}
+          dbname: {{ .Values.mongo.dbname }}
+          {{- if (eq .Values.mongo.auth.enabled true) }}
+          username: {{ .Values.mongo.auth.username }}
+          password: {{ .Values.mongo.auth.password }}
+          authSource: {{ .Values.mongo.auth.source | default "gravitee" }}
+          {{- end }}
           {{- else }}
-          trustAll: {{ .Values.gateway.management.http.ssl.trustAll | default false }}
-          {{- end}}
-          verifyHostname: {{ if hasKey .Values.gateway.management.http.ssl "verifyHostname" }}{{ .Values.gateway.management.http.ssl.verifyHostname }}{{else}}true{{end}}
-          {{- if .Values.gateway.management.http.ssl.keystore }}
+          uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
+          {{- end }}
+          {{- if .Values.mongo.keystore }}
           keystore:
-{{ toYaml .Values.gateway.management.http.ssl.keystore | indent 12 }}
+          {{- toYaml .Values.mongo.keystore | nindent 12 }}
           {{- end }}
-          {{- if .Values.gateway.management.http.ssl.truststore }}
+          {{- if .Values.mongo.truststore }}
           truststore:
-{{ toYaml .Values.gateway.management.http.ssl.truststore | indent 12 }}
+          {{- toYaml .Values.mongo.truststore | nindent 12 }}
+          {{- end }}
+        {{- else if (eq .Values.management.type "jdbc") }}
+        jdbc:
+          url: {{ .Values.jdbc.url }}
+          {{- if .Values.jdbc.username }}
+          username: {{ .Values.jdbc.username }}
+          {{- end }}
+          {{- if .Values.jdbc.password }}
+          password: {{ .Values.jdbc.password }}
+          {{- end }}
+          schema: {{ .Values.jdbc.schema | default "public" }}
+          liquibase: {{ .Values.jdbc.liquibase }}
+          {{- if .Values.jdbc.pool }}
+          pool:
+            {{ toYaml .Values.jdbc.pool | nindent 12 | trim -}}
+          {{- end }}
+        {{- else if (eq .Values.management.type "http") }}
+        http:
+          url: {{ .Values.gateway.management.http.url }}
+          keepAlive: {{ if hasKey .Values.gateway.management.http "keepAlive" }}{{ .Values.gateway.management.http.keepAlive }}{{else}}true{{end}}
+          idleTimeout: {{ .Values.gateway.management.http.idleTimeout | default 60000 }}
+          connectTimeout: {{ .Values.gateway.management.http.connectTimeout | default 5000 }}
+          keepAliveTimeout: {{ .Values.gateway.management.http.keepAliveTimeout | default 10000 }}
+          useCompression: {{ if hasKey .Values.gateway.management.http "useCompression" }}{{ .Values.gateway.management.http.useCompression }}{{else}}true{{end}}
+          followRedirects: {{ .Values.gateway.management.http.followRedirects | default false }}
+          clearTextUpgrade: {{ if hasKey .Values.gateway.management.http "clearTextUpgrade" }}{{ .Values.gateway.management.http.clearTextUpgrade }}{{else}}true{{end}}
+          version: {{ .Values.gateway.management.http.version | default "HTTP_1_1" }}
+          {{- if .Values.gateway.management.http.connectionRetry }}
+          connectionRetry:
+            delaySec: {{ .Values.gateway.management.http.connectionRetry.delaySec | default 2 }}
+            maxDelaySec: {{ .Values.gateway.management.http.connectionRetry.maxDelaySec  | default 60 }}
+            backoffFactor: {{ .Values.gateway.management.http.connectionRetry.backoffFactor  | default 1.5 }}
+          {{- end}}
+          {{- if .Values.gateway.management.http.proxy}}
+          proxy:
+{{ toYaml .Values.gateway.management.http.proxy | indent 12 -}}
+          {{- end }}
+          {{- if .Values.gateway.management.http.username }}
+          authentication:
+            type: basic
+            basic:
+              username: {{ .Values.gateway.management.http.username }}
+              password: {{ .Values.gateway.management.http.password }}
+          {{- else if .Values.gateway.management.http.authentication }}
+          authentication:
+{{ toYaml .Values.gateway.management.http.authentication | indent 12 }}
+          {{- end }}
+          {{- if .Values.gateway.management.http.ssl }}
+          ssl:
+            {{- if hasKey .Values.gateway.management.http.ssl "trustall" }}
+            trustAll: {{ .Values.gateway.management.http.ssl.trustall }}
+            {{- else }}
+            trustAll: {{ .Values.gateway.management.http.ssl.trustAll | default false }}
+            {{- end}}
+            verifyHostname: {{ if hasKey .Values.gateway.management.http.ssl "verifyHostname" }}{{ .Values.gateway.management.http.ssl.verifyHostname }}{{else}}true{{end}}
+            {{- if .Values.gateway.management.http.ssl.keystore }}
+            keystore:
+{{ toYaml .Values.gateway.management.http.ssl.keystore | indent 14 }}
+            {{- end }}
+            {{- if .Values.gateway.management.http.ssl.truststore }}
+            truststore:
+{{ toYaml .Values.gateway.management.http.ssl.truststore | indent 14 }}
+            {{- end }}
           {{- end }}
         {{- end }}
       {{- end }}
-    {{- end }}
 
-    ratelimit:
-      type: {{ .Values.ratelimit.type | default "mongodb" }}
-      {{- if or (eq .Values.ratelimit.type "mongodb") (kindIs "invalid" .Values.ratelimit.type) }}
-      mongodb:
-        sslEnabled: {{ .Values.mongo.sslEnabled }}
-        socketKeepAlive: {{ .Values.mongo.socketKeepAlive }}
-        {{- if .Values.mongo.uri }}
-        uri: {{ .Values.mongo.uri }}
-        {{- else if .Values.mongo.servers }}
-        servers:
-          {{- .Values.mongo.servers | nindent 10 }}
-        dbname: {{ .Values.mongo.dbname }}
-        {{- if (eq .Values.mongo.auth.enabled true) }}
-        username: {{ .Values.mongo.auth.username }}
-        password: {{ .Values.mongo.auth.password }}
-        authSource: {{ .Values.mongo.auth.source | default "gravitee" }}
-        {{- end }}
-        {{- else }}
-        uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
-        {{- end }}
-        {{- if .Values.mongo.keystore }}
-        keystore:{{- toYaml .Values.mongo.keystore | nindent 10 }}
-        {{- end }}
-        {{- if .Values.mongo.truststore }}
-        truststore:{{- toYaml .Values.mongo.truststore | nindent 10 }}
-        {{- end }}
-      {{- else if (eq .Values.ratelimit.type "jdbc") }}
-      jdbc:
-        url: {{ .Values.jdbc.url }}
-        {{- if .Values.jdbc.username }}
-        username: {{ .Values.jdbc.username }}
-        {{- end }}
-        {{- if .Values.jdbc.password }}
-        password: {{ .Values.jdbc.password }}
-        {{- end }}
-        schema: {{ .Values.jdbc.schema | default "public" }}
-        liquibase: {{ .Values.jdbc.liquibase }}
-        {{- if .Values.jdbc.pool }}
-        pool:
-          {{ toYaml .Values.jdbc.pool | nindent 10 | trim -}}
-        {{- end }}
-      {{- else if (eq .Values.ratelimit.type "redis") }}
-      redis:
-        host: {{ .Values.gateway.ratelimit.redis.host }}
-        port: {{ .Values.gateway.ratelimit.redis.port }}
-        {{- if .Values.gateway.ratelimit.redis.username }}
-        username: {{ .Values.gateway.ratelimit.redis.username }}
-        {{- end }}
-        {{- if .Values.gateway.ratelimit.redis.password }}
-        password: {{ .Values.gateway.ratelimit.redis.password }}
-        {{- end }}
-        {{- if .Values.gateway.ratelimit.redis.ssl }}
-        ssl: {{ .Values.gateway.ratelimit.redis.ssl }}
-        hostnameVerificationAlgorithm: {{ .Values.gateway.ratelimit.redis.hostnameVerificationAlgorithm | default "NONE" }}
-        trustAll: {{ if hasKey .Values.gateway.ratelimit.redis "trustAll" }}{{ .Values.gateway.ratelimit.redis.trustAll }}{{else}}true{{end}}
-        tlsProtocols: {{ .Values.gateway.ratelimit.redis.tlsProtocols | default "TLSv1.2" }}
-        {{- if .Values.gateway.ratelimit.redis.tlsCiphers }}
-        tlsCiphers: {{ .Values.gateway.ratelimit.redis.tlsCiphers | quote }}
-        {{- end }}
-        alpn: {{ .Values.gateway.ratelimit.redis.alpn | default false }}
-        openssl: {{ .Values.gateway.ratelimit.redis.openssl | default false }}
-        {{/* end of ssl block */}}
-        {{- end }}
-        {{- if .Values.gateway.ratelimit.redis.keystore }}
-        keystore:
-          type: {{ .Values.gateway.ratelimit.redis.keystore.type | default "pem" }}
-          path: {{ .Values.gateway.ratelimit.redis.keystore.path | default "${gravitee.home}/security/redis-keystore.jks" }}
-          password: {{ required "The password required to access the keystore must be provided (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" .Values.gateway.ratelimit.redis.keystore.password }}
-          {{- if .Values.gateway.ratelimit.redis.keystore.keyPassword }}
-          keyPassword: {{ .Values.gateway.ratelimit.redis.keystore.keyPassword | quote }}
+      ratelimit:
+        type: {{ .Values.ratelimit.type | default "mongodb" }}
+        {{- if or (eq .Values.ratelimit.type "mongodb") (kindIs "invalid" .Values.ratelimit.type) }}
+        mongodb:
+          sslEnabled: {{ .Values.mongo.sslEnabled }}
+          socketKeepAlive: {{ .Values.mongo.socketKeepAlive }}
+          {{- if .Values.mongo.uri }}
+          uri: {{ .Values.mongo.uri }}
+          {{- else if .Values.mongo.servers }}
+          servers:
+            {{- .Values.mongo.servers | nindent 12 }}
+          dbname: {{ .Values.mongo.dbname }}
+          {{- if (eq .Values.mongo.auth.enabled true) }}
+          username: {{ .Values.mongo.auth.username }}
+          password: {{ .Values.mongo.auth.password }}
+          authSource: {{ .Values.mongo.auth.source | default "gravitee" }}
           {{- end }}
-          {{- if .Values.gateway.ratelimit.redis.keystore.alias }}
-          alias: {{ .Values.gateway.ratelimit.redis.keystore.alias }}
+          {{- else }}
+          uri: mongodb://{{- if (eq .Values.mongo.auth.enabled true) }}{{ .Values.mongo.auth.username }}:{{ .Values.mongo.auth.password }}@{{- end }}{{ .Values.mongo.dbhost }}:{{ .Values.mongo.dbport }}/{{ .Values.mongo.dbname }}?{{- if .Values.mongo.rsEnabled }}&replicaSet={{ .Values.mongo.rs }}{{- end }}{{- if (eq .Values.mongo.auth.enabled true) }}&authSource={{ .Values.mongo.auth.source }}{{- end }}{{- if .Values.mongo.connectTimeoutMS }}&connectTimeoutMS={{ .Values.mongo.connectTimeoutMS }}{{- end }}
           {{- end }}
-          {{/* guard clause for pem mTLS requirements */}}
-          {{- if and ( eq .Values.gateway.ratelimit.redis.keystore.type "pem" ) ( empty .Values.gateway.ratelimit.redis.keystore.certificates ) }}
-            {{ fail "When configuring Gravitee to use a keystore for mTLS, your certificates must be provided!" }}
+          {{- if .Values.mongo.keystore }}
+          keystore:{{- toYaml .Values.mongo.keystore | nindent 12 }}
           {{- end }}
-          certificates:
-            {{- range .Values.gateway.ratelimit.redis.keystore.certificates }}
-            - cert: {{ .cert }}
-              key: {{ .key }}
+          {{- if .Values.mongo.truststore }}
+          truststore:{{- toYaml .Values.mongo.truststore | nindent 12 }}
+          {{- end }}
+        {{- else if (eq .Values.ratelimit.type "jdbc") }}
+        jdbc:
+          url: {{ .Values.jdbc.url }}
+          {{- if .Values.jdbc.username }}
+          username: {{ .Values.jdbc.username }}
+          {{- end }}
+          {{- if .Values.jdbc.password }}
+          password: {{ .Values.jdbc.password }}
+          {{- end }}
+          schema: {{ .Values.jdbc.schema | default "public" }}
+          liquibase: {{ .Values.jdbc.liquibase }}
+          {{- if .Values.jdbc.pool }}
+          pool:
+            {{ toYaml .Values.jdbc.pool | nindent 12 | trim -}}
+          {{- end }}
+        {{- else if (eq .Values.ratelimit.type "redis") }}
+        redis:
+          host: {{ .Values.gateway.ratelimit.redis.host }}
+          port: {{ .Values.gateway.ratelimit.redis.port }}
+          {{- if .Values.gateway.ratelimit.redis.username }}
+          username: {{ .Values.gateway.ratelimit.redis.username }}
+          {{- end }}
+          {{- if .Values.gateway.ratelimit.redis.password }}
+          password: {{ .Values.gateway.ratelimit.redis.password }}
+          {{- end }}
+          {{- if .Values.gateway.ratelimit.redis.ssl }}
+          ssl: {{ .Values.gateway.ratelimit.redis.ssl }}
+          hostnameVerificationAlgorithm: {{ .Values.gateway.ratelimit.redis.hostnameVerificationAlgorithm | default "NONE" }}
+          trustAll: {{ if hasKey .Values.gateway.ratelimit.redis "trustAll" }}{{ .Values.gateway.ratelimit.redis.trustAll }}{{else}}true{{end}}
+          tlsProtocols: {{ .Values.gateway.ratelimit.redis.tlsProtocols | default "TLSv1.2" }}
+          {{- if .Values.gateway.ratelimit.redis.tlsCiphers }}
+          tlsCiphers: {{ .Values.gateway.ratelimit.redis.tlsCiphers | quote }}
+          {{- end }}
+          alpn: {{ .Values.gateway.ratelimit.redis.alpn | default false }}
+          openssl: {{ .Values.gateway.ratelimit.redis.openssl | default false }}
+          {{/* end of ssl block */}}
+          {{- end }}
+          {{- if .Values.gateway.ratelimit.redis.keystore }}
+          keystore:
+            type: {{ .Values.gateway.ratelimit.redis.keystore.type | default "pem" }}
+            path: {{ .Values.gateway.ratelimit.redis.keystore.path | default "${gravitee.home}/security/redis-keystore.jks" }}
+            password: {{ required "The password required to access the keystore must be provided (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" .Values.gateway.ratelimit.redis.keystore.password }}
+            {{- if .Values.gateway.ratelimit.redis.keystore.keyPassword }}
+            keyPassword: {{ .Values.gateway.ratelimit.redis.keystore.keyPassword | quote }}
             {{- end }}
-        {{- end}}
-        {{- if .Values.gateway.ratelimit.redis.truststore }}
-        truststore:
-          type: {{ .Values.gateway.ratelimit.redis.truststore.type | default "pem" }}
-          path: {{ .Values.gateway.ratelimit.redis.truststore.path | default "${gravitee.home}/security/redis-truststore.jks" }}
-          password: {{ required "The password required to access the truststore must be provided! (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" .Values.gateway.ratelimit.redis.truststore.password }}
-          {{- if .Values.gateway.ratelimit.redis.truststore.alias }}
-          alias: {{ .Values.gateway.ratelimit.redis.truststore.alias }}
+            {{- if .Values.gateway.ratelimit.redis.keystore.alias }}
+            alias: {{ .Values.gateway.ratelimit.redis.keystore.alias }}
+            {{- end }}
+            {{/* guard clause for pem mTLS requirements */}}
+            {{- if and ( eq .Values.gateway.ratelimit.redis.keystore.type "pem" ) ( empty .Values.gateway.ratelimit.redis.keystore.certificates ) }}
+              {{ fail "When configuring Gravitee to use a keystore for mTLS, your certificates must be provided!" }}
+            {{- end }}
+            certificates:
+              {{- range .Values.gateway.ratelimit.redis.keystore.certificates }}
+              - cert: {{ .cert }}
+                key: {{ .key }}
+              {{- end }}
+          {{- end}}
+          {{- if .Values.gateway.ratelimit.redis.truststore }}
+          truststore:
+            type: {{ .Values.gateway.ratelimit.redis.truststore.type | default "pem" }}
+            path: {{ .Values.gateway.ratelimit.redis.truststore.path | default "${gravitee.home}/security/redis-truststore.jks" }}
+            password: {{ required "The password required to access the truststore must be provided! (i.e.kubernetes://{{NAMESPACE}}/secrets/{{SECRET_NAME}}/{{KEY_NAME}})" .Values.gateway.ratelimit.redis.truststore.password }}
+            {{- if .Values.gateway.ratelimit.redis.truststore.alias }}
+            alias: {{ .Values.gateway.ratelimit.redis.truststore.alias }}
+            {{- end }}
+          {{- end }}
+          {{- if (not (empty ((.Values.gateway.ratelimit.redis.sentinel).nodes))) }}
+          sentinel:
+            master: {{ .Values.gateway.ratelimit.redis.sentinel.master }}
+            nodes:
+              {{- range .Values.gateway.ratelimit.redis.sentinel.nodes }}
+              - host: {{ .host }}
+                port: {{ .port }}
+              {{- end }}
+          {{- end }}
+          {{- if (not (empty (.Values.gateway.ratelimit.redis.operation))) }}
+          operation:
+            timeout: {{ .Values.gateway.ratelimit.redis.operation.timeout | default "10" }}
+          {{- end }}
+          {{- if (not (empty (.Values.gateway.ratelimit.redis.tcp))) }}
+          tcp:
+            connectTimeout: {{ .Values.gateway.ratelimit.redis.tcp.connectTimeout | default "5000" }}
+            idleTimeout: {{ .Values.gateway.ratelimit.redis.tcp.idleTimeout | default "0" }}
           {{- end }}
         {{- end }}
-        {{- if (not (empty ((.Values.gateway.ratelimit.redis.sentinel).nodes))) }}
-        sentinel:
-          master: {{ .Values.gateway.ratelimit.redis.sentinel.master }}
-          nodes:
-            {{- range .Values.gateway.ratelimit.redis.sentinel.nodes }}
-            - host: {{ .host }}
-              port: {{ .port }}
-            {{- end }}
-        {{- end }}
-        {{- if (not (empty (.Values.gateway.ratelimit.redis.operation))) }}
-        operation:
-          timeout: {{ .Values.gateway.ratelimit.redis.operation.timeout | default "10" }}
-        {{- end }}
-        {{- if (not (empty (.Values.gateway.ratelimit.redis.tcp))) }}
-        tcp:
-          connectTimeout: {{ .Values.gateway.ratelimit.redis.tcp.connectTimeout | default "5000" }}
-          idleTimeout: {{ .Values.gateway.ratelimit.redis.tcp.idleTimeout | default "0" }}
-        {{- end }}
-      {{- end }}
 
     # Sharding tags configuration
     # Allows to define inclusion/exclusion sharding tags to only deploy a part of APIs. To exclude just prefix the tag with '!'.

--- a/helm/tests/api/configmap_mongodb_test.yaml
+++ b/helm/tests/api/configmap_mongodb_test.yaml
@@ -18,10 +18,10 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s mongodb:
-            \s   sslEnabled: true
-            \s   socketKeepAlive: true
-            \s   uri: mongodb://mongo-mongodb-replicaset:27017/gravitee
+            \s   mongodb:
+            \s     sslEnabled: true
+            \s     socketKeepAlive: true
+            \s     uri: mongodb://mongo-mongodb-replicaset:27017/gravitee
   - it: Set common value and servers
     template: api/api-configmap.yaml
     set:
@@ -43,19 +43,19 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s mongodb:
-            \s   sslEnabled: true
-            \s   socketKeepAlive: true
-            \s   servers:
-            \s     - host: mongo1
-            \s       port: 27017
-            \s     - host: mongo2
-            \s       port: 27017
+            \s   mongodb:
+            \s     sslEnabled: true
+            \s     socketKeepAlive: true
+            \s     servers:
+            \s       - host: mongo1
+            \s         port: 27017
+            \s       - host: mongo2
+            \s         port: 27017
             \s+
-            \s   dbname: dbname
-            \s   username: username
-            \s   password: password
-            \s   authSource: authSource
+            \s     dbname: dbname
+            \s     username: username
+            \s     password: password
+            \s     authSource: authSource
   - it: Set common value and properties one by one
     template: api/api-configmap.yaml
     set:
@@ -76,10 +76,10 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s mongodb:
-            \s   sslEnabled: true
-            \s   socketKeepAlive: true
-            \s   uri: mongodb://username:password@graviteeio-apim-mongodb-replicaset:27117/dbname\?&replicaSet=rs0&authSource=authSource&connectTimeoutMS=2000
+            \s   mongodb:
+            \s     sslEnabled: true
+            \s     socketKeepAlive: true
+            \s     uri: mongodb://username:password@graviteeio-apim-mongodb-replicaset:27117/dbname\?&replicaSet=rs0&authSource=authSource&connectTimeoutMS=2000
   - it: Set mongo keystore attributes with provided values
     template: api/api-configmap.yaml
     set:
@@ -93,13 +93,13 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern:  |
-            \s mongodb:
+            \s   mongodb:
             (.|\n)*
-            \s   keystore:
-            \s     keyPassword: keyPassword
-            \s     password: keystorePassword
-            \s     path: /path/to/keystore.p12
-            \s     type: pkcs12
+            \s     keystore:
+            \s       keyPassword: keyPassword
+            \s       password: keystorePassword
+            \s       path: /path/to/keystore.p12
+            \s       type: pkcs12
   - it: Set mongo truststore attributes with provided values
     template: api/api-configmap.yaml
     set:
@@ -112,9 +112,9 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s mongodb:
+            \s   mongodb:
             (.|\n)*
-            \s   truststore:
-            \s     password: truststorePassword
-            \s     path: /path/to/truststore.jks
-            \s     type: jks
+            \s     truststore:
+            \s       password: truststorePassword
+            \s       path: /path/to/truststore.jks
+            \s       type: jks

--- a/helm/tests/gateway/configmap_http_repo_test.yaml
+++ b/helm/tests/gateway/configmap_http_repo_test.yaml
@@ -15,18 +15,19 @@ tests:
           - matchRegex:
                 path: data["gravitee.yml"]
                 pattern: |
-                    management:
-                      type: http
-                      http:
-                        url: https://bridge-server.example.com
-                        keepAlive: true
-                        idleTimeout: 60000
-                        connectTimeout: 5000
-                        keepAliveTimeout: 10000
-                        useCompression: true
-                        followRedirects: false
-                        clearTextUpgrade: true
-                        version: HTTP_1_1
+                    repositories:
+                      management:
+                        type: http
+                        http:
+                          url: https://bridge-server.example.com
+                          keepAlive: true
+                          idleTimeout: 60000
+                          connectTimeout: 5000
+                          keepAliveTimeout: 10000
+                          useCompression: true
+                          followRedirects: false
+                          clearTextUpgrade: true
+                          version: HTTP_1_1
 
     - it: Set non default values URL
       template: gateway/gateway-configmap.yaml
@@ -83,52 +84,53 @@ tests:
           - matchRegex:
                 path: data["gravitee.yml"]
                 pattern: |
-                    management:
-                      type: http
-                      http:
-                        url: https://bridge-server.example.com
-                        keepAlive: false
-                        idleTimeout: 1
-                        connectTimeout: 2
-                        keepAliveTimeout: 3
-                        useCompression: false
-                        followRedirects: true
-                        clearTextUpgrade: false
-                        version: HTTP_2
-                        connectionRetry:
-                          delaySec: 1
-                          maxDelaySec: 30
-                          backoffFactor: 0.5
-                        proxy:
-                          enabled: true
-                          host: proxy.com
-                          port: 3128
-                          type: HTTP
-                          useSystemProxy: true
-                        authentication:
-                          basic:
-                            password: bar
-                            username: foo
-                          type: basic
-                        ssl:
-                          trustAll: true
-                          verifyHostname: false
-                          keystore:
-                            alias: foo
-                            certContent: secrets://kubernetes/http-repo-secret:tls.cert
-                            certPath: \${gravitee.home}/security/client-cert.pem
-                            content: secrets://kubernetes/http-repo-secret:keystore
-                            keyContent: secrets://kubernetes/http-repo-secret:tls.key
-                            keyPath: \${gravitee.home}/security/client-key.pem
-                            password: secret
-                            path: \${gravitee.home}/security/keystore.jks
-                            type: jks
-                          truststore:
-                            alias: bar
-                            content: secrets://kubernetes/http-repo-secret:truststore
-                            password: secret
-                            path: \${gravitee.home}/security/truststore.jks
-                            type: jks
+                    repositories:
+                      management:
+                        type: http
+                        http:
+                          url: https://bridge-server.example.com
+                          keepAlive: false
+                          idleTimeout: 1
+                          connectTimeout: 2
+                          keepAliveTimeout: 3
+                          useCompression: false
+                          followRedirects: true
+                          clearTextUpgrade: false
+                          version: HTTP_2
+                          connectionRetry:
+                            delaySec: 1
+                            maxDelaySec: 30
+                            backoffFactor: 0.5
+                          proxy:
+                            enabled: true
+                            host: proxy.com
+                            port: 3128
+                            type: HTTP
+                            useSystemProxy: true
+                          authentication:
+                            basic:
+                              password: bar
+                              username: foo
+                            type: basic
+                          ssl:
+                            trustAll: true
+                            verifyHostname: false
+                            keystore:
+                              alias: foo
+                              certContent: secrets://kubernetes/http-repo-secret:tls.cert
+                              certPath: \${gravitee.home}/security/client-cert.pem
+                              content: secrets://kubernetes/http-repo-secret:keystore
+                              keyContent: secrets://kubernetes/http-repo-secret:tls.key
+                              keyPath: \${gravitee.home}/security/client-key.pem
+                              password: secret
+                              path: \${gravitee.home}/security/keystore.jks
+                              type: jks
+                            truststore:
+                              alias: bar
+                              content: secrets://kubernetes/http-repo-secret:truststore
+                              password: secret
+                              path: \${gravitee.home}/security/truststore.jks
+                              type: jks
     - it: Set legacy config
       template: gateway/gateway-configmap.yaml
       set:
@@ -146,26 +148,27 @@ tests:
           - matchRegex:
                 path: data["gravitee.yml"]
                 pattern: |
-                    management:
-                      type: http
-                      http:
-                        url: https://bridge-server.example.com
-                        keepAlive: true
-                        idleTimeout: 60000
-                        connectTimeout: 5000
-                        keepAliveTimeout: 10000
-                        useCompression: true
-                        followRedirects: false
-                        clearTextUpgrade: true
-                        version: HTTP_1_1
-                        authentication:
-                          type: basic
-                          basic:
-                            username: foo
-                            password: bar
-                        ssl:
-                          trustAll: true
-                          verifyHostname: true
+                    repositories:
+                      management:
+                        type: http
+                        http:
+                          url: https://bridge-server.example.com
+                          keepAlive: true
+                          idleTimeout: 60000
+                          connectTimeout: 5000
+                          keepAliveTimeout: 10000
+                          useCompression: true
+                          followRedirects: false
+                          clearTextUpgrade: true
+                          version: HTTP_1_1
+                          authentication:
+                            type: basic
+                            basic:
+                              username: foo
+                              password: bar
+                          ssl:
+                            trustAll: true
+                            verifyHostname: true
     - it: Set legacy config trustall
       template: gateway/gateway-configmap.yaml
       set:
@@ -181,18 +184,19 @@ tests:
           - matchRegex:
                 path: data["gravitee.yml"]
                 pattern: |
-                    management:
-                      type: http
-                      http:
-                        url: https://bridge-server.example.com
-                        keepAlive: true
-                        idleTimeout: 60000
-                        connectTimeout: 5000
-                        keepAliveTimeout: 10000
-                        useCompression: true
-                        followRedirects: false
-                        clearTextUpgrade: true
-                        version: HTTP_1_1
-                        ssl:
-                          trustAll: false
-                          verifyHostname: true
+                    repositories:
+                      management:
+                        type: http
+                        http:
+                          url: https://bridge-server.example.com
+                          keepAlive: true
+                          idleTimeout: 60000
+                          connectTimeout: 5000
+                          keepAliveTimeout: 10000
+                          useCompression: true
+                          followRedirects: false
+                          clearTextUpgrade: true
+                          version: HTTP_1_1
+                          ssl:
+                            trustAll: false
+                            verifyHostname: true

--- a/helm/tests/gateway/configmap_mongodb_test.yaml
+++ b/helm/tests/gateway/configmap_mongodb_test.yaml
@@ -18,12 +18,13 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            management:
-              type: mongodb
-              mongodb:
-                sslEnabled: true
-                socketKeepAlive: true
-                uri: mongodb://mongo-mongodb-replicaset:27017/gravitee
+            repositories:
+              management:
+                type: mongodb
+                mongodb:
+                  sslEnabled: true
+                  socketKeepAlive: true
+                  uri: mongodb://mongo-mongodb-replicaset:27017/gravitee
   - it: Set common value and servers
     template: gateway/gateway-configmap.yaml
     set:
@@ -45,21 +46,22 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            management:
-              type: mongodb
-              mongodb:
-                sslEnabled: true
-                socketKeepAlive: true
-                servers:
-                  - host: mongo1
-                    port: 27017
-                  - host: mongo2
-                    port: 27017
+            repositories:
+              management:
+                type: mongodb
+                mongodb:
+                  sslEnabled: true
+                  socketKeepAlive: true
+                  servers:
+                    - host: mongo1
+                      port: 27017
+                    - host: mongo2
+                      port: 27017
             (.|\n)*
-                dbname: dbname
-                username: username
-                password: password
-                authSource: authSource
+                  dbname: dbname
+                  username: username
+                  password: password
+                  authSource: authSource
   - it: Set common value and properties one by one
     template: gateway/gateway-configmap.yaml
     set:
@@ -80,12 +82,13 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            management:
-              type: mongodb
-              mongodb:
-                sslEnabled: true
-                socketKeepAlive: true
-                uri: mongodb://username:password@graviteeio-apim-mongodb-replicaset:27117/dbname\?&replicaSet=rs0&authSource=authSource&connectTimeoutMS=2000
+            repositories:
+              management:
+                type: mongodb
+                mongodb:
+                  sslEnabled: true
+                  socketKeepAlive: true
+                  uri: mongodb://username:password@graviteeio-apim-mongodb-replicaset:27117/dbname\?&replicaSet=rs0&authSource=authSource&connectTimeoutMS=2000
   - it: Set mongo keystore attributes with provided values
     template: gateway/gateway-configmap.yaml
     set:
@@ -99,25 +102,26 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            management:
-              type: mongodb
-              mongodb:
-              (.|\n)*
-                keystore:
-                  keyPassword: keyPassword
-                  password: keystorePassword
-                  path: /path/to/keystore.p12
-                  type: pkcs12
+            repositories:
+              management:
+                type: mongodb
+                mongodb:
+                (.|\n)*
+                  keystore:
+                    keyPassword: keyPassword
+                    password: keystorePassword
+                    path: /path/to/keystore.p12
+                    type: pkcs12
             (.|\n)*
-            ratelimit:
-              type: mongodb
-              mongodb:
-              (.|\n)*
-                keystore:
-                  keyPassword: keyPassword
-                  password: keystorePassword
-                  path: /path/to/keystore.p12
-                  type: pkcs12
+              ratelimit:
+                type: mongodb
+                mongodb:
+                (.|\n)*
+                  keystore:
+                    keyPassword: keyPassword
+                    password: keystorePassword
+                    path: /path/to/keystore.p12
+                    type: pkcs12
   - it: Set mongo truststore attributes with provided values
     template: gateway/gateway-configmap.yaml
     set:
@@ -130,20 +134,21 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            management:
-              type: mongodb
-              mongodb:
-              (.|\n)*
-                truststore:
-                  password: truststorePassword
-                  path: /path/to/truststore.jks
-                  type: jks
+            repositories:
+              management:
+                type: mongodb
+                mongodb:
+                (.|\n)*
+                  truststore:
+                    password: truststorePassword
+                    path: /path/to/truststore.jks
+                    type: jks
             (.|\n)*
-            ratelimit:
-              type: mongodb
-              mongodb:
-              (.|\n)*
-                truststore:
-                  password: truststorePassword
-                  path: /path/to/truststore.jks
-                  type: jks
+              ratelimit:
+                type: mongodb
+                mongodb:
+                (.|\n)*
+                  truststore:
+                    password: truststorePassword
+                    path: /path/to/truststore.jks
+                    type: jks

--- a/helm/tests/gateway/configmap_redis_test.yaml
+++ b/helm/tests/gateway/configmap_redis_test.yaml
@@ -16,9 +16,9 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s redis:
-            \s   host: redis
-            \s   port: 6379
+            \s   redis:
+            \s     host: redis
+            \s     port: 6379
   - it: Set host and port with username and password for ACL authentication
     template: gateway/gateway-configmap.yaml
     set:
@@ -35,11 +35,11 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s redis:
-            \s   host: redis
-            \s   port: 6379
-            \s   username: myuser
-            \s   password: mypassword
+            \s   redis:
+            \s     host: redis
+            \s     port: 6379
+            \s     username: myuser
+            \s     password: mypassword
   - it: Set host and port with password and ssl enabled
     template: gateway/gateway-configmap.yaml
     set:
@@ -56,16 +56,16 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s redis:
-            \s   host: redis
-            \s   port: 6379
-            \s   password: mypassword
-            \s   ssl: true
-            \s   hostnameVerificationAlgorithm: NONE
-            \s   trustAll: true
-            \s   tlsProtocols: TLSv1.2
-            \s   alpn: false
-            \s   openssl: false
+            \s   redis:
+            \s     host: redis
+            \s     port: 6379
+            \s     password: mypassword
+            \s     ssl: true
+            \s     hostnameVerificationAlgorithm: NONE
+            \s     trustAll: true
+            \s     tlsProtocols: TLSv1.2
+            \s     alpn: false
+            \s     openssl: false
 
   - it: Set host and port with password, ssl enabled and hostname verification algorithm to HTTPS
     template: gateway/gateway-configmap.yaml
@@ -84,16 +84,16 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s redis:
-            \s   host: redis
-            \s   port: 6379
-            \s   password: mypassword
-            \s   ssl: true
-            \s   hostnameVerificationAlgorithm: HTTPS
-            \s   trustAll: true
-            \s   tlsProtocols: TLSv1.2
-            \s   alpn: false
-            \s   openssl: false
+            \s   redis:
+            \s     host: redis
+            \s     port: 6379
+            \s     password: mypassword
+            \s     ssl: true
+            \s     hostnameVerificationAlgorithm: HTTPS
+            \s     trustAll: true
+            \s     tlsProtocols: TLSv1.2
+            \s     alpn: false
+            \s     openssl: false
   - it: Set configuration with sentinels
     template: gateway/gateway-configmap.yaml
     set:
@@ -115,16 +115,16 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s redis:
-            \s   host: redis
-            \s   port: 6379
-            \s   sentinel:
-            \s     master: redismaster
-            \s     nodes:
-            \s       - host: sent1
-            \s         port: 26379
-            \s       - host: sent2
-            \s         port: 26379
+            \s   redis:
+            \s     host: redis
+            \s     port: 6379
+            \s     sentinel:
+            \s       master: redismaster
+            \s       nodes:
+            \s         - host: sent1
+            \s           port: 26379
+            \s         - host: sent2
+            \s           port: 26379
   - it: Set full SSL configuration
     template: gateway/gateway-configmap.yaml
     set:
@@ -164,35 +164,35 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s redis:
-            \s   host: redis
-            \s   port: 6379
-            \s   password: mypassword
-            \s   ssl: true
-            \s   hostnameVerificationAlgorithm: NONE
-            \s   trustAll: false
-            \s   tlsProtocols: TLSv1.2, TLSv1.3
-            \s   tlsCiphers: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
-            \s   alpn: true
-            \s   openssl: true
-            \s   
-            \s   keystore:
-            \s     type: jks
-            \s     path: \${gravitee.home}/security/redis-keystore.jks
-            \s     password: secret
-            \s     keyPassword: "secretKey"
-            \s     alias: myAlias
-            \s     
-            \s     certificates:
-            \s       - cert: \${gravitee.home}/security/redis-mycompany.org.pem
-            \s         key: \${gravitee.home}/security/redis-mycompany.org.key
-            \s       - cert: \${gravitee.home}/security/redis-mycompany.com.pem
-            \s         key: \${gravitee.home}/security/redis-mycompany.com.key
-            \s   truststore:
-            \s     type: jks
-            \s     path: \${gravitee.home}/security/redis-truststore.jks
-            \s     password: secret
-            \s     alias: anotheralias
+            \s   redis:
+            \s     host: redis
+            \s     port: 6379
+            \s     password: mypassword
+            \s     ssl: true
+            \s     hostnameVerificationAlgorithm: NONE
+            \s     trustAll: false
+            \s     tlsProtocols: TLSv1.2, TLSv1.3
+            \s     tlsCiphers: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
+            \s     alpn: true
+            \s     openssl: true
+            \s+
+            \s     keystore:
+            \s       type: jks
+            \s       path: \${gravitee.home}/security/redis-keystore.jks
+            \s       password: secret
+            \s       keyPassword: "secretKey"
+            \s       alias: myAlias
+            \s+
+            \s       certificates:
+            \s         - cert: \${gravitee.home}/security/redis-mycompany.org.pem
+            \s           key: \${gravitee.home}/security/redis-mycompany.org.key
+            \s         - cert: \${gravitee.home}/security/redis-mycompany.com.pem
+            \s           key: \${gravitee.home}/security/redis-mycompany.com.key
+            \s     truststore:
+            \s       type: jks
+            \s       path: \${gravitee.home}/security/redis-truststore.jks
+            \s       password: secret
+            \s       alias: anotheralias
 
   - it: Set operation timeout, tcp connectTimeout and idleTimeout
     template: gateway/gateway-configmap.yaml
@@ -214,13 +214,13 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            \s redis:
-            \s   host: redis
-            \s   port: 6379
-            \s   operation:
-            \s     timeout: 15
-            \s   tcp:
-            \s     connectTimeout: 10
-            \s     idleTimeout: 5
+            \s   redis:
+            \s     host: redis
+            \s     port: 6379
+            \s     operation:
+            \s       timeout: 15
+            \s     tcp:
+            \s       connectTimeout: 10
+            \s       idleTimeout: 5
 
-            
+

--- a/helm/tests/gateway/confiigmap_db_less_test.yaml
+++ b/helm/tests/gateway/confiigmap_db_less_test.yaml
@@ -30,5 +30,6 @@ tests:
       - matchRegex:
           path: data["gravitee.yml"]
           pattern: |
-            management:
-              type: none
+            repositories:
+              management:
+                type: none

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <gravitee-node.version>9.0.0-alpha.2</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
-        <gravitee-plugin.version>5.0.0</gravitee-plugin.version>
+        <gravitee-plugin.version>5.1.0</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.1.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>2.1.0</gravitee-reporter-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11302

## Description

Fix repository config resolution for `repositories.*` prefix. Adds fallback for ES cross-cluster and proxy config that bypasses `PropertySource`. Adds tests for new prefix support across MongoDB and Elasticsearch modules.