### PR TITLE
chore(gravitee-policy-jwt): Align versions with CI release version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <gravitee-policy-json-validation.version>2.2.0-alpha.2</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>2.0.0</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>7.0.1</gravitee-policy-jwt.version>
+        <gravitee-policy-jwt.version>7.0.2</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>4.0.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>2.0.1</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>3.0.1</gravitee-policy-metrics-reporter.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13239

## Description

Bumping up the version of gravitee-policy-jwt to add support for WWW-Authenticate-Header. 

## Additional context

Pre fix behaviour: 


https://github.com/user-attachments/assets/e6a4110e-5d21-485e-a0d6-d945931eb492

Post fix behaviour: 

https://github.com/user-attachments/assets/e2a39b26-27fb-4cb9-b02c-a22cd9f04d81
