### PR TITLE
feat: add policy description span attribute when verbose tracing is enabled

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -235,6 +235,7 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
         ctx.setAttribute(ContextAttributes.ATTR_ENVIRONMENT, api.getEnvironmentId());
         ctx.setInternalAttribute(ATTR_INTERNAL_INVOKER, defaultInvoker);
         ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ANALYTICS_CONTEXT, analyticsContext);
+        ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED, tracingContext.isVerbose());
         ctx.logEntries(DEFAULT_EXECUTION_CONTEXT_LOG_ENTRIES);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/HttpPolicyChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/HttpPolicyChain.java
@@ -27,10 +27,12 @@ import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.gateway.reactive.core.context.ComponentScope;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.hook.HookHelper;
+import io.gravitee.gateway.reactive.policy.tracing.TracingPolicyHook;
 import io.reactivex.rxjava3.core.Completable;
 import jakarta.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import lombok.CustomLog;
 
@@ -47,6 +49,7 @@ public class HttpPolicyChain extends AbstractPolicyChain<HttpPolicy> implements 
 
     private List<PolicyHook> policyHooks;
     private List<PolicyMessageHook> policyMessageHooks;
+    private Map<HttpPolicy, String> policyDescriptions;
 
     /**
      * Creates a policy chain with the given list of policies.
@@ -57,6 +60,14 @@ public class HttpPolicyChain extends AbstractPolicyChain<HttpPolicy> implements 
      */
     public HttpPolicyChain(@Nonnull String id, @Nonnull List<HttpPolicy> policies, @Nonnull ExecutionPhase phase) {
         super(id, policies, phase);
+    }
+
+    public void setPolicyDescriptions(final Map<HttpPolicy, String> descriptions) {
+        this.policyDescriptions = descriptions;
+    }
+
+    public Map<HttpPolicy, String> getPolicyDescriptions() {
+        return policyDescriptions;
     }
 
     @Override
@@ -110,6 +121,10 @@ public class HttpPolicyChain extends AbstractPolicyChain<HttpPolicy> implements 
             baseCtx.withLogger(log).debug("Executing policy {} on phase {} in policy chain {}", policy.id(), phase, id);
 
             HttpExecutionContext ctx = (HttpExecutionContext) baseCtx;
