### PR TITLE
feat(portal): add certificate deletion confirmation dialogs and impro…

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.html
@@ -39,9 +39,11 @@
     }
   </div>
 
-  @if (loadError()) {
-    <p class="next-gen-small certificates__error" i18n="@@certificatesLoadError">Failed to load certificates. Please try again.</p>
-  } @else if (certificates().length === 0) {
+  @if (error(); as errorText) {
+    <p class="certificates__error next-gen-small" data-testid="certificate-error" role="alert">{{ errorText }}</p>
+  }
+
+  @if (certificates().length === 0 && !error()) {
     <div class="certificates__empty">
       <span class="material-icons icon-with-background" aria-hidden="true">workspace_premium</span>
       <span class="next-gen-h5" i18n="@@noCertificatesTitle">No mTLS certificates added</span>
@@ -49,7 +51,7 @@
         Add your first certificate to enable mTLS authentication for this application
       </span>
     </div>
-  } @else {
+  } @else if (certificates().length > 0) {
     <mat-tab-group (selectedTabChange)="onTabChange()">
       <mat-tab>
         <ng-template mat-tab-label>
@@ -62,7 +64,10 @@
           [totalElements]="totalElements()"
           [currentPage]="currentPage()"
           [pageSize]="pageSize"
+          [navigable]="false"
+          [actions]="canManage() ? activeActions : []"
           (pageChange)="onPageChange($event)"
+          (actionClick)="onActiveAction($event)"
         />
       </mat-tab>
       <mat-tab>
@@ -76,7 +81,10 @@
           [totalElements]="totalElements()"
           [currentPage]="currentPage()"
           [pageSize]="pageSize"
+          [navigable]="false"
+          [actions]="canManage() ? historyActions : []"
           (pageChange)="onPageChange($event)"
+          (actionClick)="onHistoryAction($event)"
         />
       </mat-tab>
     </mat-tab-group>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.spec.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
@@ -23,6 +25,7 @@ import { provideRouter } from '@angular/router';
 
 import { ApplicationTabSettingsCertificatesComponent } from './application-tab-settings-certificates.component';
 import { ApplicationTabSettingsCertificatesHarness } from './application-tab-settings-certificates.harness';
+import { ConfirmDialogHarness } from '../../../../../components/confirm-dialog/confirm-dialog.harness';
 import { ClientCertificate } from '../../../../../entities/application/client-certificate';
 import { fakeUserApplicationPermissions } from '../../../../../entities/permission/permission.fixtures';
 import { ConfigService } from '../../../../../services/config.service';
@@ -39,6 +42,7 @@ const fakeCertificate = (overrides: Partial<ClientCertificate> = {}): ClientCert
 describe('ApplicationTabSettingsCertificatesComponent', () => {
   let fixture: ComponentFixture<ApplicationTabSettingsCertificatesComponent>;
   let httpTestingController: HttpTestingController;
+  let rootLoader: HarnessLoader;
   const applicationId = 'app-1';
 
   beforeEach(async () => {
@@ -51,10 +55,17 @@ describe('ApplicationTabSettingsCertificatesComponent', () => {
         provideRouter([]),
         { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
       ],
-    }).compileComponents();
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true,
+        },
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(ApplicationTabSettingsCertificatesComponent);
     httpTestingController = TestBed.inject(HttpTestingController);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     fixture.componentRef.setInput('applicationId', applicationId);
     fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ DEFINITION: ['U'] }));
   });
@@ -177,4 +188,248 @@ describe('ApplicationTabSettingsCertificatesComponent', () => {
 
     expect(openSpy).toHaveBeenCalled();
   });
