### PR TITLE
feat(security): enhance JWT handling in security chain 

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/AbstractSecurityChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/AbstractSecurityChain.java
@@ -23,6 +23,7 @@ import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_SECURITY_TOKEN;
 import static io.reactivex.rxjava3.core.Completable.defer;
 
+import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.reactive.api.ComponentType;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
@@ -52,6 +53,10 @@ public abstract class AbstractSecurityChain<
     P extends AbstractSecurityPlan<? extends BaseSecurityPolicy, C>,
     C extends BaseExecutionContext
 > {
+
+    private static final String JWT_SECURITY_TYPE = "JWT";
+    private static final String BEARER_AUTHORIZATION_TYPE = "Bearer";
+    private static final String BEARER_REALM = "gravitee.io";
 
     protected static final String PLAN_UNRESOLVABLE = "GATEWAY_PLAN_UNRESOLVABLE";
     protected static final String PLAN_RESOLUTION_FAILURE = "GATEWAY_PLAN_RESOLUTION_FAILURE";
@@ -106,25 +111,7 @@ public abstract class AbstractSecurityChain<
                                         .message(TEMPORARILY_UNAVAILABLE_MESSAGE)
                                 );
                             }
-
-                            return chain
-                                .filter(securityPlan -> securityPlan instanceof HttpSecurityPlan)
-                                .flatMapSingle(securityPlan -> {
-                                    if (ctx instanceof HttpPlainExecutionContext httpCtx) {
-                                        return ((HttpSecurityPlan) securityPlan).wwwAuthenticate(httpCtx);
-                                    }
-                                    return Single.just(false);
-                                })
-                                .any(Boolean::booleanValue)
-                                .flatMapCompletable(wwwAuthenticate ->
-                                    sendError(
-                                        ctx,
-                                        new ExecutionFailure(UNAUTHORIZED_401)
-                                            .key(PLAN_UNRESOLVABLE)
-                                            .message(securityChainDiagnostic.message())
-                                            .cause(securityChainDiagnostic.cause())
-                                    )
-                                );
+                            return handleUnresolvablePlan(ctx, securityChainDiagnostic);
                         }
                         return Completable.complete();
                     })
@@ -162,5 +149,67 @@ public abstract class AbstractSecurityChain<
                 }
                 return FALSE;
             });
