### PR TITLE
chore: bump kafka version from 3.9.1 to 3.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <json-smart.version>2.5.2</json-smart.version>
         <json-unit.version>4.1.1</json-unit.version>
         <jsoup.version>1.21.2</jsoup.version>
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
         <lucene.version>10.1.0</lucene.version>
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
         <mapstruct.version>1.6.3</mapstruct.version>


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13440

Kafka version 3.9.1 is vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2025-12183