+
+  it('should keep certificate untouched when first delete confirmation is cancelled', async () => {
+    const certificate = fakeCertificate();
+    await initWithCertificates([certificate]);
+
+    await clickDeleteButton();
+
+    const confirmDialog = await getConfirmDialog();
+    expect(confirmDialog).not.toBeNull();
+    expect(await confirmDialog?.getTitle()).toBe('Delete certificate');
+    await confirmDialog?.cancel();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(await getConfirmDialog()).toBeNull();
+    httpTestingController.expectNone(req => req.method === 'DELETE');
+    expect(fixture.componentInstance.activeCertificates().map(cert => cert.id)).toEqual([certificate.id]);
+  });
+
+  it('should delete a non-last-active certificate after the initial confirmation', async () => {
+    const certificates = [
+      fakeCertificate({ id: 'cert-1', name: 'Certificate 1' }),
+      fakeCertificate({ id: 'cert-2', name: 'Certificate 2' }),
+    ];
+    await initWithCertificates(certificates, 2);
+
+    await clickDeleteButton();
+
+    const confirmDialog = await getConfirmDialog();
+    await confirmDialog?.confirm();
+
+    expect(await getConfirmDialog()).toBeNull();
+    httpTestingController.expectNone(`${TESTING_BASE_URL}/applications/${applicationId}/certificates?page=1&size=${certificates.length}`);
+
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates/cert-1`,
+        method: 'DELETE',
+      })
+      .flush(null);
+
+    flushCertificatesRequest([certificates[1]], 1);
+
+    expect(fixture.componentInstance.activeCertificates().map(cert => cert.id)).toEqual(['cert-2']);
+  });
+
+  it('should require a final warning confirmation before deleting the last active certificate', async () => {
+    const certificate = fakeCertificate();
+    await initWithCertificates([certificate]);
+
+    await clickDeleteButton();
+
+    const firstConfirmDialog = await getConfirmDialog();
+    expect(await firstConfirmDialog?.getTitle()).toBe('Delete certificate');
+    await firstConfirmDialog?.confirm();
+
+    httpTestingController.expectNone(req => req.method === 'DELETE');
+    flushCertificatesRequest([certificate], 1);
+
+    const warningDialog = await getConfirmDialog();
+    expect(warningDialog).not.toBeNull();
+    expect(await warningDialog?.getTitle()).toBe('Warning');
+    expect(await warningDialog?.getContent()).toContain(
+      'There is no active certificate in case you proceed with the deletion. Do you want to proceed?',
+    );
+    httpTestingController.expectNone(req => req.method === 'DELETE');
+
+    await warningDialog?.confirm();
+
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates/${certificate.id}`,
+        method: 'DELETE',
+      })
+      .flush(null);
+
+    flushCertificatesRequest([], 0);
+
+    expect(fixture.componentInstance.activeCertificates()).toEqual([]);
+  });
+
+  it('should keep the last active certificate untouched when the warning is cancelled', async () => {
+    const certificate = fakeCertificate();
+    await initWithCertificates([certificate]);
+
+    await clickDeleteButton();
+
+    const firstConfirmDialog = await getConfirmDialog();
+    await firstConfirmDialog?.confirm();
+
+    flushCertificatesRequest([certificate], 1);
+
+    const warningDialog = await getConfirmDialog();
+    expect(warningDialog).not.toBeNull();
+    await warningDialog?.cancel();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(await getConfirmDialog()).toBeNull();
+    httpTestingController.expectNone(req => req.method === 'DELETE');
+    expect(fixture.componentInstance.activeCertificates().map(cert => cert.id)).toEqual([certificate.id]);
+  });
+
+  it('should delete a certificate from history after confirmation', async () => {
+    const activeCertificate = fakeCertificate({ id: 'cert-active', status: 'ACTIVE' });
+    const historyCertificate = fakeCertificate({ id: 'cert-history', status: 'REVOKED', name: 'Revoked certificate' });
+    await initWithCertificates([activeCertificate, historyCertificate], 2);
+
+    await clickHistoryTab();
+    await clickHistoryDeleteButton();
+
+    const confirmDialog = await getConfirmDialog();
+    expect(confirmDialog).not.toBeNull();
+    expect(await confirmDialog?.getTitle()).toBe('Delete certificate');
+    await confirmDialog?.confirm();
+
+    expect(await getConfirmDialog()).toBeNull();
+    httpTestingController.expectNone(`${TESTING_BASE_URL}/applications/${applicationId}/certificates?page=1&size=2`);
+
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates/${historyCertificate.id}`,
+        method: 'DELETE',
+      })
+      .flush(null);
+
+    flushCertificatesRequest([activeCertificate], 1);
+
+    expect(fixture.componentInstance.historyCertificates()).toEqual([]);
+  });
+
+  it('should show a persistent inline error when certificate deletion fails', async () => {
+    const certificates = [fakeCertificate({ id: 'cert-1' }), fakeCertificate({ id: 'cert-2' })];
+    await initWithCertificates(certificates, 2);
+
+    await clickDeleteButton();
+
+    const confirmDialog = await getConfirmDialog();
+    await confirmDialog?.confirm();
+    httpTestingController.expectNone(`${TESTING_BASE_URL}/applications/${applicationId}/certificates?page=1&size=${certificates.length}`);
+
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates/${certificates[0].id}`,
+        method: 'DELETE',
+      })
+      .flush({ error: 'Delete failed' }, { status: 500, statusText: 'Internal Server Error' });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(getErrorMessage()?.textContent).toContain('An error occurred while deleting the certificate. Please try again');
+    expect(fixture.componentInstance.activeCertificates().map(cert => cert.id)).toEqual(['cert-1', 'cert-2']);
+  });
+
+  it('should clear delete error when retrying certificate deletion', async () => {
+    const certificates = [fakeCertificate({ id: 'cert-1' }), fakeCertificate({ id: 'cert-2' })];
+    await initWithCertificates(certificates, 2);
+
+    await failDeleteAttempt(certificates[0]);
+    expect(getErrorMessage()?.textContent).toContain('An error occurred while deleting the certificate. Please try again');
+
+    await clickDeleteButton();
+
+    expect(getErrorMessage()).toBeNull();
+
+    const confirmDialog = await getConfirmDialog();
+    await confirmDialog?.cancel();
+  });
+
+  it('should clear delete error after a successful certificates reload', async () => {
+    const certificates = [fakeCertificate({ id: 'cert-1' }), fakeCertificate({ id: 'cert-2' })];
+    await initWithCertificates(certificates, 2);
+
+    await failDeleteAttempt(certificates[0]);
+    expect(getErrorMessage()?.textContent).toContain('An error occurred while deleting the certificate. Please try again');
+
+    fixture.componentInstance.loadCertificates();
+    flushCertificatesRequest(certificates, 2);
+
+    expect(getErrorMessage()).toBeNull();
+  });
+
+  function flushCertificatesRequest(data: ClientCertificate[] = [], totalElements = data.length, page = 1, size = 10): void {
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates?page=${page}&size=${size}`,
+        method: 'GET',
+      })
+      .flush({
+        data,
+        metadata: { paginateMetaData: { totalElements } },
+      });
+    fixture.detectChanges();
+  }
+
+  async function clickDeleteButton(index = 0): Promise<void> {
+    const deleteButtons = fixture.nativeElement.querySelectorAll('[data-testid="paginated-table-action-delete-certificate-button"]');
+    (deleteButtons[index] as HTMLButtonElement | undefined)?.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  async function clickHistoryDeleteButton(index = 0): Promise<void> {
+    const deleteButtons = fixture.nativeElement.querySelectorAll(
+      '[data-testid="paginated-table-action-delete-history-certificate-button"]',
+    );
+    (deleteButtons[index] as HTMLButtonElement | undefined)?.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  async function clickHistoryTab(): Promise<void> {
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationTabSettingsCertificatesHarness);
+    await harness.clickTab('history');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    flushCertificatesRequest(fixture.componentInstance.certificates(), fixture.componentInstance.totalElements());
+  }
+
+  async function getConfirmDialog(): Promise<ConfirmDialogHarness | null> {
+    return rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+  }
+
+  async function failDeleteAttempt(certificate: ClientCertificate): Promise<void> {
+    await clickDeleteButton();
+
+    const confirmDialog = await getConfirmDialog();
+    await confirmDialog?.confirm();
+
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates/${certificate.id}`,
+        method: 'DELETE',
+      })
+      .flush({ error: 'Delete failed' }, { status: 500, statusText: 'Internal Server Error' });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  function getErrorMessage(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('[data-testid="certificate-error"]');
+  }
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
@@ -20,12 +20,24 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { differenceInCalendarDays } from 'date-fns';
+import { EMPTY, map, Observable, of, switchMap, tap } from 'rxjs';
 
 import { AddCertificateDialogComponent, AddCertificateDialogData } from './add-certificate-dialog/add-certificate-dialog.component';
