### PR TITLE
feat(portal): include certificate name in update payloads and related…

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
@@ -122,7 +122,13 @@ describe('AddCertificateDialogComponent', () => {
     await harness.clickContinueUpload();
     fixture.detectChanges();
 
-    httpTestingController.expectOne(VALIDATE_URL).flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
+    httpTestingController.expectOne(VALIDATE_URL).flush(
+      { error: 'Invalid PEM' },
+      {
+        status: 400,
+        statusText: 'Bad Request',
+      },
+    );
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -169,7 +175,8 @@ describe('AddCertificateDialogComponent', () => {
 
   it('should also call update on old cert when gracePeriodEnd is set', async () => {
     const activeCertificateId = 'old-cert-id';
-    await init(makeData({ hasActiveCertificates: true, activeCertificateId }));
+    const activeCertificateName = 'Old Cert Name';
+    await init(makeData({ hasActiveCertificates: true, activeCertificateId, activeCertificateName }));
     await fillAndValidate();
 
     const graceDate = new Date('2026-12-31');
@@ -188,6 +195,36 @@ describe('AddCertificateDialogComponent', () => {
 
     const updateReq = httpTestingController.expectOne(`${CERTIFICATES_URL}/${activeCertificateId}`);
     expect(updateReq.request.method).toBe('PUT');
+    expect(updateReq.request.body).toMatchObject({ name: activeCertificateName, endsAt: graceDate.toISOString() });
+    updateReq.flush({ id: activeCertificateId, name: activeCertificateName, status: 'ACTIVE_WITH_END' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should not send name in update when activeCertificateName is missing', async () => {
+    const activeCertificateId = 'old-cert-id';
+    await init(makeData({ hasActiveCertificates: true, activeCertificateId, activeCertificateName: undefined }));
+    await fillAndValidate();
+
+    const graceDate = new Date('2026-12-31');
+    fixture.componentInstance.configureForm.controls.gracePeriodEnd.setValue(graceDate);
+    await harness.clickContinueConfigure();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    const createReq = httpTestingController.expectOne(CERTIFICATES_URL);
+    createReq.flush({ id: 'new-cert', name: 'My Cert', status: 'ACTIVE' });
+    fixture.detectChanges();
+
+    const updateReq = httpTestingController.expectOne(`${CERTIFICATES_URL}/${activeCertificateId}`);
+    expect(updateReq.request.method).toBe('PUT');
+    expect(updateReq.request.body).not.toHaveProperty('name');
     expect(updateReq.request.body).toMatchObject({ endsAt: graceDate.toISOString() });
     updateReq.flush({ id: activeCertificateId, name: 'Old Cert', status: 'ACTIVE_WITH_END' });
     fixture.detectChanges();
@@ -208,7 +245,13 @@ describe('AddCertificateDialogComponent', () => {
     await harness.clickSubmit();
     fixture.detectChanges();
 
-    httpTestingController.expectOne(CERTIFICATES_URL).flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
+    httpTestingController.expectOne(CERTIFICATES_URL).flush(
+      { error: 'Invalid PEM' },
+      {
+        status: 400,
+        statusText: 'Bad Request',
+      },
+    );
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
@@ -35,6 +35,7 @@ export interface AddCertificateDialogData {
   applicationId: string;
   hasActiveCertificates: boolean;
   activeCertificateId?: string;
+  activeCertificateName?: string;
   activeCertificateExpiration?: string;
 }
 
@@ -157,6 +158,7 @@ export class AddCertificateDialogComponent {
         switchMap(() => {
           if (gracePeriodEnd && this.data.activeCertificateId) {
             return this.certService.update(this.data.applicationId, this.data.activeCertificateId!, {
+              ...(this.data.activeCertificateName ? { name: this.data.activeCertificateName } : {}),
               endsAt: gracePeriodEnd.toISOString(),
             });
           }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
@@ -135,6 +135,7 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
       applicationId: this.applicationId(),
       hasActiveCertificates: activeCerts.length > 0,
       activeCertificateId: activeCert?.id,
+      activeCertificateName: activeCert?.name,
       activeCertificateExpiration: activeCert?.endsAt,
     };
     this.dialog


### PR DESCRIPTION
… tests

Adds support for passing `activeCertificateName` in addition to `activeCertificateId` when updating certificates. Updates relevant tests to validate the changes.

## Issue

https://gravitee.atlassian.net/browse/APIM-13502

## Description


https://github.com/user-attachments/assets/a0d041f8-63d3-4910-82cd-bea724398109



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

