### PR TITLE
Reject unsupported API version during deserialization

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
@@ -217,18 +217,24 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
     }
 
     private static DefinitionVersion foundDefinitionVersion(JsonNode node) {
-        try {
-            if (node.hasNonNull("definitionVersion")) {
-                JsonNode definitionVersion = node.get("definitionVersion");
+        if (node.hasNonNull("definitionVersion")) {
+            JsonNode definitionVersion = node.get("definitionVersion");
+            try {
                 return DefinitionVersion.valueOf(definitionVersion.asText());
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Unsupported API definition version: " + definitionVersion.asText());
             }
-        } catch (IllegalArgumentException ignored) {}
-        try {
-            if (node.hasNonNull("gravitee")) {
-                JsonNode gravitee = node.get("gravitee");
-                return DefinitionVersion.valueOfLabel(gravitee.asText());
+        }
+
+        if (node.hasNonNull("gravitee")) {
+            JsonNode gravitee = node.get("gravitee");
+            DefinitionVersion version = DefinitionVersion.valueOfLabel(gravitee.asText());
+            if (version != null) {
+                return version;
             }
-        } catch (IllegalArgumentException ignored) {}
+            throw new IllegalArgumentException("Unsupported API definition version: " + gravitee.asText());
+        }
+
         return DefinitionVersion.V2;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -180,7 +180,6 @@ import io.gravitee.rest.api.service.exceptions.ApiMetadataNotFoundException;
 import io.gravitee.rest.api.service.exceptions.ApiNotDeletableException;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.ApiRunningStateException;
-import io.gravitee.rest.api.service.exceptions.BadNotificationConfigException;
 import io.gravitee.rest.api.service.exceptions.DefinitionVersionException;
 import io.gravitee.rest.api.service.exceptions.EndpointGroupNameAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.EndpointMissingException;
@@ -895,7 +894,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         var apiEntity = switch (api.getDefinitionVersion()) {
             case V2 -> convertWithApiFlowsAndPlansAndApiCategories(executionContext, api, getPrimaryOwner(executionContext, api));
             case V4 -> apiSearchService.findById(executionContext, id);
-            default -> throw new BadNotificationConfigException();
+            default -> throw new IllegalStateException("Unsupported definition version: " + api.getDefinitionVersion());
         };
 
         var dataAsMap = objectMapper.convertValue(apiEntity, MAPPER_TYPE_REFERENCE);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByIdAsMapTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByIdAsMapTest.java
@@ -16,7 +16,6 @@
 package io.gravitee.rest.api.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -34,7 +33,6 @@ import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.UserEntity;
-import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.ApiMetadataService;
 import io.gravitee.rest.api.service.CategoryService;
 import io.gravitee.rest.api.service.EnvironmentService;
@@ -45,7 +43,6 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
-import io.gravitee.rest.api.service.exceptions.BadNotificationConfigException;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13393

## Description

APIs with an unrecognized definition version (e.g. V1 "1.0.0") now fail to deserialize with a clear IllegalArgumentException instead of being silently loaded as V2 with empty flows and no policy enforcement.

This prevents V1 APIs still in the database from being deployed on the gateway without any security policies applied.