-import { PaginatedTableComponent, TableColumn } from '../../../../../components/paginated-table/paginated-table.component';
+import { ConfirmDialogComponent, ConfirmDialogData } from '../../../../../components/confirm-dialog/confirm-dialog.component';
+import { PaginatedTableComponent, TableAction, TableColumn } from '../../../../../components/paginated-table/paginated-table.component';
 import { ClientCertificate } from '../../../../../entities/application/client-certificate';
 import { UserApplicationPermissions } from '../../../../../entities/permission/permission';
 import { ApplicationCertificateService } from '../../../../../services/application-certificate.service';
+
+interface CertificateTableRow {
+  certificate: ClientCertificate;
+  id: string;
+  name: string;
+  createdAt: string;
+  endsAt: string;
+  status: string;
+  daysRemaining: string;
+}
 
 @Component({
   selector: 'app-application-tab-settings-certificates',
@@ -46,13 +58,13 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
   certificates = signal<ClientCertificate[]>([]);
   currentPage = signal(1);
   totalElements = signal(0);
-  loadError = signal(false);
+  error = signal<string | null>(null);
   readonly pageSize = 10;
 
-  activeCertificates = computed(() =>
-    this.certificates().filter(c => c.status === 'ACTIVE' || c.status === 'ACTIVE_WITH_END' || c.status === 'SCHEDULED'),
-  );
+  activeCertificates = computed(() => this.certificates().filter(cert => this.isActiveCertificate(cert)));
   historyCertificates = computed(() => this.certificates().filter(c => c.status === 'REVOKED'));
+  activeRows = computed(() => this.activeCertificates().map(cert => this.toTableRow(cert)));
+  historyRows = computed(() => this.historyCertificates().map(cert => this.toTableRow(cert)));
 
   tableColumns: TableColumn[] = [
     { id: 'name', label: 'Name' },
@@ -62,8 +74,23 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
     { id: 'daysRemaining', label: 'Days Remaining' },
   ];
 
-  activeRows = computed(() => this.toRows(this.activeCertificates()));
-  historyRows = computed(() => this.toRows(this.historyCertificates()));
+  activeActions: TableAction<CertificateTableRow>[] = [
+    {
+      id: 'delete-certificate-button',
+      icon: 'delete',
+      ariaLabel: $localize`:@@deleteCertificateAriaLabel:Delete certificate`,
+      color: 'warn',
+    },
+  ];
+
+  historyActions: TableAction<CertificateTableRow>[] = [
+    {
+      id: 'delete-history-certificate-button',
+      icon: 'delete',
+      ariaLabel: $localize`:@@deleteCertificateAriaLabel:Delete certificate`,
+      color: 'warn',
+    },
+  ];
 
   ngOnInit(): void {
     this.loadCertificates();
@@ -75,12 +102,12 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: res => {
-          this.loadError.set(false);
+          this.error.set(null);
           this.certificates.set(res.data ?? []);
           this.totalElements.set(res.metadata?.paginateMetaData?.totalElements ?? 0);
         },
         error: () => {
-          this.loadError.set(true);
+          this.error.set($localize`:@@certificatesLoadError:Failed to load certificates. Please try again.`);
         },
       });
   }
