### PR TITLE
feat: validate certificate before step 2 and pre-fill expiry date

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.harness.ts
@@ -37,6 +37,7 @@ export class AddCertificateDialogHarness extends ComponentHarness {
     MatInputHarness.with({ selector: '[data-testid="certificate-grace-period-input"]' }),
   );
   protected locateSubmitErrorEl = this.locatorForOptional('[data-testid="certificate-submit-error"]');
+  protected locateValidateErrorEl = this.locatorForOptional('[data-testid="certificate-validate-error"]');
 
   public async nameInput(): Promise<MatInputHarness> {
     return this.locateNameInput();
@@ -72,6 +73,11 @@ export class AddCertificateDialogHarness extends ComponentHarness {
 
   public async submitErrorText(): Promise<string | null> {
     const el = await this.locateSubmitErrorEl();
+    return el ? el.text() : null;
+  }
+
+  public async validateErrorText(): Promise<string | null> {
+    const el = await this.locateValidateErrorEl();
     return el ? el.text() : null;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.html
@@ -25,7 +25,7 @@
         <span i18n="@@addCertificateStepUpload">Upload</span>
       </ng-template>
       <form [formGroup]="uploadForm" class="add-certificate-dialog__step">
-        <mat-form-field class="add-certificate-dialog__field">
+        <mat-form-field appearance="outline" class="add-certificate-dialog__field">
           <mat-label i18n="@@addCertificateNameLabel">Certificate Name</mat-label>
           <input matInput formControlName="name" type="text" maxlength="256" data-testid="certificate-name-input" />
           @if (uploadForm.controls.name.hasError('required') && uploadForm.controls.name.touched) {
@@ -36,7 +36,7 @@
         <div class="add-certificate-dialog__certificate-input">
           <div class="add-certificate-dialog__section">
             <span class="next-gen-h4" i18n="@@addCertificatePasteLabel">Paste certificate</span>
-            <mat-form-field class="add-certificate-dialog__field">
+            <mat-form-field appearance="outline" class="add-certificate-dialog__field">
               <mat-label i18n="@@addCertificatePemLabel">Certificate (PEM)</mat-label>
               <textarea
                 matInput
@@ -70,6 +70,12 @@
             </label>
           </div>
         </div>
+
+        @if (validateError(); as validateError) {
+          <p class="add-certificate-dialog__error next-gen-small" data-testid="certificate-validate-error" role="alert">
+            {{ validateError }}
+          </p>
+        }
       </form>
     </mat-step>
 
@@ -79,7 +85,7 @@
         <span i18n="@@addCertificateStepConfigure">Configure</span>
       </ng-template>
       <form [formGroup]="configureForm" class="add-certificate-dialog__step">
-        <mat-form-field class="add-certificate-dialog__field">
+        <mat-form-field appearance="outline" class="add-certificate-dialog__field">
           <mat-label i18n="@@addCertificateEndsAtLabel">Active until (optional)</mat-label>
           <input matInput [matDatepicker]="endsAtPicker" [min]="minDate" formControlName="endsAt" data-testid="certificate-ends-at-input" />
           <mat-datepicker-toggle
@@ -100,7 +106,7 @@
             </span>
           </div>
 
-          <mat-form-field class="add-certificate-dialog__field">
+          <mat-form-field appearance="outline" class="add-certificate-dialog__field">
             <mat-label i18n="@@addCertificateGracePeriodLabel">Grace period end for current certificate</mat-label>
             <input
               matInput
@@ -200,7 +206,8 @@
       mat-flat-button
       color="primary"
       type="button"
-      (click)="continueStep(uploadForm)"
+      [disabled]="isValidating()"
+      (click)="validateAndContinue()"
       data-testid="certificate-continue-upload-button"
       i18n="@@addCertificateContinueButton"
     >

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
@@ -26,6 +26,8 @@ import { ConfigService } from '../../../../../../services/config.service';
 import { AppTestingModule, TESTING_BASE_URL } from '../../../../../../testing/app-testing.module';
 
 const APPLICATION_ID = 'app-1';
+const VALIDATE_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates/_validate`;
+const CERTIFICATES_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`;
 
 function makeData(overrides: Partial<AddCertificateDialogData> = {}): AddCertificateDialogData {
   return {
@@ -64,6 +66,23 @@ describe('AddCertificateDialogComponent', () => {
     fixture.detectChanges();
   }
 
+  function flushValidate(overrides: object = {}): void {
+    const req = httpTestingController.expectOne(VALIDATE_URL);
+    expect(req.request.method).toBe('POST');
+    req.flush({ certificateExpiration: '2027-06-01T00:00:00.000Z', subject: 'CN=test', issuer: 'CN=ca', ...overrides });
+  }
+
+  async function fillAndValidate(): Promise<void> {
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    fixture.detectChanges();
+    await harness.clickContinueUpload();
+    fixture.detectChanges();
+    flushValidate();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
   afterEach(() => httpTestingController.verify());
 
   it('should show upload step initially', async () => {
@@ -81,52 +100,54 @@ describe('AddCertificateDialogComponent', () => {
     expect(fixture.componentInstance.uploadForm.invalid).toBe(true);
   });
 
-  it('should advance to configure step when upload form is valid', async () => {
+  it('should advance to configure step after successful certificate validation', async () => {
     await init();
-
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    fixture.detectChanges();
-
-    await harness.clickContinueUpload();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await fillAndValidate();
 
     expect(fixture.componentInstance.stepper().selectedIndex).toBe(1);
   });
 
-  it('should not show grace period field when hasActiveCertificates is false', async () => {
-    await init(makeData({ hasActiveCertificates: false }));
+  it('should pre-fill endsAt from certificate expiration returned by validation', async () => {
+    await init();
+    await fillAndValidate();
 
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    expect(fixture.componentInstance.configureForm.controls.endsAt.value).toEqual(new Date('2027-06-01T00:00:00.000Z'));
+  });
+
+  it('should show validate error when certificate validation returns 400', async () => {
+    await init();
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: 'INVALID PEM' });
+    fixture.detectChanges();
     await harness.clickContinueUpload();
+    fixture.detectChanges();
+
+    httpTestingController.expectOne(VALIDATE_URL).flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+
+    expect(await harness.validateErrorText()).toBeTruthy();
+    expect(fixture.componentInstance.stepper().selectedIndex).toBe(0);
+  });
+
+  it('should not show grace period field when hasActiveCertificates is false', async () => {
+    await init(makeData({ hasActiveCertificates: false }));
+    await fillAndValidate();
 
     expect(await harness.gracePeriodInput()).toBeNull();
   });
 
   it('should show grace period field when hasActiveCertificates is true', async () => {
     await init(makeData({ hasActiveCertificates: true, activeCertificateId: 'old-cert' }));
-
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    await harness.clickContinueUpload();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await fillAndValidate();
 
     expect(await harness.gracePeriodInput()).toBeTruthy();
   });
 
   it('should call create and close dialog on successful submit', async () => {
     await init();
-
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    await harness.clickContinueUpload();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await fillAndValidate();
 
     await harness.clickContinueConfigure();
     fixture.detectChanges();
@@ -136,7 +157,7 @@ describe('AddCertificateDialogComponent', () => {
     await harness.clickSubmit();
     fixture.detectChanges();
 
-    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`);
+    const req = httpTestingController.expectOne(CERTIFICATES_URL);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toMatchObject({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
     req.flush({ id: 'new-cert', name: 'My Cert', status: 'ACTIVE' });
@@ -149,12 +170,7 @@ describe('AddCertificateDialogComponent', () => {
   it('should also call update on old cert when gracePeriodEnd is set', async () => {
     const activeCertificateId = 'old-cert-id';
     await init(makeData({ hasActiveCertificates: true, activeCertificateId }));
-
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    await harness.clickContinueUpload();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await fillAndValidate();
 
     const graceDate = new Date('2026-12-31');
     fixture.componentInstance.configureForm.controls.gracePeriodEnd.setValue(graceDate);
@@ -166,13 +182,11 @@ describe('AddCertificateDialogComponent', () => {
     await harness.clickSubmit();
     fixture.detectChanges();
 
-    const createReq = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`);
+    const createReq = httpTestingController.expectOne(CERTIFICATES_URL);
     createReq.flush({ id: 'new-cert', name: 'My Cert', status: 'ACTIVE' });
     fixture.detectChanges();
 
-    const updateReq = httpTestingController.expectOne(
-      `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates/${activeCertificateId}`,
-    );
+    const updateReq = httpTestingController.expectOne(`${CERTIFICATES_URL}/${activeCertificateId}`);
     expect(updateReq.request.method).toBe('PUT');
     expect(updateReq.request.body).toMatchObject({ endsAt: graceDate.toISOString() });
     updateReq.flush({ id: activeCertificateId, name: 'Old Cert', status: 'ACTIVE_WITH_END' });
@@ -182,14 +196,9 @@ describe('AddCertificateDialogComponent', () => {
     expect(dialogRef.close).toHaveBeenCalledWith(true);
   });
 
-  it('should show validation error on 400 response', async () => {
+  it('should show submit error on 400 response from create', async () => {
     await init();
-
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: 'INVALID PEM' });
-    await harness.clickContinueUpload();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await fillAndValidate();
 
     await harness.clickContinueConfigure();
     fixture.detectChanges();
@@ -199,14 +208,36 @@ describe('AddCertificateDialogComponent', () => {
     await harness.clickSubmit();
     fixture.detectChanges();
 
-    httpTestingController
-      .expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`)
-      .flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
+    httpTestingController.expectOne(CERTIFICATES_URL).flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
     expect(await harness.submitErrorText()).toBeTruthy();
     expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('should fill certificate name from uploaded file name', async () => {
+    await init();
+
+    const file = new File(['-----BEGIN CERTIFICATE-----'], 'my-server.crt', { type: 'application/x-x509-ca-cert' });
+    const mockEvent = { target: { files: [file], value: '' } } as unknown as Event;
+    await fixture.componentInstance.onFileSelected(mockEvent);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.uploadForm.controls.name.value).toBe('my-server');
+  });
+
+  it('should not overwrite an existing certificate name when uploading a file', async () => {
+    await init();
+
+    fixture.componentInstance.uploadForm.controls.name.setValue('already-set');
+
+    const file = new File(['-----BEGIN CERTIFICATE-----'], 'my-server.crt', { type: 'application/x-x509-ca-cert' });
+    const mockEvent = { target: { files: [file], value: '' } } as unknown as Event;
+    await fixture.componentInstance.onFileSelected(mockEvent);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.uploadForm.controls.name.value).toBe('already-set');
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
@@ -26,7 +26,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatStepper, MatStepperModule } from '@angular/material/stepper';
-import { of, switchMap } from 'rxjs';
+import { of, switchMap, tap } from 'rxjs';
 
 import { ApplicationCertificateService } from '../../../../../../services/application-certificate.service';
 
@@ -69,6 +69,8 @@ export class AddCertificateDialogComponent {
 
   isSubmitting = signal(false);
   submitError = signal<string | null>(null);
+  isValidating = signal(false);
+  validateError = signal<string | null>(null);
 
   readonly uploadForm = new FormGroup({
     name: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
@@ -86,12 +88,53 @@ export class AddCertificateDialogComponent {
     this.stepper().next();
   }
 
+  validateAndContinue(): void {
+    this.uploadForm.markAllAsTouched();
+    if (this.uploadForm.invalid) return;
+
+    this.isValidating.set(true);
+    this.validateError.set(null);
+
+    this.certService
+      .validate(this.data.applicationId, this.uploadForm.controls.certificate.value)
+      .pipe(
+        tap(response => {
+          if (response.certificateExpiration) {
+            this.configureForm.controls.endsAt.setValue(new Date(response.certificateExpiration));
+          }
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: () => {
+          this.isValidating.set(false);
+          this.stepper().next();
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isValidating.set(false);
+          if (err.status === 400) {
+            this.validateError.set(
+              $localize`:@@addCertificateValidationError:Validation failed for Certificate uploaded. Please try again`,
+            );
+          } else {
+            this.validateError.set(
+              $localize`:@@addCertificateValidateError:An error occurred while validating the certificate. Please try again`,
+            );
+          }
+        },
+      });
+  }
+
   async onFileSelected(event: Event): Promise<void> {
     const input = event.target as HTMLInputElement;
     const file = input.files?.[0];
     if (!file) return;
     const content = await this.readFileAsText(file);
     this.uploadForm.controls.certificate.setValue(content);
+    if (!this.uploadForm.controls.name.value) {
+      const nameWithoutExtension = file.name.replace(/\.[^.]+$/, '');
+      this.uploadForm.controls.name.setValue(nameWithoutExtension);
+    }
     input.value = '';
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
@@ -29,6 +29,7 @@ import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import { of, switchMap, tap } from 'rxjs';
 
 import { ApplicationCertificateService } from '../../../../../../services/application-certificate.service';
+import { fileNameWithoutExtension } from '../../../../../../utils/common.utils';
 
 export interface AddCertificateDialogData {
   applicationId: string;
@@ -132,8 +133,7 @@ export class AddCertificateDialogComponent {
     const content = await this.readFileAsText(file);
     this.uploadForm.controls.certificate.setValue(content);
     if (!this.uploadForm.controls.name.value) {
-      const nameWithoutExtension = file.name.replace(/\.[^.]+$/, '');
-      this.uploadForm.controls.name.setValue(nameWithoutExtension);
+      this.uploadForm.controls.name.setValue(fileNameWithoutExtension(file.name));
     }
     input.value = '';
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
@@ -13,25 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentHarness } from '@angular/cdk/testing';
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
 
 export class ApplicationTabSettingsCertificatesHarness extends ComponentHarness {
   public static readonly hostSelector = 'app-application-tab-settings-certificates';
 
-  getEmptyState = this.locatorForOptional('.certificates__empty');
-  getPaginatedTable = this.locatorForOptional('app-paginated-table');
-  getErrorMessage = this.locatorForOptional('.certificates__error');
-  getTabButtons = this.locatorForAll('.certificates__tabs__tab');
-  getActiveTabButton = this.locatorForOptional('.certificates__tabs__tab--active');
-  getUploadButton = this.locatorForOptional('[data-testid="upload-certificate-button"]');
+  protected locateEmptyState = this.locatorForOptional('.certificates__empty');
+  protected locatePaginatedTable = this.locatorForOptional('app-paginated-table');
+  protected locateErrorMessage = this.locatorForOptional('.certificates__error');
+  protected locateTabButtons = this.locatorForAll('.certificates__tabs__tab');
+  protected locateActiveTabButton = this.locatorForOptional('.certificates__tabs__tab--active');
+  protected locateUploadButton = this.locatorForOptional('[data-testid="upload-certificate-button"]');
 
-  async clickUploadButton(): Promise<void> {
-    const btn = await this.getUploadButton();
+  public async getEmptyState(): Promise<TestElement | null> {
+    return this.locateEmptyState();
+  }
+
+  public async getPaginatedTable(): Promise<TestElement | null> {
+    return this.locatePaginatedTable();
+  }
+
+  public async getErrorMessage(): Promise<TestElement | null> {
+    return this.locateErrorMessage();
+  }
+
+  public async getActiveTabButton(): Promise<TestElement | null> {
+    return this.locateActiveTabButton();
+  }
+
+  public async getUploadButton(): Promise<TestElement | null> {
+    return this.locateUploadButton();
+  }
+
+  public async clickUploadButton(): Promise<void> {
+    const btn = await this.locateUploadButton();
     await btn?.click();
   }
 
-  async clickTab(label: 'active' | 'history'): Promise<void> {
-    const tabs = await this.getTabButtons();
+  public async clickTab(label: 'active' | 'history'): Promise<void> {
+    const tabs = await this.locateTabButtons();
     const index = label === 'active' ? 0 : 1;
     await tabs[index].click();
   }

--- a/gravitee-apim-portal-webui-next/src/entities/application/client-certificate.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/client-certificate.ts
@@ -35,6 +35,12 @@ export interface CreateClientCertificateInput {
   endsAt?: string;
 }
 
+export interface ValidateCertificateResponse {
+  certificateExpiration?: string;
+  subject?: string;
+  issuer?: string;
+}
+
 export interface UpdateClientCertificateInput {
   name?: string;
   startsAt?: string;

--- a/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
@@ -68,6 +68,14 @@ mat-expansion-panel {
   --mat-expansion-container-background-color: #{theme.$card-background-color};
 }
 
+mat-stepper {
+  @include mat.stepper-overrides(
+    (
+      container-color: transparent,
+    )
+  );
+}
+
 .mat-mdc-select-panel {
   --mat-select-panel-background-color: #{theme.$select-panel-background-color};
 }

--- a/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
@@ -71,7 +71,7 @@ mat-expansion-panel {
 mat-stepper {
   @include mat.stepper-overrides(
     (
-      container-color: transparent,
+      container-color: #{theme.$card-background-color},
     )
   );
 }

--- a/gravitee-apim-portal-webui-next/src/services/application-certificate.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-certificate.service.spec.ts
@@ -90,4 +90,19 @@ describe('ApplicationCertificateService', () => {
     expect(req.request.method).toEqual('DELETE');
     req.flush(null);
   });
+
+  it('should POST to _validate and return certificate metadata', done => {
+    const certificate = '-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpE...\n-----END CERTIFICATE-----';
+    const response = { certificateExpiration: '2027-06-01T00:00:00.000Z', subject: 'CN=test', issuer: 'CN=ca' };
+
+    service.validate(appId, certificate).subscribe(res => {
+      expect(res).toMatchObject(response);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${appId}/certificates/_validate`);
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toEqual({ certificate });
+    req.flush(response);
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/application-certificate.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-certificate.service.ts
@@ -23,6 +23,7 @@ import {
   ClientCertificatesResponse,
   CreateClientCertificateInput,
   UpdateClientCertificateInput,
+  ValidateCertificateResponse,
 } from '../entities/application/client-certificate';
 
 @Injectable({
@@ -46,6 +47,13 @@ export class ApplicationCertificateService {
 
   update(applicationId: string, certId: string, body: UpdateClientCertificateInput): Observable<ClientCertificate> {
     return this.http.put<ClientCertificate>(`${this.configService.baseURL}/applications/${applicationId}/certificates/${certId}`, body);
+  }
+
+  validate(applicationId: string, certificate: string): Observable<ValidateCertificateResponse> {
+    return this.http.post<ValidateCertificateResponse>(
+      `${this.configService.baseURL}/applications/${applicationId}/certificates/_validate`,
+      { certificate },
+    );
   }
 
   delete(applicationId: string, certId: string): Observable<void> {

--- a/gravitee-apim-portal-webui-next/src/utils/common.utils.ts
+++ b/gravitee-apim-portal-webui-next/src/utils/common.utils.ts
@@ -63,6 +63,14 @@ export function toTitleCase(value: string): string {
 }
 
 /**
+ * Returns the file name without its last extension (`cert.pem` → `cert`).
+ * If there is no `.suffix`, returns `fileName` unchanged.
+ */
+export function fileNameWithoutExtension(fileName: string): string {
+  return fileName.replace(/\.[^.]+$/, '');
+}
+
+/**
  * Compares two filter objects for equality.
  * Compares arrays and primitive values within the filter objects.
  */

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResource.java
@@ -17,7 +17,10 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.ValidateClientCertificateUseCase;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.clientcertificate.ValidateCertificateRequest;
+import io.gravitee.rest.api.model.clientcertificate.ValidateCertificateResponse;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
@@ -67,6 +70,9 @@ public class PortalApplicationClientCertificatesResource extends AbstractResourc
 
     @Inject
     private CreateClientCertificateUseCase createClientCertificateUseCase;
+
+    @Inject
+    private ValidateClientCertificateUseCase validateClientCertificateUseCase;
 
     private final PortalClientCertificateMapper mapper = PortalClientCertificateMapper.INSTANCE;
 
@@ -123,6 +129,30 @@ public class PortalApplicationClientCertificatesResource extends AbstractResourc
             .execute(new CreateClientCertificateUseCase.Input(applicationId, mapper.toDomain(input)))
             .clientCertificate();
         return Response.created(this.getLocationHeader(created.id())).entity(mapper.toDto(created)).build();
+    }
+
+    @POST
+    @Path("_validate")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "Validate a PEM-encoded client certificate",
+        description = "Parses the certificate and returns its metadata without persisting it. User must have the APPLICATION_DEFINITION[READ] permission to use this service."
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Certificate is valid",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ValidateCertificateResponse.class))
+    )
+    @ApiResponse(responseCode = "400", description = "Certificate is invalid, empty, or is a CA certificate")
+    @ApiResponse(responseCode = "403", description = "Forbidden")
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
+    public Response validateCertificate(@Valid @NotNull final ValidateCertificateRequest request) {
+        var result = validateClientCertificateUseCase.execute(new ValidateClientCertificateUseCase.Input(request.certificate()));
+        var certificateInfo = result.certificateInfo();
+        return Response.ok(
+            new ValidateCertificateResponse(certificateInfo.certificateExpiration(), certificateInfo.subject(), certificateInfo.issuer())
+        ).build();
     }
 
     @Path("{certId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -1906,6 +1906,40 @@ paths:
                     $ref: "#/components/responses/ApplicationNotFoundError"
                 500:
                     $ref: "#/components/responses/InternalServerError"
+    /applications/{applicationId}/certificates/_validate:
+        parameters:
+            - $ref: "#/components/parameters/applicationIdParam"
+        post:
+            tags:
+                - Application Client Certificates
+            requestBody:
+                description: Use to validate a client certificate.
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ValidateCertificateRequest"
+            summary: Validate a PEM-encoded client certificate
+            description: |
+                Parses the certificate and returns its metadata without persisting it.
+
+                User must have the APPLICATION_DEFINITION[READ] permission.
+            operationId: validateApplicationCertificate
+            responses:
+                200:
+                    description: Certificate is valid
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ValidateCertificateResponse"
+                400:
+                    $ref: "#/components/responses/BadRequestError"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                404:
+                    $ref: "#/components/responses/ApplicationNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
     /applications/{applicationId}/certificates/{certId}:
         parameters:
             - $ref: "#/components/parameters/applicationIdParam"
@@ -6752,6 +6786,27 @@ components:
                 - GRAVITEE_MARKDOWN
                 - OPENAPI
 
+        ValidateCertificateRequest:
+            type: object
+            required:
+                - certificate
+            properties:
+                certificate:
+                    type: string
+                    description: The certificate in PEM format to validate.
+        ValidateCertificateResponse:
+            type: object
+            properties:
+                certificateExpiration:
+                    type: string
+                    format: date-time
+                    description: Expiration date extracted from the certificate.
+                subject:
+                    type: string
+                    description: Subject of the certificate.
+                issuer:
+                    type: string
+                    description: Issuer of the certificate.
         PortalClientCertificate:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertif
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.ValidateClientCertificateUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.rest.api.portal.rest.JerseySpringTest;
@@ -137,6 +138,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected DeleteClientCertificateUseCase deleteClientCertificateUseCase;
+
+    @Autowired
+    protected ValidateClientCertificateUseCase validateClientCertificateUseCase;
 
     @Autowired
     protected CustomUserFieldService customUserFieldService;
@@ -371,6 +375,7 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
             createClientCertificateUseCase,
             updateClientCertificateUseCase,
             deleteClientCertificateUseCase,
+            validateClientCertificateUseCase,
             apiService,
             apiSearchService,
             apiAuthorizationService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResourceTest.java
@@ -20,12 +20,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService.CertificateInfo;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.ValidateClientCertificateUseCase;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.clientcertificate.ValidateCertificateRequest;
+import io.gravitee.rest.api.model.clientcertificate.ValidateCertificateResponse;
 import io.gravitee.rest.api.portal.rest.model.CreatePortalClientCertificateInput;
 import io.gravitee.rest.api.portal.rest.model.PortalClientCertificate;
 import io.gravitee.rest.api.portal.rest.model.PortalClientCertificatesResponse;
@@ -113,6 +117,34 @@ public class PortalApplicationClientCertificatesResourceTest extends AbstractRes
         createRequest.setName("My Certificate");
 
         final Response response = target().request().post(Entity.json(createRequest));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+    }
+
+    @Test
+    public void should_validate_certificate_and_return_metadata() {
+        var expiration = new Date();
+        var certInfo = new CertificateInfo(expiration, "CN=test", "CN=ca", "abc123");
+        when(validateClientCertificateUseCase.execute(any(ValidateClientCertificateUseCase.Input.class))).thenReturn(
+            new ValidateClientCertificateUseCase.Output(certInfo)
+        );
+
+        var request = new ValidateCertificateRequest("-----BEGIN CERTIFICATE-----\nMIIBkTCB...\n-----END CERTIFICATE-----");
+        final Response response = target("/_validate").request().post(Entity.json(request));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            var result = response.readEntity(ValidateCertificateResponse.class);
+            soft.assertThat(result.certificateExpiration()).isEqualTo(expiration);
+            soft.assertThat(result.subject()).isEqualTo("CN=test");
+            soft.assertThat(result.issuer()).isEqualTo("CN=ca");
+        });
+        verify(validateClientCertificateUseCase).execute(any(ValidateClientCertificateUseCase.Input.class));
+    }
+
+    @Test
+    public void should_return_400_when_certificate_is_missing_in_validate_request() {
+        final Response response = target("/_validate").request().post(Entity.json("{}"));
 
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -70,6 +70,7 @@ import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertif
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.ValidateClientCertificateUseCase;
 import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
 import io.gravitee.apim.core.audit.query_service.AuditMetadataQueryService;
 import io.gravitee.apim.core.audit.query_service.AuditQueryService;
@@ -1253,6 +1254,11 @@ public class ResourceContextConfiguration {
     @Bean
     public DeleteClientCertificateUseCase deleteClientCertificateUseCase() {
         return mock(DeleteClientCertificateUseCase.class);
+    }
+
+    @Bean
+    public ValidateClientCertificateUseCase validateClientCertificateUseCase() {
+        return mock(ValidateClientCertificateUseCase.class);
     }
 
     @Bean


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13260

## Description

- Added `POST /applications/{applicationId}/certificates/_validate` endpoint to PAPI — parses PEM and returns certificate metadata (expiration, subject, issuer) without persisting; requires `APPLICATION_DEFINITION[READ]`
- Certificate dialog now calls `_validate` on step 1 "Continue" — invalid certificates are rejected before reaching step 2, with an inline error message
- `endsAt` (Active until) is pre-filled from the certificate's expiration date returned by `_validate`
- Certificate name auto-filled from the uploaded file name (without extension) when the name field is empty
- Harnesses refactored to follow `protected locator` + `public async method` pattern

## Additional context

- Spec listed "Automatic grace period calculation from certificate expiry" as out of scope for initial delivery — this commit partially delivers it by pre-filling `endsAt` from the cert's own expiry date as a convenience, leaving the user free to override     