### PR TITLE
fix: api field in subscription queries for backward compatibility

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
@@ -339,7 +339,13 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
                 // Filter by API only (e.g. Portal): include legacy subscriptions with null reference_type
                 builder.append("( s.reference_type = ? OR s.reference_type IS NULL )");
                 argsList.add(criteria.getReferenceType().name());
+            } else if (
+                !isEmpty(criteria.getReferenceIds()) &&
+                criteria.getReferenceType() == io.gravitee.repository.management.model.SubscriptionReferenceType.API
+            ) {
+                appendApiReferenceIdsFilter(criteria.getReferenceIds(), builder, argsList);
             } else {
+                // API_PRODUCT and other reference types: strict filter (no legacy fallback needed)
                 builder.append("s.reference_type = ?");
                 argsList.add(criteria.getReferenceType().name());
                 started = true;
@@ -446,6 +452,23 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
         } catch (final Exception e) {
             throw new TechnicalException("Failed to find subscriptions by ids", e);
         }
+    }
+
+    /**
+     * Appends an OR filter covering both migrated subscriptions (reference_type/reference_id) and legacy ones
+     * (reference_type IS NULL, api field set) created by old nodes during a rolling upgrade.
+     */
+    private void appendApiReferenceIdsFilter(Collection<String> referenceIds, StringBuilder builder, List<Object> argsList) {
+        String inClause = getOrm().buildInClause(referenceIds);
+        builder
+            .append("( ( s.reference_type = ? AND s.reference_id IN (")
+            .append(inClause)
+            .append(") ) OR ( s.reference_type IS NULL AND s.api IN (")
+            .append(inClause)
+            .append(") ) )");
+        argsList.add(io.gravitee.repository.management.model.SubscriptionReferenceType.API.name());
+        argsList.addAll(referenceIds); // for reference_id IN
+        argsList.addAll(referenceIds); // for api IN
     }
 
     private void storeMetadata(Subscription subscription, boolean deleteFirst) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
@@ -91,11 +91,16 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
                     dataPipeline.add(match(eq("referenceType", criteria.getReferenceType().name())));
                 }
             } else {
-                dataPipeline.add(match(eq("referenceType", criteria.getReferenceType().name())));
-                if (criteria.getReferenceIds().size() == 1) {
-                    dataPipeline.add(match(eq("referenceId", criteria.getReferenceIds().iterator().next())));
+                if (criteria.getReferenceType() == SubscriptionReferenceType.API) {
+                    addApiReferenceIdsFilter(dataPipeline, criteria.getReferenceIds());
                 } else {
-                    dataPipeline.add(match(in("referenceId", criteria.getReferenceIds())));
+                    // API_PRODUCT and other types: strict filter (new feature, no legacy fallback needed)
+                    dataPipeline.add(match(eq("referenceType", criteria.getReferenceType().name())));
+                    if (criteria.getReferenceIds().size() == 1) {
+                        dataPipeline.add(match(eq("referenceId", criteria.getReferenceIds().iterator().next())));
+                    } else {
+                        dataPipeline.add(match(in("referenceId", criteria.getReferenceIds())));
+                    }
                 }
             }
         }
@@ -239,6 +244,21 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
             references.add(referenceId);
         });
         return references;
+    }
+
+    /**
+     * Appends an OR filter covering both migrated subscriptions (referenceType/referenceId) and legacy ones
+     * (referenceType null or absent, api field set) created by old nodes during a rolling upgrade.
+     */
+    private void addApiReferenceIdsFilter(List<Bson> dataPipeline, Collection<String> referenceIds) {
+        final boolean isSingle = referenceIds.size() == 1;
+        final String firstId = isSingle ? referenceIds.iterator().next() : null;
+        final Bson referenceIdFilter = isSingle ? eq("referenceId", firstId) : in("referenceId", referenceIds);
+        final Bson apiFilter = isSingle ? eq("api", firstId) : in("api", referenceIds);
+
+        Bson migratedFilter = and(eq("referenceType", SubscriptionReferenceType.API.name()), referenceIdFilter);
+        Bson legacyFilter = and(or(eq("referenceType", null), exists("referenceType", false)), apiFilter);
+        dataPipeline.add(match(or(migratedFilter, legacyFilter)));
     }
 
     private Page<SubscriptionMongo> buildSubscriptionsPage(

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionRepositoryTest.java
@@ -353,10 +353,10 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
             SubscriptionCriteria.builder().endingAtAfter(1449022010880L).includeWithoutEnd(true).build()
         );
 
-        assertEquals("Subscriptions size", 8, subscriptions.size());
+        assertEquals("Subscriptions size", 9, subscriptions.size());
         assertTrue(
             "Subscription id",
-            List.of("sub3", "sub2", "sub5", "sub4", "sub1", "sub6", "sub7", "sub8").containsAll(
+            List.of("sub3", "sub2", "sub5", "sub4", "sub1", "sub6", "sub7", "sub8", "sub-legacy-push").containsAll(
                 subscriptions.stream().map(Subscription::getId).toList()
             )
         );
@@ -381,12 +381,24 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
             SubscriptionCriteria.builder().endingAtBefore(1569022010883L).includeWithoutEnd(true).build()
         );
 
