### PR TITLE
feat: api product user permissions tab changes

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -51,7 +51,22 @@ export const API_PRODUCTS_ROUTES: Routes = [
       },
       {
         path: 'configuration',
+        redirectTo: 'configuration/general',
+        pathMatch: 'full',
+      },
+      {
+        path: 'configuration/general',
         loadComponent: () => import('./configuration/api-product-configuration.component').then(m => m.ApiProductConfigurationComponent),
+      },
+      {
+        path: 'configuration/members',
+        loadComponent: () => import('./members/api-product-members.component').then(m => m.ApiProductMembersComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-member-r'],
+            unauthorizedFallbackTo: 'configuration/general',
+          },
+        },
       },
       {
         path: 'apis',

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
@@ -17,11 +17,6 @@
 -->
 
 @if (apiProduct(); as product) {
-  <div class="configuration-section">
-    <h2 class="configuration-section__title">Configuration</h2>
-    <p class="configuration-section__subtitle">Manage general settings and product details.</p>
-  </div>
-
   <form [formGroup]="form" gioFormFocusInvalid>
     <mat-card class="configuration-card">
       <mat-card-content>

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.scss
@@ -18,19 +18,12 @@
 @use '@angular/material' as mat;
 @use '@gravitee/ui-particles-angular' as gio;
 
+@use '../../../scss/gio-layout' as gio-layout;
+
 $typography: map.get(gio.$mat-theme, typography);
 
-.configuration-section {
-  &__title {
-    @include mat.m2-typography-level($typography, headline-6);
-    margin: 0 0 8px 0;
-  }
-
-  &__subtitle {
-    @include mat.m2-typography-level($typography, body-2);
-    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
-    margin: 0 0 24px 0;
-  }
+:host {
+  @include gio-layout.gio-responsive-margin-container;
 }
 
 .configuration-card {

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
@@ -86,7 +86,7 @@
         <ng-container matColumnDef="name">
           <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
           <td mat-cell *matCellDef="let element" title="{{ element.name }}">
-            <a [routerLink]="'./' + element.id">{{ element.name }}</a>
+            <a [routerLink]="[element.id, 'configuration', 'general']">{{ element.name }}</a>
           </td>
         </ng-container>
 
@@ -120,7 +120,7 @@
           <td mat-cell *matCellDef="let element">
             <div class="actions__edit">
               <button
-                [routerLink]="'./' + element.id"
+                [routerLink]="[element.id, 'configuration', 'general']"
                 mat-icon-button
                 aria-label="Button to edit an API Product"
                 matTooltip="Edit API Product"

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.html
@@ -1,0 +1,79 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card>
+  <mat-card-content>
+    <div class="card__header">
+      <div class="card__header__title">
+        <h3 data-testid="api_product_members_title">Members</h3>
+        <p data-testid="api_product_members_description">
+          Manage who can interact with your API Product through the API Management console
+        </p>
+      </div>
+      <div class="card__header__actions">
+        <button class="card__header__actions__button" mat-stroked-button color="basic" type="button" disabled>Transfer ownership</button>
+        <button class="card__header__actions__button" mat-raised-button type="button" disabled aria-label="Manage groups">
+          Manage groups
+        </button>
+        <button class="card__header__actions__button" mat-raised-button color="primary" type="button" disabled>
+          <mat-icon svgIcon="gio:plus"></mat-icon> Add members
+        </button>
+      </div>
+    </div>
+
+    <form [formGroup]="notifyForm">
+      <gio-form-slide-toggle class="card__enable-notification-toggle">
+        Notify members when they are added to the API Product
+        <mat-slide-toggle
+          gioFormSlideToggle
+          formControlName="isNotificationsEnabled"
+          aria-label="Enable notifications when members are added to this API Product"
+        ></mat-slide-toggle>
+      </gio-form-slide-toggle>
+    </form>
+
+    <gio-table-wrapper
+      [disableSearchInput]="true"
+      [length]="membersTableDSUnpaginatedLength"
+      [filters]="filters"
+      (filtersChange)="onFiltersChanged($event)"
+      [paginationPageSizeOptions]="[10, 20, 50, 100]"
+    >
+      <table mat-table [dataSource]="[]" class="card__table" aria-label="Direct members table">
+        <ng-container matColumnDef="picture">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let member">
+            <gio-avatar [src]="member.picture" [name]="member.displayName" [size]="24" [roundedBorder]="true"></gio-avatar>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="displayName">
+          <th mat-header-cell *matHeaderCellDef>Name</th>
+          <td mat-cell *matCellDef="let member">{{ member.displayName }}</td>
+        </ng-container>
+        <ng-container matColumnDef="role">
+          <th mat-header-cell *matHeaderCellDef>Role</th>
+          <td mat-cell *matCellDef="let member">{{ member.role }}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        <tr class="mat-mdc-no-data-row" *matNoDataRow>
+          <td [attr.colspan]="displayedColumns.length">No members found</td>
+        </tr>
+      </table>
+    </gio-table-wrapper>
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.scss
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+  display: block;
+  max-width: 100%;
+}
+
+mat-card {
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  &__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    max-width: 100%;
+
+    &__title {
+      flex: 1 1 0;
+      min-width: 0;
+      text-align: start;
+
+      h3 {
+        margin: 0;
+        padding: 0;
+      }
+
+      p {
+        margin: 0.25rem 0 0;
+        padding: 0;
+      }
+    }
+
+    &__actions {
+      display: flex;
+      flex: 0 0 auto;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      align-items: center;
+      align-self: center;
+      gap: 0.375rem;
+    }
+  }
+
+  &__enable-notification-toggle {
+    width: 100%;
+  }
+
+  &__table {
+    width: 100%;
+    max-width: 100%;
+
+    .mat-column-picture {
+      text-align: center;
+      width: 1.5rem;
+      padding-right: 0.5rem;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatTableHarness } from '@angular/material/table/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { ApiProductMembersComponent } from './api-product-members.component';
+
+describe('ApiProductMembersComponent', () => {
+  let fixture: ComponentFixture<ApiProductMembersComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApiProductMembersComponent, MatIconTestingModule, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductMembersComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  });
+
+  it('should render the Members section with title and description', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('[data-testid="api_product_members_title"]')?.textContent?.trim()).toBe('Members');
+    expect(compiled.querySelector('[data-testid="api_product_members_description"]')?.textContent).toContain(
+      'Manage who can interact with your API Product',
+    );
+  });
+
+  it('should render picture, Name and Role column headers in the members table', async () => {
+    const table = await loader.getHarness(MatTableHarness);
+    const headerRows = await table.getHeaderRows();
+    const cells = await headerRows[0].getCells();
+    const headerTexts = await Promise.all(cells.map(c => c.getText()));
+    expect(headerTexts).toEqual(['', 'Name', 'Role']);
+  });
+
+  it('should show an empty state when there are no members', async () => {
+    const table = await loader.getHarness(MatTableHarness);
+    const rows = await table.getRows();
+    expect(rows.length).toBe(0);
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.mat-mdc-no-data-row')?.textContent).toContain('No members found');
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatTableModule } from '@angular/material/table';
+import { GioAvatarModule, GioFormSlideToggleModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+
+import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+
+@Component({
+  selector: 'api-product-members',
+  templateUrl: './api-product-members.component.html',
+  styleUrls: ['./api-product-members.component.scss'],
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSlideToggleModule,
+    MatTableModule,
+    GioIconsModule,
+    GioAvatarModule,
+    GioFormSlideToggleModule,
+    GioTableWrapperModule,
+  ],
+})
+export class ApiProductMembersComponent {
+  protected readonly displayedColumns = ['picture', 'displayName', 'role'] as const;
+
+  protected readonly notifyForm = new FormGroup({
+    isNotificationsEnabled: new FormControl(true),
+  });
+
+  protected readonly filters: GioTableWrapperFilters = {
+    pagination: { index: 1, size: 10 },
+    searchTerm: '',
+  };
+
+  protected membersTableDSUnpaginatedLength = 0;
+
+  protected onFiltersChanged(_filters: GioTableWrapperFilters): void {}
+}

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation-tabs/api-product-navigation-tabs.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation-tabs/api-product-navigation-tabs.component.scss
@@ -13,22 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, input } from '@angular/core';
-import { RouterModule } from '@angular/router';
-import { MatTabsModule } from '@angular/material/tabs';
 
-export interface ApiProductTabMenuItem {
-  displayName: string;
-  routerLink: string;
-}
-
-@Component({
-  selector: 'api-product-navigation-tabs',
-  templateUrl: './api-product-navigation-tabs.component.html',
-  styleUrls: ['./api-product-navigation-tabs.component.scss'],
-  standalone: true,
-  imports: [RouterModule, MatTabsModule],
-})
-export class ApiProductNavigationTabsComponent {
-  tabMenuItems = input.required<ApiProductTabMenuItem[]>();
+.api-product-navigation-tabs {
+  display: flex;
+  align-items: center;
+  width: 100%;
 }

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
@@ -48,6 +48,26 @@ describe('ApiProductNavigationComponent', () => {
   let httpTestingController: HttpTestingController;
   const fakeSnackBarService = { error: jest.fn(), success: jest.fn() };
 
+  async function configureNavigationTestBed(testingPermissions: string[]): Promise<void> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ApiProductNavigationComponent, RouterOutlet, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: GioTestingPermissionProvider, useValue: testingPermissions },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ apiProductId: API_PRODUCT_ID }),
+            snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+            parent: null,
+          },
+        },
+      ],
+    }).compileComponents();
+  }
+
   function flushRequests(product: ApiProduct, verifyOk = true, verifyReason?: string): void {
     httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`).flush(product);
     httpTestingController
@@ -63,23 +83,8 @@ describe('ApiProductNavigationComponent', () => {
     fixture.detectChanges();
   }
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [ApiProductNavigationComponent, RouterOutlet, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
-      providers: [
-        { provide: Constants, useValue: CONSTANTS_TESTING },
-        { provide: SnackBarService, useValue: fakeSnackBarService },
-        { provide: GioTestingPermissionProvider, useValue: ['api_product-definition-u'] },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            params: of({ apiProductId: API_PRODUCT_ID }),
-            snapshot: { params: { apiProductId: API_PRODUCT_ID } },
-            parent: null,
-          },
-        },
-      ],
-    }).compileComponents();
+  beforeEach(async () => {
+    await configureNavigationTestBed(['api_product-definition-u', 'api_product-member-r']);
   });
 
   afterEach(() => {
@@ -194,7 +199,7 @@ describe('ApiProductNavigationComponent', () => {
   });
 
   it('should show out-of-sync banner without Deploy button when user lacks update permission', async () => {
-    TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: [] });
+    await configureNavigationTestBed([]);
     createFixture();
     flushRequests({ ...fakeApiProduct, deploymentState: 'NEED_REDEPLOY' }, true);
     await fixture.whenStable();
@@ -233,9 +238,31 @@ describe('ApiProductNavigationComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('This API Product is out of sync.');
   });
 
+  describe('Configuration User Permissions tab visibility', () => {
+    it('should show User Permissions tab when user has api product member read', async () => {
+      await configureNavigationTestBed(['api_product-member-r']);
+      createFixture();
+      flushRequests(fakeApiProduct);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('User Permissions');
+    });
+
+    it('should hide User Permissions tab when user lacks api product member permissions', async () => {
+      await configureNavigationTestBed(['api_product-plan-r', 'api_product-subscription-r']);
+      createFixture();
+      flushRequests(fakeApiProduct);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).not.toContain('User Permissions');
+    });
+  });
+
   describe('Consumers menu item visibility', () => {
     it('should show consumers menu item when user has api product plan read permission', async () => {
-      TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: ['api_product-plan-r'] });
+      await configureNavigationTestBed(['api_product-plan-r']);
       createFixture();
       flushRequests(fakeApiProduct);
       await fixture.whenStable();
@@ -245,7 +272,7 @@ describe('ApiProductNavigationComponent', () => {
     });
 
     it('should hide consumers menu item when user lacks api product plan read permission', async () => {
-      TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: ['api_product-definition-r'] });
+      await configureNavigationTestBed(['api_product-definition-r']);
       createFixture();
       flushRequests(fakeApiProduct);
       await fixture.whenStable();

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -242,8 +242,19 @@ export class ApiProductNavigationComponent {
   }
 
   private buildSubMenuItems(): MenuItem[] {
+    const configurationTabs: ApiProductTabMenuItem[] = [{ displayName: 'General', routerLink: 'configuration/general' }];
+    if (this.canAccessApiProductUserPermissions()) {
+      configurationTabs.push({ displayName: 'User Permissions', routerLink: 'configuration/members' });
+    }
+
     const items: MenuItem[] = [
-      { displayName: 'Configuration', routerLink: 'configuration', icon: 'gio:settings' },
+      {
+        displayName: 'Configuration',
+        routerLink: 'configuration',
+        icon: 'gio:settings',
+        header: { title: 'Configuration', subtitle: 'Manage general settings and user permissions.' },
+        tabs: configurationTabs,
+      },
       { displayName: 'APIs', routerLink: 'apis', icon: 'gio:cloud-settings' },
     ];
 
@@ -270,6 +281,10 @@ export class ApiProductNavigationComponent {
     });
 
     return items;
+  }
+
+  private canAccessApiProductUserPermissions(): boolean {
+    return this.permissionService.hasAnyMatching(['api_product-member-r']);
   }
 
   private isItemActive(item: MenuItem): boolean {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/ApiProductPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/ApiProductPermission.java
@@ -22,7 +22,8 @@ public enum ApiProductPermission implements Permission {
     DEFINITION("DEFINITION", 1000),
     PLAN("PLAN", 1100),
     SUBSCRIPTION("SUBSCRIPTION", 1200),
-    NOTIFICATION("NOTIFICATION", 1300);
+    NOTIFICATION("NOTIFICATION", 1300),
+    MEMBER("MEMBER", 1400);
 
     final String name;
     final int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -118,7 +118,8 @@ public enum RolePermission {
     API_PRODUCT_DEFINITION(RoleScope.API_PRODUCT, ApiProductPermission.DEFINITION),
     API_PRODUCT_PLAN(RoleScope.API_PRODUCT, ApiProductPermission.PLAN),
     API_PRODUCT_SUBSCRIPTION(RoleScope.API_PRODUCT, ApiProductPermission.SUBSCRIPTION),
-    API_PRODUCT_NOTIFICATION(RoleScope.API_PRODUCT, ApiProductPermission.NOTIFICATION);
+    API_PRODUCT_NOTIFICATION(RoleScope.API_PRODUCT, ApiProductPermission.NOTIFICATION),
+    API_PRODUCT_MEMBER(RoleScope.API_PRODUCT, ApiProductPermission.MEMBER);
 
     final RoleScope scope;
     final Permission permission;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
@@ -219,6 +219,7 @@ public interface DefaultRoleEntityDefinition {
             .put(ApiProductPermission.PLAN.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
             .put(ApiProductPermission.SUBSCRIPTION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
             .put(ApiProductPermission.NOTIFICATION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(ApiProductPermission.MEMBER.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
             .build()
     );
 
@@ -232,6 +233,7 @@ public interface DefaultRoleEntityDefinition {
             .put(ApiProductPermission.PLAN.getName(), new char[] { READ.getId() })
             .put(ApiProductPermission.SUBSCRIPTION.getName(), new char[] { READ.getId() })
             .put(ApiProductPermission.NOTIFICATION.getName(), new char[] { READ.getId() })
+            .put(ApiProductPermission.MEMBER.getName(), new char[] { READ.getId() })
             .build()
     );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiProductMemberPermissionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiProductMemberPermissionUpgrader.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.API_PRODUCT;
+import static io.gravitee.rest.api.model.permissions.SystemRole.PRIMARY_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_USER;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.UpdateRoleEntity;
+import io.gravitee.rest.api.model.permissions.ApiProductPermission;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@CustomLog
+@Component
+public class ApiProductMemberPermissionUpgrader implements Upgrader {
+
+    private final RoleService roleService;
+    private final OrganizationRepository organizationRepository;
+
+    @Autowired
+    public ApiProductMemberPermissionUpgrader(RoleService roleService, @Lazy OrganizationRepository organizationRepository) {
+        this.roleService = roleService;
+        this.organizationRepository = organizationRepository;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+            organizationRepository
+                .findAll()
+                .forEach(organization -> {
+                    ExecutionContext executionContext = new ExecutionContext(organization);
+                    ensureApiProductRolesHaveMemberPermission(executionContext);
+                });
+            return true;
+        });
+    }
+
+    private void ensureApiProductRolesHaveMemberPermission(ExecutionContext executionContext) {
+        String orgId = executionContext.getOrganizationId();
+        roleService
+            .findByScopeAndName(API_PRODUCT, ROLE_API_PRODUCT_OWNER.getName(), orgId)
+            .ifPresent(role -> addMemberPermissionIfMissing(executionContext, role, ROLE_API_PRODUCT_OWNER.getPermissions()));
+        roleService
+            .findByScopeAndName(API_PRODUCT, ROLE_API_PRODUCT_USER.getName(), orgId)
+            .ifPresent(role -> addMemberPermissionIfMissing(executionContext, role, ROLE_API_PRODUCT_USER.getPermissions()));
+        roleService.createOrUpdateSystemRole(executionContext, PRIMARY_OWNER, API_PRODUCT, ApiProductPermission.values(), orgId);
+    }
+
+    private void addMemberPermissionIfMissing(ExecutionContext executionContext, RoleEntity role, Map<String, char[]> expectedPermissions) {
+        if (expectedPermissions == null) {
+            return;
+        }
+        char[] expectedMemberPerms = expectedPermissions.get(ApiProductPermission.MEMBER.getName());
+        if (expectedMemberPerms == null) {
+            return;
+        }
+
+        Map<String, char[]> perms = role.getPermissions();
+        String memberKey = ApiProductPermission.MEMBER.getName();
+        if (perms != null && perms.containsKey(memberKey)) {
+            return;
+        }
+
+        Map<String, char[]> newPerms = perms == null ? new HashMap<>() : new HashMap<>(perms);
+        newPerms.put(memberKey, expectedMemberPerms);
+
+        UpdateRoleEntity update = UpdateRoleEntity.from(role);
+        update.setPermissions(newPerms);
+        roleService.update(executionContext, update);
+
+        log.info("     - <API_PRODUCT> {}: added MEMBER permission", role.getName());
+    }
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.API_PRODUCT_MEMBER_PERMISSION_UPGRADER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -68,4 +68,5 @@ public class UpgraderOrder {
     public static final int CLUSTER_ROLES_UPGRADER = 900;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;
     public static final int API_PRODUCT_ROLES_UPGRADER = 950;
+    public static final int API_PRODUCT_MEMBER_PERMISSION_UPGRADER = 951;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiProductMemberPermissionUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApiProductMemberPermissionUpgraderTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.API_PRODUCT;
+import static io.gravitee.rest.api.model.permissions.SystemRole.PRIMARY_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_OWNER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Organization;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.UpdateRoleEntity;
+import io.gravitee.rest.api.model.permissions.ApiProductPermission;
+import io.gravitee.rest.api.model.permissions.Permission;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApiProductMemberPermissionUpgraderTest {
+
+    @InjectMocks
+    ApiProductMemberPermissionUpgrader upgrader;
+
+    @Mock
+    RoleService roleService;
+
+    @Mock
+    OrganizationRepository organizationRepository;
+
+    private void verifyPrimaryOwnerSyncedForOrg(String organizationId) {
+        verify(roleService).createOrUpdateSystemRole(
+            any(ExecutionContext.class),
+            eq(PRIMARY_OWNER),
+            eq(API_PRODUCT),
+            any(Permission[].class),
+            eq(organizationId)
+        );
+    }
+
+    @Test(expected = UpgraderException.class)
+    public void upgrade_should_fail_when_organization_repository_throws() throws TechnicalException, UpgraderException {
+        when(organizationRepository.findAll()).thenThrow(new RuntimeException("db error"));
+        upgrader.upgrade();
+    }
+
+    @Test
+    public void should_add_member_permission_to_owner_and_user_when_missing() throws TechnicalException, UpgraderException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        RoleEntity ownerWithoutMember = roleWithoutMember(
+            "owner-id",
+            ROLE_API_PRODUCT_OWNER.getName(),
+            ROLE_API_PRODUCT_OWNER.getPermissions()
+        );
+        RoleEntity userWithoutMember = roleWithoutMember(
+            "user-id",
+            ROLE_API_PRODUCT_USER.getName(),
+            ROLE_API_PRODUCT_USER.getPermissions()
+        );
+
+        when(roleService.findByScopeAndName(API_PRODUCT, ROLE_API_PRODUCT_OWNER.getName(), organizationId)).thenReturn(
+            Optional.of(ownerWithoutMember)
+        );
+        when(roleService.findByScopeAndName(API_PRODUCT, ROLE_API_PRODUCT_USER.getName(), organizationId)).thenReturn(
+            Optional.of(userWithoutMember)
+        );
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<UpdateRoleEntity> updateCaptor = ArgumentCaptor.forClass(UpdateRoleEntity.class);
+        verify(roleService, times(2)).update(any(ExecutionContext.class), updateCaptor.capture());
+
+        List<UpdateRoleEntity> updates = updateCaptor.getAllValues();
+        assertThat(updates).hasSize(2);
+
+        char[] expectedOwnerMember = ROLE_API_PRODUCT_OWNER.getPermissions().get(ApiProductPermission.MEMBER.getName());
+        char[] expectedUserMember = ROLE_API_PRODUCT_USER.getPermissions().get(ApiProductPermission.MEMBER.getName());
+
+        for (UpdateRoleEntity update : updates) {
+            Map<String, char[]> perms = update.getPermissions();
+            assertThat(perms).containsKey(ApiProductPermission.MEMBER.getName());
+            if (ROLE_API_PRODUCT_OWNER.getName().equals(update.getName())) {
+                assertThat(perms.get(ApiProductPermission.MEMBER.getName())).isEqualTo(expectedOwnerMember);
+            } else if (ROLE_API_PRODUCT_USER.getName().equals(update.getName())) {
+                assertThat(perms.get(ApiProductPermission.MEMBER.getName())).isEqualTo(expectedUserMember);
+            }
+        }
+
+        verifyPrimaryOwnerSyncedForOrg(organizationId);
+    }
+
+    @Test
+    public void should_not_call_update_when_member_already_present_on_both_roles() throws TechnicalException, UpgraderException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        RoleEntity owner = new RoleEntity();
+        owner.setId("owner-id");
+        owner.setName(ROLE_API_PRODUCT_OWNER.getName());
+        owner.setPermissions(new HashMap<>(ROLE_API_PRODUCT_OWNER.getPermissions()));
+
+        RoleEntity user = new RoleEntity();
+        user.setId("user-id");
+        user.setName(ROLE_API_PRODUCT_USER.getName());
+        user.setPermissions(new HashMap<>(ROLE_API_PRODUCT_USER.getPermissions()));
+
+        when(roleService.findByScopeAndName(API_PRODUCT, ROLE_API_PRODUCT_OWNER.getName(), organizationId)).thenReturn(Optional.of(owner));
+        when(roleService.findByScopeAndName(API_PRODUCT, ROLE_API_PRODUCT_USER.getName(), organizationId)).thenReturn(Optional.of(user));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(roleService, never()).update(any(), any());
+        verifyPrimaryOwnerSyncedForOrg(organizationId);
+    }
+
+    @Test
+    public void should_add_member_only_for_owner_when_user_role_absent() throws TechnicalException, UpgraderException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        RoleEntity ownerWithoutMember = roleWithoutMember(
+            "owner-id",
+            ROLE_API_PRODUCT_OWNER.getName(),
+            ROLE_API_PRODUCT_OWNER.getPermissions()
+        );
+
+        when(roleService.findByScopeAndName(API_PRODUCT, ROLE_API_PRODUCT_OWNER.getName(), organizationId)).thenReturn(
+            Optional.of(ownerWithoutMember)
+        );
+        when(roleService.findByScopeAndName(API_PRODUCT, ROLE_API_PRODUCT_USER.getName(), organizationId)).thenReturn(Optional.empty());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<UpdateRoleEntity> updateCaptor = ArgumentCaptor.forClass(UpdateRoleEntity.class);
+        verify(roleService, times(1)).update(any(ExecutionContext.class), updateCaptor.capture());
+        UpdateRoleEntity update = updateCaptor.getValue();
+        assertThat(update.getName()).isEqualTo(ROLE_API_PRODUCT_OWNER.getName());
+        assertThat(update.getPermissions()).containsKey(ApiProductPermission.MEMBER.getName());
+
+        verifyPrimaryOwnerSyncedForOrg(organizationId);
+    }
+
+    @Test
+    public void should_add_member_when_role_permissions_map_is_null() throws TechnicalException, UpgraderException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        RoleEntity owner = new RoleEntity();
+        owner.setId("owner-id");
+        owner.setName(ROLE_API_PRODUCT_OWNER.getName());
+        owner.setPermissions(null);
+
+        when(roleService.findByScopeAndName(API_PRODUCT, ROLE_API_PRODUCT_OWNER.getName(), organizationId)).thenReturn(Optional.of(owner));
+        when(roleService.findByScopeAndName(API_PRODUCT, ROLE_API_PRODUCT_USER.getName(), organizationId)).thenReturn(Optional.empty());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<UpdateRoleEntity> updateCaptor = ArgumentCaptor.forClass(UpdateRoleEntity.class);
+        verify(roleService).update(any(ExecutionContext.class), updateCaptor.capture());
+        assertThat(updateCaptor.getValue().getPermissions()).containsEntry(
+            ApiProductPermission.MEMBER.getName(),
+            ROLE_API_PRODUCT_OWNER.getPermissions().get(ApiProductPermission.MEMBER.getName())
+        );
+
+        verifyPrimaryOwnerSyncedForOrg(organizationId);
+    }
+
+    @Test
+    public void should_process_each_organization() throws TechnicalException, UpgraderException {
+        Organization orgA = mock(Organization.class);
+        when(orgA.getId()).thenReturn("org-a");
+        Organization orgB = mock(Organization.class);
+        when(orgB.getId()).thenReturn("org-b");
+        when(organizationRepository.findAll()).thenReturn(Set.of(orgA, orgB));
+
+        for (String orgId : List.of("org-a", "org-b")) {
+            RoleEntity owner = roleWithoutMember(
+                "owner-" + orgId,
+                ROLE_API_PRODUCT_OWNER.getName(),
+                ROLE_API_PRODUCT_OWNER.getPermissions()
+            );
+            RoleEntity user = roleWithoutMember("user-" + orgId, ROLE_API_PRODUCT_USER.getName(), ROLE_API_PRODUCT_USER.getPermissions());
+            when(roleService.findByScopeAndName(eq(API_PRODUCT), eq(ROLE_API_PRODUCT_OWNER.getName()), eq(orgId))).thenReturn(
+                Optional.of(owner)
+            );
+            when(roleService.findByScopeAndName(eq(API_PRODUCT), eq(ROLE_API_PRODUCT_USER.getName()), eq(orgId))).thenReturn(
+                Optional.of(user)
+            );
+        }
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(roleService, times(4)).update(any(ExecutionContext.class), any(UpdateRoleEntity.class));
+        verify(roleService, times(2)).createOrUpdateSystemRole(
+            any(ExecutionContext.class),
+            eq(PRIMARY_OWNER),
+            eq(API_PRODUCT),
+            any(Permission[].class),
+            any(String.class)
+        );
+    }
+
+    @Test
+    public void getOrder_matches_api_product_member_permission_upgrader() {
+        Assert.assertEquals(UpgraderOrder.API_PRODUCT_MEMBER_PERMISSION_UPGRADER, upgrader.getOrder());
+    }
+
+    private static RoleEntity roleWithoutMember(String id, String name, Map<String, char[]> fullPermissions) {
+        Map<String, char[]> withoutMember = new HashMap<>(fullPermissions);
+        withoutMember.remove(ApiProductPermission.MEMBER.getName());
+        RoleEntity role = new RoleEntity();
+        role.setId(id);
+        role.setName(name);
+        role.setPermissions(withoutMember);
+        return role;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13371

## Description


Area | Change
-- | --
Console – Configuration | Added User Permissions under API Product Configuration (tab + configuration/members route)
Console – permissions | Tab and route gated with api_product-member-r only; permissions come from GET …/api-products/{id}/members/permissions via GioPermissionService.loadApiProductPermissions.
Backend – model | ApiProductPermission.MEMBER and RolePermission.API_PRODUCT_MEMBER; default API Product OWNER/USER roles include MEMBER rights.
Backend – upgrade | ApiProductMemberPermissionUpgrader (new order 951) backfills MEMBER on stored API_PRODUCT OWNER/USER roles when missing (existing installs where ApiProductRolesUpgrader already ran).



<img width="754" height="350" alt="image" src="https://github.com/user-attachments/assets/46831ff9-08c4-4fa9-81c8-c2d622ba9865" />
