### PR TITLE
add mcpMethod field to environment log response

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-logs.yaml
@@ -398,6 +398,10 @@ components:
           type: object
           additionalProperties: true
           description: A map of string keys to values
+        mcpMethod:
+          type: string
+          description: The MCP method invoked (MCP Proxy APIs only).
+          example: "tools/list"
 
     Filter:
       description: |

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/log/connection/BaseConnectionLog.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/log/connection/BaseConnectionLog.java
@@ -52,4 +52,5 @@ public class BaseConnectionLog {
     private String errorComponentType;
     private List<ConnectionDiagnosticModel> warnings;
     private Map<String, Object> additionalMetrics;
+    private String mcpMethod;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/ApiLog.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/model/ApiLog.java
@@ -45,5 +45,6 @@ public record ApiLog(
     String errorComponentName,
     String errorComponentType,
     List<ApiLogDiagnostic> warnings,
-    Map<String, Object> additionalMetrics
+    Map<String, Object> additionalMetrics,
+    String mcpMethod
 ) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
@@ -378,6 +378,7 @@ public class SearchEnvironmentLogsUseCase {
             .errorComponentType(item.getErrorComponentType())
             .warnings(mapWarnings(item.getWarnings()))
             .additionalMetrics(item.getAdditionalMetrics() != null ? item.getAdditionalMetrics() : Map.of())
+            .mcpMethod(item.getAdditionalMetrics() != null ? (String) item.getAdditionalMetrics().get("keyword_mcp-proxy_method") : null)
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCase.java
@@ -378,7 +378,7 @@ public class SearchEnvironmentLogsUseCase {
             .errorComponentType(item.getErrorComponentType())
             .warnings(mapWarnings(item.getWarnings()))
             .additionalMetrics(item.getAdditionalMetrics() != null ? item.getAdditionalMetrics() : Map.of())
-            .mcpMethod(item.getAdditionalMetrics() != null ? (String) item.getAdditionalMetrics().get("keyword_mcp-proxy_method") : null)
+            .mcpMethod(item.getMcpMethod())
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ConnectionLogAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ConnectionLogAdapter.java
@@ -55,6 +55,10 @@ public interface ConnectionLogAdapter {
         if (metrics == null) {
             return;
         }
-        target.setMcpMethod((String) metrics.get(MCP_PROXY_METHOD_KEY));
+
+        Object mcpMethodObj = metrics.get(MCP_PROXY_METHOD_KEY);
+        if (mcpMethodObj instanceof String mcpMethod) {
+            target.setMcpMethod(mcpMethod);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ConnectionLogAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ConnectionLogAdapter.java
@@ -23,7 +23,10 @@ import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionDiagnosticModel;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
 import java.util.List;
+import java.util.Map;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -32,6 +35,7 @@ import org.mapstruct.factory.Mappers;
  */
 @Mapper
 public interface ConnectionLogAdapter {
+    String MCP_PROXY_METHOD_KEY = "keyword_mcp-proxy_method";
     ConnectionLogAdapter INSTANCE = Mappers.getMapper(ConnectionLogAdapter.class);
 
     BaseConnectionLog toEntity(Metrics connectionLog);
@@ -44,4 +48,13 @@ public interface ConnectionLogAdapter {
     List<MetricsQuery.Filter.ResponseTimeRange> convert(List<Range> range);
 
     ConnectionDiagnosticModel convert(ConnectionDiagnostic connectionDiagnostic);
+
+    @AfterMapping
+    default void extractMcpMethod(@MappingTarget BaseConnectionLog target) {
+        Map<String, Object> metrics = target.getAdditionalMetrics();
+        if (metrics == null) {
+            return;
+        }
+        target.setMcpMethod((String) metrics.get(MCP_PROXY_METHOD_KEY));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
@@ -1076,7 +1076,8 @@ class SearchEnvironmentLogsUseCaseTest {
                 .errorComponentName("error-component")
                 .errorComponentType("error-type")
                 .warnings(List.of(new ConnectionDiagnosticModel("type", "name", "key", "msg")))
-                .additionalMetrics(Map.of("custom", "metric", "keyword_mcp-proxy_method", "tools/list"))
+                .additionalMetrics(Map.of("custom", "metric"))
+                .mcpMethod("tools/list")
                 .build();
 
             when(userContextLoader.loadApis(any())).thenReturn(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/logs_engine/use_case/SearchEnvironmentLogsUseCaseTest.java
@@ -1076,7 +1076,7 @@ class SearchEnvironmentLogsUseCaseTest {
                 .errorComponentName("error-component")
                 .errorComponentType("error-type")
                 .warnings(List.of(new ConnectionDiagnosticModel("type", "name", "key", "msg")))
-                .additionalMetrics(Map.of("custom", "metric"))
+                .additionalMetrics(Map.of("custom", "metric", "keyword_mcp-proxy_method", "tools/list"))
                 .build();
 
             when(userContextLoader.loadApis(any())).thenReturn(
@@ -1123,6 +1123,7 @@ class SearchEnvironmentLogsUseCaseTest {
                 soft.assertThat(log.warnings()).containsExactly(new ApiLogDiagnostic("type", "name", "key", "msg"));
 
                 soft.assertThat(log.additionalMetrics()).containsEntry("custom", "metric");
+                soft.assertThat(log.mcpMethod()).isEqualTo("tools/list");
             });
         }
 
@@ -1188,6 +1189,7 @@ class SearchEnvironmentLogsUseCaseTest {
             assertThat(apiLog.method()).isNull();
             assertThat(apiLog.warnings()).isEmpty();
             assertThat(apiLog.additionalMetrics()).isEmpty();
+            assertThat(apiLog.mcpMethod()).isNull();
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ConnectionLogAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ConnectionLogAdapterTest.java
@@ -21,6 +21,7 @@ import io.gravitee.common.http.HttpMethod;
 import io.gravitee.repository.log.v4.model.connection.Metrics;
 import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,27 @@ class ConnectionLogAdapterTest {
         assertThat(result.isRequestEnded()).isEqualTo(toConvert.isRequestEnded());
         assertThat(result.getTransactionId()).isEqualTo(toConvert.getTransactionId());
         assertThat(result.getStatus()).isEqualTo(toConvert.getStatus());
+    }
+
+    @Test
+    void should_extract_mcp_method_from_additional_metrics() {
+        final Metrics toConvert = Metrics.builder()
+            .requestId("request-id")
+            .additionalMetrics(Map.of(ConnectionLogAdapter.MCP_PROXY_METHOD_KEY, "tools/call"))
+            .build();
+
+        final BaseConnectionLog result = ConnectionLogAdapter.INSTANCE.toEntity(toConvert);
+
+        assertThat(result.getMcpMethod()).isEqualTo("tools/call");
+    }
+
+    @Test
+    void should_leave_mcp_method_null_when_additional_metrics_is_null() {
+        final Metrics toConvert = Metrics.builder().requestId("request-id").build();
+
+        final BaseConnectionLog result = ConnectionLogAdapter.INSTANCE.toEntity(toConvert);
+
+        assertThat(result.getMcpMethod()).isNull();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/logs_engine/LogNamesPostProcessorImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/logs_engine/LogNamesPostProcessorImplTest.java
@@ -246,7 +246,8 @@ class LogNamesPostProcessorImplTest {
                 "err-comp",
                 "err-type",
                 List.of(warning),
-                Map.of("k", "v")
+                Map.of("k", "v"),
+                "tools/list"
             );
 
             var context = BASE_CONTEXT.withApiNamesById(Map.of("api-1", "New API"))
@@ -285,6 +286,7 @@ class LogNamesPostProcessorImplTest {
             assertThat(log.errorComponentType()).isEqualTo("err-type");
             assertThat(log.warnings()).containsExactly(warning);
             assertThat(log.additionalMetrics()).containsEntry("k", "v");
+            assertThat(log.mcpMethod()).isEqualTo("tools/list");
 
             // Plan non-name fields must survive unchanged
             assertThat(log.plan().id()).isEqualTo("plan-1");


### PR DESCRIPTION
## Summary

Issue [APIM-13093](https://gravitee.atlassian.net/browse/APIM-13093)

- Adds `mcpMethod` string field to the `EnvironmentApiLog` REST response, surfacing the MCP method (e.g. `tools/list`, `resources/read`) for MCP Proxy APIs
- The value was already stored in Elasticsearch (`additional-metrics.keyword_mcp-proxy_method`) and filterable via `MCP_METHOD` — this change extracts it into a dedicated response field
- Non-MCP APIs return `null` for this field

## Changes

- **OpenAPI spec** (`openapi-logs.yaml`): added `mcpMethod` property to `EnvironmentApiLog`
- **Domain model** (`ApiLog.java`): added `String mcpMethod` field
- **Use case** (`SearchEnvironmentLogsUseCase.java`): extracts value from `additionalMetrics` map
- **Tests**: happy-path extraction, null-safety, and `toBuilder()` field-preservation

## Test plan

- [x] `SearchEnvironmentLogsUseCaseTest` — verifies `mcpMethod` is extracted from `additionalMetrics` and null when map is absent
- [x] `LogNamesPostProcessorImplTest` — verifies field survives `toBuilder()` round-trip
- [x] `LogsEngineMapperTest` — passes (MapStruct auto-maps the String field)

[APIM-13093]: https://gravitee.atlassian.net/browse/APIM-13093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