### PR TITLE
fix(gateway): prevent CME with copy-on-write acceptors (APIM-13436)

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/impl/DefaultReactorHandlerRegistry.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/impl/DefaultReactorHandlerRegistry.java
@@ -204,13 +204,10 @@ public class DefaultReactorHandlerRegistry implements ReactorHandlerRegistry {
                     Class<? extends Acceptor<?>> acceptorType = resolve(acceptor.getClass());
                     if (acceptorType != null) {
                         acceptors.compute(acceptorType, (k, v) -> {
-                            if (v == null) {
-                                v = new ArrayList<>();
-                            }
-                            v.add(acceptor);
-                            // Sort list based on Acceptor comparable
-                            v.sort(null);
-                            return v;
+                            var copy = v == null ? new ArrayList<Acceptor<?>>() : new ArrayList<>(v);
+                            copy.add(acceptor);
+                            copy.sort(null);
+                            return Collections.unmodifiableList(copy);
                         });
                     }
                 });
@@ -225,12 +222,12 @@ public class DefaultReactorHandlerRegistry implements ReactorHandlerRegistry {
                     Class<? extends Acceptor<?>> acceptorType = resolve(acceptor.getClass());
                     if (acceptorType != null) {
                         acceptors.computeIfPresent(acceptorType, (k, v) -> {
-                            v.remove(acceptor);
+                            var copy = new ArrayList<>(v);
+                            copy.remove(acceptor);
                             acceptor.clear();
-                            if (!v.isEmpty()) {
-                                // Sort list based on Acceptor comparable
-                                v.sort(null);
-                                return v;
+                            if (!copy.isEmpty()) {
+                                copy.sort(null);
+                                return Collections.unmodifiableList(copy);
                             } else {
                                 return null;
                             }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorHandlerRegistryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorHandlerRegistryTest.java
@@ -626,6 +626,88 @@ public class ReactorHandlerRegistryTest {
         Assert.assertEquals(0, reactorHandlerRegistry.getAcceptors(DummyAcceptor.class).size());
     }
 
+    @Test
+    public void shouldReturnUnmodifiableListFromGetAcceptors() {
+        Reactable reactable = createReactable("reactable1");
+        ReactorHandler handler = createReactorHandler("/");
+        when(reactorHandlerFactoryManager.create(reactable)).thenReturn(List.of(handler));
+        reactorHandlerRegistry.create(reactable);
+
+        Collection<HttpAcceptor> acceptorList = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
+        Assert.assertEquals(1, acceptorList.size());
+
+        try {
+            ((List<HttpAcceptor>) acceptorList).add(mock(HttpAcceptor.class));
+            Assert.fail("Expected UnsupportedOperationException");
+        } catch (UnsupportedOperationException e) {
+            // expected: list is unmodifiable
+        }
+    }
+
+    @Test
+    public void shouldNotThrowConcurrentModificationException_concurrentReadersAndWriters() throws InterruptedException {
+        // Pre-populate some APIs so readers always have something to iterate
+        for (int i = 0; i < 5; i++) {
+            DummyReactable reactable = createReactable("seed" + i);
+            ReactorHandler handler = createReactorHandler("/seed" + i);
+            when(reactorHandlerFactoryManager.create(reactable)).thenReturn(List.of(handler));
+            reactorHandlerRegistry.create(reactable);
+        }
+
+        var errors = new java.util.concurrent.atomic.AtomicReference<Throwable>();
+        int durationMs = 3000;
+        long deadline = System.currentTimeMillis() + durationMs;
+
+        // Reader threads: continuously iterate getAcceptors on event-loop-like threads
+        int readerCount = 4;
+        ExecutorService readers = Executors.newFixedThreadPool(readerCount);
+        for (int r = 0; r < readerCount; r++) {
+            readers.submit(() -> {
+                while (System.currentTimeMillis() < deadline && errors.get() == null) {
+                    try {
+                        Collection<HttpAcceptor> snapshot = reactorHandlerRegistry.getAcceptors(HttpAcceptor.class);
+                        for (HttpAcceptor a : snapshot) {
+                            // force full iteration
+                            a.path();
+                        }
+                        // Also iterate DummyAcceptor (simulates TcpAcceptor, separate map key)
+                        Collection<DummyAcceptor> dummySnapshot = reactorHandlerRegistry.getAcceptors(DummyAcceptor.class);
+                        for (DummyAcceptor d : dummySnapshot) {
+                            d.apiId();
+                        }
+                    } catch (Throwable t) {
+                        errors.compareAndSet(null, t);
+                    }
+                }
+            });
+        }
+
+        // Writer thread: continuously create and remove reactables
+        ExecutorService writer = Executors.newSingleThreadExecutor();
+        writer.submit(() -> {
+            int idx = 100;
+            while (System.currentTimeMillis() < deadline && errors.get() == null) {
+                try {
+                    String id = "stress" + (idx++);
+                    DummyReactable reactable = createReactable(id);
+                    ReactorHandler handler = createReactorHandler(new DefaultHttpAcceptor("/" + id), new DefaultDummyAcceptor(id));
+                    when(reactorHandlerFactoryManager.create(reactable)).thenReturn(List.of(handler));
+                    reactorHandlerRegistry.create(reactable);
+                    reactorHandlerRegistry.remove(reactable);
+                } catch (Throwable t) {
+                    errors.compareAndSet(null, t);
+                }
+            }
+        });
+
+        readers.shutdown();
+        writer.shutdown();
+        assertTrue("Readers did not finish", readers.awaitTermination(durationMs + 5000, TimeUnit.MILLISECONDS));
+        assertTrue("Writer did not finish", writer.awaitTermination(durationMs + 5000, TimeUnit.MILLISECONDS));
+
+        Assert.assertNull("Concurrent modification detected: " + errors.get(), errors.get());
+    }
+
     private void assertEntryPoint(String host, String path, HttpAcceptor httpAcceptor) {
         Assert.assertEquals(host, httpAcceptor.host());
         Assert.assertEquals(path, httpAcceptor.path());


### PR DESCRIPTION
## Summary

Fixes a ConcurrentModificationException race condition in `DefaultReactorHandlerRegistry` under concurrent API deployment + traffic.

- `getAcceptors()` returned raw `ArrayList` reference; event-loop threads iterated it without a lock
- `registerAcceptors()` / `unregisterAcceptors()` mutated the same list in-place under `synchronized(this)`
- Result: CME when sync-deployer writes concurrently with event-loop readers (`DefaultHttpAcceptorResolver`, `DefaultAcceptorResolver`, `DefaultTcpAcceptorResolver`)
- Same pattern was fixed for `registeredEntrypoints` in Nov 2021 (commit 2afc549); the `acceptors` path never got the same treatment

Fix: copy-on-write immutable snapshots. On write, create a new ArrayList copy, mutate, store `Collections.unmodifiableList(copy)`. Readers always get a stable snapshot. `synchronized(this)` block kept for cross-key atomicity.

Jira: https://gravitee.atlassian.net/browse/APIM-13436

## Test plan

- [ ] All 20 unit tests pass (18 existing + 2 new)
- [ ] New `shouldReturnUnmodifiableListFromGetAcceptors`: verifies UnsupportedOperationException on write attempt
- [ ] New `shouldNotThrowConcurrentModificationException_concurrentReadersAndWriters`: 3s stress test with 4 reader threads + 1 writer thread, asserts no CME