### PR TITLE
fix(portal): avoid duplicate discard dialog when unpublishing with unsaved edits

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -1275,6 +1275,112 @@ describe('PortalNavigationItemsComponent', () => {
       });
     });
 
+    describe('with unsaved content changes', () => {
+      it('should show exactly one dialog at a time when Publish button is clicked', async () => {
+        const unpublishedNavItem = fakePortalNavigationPage({
+          id: 'nav-item-1',
+          title: 'Nav Item 1',
+          portalPageContentId: 'nav-item-1-content',
+          published: false,
+        });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [unpublishedNavItem] }));
+        expectGetPageContent('nav-item-1-content', 'Original content');
+
+        await harness.setEditorContentText('Edited content');
+        await harness.clickPublishButton();
+
+        const openDialogsAfterClick = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
+        expect(openDialogsAfterClick).toHaveLength(1);
+        await openDialogsAfterClick[0].confirm();
+
+        const openDialogsAfterDiscard = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
+        expect(openDialogsAfterDiscard).toHaveLength(1);
+        await openDialogsAfterDiscard[0].confirm();
+
+        expectPutPortalNavigationItem('nav-item-1', { ...unpublishedNavItem, published: true }, fakePortalNavigationPage({}));
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [unpublishedNavItem] }));
+        expectGetPageContent('nav-item-1-content', 'Original content');
+      });
+
+      it('should show exactly one dialog at a time when publish is triggered from More Actions', async () => {
+        const unpublishedNavItem = fakePortalNavigationPage({
+          id: 'nav-item-1',
+          title: 'Nav Item 1',
+          portalPageContentId: 'nav-item-1-content',
+          published: false,
+        });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [unpublishedNavItem] }));
+        expectGetPageContent('nav-item-1-content', 'Original content');
+
+        await harness.setEditorContentText('Edited content');
+        await harness.publishNodeById('nav-item-1');
+
+        const openDialogsAfterClick = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
+        expect(openDialogsAfterClick).toHaveLength(1);
+        await openDialogsAfterClick[0].confirm();
+
+        const openDialogsAfterDiscard = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
+        expect(openDialogsAfterDiscard).toHaveLength(1);
+        await openDialogsAfterDiscard[0].confirm();
+
+        expectPutPortalNavigationItem('nav-item-1', { ...unpublishedNavItem, published: true }, fakePortalNavigationPage({}));
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [unpublishedNavItem] }));
+        expectGetPageContent('nav-item-1-content', 'Original content');
+      });
+
+      it('should show exactly one dialog at a time when Unpublish button is clicked', async () => {
+        const publishedNavItem = fakePortalNavigationPage({
+          id: 'nav-item-1',
+          title: 'Nav Item 1',
+          portalPageContentId: 'nav-item-1-content',
+          published: true,
+        });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [publishedNavItem] }));
+        expectGetPageContent('nav-item-1-content', 'Original content');
+
+        await harness.setEditorContentText('Edited content');
+        await harness.clickUnpublishButton();
+
+        const openDialogsAfterClick = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
+        expect(openDialogsAfterClick).toHaveLength(1);
+        await openDialogsAfterClick[0].confirm();
+
+        const openDialogsAfterDiscard = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
+        expect(openDialogsAfterDiscard).toHaveLength(1);
+        await openDialogsAfterDiscard[0].confirm();
+
+        expectPutPortalNavigationItem('nav-item-1', { ...publishedNavItem, published: false }, fakePortalNavigationPage({}));
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [publishedNavItem] }));
+        expectGetPageContent('nav-item-1-content', 'Original content');
+      });
+
+      it('should show exactly one dialog at a time when unpublish is triggered from More Actions', async () => {
+        const publishedNavItem = fakePortalNavigationPage({
+          id: 'nav-item-1',
+          title: 'Nav Item 1',
+          portalPageContentId: 'nav-item-1-content',
+          published: true,
+        });
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [publishedNavItem] }));
+        expectGetPageContent('nav-item-1-content', 'Original content');
+
+        await harness.setEditorContentText('Edited content');
+        await harness.unpublishNodeById('nav-item-1');
+
+        const openDialogsAfterClick = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
+        expect(openDialogsAfterClick).toHaveLength(1);
+        await openDialogsAfterClick[0].confirm();
+
+        const openDialogsAfterDiscard = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
+        expect(openDialogsAfterDiscard).toHaveLength(1);
+        await openDialogsAfterDiscard[0].confirm();
+
+        expectPutPortalNavigationItem('nav-item-1', { ...publishedNavItem, published: false }, fakePortalNavigationPage({}));
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [publishedNavItem] }));
+        expectGetPageContent('nav-item-1-content', 'Original content');
+      });
+    });
+
     describe('unpublished navigation item with unpublished parent', () => {
       const unpublishedParent = fakePortalNavigationFolder({
         id: 'parent-folder-1',

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -547,7 +547,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   }
 
   onPublishToggle() {
-    this.handlePublishToggle(this.selectedNavigationItem()!.data);
+    this.checkUnsavedChangesAndRun(() => this.handlePublishToggle(this.selectedNavigationItem()!.data));
   }
 
   onDeleteSection(node: SectionNode): Observable<void> {
@@ -576,32 +576,30 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   }
 
   private handlePublishToggle(navItem: PortalNavigationItem): void {
-    this.checkUnsavedChangesAndRun(() => {
-      this.matDialog
-        .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
-          width: GIO_DIALOG_WIDTH.SMALL,
-          data: this.getPublishDialogData(navItem),
-          role: 'alertdialog',
-          id: 'managePublishNavigationItemConfirmDialog',
-        })
-        .afterClosed()
-        .pipe(
-          filter(confirmed => !!confirmed),
-          switchMap(() =>
-            this.update(navItem.id, {
-              ...navItem,
-              published: !navItem.published,
-            }),
-          ),
-          tap(() => this.refreshMenuList.next(1)),
-          catchError(() => {
-            this.snackBarService.error('Failed to update publication status');
-            return EMPTY;
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+        width: GIO_DIALOG_WIDTH.SMALL,
+        data: this.getPublishDialogData(navItem),
+        role: 'alertdialog',
+        id: 'managePublishNavigationItemConfirmDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirmed => !!confirmed),
+        switchMap(() =>
+          this.update(navItem.id, {
+            ...navItem,
+            published: !navItem.published,
           }),
-          takeUntilDestroyed(this.destroyRef),
-        )
-        .subscribe();
-    });
+        ),
+        tap(() => this.refreshMenuList.next(1)),
+        catchError(() => {
+          this.snackBarService.error('Failed to update publication status');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 
   private getPublishDialogData(navItem: PortalNavigationItem): GioConfirmDialogData {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13247

## Description

Avoid duplicate discard dialog when unpublishing with unsaved edits

### Problem

When a user had unsaved content changes and triggered publish/unpublish via the tree node **More Actions** menu, two "Discard changes?" dialogs appeared back-to-back.

### Fix

- Moved the `checkUnsavedChangesAndRun()` guard from `handlePublishToggle()` into `onPublishToggle()` (the toolbar button handler), so the check lives at the call site for each entry point:
- Added tests accordingly


https://github.com/user-attachments/assets/34a59927-fe53-44e3-b492-2fd2914f4a43