+    }
+
+    private Completable handleUnresolvablePlan(C ctx, SecurityChainDiagnostic securityChainDiagnostic) {
+        return shouldSetDefaultJwtChallenge(ctx).flatMapCompletable(shouldSetJwtChallenge ->
+            sendUnauthorizedWithOptionalJwtChallenge(ctx, securityChainDiagnostic, shouldSetJwtChallenge)
+        );
+    }
+
+    private Single<Boolean> shouldSetDefaultJwtChallenge(C ctx) {
+        return Single.zip(
+            hasWwwAuthenticateHeaderInChain(ctx),
+            chain.any(securityPlan -> securityPlan.hasSecurityType(JWT_SECURITY_TYPE)),
+            this::shouldApplyDefaultJwtChallenge
+        );
+    }
+
+    private Completable sendUnauthorizedWithOptionalJwtChallenge(
+        C ctx,
+        SecurityChainDiagnostic securityChainDiagnostic,
+        Boolean shouldSetJwtChallenge
+    ) {
+        applyDefaultJwtChallengeIfNeeded(ctx, shouldSetJwtChallenge);
+        return sendError(ctx, buildUnresolvablePlanFailure(securityChainDiagnostic));
+    }
+
+    private Single<Boolean> hasWwwAuthenticateHeaderInChain(C ctx) {
+        return chain
+            .filter(securityPlan -> securityPlan instanceof HttpSecurityPlan)
+            .flatMapSingle(securityPlan -> resolveWwwAuthenticate(ctx, securityPlan))
+            .any(Boolean::booleanValue);
+    }
+
+    private Single<Boolean> resolveWwwAuthenticate(C ctx, P securityPlan) {
+        if (ctx instanceof HttpPlainExecutionContext httpCtx) {
+            return ((HttpSecurityPlan) securityPlan).wwwAuthenticate(httpCtx);
+        }
+        return FALSE;
+    }
+
+    private boolean shouldApplyDefaultJwtChallenge(boolean wwwAuthenticate, boolean hasJwtPlan) {
+        return !wwwAuthenticate && hasJwtPlan;
+    }
+
+    private void applyDefaultJwtChallengeIfNeeded(C ctx, Boolean shouldSetJwtChallenge) {
+        if (ctx instanceof HttpPlainExecutionContext httpCtx && Boolean.TRUE.equals(shouldSetJwtChallenge)) {
+            setDefaultBearerChallenge(httpCtx);
+        }
+    }
+
+    private ExecutionFailure buildUnresolvablePlanFailure(SecurityChainDiagnostic securityChainDiagnostic) {
+        return new ExecutionFailure(UNAUTHORIZED_401)
+            .key(PLAN_UNRESOLVABLE)
+            .message(securityChainDiagnostic.message())
+            .cause(securityChainDiagnostic.cause());
+    }
+
+    private static void setDefaultBearerChallenge(HttpPlainExecutionContext ctx) {
+        final var authenticateHeaders = ctx.response().headers().getAll(HttpHeaders.WWW_AUTHENTICATE);
+        if (authenticateHeaders == null || authenticateHeaders.isEmpty()) {
+            String headerValue = BEARER_AUTHORIZATION_TYPE + " realm=\"" + BEARER_REALM + "\"";
+            ctx.response().headers().set(HttpHeaders.WWW_AUTHENTICATE, headerValue);
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/AbstractSecurityPlan.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/AbstractSecurityPlan.java
@@ -114,6 +114,10 @@ public abstract class AbstractSecurityPlan<T extends BaseSecurityPolicy, C exten
         return policy.order();
     }
 
+    public boolean hasSecurityType(String securityType) {
+        return planContext.securityType() != null && planContext.securityType().equalsIgnoreCase(securityType);
+    }
+
     protected abstract Maybe<SecurityToken> extractSecurityToken(final C executionContext);
 
     protected abstract Completable executeSecurityPolicy(final C ctx, final ExecutionPhase executionPhase);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/SecurityPlanContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/security/plan/SecurityPlanContext.java
@@ -24,7 +24,11 @@ import io.gravitee.definition.model.v4.plan.AbstractPlan;
  *
  * @author GraviteeSource Team
  */
-public record SecurityPlanContext(String planId, String planName, String selectionRule) {
+public record SecurityPlanContext(String planId, String planName, String selectionRule, String securityType) {
+    public SecurityPlanContext(String planId, String planName, String selectionRule) {
+        this(planId, planName, selectionRule, null);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -39,6 +43,7 @@ public record SecurityPlanContext(String planId, String planName, String selecti
             this.planId = plan.getId();
             this.planName = plan.getName();
             this.selectionRule = plan.getSelectionRule();
+            this.securityType = plan.getSecurity();
             return this;
         }
 
@@ -46,11 +51,14 @@ public record SecurityPlanContext(String planId, String planName, String selecti
             this.planId = plan.getId();
             this.planName = plan.getName();
             this.selectionRule = plan.getSelectionRule();
+            this.securityType = plan.getSecurity() != null ? plan.getSecurity().getType() : null;
             return this;
         }
 
         public SecurityPlanContext build() {
-            return new SecurityPlanContext(planId, planName, selectionRule);
+            return new SecurityPlanContext(planId, planName, selectionRule, securityType);
         }
+
+        private String securityType;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -216,7 +216,7 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         // Check that the API contains at least one subscription listener.
         return (
             api.getDefinitionVersion() == DefinitionVersion.V4 &&
-            api.getDefinition().getType() == ApiType.PROXY &&
+            (api.getDefinition().getType() == ApiType.PROXY || api.getDefinition().getType() == ApiType.MCP_PROXY) &&
             api
                 .getDefinition()
                 .getListeners()
@@ -454,7 +454,7 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
 
     private List<TemplateVariableProvider> ctxTemplateVariableProviders(Api api) {
         final List<TemplateVariableProvider> requestTemplateVariableProviders = commonTemplateVariableProviders(api);
-        if (api.getDefinition().getType() == ApiType.PROXY) {
+        if (api.getDefinition().getType() == ApiType.PROXY || api.getDefinition().getType() == ApiType.MCP_PROXY) {
             requestTemplateVariableProviders.add(new ContentTemplateVariableProvider());
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/security/HttpSecurityChainTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/security/HttpSecurityChainTest.java
@@ -23,11 +23,13 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.Plan;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpResponse;
 import io.gravitee.gateway.reactive.api.policy.SecurityPolicy;
 import io.gravitee.gateway.reactive.api.policy.SecurityToken;
 import io.gravitee.gateway.reactive.policy.PolicyManager;
@@ -38,6 +40,7 @@ import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,11 +73,17 @@ class HttpSecurityChainTest {
     @Mock
     private Configuration configuration;
 
+    @Mock
+    private HttpResponse response;
+
     @BeforeEach
     void setUp() {
         lenient().when(ctx.withLogger(any())).thenReturn(NOPLogger.NOP_LOGGER);
         lenient().when(configuration.getProperty("api.security.verbose401", Boolean.class, false)).thenReturn(false);
         lenient().when(ctx.getComponent(Configuration.class)).thenReturn(configuration);
+        lenient().when(ctx.response()).thenReturn(response);
+        lenient().when(response.headers()).thenReturn(io.gravitee.gateway.api.http.HttpHeaders.create());
+        setupInternalAttributesMock();
     }
 
     @Test
@@ -169,9 +178,9 @@ class HttpSecurityChainTest {
 
     @Test
     void shouldInterrupt401WhenNoPolicyHasRelevantSecurityTokenAndWwwAuthenticateReturnsFalse() {
-        final Plan plan1 = mockPlan("plan1");
+        final Plan plan1 = mockPlan("plan1", "jwt");
         final Plan plan2 = mockPlan("plan2");
-        final SecurityPolicy policy1 = mockSecurityPolicy("plan1", false, false);
+        final SecurityPolicy policy1 = mockSecurityPolicy("plan1", "jwt", false, false);
         final SecurityPolicy policy2 = mockSecurityPolicy("plan2", false, false);
 
         final ArrayList<Plan> plans = new ArrayList<>();
@@ -192,6 +201,7 @@ class HttpSecurityChainTest {
         obs.assertError(Throwable.class);
         verifyUnauthorized();
         verify(ctx, times(1)).removeInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
+        assertEquals(List.of("Bearer realm=\"gravitee.io\""), response.headers().getAll(HttpHeaders.WWW_AUTHENTICATE));
     }
 
     @Test
@@ -213,6 +223,27 @@ class HttpSecurityChainTest {
         obs.assertError(Throwable.class);
         verifyUnauthorized();
         verify(ctx, times(1)).removeInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
+    }
+
+    @Test
+    void shouldNotAddWwwAuthenticateHeaderWhenNoJwtPlan() {
+        final Plan plan1 = mockPlan("plan1", "oauth2");
+        final SecurityPolicy policy1 = mockSecurityPolicy("plan1", "oauth2", false, false);
+
+        final ArrayList<Plan> plans = new ArrayList<>();
+        plans.add(plan1);
+
+        when(api.getPlans()).thenReturn(plans);
+        when(policy1.wwwAuthenticate(any())).thenReturn(Single.just(false));
+        when(ctx.interruptWith(any())).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
+
+        final HttpSecurityChain cut = new HttpSecurityChain(api, policyManager, ExecutionPhase.REQUEST);
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+
+        obs.assertError(Throwable.class);
+        verifyUnauthorized();
+        List<String> authenticateHeaders = response.headers().getAll(HttpHeaders.WWW_AUTHENTICATE);
+        Assertions.assertTrue(authenticateHeaders == null || authenticateHeaders.isEmpty());
     }
 
     @Test
@@ -273,17 +304,21 @@ class HttpSecurityChainTest {
 
     private void setupInternalAttributesMock() {
         Map<String, Object> internalAttributes = new HashMap<>();
-        doAnswer(inv -> {
-            internalAttributes.put(inv.getArgument(0), inv.getArgument(1));
-            return null;
-        })
+        lenient()
+            .doAnswer(inv -> {
+                internalAttributes.put(inv.getArgument(0), inv.getArgument(1));
+                return null;
+            })
             .when(ctx)
             .setInternalAttribute(anyString(), any());
-        when(ctx.getInternalAttribute(anyString())).thenAnswer(inv -> internalAttributes.get(inv.<String>getArgument(0)));
-        doAnswer(inv -> {
-            internalAttributes.remove(inv.<String>getArgument(0));
-            return null;
-        })
+        lenient()
+            .when(ctx.getInternalAttribute(anyString()))
+            .thenAnswer(inv -> internalAttributes.get(inv.<String>getArgument(0)));
+        lenient()
+            .doAnswer(inv -> {
+                internalAttributes.remove(inv.<String>getArgument(0));
+                return null;
+            })
             .when(ctx)
             .removeInternalAttribute(anyString());
     }
@@ -303,24 +338,29 @@ class HttpSecurityChainTest {
     }
 
     private Plan mockPlan(String name) {
+        return mockPlan(name, MOCK_POLICY + "-" + name);
+    }
+
+    private Plan mockPlan(String name, String security) {
         final Plan plan = mock(Plan.class);
 
-        when(plan.getSecurity()).thenReturn(MOCK_POLICY + "-" + name);
+        when(plan.getSecurity()).thenReturn(security);
         when(plan.getSecurityDefinition()).thenReturn(MOCK_POLICY_CONFIG + '-' + name);
 
         return plan;
     }
 
     private SecurityPolicy mockSecurityPolicy(String name, boolean hasSecurityToken, boolean validateSubscription) {
+        return mockSecurityPolicy(name, MOCK_POLICY + "-" + name, hasSecurityToken, validateSubscription);
+    }
+
+    private SecurityPolicy mockSecurityPolicy(String name, String securityType, boolean hasSecurityToken, boolean validateSubscription) {
         final SecurityPolicy policy = mock(SecurityPolicy.class);
 
         when(
             policyManager.create(
                 eq(ExecutionPhase.REQUEST),
-                argThat(
-                    meta ->
-                        meta.getName().equals(MOCK_POLICY + "-" + name) && meta.getConfiguration().equals(MOCK_POLICY_CONFIG + '-' + name)
-                )
+                argThat(meta -> meta.getName().equals(securityType) && meta.getConfiguration().equals(MOCK_POLICY_CONFIG + '-' + name))
             )
         ).thenReturn(policy);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
@@ -207,6 +207,15 @@ class DefaultApiReactorFactoryTest {
         }
 
         @Test
+        void should_create_mcp_proxy_api_with_http_listener() {
+            when(definition.getType()).thenReturn(ApiType.MCP_PROXY);
+            when(definition.getListeners()).thenReturn(Collections.singletonList(new HttpListener()));
+
+            boolean create = cut.canCreate(anApi());
+            assertTrue(create);
+        }
+
+        @Test
         void should_not_create_api_with_subscription_listener() {
             when(definition.getListeners()).thenReturn(Collections.singletonList(new SubscriptionListener()));
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/main/java/io/gravitee/gateway/security/jwt/policy/CheckSubscriptionPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/main/java/io/gravitee/gateway/security/jwt/policy/CheckSubscriptionPolicy.java
@@ -17,8 +17,10 @@ package io.gravitee.gateway.security.jwt.policy;
 
 import static io.gravitee.reporter.api.http.SecurityType.JWT;
 
+import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.policy.Policy;
@@ -36,7 +38,7 @@ public class CheckSubscriptionPolicy implements Policy {
     static final String CONTEXT_ATTRIBUTE_PLAN_SELECTION_RULE_BASED =
         ExecutionContext.ATTR_PREFIX + ExecutionContext.ATTR_PLAN + ".selection.rule.based";
     static final String CONTEXT_ATTRIBUTE_CLIENT_ID = "oauth.client_id";
-
+    static final String BEARER_AUTHORIZATION_TYPE = "Bearer";
     static final String OAUTH2_UNAUTHORIZED_MESSAGE = "Unauthorized";
     static final String GATEWAY_OAUTH2_ACCESS_DENIED_KEY = "GATEWAY_OAUTH2_ACCESS_DENIED";
 
@@ -80,13 +82,22 @@ public class CheckSubscriptionPolicy implements Policy {
             }
         }
 
-        policyChain.failWith(
-            PolicyResult.failure(GATEWAY_OAUTH2_ACCESS_DENIED_KEY, HttpStatusCode.UNAUTHORIZED_401, OAUTH2_UNAUTHORIZED_MESSAGE)
-        );
+        sendError(executionContext.response(), policyChain);
     }
 
     @Override
     public String id() {
         return "check-subscription";
+    }
+
+    private void sendError(Response response, PolicyChain policyChain) {
+        final var authenticateHeaders = response.headers().getAll(HttpHeaders.WWW_AUTHENTICATE);
+        if (authenticateHeaders == null || authenticateHeaders.isEmpty()) {
+            String headerValue = BEARER_AUTHORIZATION_TYPE + " realm=\"gravitee.io\"";
+            response.headers().set(HttpHeaders.WWW_AUTHENTICATE, headerValue);
+        }
+        policyChain.failWith(
+            PolicyResult.failure(GATEWAY_OAUTH2_ACCESS_DENIED_KEY, HttpStatusCode.UNAUTHORIZED_401, OAUTH2_UNAUTHORIZED_MESSAGE)
+        );
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/test/java/io/gravitee/gateway/security/jwt/policy/CheckSubscriptionPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/test/java/io/gravitee/gateway/security/jwt/policy/CheckSubscriptionPolicyTest.java
@@ -17,8 +17,10 @@ package io.gravitee.gateway.security.jwt.policy;
 
 import static io.gravitee.reporter.api.http.Metrics.on;
 import static java.lang.System.currentTimeMillis;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
@@ -72,10 +74,14 @@ public class CheckSubscriptionPolicyTest {
     public void shouldReturnUnauthorized_noSubscription() throws PolicyException {
         CheckSubscriptionPolicy policy = new CheckSubscriptionPolicy();
 
+        Response response = mock(Response.class);
+        io.gravitee.gateway.api.http.HttpHeaders headers = io.gravitee.gateway.api.http.HttpHeaders.create();
         PolicyChain policyChain = mock(PolicyChain.class);
 
         // Search subscription now includes all criteria so the result is empty in case of bad clientId or planId.
         when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.empty());
+        when(executionContext.response()).thenReturn(response);
+        when(response.headers()).thenReturn(headers);
 
         policy.execute(policyChain, executionContext);
 
@@ -86,6 +92,33 @@ public class CheckSubscriptionPolicyTest {
                     CheckSubscriptionPolicy.GATEWAY_OAUTH2_ACCESS_DENIED_KEY.equals(result.key())
             )
         );
+        assertEquals("Bearer realm=\"gravitee.io\"", headers.getFirst(HttpHeaders.WWW_AUTHENTICATE));
+    }
+
+    @Test
+    public void shouldKeepExistingWwwAuthenticateHeader_noSubscription() throws PolicyException {
+        CheckSubscriptionPolicy policy = new CheckSubscriptionPolicy();
+
+        Response response = mock(Response.class);
+        io.gravitee.gateway.api.http.HttpHeaders headers = io.gravitee.gateway.api.http.HttpHeaders.create();
+        headers.add(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"existing\"");
+        PolicyChain policyChain = mock(PolicyChain.class);
+
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.empty());
+        when(executionContext.response()).thenReturn(response);
+        when(response.headers()).thenReturn(headers);
+
+        policy.execute(policyChain, executionContext);
+
+        verify(policyChain, times(1)).failWith(
+            argThat(
+                result ->
+                    result.statusCode() == HttpStatusCode.UNAUTHORIZED_401 &&
+                    CheckSubscriptionPolicy.GATEWAY_OAUTH2_ACCESS_DENIED_KEY.equals(result.key())
+            )
+        );
+        assertEquals("Basic realm=\"existing\"", headers.getFirst(HttpHeaders.WWW_AUTHENTICATE));
+        assertEquals(1, headers.getAll(HttpHeaders.WWW_AUTHENTICATE).size());
     }
 
     @Test


### PR DESCRIPTION
Enhance JWT handling in security chain
## Issue

https://gravitee.atlassian.net/browse/APIM-13239

## Description

This pull request implements logic to automatically provide a default WWW-Authenticate header with a Bearer challenge when a JWT security plan is active but no challenge is present.

## Additional context

Pre Fix behaviour: 


https://github.com/user-attachments/assets/330b6757-356a-4078-928f-f261ebd10f09

Post fix behaviour: 

https://github.com/user-attachments/assets/d0c760ad-838a-4537-98ec-a0f6dd76a595



