### PR TITLE
fix(deps): bump gravitee-resource-cache-redis to 4.0.4 (APIM-13439)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <gravitee-resource-auth-provider-http.version>1.4.0</gravitee-resource-auth-provider-http.version>
         <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
         <gravitee-resource-auth-provider-ldap.version>2.0.1</gravitee-resource-auth-provider-ldap.version>
-        <gravitee-resource-cache-redis.version>4.0.3</gravitee-resource-cache-redis.version>
+        <gravitee-resource-cache-redis.version>4.0.4</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>2.1.0</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>
         <gravitee-secretprovider-kubernetes.version>2.0.0</gravitee-secretprovider-kubernetes.version>


### PR DESCRIPTION
## Summary
- Bumps `gravitee-resource-cache-redis` from 4.0.3 to 4.0.4
- Fixes connection leak: `RedisCacheResource` was not destroying `LettuceConnectionFactory` on API redeploy, leaking 2 threads per redeploy until OOM

## APIM-13439
https://gravitee.atlassian.net/browse/APIM-13439