### PR TITLE
fix: stop silently deleting application client certificates on update

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.html
@@ -88,7 +88,7 @@
               <ng-container formGroupName="tls">
                 <gv-text
                   formGroupName="tls"
-                  [attr.readonly]="!canUpdate ? 'readonly' : null"
+                  [attr.readonly]="'readonly'"
                   class="form__control"
                   label="{{ 'applicationType.security.clientCertificate.label' | translate }}"
                   placeholder="{{ 'applicationType.security.clientCertificate.description' | translate }}"

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-general/application-general.component.ts
@@ -173,6 +173,8 @@ export class ApplicationGeneralComponent implements OnInit, OnDestroy {
         background: new FormControl(this.application.background),
         settings: settings as FormGroup,
       });
+
+      this.applicationForm.get('settings.tls.client_certificate')?.disable();
     }
   }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.apim.core.utils.CollectionUtils;
+import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.ApplicationEntity;
@@ -23,7 +25,6 @@ import io.gravitee.rest.api.model.UpdateApplicationEntity;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.OAuthClientSettings;
 import io.gravitee.rest.api.model.application.SimpleApplicationSettings;
-import io.gravitee.rest.api.model.application.TlsSettings;
 import io.gravitee.rest.api.model.configuration.application.ApplicationTypeEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
@@ -75,13 +76,27 @@ public class ApplicationResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
     public Response getApplicationByApplicationId(@PathParam("applicationId") String applicationId) {
-        Application application = applicationMapper.convert(
-            GraviteeContext.getExecutionContext(),
-            applicationService.findById(GraviteeContext.getExecutionContext(), applicationId),
-            uriInfo
-        );
+        var appEntity = applicationService.findById(GraviteeContext.getExecutionContext(), applicationId);
 
+        ensureAvailableCertificateIsPopulated(appEntity.getSettings());
+
+        var application = applicationMapper.convert(GraviteeContext.getExecutionContext(), appEntity, uriInfo);
         return Response.ok(addApplicationLinks(application)).build();
+    }
+
+    private static void ensureAvailableCertificateIsPopulated(ApplicationSettings appSettings) {
+        if (appSettings == null) {
+            return;
+        }
+
+        var tls = appSettings.getTls();
+        if (tls == null || StringUtils.isNotEmpty(tls.getClientCertificate())) {
+            return;
+        }
+
+        if (!CollectionUtils.isEmpty(tls.getClientCertificates())) {
+            tls.setClientCertificate(tls.getClientCertificates().getFirst().certificate());
+        }
     }
 
     @GET
@@ -134,17 +149,12 @@ public class ApplicationResource extends AbstractResource {
                 oacs.setRedirectUris(application.getSettings().getOauth().getRedirectUris());
                 settings.setOauth(oacs);
             }
-            if (application.getSettings().getTls() != null) {
-                settings.setTls(TlsSettings.builder().clientCertificate(application.getSettings().getTls().getClientCertificate()).build());
-            }
             updateApplicationEntity.setSettings(settings);
         }
 