@@ -119,18 +146,116 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
       });
   }
 
-  private toRows(certs: ClientCertificate[]) {
-    return certs.map(cert => ({
-      id: cert.id,
-      name: cert.name,
-      createdAt: cert.createdAt ?? '',
-      endsAt: cert.endsAt ? new Date(cert.endsAt).toLocaleDateString() : '—',
-      status: this.formatStatus(cert.status),
-      daysRemaining: this.formatDaysRemaining(cert.endsAt),
-    }));
+  deleteCertificate(cert: ClientCertificate): void {
+    this.error.set(null);
+
+    this.openConfirmDialog(this.buildDeleteDialogData(cert), 'confirmCertificateDeleteDialog')
+      .pipe(
+        switchMap(confirmed => (confirmed ? this.loadCertificatesForDeleteCheck(cert) : EMPTY)),
+        switchMap(certificates => this.confirmAndDeleteCertificate(cert, certificates)),
+        tap(() => this.loadCertificates()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        error: () => {
+          this.error.set($localize`:@@deleteCertificateError:An error occurred while deleting the certificate. Please try again`);
+        },
+      });
+  }
+
+  onActiveAction(event: { actionId: string; row: CertificateTableRow }): void {
+    this.handleCertificateAction(event);
+  }
+
+  onHistoryAction(event: { actionId: string; row: CertificateTableRow }): void {
+    this.handleCertificateAction(event);
+  }
+
+  private formatEndsAtDisplay(endsAt: string | undefined): string {
+    return endsAt ? new Date(endsAt).toLocaleDateString() : '—';
   }
 
   private formatStatus(status: string): string {
     return status.charAt(0) + status.slice(1).toLowerCase().replace(/_/g, ' ');
+  }
+
+  private openConfirmDialog(dialogData: ConfirmDialogData, id: string): Observable<boolean | undefined> {
+    return this.dialog
+      .open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
+        role: 'alertdialog',
+        id,
+        data: dialogData,
+      })
+      .afterClosed();
+  }
+
+  private buildDeleteDialogData(cert: ClientCertificate): ConfirmDialogData {
+    return {
+      title: $localize`:@@titleDeleteCertificateDialog:Delete certificate`,
+      content: $localize`:@@contentDeleteCertificateDialog:Are you sure you want to delete the certificate "${cert.name}:certificateName:"?`,
+      confirmLabel: $localize`:@@confirmDeleteCertificateDialog:Delete`,
+      cancelLabel: $localize`:@@cancelDeleteCertificateDialog:Cancel`,
+    };
+  }
+
+  private buildLastActiveWarningDialogData(): ConfirmDialogData {
+    return {
+      title: $localize`:@@titleDeleteLastCertificateDialog:Warning`,
+      content: $localize`:@@contentDeleteLastCertificateDialog:There is no active certificate in case you proceed with the deletion. Do you want to proceed?`,
+      confirmLabel: $localize`:@@confirmDeleteCertificateDialog:Delete`,
+      cancelLabel: $localize`:@@cancelDeleteCertificateDialog:Cancel`,
+    };
+  }
+
+  private loadCertificatesForDeleteCheck(cert: ClientCertificate): Observable<ClientCertificate[]> {
+    if (!this.isActiveCertificate(cert)) {
+      return of(this.certificates());
+    }
+
+    const currentPageActiveCertificates = this.certificates().filter(candidate => this.isActiveCertificate(candidate));
+    if (currentPageActiveCertificates.some(candidate => candidate.id !== cert.id)) {
+      return of(this.certificates());
+    }
+
+    const pageSize = Math.max(this.totalElements(), this.pageSize);
+
+    return this.certService.list(this.applicationId(), 1, pageSize).pipe(map(response => response.data ?? []));
+  }
+
+  private handleCertificateAction(event: { actionId: string; row: CertificateTableRow }): void {
+    if (event.actionId === 'delete-certificate-button' || event.actionId === 'delete-history-certificate-button') {
+      this.deleteCertificate(event.row.certificate);
+    }
+  }
+
+  private confirmAndDeleteCertificate(cert: ClientCertificate, certificates: ClientCertificate[]): Observable<unknown> {
+    if (!this.isLastActiveCertificate(cert, certificates)) {
+      return this.certService.delete(this.applicationId(), cert.id);
+    }
+
+    return this.openConfirmDialog(this.buildLastActiveWarningDialogData(), 'confirmLastActiveCertificateDeleteDialog').pipe(
+      switchMap(confirmed => (confirmed ? this.certService.delete(this.applicationId(), cert.id) : EMPTY)),
+    );
+  }
+
+  private isLastActiveCertificate(cert: ClientCertificate, certificates: ClientCertificate[]): boolean {
+    const activeCertificates = certificates.filter(candidate => this.isActiveCertificate(candidate));
+    return activeCertificates.length === 1 && activeCertificates[0].id === cert.id;
+  }
+
+  private isActiveCertificate(cert: ClientCertificate): boolean {
+    return cert.status === 'ACTIVE' || cert.status === 'ACTIVE_WITH_END' || cert.status === 'SCHEDULED';
+  }
+
+  private toTableRow(cert: ClientCertificate): CertificateTableRow {
+    return {
+      certificate: cert,
+      id: cert.id,
+      name: cert.name,
+      createdAt: cert.createdAt ?? '',
+      endsAt: this.formatEndsAtDisplay(cert.endsAt),
+      status: this.formatStatus(cert.status),
+      daysRemaining: this.formatDaysRemaining(cert.endsAt),
+    };
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
@@ -21,8 +21,8 @@ export class ApplicationTabSettingsCertificatesHarness extends ComponentHarness 
   protected locateEmptyState = this.locatorForOptional('.certificates__empty');
   protected locatePaginatedTable = this.locatorForOptional('app-paginated-table');
   protected locateErrorMessage = this.locatorForOptional('.certificates__error');
-  protected locateTabButtons = this.locatorForAll('.certificates__tabs__tab');
-  protected locateActiveTabButton = this.locatorForOptional('.certificates__tabs__tab--active');
+  protected locateTabButtons = this.locatorForAll('[role="tab"]');
+  protected locateActiveTabButton = this.locatorForOptional('[role="tab"][aria-selected="true"]');
   protected locateUploadButton = this.locatorForOptional('[data-testid="upload-certificate-button"]');
 
   public async getEmptyState(): Promise<TestElement | null> {

--- a/gravitee-apim-portal-webui-next/src/components/confirm-dialog/confirm-dialog.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/confirm-dialog/confirm-dialog.harness.ts
@@ -21,6 +21,8 @@ export class ConfirmDialogHarness extends ComponentHarness {
 
   private readonly getConfirmButtonHarness = this.locatorFor(MatButtonHarness.with({ selector: '.confirm-dialog__confirm-button' }));
   private readonly getCancelButtonHarness = this.locatorFor(MatButtonHarness.with({ selector: '.confirm-dialog__cancel-button' }));
+  private readonly getTitleText = this.locatorFor('.confirm-dialog__title');
+  private readonly getContentText = this.locatorFor('.confirm-dialog__content');
 
   public async confirm(): Promise<void> {
     await this.getConfirmButtonHarness().then(button => button.click());
@@ -36,5 +38,13 @@ export class ConfirmDialogHarness extends ComponentHarness {
 
   public async getCancelText(): Promise<string> {
     return await this.getCancelButtonHarness().then(button => button.getText());
+  }
+
+  public async getTitle(): Promise<string> {
+    return await this.getTitleText().then(title => title.text());
+  }
+
+  public async getContent(): Promise<string> {
+    return await this.getContentText().then(content => content.text());
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
@@ -19,7 +19,7 @@
   <table mat-table [dataSource]="rows()" class="paginated-table">
     @for (column of columns(); track column.id) {
       <ng-container [matColumnDef]="column.id">
-        <th mat-header-cell *matHeaderCellDef>{{ column.label }}</th>
+        <th mat-header-cell *matHeaderCellDef class="next-gen-small-bold">{{ column.label }}</th>
         <td mat-cell *matCellDef="let element">
           @switch (column.type) {
             @case ('date') {
@@ -33,15 +33,46 @@
       </ng-container>
     }
 
-    <ng-container matColumnDef="expand">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let element" class="paginated-table__column-expand">
-        <mat-icon>chevron_right</mat-icon>
-      </td>
-    </ng-container>
+    @if (actions().length > 0) {
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let element" class="paginated-table__actions">
+          @for (action of actions(); track action.id) {
+            @if (!action.isVisible || action.isVisible(element)) {
+              <button
+                mat-icon-button
+                type="button"
+                [color]="action.color ?? 'primary'"
+                [disabled]="action.isDisabled?.(element) ?? false"
+                [attr.aria-label]="action.ariaLabel"
+                [attr.data-testid]="'paginated-table-action-' + action.id"
+                (click)="onActionClick($event, action.id, element)"
+              >
+                <mat-icon aria-hidden="true">{{ action.icon }}</mat-icon>
+              </button>
+            }
+          }
+        </td>
+      </ng-container>
+    }
+
+    @if (navigable()) {
+      <ng-container matColumnDef="expand">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let element" class="paginated-table__column-expand">
+          <mat-icon>chevron_right</mat-icon>
+        </td>
+      </ng-container>
+    }
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns()"></tr>
-    <tr mat-row class="paginated-table__row" *matRowDef="let row; columns: displayedColumns()" [routerLink]="[row.id]"></tr>
+    <tr
+      mat-row
+      class="paginated-table__row"
+      [class.paginated-table__row--navigable]="navigable()"
+      *matRowDef="let row; columns: displayedColumns()"
+      [routerLink]="navigable() ? [row.id] : null"
+    ></tr>
   </table>
 </div>
 

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.scss
@@ -35,11 +35,19 @@
   }
 
   &__row {
-    cursor: pointer;
-
     &:last-child td {
       border-bottom: none;
     }
+  }
+
+  &__row--navigable {
+    cursor: pointer;
+  }
+
+  &__actions,
+  &__column-expand {
+    width: 1%;
+    white-space: nowrap;
   }
 
   &__column-expand {

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.spec.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+
+import { PaginatedTableComponent, TableAction, TableColumn } from './paginated-table.component';
+import { PaginatedTableHarness } from './paginated-table.harness';
+
+type TestRow = {
+  id: string;
+  name: string;
+  createdAt: string;
+};
+
+@Component({
+  standalone: true,
+  imports: [PaginatedTableComponent],
+  template: `
+    <app-paginated-table
+      [columns]="columns"
+      [rows]="rows"
+      [totalElements]="totalElements"
+      [currentPage]="currentPage"
+      [pageSize]="pageSize"
+      [navigable]="navigable"
+      [actions]="actions"
+      (actionClick)="onActionClick($event)"
+    />
+  `,
+})
+class TestHostComponent {
+  columns: TableColumn[] = [
+    { id: 'name', label: 'Name' },
+    { id: 'createdAt', label: 'Created', type: 'date' },
+  ];
+  rows: TestRow[] = [{ id: 'row-1', name: 'First row', createdAt: '2026-01-01T00:00:00Z' }];
+  totalElements = 1;
+  currentPage = 1;
+  pageSize = 10;
+  navigable = true;
+  actions: TableAction<TestRow>[] = [];
+  receivedAction: { actionId: string; row: TestRow } | null = null;
+
+  onActionClick(event: { actionId: string; row: TestRow }): void {
+    this.receivedAction = event;
+  }
+}
+
+describe('PaginatedTableComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let harness: PaginatedTableHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideNoopAnimations(), provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+  });
+
+  it('should render navigable rows with expand column by default', async () => {
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, PaginatedTableHarness);
+
+    expect((await harness.getNavigableRows()).length).toBeGreaterThan(0);
+    expect((await harness.getExpandColumns()).length).toBeGreaterThan(0);
+    expect((await harness.getActionButtons()).length).toBe(0);
+  });
+
+  it('should render action buttons and disable navigation when configured', async () => {
+    host.navigable = false;
+    host.actions = [
+      {
+        id: 'delete',
+        icon: 'delete',
+        ariaLabel: 'Delete row',
+        color: 'warn',
+      },
+    ];
+
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, PaginatedTableHarness);
+
+    expect((await harness.getNavigableRows()).length).toBe(0);
+    expect((await harness.getExpandColumns()).length).toBe(0);
+
+    const deleteButton = await harness.getActionButton('delete');
+    expect(deleteButton).toBeTruthy();
+
+    await deleteButton!.click();
+
+    expect(host.receivedAction).toEqual({
+      actionId: 'delete',
+      row: host.rows[0],
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.ts
@@ -15,6 +15,7 @@
  */
 import { DatePipe } from '@angular/common';
 import { Component, computed, input, output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
@@ -27,10 +28,19 @@ export interface TableColumn {
   type?: 'text' | 'date';
 }
 
+export interface TableAction<T> {
+  id: string;
+  icon: string;
+  ariaLabel: string;
+  color?: 'primary' | 'accent' | 'warn';
+  isVisible?: (row: T) => boolean;
+  isDisabled?: (row: T) => boolean;
+}
+
 @Component({
   selector: 'app-paginated-table',
   standalone: true,
-  imports: [DatePipe, MatTableModule, MatIcon, RouterLink, PaginationComponent],
+  imports: [DatePipe, MatTableModule, MatIcon, RouterLink, PaginationComponent, MatButtonModule],
   templateUrl: './paginated-table.component.html',
   styleUrl: './paginated-table.component.scss',
 })
@@ -41,13 +51,25 @@ export class PaginatedTableComponent<T> {
   currentPage = input.required<number>();
   pageSize = input.required<number>();
   pageSizeOptions = input<number[]>(DEFAULT_PAGE_SIZE_OPTIONS);
+  navigable = input(true);
+  actions = input<TableAction<T>[]>([]);
 
   pageChange = output<number>();
   pageSizeChange = output<number>();
+  actionClick = output<{ actionId: string; row: T }>();
 
-  displayedColumns = computed(() => [...this.columns().map(c => c.id as string), 'expand']);
+  displayedColumns = computed(() => [
+    ...this.columns().map(c => c.id as string),
+    ...(this.actions().length > 0 ? ['actions'] : []),
+    ...(this.navigable() ? ['expand'] : []),
+  ]);
 
   onPageChange(page: number): void {
     this.pageChange.emit(page);
+  }
+
+  onActionClick(event: Event, actionId: string, row: T): void {
+    event.stopPropagation();
+    this.actionClick.emit({ actionId, row });
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.harness.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class PaginatedTableHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-paginated-table';
+
+  protected locateNavigableRows = this.locatorForAll('.paginated-table__row--navigable');
+  protected locateExpandColumns = this.locatorForAll('.paginated-table__column-expand');
+  protected locateActionButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[data-testid^="paginated-table-action-"]' }));
+
+  async getNavigableRows(): Promise<TestElement[]> {
+    return this.locateNavigableRows();
+  }
+
+  async getExpandColumns(): Promise<TestElement[]> {
+    return this.locateExpandColumns();
+  }
+
+  async getActionButtons(): Promise<MatButtonHarness[]> {
+    return this.locateActionButtons();
+  }
+
+  async getActionButton(actionId: string): Promise<MatButtonHarness | null> {
+    return this.locatorForOptional(MatButtonHarness.with({ selector: `[data-testid="paginated-table-action-${actionId}"]` }))();
+  }
+}


### PR DESCRIPTION
This PR adds a safe certificate deletion workflow in the Portal “Application → Settings → Certificates” section.

- Adds confirmation dialogs for certificate deletion.
- Adds an extra warning confirmation when deleting the last active certificate (to prevent accidental outages).
- Improves the certificates UI by using the shared app-paginated-table with row actions and disables navigation for this view.
- Adds a persistent inline error message for delete/load failures (no snackbars) and extends tests/harnesses accordingly.

## Issue

https://gravitee.atlassian.net/browse/APIM-13262

## Description


https://github.com/user-attachments/assets/f396af50-a0c5-4b30-9add-7842ffdaaacf



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

