### PR TITLE
chore: set default build mode to development (portal-next, console).

### DIFF
--- a/gravitee-apim-console-webui/project.json
+++ b/gravitee-apim-console-webui/project.json
@@ -145,7 +145,7 @@
           "namedChunks": true
         }
       },
-      "defaultConfiguration": "production"
+      "defaultConfiguration": "development"
     },
     "serve": {
       "executor": "@angular-devkit/build-angular:dev-server",
@@ -195,7 +195,7 @@
     "storybook": {
       "executor": "@storybook/angular:start-storybook",
       "options": {
-        "browserTarget": "console:build",
+        "browserTarget": "console:build:production",
         "compodoc": false,
         "port": 9008,
         "configDir": "gravitee-apim-console-webui/.storybook"
@@ -204,7 +204,7 @@
     "build-storybook": {
       "executor": "@storybook/angular:build-storybook",
       "options": {
-        "browserTarget": "console:build",
+        "browserTarget": "console:build:production",
         "compodoc": false,
         "configDir": "gravitee-apim-console-webui/.storybook",
         "outputDir": "gravitee-apim-console-webui/storybook-static"

--- a/gravitee-apim-portal-webui-next/project.json
+++ b/gravitee-apim-portal-webui-next/project.json
@@ -89,7 +89,7 @@
           "sourceMap": true
         }
       },
-      "defaultConfiguration": "production"
+      "defaultConfiguration": "development"
     },
     "serve": {
       "executor": "@angular/build:dev-server",
@@ -147,7 +147,7 @@
       "options": {
         "configDir": "gravitee-apim-portal-webui-next/.storybook",
         "styles": ["gravitee-apim-portal-webui-next/.storybook/index.scss"],
-        "browserTarget": "portal-next:build",
+        "browserTarget": "portal-next:build:production",
         "compodoc": false,
         "port": 6006
       }
@@ -156,7 +156,7 @@
       "executor": "@storybook/angular:build-storybook",
       "options": {
         "configDir": "gravitee-apim-portal-webui-next/.storybook",
-        "browserTarget": "portal-next:build",
+        "browserTarget": "portal-next:build:production",
         "compodoc": false,
         "outputDir": "gravitee-apim-portal-webui-next/storybook-static"
       }


### PR DESCRIPTION
## Issue

[package.json](https://github.com/gravitee-io/gravitee-api-management/blob/ffc8bbc7cce4f15d33d00b0032c59b37030e93ac/package.json) contains 2 types of build scripts for Portal and Console:

```
"console:build": ...,
"console:build:prod": ...,
"portal-next:build": ...,
"portal-next:build:prod": ...,
```

But since the default configuration is set to `production`, both scripts run the same builds.

## Description

- Change the default configuration to `development`.
- Fix storybook builds