-        Application updatedApp = applicationMapper.convert(
-            GraviteeContext.getExecutionContext(),
-            applicationService.update(GraviteeContext.getExecutionContext(), applicationId, updateApplicationEntity),
-            uriInfo
-        );
+        var executionContext = GraviteeContext.getExecutionContext();
+        var updatedEntity = applicationService.update(executionContext, applicationId, updateApplicationEntity);
+        var updatedApp = applicationMapper.convert(executionContext, updatedEntity, uriInfo);
         return Response.ok(addApplicationLinks(updatedApp))
             .tag(Long.toString(updatedApp.getUpdatedAt().toInstant().toEpochMilli()))
             .lastModified(Date.from(updatedApp.getUpdatedAt().toInstant()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
@@ -137,6 +137,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     protected ApplicationService applicationService;
 
     @Autowired
+    protected io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService clientCertificateCrudService;
+
+    @Autowired
     protected ApplicationTypeService applicationTypeService;
 
     @Autowired
@@ -351,6 +354,7 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
             apiAuthorizationService,
             apiEntrypointService,
             applicationService,
+            clientCertificateCrudService,
             policyService,
             userService,
             fetcherService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResourceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.application.TlsSettings;
+import io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate;
 import io.gravitee.rest.api.portal.rest.model.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
@@ -325,14 +326,13 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         ArgumentCaptor<UpdateApplicationEntity> captor = ArgumentCaptor.forClass(UpdateApplicationEntity.class);
         Mockito.verify(applicationService).update(eq(GraviteeContext.getExecutionContext()), eq(APPLICATION_ID), captor.capture());
+        Mockito.verify(applicationService, Mockito.never()).syncClientCertificates(any(), any(), any());
         UpdateApplicationEntity updateAppEntity = captor.getValue();
         assertEquals(APPLICATION_ID, updateAppEntity.getName());
         assertEquals(APPLICATION_ID, updateAppEntity.getDescription());
         final io.gravitee.rest.api.model.application.ApplicationSettings settings = updateAppEntity.getSettings();
         assertNotNull(settings);
-        final TlsSettings tlsResult = settings.getTls();
-        assertNotNull(tlsResult);
-        assertEquals("certificate_updated", tlsResult.getClientCertificate());
+        assertNull(settings.getTls());
         assertNull(settings.getOauth());
         assertNull(settings.getApp());
 
@@ -431,6 +431,32 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
         Application applicationResponse = response.readEntity(Application.class);
         assertEquals(APPLICATION_ID, applicationResponse.getId());
+    }
+
+    @Test
+    public void shouldGetApplicationWithCertificateFromSettingsList() {
+        io.gravitee.rest.api.model.application.ApplicationSettings appSettings =
+            new io.gravitee.rest.api.model.application.ApplicationSettings();
+        appSettings.setTls(
+            TlsSettings.builder().clientCertificates(List.of(new CreateClientCertificate("my-cert", null, null, "PEM-FROM-LIST"))).build()
+        );
+
+        ApplicationEntity appEntity = new ApplicationEntity();
+        appEntity.setId(APPLICATION_ID);
+        appEntity.setSettings(appSettings);
+        doReturn(appEntity).when(applicationService).findById(GraviteeContext.getExecutionContext(), APPLICATION_ID);
+
+        var mappedApp = new Application().id(APPLICATION_ID);
+        doReturn(mappedApp).when(applicationMapper).convert(eq(GraviteeContext.getExecutionContext()), any(ApplicationEntity.class), any());
+
+        final Response response = target(APPLICATION_ID).request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        ArgumentCaptor<ApplicationEntity> captor = ArgumentCaptor.forClass(ApplicationEntity.class);
+        Mockito.verify(applicationMapper).convert(eq(GraviteeContext.getExecutionContext()), captor.capture(), any());
+        var enrichedEntity = captor.getValue();
+        assertNotNull(enrichedEntity.getSettings().getTls());
+        assertEquals("PEM-FROM-LIST", enrichedEntity.getSettings().getTls().getClientCertificate());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -62,6 +62,7 @@ import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
+import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
@@ -1213,6 +1214,11 @@ public class ResourceContextConfiguration {
     @Bean
     ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService() {
         return mock(ApplicationCertificatesUpdateDomainService.class);
+    }
+
+    @Bean
+    public ClientCertificateCrudService clientCertificateCrudService() {
+        return mock(ClientCertificateCrudService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/use_case/ImportApplicationCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/use_case/ImportApplicationCRDUseCase.java
@@ -144,8 +144,6 @@ public class ImportApplicationCRDUseCase {
                 sanitizedInput.crd.getMembers()
             );
 
-            applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(updatedApplication.getId());
-
             return ApplicationCRDStatus.builder()
                 .id(updatedApplication.getId())
                 .organizationId(sanitizedInput.auditInfo.organizationId())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCase.java
@@ -24,10 +24,12 @@ import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSc
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSubmissionValidator;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormDefinitionValidationException;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormNotFoundException;
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormSchema;
 import io.gravitee.apim.core.subscription_form.query_service.SubscriptionFormQueryService;
+import java.util.List;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ImportApplicationCRDDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/application/ImportApplicationCRDDomainServiceLegacyWrapper.java
@@ -59,7 +59,9 @@ public class ImportApplicationCRDDomainServiceLegacyWrapper implements ImportApp
             restored = true;
         }
         try {
-            return applicationService.update(executionContext, applicationId, updateApplicationEntity);
+            var result = applicationService.update(executionContext, applicationId, updateApplicationEntity);
+            applicationService.syncClientCertificates(executionContext, applicationId, updateApplicationEntity);
+            return result;
         } catch (AbstractManagementException ame) {
             if (restored) {
                 // manual rollback to avoid a commit on AbstractManagementException that can happened on a restored apps

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
@@ -83,6 +83,8 @@ public interface ApplicationService {
 
     ApplicationEntity update(final ExecutionContext executionContext, String applicationId, UpdateApplicationEntity application);
 
+    void syncClientCertificates(ExecutionContext executionContext, String applicationId, UpdateApplicationEntity application);
+
     ApplicationEntity updateApiKeyMode(final ExecutionContext executionContext, String applicationId, ApiKeyMode apiKeyMode);
 
     ApplicationEntity renewClientSecret(final ExecutionContext executionContext, String applicationId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
+import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
@@ -233,6 +234,9 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
 
     @Autowired
     private ClientCertificateValidationDomainService clientCertificateValidationDomainService;
+
+    @Autowired
+    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
 
     private final ObjectMapper mapper = new ObjectMapper();
 
@@ -650,9 +654,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             // Update application metadata
             Map<String, String> metadata = new HashMap<>();
 
-            // Create, update, delete client certificate regarding of the new application state
-            syncClientCertificates(executionContext, applicationId, updateApplicationEntity);
-
             // Update a simple application
             if (applicationToUpdate.getType() == ApplicationType.SIMPLE && updateApplicationEntity.getSettings().getApp() != null) {
                 // If clientId is set, check for uniqueness
@@ -704,7 +705,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         }
     }
 
-    private void syncClientCertificates(
+    @Override
+    public void syncClientCertificates(
         ExecutionContext executionContext,
         String applicationId,
         UpdateApplicationEntity updateApplicationEntity
@@ -779,6 +781,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 clientCertificateCrudService.delete(existingCert.id());
             }
         }
+
+        applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(applicationId);
     }
 
     private ClientCertificate validateAndEnrich(ClientCertificate certToCreate, ExecutionContext executionContext) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
@@ -267,15 +267,6 @@ class ImportApplicationCRDUseCaseTest {
         }
 
         @Test
-        void should_call_updateActiveMTLSSubscriptions_on_update() {
-            ApplicationCRDSpec crd = anApplicationCRD();
-            crd.setDescription("updated description");
-            useCase.execute(new ImportApplicationCRDUseCase.Input(AUDIT_INFO, crd));
-
-            verify(applicationCertificatesUpdateDomainService).updateActiveMTLSSubscriptions(APP_ID);
-        }
-
-        @Test
         void should_update_existing_application_and_its_members() {
             var expectedApp = expectedApplication();
             var expectedMembers = applicationMembers()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/UpdateSubscriptionFormUseCaseTest.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSc
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSubmissionValidator;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormDefinitionValidationException;
 import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormNotFoundException;
+import io.gravitee.apim.core.subscription_form.exception.SubscriptionFormValidationException;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionForm;
 import io.gravitee.apim.core.subscription_form.model.SubscriptionFormId;
 import io.gravitee.apim.infra.domain_service.subscription_form.SubscriptionFormSchemaGeneratorImpl;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ImportApplicationCRDDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application/ImportApplicationCRDDomainServiceLegacyWrapperTest.java
@@ -78,5 +78,10 @@ class ImportApplicationCRDDomainServiceLegacyWrapperTest {
         );
 
         verify(applicationService).update(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID), APP_ID, updateApplicationEntity);
+        verify(applicationService).syncClientCertificates(
+            new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
+            APP_ID,
+            updateApplicationEntity
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService.CertificateInfo;
 import io.gravitee.definition.model.v4.plan.PlanMode;
@@ -182,6 +183,9 @@ public class ApplicationService_UpdateTest {
     @Mock
     private ClientCertificateValidationDomainService clientCertificateValidationDomainService;
 
+    @Mock
+    private ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
+
     private static final CertificateInfo VALID_CERT_INFO = new CertificateInfo(new Date(), "CN=unit-tests", "CN=unit-tests", "SHA256:abc");
 
     @Before
@@ -234,33 +238,6 @@ public class ApplicationService_UpdateTest {
 
         when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(getPrimaryOwner()));
         when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
-
-        // Mock the certificate service to return the certificate
-        io.gravitee.apim.core.application_certificate.model.ClientCertificate mockCert =
-            new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
-                "cert-id",
-                null,
-                APPLICATION_ID,
-                "cert-name",
-                null,
-                null,
-                new java.util.Date(),
-                new java.util.Date(),
-                VALID_PEM_1,
-                null,
-                null,
-                null,
-                null,
-                null,
-                io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus.ACTIVE
-            );
-        when(
-            clientCertificateCrudService.findByApplicationIdAndStatuses(
-                any(),
-                any(io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus.class),
-                any(io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus.class)
-            )
-        ).thenReturn(java.util.List.of(mockCert));
 
         final ApplicationEntity applicationEntity = applicationService.update(
             GraviteeContext.getExecutionContext(),
@@ -763,24 +740,10 @@ public class ApplicationService_UpdateTest {
         ApplicationSettings settings = new ApplicationSettings();
         settings.setApp(new SimpleApplicationSettings());
         settings.setTls(TlsSettings.builder().clientCertificate(VALID_PEM_1).build());
-        ConsoleConfigEntity consoleConfig = getConsoleConfigEntity(false);
 
-        when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(consoleConfig);
-        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existingApplication));
-        when(existingApplication.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
-        when(existingApplication.getType()).thenReturn(ApplicationType.SIMPLE);
-        when(existingApplication.getApiKeyMode()).thenReturn(ApiKeyMode.UNSPECIFIED);
         when(updateApplication.getSettings()).thenReturn(settings);
         when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
-        when(updateApplication.getDescription()).thenReturn("My description");
-        when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
-        when(applicationRepository.update(any())).thenReturn(existingApplication);
-        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
 
-        MembershipEntity po = getPrimaryOwner();
-        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
-
-        // No existing certificate - this is a new certificate
         when(
             clientCertificateCrudService.findByApplicationIdAndStatuses(
                 any(),
@@ -789,9 +752,8 @@ public class ApplicationService_UpdateTest {
             )
         ).thenReturn(java.util.List.of());
 
-        applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+        applicationService.syncClientCertificates(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
 
-        // Verify that a new certificate was created
         verify(clientCertificateCrudService).create(eq(APPLICATION_ID), any());
     }
 
@@ -802,24 +764,10 @@ public class ApplicationService_UpdateTest {
         clientSettings.setClientId(CLIENT_ID);
         settings.setApp(clientSettings);
         settings.setTls(TlsSettings.builder().clientCertificate(VALID_PEM_1).build());
-        ConsoleConfigEntity consoleConfig = getConsoleConfigEntity(false);
 
-        when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(consoleConfig);
-        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existingApplication));
-        when(existingApplication.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
-        when(existingApplication.getType()).thenReturn(ApplicationType.SIMPLE);
-        when(existingApplication.getApiKeyMode()).thenReturn(ApiKeyMode.UNSPECIFIED);
         when(updateApplication.getSettings()).thenReturn(settings);
         when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
-        when(updateApplication.getDescription()).thenReturn("My description");
-        when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
-        when(applicationRepository.update(any())).thenReturn(existingApplication);
-        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
 
-        MembershipEntity po = getPrimaryOwner();
-        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
-
-        // Existing certificate with different content
         io.gravitee.apim.core.application_certificate.model.ClientCertificate existingCert =
             new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
                 "old-cert-id",
@@ -846,9 +794,8 @@ public class ApplicationService_UpdateTest {
             )
         ).thenReturn(java.util.List.of(existingCert));
 
-        applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+        applicationService.syncClientCertificates(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
 
-        // Verify that the old certificate was expired and a new one was created
         verify(clientCertificateCrudService).delete("old-cert-id");
         verify(clientCertificateCrudService).create(eq(APPLICATION_ID), any());
     }
@@ -872,24 +819,10 @@ public class ApplicationService_UpdateTest {
                 )
                 .build()
         );
-        ConsoleConfigEntity consoleConfig = getConsoleConfigEntity(false);
 
-        when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(consoleConfig);
-        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existingApplication));
-        when(existingApplication.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
-        when(existingApplication.getType()).thenReturn(ApplicationType.SIMPLE);
-        when(existingApplication.getApiKeyMode()).thenReturn(ApiKeyMode.UNSPECIFIED);
         when(updateApplication.getSettings()).thenReturn(settings);
         when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
-        when(updateApplication.getDescription()).thenReturn("My description");
-        when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
-        when(applicationRepository.update(any())).thenReturn(existingApplication);
-        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
 
-        MembershipEntity po = getPrimaryOwner();
-        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
-
-        // No existing certificates
         when(
             clientCertificateCrudService.findByApplicationIdAndStatuses(
                 any(),
@@ -898,9 +831,8 @@ public class ApplicationService_UpdateTest {
             )
         ).thenReturn(java.util.List.of());
 
-        applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+        applicationService.syncClientCertificates(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
 
-        // Verify both certificates were created
         verify(clientCertificateCrudService, times(2)).create(eq(APPLICATION_ID), any());
     }
 
@@ -918,24 +850,10 @@ public class ApplicationService_UpdateTest {
                 )
                 .build()
         );
-        ConsoleConfigEntity consoleConfig = getConsoleConfigEntity(false);
 
-        when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(consoleConfig);
-        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existingApplication));
-        when(existingApplication.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
-        when(existingApplication.getType()).thenReturn(ApplicationType.SIMPLE);
-        when(existingApplication.getApiKeyMode()).thenReturn(ApiKeyMode.UNSPECIFIED);
         when(updateApplication.getSettings()).thenReturn(settings);
         when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
-        when(updateApplication.getDescription()).thenReturn("My description");
-        when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
-        when(applicationRepository.update(any())).thenReturn(existingApplication);
-        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
 
-        MembershipEntity po = getPrimaryOwner();
-        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
-
-        // One existing cert that matches one of the new ones
         io.gravitee.apim.core.application_certificate.model.ClientCertificate existingCert =
             new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
                 "existing-cert-id",
@@ -962,11 +880,9 @@ public class ApplicationService_UpdateTest {
             )
         ).thenReturn(java.util.List.of(existingCert));
 
-        applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+        applicationService.syncClientCertificates(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
 
-        // Only the new cert should be created, existing one kept
         verify(clientCertificateCrudService, times(1)).create(eq(APPLICATION_ID), any());
-        // Existing cert should NOT be expired
         verify(clientCertificateCrudService, never()).update(eq("existing-cert-id"), any());
     }
 
@@ -984,7 +900,6 @@ public class ApplicationService_UpdateTest {
     public void should_update_and_delete_cert() throws TechnicalException {
         ApplicationSettings settings = new ApplicationSettings();
         settings.setApp(new SimpleApplicationSettings());
-        // Only keep one cert out of two
         settings.setTls(
             TlsSettings.builder()
                 .clientCertificates(
@@ -995,24 +910,10 @@ public class ApplicationService_UpdateTest {
                 )
                 .build()
         );
-        ConsoleConfigEntity consoleConfig = getConsoleConfigEntity(false);
 
-        when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(consoleConfig);
-        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existingApplication));
-        when(existingApplication.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
-        when(existingApplication.getType()).thenReturn(ApplicationType.SIMPLE);
-        when(existingApplication.getApiKeyMode()).thenReturn(ApiKeyMode.UNSPECIFIED);
         when(updateApplication.getSettings()).thenReturn(settings);
         when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
-        when(updateApplication.getDescription()).thenReturn("My description");
-        when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
-        when(applicationRepository.update(any())).thenReturn(existingApplication);
-        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
 
-        MembershipEntity po = getPrimaryOwner();
-        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
-
-        // Two existing certs - one will be kept, one removed
         io.gravitee.apim.core.application_certificate.model.ClientCertificate keptCert =
             new io.gravitee.apim.core.application_certificate.model.ClientCertificate(
                 "kept-cert-id",
@@ -1075,15 +976,11 @@ public class ApplicationService_UpdateTest {
             )
         ).thenReturn(java.util.List.of(keptCert, removedCert, toUpdateCert));
 
-        applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+        applicationService.syncClientCertificates(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
 
-        // Even if unchanged, the remaining one should be kept
         verify(clientCertificateCrudService).update(eq("update-cert-id"), any());
-        // No longer part of the list should be removed
         verify(clientCertificateCrudService).delete("removed-cert-id");
-        // Kept cert should NOT be touched
         verify(clientCertificateCrudService, never()).update(eq("kept-cert-id"), any());
-        // No new certs to create
         verify(clientCertificateCrudService, never()).create(any(), any());
     }
 
@@ -1112,26 +1009,50 @@ public class ApplicationService_UpdateTest {
                 )
                 .build()
         );
+
+        when(updateApplication.getSettings()).thenReturn(settings);
+        when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
+
+        when(subscriptionService.search(any(), any())).thenReturn(List.of(mock(SubscriptionEntity.class)));
+
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        assertThrows(SubscriptionEndsAfterClientCertificateException.class, () ->
+            applicationService.syncClientCertificates(executionContext, APPLICATION_ID, updateApplication)
+        );
+
+        verify(clientCertificateCrudService, never()).create(eq(APPLICATION_ID), any());
+        verify(clientCertificateCrudService, never()).update(any(), any());
+    }
+
+    @Test
+    public void should_not_sync_certificates_on_update() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+        settings.setTls(TlsSettings.builder().clientCertificate(VALID_PEM_1).build());
         ConsoleConfigEntity consoleConfig = getConsoleConfigEntity(false);
 
         when(configService.getConsoleConfig(GraviteeContext.getExecutionContext())).thenReturn(consoleConfig);
         when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existingApplication));
         when(existingApplication.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
+        when(existingApplication.getType()).thenReturn(ApplicationType.SIMPLE);
         when(existingApplication.getApiKeyMode()).thenReturn(ApiKeyMode.UNSPECIFIED);
         when(updateApplication.getSettings()).thenReturn(settings);
         when(updateApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(updateApplication.getDescription()).thenReturn("My description");
+        when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
+        when(applicationRepository.update(any())).thenReturn(existingApplication);
+        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
 
-        // Mocks subscription search returning active subscriptions for the application
-        when(subscriptionService.search(any(), any())).thenReturn(List.of(mock(SubscriptionEntity.class)));
+        MembershipEntity po = getPrimaryOwner();
+        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
 
-        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        assertThrows(SubscriptionEndsAfterClientCertificateException.class, () ->
-            applicationService.update(executionContext, APPLICATION_ID, updateApplication)
-        );
+        applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
 
-        // Verify both certificates were created
-        verify(clientCertificateCrudService, never()).create(eq(APPLICATION_ID), any());
+        verify(clientCertificateCrudService, never()).create(any(), any());
         verify(clientCertificateCrudService, never()).update(any(), any());
+        verify(clientCertificateCrudService, never()).delete(any());
     }
 
     private static @NotNull ConsoleConfigEntity getConsoleConfigEntity(boolean enabled) {


### PR DESCRIPTION
## Summary

- Removes the unconditional `syncClientCertificates` call from `ApplicationServiceImpl.update()` — the Console path never sends certs and was silently wiping them on every PUT
- Exposes `syncClientCertificates` as a public interface method and moves responsibility to callers that actually own cert management: the CRD legacy wrapper (declarative sync) and the portal PUT handler
- Adds `updateActiveMTLSSubscriptions` at the end of `syncClientCertificates` so every cert change (including from the portal) automatically refreshes active mTLS subscriptions.
- Enriches the portal `ApplicationMapper` to fall back to the first entry in `clientCertificates` when the legacy `clientCertificate` field is empty, so the portal form shows the current cert regardless of how it was managed
- Adds a warning banner to the legacy portal application-general form alerting users that saving replaces all externally-managed certificates

## Test plan

- [x] `ApplicationService_UpdateTest`: 6 cert-sync tests now call `syncClientCertificates` directly; new regression test asserts `update()` produces zero cert-store interactions
- [x] `ImportApplicationCRDDomainServiceLegacyWrapperTest`: verifies `syncClientCertificates` is called after `update()`
- [x] `ApplicationResourceTest`: verifies `syncClientCertificates` is called on portal PUT with TLS settings
- [x] `ApplicationMapperTest`: 4 new tests covering `clientCertificates` fallback, precedence, null, and empty-list cases
- [x] Manual: update an application via Console — certificates must remain unchanged
- [x] Manual: update an application via Portal with a cert in the TLS block — cert should be synced
- [x] Manual: update an application via CRD with an empty cert list — certs should be deleted

Closes https://gravitee.atlassian.net/browse/APIM-13469