-        assertEquals("Subscriptions size", 10, subscriptions.size());
+        assertEquals("Subscriptions size", 11, subscriptions.size());
         Set<String> subscriptionIds = subscriptions.stream().map(Subscription::getId).collect(Collectors.toSet());
         assertTrue(
             "Should contain expected subscriptions",
             subscriptionIds.containsAll(
-                List.of("sub3", "sub2", "sub5", "sub4", "sub1", "sub6", "sub7", "sub8", "sub-api-product-1", "sub-api-product-2")
+                List.of(
+                    "sub3",
+                    "sub2",
+                    "sub5",
+                    "sub4",
+                    "sub1",
+                    "sub6",
+                    "sub7",
+                    "sub8",
+                    "sub-api-product-1",
+                    "sub-api-product-2",
+                    "sub-legacy-push"
+                )
             )
         );
     }
@@ -416,6 +428,20 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
         assertNotNull(ranking);
         assertEquals("Ranking size", 1, ranking.size());
         assertEquals("Ranking", "api1", ranking.iterator().next());
+    }
+
+    @Test
+    public void should_search_subscriptions_including_legacy_api_field() throws TechnicalException {
+        // Regression test for APIM-13150: subscriptions with api field set but no referenceId/referenceType
+        // (created by old nodes during rolling upgrade from 4.10 to 4.11) must be included in results
+        List<Subscription> subscriptions = this.subscriptionRepository.search(
+            SubscriptionCriteria.builder().referenceIds(List.of("api1")).referenceType(SubscriptionReferenceType.API).build()
+        );
+
+        assertNotNull(subscriptions);
+        Set<String> ids = subscriptions.stream().map(Subscription::getId).collect(Collectors.toSet());
+        assertTrue("Should include migrated subscription (referenceId/referenceType set)", ids.contains("sub1"));
+        assertTrue("Should include legacy subscription with only api field set", ids.contains("sub-legacy-push"));
     }
 
     @Test
@@ -555,16 +581,28 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
     @Test
     public void shouldSearchByReferenceIdsAndType() throws TechnicalException {
         // Criteria with referenceIds/referenceType for API subscriptions
+        // Expects both the migrated subscription (referenceId/referenceType set) and the legacy one (only api field set)
         List<Subscription> subscriptions = this.subscriptionRepository.search(
             SubscriptionCriteria.builder().referenceIds(List.of("api1")).referenceType(SubscriptionReferenceType.API).build()
         );
 
         assertNotNull(subscriptions);
-        assertFalse(subscriptions.isEmpty());
-        assertEquals("Subscriptions size", 1, subscriptions.size());
-        assertEquals("Subscription id", "sub1", subscriptions.get(0).getId());
-        assertEquals("API (reference)", "api1", subscriptions.get(0).getReferenceId());
-        assertEquals("Reference type", SubscriptionReferenceType.API, subscriptions.get(0).getReferenceType());
+        Set<String> ids = subscriptions.stream().map(Subscription::getId).collect(Collectors.toSet());
+        assertTrue("Should include migrated subscription", ids.contains("sub1"));
+        assertTrue("Should include legacy subscription (only api field set)", ids.contains("sub-legacy-push"));
+    }
+
+    @Test
+    public void should_search_by_multiple_reference_ids_including_legacy_api_field() throws TechnicalException {
+        // Regression test for APIM-13150: the multi-ID (IN clause) path must also include legacy subscriptions
+        List<Subscription> subscriptions = this.subscriptionRepository.search(
+            SubscriptionCriteria.builder().referenceIds(List.of("api1", "api-unknown")).referenceType(SubscriptionReferenceType.API).build()
+        );
+
+        assertNotNull(subscriptions);
+        Set<String> ids = subscriptions.stream().map(Subscription::getId).collect(Collectors.toSet());
+        assertTrue("Should include migrated subscription", ids.contains("sub1"));
+        assertTrue("Should include legacy subscription with only api field set", ids.contains("sub-legacy-push"));
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/subscription-tests/subscriptions.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/subscription-tests/subscriptions.json
@@ -99,6 +99,17 @@
     "createdAt": 1449022010870
   },
   {
+    "id": "sub-legacy-push",
+    "plan": "plan3",
+    "application": "app4",
+    "applicationName": "app4 name",
+    "api": "api1",
+    "environmentId": "other-env-2",
+    "status": "ACCEPTED",
+    "type": "PUSH",
+    "createdAt": 1669022010883
+  },
+  {
     "id":"sub-api-product-1",
     "plan": "plan4",
     "application": "app4",


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13150

## Description

During a rolling upgrade from 4.10 to 4.11, subscriptions created by old nodes have only the legacy `api` field set — `referenceId` and `referenceType` are null. This caused those subscriptions to be silently dropped from query results in both the JDBC and MongoDB repository implementations.

This PR fixes the `search` queries to include both:
- **Migrated subscriptions** — matched via `referenceType = API` and `referenceId IN (...)`
- **Legacy subscriptions** — matched via `referenceType IS NULL` and `api IN (...)`

The backward-compat logic is isolated in two private helpers (`appendApiReferenceIdsFilter` for JDBC, `addApiReferenceIdsFilter` for MongoDB) and only applies to `API` reference type; `API_PRODUCT` and other types use strict filtering as before.

## Additional context

Regression test added with a fixture (`sub-legacy-push`) that has only the `api` field set, validating both the single-ID and multi-ID query paths.