### PR TITLE
feat(api-product) : auto add groups to new, old api-product || backend

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiProduct.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiProduct.java
@@ -17,7 +17,9 @@ package io.gravitee.repository.management.model;
 
 import java.time.ZonedDateTime;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -39,6 +41,14 @@ public class ApiProduct {
     private String description;
     private String version;
     private List<String> apiIds;
+    private Set<String> groups;
     private Date createdAt;
     private Date updatedAt;
+
+    public boolean addGroup(String groupId) {
+        if (groups == null) {
+            groups = new HashSet<>();
+        }
+        return groups.add(groupId);
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/GroupEvent.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/GroupEvent.java
@@ -22,4 +22,5 @@ package io.gravitee.repository.management.model;
 public enum GroupEvent {
     API_CREATE,
     APPLICATION_CREATE,
+    API_PRODUCT_CREATE,
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
@@ -40,10 +40,12 @@ import org.springframework.util.CollectionUtils;
 public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProduct, String> implements ApiProductsRepository {
 
     private final String API_PRODUCT_APIS;
+    private final String API_PRODUCT_GROUPS;
 
     JdbcApiProductRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
         super(tablePrefix, "api_products");
         API_PRODUCT_APIS = getTableNameFor("api_product_apis");
+        API_PRODUCT_GROUPS = getTableNameFor("api_product_groups");
     }
 
     @Override
@@ -70,6 +72,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
         try {
             jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(apiProduct));
             storeApiIds(apiProduct, false);
+            storeGroupIds(apiProduct, false);
             return findById(apiProduct.getId()).orElse(null);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to create api product", ex);
@@ -82,6 +85,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
         try {
             jdbcTemplate.update(getOrm().buildUpdatePreparedStatementCreator(apiProduct, apiProduct.getId()));
             storeApiIds(apiProduct, true);
+            storeGroupIds(apiProduct, true);
             return findById(apiProduct.getId()).orElseThrow(() ->
                 new IllegalStateException(String.format("No api product found with id [%s]", apiProduct.getId()))
             );
@@ -103,6 +107,12 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 id
             );
             apiProduct.setApiIds(apiIds);
+            List<String> groupIds = jdbcTemplate.query(
+                "SELECT group_id FROM " + API_PRODUCT_GROUPS + " WHERE api_product_id = ?",
+                (ResultSet rs, int rowNum) -> rs.getString("group_id"),
+                id
+            );
+            apiProduct.setGroups(groupIds.isEmpty() ? null : new HashSet<>(groupIds));
             return Optional.of(apiProduct);
         }
         return opt;
@@ -125,7 +135,9 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                     return apiProduct;
                 }
             );
-            return new HashSet<>(aggregateApiProducts(apiProducts));
+            List<ApiProduct> aggregated = aggregateApiProducts(apiProducts);
+            enrichWithGroupIds(aggregated);
+            return new HashSet<>(aggregated);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find all api products", ex);
         }
@@ -150,7 +162,9 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 environmentId,
                 name
             );
-            return apiProducts.isEmpty() ? Optional.empty() : Optional.of(aggregateApiProducts(apiProducts).get(0));
+            List<ApiProduct> aggregated = aggregateApiProducts(apiProducts);
+            enrichWithGroupIds(aggregated);
+            return aggregated.isEmpty() ? Optional.empty() : Optional.of(aggregated.get(0));
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api product by environment and name", ex);
         }
@@ -175,7 +189,9 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 },
                 environmentId
             );
-            return new HashSet<>(aggregateApiProducts(apiProducts));
+            List<ApiProduct> aggregatedByEnv = aggregateApiProducts(apiProducts);
+            enrichWithGroupIds(aggregatedByEnv);
+            return new HashSet<>(aggregatedByEnv);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by environment", ex);
         }
@@ -186,6 +202,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
         log.debug("JdbcApiProductRepository.delete({})", id);
         try {
             jdbcTemplate.update("DELETE FROM " + API_PRODUCT_APIS + " WHERE api_product_id = ?", id);
+            jdbcTemplate.update("DELETE FROM " + API_PRODUCT_GROUPS + " WHERE api_product_id = ?", id);
             jdbcTemplate.update(getOrm().getDeleteSql(), id);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to delete api product", ex);
@@ -213,7 +230,9 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 },
                 apiId
             );
