### PR TITLE
fix(elasticsearch): preserve Lucene grouping parentheses in log query filters

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
@@ -252,9 +252,11 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
     }
 
     /**
-     * Fix APIM-12955: Escapes Lucene special characters in the query string.
-     * Quadruple backslashes are required to survive both Java and JSON parsing levels
-     * so that Lucene finally receives the mandatory single backslash escape (e.g., \( ).
+     * Escapes backslashes and forward slashes so they survive both JSON
+     * and Lucene parsing levels (fix APIM-12955).
+     *
+     * Parentheses are intentionally left unescaped to preserve Lucene
+     * grouping syntax (e.g., {@code status:(200 OR 400)}).
      */
     private String createSafeElasticsearchJsonQuery(final TabularQuery query) {
         String json = this.createElasticsearchJsonQuery(query);
@@ -263,12 +265,20 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
             String filter = query.query().filter();
 
             if (!filter.isEmpty()) {
-                String escaped = filter.replace("\\", "\\\\\\\\").replace("/", "\\\\/").replace("(", "\\\\(").replace(")", "\\\\)");
+                String escaped = escapeForJsonLucene(filter);
 
                 // Targeted replacement within quotes to protect JSON structure
                 json = json.replace("\"" + filter + "\"", "\"" + escaped + "\"");
             }
         }
         return json;
+    }
+
+    /**
+     * Escapes backslashes and forward slashes for safe embedding in a JSON
+     * {@code query_string} value that will be parsed by Lucene.
+     */
+    static String escapeForJsonLucene(String filter) {
+        return filter.replace("\\", "\\\\\\\\").replace("/", "\\\\/");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/LuceneEscapeTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/LuceneEscapeTest.java
@@ -17,26 +17,63 @@ package io.gravitee.repository.elasticsearch.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.lucene.queryparser.classic.QueryParser;
 import org.junit.jupiter.api.Test;
 
-public class LuceneEscapeTest {
+class LuceneEscapeTest {
 
     @Test
-    public void compareImplementationWithStandardParser() {
+    void should_not_alter_simple_status_filter() {
+        String result = ElasticLogRepository.escapeForJsonLucene("status:200");
+
+        assertThat(result).isEqualTo("status:200");
+    }
+
+    @Test
+    void should_preserve_lucene_grouping_parentheses_for_multi_status_filter() {
+        String result = ElasticLogRepository.escapeForJsonLucene("status:(200 OR 400)");
+
+        // Parentheses must NOT be escaped — they are Lucene grouping syntax
+        assertThat(result).isEqualTo("status:(200 OR 400)");
+    }
+
+    @Test
+    void should_preserve_grouping_parentheses_with_multiple_filter_types() {
+        String result = ElasticLogRepository.escapeForJsonLucene("status:(200 OR 400) AND method:(GET OR POST)");
+
+        assertThat(result).isEqualTo("status:(200 OR 400) AND method:(GET OR POST)");
+    }
+
+    @Test
+    void should_escape_forward_slashes() {
+        String result = ElasticLogRepository.escapeForJsonLucene("uri:/api/test");
+
+        assertThat(result).isEqualTo("uri:\\\\/api\\\\/test");
+    }
+
+    @Test
+    void should_quadruple_backslashes() {
+        String result = ElasticLogRepository.escapeForJsonLucene("path:C\\Users\\test");
+
+        assertThat(result).isEqualTo("path:C\\\\\\\\Users\\\\\\\\test");
+    }
+
+    @Test
+    void should_escape_slashes_and_preserve_grouping_parentheses() {
         String input = "status:200 AND custom.userAgent:RMel/1.0.0 (Ubuntu)";
 
-        String luceneStandard = QueryParser.escape(input);
+        String result = ElasticLogRepository.escapeForJsonLucene(input);
 
-        String result = input.replace("\\", "\\\\\\\\").replace("/", "\\\\/").replace("(", "\\\\(").replace(")", "\\\\)");
-
-        assertThat(result).contains("RMel\\\\/1.0.0");
-        assertThat(result).contains("\\\\(Ubuntu\\\\)");
-
-        // NO REGRESSION Test
+        assertThat(result).doesNotContain("RMel/1.0.0");
         assertThat(result).contains("status:200");
         assertThat(result).contains("custom.userAgent:");
+        assertThat(result).contains("(Ubuntu)");
+    }
 
-        assertThat(luceneStandard).contains("status\\:200");
+    @Test
+    void should_preserve_grouping_while_escaping_slashes() {
+        String result = ElasticLogRepository.escapeForJsonLucene("status:(200 OR 400) AND uri:/api/test*");
+
+        assertThat(result).startsWith("status:(200 OR 400)");
+        assertThat(result).doesNotContain("uri:/");
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13415

## Description

Log query filters using Lucene grouping syntax (e.g., `status:(200 OR 400)`) were broken because parentheses were being escaped by the JSON/Lucene escaping layer introduced in APIM-12955.

The escaping logic now only handles backslashes and forward slashes, preserving parentheses for Lucene grouping.

