### PR TITLE
feat: env logs tabs

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.html
@@ -17,12 +17,6 @@
 -->
 
 <gio-header title="Logs" subtitle="Inspect and analyze API runtime logs." />
-<gio-banner-info class="banner-warning">
-  <div class="banner-warning__content">
-    Currently, only HTTP Proxy is supported.
-    <span class="mat-body">Message APIs, SSEs, and webhook support are coming soon.</span>
-  </div>
-</gio-banner-info>
 
 @if (error()) {
   <gio-banner-error>{{ error() }}</gio-banner-error>
@@ -35,10 +29,29 @@
     (refresh)="onRefresh()"
     (filtersChanged)="onFiltersChanged($event)"
   ></env-logs-filter-bar>
-  <env-logs-table
-    class="env-runtime-logs__table"
-    [logs]="logs()"
-    [pagination]="paginationWithTotal()"
-    (paginationUpdated)="onPaginationUpdated($event)"
-  ></env-logs-table>
+
+  <mat-tab-group
+    [selectedIndex]="activeTab()"
+    (selectedIndexChange)="onTabChanged($event)"
+    animationDuration="0ms"
+    data-testid="env-logs-tab-group"
+  >
+    <mat-tab label="All non-message APIs">
+      <env-logs-table
+        class="env-runtime-logs__table"
+        [logs]="logs()"
+        [pagination]="paginationWithTotal()"
+        (paginationUpdated)="onPaginationUpdated($event)"
+      ></env-logs-table>
+    </mat-tab>
+
+    <mat-tab label="Messages and Events">
+      <env-logs-table
+        class="env-runtime-logs__table"
+        [logs]="messageLogs()"
+        [pagination]="messagePaginationWithTotal()"
+        (paginationUpdated)="onMessagePaginationUpdated($event)"
+      ></env-logs-table>
+    </mat-tab>
+  </mat-tab-group>
 </mat-card>

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.scss
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.scss
@@ -8,15 +8,13 @@
   @include gio-layout.gio-responsive-content-container;
 }
 
-.banner-warning {
-  margin-bottom: 24px;
-
-  &__content {
-    display: flex;
-    flex-direction: column;
-  }
-}
-
 .logs-section {
   border: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20');
+
+  // ::ng-deep is required because the M2 theme does not expose CSS custom properties
+  // for --mat-tab-header-divider-color (M3 only). The .mat-mdc-tab-header element is
+  // inside Angular Material's view encapsulation, so scoped styles cannot reach it.
+  ::ng-deep .mat-mdc-tab-header {
+    border-bottom: 1px solid mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker20');
+  }
 }

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
@@ -19,12 +19,13 @@ import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { GioBannerModule } from '@gravitee/ui-particles-angular';
 import { HttpTestingController } from '@angular/common/http/testing';
 
-import { EnvLogsComponent } from './env-logs.component';
+import { EnvLogsComponent, EnvLogsTab } from './env-logs.component';
 import { EnvLogsTableHarness } from './components/env-logs-table/env-logs-table.harness';
 import { EnvLogsFilterBarHarness } from './components/env-logs-filter-bar/env-logs-filter-bar.harness';
 
@@ -67,7 +68,7 @@ describe('EnvLogsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, GioTestingModule, MatCardModule, GioBannerModule, EnvLogsComponent],
+      imports: [NoopAnimationsModule, GioTestingModule, MatCardModule, MatTabsModule, GioBannerModule, EnvLogsComponent],
     }).compileComponents();
 
     httpTestingController = TestBed.inject(HttpTestingController);
@@ -111,11 +112,13 @@ describe('EnvLogsComponent', () => {
     expect(title.textContent).toContain('Logs');
   }));
 