-            return new HashSet<>(aggregateApiProducts(apiProducts));
+            List<ApiProduct> aggregatedByApiId = aggregateApiProducts(apiProducts);
+            enrichWithGroupIds(aggregatedByApiId);
+            return new HashSet<>(aggregatedByApiId);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by apiId", ex);
         }
@@ -257,7 +276,9 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 },
                 idList.toArray()
             );
-            return new HashSet<>(aggregateApiProducts(apiProducts));
+            List<ApiProduct> aggregatedByApiIds = aggregateApiProducts(apiProducts);
+            enrichWithGroupIds(aggregatedByApiIds);
+            return new HashSet<>(aggregatedByApiIds);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by api ids", ex);
         }
@@ -289,7 +310,9 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 },
                 idList.toArray()
             );
-            return new HashSet<>(aggregateApiProducts(apiProducts));
+            List<ApiProduct> aggregatedByIds = aggregateApiProducts(apiProducts);
+            enrichWithGroupIds(aggregatedByIds);
+            return new HashSet<>(aggregatedByIds);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by ids", ex);
         }
@@ -402,6 +425,50 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 }
             );
         }
+    }
+
+    private void storeGroupIds(ApiProduct apiProduct, boolean deleteFirst) {
+        if (deleteFirst) {
+            jdbcTemplate.update("DELETE FROM " + API_PRODUCT_GROUPS + " WHERE api_product_id = ?", apiProduct.getId());
+        }
+        if (apiProduct.getGroups() != null && !apiProduct.getGroups().isEmpty()) {
+            List<String> groupIds = new ArrayList<>(apiProduct.getGroups());
+            jdbcTemplate.batchUpdate(
+                "INSERT INTO " + API_PRODUCT_GROUPS + " (api_product_id, group_id) VALUES (?, ?)",
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, apiProduct.getId());
+                        ps.setString(2, groupIds.get(i));
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return groupIds.size();
+                    }
+                }
+            );
+        }
+    }
+
+    private void enrichWithGroupIds(List<ApiProduct> products) {
+        if (products == null || products.isEmpty()) {
+            return;
+        }
+        List<String> productIds = products.stream().map(ApiProduct::getId).toList();
+        Map<String, Set<String>> groupsByProductId = new HashMap<>();
+        jdbcTemplate.query(
+            "SELECT api_product_id, group_id FROM " +
+                API_PRODUCT_GROUPS +
+                " WHERE api_product_id IN (" +
+                getOrm().buildInClause(productIds) +
+                ")",
+            rs -> {
+                groupsByProductId.computeIfAbsent(rs.getString("api_product_id"), k -> new HashSet<>()).add(rs.getString("group_id"));
+            },
+            productIds.toArray()
+        );
+        products.forEach(p -> p.setGroups(groupsByProductId.getOrDefault(p.getId(), null)));
     }
 
     private void addApiId(ApiProduct apiProduct, ResultSet rs) throws SQLException {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/02_add_api_product_groups_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/02_add_api_product_groups_table.yml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_02_add_api_product_groups_table
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}api_product_groups
+            columns:
+              - column: {name: api_product_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false } }
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}api_product_groups
+            columnNames: api_product_id, group_id
+            tableName: ${gravitee_prefix}api_product_groups
+        - createIndex:
+            indexName: idx_${gravitee_prefix}api_product_groups_group_id
+            tableName: ${gravitee_prefix}api_product_groups
+            columns:
+              - column:
+                  name: group_id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -329,3 +329,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/00_add_tags_key_column.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/01_add_tenants_key_column.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/02_add_api_product_groups_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiProductRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiProductRepository.java
@@ -47,10 +47,6 @@ public class MongoApiProductRepository implements ApiProductsRepository {
     @Autowired
     private GraviteeMapper mapper;
 
-    public MongoApiProductRepository() {
-        log.info("MongoApiProductRepository constructor called - bean created!");
-    }
-
     @Override
     public Optional<ApiProduct> findByEnvironmentIdAndName(String environmentId, String name) throws TechnicalException {
         log.debug("MongoApiProductRepository.findByEnvironmentIdAndName({} , {})", environmentId, name);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiProductMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiProductMongo.java
@@ -46,6 +46,7 @@ public class ApiProductMongo {
     private String description;
     private String version;
     private List<String> apiIds;
+    private List<String> groups;
     private Date createdAt;
     private Date updatedAt;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
@@ -42,6 +42,7 @@ public class ApiProduct {
     private String description;
     private String version;
     private Set<String> apiIds;
+    private Set<String> groups;
     private ZonedDateTime createdAt;
     private ZonedDateTime updatedAt;
     private PrimaryOwnerEntity primaryOwner;
@@ -60,6 +61,9 @@ public class ApiProduct {
         }
         if (updateApiProduct.getApiIds() != null) {
             this.apiIds = updateApiProduct.getApiIds();
+        }
+        if (updateApiProduct.getGroups() != null) {
+            this.groups = updateApiProduct.getGroups();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/UpdateApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/UpdateApiProduct.java
@@ -33,5 +33,6 @@ public class UpdateApiProduct {
     private String description;
     private String version;
     private Set<String> apiIds;
+    private Set<String> groups;
     private ZonedDateTime updatedAt;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.api_product.use_case;
 
 import static io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService.oneShotIndexation;
+import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
@@ -31,15 +32,19 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.ApiProductAuditEvent;
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerFactory;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
 import io.gravitee.apim.core.notification.model.config.NotificationConfig;
+import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.time.ZonedDateTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -59,6 +64,7 @@ public class CreateApiProductUseCase {
     private final ApiProductIndexerDomainService apiProductIndexerDomainService;
     private final NotificationConfigCrudService notificationConfigCrudService;
     private final DeployApiProductDomainService deployApiProductDomainService;
+    private final GroupQueryService groupQueryService;
 
     public record Input(CreateApiProduct createApiProduct, AuditInfo auditInfo) {}
 
@@ -100,6 +106,18 @@ public class CreateApiProductUseCase {
                     Map.of("environmentId", auditInfo.environmentId(), "name", apiProduct.getName())
                 );
             });
+
+        Set<String> defaultGroups = groupQueryService
+            .findByEvent(auditInfo.environmentId(), Group.GroupEvent.API_PRODUCT_CREATE)
+            .stream()
+            .filter(group -> StringUtils.isEmpty(group.getApiPrimaryOwner()))
+            .map(Group::getId)
+            .collect(toSet());
+        if (!defaultGroups.isEmpty()) {
+            Set<String> sanitizedGroups = new HashSet<>(apiProduct.getGroups() != null ? apiProduct.getGroups() : Set.of());
+            sanitizedGroups.addAll(defaultGroups);
+            apiProduct.setGroups(sanitizedGroups);
+        }
 
         ApiProduct created = apiProductCrudService.create(apiProduct);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/Group.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/Group.java
@@ -51,5 +51,6 @@ public class Group {
     public enum GroupEvent {
         API_CREATE,
         APPLICATION_CREATE,
+        API_PRODUCT_CREATE,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api_product/ApiProductCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/api_product/ApiProductCrudServiceImpl.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
@@ -75,6 +76,9 @@ public class ApiProductCrudServiceImpl implements ApiProductCrudService {
             }
             if (updateApiProduct.getApiIds() != null) {
                 repositoryModel.setApiIds(new ArrayList<>(updateApiProduct.getApiIds()));
+            }
+            if (updateApiProduct.getGroups() != null) {
+                repositoryModel.setGroups(new HashSet<>(updateApiProduct.getGroups()));
             }
             var updatedRepositoryModel = apiProductsRepository.update(repositoryModel);
             return ApiProductAdapter.INSTANCE.toModel(updatedRepositoryModel);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -43,6 +43,7 @@ import io.gravitee.repository.management.model.Group;
 import io.gravitee.repository.management.model.GroupEvent;
 import io.gravitee.repository.management.model.GroupEventRule;
 import io.gravitee.repository.management.model.IdentityProvider;
+import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.Page;
 import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.repository.management.model.Plan;
@@ -89,6 +90,7 @@ import io.gravitee.rest.api.service.exceptions.GroupsNotFoundException;
 import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductTemplateModel;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
@@ -133,6 +135,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     @Lazy
     @Autowired
     private ApplicationRepository applicationRepository;
+
+    @Lazy
+    @Autowired
+    private io.gravitee.repository.management.api.ApiProductsRepository apiProductsRepository;
 
     @Autowired
     private MembershipService membershipService;
@@ -598,6 +604,16 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                         new ApplicationAlertMembershipEvent(executionContext.getOrganizationId(), Set.of(), Set.of(groupId))
                     );
                     break;
+                case "api_product":
+                    apiProductsRepository
+                        .findByEnvironmentId(executionContext.getEnvironmentId())
+                        .stream()
+                        .filter(apiProduct -> apiProduct.addGroup(groupId))
+                        .forEach(apiProduct -> {
+                            runAndManageTechnicalException(() -> apiProductsRepository.update(apiProduct));
+                            triggerApiProductUpdateNotification(executionContext, apiProduct);
+                        });
+                    break;
             }
         } catch (TechnicalException ex) {
             throw new TechnicalManagementException("An error occurs while trying to associate group to all " + associationType, ex);
@@ -766,6 +782,16 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 ApplicationAlertEventType.APPLICATION_MEMBERSHIP_UPDATE,
                 new ApplicationAlertMembershipEvent(executionContext.getOrganizationId(), applicationIds, Collections.emptySet())
             );
+
+            //remove from api products
+            apiProductsRepository
+                .findByEnvironmentId(executionContext.getEnvironmentId())
+                .stream()
+                .filter(p -> p.getGroups() != null && p.getGroups().contains(groupId))
+                .forEach(p -> {
+                    p.getGroups().remove(groupId);
+                    runAndManageTechnicalException(() -> apiProductsRepository.update(p));
+                });
 
             //remove from portal pages
             PageCriteria environmentPageCriteria = new PageCriteria.Builder()
@@ -1278,6 +1304,41 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             ApiHook.API_UPDATED,
             api.getId(),
             new NotificationParamsBuilder().api(apiEntity).user(userService.findById(executionContext, getAuthenticatedUsername())).build()
+        );
+    }
+
+    private void triggerApiProductUpdateNotification(
+        ExecutionContext executionContext,
+        io.gravitee.repository.management.model.ApiProduct apiProduct
+    ) {
+        io.gravitee.rest.api.model.PrimaryOwnerEntity primaryOwner = null;
+        try {
+            String ownerUserId = membershipService.getPrimaryOwnerUserId(
+                executionContext.getOrganizationId(),
+                MembershipReferenceType.API_PRODUCT,
+                apiProduct.getId()
+            );
+            if (ownerUserId != null) {
+                primaryOwner = new io.gravitee.rest.api.model.PrimaryOwnerEntity(userService.findById(executionContext, ownerUserId));
+            }
+        } catch (Exception e) {
+            log.debug("Could not resolve primary owner for API Product {} notification", apiProduct.getId(), e);
+        }
+        ApiProductTemplateModel model = ApiProductTemplateModel.builder()
+            .id(apiProduct.getId())
+            .name(apiProduct.getName())
+            .version(apiProduct.getVersion() != null ? apiProduct.getVersion() : "")
+            .primaryOwner(primaryOwner)
+            .build();
+        notifierService.trigger(
+            executionContext,
+            ApiHook.API_UPDATED,
+            NotificationReferenceType.API_PRODUCT,
+            apiProduct.getId(),
+            new NotificationParamsBuilder()
+                .apiProduct(model)
+                .user(userService.findById(executionContext, getAuthenticatedUsername()))
+                .build()
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -46,6 +46,7 @@ import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerFactory;
@@ -141,7 +142,8 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
             apiProductIndexerDomainService,
             notificationConfigCrudService,
-            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService)
+            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService),
+            groupQueryService
         );
 
         initRoles();
@@ -359,6 +361,112 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
         Assertions.assertThat(message).contains("api-v2");
         Assertions.assertThat(message).contains("not allowed in API Products");
         Assertions.assertThat(message).contains("api-not-allowed");
+    }
+
+    @Test
+    void should_auto_attach_groups_with_api_product_create_event_rule() {
+        groupQueryService.initWith(
+            List.of(
+                Group.builder()
+                    .id("group-1")
+                    .environmentId(ENV_ID)
+                    .eventRules(List.of(new Group.GroupEventRule(Group.GroupEvent.API_PRODUCT_CREATE)))
+                    .build(),
+                Group.builder()
+                    .id("group-2")
+                    .environmentId(ENV_ID)
+                    .eventRules(List.of(new Group.GroupEventRule(Group.GroupEvent.API_PRODUCT_CREATE)))
+                    .build()
+            )
+        );
+
+        var toCreate = CreateApiProduct.builder().name("API Product 1").version("1.0.0").description("desc").apiIds(List.of()).build();
+
+        var output = createApiProductUseCase.execute(new CreateApiProductUseCase.Input(toCreate, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getGroups()).containsExactlyInAnyOrder("group-1", "group-2");
+    }
+
+    @Test
+    void should_not_attach_groups_with_only_api_create_event_rule() {
+        groupQueryService.initWith(
+            List.of(
+                Group.builder()
+                    .id("group-api-create")
+                    .environmentId(ENV_ID)
+                    .eventRules(List.of(new Group.GroupEventRule(Group.GroupEvent.API_CREATE)))
+                    .build(),
+                Group.builder()
+                    .id("group-app-create")
+                    .environmentId(ENV_ID)
+                    .eventRules(List.of(new Group.GroupEventRule(Group.GroupEvent.APPLICATION_CREATE)))
+                    .build()
+            )
+        );
+
+        var toCreate = CreateApiProduct.builder().name("API Product 1").version("1.0.0").description("desc").apiIds(List.of()).build();
+
+        var output = createApiProductUseCase.execute(new CreateApiProductUseCase.Input(toCreate, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getGroups()).isNullOrEmpty();
+    }
+
+    @Test
+    void should_create_product_with_no_groups_when_no_groups_have_api_product_create_rule() {
+        var toCreate = CreateApiProduct.builder().name("API Product 1").version("1.0.0").description("desc").apiIds(List.of()).build();
+
+        var output = createApiProductUseCase.execute(new CreateApiProductUseCase.Input(toCreate, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getGroups()).isNullOrEmpty();
+    }
+
+    @Test
+    void should_only_attach_groups_with_api_product_create_rule_when_mixed_groups_exist() {
+        groupQueryService.initWith(
+            List.of(
+                Group.builder()
+                    .id("group-api-product-create")
+                    .environmentId(ENV_ID)
+                    .eventRules(List.of(new Group.GroupEventRule(Group.GroupEvent.API_PRODUCT_CREATE)))
+                    .build(),
+                Group.builder()
+                    .id("group-api-create")
+                    .environmentId(ENV_ID)
+                    .eventRules(List.of(new Group.GroupEventRule(Group.GroupEvent.API_CREATE)))
+                    .build()
+            )
+        );
+
+        var toCreate = CreateApiProduct.builder().name("API Product 1").version("1.0.0").description("desc").apiIds(List.of()).build();
+
+        var output = createApiProductUseCase.execute(new CreateApiProductUseCase.Input(toCreate, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getGroups()).containsExactly("group-api-product-create");
+    }
+
+    @Test
+    void should_not_attach_group_with_api_primary_owner_set() {
+        groupQueryService.initWith(
+            List.of(
+                Group.builder()
+                    .id("group-with-po")
+                    .environmentId(ENV_ID)
+                    .apiPrimaryOwner("some-user-id")
+                    .eventRules(List.of(new Group.GroupEventRule(Group.GroupEvent.API_PRODUCT_CREATE)))
+                    .build(),
+                Group.builder()
+                    .id("group-no-po")
+                    .environmentId(ENV_ID)
+                    .eventRules(List.of(new Group.GroupEventRule(Group.GroupEvent.API_PRODUCT_CREATE)))
+                    .build()
+            )
+        );
+
+        var toCreate = CreateApiProduct.builder().name("API Product 1").version("1.0.0").description("desc").apiIds(List.of()).build();
+
+        var output = createApiProductUseCase.execute(new CreateApiProductUseCase.Input(toCreate, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getGroups()).containsExactly("group-no-po");
     }
 
     private Api createV4ProxyApi(String id, Boolean allowedInApiProducts) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.common.event.EventManager;
+import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.GroupRepository;
@@ -33,6 +34,7 @@ import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.AccessControl;
 import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.ApiProduct;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.Group;
 import io.gravitee.repository.management.model.Page;
@@ -112,6 +114,9 @@ public class GroupService_DeleteTest {
 
     @Mock
     private PortalNotificationConfigService portalNotificationConfigService;
+
+    @Mock
+    private ApiProductsRepository apiProductsRepository;
 
     @Test(expected = GroupNotFoundException.class)
     public void throwGroupNotFoundException() throws Exception {
@@ -199,6 +204,9 @@ public class GroupService_DeleteTest {
         when(userService.findById(any(), any())).thenReturn(UserEntity.builder().sourceId("test").build());
 
         when(applicationRepository.findByGroups(Collections.singletonList(GROUP_ID))).thenReturn(Collections.emptySet());
+        when(apiProductsRepository.findByEnvironmentId(GraviteeContext.getExecutionContext().getEnvironmentId())).thenReturn(
+            Collections.emptySet()
+        );
 
         when(
             pageRepository.search(
@@ -304,6 +312,9 @@ public class GroupService_DeleteTest {
         when(applicationRepository.findByGroups(Collections.singletonList(GROUP_ID))).thenReturn(
             new HashSet<>(Collections.singletonList(application))
         );
+        when(apiProductsRepository.findByEnvironmentId(GraviteeContext.getExecutionContext().getEnvironmentId())).thenReturn(
+            Collections.emptySet()
+        );
 
         Page page = new Page();
         AccessControl accessControlToRemove = new AccessControl();
@@ -329,5 +340,59 @@ public class GroupService_DeleteTest {
         verify(applicationRepository).update(
             argThat(app -> app.getGroups().size() == 1 && !app.getGroups().contains(GROUP_ID) && app.getGroups().contains(ANOTHER_GROUP_ID))
         );
+    }
+
+    @Test
+    public void shouldRemoveGroupFromApiProductsOnDelete() throws Exception {
+        final Group group = new Group();
+        group.setId(GROUP_ID);
+        group.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+
+        RoleEntity role = new RoleEntity();
+        role.setId("API_PRIMARY_OWNER_ID");
+        when(
+            roleService.findByScopeAndName(
+                RoleScope.API,
+                SystemRole.PRIMARY_OWNER.name(),
+                GraviteeContext.getExecutionContext().getOrganizationId()
+            )
+        ).thenReturn(Optional.of(role));
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                GROUP_ID,
+                MembershipReferenceType.API,
+                "API_PRIMARY_OWNER_ID"
+            )
+        ).thenReturn(Collections.emptySet());
+
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).groups(GROUP_ID).build(),
+                null,
+                new PageableBuilder().pageSize(100).pageNumber(0).build(),
+                ApiFieldFilter.allFields()
+            )
+        ).thenReturn(new io.gravitee.common.data.domain.Page<>(List.of(), 0, 0, 0));
+        when(applicationRepository.findByGroups(Collections.singletonList(GROUP_ID))).thenReturn(Collections.emptySet());
+        when(pageRepository.search(any())).thenReturn(Collections.emptyList());
+        lenient().when(identityProviderRepository.findAll()).thenReturn(Collections.emptySet());
+
+        ApiProduct productWithGroup = new ApiProduct();
+        productWithGroup.setId("product-1");
+        productWithGroup.setGroups(new HashSet<>(Set.of(GROUP_ID)));
+
+        ApiProduct productWithoutGroup = new ApiProduct();
+        productWithoutGroup.setId("product-2");
+
+        when(apiProductsRepository.findByEnvironmentId(GraviteeContext.getExecutionContext().getEnvironmentId())).thenReturn(
+            Set.of(productWithGroup, productWithoutGroup)
+        );
+
+        groupService.delete(GraviteeContext.getExecutionContext(), GROUP_ID);
+
+        verify(apiProductsRepository, times(1)).update(argThat(p -> !p.getGroups().contains(GROUP_ID)));
+        verify(apiProductsRepository, never()).update(argThat(p -> p.getId().equals("product-2")));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_AssociateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_AssociateTest.java
@@ -20,13 +20,16 @@ import static org.mockito.Mockito.*;
 
 import io.gravitee.common.event.EventManager;
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.GroupRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.ApiProduct;
 import io.gravitee.repository.management.model.Application;
+import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.alert.ApplicationAlertEventType;
 import io.gravitee.rest.api.model.api.ApiEntity;
@@ -74,6 +77,12 @@ public class GroupService_AssociateTest extends TestCase {
 
     @Mock
     private EventManager eventManager;
+
+    @Mock
+    private ApiProductsRepository apiProductsRepository;
+
+    @Mock
+    private MembershipService membershipService;
 
     @Test(expected = GroupNotFoundException.class)
     public void shouldThrowGroupNotFoundException() throws TechnicalException {
@@ -129,5 +138,54 @@ public class GroupService_AssociateTest extends TestCase {
 
         verify(applicationRepository, times(1)).update(app1);
         verify(eventManager, times(1)).publishEvent(eq(ApplicationAlertEventType.APPLICATION_MEMBERSHIP_UPDATE), any());
+    }
+
+    @Test
+    public void shouldAssociateAllApiProducts() throws TechnicalException {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+
+        ApiProduct product1 = new ApiProduct();
+        product1.setId("product-1");
+
+        ApiProduct product2 = new ApiProduct();
+        product2.setId("product-2");
+        product2.setGroups(new java.util.HashSet<>(java.util.Set.of(GROUP_ID)));
+
+        when(apiProductsRepository.findByEnvironmentId(executionContext.getEnvironmentId())).thenReturn(Set.of(product1, product2));
+
+        UserEntity fakeUser = new UserEntity();
+        fakeUser.setFirstname("firstName");
+        fakeUser.setLastname("lastName");
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(fakeUser);
+        when(membershipService.getPrimaryOwnerUserId(any(), eq(MembershipReferenceType.API_PRODUCT), eq(product1.getId()))).thenReturn(
+            null
+        );
+
+        groupService.associate(executionContext, GROUP_ID, "api_product");
+
+        verify(apiProductsRepository, times(1)).update(product1);
+        verify(apiProductsRepository, never()).update(product2);
+        verify(notifierService, times(1)).trigger(
+            eq(executionContext),
+            eq(ApiHook.API_UPDATED),
+            eq(io.gravitee.repository.management.model.NotificationReferenceType.API_PRODUCT),
+            eq(product1.getId()),
+            any()
+        );
+    }
+
+    @Test
+    public void shouldSkipApiProductAlreadyHavingGroup() throws TechnicalException {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+
+        ApiProduct product = new ApiProduct();
+        product.setId("product-1");
+        product.setGroups(new java.util.HashSet<>(java.util.Set.of(GROUP_ID)));
+
+        when(apiProductsRepository.findByEnvironmentId(executionContext.getEnvironmentId())).thenReturn(Set.of(product));
+
+        groupService.associate(executionContext, GROUP_ID, "api_product");
+
+        verify(apiProductsRepository, never()).update(any());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13445

## Description

Backend support for attaching groups to API Products.

- **Auto-add to new API Products:** Added `API_PRODUCT_CREATE` group event rule. `CreateApiProductUseCase` now auto-attaches matching groups on product creation (consistent with API behavior).
- **Add to existing API Products:** Extended `GroupServiceImpl.associate()` with `"api_product"` case to add a group to all existing products in the environment.
- **Group deletion cleanup:** Removing a group now cleans it up from all API Products.
- **Persistence:** New `api_product_groups` JDBC table + Liquibase migration. Added `groups` field across core, repository, and MongoDB models.

### working video :


https://github.com/user-attachments/assets/7cab39cd-e154-4e9d-8e8f-fed24a5b2b74


## Additional context

- 8 new unit tests covering auto-attach, negative cases, associate to existing, and deletion cleanup
- No changes to existing API/Application group flows

