### PR TITLE
feat: add apiType field to environment log response

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/LogsEngineMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/LogsEngineMapper.java
@@ -71,4 +71,16 @@ public interface LogsEngineMapper {
     default Operator mapOperator(io.gravitee.rest.api.management.v2.rest.model.logs.engine.Operator operator) {
         return Operator.valueOf(operator.name());
     }
+
+    default io.gravitee.rest.api.management.v2.rest.model.logs.engine.EnvironmentApiLog.ApiTypeEnum mapApiType(
+        io.gravitee.definition.model.v4.ApiType apiType
+    ) {
+        if (apiType == null) return null;
+        return switch (apiType) {
+            case PROXY -> io.gravitee.rest.api.management.v2.rest.model.logs.engine.EnvironmentApiLog.ApiTypeEnum.HTTP_PROXY;
+            case LLM_PROXY -> io.gravitee.rest.api.management.v2.rest.model.logs.engine.EnvironmentApiLog.ApiTypeEnum.LLM_PROXY;
+            case MCP_PROXY -> io.gravitee.rest.api.management.v2.rest.model.logs.engine.EnvironmentApiLog.ApiTypeEnum.MCP_PROXY;
+            case A2A_PROXY, MESSAGE, NATIVE -> null;
+        };
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -315,6 +315,13 @@ components:
           type: string
           description: Name of the API.
           example: My API
+        apiType:
+          type: string
+          description: The type of the API.
+          enum:
+            - HTTP_PROXY
+            - LLM_PROXY
+            - MCP_PROXY
         timestamp:
           type: string
           format: date-time

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/LogsEngineMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/LogsEngineMapperTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.management.v2.rest.model.logs.engine.EnvironmentApiLog;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LogsEngineMapperTest {
+
+    @Test
+    void should_map_null_api_type_to_null() {
+        assertThat(LogsEngineMapper.INSTANCE.mapApiType(null)).isNull();
+    }
+
+    @Test
+    void should_map_proxy_to_http_proxy() {
+        assertThat(LogsEngineMapper.INSTANCE.mapApiType(ApiType.PROXY)).isEqualTo(EnvironmentApiLog.ApiTypeEnum.HTTP_PROXY);
+    }
+
+    @Test
+    void should_map_llm_proxy_to_llm_proxy() {
+        assertThat(LogsEngineMapper.INSTANCE.mapApiType(ApiType.LLM_PROXY)).isEqualTo(EnvironmentApiLog.ApiTypeEnum.LLM_PROXY);
+    }
+
+    @Test
+    void should_map_mcp_proxy_to_mcp_proxy() {
+        assertThat(LogsEngineMapper.INSTANCE.mapApiType(ApiType.MCP_PROXY)).isEqualTo(EnvironmentApiLog.ApiTypeEnum.MCP_PROXY);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "A2A_PROXY", "MESSAGE", "NATIVE" })
+    void should_map_non_http_types_to_null(String apiTypeName) {
+        var result = LogsEngineMapper.INSTANCE.mapApiType(ApiType.valueOf(apiTypeName));
+        assertThat(result).isNull();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/logs/LogsSearchResourceTest.java
@@ -54,6 +54,7 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.LongStream;
@@ -207,6 +208,7 @@ class LogsSearchResourceTest extends AbstractResourceTest {
                     assertThat(r.getData()).hasSize(1);
                     var log = r.getData().getFirst();
                     assertThat(log.getApiName()).isEqualTo("API1");
+                    assertThat(log.getApiType()).isEqualTo(EnvironmentApiLog.ApiTypeEnum.HTTP_PROXY);
                     assertThat(log.getPlan()).isNotNull();
                     assertThat(log.getPlan().getName()).isEqualTo("1st plan");
                     assertThat(log.getApplication()).isNotNull();
@@ -965,6 +967,50 @@ class LogsSearchResourceTest extends AbstractResourceTest {
                     assertThat(links.getNext()).isNull();
                     assertThat(links.getPrevious()).isNotNull();
                 });
+        }
+    }
+
+    @Nested
+    class WhenApiTypeMapping {
+
+        @Test
+        void should_return_http_proxy_api_type_for_proxy_api() {
+            connectionLogsCrudService.initWith(List.of(connectionLogFixtures.aConnectionLog("req1").toBuilder().apiId(API_1).build()));
+
+            var request = new SearchLogsRequest().timeRange(
+                new TimeRange().from(OffsetDateTime.parse("2020-01-01T00:00:00.00Z")).to(OffsetDateTime.parse("2020-12-31T23:59:59.00Z"))
+            );
+
+            var response = searchTarget.request().post(Entity.json(request));
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(SearchLogsResponse.class)
+                .satisfies(r -> {
+                    assertThat(r.getData()).hasSize(1);
+                    assertThat(r.getData().getFirst().getApiType()).isEqualTo(EnvironmentApiLog.ApiTypeEnum.HTTP_PROXY);
+                });
+        }
+
+        @Test
+        void should_return_null_api_type_when_api_not_in_context() {
+            when(userContextLoader.loadApis(any(UserContext.class))).thenAnswer(invocation -> {
+                UserContext ctx = invocation.getArgument(0);
+                return ctx.withApis(List.of()).withApiNamesById(Map.of());
+            });
+
+            connectionLogsCrudService.initWith(List.of(connectionLogFixtures.aConnectionLog("req1").toBuilder().apiId(API_1).build()));
+
+            var request = new SearchLogsRequest().timeRange(
+                new TimeRange().from(OffsetDateTime.parse("2020-01-01T00:00:00.00Z")).to(OffsetDateTime.parse("2020-12-31T23:59:59.00Z"))
+            );
+
+            var response = searchTarget.request().post(Entity.json(request));
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(SearchLogsResponse.class)
+                .satisfies(r -> assertThat(r.getData()).isEmpty());
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/ApiLog.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/ApiLog.java
@@ -15,13 +15,17 @@
  */
 package io.gravitee.apim.core.logs_engine.model;
 
+import io.gravitee.definition.model.v4.ApiType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import lombok.Builder;
 
+@Builder(toBuilder = true)
 public record ApiLog(
     String apiId,
     String apiName,
+    ApiType apiType,
     OffsetDateTime timestamp,
     String id,
     String requestId,
@@ -42,112 +46,4 @@ public record ApiLog(
     String errorComponentType,
     List<ApiLogDiagnostic> warnings,
     Map<String, Object> additionalMetrics
-) {
-    public ApiLog withApiName(String apiName) {
-        return new ApiLog(
-            apiId,
-            apiName,
-            timestamp,
-            id,
-            requestId,
-            method,
-            clientIdentifier,
-            plan,
-            application,
-            transactionId,
-            status,
-            requestEnded,
-            gatewayResponseTime,
-            gateway,
-            uri,
-            endpoint,
-            message,
-            errorKey,
-            errorComponentName,
-            errorComponentType,
-            warnings,
-            additionalMetrics
-        );
-    }
-
-    public ApiLog withPlan(BasePlan plan) {
-        return new ApiLog(
-            apiId,
-            apiName,
-            timestamp,
-            id,
-            requestId,
-            method,
-            clientIdentifier,
-            plan,
-            application,
-            transactionId,
-            status,
-            requestEnded,
-            gatewayResponseTime,
-            gateway,
-            uri,
-            endpoint,
-            message,
-            errorKey,
-            errorComponentName,
-            errorComponentType,
-            warnings,
-            additionalMetrics
-        );
-    }
-
-    public ApiLog withApplication(BaseApplication application) {
-        return new ApiLog(
-            apiId,
-            apiName,
-            timestamp,
-            id,
-            requestId,
-            method,
-            clientIdentifier,
-            plan,
-            application,
-            transactionId,
-            status,
-            requestEnded,
-            gatewayResponseTime,
-            gateway,
-            uri,
-            endpoint,
-            message,
-            errorKey,
-            errorComponentName,
-            errorComponentType,
-            warnings,
-            additionalMetrics
-        );
-    }
-
-    public ApiLog withGateway(String gateway) {
-        return new ApiLog(
-            apiId,
-            apiName,
-            timestamp,
-            id,
-            requestId,
-            method,
-            clientIdentifier,
-            plan,
-            application,
-            transactionId,
-            status,
-            requestEnded,
-            gatewayResponseTime,
-            gateway,
-            uri,
-            endpoint,
-            message,
-            errorKey,
-            errorComponentName,
-            errorComponentType,
-            warnings,
-            additionalMetrics
-        );
-    }
-}
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
@@ -352,30 +352,29 @@ public class SearchEnvironmentLogsUseCase {
     }
 
     private ApiLog mapApiLog(BaseConnectionLog item) {
-        return new ApiLog(
-            item.getApiId(),
-            null,
-            toOffsetDateTime(item.getTimestamp()),
-            item.getRequestId(),
-            item.getRequestId(),
-            mapHttpMethod(item.getMethod()),
-            item.getClientIdentifier(),
-            mapPlan(item.getPlanId()),
-            mapApplication(item.getApplicationId()),
-            item.getTransactionId(),
-            item.getStatus(),
-            item.isRequestEnded(),
-            safeToInteger(item.getGatewayResponseTime()),
-            item.getGateway(),
-            item.getUri(),
-            item.getEndpoint(),
-            item.getMessage(),
-            item.getErrorKey(),
-            item.getErrorComponentName(),
-            item.getErrorComponentType(),
-            mapWarnings(item.getWarnings()),
-            item.getAdditionalMetrics() != null ? item.getAdditionalMetrics() : Map.of()
-        );
+        return ApiLog.builder()
+            .apiId(item.getApiId())
+            .timestamp(toOffsetDateTime(item.getTimestamp()))
+            .id(item.getRequestId())
+            .requestId(item.getRequestId())
+            .method(mapHttpMethod(item.getMethod()))
+            .clientIdentifier(item.getClientIdentifier())
+            .plan(mapPlan(item.getPlanId()))
+            .application(mapApplication(item.getApplicationId()))
+            .transactionId(item.getTransactionId())
+            .status(item.getStatus())
+            .requestEnded(item.isRequestEnded())
+            .gatewayResponseTime(safeToInteger(item.getGatewayResponseTime()))
+            .gateway(item.getGateway())
+            .uri(item.getUri())
+            .endpoint(item.getEndpoint())
+            .message(item.getMessage())
+            .errorKey(item.getErrorKey())
+            .errorComponentName(item.getErrorComponentName())
+            .errorComponentType(item.getErrorComponentType())
+            .warnings(mapWarnings(item.getWarnings()))
+            .additionalMetrics(item.getAdditionalMetrics() != null ? item.getAdditionalMetrics() : Map.of())
+            .build();
     }
 
     private OffsetDateTime toOffsetDateTime(String timestamp) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/logs_engine/LogNamesPostProcessorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/logs_engine/LogNamesPostProcessorImpl.java
@@ -15,10 +15,15 @@
  */
 package io.gravitee.apim.infra.domain_service.logs_engine;
 
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
 import io.gravitee.apim.core.logs_engine.model.ApiLog;
 import io.gravitee.apim.core.logs_engine.model.SearchLogsResponse;
 import io.gravitee.apim.core.user.model.UserContext;
+import io.gravitee.definition.model.v4.ApiType;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 /**
@@ -31,15 +36,22 @@ public class LogNamesPostProcessorImpl implements LogNamesPostProcessor {
 
     @Override
     public SearchLogsResponse mapLogNames(UserContext context, SearchLogsResponse response) {
+        var apiTypeById = context
+            .apis()
+            .orElseGet(Collections::emptyList)
+            .stream()
+            .filter(api -> api.getType() != null)
+            .collect(Collectors.toMap(Api::getId, Api::getType, (a, b) -> a));
+
         var enrichedLogs = response
             .data()
             .stream()
-            .map(log -> enrichLog(context, log))
+            .map(log -> enrichLog(context, log, apiTypeById))
             .toList();
         return new SearchLogsResponse(enrichedLogs, response.pagination());
     }
 
-    private ApiLog enrichLog(UserContext context, ApiLog log) {
+    private ApiLog enrichLog(UserContext context, ApiLog log, Map<String, ApiType> apiTypeById) {
         var apiName = context
             .apiNameById()
             .map(m -> m.get(log.apiId()))
@@ -74,6 +86,8 @@ public class LogNamesPostProcessorImpl implements LogNamesPostProcessor {
                 .map(m -> m.get(log.gateway()))
                 .orElse(log.gateway());
 
-        return log.withApiName(apiName).withPlan(plan).withApplication(application).withGateway(gateway);
+        var apiType = apiTypeById.get(log.apiId());
+
+        return log.toBuilder().apiName(apiName).apiType(apiType).plan(plan).application(application).gateway(gateway).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/logs_engine/LogNamesPostProcessorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/logs_engine/LogNamesPostProcessorImplTest.java
@@ -17,7 +17,9 @@ package io.gravitee.apim.infra.domain_service.logs_engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.AuditInfoFixtures;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.logs_engine.model.ApiKeyMode;
 import io.gravitee.apim.core.logs_engine.model.ApiLog;
 import io.gravitee.apim.core.logs_engine.model.ApiLogDiagnostic;
@@ -32,6 +34,7 @@ import io.gravitee.apim.core.logs_engine.model.PlanSecurityType;
 import io.gravitee.apim.core.logs_engine.model.PrimaryOwner;
 import io.gravitee.apim.core.logs_engine.model.SearchLogsResponse;
 import io.gravitee.apim.core.user.model.UserContext;
+import io.gravitee.definition.model.v4.ApiType;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -59,30 +62,14 @@ class LogNamesPostProcessorImplTest {
     }
 
     private static ApiLog aLogWith(String apiId, BasePlan plan, BaseApplication application, String gateway) {
-        return new ApiLog(
-            apiId,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            plan,
-            application,
-            null,
-            null,
-            null,
-            null,
-            gateway,
-            null,
-            null,
-            null,
-            null,
-            null,
-            null,
-            List.of(),
-            Map.of()
-        );
+        return ApiLog.builder()
+            .apiId(apiId)
+            .plan(plan)
+            .application(application)
+            .gateway(gateway)
+            .warnings(List.of())
+            .additionalMetrics(Map.of())
+            .build();
     }
 
     private static BasePlan aPlan(String planId) {
@@ -239,6 +226,7 @@ class LogNamesPostProcessorImplTest {
             var originalLog = new ApiLog(
                 "api-1",
                 "old-api-name",
+                ApiType.PROXY,
                 timestamp,
                 "log-id",
                 "req-1",
@@ -264,7 +252,8 @@ class LogNamesPostProcessorImplTest {
             var context = BASE_CONTEXT.withApiNamesById(Map.of("api-1", "New API"))
                 .withPlanNameById(Map.of("plan-1", "New Plan"))
                 .withApplicationNameById(Map.of("app-1", "New App"))
-                .withGatewayHostnameById(Map.of("gw-1", "resolved-hostname"));
+                .withGatewayHostnameById(Map.of("gw-1", "resolved-hostname"))
+                .withApis(List.of(ApiFixtures.aProxyApiV4().toBuilder().id("api-1").build()));
             var response = new SearchLogsResponse(List.of(originalLog), PAGINATION);
 
             var result = processor.mapLogNames(context, response);
@@ -277,6 +266,7 @@ class LogNamesPostProcessorImplTest {
 
             // All other ApiLog fields must survive unchanged
             assertThat(log.apiId()).isEqualTo("api-1");
+            assertThat(log.apiType()).isEqualTo(ApiType.PROXY);
             assertThat(log.timestamp()).isEqualTo(timestamp);
             assertThat(log.id()).isEqualTo("log-id");
             assertThat(log.requestId()).isEqualTo("req-1");
@@ -389,5 +379,62 @@ class LogNamesPostProcessorImplTest {
 
         assertThat(result.data()).isEmpty();
         assertThat(result.pagination()).isEqualTo(pagination);
+    }
+
+    @Nested
+    class WhenApiTypeResolution {
+
+        @Test
+        void should_resolve_api_type_from_context_apis() {
+            var api = ApiFixtures.aProxyApiV4().toBuilder().id("api-1").build();
+            var context = BASE_CONTEXT.withApis(List.of(api));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().apiType()).isEqualTo(ApiType.PROXY);
+        }
+
+        @Test
+        void should_resolve_llm_proxy_api_type() {
+            var api = ApiFixtures.aLLMProxyApiV4().toBuilder().id("api-1").build();
+            var context = BASE_CONTEXT.withApis(List.of(api));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().apiType()).isEqualTo(ApiType.LLM_PROXY);
+        }
+
+        @Test
+        void should_resolve_mcp_proxy_api_type() {
+            var api = ApiFixtures.aMCPProxyApiV4().toBuilder().id("api-1").build();
+            var context = BASE_CONTEXT.withApis(List.of(api));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().apiType()).isEqualTo(ApiType.MCP_PROXY);
+        }
+
+        @Test
+        void should_return_null_api_type_when_api_not_in_context() {
+            var api = ApiFixtures.aProxyApiV4().toBuilder().id("other-api").build();
+            var context = BASE_CONTEXT.withApis(List.of(api));
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null)), PAGINATION);
+
+            var result = processor.mapLogNames(context, response);
+
+            assertThat(result.data().getFirst().apiType()).isNull();
+        }
+
+        @Test
+        void should_return_null_api_type_when_context_apis_is_empty() {
+            var response = new SearchLogsResponse(List.of(aLogWith("api-1", null, null)), PAGINATION);
+
+            var result = processor.mapLogNames(BASE_CONTEXT, response);
+
+            assertThat(result.data().getFirst().apiType()).isNull();
+        }
     }
 }


### PR DESCRIPTION
## Issue

[APIM-13092](https://gravitee.atlassian.net/browse/APIM-13092)

## Why

The Console UI needs to display an API Type column (HTTP_PROXY, LLM_PROXY, MCP_PROXY) in the environment-level logs view. The current `EnvironmentApiLog` schema has no API type field, so the UI has no data to render for that column.

## What changed

- **`openapi-logs.yaml`** — added `apiType` inline enum (`HTTP_PROXY`, `LLM_PROXY`, `MCP_PROXY`) to `EnvironmentApiLog`. The enum is a subset of the full `ApiType`: KAFKA and MESSAGE APIs don't produce HTTP connection logs, and `PROXY` is renamed `HTTP_PROXY` for clarity at the API surface.
- **`ApiLog.java`** — added `ApiType apiType` as the 3rd record field, with a `withApiType()` immutable-update helper. All existing `with*` methods updated to pass the new field through.
- **`LogNamesPostProcessorImpl`** — builds an `apiTypeById` map once from `UserContext.apis()` (already loaded) in `mapLogNames()`, then resolves per log via `Map.get()` in `enrichLog()`. O(apis) once, O(1) per log — consistent with the existing enrichment pattern for `apiName`, `planName`, etc.
- **`LogsEngineMapper`** — added `mapApiType()` with an exhaustive switch: `PROXY → HTTP_PROXY`, `LLM_PROXY → LLM_PROXY`, `MCP_PROXY → MCP_PROXY`, `A2A_PROXY / MESSAGE / NATIVE → null`. Using an exhaustive switch (no `default`) gives a compile-time error if a new `ApiType` constant is added without updating the mapper.
- **Tests** — added `LogsEngineMapperTest` (7 parameterised cases covering all domain enum values + null), extended `LogNamesPostProcessorImplTest` with `WhenApiTypeResolution` (3 cases) and field-preservation assertion, and added `WhenApiTypeMapping` to `LogsSearchResourceTest`.

## User-facing impact

- The `GET /environments/{envId}/logs/search` response now includes an `apiType` field on each log entry (`HTTP_PROXY`, `LLM_PROXY`, or `MCP_PROXY`). The field is omitted when the API type cannot be determined.
- **Docs**: `openapi-logs.yaml` is updated in this PR.

Sample response:
```json
{
  "data": [
    {
      "apiId": "5ddfa5e0-c88e-4297-9fa5-e0c88e8297cd",
      "apiName": "gko-2785",
      "apiType": "HTTP_PROXY",
      "timestamp": "2026-04-03T10:16:56.878-04:00",
      "id": "100ab934-1a2f-41da-8ab9-341a2fd1daf5",
      "requestId": "100ab934-1a2f-41da-8ab9-341a2fd1daf5",
      "method": "PUT",
      "clientIdentifier": "12ca17b49af2289436f303e0166030a21e525d266e209267433801a8fd4071a0",
      "plan": {
        "id": "ba29872f-17bc-46a9-a987-2f17bcf6a941",
        "name": "keyless"
      },
      "application": {
        "id": "1",
        "name": "Unknown"
      },
      "transactionId": "100ab934-1a2f-41da-8ab9-341a2fd1daf5",
      "status": 405,
      "requestEnded": true,
      "gatewayResponseTime": 127,
      "gateway": "Andress-MacBook-Pro.local",
      "uri": "/gko-2785/?statusCode=374",
      "endpoint": "https://api.gravitee.io/echo/?statusCode=374",
      "warnings": [],
      "additionalMetrics": {}
    }
  ]
}
```


## How to test

POST `/environments/{envId}/logs/search` with a time range that returns results. Verify the response contains `"apiType": "HTTP_PROXY"` on each log entry.

## Known Issues

- MINOR: `LogNamesPostProcessorImpl` does not emit a debug log when `apiType` resolves to `null` (API absent from context). The null case is handled gracefully; logging was deferred as it is not observable by users.


[APIM-13092]: https://gravitee.atlassian.net/browse/APIM-13092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