-  it('should render the banner warning', fakeAsync(() => {
+  it('should render two tabs', fakeAsync(() => {
     initComponent();
 
-    const banner = fixture.nativeElement.querySelector('gio-banner-info');
-    expect(banner).toBeTruthy();
+    const tabs = fixture.nativeElement.querySelectorAll('.mat-mdc-tab');
+    expect(tabs.length).toBe(2);
+    expect(tabs[0].textContent).toContain('All non-message APIs');
+    expect(tabs[1].textContent).toContain('Messages and Events');
   }));
 
   it('should display filters section', fakeAsync(async () => {
@@ -383,6 +386,54 @@ describe('EnvLogsComponent', () => {
       expect(log.warnings).toEqual([{ key: 'SLOW_RESPONSE' }, { key: 'DEPRECATED_HEADER' }]);
     }));
   });
+
+  describe('tab infrastructure', () => {
+    it('should default to first tab (non-message APIs)', fakeAsync(() => {
+      initComponent();
+
+      expect(component.activeTab()).toBe(EnvLogsTab.NON_MESSAGE_APIS);
+    }));
+
+    it('should switch to messages tab and reset pagination', fakeAsync(() => {
+      initComponent(MOCK_RESPONSE);
+
+      component.onPaginationUpdated({ index: 3, size: 10 });
+      fixture.detectChanges();
+      tick(1);
+
+      const page3Url = `${CONSTANTS_TESTING.env.v2BaseURL}/logs/search?page=3&perPage=10`;
+      flushSearch(EMPTY_RESPONSE, page3Url);
+
+      component.onTabChanged(1);
+      fixture.detectChanges();
+      tick(1);
+
+      // Tab change resets pagination to page 1, which re-triggers the search pipeline.
+      // Drain all pending search requests from the debounce cascade.
+      let pending = httpTestingController.match(req => req.method === 'POST' && req.url.includes('/logs/search'));
+      pending.forEach(req => req.flush(EMPTY_RESPONSE));
+      fixture.detectChanges();
+      tick(1);
+      pending = httpTestingController.match(req => req.method === 'POST' && req.url.includes('/logs/search'));
+      pending.forEach(req => req.flush(EMPTY_RESPONSE));
+
+      expect(component.activeTab()).toBe(EnvLogsTab.MESSAGES);
+      expect(component.pagination().page).toBe(1);
+      expect(component.messagePagination().page).toBe(1);
+    }));
+
+    it('should update message pagination independently', fakeAsync(() => {
+      initComponent();
+
+      component.onMessagePaginationUpdated({ index: 2, size: 25 });
+
+      expect(component.messagePagination().page).toBe(2);
+      expect(component.messagePagination().perPage).toBe(25);
+      // Non-message pagination should be unaffected
+      expect(component.pagination().page).toBe(1);
+      expect(component.pagination().perPage).toBe(10);
+    }));
+  });
 });
 
 describe('EnvLogsComponent — query param persistence', () => {
@@ -392,7 +443,7 @@ describe('EnvLogsComponent — query param persistence', () => {
 
   function createComponentWithQueryParams(queryParams: Record<string, string>) {
     TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, GioTestingModule, MatCardModule, GioBannerModule, EnvLogsComponent],
+      imports: [NoopAnimationsModule, GioTestingModule, MatCardModule, MatTabsModule, GioBannerModule, EnvLogsComponent],
       providers: [
         {
           provide: ActivatedRoute,
@@ -420,7 +471,7 @@ describe('EnvLogsComponent — query param persistence', () => {
     fixture?.destroy();
   });
 
-  it('should_restore_filters_from_query_params', fakeAsync(() => {
+  it('should restore filters from query params', fakeAsync(() => {
     createComponentWithQueryParams({
       period: '-7d',
       methods: 'GET,POST',
@@ -444,7 +495,7 @@ describe('EnvLogsComponent — query param persistence', () => {
     searchReq.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
   }));
 
-  it('should_restore_pagination_from_query_params', fakeAsync(() => {
+  it('should restore pagination from query params', fakeAsync(() => {
     createComponentWithQueryParams({
       perPage: '25',
       methods: 'GET',
@@ -463,7 +514,7 @@ describe('EnvLogsComponent — query param persistence', () => {
     );
   }));
 
-  it('should_return_undefined_when_no_filter_query_params_exist', fakeAsync(() => {
+  it('should return undefined when no filter query params exist', fakeAsync(() => {
     createComponentWithQueryParams({});
 
     fixture.detectChanges();
@@ -474,7 +525,7 @@ describe('EnvLogsComponent — query param persistence', () => {
     searchReq.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
   }));
 
-  it('should_restore_more_filter_values_from_query_params', fakeAsync(() => {
+  it('should restore more filter values from query params', fakeAsync(() => {
     createComponentWithQueryParams({
       transactionId: 'txn-123',
       requestId: 'req-456',
@@ -497,6 +548,30 @@ describe('EnvLogsComponent — query param persistence', () => {
         expect.objectContaining({ name: 'RESPONSE_TIME', operator: 'GTE', value: 500 }),
       ]),
     );
+    searchReq.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+  }));
+
+  it('should restore messages tab from query params', fakeAsync(() => {
+    createComponentWithQueryParams({ tab: 'messages' });
+
+    fixture.detectChanges();
+    tick();
+
+    expect(component.activeTab()).toBe(EnvLogsTab.MESSAGES);
+
+    const searchReq = httpTestingController.expectOne(req => req.method === 'POST' && req.url.includes('/logs/search'));
+    searchReq.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
+  }));
+
+  it('should default to first tab when no tab query param', fakeAsync(() => {
+    createComponentWithQueryParams({});
+
+    fixture.detectChanges();
+    tick();
+
+    expect(component.activeTab()).toBe(EnvLogsTab.NON_MESSAGE_APIS);
+
+    const searchReq = httpTestingController.expectOne(req => req.method === 'POST' && req.url.includes('/logs/search'));
     searchReq.flush({ data: [], pagination: { page: 1, perPage: 10, pageCount: 0, pageItemsCount: 0, totalCount: 0 } });
   }));
 });

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.ts
@@ -20,6 +20,7 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
+import { MatTabsModule } from '@angular/material/tabs';
 import { GioBannerModule } from '@gravitee/ui-particles-angular';
 import { EMPTY } from 'rxjs';
 import { catchError, debounceTime, switchMap, tap } from 'rxjs/operators';
@@ -42,13 +43,20 @@ import { Pagination } from '../../../entities/management-api-v2';
 import { GioHeaderComponent } from '../../../shared/components/gio-header/gio-header.component';
 
 const EMPTY_FIELD = '—';
+const TAB_QUERY_PARAM = 'tab';
+const MESSAGES_TAB_VALUE = 'messages';
 const DEFAULT_PER_PAGE = 10;
+
+export const enum EnvLogsTab {
+  NON_MESSAGE_APIS = 0,
+  MESSAGES = 1,
+}
 
 @Component({
   selector: 'env-logs',
   templateUrl: './env-logs.component.html',
   styleUrl: './env-logs.component.scss',
-  imports: [EnvLogsTableComponent, EnvLogsFilterBarComponent, MatCardModule, GioBannerModule, GioHeaderComponent],
+  imports: [EnvLogsTableComponent, EnvLogsFilterBarComponent, MatCardModule, MatTabsModule, GioBannerModule, GioHeaderComponent],
   providers: [DatePipe],
   standalone: true,
 })
@@ -63,6 +71,18 @@ export class EnvLogsComponent {
   filters = signal<EnvLogsFilterValues | null>(null);
   loading = signal(true);
   error = signal<string | null>(null);
+
+  activeTab = signal<EnvLogsTab>(this.initialTabIndex());
+
+  /** Placeholder: message logs are empty until APIM-13200 wires the backend */
+  messageLogs = signal<EnvLog[]>([]);
+  messagePagination = signal<Pagination>({ page: 1, perPage: DEFAULT_PER_PAGE, totalCount: 0 });
+
+  messagePaginationWithTotal = computed(() => ({
+    ...this.messagePagination(),
+    // TODO(APIM-13200): Replace with actual totalCount from message logs response
+    totalCount: 0,
+  }));
 
   initialValues = signal<EnvLogsInitialValues | undefined>(this.parseQueryParams());
 
@@ -95,16 +115,31 @@ export class EnvLogsComponent {
   onFiltersChanged(filters: EnvLogsFilterValues) {
     this.filters.set(filters);
     this.pagination.update(prev => (prev.page === 1 ? prev : { ...prev, page: 1 }));
-    this.syncQueryParams(filters, this.pagination());
+    this.syncQueryParams();
   }
 
   onPaginationUpdated(event: GioTableWrapperPagination) {
     this.pagination.update(prev => ({ ...prev, page: event.index, perPage: event.size }));
-    this.syncQueryParams(this.filters(), this.pagination());
+    this.syncQueryParams();
   }
 
-  private syncQueryParams(filters: EnvLogsFilterValues | null, pagination: Pagination) {
+  onTabChanged(index: number) {
+    this.activeTab.set(index);
+    this.pagination.update(prev => (prev.page === 1 ? prev : { ...prev, page: 1 }));
+    this.messagePagination.update(prev => (prev.page === 1 ? prev : { ...prev, page: 1 }));
+    this.syncQueryParams();
+  }
+
+  onMessagePaginationUpdated(event: GioTableWrapperPagination) {
+    this.messagePagination.update(prev => ({ ...prev, page: event.index, perPage: event.size }));
+    this.syncQueryParams();
+  }
+
+  private syncQueryParams() {
+    const filters = this.filters();
+    const pagination = this.activeTab() === EnvLogsTab.MESSAGES ? this.messagePagination() : this.pagination();
     const queryParams: Record<string, string | null> = {
+      tab: this.activeTab() === EnvLogsTab.MESSAGES ? MESSAGES_TAB_VALUE : null,
       page: pagination.page > 1 ? String(pagination.page) : null,
       perPage: pagination.perPage === DEFAULT_PER_PAGE ? null : String(pagination.perPage),
       period: filters?.period && filters.period !== '0' ? filters.period : null,
@@ -130,11 +165,16 @@ export class EnvLogsComponent {
     });
   }
 
+  private initialTabIndex(): EnvLogsTab {
+    const queryParams = this.activatedRoute.snapshot.queryParams;
+    return queryParams[TAB_QUERY_PARAM] === MESSAGES_TAB_VALUE ? EnvLogsTab.MESSAGES : EnvLogsTab.NON_MESSAGE_APIS;
+  }
+
   private parseQueryParams(): EnvLogsInitialValues | undefined {
     const queryParams = this.activatedRoute.snapshot.queryParams;
     this.restorePagination(queryParams);
 
-    const nonFilterKeys = new Set(['apiId', 'page', 'perPage']);
+    const nonFilterKeys = new Set(['apiId', 'page', 'perPage', TAB_QUERY_PARAM]);
     const hasAnyFilter = Object.keys(queryParams).some(k => !nonFilterKeys.has(k));
     if (!hasAnyFilter) return undefined;
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13199
## Description
Adds tabbed view for env level logging: 

<img width="1291" height="636" alt="Screenshot 2026-04-06 at 12 25 40 PM" src="https://github.com/user-attachments/assets/76dd15a6-4b65-4db2-8be8-2e87898e13db" />


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

