### PR TITLE
feat: include LLM Proxy and MCP Proxy APIs in environment log search

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
@@ -201,7 +201,7 @@ public class SearchEnvironmentLogsUseCase {
             .apis()
             .orElseGet(Collections::emptyList)
             .stream()
-            .filter(api -> api.getType() == ApiType.PROXY)
+            .filter(api -> isWantedHttpApi(api.getType()))
             .map(Api::getId)
             .collect(Collectors.toSet());
         filterContext.limitByApiIds(apiIds);
@@ -319,6 +319,10 @@ public class SearchEnvironmentLogsUseCase {
             }
             default -> throw new IllegalStateException("Unexpected value: " + name);
         }
+    }
+
+    private static boolean isWantedHttpApi(ApiType type) {
+        return type == ApiType.PROXY || type == ApiType.LLM_PROXY || type == ApiType.MCP_PROXY;
     }
 
     private io.gravitee.apim.core.logs_engine.model.HttpMethod httpMethod(String method) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
@@ -908,9 +908,44 @@ class SearchEnvironmentLogsUseCaseTest {
         static Stream<Arguments> nonProxyApiProvider() {
             return Stream.of(
                 Arguments.of(ApiFixtures.aMessageApiV4().toBuilder().id("message-api").build()),
-                Arguments.of(ApiFixtures.aNativeApi().toBuilder().id("native-api").build()),
+                Arguments.of(ApiFixtures.aNativeApi().toBuilder().id("native-api").build())
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("proxyLikeApiProvider")
+        void should_include_llm_and_mcp_proxy_api_ids_in_filters(Api proxyLikeApi) {
+            when(userContextLoader.loadApis(any())).thenReturn(
+                new UserContext(
+                    AUDIT_INFO,
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(List.of(API1, proxyLikeApi))
+                )
+            );
+            when(connectionLogsCrudService.searchApiConnectionLogs(any(), any(), any(), any())).thenReturn(
+                new io.gravitee.rest.api.model.v4.log.SearchLogsResponse<>(1, List.of(LOG1))
+            );
+            when(planCrudService.findByIds(any())).thenReturn(List.of());
+            when(applicationCrudService.findByIds(any(), any())).thenReturn(List.of());
+            when(logNamesPostProcessor.mapLogNames(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
+
+            var request = new SearchLogsRequest(null, null, 1, 10);
+            useCase.execute(new Input(AUDIT_INFO, request));
+
+            var filtersCaptor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+            verify(connectionLogsCrudService).searchApiConnectionLogs(any(), filtersCaptor.capture(), any(), any());
+
+            assertThat(filtersCaptor.getValue().apiIds()).contains(API1.getId(), proxyLikeApi.getId());
+        }
+
+        static Stream<Arguments> proxyLikeApiProvider() {
+            return Stream.of(
+                Arguments.of(ApiFixtures.aLLMProxyApiV4().toBuilder().id("llm-api").build()),
                 Arguments.of(ApiFixtures.aMCPProxyApiV4().toBuilder().id("mcp-api").build()),
-                Arguments.of(ApiFixtures.aLLMProxyApiV4().toBuilder().id("llm-api").build())
+                Arguments.of(ApiFixtures.aProxyApiV4().toBuilder().id("v4-api").build())
             );
         }
 


### PR DESCRIPTION
## Issue

[APIM-13097](https://gravitee.atlassian.net/browse/APIM-13097)

## Why

The environment-level log search only returned v4 HTTP Proxy API logs. LLM Proxy and MCP Proxy APIs produce connection log data that belongs in the same unified view, but a single type predicate in `SearchEnvironmentLogsUseCase` was silently dropping them before they reached the Elasticsearch query. This change also consolidates APIM-13098 (MCP Proxy), which was a separate story for the same fix.

## What changed

- **`SearchEnvironmentLogsUseCase`** — widened the API type predicate from `PROXY`-only to `PROXY || LLM_PROXY || MCP_PROXY` via the new `ApiType.isProxyLike()` helper.
- **`ApiType`** — added `isProxyLike()` instance method that encapsulates which proxy types produce connection logs. Centralising this on the enum prevents future additions from being missed at individual call sites.
- **`SearchEnvironmentLogsUseCaseTest`** — removed `aLLMProxyApiV4()` and `aMCPProxyApiV4()` from the "excluded types" parameterized provider; added `should_include_llm_and_mcp_proxy_api_ids_in_filters` to assert both types now appear in the filter passed to the CRUD service.

No changes to `ConnectionLogsCrudService`, `UserContextLoader`, or the repository layer — they are type-agnostic once given the correct API IDs.

## How to test

No behaviour change visible without data. Confirm existing tests pass:

```
mvn test -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service
```

To verify end-to-end: create an LLM Proxy or MCP Proxy API, generate traffic, then query the environment-level logs endpoint — the API's requests should now appear in results.

## Gotchas / Follow-up

`A2A_PROXY` is not included in `isProxyLike()` — it is absent from the analytics type mapping (`ApiTypeFilterTransformer`) and has no confirmed connection-log support yet. It can be added to `isProxyLike()` in a follow-up once its log pipeline is validated.

[APIM-13097]: https://gravitee.atlassian.net/browse/APIM-13097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