### PR TITLE
fix(v4-logs): persist filter state and period on navigation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.html
@@ -22,7 +22,9 @@
         <div class="card__header__title">Details</div>
         <div class="card__header__subtitle">Analyse the connection logs and messages for a specific connection</div>
       </div>
-      <a mat-button mat-raised-button [routerLink]="'..'" aria-label="Back to Connections">Back to Connections</a>
+      <button mat-button mat-raised-button routerLink=".." queryParamsHandling="preserve" aria-label="Back to Connections">
+        Back to Connections
+      </button>
     </div>
 
     <mat-tab-group (selectedTabChange)="onTabChange($event)">

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-messages/api-runtime-logs-messages.component.spec.ts
@@ -18,7 +18,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ApiRuntimeLogsMessagesComponent } from './api-runtime-logs-messages.component';
@@ -60,6 +60,21 @@ describe('ApiRuntimeLogsMessagesComponent', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('should navigate to parent route when clicking the back button', async () => {
+    await initComponent();
+
+    const router = TestBed.inject(Router);
+    const navigateSpy = jest.spyOn(router, 'navigateByUrl');
+
+    expectApiWithConnectionLog(fakeConnectionLogDetail());
+    expectApiWithMessageLogs([]);
+
+    const backButton: HTMLButtonElement = fixture.nativeElement.querySelector('button[aria-label="Back to Connections"]');
+    backButton.click();
+
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
   });
 
   describe('GIVEN there are connection logs', () => {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.html
@@ -15,7 +15,9 @@
     limitations under the License.
 
 -->
-<a mat-flat-button routerLink=".." aria-label="Back to logs"><mat-icon svgIcon="gio:arrow-left"></mat-icon>Back to logs</a>
+<button mat-flat-button routerLink=".." queryParamsHandling="preserve" aria-label="Back to logs">
+  <mat-icon svgIcon="gio:arrow-left"></mat-icon>Back to logs
+</button>
 <div class="mat-h2">Log</div>
 <div class="card__container">
   <api-proxy-request-metric-overview [metric]="apiMetricsDetail()" [apiType]="apiType()" />

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-details/components/runtime-logs-proxy/api-runtime-logs-proxy.component.spec.ts
@@ -16,7 +16,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 
@@ -186,6 +186,21 @@ describe('ApiRuntimeLogsProxyComponent', () => {
       { key: 'X-Header-Multiple', value: 'first-header,second-header' },
     ]);
     expect(await logHarness.getBodies()).toEqual(['entrypoint-only-body', 'endpoint-only-body']);
+  });
+
+  it('should navigate to parent route when clicking the back button', async () => {
+    await initComponent();
+
+    const router = TestBed.inject(Router);
+    const navigateSpy = jest.spyOn(router, 'navigateByUrl');
+
+    expectApiWithConnectionLog(fakeConnectionLogDetail({ apiId: API_ID, requestId: REQUEST_ID }));
+    expectApiMetric(fakeApiMetricResponse({ apiId: API_ID, requestId: REQUEST_ID }));
+
+    const backButton: HTMLButtonElement = fixture.nativeElement.querySelector('button[aria-label="Back to logs"]');
+    backButton.click();
+
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should display nothing when connection log is not found', async () => {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.spec.ts
@@ -310,7 +310,7 @@ describe('ApiRuntimeLogsComponent', () => {
         expectApiWithLogs(total, { perPage, page: 1, from: expectedFrom, to: expectedTo });
 
         // First time, add filters to URL
-        expectRouterUrlChange(2, { page: 1, perPage: 10, from: expectedFrom, to: expectedTo });
+        expectRouterUrlChange(2, { page: 1, perPage: 10, period: '-5m', from: expectedFrom, to: expectedTo });
 
         await componentHarness.removePeriodChip();
         expectApiWithLogs(total, { perPage, page: 1 });
@@ -812,6 +812,41 @@ describe('ApiRuntimeLogsComponent', () => {
         expect(await componentHarness.getStatusesInputChips()).toEqual(['200', '202']);
       });
     });
+
+    describe('there is a period filter in the url', () => {
+      const fakeNow = moment('2023-10-05T00:00:00.000Z');
+
+      it('should init the form with period preselected and restore it on back navigation', async () => {
+        jest.spyOn(Date, 'now').mockReturnValue(new Date('2023-10-05T00:00:00.000Z').getTime());
+
+        const expectedTo = fakeNow.valueOf();
+        const expectedFrom = expectedTo - 60 * 60 * 1000; // Last 1 Hour
+
+        await TestBed.overrideProvider(ActivatedRoute, {
+          useValue: {
+            snapshot: {
+              params: { apiId: API_ID },
+              queryParams: {
+                ...queryParams,
+                period: '-1h',
+                from: expectedFrom,
+                to: expectedTo,
+              },
+            },
+          },
+        }).compileComponents();
+
+        await initComponent();
+        expectPlanList();
+        expectApiWithLogs(10, { page: 1, perPage: 10, from: expectedFrom, to: expectedTo });
+        expectEntrypointListGet();
+        expectApiWithLogEnabled();
+
+        const periodSelectInput = await componentHarness.selectPeriodQuickFilter();
+        expect(await periodSelectInput.getValueText()).toEqual('Last 1 Hour');
+        expect(await componentHarness.getPeriodChipText()).toStrictEqual('period: Last 1 Hour');
+      });
+    });
   });
 
   function expectApiWithLogEnabled(modifier?: Partial<ApiV4>) {
@@ -956,6 +991,7 @@ describe('ApiRuntimeLogsComponent', () => {
         methods: null,
         mcpMethods: null,
         statuses: null,
+        period: null,
         from: null,
         to: null,
         errorKeys: null,

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/api-runtime-logs.component.ts
@@ -22,7 +22,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 
 import { QuickFiltersStoreService } from './services';
-import { LogFiltersInitialValues } from './models';
+import { LogFiltersInitialValues, PERIODS } from './models';
 
 import { ApiLogsV2Service } from '../../../../services-ngx/api-logs-v2.service';
 import { ApiLogsParam, ApiLogsResponse, ApiType, ApiV4 } from '../../../../entities/management-api-v2';
@@ -146,15 +146,12 @@ export class ApiRuntimeLogsComponent implements OnInit {
   }
 
   private initData() {
-    const applicationIds: string[] = this.activatedRoute.snapshot.queryParams?.applicationIds
-      ? this.activatedRoute.snapshot.queryParams.applicationIds.split(',')
-      : null;
-    const planIds: string[] = this.activatedRoute.snapshot.queryParams?.planIds
-      ? this.activatedRoute.snapshot.queryParams.planIds.split(',')
-      : null;
-    const statuses: Set<number> = this.activatedRoute.snapshot.queryParams?.statuses
-      ? new Set(this.activatedRoute.snapshot.queryParams.statuses.split(',').map(Number))
-      : null;
+    const qp = this.activatedRoute.snapshot.queryParams;
+    const applicationIds: string[] = qp?.applicationIds ? qp.applicationIds.split(',') : null;
+    const planIds: string[] = qp?.planIds ? qp.planIds.split(',') : null;
+    const statuses: Set<number> = qp?.statuses ? new Set(qp.statuses.split(',').map(Number)) : null;
+    const period = PERIODS.find(p => p.value === qp?.period) ?? undefined;
+    const hasRelativePeriod = period && period.value !== '0';
 
     forkJoin([
       applicationIds?.length > 0 ? this.applicationService.findByIds(applicationIds, 1, applicationIds?.length ?? 10) : of(null),
@@ -163,6 +160,7 @@ export class ApiRuntimeLogsComponent implements OnInit {
       .pipe(
         map(([applications, plans]) => {
           return {
+            period,
             plans:
               planIds?.map(id => {
                 const plan = plans.find(p => p.id === id);
@@ -173,15 +171,13 @@ export class ApiRuntimeLogsComponent implements OnInit {
                 const application = applications.data.find(app => app.id === id);
                 return { value: id, label: `${application.name} ( ${application.owner?.displayName} )` };
               }) ?? undefined,
-            from: this.activatedRoute.snapshot.queryParams?.from
-              ? moment(Number(this.activatedRoute.snapshot.queryParams.from))
-              : undefined,
-            to: this.activatedRoute.snapshot.queryParams?.to ? moment(Number(this.activatedRoute.snapshot.queryParams.to)) : undefined,
-            methods: this.activatedRoute.snapshot.queryParams?.methods?.split(',') ?? undefined,
-            mcpMethods: this.activatedRoute.snapshot.queryParams?.mcpMethods?.split(',') ?? undefined,
+            from: !hasRelativePeriod && qp?.from ? moment(Number(qp.from)) : undefined,
+            to: !hasRelativePeriod && qp?.to ? moment(Number(qp.to)) : undefined,
+            methods: qp?.methods?.split(',') ?? undefined,
+            mcpMethods: qp?.mcpMethods?.split(',') ?? undefined,
             statuses: statuses?.size > 0 ? statuses : undefined,
-            entrypoints: this.activatedRoute.snapshot.queryParams?.entrypointIds?.split(',') ?? undefined,
-            errorKeys: this.activatedRoute.snapshot.queryParams?.errorKeys?.split(',') ?? undefined,
+            entrypoints: qp?.entrypointIds?.split(',') ?? undefined,
+            errorKeys: qp?.errorKeys?.split(',') ?? undefined,
           };
         }),
       )

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-list/api-runtime-logs-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-list/api-runtime-logs-list.component.html
@@ -28,7 +28,7 @@
     <ng-container matColumnDef="timestamp">
       <th mat-header-cell *matHeaderCellDef id="timestamp">Timestamp</th>
       <td mat-cell *matCellDef="let log">
-        <a [routerLink]="'./' + log.requestId">{{ log.timestamp | date: 'dd/MM/yyyy HH:mm:ss.SSS' }}</a>
+        <a [routerLink]="'./' + log.requestId" queryParamsHandling="preserve">{{ log.timestamp | date: 'dd/MM/yyyy HH:mm:ss.SSS' }}</a>
       </td>
     </ng-container>
 
@@ -145,7 +145,7 @@
       </th>
       <td mat-cell *matCellDef="let log">
         <div>
-          <a mat-button data-testid="api_logs_details_button" [routerLink]="'./' + log.requestId"
+          <a mat-button data-testid="api_logs_details_button" [routerLink]="'./' + log.requestId" queryParamsHandling="preserve"
             ><mat-icon svgIcon="gio:eye-empty"></mat-icon
           ></a>
         </div>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-list/api-runtime-logs-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-list/api-runtime-logs-list.component.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
+import { RouterLink } from '@angular/router';
+
+import { ApiRuntimeLogsListComponent } from './api-runtime-logs-list.component';
+
+import { fakeConnectionLog } from '../../../../../../entities/management-api-v2';
+import { GioTestingModule } from '../../../../../../shared/testing';
+
+describe('ApiRuntimeLogsListComponent', () => {
+  const LOG = fakeConnectionLog();
+  const PAGINATION = { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 1, totalCount: 1 };
+
+  let fixture: ComponentFixture<ApiRuntimeLogsListComponent>;
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [ApiRuntimeLogsListComponent, GioTestingModule, NoopAnimationsModule],
+    });
+
+    await TestBed.compileComponents();
+    fixture = TestBed.createComponent(ApiRuntimeLogsListComponent);
+
+    fixture.componentRef.setInput('logs', [LOG]);
+    fixture.componentRef.setInput('pagination', PAGINATION);
+    fixture.componentRef.setInput('apiType', 'PROXY');
+    fixture.detectChanges();
+  });
+
+  it('should render a row per log entry', () => {
+    const rows = fixture.nativeElement.querySelectorAll('[data-testid="api_logs_table_row"]');
+    expect(rows).toHaveLength(1);
+  });
+
+  describe('detail navigation links', () => {
+    it('should set queryParamsHandling="preserve" on the timestamp link', () => {
+      const timestampLink = fixture.debugElement.query(By.css('td a:not([data-testid])'));
+      expect(timestampLink).toBeTruthy();
+      expect(timestampLink.injector.get(RouterLink).queryParamsHandling).toBe('preserve');
+    });
+
+    it('should set queryParamsHandling="preserve" on the details button', () => {
+      const detailsButton = fixture.debugElement.query(By.css('[data-testid="api_logs_details_button"]'));
+      expect(detailsButton).toBeTruthy();
+      expect(detailsButton.injector.get(RouterLink).queryParamsHandling).toBe('preserve');
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/components/api-runtime-logs-quick-filters/api-runtime-logs-quick-filters.component.ts
@@ -131,7 +131,7 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.moreFiltersValues = {
-      period: DEFAULT_PERIOD,
+      period: this.initialValues.period ?? DEFAULT_PERIOD,
       from: this.initialValues.from,
       to: this.initialValues.to,
       statuses: this.initialValues.statuses,
@@ -139,7 +139,7 @@ export class ApiRuntimeLogsQuickFiltersComponent implements OnInit, OnDestroy {
       errorKeys: this.initialValues.errorKeys,
     };
     this.quickFiltersForm = new UntypedFormGroup({
-      period: new UntypedFormControl({ value: DEFAULT_PERIOD, disabled: true }),
+      period: new UntypedFormControl({ value: this.initialValues.period ?? DEFAULT_PERIOD, disabled: true }),
       entrypoints: new UntypedFormControl({ value: this.initialValues.entrypoints, disabled: true }),
       plans: new UntypedFormControl({
         value: this.initialValues.plans?.map(plan => plan.value) ?? DEFAULT_FILTERS.plans,

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/models/api-runtime-logs-quick-filters.models.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/models/api-runtime-logs-quick-filters.models.ts
@@ -55,6 +55,7 @@ export type MoreFiltersForm = {
 };
 
 export type LogFiltersInitialValues = {
+  period?: SimpleFilter;
   applications?: MultiFilter;
   plans?: MultiFilter;
   from: Moment;

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/services/quick-filters-store.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs/services/quick-filters-store.service.ts
@@ -19,7 +19,7 @@ import moment from 'moment';
 
 import DurationConstructor = moment.unitOfTime.DurationConstructor;
 
-import { DEFAULT_FILTERS, LogFilters, SimpleFilter } from '../models';
+import { DEFAULT_FILTERS, DEFAULT_PERIOD, LogFilters, SimpleFilter } from '../models';
 
 @Injectable()
 export class QuickFiltersStoreService {
@@ -42,6 +42,7 @@ export class QuickFiltersStoreService {
     return {
       page,
       perPage,
+      period: logFilters.period?.value !== DEFAULT_PERIOD.value ? logFilters.period?.value : null,
       from: logFilters.from ? logFilters.from : from,
       to: logFilters.to ? logFilters.to : to,
       entrypointIds: logFilters.entrypoints?.length > 0 ? logFilters.entrypoints.join(',') : null,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13403

## Description

Fixed filter loss when navigating v4 runtime logs by ensuring state is correctly synced with the URL and browser history.

Sync the period filter with URL query parameters and replace detail view routerLinks with browser history navigation to prevent state loss.

## Additional context

**_Before fix:_**

https://github.com/user-attachments/assets/c3c35b93-a248-4879-8693-6e1e50f9883a


**_After fix:_**

https://github.com/user-attachments/assets/989d1480-c14a-4726-b2a5-fcd7cba7794e



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