+            ctx.putInternalAttribute(
+                TracingPolicyHook.ATTR_CURRENT_POLICY_DESCRIPTION,
+                policyDescriptions != null ? policyDescriptions.get(policy) : null
+            );
             return switch (phase) {
                 case REQUEST -> HookHelper.hook(() -> policy.onRequest(ctx), policy.id(), policyHooks, ctx, phase);
                 case RESPONSE -> HookHelper.hook(() -> policy.onResponse(ctx), policy.id(), policyHooks, ctx, phase);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/HttpPolicyChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/HttpPolicyChainFactory.java
@@ -28,15 +28,14 @@ import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.gateway.reactive.policy.tracing.TracingPolicyHook;
 import io.gravitee.node.api.cache.Cache;
 import io.gravitee.node.api.cache.CacheConfiguration;
-import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.plugin.cache.common.InMemoryCache;
 import io.netty.util.internal.StringUtil;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 /**
  * {@link PolicyChainFactory} that can be instantiated per-api or per-organization, and optimized to maximize the reuse of created {@link HttpPolicyChain} thanks to a cache.
@@ -85,18 +84,25 @@ public class HttpPolicyChainFactory implements PolicyChainFactory<HttpPolicyChai
 
         if (policyChain == null) {
             final List<Step> steps = getSteps(flow, phase);
+            final List<HttpPolicy> policies = new ArrayList<>(steps.size());
+            final Map<HttpPolicy, String> policyDescriptions = new IdentityHashMap<>();
 
-            final List<HttpPolicy> policies = steps
-                .stream()
-                .filter(Step::isEnabled)
-                .map(this::buildPolicyMetadata)
-                .map(policyMetadata -> (HttpPolicy) policyManager.create(phase, policyMetadata))
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+            for (Step step : steps) {
+                if (!step.isEnabled()) continue;
+                HttpPolicy policy = (HttpPolicy) policyManager.create(phase, buildPolicyMetadata(step));
+                if (policy == null) continue;
+                policies.add(policy);
+                String desc = step.getDescription();
+                if (desc != null && !desc.isBlank()) policyDescriptions.put(policy, desc);
+            }
 
             String policyChainId = getFlowId(flowChainId, flow);
             policyChain = new HttpPolicyChain(policyChainId, policies, phase);
             policyChain.addHooks(policyHooks);
+            if (!policyDescriptions.isEmpty()) {
+                policyChain.setPolicyDescriptions(policyDescriptions);
+            }
+
             policyChains.put(key, policyChain);
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHook.java
@@ -35,6 +35,8 @@ public class TracingPolicyHook extends AbstractTracingHook implements PolicyHook
     private static final String HOOK_ID = "hook-tracing-policy";
 
     public static final String SPAN_POLICY_ATTR = "gravitee.policy";
+    public static final String SPAN_POLICY_DESCRIPTION_ATTR = "gravitee.policy.description";
+    public static final String ATTR_CURRENT_POLICY_DESCRIPTION = "tracing.policy.current-description";
     private static final String ATTR_SPAN_POLICY_TRIGGER_EXECUTED = "gravitee.policy.trigger.executed";
     private static final String ATTR_SPAN_POLICY_TRIGGER_CONDITION = "gravitee.policy.trigger.condition";
     public static final String ATTR_POLICY_TRIGGER_CONDITION_PREFIX = "gravitee.policy.trigger.condition.";
@@ -104,6 +106,12 @@ public class TracingPolicyHook extends AbstractTracingHook implements PolicyHook
     protected Map<String, String> spanAttributes(final String id, final HttpExecutionContext ctx, final ExecutionPhase executionPhase) {
         Map<String, String> spanAttributes = super.spanAttributes(id, ctx, executionPhase);
         spanAttributes.put(SPAN_POLICY_ATTR, id);
+        if (isVerboseEnabled(ctx)) {
+            String description = ctx.getInternalAttribute(ATTR_CURRENT_POLICY_DESCRIPTION);
+            if (description != null && !description.isBlank()) {
+                spanAttributes.put(SPAN_POLICY_DESCRIPTION_ATTR, description);
+            }
+        }
         return spanAttributes;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/v4/policy/AbstractPolicyChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/v4/policy/AbstractPolicyChainFactory.java
@@ -16,19 +16,19 @@
 package io.gravitee.gateway.reactive.v4.policy;
 
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
-import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.gateway.policy.PolicyMetadata;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
 import io.gravitee.gateway.reactive.api.policy.base.BasePolicy;
 import io.gravitee.gateway.reactive.policy.AbstractPolicyChain;
-import io.gravitee.gateway.reactive.policy.HttpPolicyChain;
 import io.gravitee.gateway.reactive.policy.PolicyManager;
 import io.gravitee.node.api.cache.Cache;
 import io.gravitee.node.api.cache.CacheConfiguration;
 import io.gravitee.node.plugin.cache.common.InMemoryCache;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 
 /**
  * {@link AbstractPolicyChainFactory} that can be instantiated per-api or per-organization, and optimized to maximize the reuse of created {@link AbstractPolicyChain} thanks to a cache.
@@ -63,7 +63,7 @@ public abstract class AbstractPolicyChainFactory<T extends BasePolicy, F extends
 
     protected abstract List<Step> getSteps(F flow, ExecutionPhase phase);
 
-    protected abstract PC buildPolicyChain(String flowChainId, F flow, ExecutionPhase phase, List<T> policies);
+    protected abstract PC buildPolicyChain(String flowChainId, F flow, ExecutionPhase phase, List<T> policies, Map<T, String> descriptions);
 
     protected abstract PolicyMetadata buildPolicyMetadata(Step step);
 
@@ -81,23 +81,26 @@ public abstract class AbstractPolicyChainFactory<T extends BasePolicy, F extends
     public PC create(final String flowChainId, F flow, ExecutionPhase phase) {
         final String key = getFlowKey(flow, phase);
         PC policyChain = policyChains.get(key);
-
-        if (policyChain == null) {
-            final List<Step> steps = getSteps(flow, phase);
-
-            final List<T> policies = steps
-                .stream()
-                .filter(Step::isEnabled)
-                .map(this::buildPolicyMetadata)
-                .map(policyMetadata -> (T) policyManager.create(phase, policyMetadata))
-                .filter(Objects::nonNull)
-                .toList();
-
-            policyChain = buildPolicyChain(flowChainId, flow, phase, policies);
-            policyChains.put(key, policyChain);
+        if (policyChain != null) {
+            return policyChain;
         }
-
+        policyChain = createChain(flowChainId, flow, phase);
+        policyChains.put(key, policyChain);
         return policyChain;
+    }
+
+    private PC createChain(final String flowChainId, F flow, ExecutionPhase phase) {
+        final List<T> policies = new ArrayList<>();
+        final Map<T, String> descriptions = new IdentityHashMap<>();
+        for (Step step : getSteps(flow, phase)) {
+            if (!step.isEnabled()) continue;
+            T policy = policyManager.create(phase, buildPolicyMetadata(step));
+            if (policy == null) continue;
+            policies.add(policy);
+            String desc = step.getDescription();
+            if (desc != null && !desc.isBlank()) descriptions.put(policy, desc);
+        }
+        return buildPolicyChain(flowChainId, flow, phase, policies, descriptions);
     }
 
     private String getFlowKey(F flow, ExecutionPhase phase) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/v4/policy/HttpPolicyChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/v4/policy/HttpPolicyChainFactory.java
@@ -31,6 +31,7 @@ import io.netty.util.internal.StringUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * {@link HttpPolicyChainFactory} that can be instantiated per-api or per-organization, and optimized to maximize the reuse of created {@link HttpPolicyChain} thanks to a cache.
@@ -72,10 +73,19 @@ public class HttpPolicyChainFactory extends AbstractPolicyChainFactory<HttpPolic
     }
 
     @Override
-    protected HttpPolicyChain buildPolicyChain(String flowChainId, Flow flow, ExecutionPhase phase, List<HttpPolicy> policies) {
+    protected HttpPolicyChain buildPolicyChain(
+        String flowChainId,
+        Flow flow,
+        ExecutionPhase phase,
+        List<HttpPolicy> policies,
+        Map<HttpPolicy, String> descriptions
+    ) {
         String policyChainId = getPolicyChainId(flowChainId, flow);
         HttpPolicyChain httpPolicyChain = new HttpPolicyChain(policyChainId, policies, phase);
         httpPolicyChain.addHooks(policyHooks);
+        if (!descriptions.isEmpty()) {
+            httpPolicyChain.setPolicyDescriptions(descriptions);
+        }
         return httpPolicyChain;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/HttpPolicyChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/HttpPolicyChainFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.policy;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,6 +33,7 @@ import io.gravitee.definition.model.flow.Step;
 import io.gravitee.gateway.policy.PolicyMetadata;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
 import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.node.container.spring.SpringEnvironmentConfiguration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -245,5 +247,50 @@ class HttpPolicyChainFactoryTest {
         assertNotNull(policyChain);
 
         verifyNoInteractions(policyManager);
+    }
+
+    @Test
+    void should_set_policy_descriptions_when_steps_have_descriptions() throws Exception {
+        final HttpPolicy policy1 = mock(HttpPolicy.class);
+        final HttpPolicy policy2 = mock(HttpPolicy.class);
+        final Flow flow = mock(Flow.class);
+        final Step step1 = mock(Step.class);
+        final Step step2 = mock(Step.class);
+
+        when(step1.isEnabled()).thenReturn(true);
+        when(step2.isEnabled()).thenReturn(true);
+        when(step1.getDescription()).thenReturn("description-1");
+        when(step2.getDescription()).thenReturn("description-2");
+        when(step1.getPolicy()).thenReturn("policy-step1");
+        when(step1.getConfiguration()).thenReturn("config-step1");
+        when(step1.getCondition()).thenReturn("condition-step1");
+        when(step2.getPolicy()).thenReturn("policy-step2");
+        when(step2.getConfiguration()).thenReturn("config-step2");
+        when(step2.getCondition()).thenReturn("condition-step2");
+        when(flow.getPre()).thenReturn(List.of(step1, step2));
+        when(policyManager.create(eq(ExecutionPhase.REQUEST), any(PolicyMetadata.class))).thenReturn(policy1).thenReturn(policy2);
+
+        final HttpPolicyChain policyChain = cut.create("flowchain-test", flow, ExecutionPhase.REQUEST);
+
+        assertThat(policyChain.getPolicyDescriptions()).containsEntry(policy1, "description-1").containsEntry(policy2, "description-2");
+    }
+
+    @Test
+    void should_not_set_descriptions_when_steps_have_no_descriptions() {
+        final HttpPolicy policy1 = mock(HttpPolicy.class);
+        final Flow flow = mock(Flow.class);
+        final Step step1 = mock(Step.class);
+
+        when(step1.isEnabled()).thenReturn(true);
+        when(step1.getDescription()).thenReturn(null);
+        when(step1.getPolicy()).thenReturn("policy-step1");
+        when(step1.getConfiguration()).thenReturn("config-step1");
+        when(step1.getCondition()).thenReturn("condition-step1");
+        when(flow.getPre()).thenReturn(List.of(step1));
+        when(policyManager.create(eq(ExecutionPhase.REQUEST), any(PolicyMetadata.class))).thenReturn(policy1);
+
+        final HttpPolicyChain policyChain = cut.create("flowchain-test", flow, ExecutionPhase.REQUEST);
+
+        assertThat(policyChain.getPolicyDescriptions()).isNull();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/HttpPolicyChainTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/HttpPolicyChainTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.policy;
 
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -33,11 +34,14 @@ import io.gravitee.gateway.reactive.core.context.MutableRequest;
 import io.gravitee.gateway.reactive.core.context.MutableResponse;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionException;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
+import io.gravitee.gateway.reactive.policy.tracing.TracingPolicyHook;
 import io.gravitee.node.api.Node;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -270,6 +274,74 @@ class HttpPolicyChainTest {
 
         verify(policy1).onRequest(ctx);
         verifyNoMoreInteractions(policy2);
+    }
+
+    @Test
+    void should_set_policy_description_in_context_before_execution() {
+        final HttpPolicy httpPolicy1 = mock(HttpPolicy.class);
+        final HttpPolicy httpPolicy2 = mock(HttpPolicy.class);
+
+        final HttpPolicyChain httpPolicyChain = new HttpPolicyChain(CHAIN_ID, asList(httpPolicy1, httpPolicy2), ExecutionPhase.REQUEST);
+
+        Map<HttpPolicy, String> descriptions = new IdentityHashMap<>();
+        descriptions.put(httpPolicy1, "description-1");
+        descriptions.put(httpPolicy2, "description-2");
+        httpPolicyChain.setPolicyDescriptions(descriptions);
+
+        when(httpPolicy1.onRequest(ctx)).thenAnswer(inv -> {
+            assertThat((String) ctx.getInternalAttribute(TracingPolicyHook.ATTR_CURRENT_POLICY_DESCRIPTION)).isEqualTo("description-1");
+            return Completable.complete();
+        });
+        when(httpPolicy2.onRequest(ctx)).thenAnswer(inv -> {
+            assertThat((String) ctx.getInternalAttribute(TracingPolicyHook.ATTR_CURRENT_POLICY_DESCRIPTION)).isEqualTo("description-2");
+            return Completable.complete();
+        });
+
+        httpPolicyChain.execute(ctx).test().assertComplete();
+
+        verify(httpPolicy1).onRequest(ctx);
+        verify(httpPolicy2).onRequest(ctx);
+    }
+
+    @Test
+    void should_not_set_policy_description_in_context_when_no_descriptions_configured() {
+        final HttpPolicy httpPolicy1 = mock(HttpPolicy.class);
+
+        final HttpPolicyChain httpPolicyChain = new HttpPolicyChain(CHAIN_ID, asList(httpPolicy1), ExecutionPhase.REQUEST);
+
+        when(httpPolicy1.onRequest(ctx)).thenAnswer(inv -> {
+            assertThat((String) ctx.getInternalAttribute(TracingPolicyHook.ATTR_CURRENT_POLICY_DESCRIPTION)).isNull();
+            return Completable.complete();
+        });
+
+        httpPolicyChain.execute(ctx).test().assertComplete();
+    }
+
+    @Test
+    void should_clear_policy_description_in_context_when_subsequent_policy_has_no_description() {
+        final HttpPolicy httpPolicy1 = mock(HttpPolicy.class);
+        final HttpPolicy httpPolicy2 = mock(HttpPolicy.class);
+
+        final HttpPolicyChain httpPolicyChain = new HttpPolicyChain(CHAIN_ID, asList(httpPolicy1, httpPolicy2), ExecutionPhase.REQUEST);
+
+        Map<HttpPolicy, String> descriptions = new IdentityHashMap<>();
+        descriptions.put(httpPolicy1, "description-1");
+        // httpPolicy2 intentionally has no description
+        httpPolicyChain.setPolicyDescriptions(descriptions);
+
+        when(httpPolicy1.onRequest(ctx)).thenAnswer(inv -> {
+            assertThat((String) ctx.getInternalAttribute(TracingPolicyHook.ATTR_CURRENT_POLICY_DESCRIPTION)).isEqualTo("description-1");
+            return Completable.complete();
+        });
+        when(httpPolicy2.onRequest(ctx)).thenAnswer(inv -> {
+            assertThat((String) ctx.getInternalAttribute(TracingPolicyHook.ATTR_CURRENT_POLICY_DESCRIPTION)).isNull();
+            return Completable.complete();
+        });
+
+        httpPolicyChain.execute(ctx).test().assertComplete();
+
+        verify(httpPolicy1).onRequest(ctx);
+        verify(httpPolicy2).onRequest(ctx);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHookTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHookTest.java
@@ -85,6 +85,7 @@ class TracingPolicyHookTest {
         when(tracer.startSpanFrom(any(InternalRequest.class))).thenReturn(span);
         when(ctx.getInternalAttribute("tracing-span-test-policy")).thenReturn(span);
         when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(true);
+        when(ctx.getInternalAttribute(TracingPolicyHook.ATTR_CURRENT_POLICY_DESCRIPTION)).thenReturn(null);
         when(ctx.request()).thenReturn(request);
         when(request.headers()).thenReturn(httpHeaders);
         when(httpHeaders.toSingleValueMap()).thenReturn(singleValueMap);
@@ -143,6 +144,39 @@ class TracingPolicyHookTest {
         hook.post(policyId, ctx, ExecutionPhase.REQUEST).test().assertResult();
         verify(span, never()).withAttribute(eq("gravitee.policy.trigger.condition"), anyString());
         verify(span).withAttribute("gravitee.policy.trigger.executed", "true");
+    }
+
+    @Test
+    void shouldAddDescriptionAttributeToSpanWhenVerboseEnabled() {
+        String policyId = "test-policy";
+        String description = "Transform request for legacy system";
+
+        when(ctx.getTracer()).thenReturn(tracer);
+        when(tracer.startSpanFrom(any(InternalRequest.class))).thenReturn(span);
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(true);
+        when(ctx.getInternalAttribute(TracingPolicyHook.ATTR_CURRENT_POLICY_DESCRIPTION)).thenReturn(description);
+
+        hook.pre(policyId, ctx, ExecutionPhase.REQUEST).test().assertResult();
+
+        verify(tracer).startSpanFrom(
+            argThat(req -> req instanceof InternalRequest ir && description.equals(ir.attributes().get("gravitee.policy.description")))
+        );
+    }
+
+    @Test
+    void shouldNotAddDescriptionAttributeToSpanWhenVerboseDisabled() {
+        String policyId = "test-policy";
+
+        when(ctx.getTracer()).thenReturn(tracer);
+        when(tracer.startSpanFrom(any(InternalRequest.class))).thenReturn(span);
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(false);
+
+        hook.pre(policyId, ctx, ExecutionPhase.REQUEST).test().assertResult();
+
+        verify(tracer).startSpanFrom(
+            argThat(req -> req instanceof InternalRequest ir && !ir.attributes().containsKey("gravitee.policy.description"))
+        );
+        verify(ctx, never()).getInternalAttribute(TracingPolicyHook.ATTR_CURRENT_POLICY_DESCRIPTION);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/v4/policy/HttpPolicyChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/v4/policy/HttpPolicyChainFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.v4.policy;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,6 +35,7 @@ import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.gateway.policy.PolicyMetadata;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
 import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.gateway.reactive.policy.HttpPolicyChain;
 import io.gravitee.gateway.reactive.policy.PolicyManager;
 import io.gravitee.node.container.spring.SpringEnvironmentConfiguration;
@@ -240,6 +242,51 @@ class HttpPolicyChainFactoryTest {
         verify(policyManager, times(2)).create(eq(ExecutionPhase.REQUEST), any(PolicyMetadata.class));
 
         verifyNoMoreInteractions(policyManager);
+    }
+
+    @Test
+    public void shouldSetPolicyDescriptionsWhenStepsHaveDescriptions() throws Exception {
+        final HttpPolicy policy1 = mock(HttpPolicy.class);
+        final HttpPolicy policy2 = mock(HttpPolicy.class);
+        final Flow flow = mock(Flow.class);
+        final Step step1 = mock(Step.class);
+        final Step step2 = mock(Step.class);
+
+        when(step1.isEnabled()).thenReturn(true);
+        when(step2.isEnabled()).thenReturn(true);
+        when(step1.getDescription()).thenReturn("description-1");
+        when(step2.getDescription()).thenReturn("description-2");
+        when(step1.getPolicy()).thenReturn("policy-step1");
+        when(step1.getConfiguration()).thenReturn("config-step1");
+        when(step1.getCondition()).thenReturn("condition-step1");
+        when(step2.getPolicy()).thenReturn("policy-step2");
+        when(step2.getConfiguration()).thenReturn("config-step2");
+        when(step2.getCondition()).thenReturn("condition-step2");
+        when(flow.getRequest()).thenReturn(List.of(step1, step2));
+        when(policyManager.create(eq(ExecutionPhase.REQUEST), any(PolicyMetadata.class))).thenReturn(policy1).thenReturn(policy2);
+
+        final HttpPolicyChain policyChain = cut.create("flowchain-test", flow, ExecutionPhase.REQUEST);
+
+        assertThat(policyChain.getPolicyDescriptions()).containsEntry(policy1, "description-1").containsEntry(policy2, "description-2");
+    }
+
+    @Test
+    public void shouldNotSetDescriptionsWhenStepsHaveNoDescriptions() {
+        final HttpPolicy policy1 = mock(HttpPolicy.class);
+        final Flow flow = mock(Flow.class);
+        final Step step1 = mock(Step.class);
+
+        when(step1.isEnabled()).thenReturn(true);
+        when(step1.getDescription()).thenReturn(null);
+        when(step1.getPolicy()).thenReturn("policy-step1");
+        when(step1.getConfiguration()).thenReturn("config-step1");
+        when(step1.getCondition()).thenReturn("condition-step1");
+        when(flow.getRequest()).thenReturn(List.of(step1));
+        when(policyManager.create(eq(ExecutionPhase.REQUEST), any(PolicyMetadata.class))).thenReturn(policy1);
+
+        final HttpPolicyChain policyChain = cut.create("flowchain-test", flow, ExecutionPhase.REQUEST);
+
+        assertThat(policyChain.getPolicyDescriptions()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13410

## Description

Adds the policy description as a `policy.description` span attribute to OpenTelemetry traces when verbose tracing is enabled, improving observability and traceability of policy execution.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

