### PR TITLE
feat: add Kafka Cluster type to Cluster model

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/Cluster.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/Cluster.fixture.ts
@@ -18,6 +18,7 @@ import { Cluster } from './Cluster';
 export function fakeCluster(overrides: Partial<Cluster> = {}): Cluster {
   return {
     id: 'cluster-id',
+    type: 'KAFKA_CLUSTER_CONNECTION',
     name: 'Cluster Name',
     description: 'A test cluster',
     configuration: {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/Cluster.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/Cluster.ts
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export type ClusterType = 'KAFKA_CLUSTER_CONNECTION';
+
 export interface Cluster {
   id: string;
+  type: ClusterType;
   name: string;
   description?: string;
   configuration: KafkaClusterConfiguration;

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/CreateCluster.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/CreateCluster.ts
@@ -15,4 +15,4 @@
  */
 import { Cluster } from './Cluster';
 
-export type CreateCluster = Pick<Cluster, 'name' | 'description' | 'configuration'>;
+export type CreateCluster = Pick<Cluster, 'type' | 'name' | 'description' | 'configuration'>;

--- a/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/list/cluster-list.component.ts
@@ -156,6 +156,7 @@ export class ClusterListComponent implements OnInit {
           }
 
           return this.clusterService.create({
+            type: 'KAFKA_CLUSTER_CONNECTION',
             name: result.name,
             description: result.description,
             configuration: {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/cluster/Cluster.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/cluster/Cluster.java
@@ -27,6 +27,7 @@ import lombok.NoArgsConstructor;
 public class Cluster {
 
     private String id;
+    private String type;
     private String name;
     private Object configuration;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Cluster.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Cluster.java
@@ -37,6 +37,7 @@ public class Cluster {
     private String organizationId;
     private String name;
     private String description;
+    private String type;
     private String definition;
     private Set<String> groups;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClusterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClusterRepository.java
@@ -65,6 +65,7 @@ public class JdbcClusterRepository extends JdbcAbstractCrudRepository<Cluster, S
             .addColumn("updated_at", Types.TIMESTAMP, Instant.class)
             .addColumn("environment_id", Types.NVARCHAR, String.class)
             .addColumn("organization_id", Types.NVARCHAR, String.class)
+            .addColumn("type", Types.NVARCHAR, String.class)
             .addColumn("name", Types.NVARCHAR, String.class)
             .addColumn("description", Types.NVARCHAR, String.class)
             .addColumn("definition", Types.NVARCHAR, String.class)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/02_add_type_to_clusters_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/02_add_type_to_clusters_table.yml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_02_add_type_to_clusters_table
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}clusters
+            columns:
+              - column:
+                  name: type
+                  type: nvarchar(64)
+        - update:
+            tableName: ${gravitee_prefix}clusters
+            columns:
+              - column:
+                  name: type
+                  value: KAFKA_CLUSTER_CONNECTION
+            where: type IS NULL

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -333,3 +333,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/02_add_api_product_groups_table.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/03_add_lock_api_product_role_to_groups.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/02_add_type_to_clusters_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ClusterMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ClusterMongo.java
@@ -31,6 +31,7 @@ public class ClusterMongo extends Auditable {
 
     private String environmentId;
     private String organizationId;
+    private String type;
     private String name;
     private String description;
     private String definition;

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/clusters/ClusterTypeUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/clusters/ClusterTypeUpgrader.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.clusters;
+
+import com.mongodb.client.model.Updates;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.sharedpolicygroups.SharedPolicyGroupHistoriesPhaseUpgrader;
+import org.bson.Document;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClusterTypeUpgrader extends MongoUpgrader {
+
+    public static final int CLUSTER_TYPE_UPGRADER_ORDER =
+        SharedPolicyGroupHistoriesPhaseUpgrader.SHARED_POLICY_GROUP_HISTORIES_PHASE_UPGRADER_ORDER + 1;
+
+    @Override
+    public String version() {
+        return "v1";
+    }
+
+    @Override
+    public boolean upgrade() {
+        this.getCollection("clusters").updateMany(
+            new Document("type", new Document("$exists", false)),
+            Updates.set("type", "KAFKA_CLUSTER_CONNECTION")
+        );
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return CLUSTER_TYPE_UPGRADER_ORDER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/domain_service/KafkaClusterDomainService.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.kafkaexplorer.domain.domain_service;
 
-import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
+import io.gravitee.apim.core.cluster.model.KafkaClusterConnectionConfiguration;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrokerInfo;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.BrowseMessagesResult;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.ConsumerGroupDetail;
@@ -25,12 +25,19 @@ import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicDetail;
 import io.gravitee.rest.api.kafkaexplorer.domain.model.TopicsPage;
 
 public interface KafkaClusterDomainService {
-    KafkaClusterInfo describeCluster(KafkaClusterConfiguration config);
-    TopicsPage listTopics(KafkaClusterConfiguration config, String nameFilter, int page, int perPage, String sortBy, String sortOrder);
-    TopicDetail describeTopic(KafkaClusterConfiguration config, String topicName);
-    BrokerInfo describeBroker(KafkaClusterConfiguration config, int brokerId);
+    KafkaClusterInfo describeCluster(KafkaClusterConnectionConfiguration config);
+    TopicsPage listTopics(
+        KafkaClusterConnectionConfiguration config,
+        String nameFilter,
+        int page,
+        int perPage,
+        String sortBy,
+        String sortOrder
+    );
+    TopicDetail describeTopic(KafkaClusterConnectionConfiguration config, String topicName);
+    BrokerInfo describeBroker(KafkaClusterConnectionConfiguration config, int brokerId);
     ConsumerGroupsPage listConsumerGroups(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String nameFilter,
         String topicFilter,
         int page,
@@ -38,9 +45,9 @@ public interface KafkaClusterDomainService {
         String sortBy,
         String sortOrder
     );
-    ConsumerGroupDetail describeConsumerGroup(KafkaClusterConfiguration config, String groupId);
+    ConsumerGroupDetail describeConsumerGroup(KafkaClusterConnectionConfiguration config, String groupId);
     BrowseMessagesResult browseMessages(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String topicName,
         Integer partition,
         String offsetMode,
@@ -50,7 +57,7 @@ public interface KafkaClusterDomainService {
         int limit
     );
     void tailMessages(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String topicName,
         Integer partition,
         String keyFilter,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/BrowseMessagesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/BrowseMessagesUseCase.java
@@ -40,7 +40,7 @@ public class BrowseMessagesUseCase {
 
     public Output execute(Input input) {
         var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
-        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var config = cluster.getKafkaClusterConnectionConfiguration(objectMapper);
         var result = kafkaClusterDomainService.browseMessages(
             config,
             input.topicName(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeBrokerUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeBrokerUseCase.java
@@ -40,7 +40,7 @@ public class DescribeBrokerUseCase {
 
     public Output execute(Input input) {
         var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
-        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var config = cluster.getKafkaClusterConnectionConfiguration(objectMapper);
         var brokerInfo = kafkaClusterDomainService.describeBroker(config, input.brokerId());
         return new Output(brokerInfo);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeConsumerGroupUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeConsumerGroupUseCase.java
@@ -40,7 +40,7 @@ public class DescribeConsumerGroupUseCase {
 
     public Output execute(Input input) {
         var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
-        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var config = cluster.getKafkaClusterConnectionConfiguration(objectMapper);
         var consumerGroupDetail = kafkaClusterDomainService.describeConsumerGroup(config, input.groupId());
         return new Output(consumerGroupDetail);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeKafkaClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeKafkaClusterUseCase.java
@@ -40,7 +40,7 @@ public class DescribeKafkaClusterUseCase {
 
     public Output execute(Input input) {
         var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
-        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var config = cluster.getKafkaClusterConnectionConfiguration(objectMapper);
         var clusterInfo = kafkaClusterDomainService.describeCluster(config);
         return new Output(clusterInfo);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeTopicUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/DescribeTopicUseCase.java
@@ -40,7 +40,7 @@ public class DescribeTopicUseCase {
 
     public Output execute(Input input) {
         var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
-        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var config = cluster.getKafkaClusterConnectionConfiguration(objectMapper);
         var topicDetail = kafkaClusterDomainService.describeTopic(config, input.topicName());
         return new Output(topicDetail);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListConsumerGroupsUseCase.java
@@ -40,7 +40,7 @@ public class ListConsumerGroupsUseCase {
 
     public Output execute(Input input) {
         var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
-        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var config = cluster.getKafkaClusterConnectionConfiguration(objectMapper);
         var consumerGroupsPage = kafkaClusterDomainService.listConsumerGroups(
             config,
             input.nameFilter(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListTopicsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/ListTopicsUseCase.java
@@ -40,7 +40,7 @@ public class ListTopicsUseCase {
 
     public Output execute(Input input) {
         var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
-        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var config = cluster.getKafkaClusterConnectionConfiguration(objectMapper);
         var topicsPage = kafkaClusterDomainService.listTopics(
             config,
             input.nameFilter(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/TailMessagesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/domain/use_case/TailMessagesUseCase.java
@@ -40,7 +40,7 @@ public class TailMessagesUseCase {
 
     public void execute(Input input, MessageConsumer consumer) {
         var cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId(), input.environmentId());
-        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var config = cluster.getKafkaClusterConnectionConfiguration(objectMapper);
         kafkaClusterDomainService.tailMessages(
             config,
             input.topicName(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/main/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImpl.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service;
 
-import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
+import io.gravitee.apim.core.cluster.model.KafkaClusterConnectionConfiguration;
 import io.gravitee.apim.core.cluster.model.SaslMechanism;
 import io.gravitee.apim.core.cluster.model.SecurityProtocol;
 import io.gravitee.plugin.configurations.ssl.KeyStore;
@@ -102,7 +102,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
     private static final long GET_TIMEOUT_SECONDS = TIMEOUT_SECONDS + 2;
 
     @Override
-    public KafkaClusterInfo describeCluster(KafkaClusterConfiguration config) {
+    public KafkaClusterInfo describeCluster(KafkaClusterConnectionConfiguration config) {
         return withAdminClient(config, adminClient -> {
             DescribeClusterResult result = adminClient.describeCluster();
 
@@ -132,7 +132,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
 
     @Override
     public TopicsPage listTopics(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String nameFilter,
         int page,
         int perPage,
@@ -219,7 +219,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
     }
 
     @Override
-    public TopicDetail describeTopic(KafkaClusterConfiguration config, String topicName) {
+    public TopicDetail describeTopic(KafkaClusterConnectionConfiguration config, String topicName) {
         return withAdminClient(config, adminClient -> {
             // Describe topic to get partition info
             TopicDescription description = adminClient
@@ -265,7 +265,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
     }
 
     @Override
-    public BrokerInfo describeBroker(KafkaClusterConfiguration config, int brokerId) {
+    public BrokerInfo describeBroker(KafkaClusterConnectionConfiguration config, int brokerId) {
         return withAdminClient(config, adminClient -> {
             // Step 1: describeCluster to find the node and detect controller
             DescribeClusterResult clusterResult = adminClient.describeCluster();
@@ -354,7 +354,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
 
     @Override
     public ConsumerGroupsPage listConsumerGroups(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String nameFilter,
         String topicFilter,
         int page,
@@ -452,7 +452,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
     }
 
     @Override
-    public ConsumerGroupDetail describeConsumerGroup(KafkaClusterConfiguration config, String groupId) {
+    public ConsumerGroupDetail describeConsumerGroup(KafkaClusterConnectionConfiguration config, String groupId) {
         return withAdminClient(config, adminClient -> {
             // Step 1: Describe the consumer group
             ConsumerGroupDescription description = adminClient
@@ -493,7 +493,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
 
     @Override
     public BrowseMessagesResult browseMessages(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String topicName,
         Integer partition,
         String offsetMode,
@@ -594,7 +594,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
 
     @Override
     public void tailMessages(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String topicName,
         Integer partition,
         String keyFilter,
@@ -637,7 +637,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
         });
     }
 
-    private List<TopicPartition> resolvePartitions(KafkaClusterConfiguration config, String topicName, Integer partition) {
+    private List<TopicPartition> resolvePartitions(KafkaClusterConnectionConfiguration config, String topicName, Integer partition) {
         return withAdminClient(config, adminClient -> {
             TopicDescription description;
             try {
@@ -689,7 +689,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
         T execute(KafkaConsumer<String, String> consumer) throws Exception;
     }
 
-    private <T> T withConsumer(KafkaClusterConfiguration config, int maxPollRecords, ConsumerAction<T> action) {
+    private <T> T withConsumer(KafkaClusterConnectionConfiguration config, int maxPollRecords, ConsumerAction<T> action) {
         List<Path> tempFiles = new ArrayList<>();
         Properties properties = buildConsumerProperties(config, maxPollRecords, tempFiles);
         try (KafkaConsumer<String, String> consumer = createConsumer(properties)) {
@@ -714,7 +714,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
         return new KafkaConsumer<>(properties);
     }
 
-    private Properties buildConsumerProperties(KafkaClusterConfiguration config, int maxPollRecords, List<Path> tempFiles) {
+    private Properties buildConsumerProperties(KafkaClusterConnectionConfiguration config, int maxPollRecords, List<Path> tempFiles) {
         Properties properties = buildProperties(config, tempFiles);
         properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
@@ -919,7 +919,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
         T execute(AdminClient adminClient) throws Exception;
     }
 
-    private <T> T withAdminClient(KafkaClusterConfiguration config, AdminClientAction<T> action) {
+    private <T> T withAdminClient(KafkaClusterConnectionConfiguration config, AdminClientAction<T> action) {
         List<Path> tempFiles = new ArrayList<>();
         Properties properties = buildProperties(config, tempFiles);
         try (AdminClient adminClient = createAdminClient(properties)) {
@@ -1017,7 +1017,7 @@ public class KafkaClusterDomainServiceImpl implements KafkaClusterDomainService 
         );
     }
 
-    private Properties buildProperties(KafkaClusterConfiguration config, List<Path> tempFiles) {
+    private Properties buildProperties(KafkaClusterConnectionConfiguration config, List<Path> tempFiles) {
         Properties properties = new Properties();
         // TODO: Add allowed bootstrap servers validation via gravitee.yml config to prevent SSRF
         properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, config.bootstrapServers());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceImplTest.java
@@ -22,7 +22,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
+import io.gravitee.apim.core.cluster.model.KafkaClusterConnectionConfiguration;
 import io.gravitee.apim.core.cluster.model.SaslConfig;
 import io.gravitee.apim.core.cluster.model.SaslMechanism;
 import io.gravitee.apim.core.cluster.model.SecurityConfig;
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Test;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class KafkaClusterDomainServiceImplTest {
 
-    private static final KafkaClusterConfiguration CONFIG = new KafkaClusterConfiguration(
+    private static final KafkaClusterConnectionConfiguration CONFIG = new KafkaClusterConnectionConfiguration(
         "localhost:9092",
         new SecurityConfig(SecurityProtocol.PLAINTEXT, null, null)
     );
@@ -312,11 +312,11 @@ class KafkaClusterDomainServiceImplTest {
             assertThat(Path.of(tempFilePath.get())).doesNotExist();
         }
 
-        private KafkaClusterConfiguration configWith(SecurityProtocol protocol, SaslConfig sasl, SslOptions ssl) {
-            return new KafkaClusterConfiguration("localhost:9092", new SecurityConfig(protocol, sasl, ssl));
+        private KafkaClusterConnectionConfiguration configWith(SecurityProtocol protocol, SaslConfig sasl, SslOptions ssl) {
+            return new KafkaClusterConnectionConfiguration("localhost:9092", new SecurityConfig(protocol, sasl, ssl));
         }
 
-        private Properties captureProperties(KafkaClusterConfiguration config) {
+        private Properties captureProperties(KafkaClusterConnectionConfiguration config) {
             var captured = new AtomicReference<Properties>();
             var service = new KafkaClusterDomainServiceImpl() {
                 @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/infrastructure/domain_service/KafkaClusterDomainServiceInMemory.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.kafkaexplorer.infrastructure.domain_service;
 
-import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
+import io.gravitee.apim.core.cluster.model.KafkaClusterConnectionConfiguration;
 import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.KafkaClusterDomainService;
 import io.gravitee.rest.api.kafkaexplorer.domain.domain_service.MessageConsumer;
 import io.gravitee.rest.api.kafkaexplorer.domain.exception.KafkaExplorerException;
@@ -89,7 +89,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
     }
 
     @Override
-    public KafkaClusterInfo describeCluster(KafkaClusterConfiguration config) {
+    public KafkaClusterInfo describeCluster(KafkaClusterConnectionConfiguration config) {
         if (exception != null) {
             throw exception;
         }
@@ -98,7 +98,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
 
     @Override
     public TopicsPage listTopics(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String nameFilter,
         int page,
         int perPage,
@@ -127,7 +127,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
     }
 
     @Override
-    public TopicDetail describeTopic(KafkaClusterConfiguration config, String topicName) {
+    public TopicDetail describeTopic(KafkaClusterConnectionConfiguration config, String topicName) {
         if (exception != null) {
             throw exception;
         }
@@ -135,7 +135,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
     }
 
     @Override
-    public BrokerInfo describeBroker(KafkaClusterConfiguration config, int brokerId) {
+    public BrokerInfo describeBroker(KafkaClusterConnectionConfiguration config, int brokerId) {
         if (exception != null) {
             throw exception;
         }
@@ -144,7 +144,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
 
     @Override
     public ConsumerGroupsPage listConsumerGroups(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String nameFilter,
         String topicFilter,
         int page,
@@ -174,7 +174,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
     }
 
     @Override
-    public ConsumerGroupDetail describeConsumerGroup(KafkaClusterConfiguration config, String groupId) {
+    public ConsumerGroupDetail describeConsumerGroup(KafkaClusterConnectionConfiguration config, String groupId) {
         if (exception != null) {
             throw exception;
         }
@@ -183,7 +183,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
 
     @Override
     public BrowseMessagesResult browseMessages(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String topicName,
         Integer partition,
         String offsetMode,
@@ -200,7 +200,7 @@ public class KafkaClusterDomainServiceInMemory implements KafkaClusterDomainServ
 
     @Override
     public void tailMessages(
-        KafkaClusterConfiguration config,
+        KafkaClusterConnectionConfiguration config,
         String topicName,
         Integer partition,
         String keyFilter,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ClusterMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ClusterMapper.java
@@ -15,11 +15,13 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.rest.api.management.v2.rest.model.Cluster;
 import io.gravitee.rest.api.management.v2.rest.model.CreateCluster;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateCluster;
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.ValueMapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(uses = { DateMapper.class })
@@ -33,4 +35,8 @@ public interface ClusterMapper {
     io.gravitee.apim.core.cluster.model.UpdateCluster map(UpdateCluster updateCluster);
 
     List<Cluster> map(List<io.gravitee.apim.core.cluster.model.Cluster> clusters);
+
+    ClusterType map(io.gravitee.rest.api.management.v2.rest.model.ClusterType clusterType);
+
+    io.gravitee.rest.api.management.v2.rest.model.ClusterType map(ClusterType clusterType);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResource.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.cluster;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.cluster.domain_service.ClusterConfigurationSchemaService;
+import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.apim.core.cluster.use_case.CreateClusterUseCase;
 import io.gravitee.apim.core.cluster.use_case.SearchClusterUseCase;
 import io.gravitee.common.http.MediaType;
@@ -126,8 +127,9 @@ public class ClustersResource extends AbstractResource {
     @Path("schema/configuration")
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLUSTER, acls = { RolePermissionAction.READ }) })
-    public Response getConfigurationSchema() {
-        return Response.ok(clusterConfigurationSchemaService.getConfigurationSchema()).build();
+    public Response getConfigurationSchema(@QueryParam("type") ClusterType type) {
+        ClusterType clusterType = type != null ? type : ClusterType.KAFKA_CLUSTER_CONNECTION;
+        return Response.ok(clusterConfigurationSchemaService.getConfigurationSchema(clusterType)).build();
     }
 
     @Path("{clusterId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1385,21 +1385,28 @@ components:
         - PENDING
 
     # Cluster
+    ClusterType:
+      type: string
+      enum: [ KAFKA_CLUSTER_CONNECTION ]
     CreateCluster:
       type: object
       properties:
+        type:
+          $ref: "#/components/schemas/ClusterType"
         name:
           type: string
         description:
           type: string
         configuration:
           type: object
-      required: [ "name", "configuration" ]
+      required: [ "type", "name", "configuration" ]
     Cluster:
       type: object
       properties:
         id:
           type: string
+        type:
+          $ref: "#/components/schemas/ClusterType"
         createdAt:
           type: string
           format: date-time

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1387,7 +1387,7 @@ components:
     # Cluster
     ClusterType:
       type: string
-      enum: [ KAFKA_CLUSTER_CONNECTION ]
+      enum: [ KAFKA_CLUSTER_CONNECTION, KAFKA_CLUSTER ]
     CreateCluster:
       type: object
       properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
@@ -139,6 +139,35 @@ class ClustersResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_create_kafka_cluster() {
+            CreateCluster createCluster = new CreateCluster();
+            createCluster.setType(io.gravitee.rest.api.management.v2.rest.model.ClusterType.KAFKA_CLUSTER);
+            createCluster.setName("kafka-cluster-1");
+            createCluster.setConfiguration(Map.of("connections", java.util.List.of(Map.of("bootstrapServers", "kafka1:9092"))));
+
+            Cluster output = Cluster.builder()
+                .createdAt(Instant.now())
+                .id("cl-id-2")
+                .type(io.gravitee.apim.core.cluster.model.ClusterType.KAFKA_CLUSTER)
+                .name(createCluster.getName())
+                .environmentId(ENV_ID)
+                .organizationId(ORGANIZATION)
+                .configuration(createCluster.getConfiguration())
+                .build();
+
+            when(createClusterUseCase.execute(any())).thenReturn(new CreateClusterUseCase.Output(output));
+
+            final Response response = rootTarget().request().post(json(createCluster));
+
+            assertThat(response.getStatus()).isEqualTo(CREATED_201);
+
+            var createdCluster = response.readEntity(io.gravitee.rest.api.management.v2.rest.model.Cluster.class);
+
+            assertThat(createdCluster.getType()).isEqualTo(io.gravitee.rest.api.management.v2.rest.model.ClusterType.KAFKA_CLUSTER);
+            assertThat(createdCluster.getName()).isEqualTo(createCluster.getName());
+        }
+
+        @Test
         void should_return_400_if_execute_fails_with_invalid_data_exception() {
             CreateCluster createCluster = new CreateCluster();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
@@ -94,6 +94,7 @@ class ClustersResourceTest extends AbstractResourceTest {
         @Test
         void should_create_cluster() {
             CreateCluster createCluster = new CreateCluster();
+            createCluster.setType(io.gravitee.rest.api.management.v2.rest.model.ClusterType.KAFKA_CLUSTER_CONNECTION);
             createCluster.setName("cluster-1");
             createCluster.setDescription("Cluster 1 description");
             createCluster.setConfiguration(Map.of("bootstrapServers", "localhost:9092"));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResourceTest.java
@@ -143,7 +143,9 @@ class ClustersResourceTest extends AbstractResourceTest {
             CreateCluster createCluster = new CreateCluster();
             createCluster.setType(io.gravitee.rest.api.management.v2.rest.model.ClusterType.KAFKA_CLUSTER);
             createCluster.setName("kafka-cluster-1");
-            createCluster.setConfiguration(Map.of("connections", java.util.List.of(Map.of("bootstrapServers", "kafka1:9092"))));
+            createCluster.setConfiguration(
+                Map.of("connections", java.util.List.of(Map.of("name", "conn-1", "bootstrapServers", "kafka1:9092")))
+            );
 
             Cluster output = Cluster.builder()
                 .createdAt(Instant.now())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResource_GetConfigurationSchemaTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResource_GetConfigurationSchemaTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.cluster.domain_service.ClusterConfigurationSchemaService;
+import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -68,11 +69,22 @@ class ClustersResource_GetConfigurationSchemaTest extends AbstractResourceTest {
     }
 
     @Test
-    void should_return_configuration_schema() {
+    void should_return_configuration_schema_default_type() {
         String schema = "{\"type\":\"object\",\"properties\":{\"protocol\":{\"type\":\"string\"}}}";
-        when(clusterConfigurationSchemaService.getConfigurationSchema()).thenReturn(schema);
+        when(clusterConfigurationSchemaService.getConfigurationSchema(ClusterType.KAFKA_CLUSTER_CONNECTION)).thenReturn(schema);
 
         final Response response = rootTarget().request().get();
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        assertThat(response.readEntity(String.class)).isEqualTo(schema);
+    }
+
+    @Test
+    void should_return_configuration_schema_for_kafka_cluster_type() {
+        String schema = "{\"type\":\"object\",\"properties\":{\"connections\":{\"type\":\"array\"}}}";
+        when(clusterConfigurationSchemaService.getConfigurationSchema(ClusterType.KAFKA_CLUSTER)).thenReturn(schema);
+
+        final Response response = rootTarget().queryParam("type", "KAFKA_CLUSTER").request().get();
 
         assertThat(response.getStatus()).isEqualTo(OK_200);
         assertThat(response.readEntity(String.class)).isEqualTo(schema);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -476,14 +476,27 @@
 					<includeSchemas>
 						<include>schemas/**/schema-form-ssl.json</include>
 					</includeSchemas>
-					<localSchemaFile>${project.basedir}/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json</localSchemaFile>
-					<outputFile>${project.build.outputDirectory}/cluster/kafka-cluster-configuration-schema-form.json</outputFile>
 				</configuration>
 				<executions>
 					<execution>
+						<id>bundle-kafka-cluster-connection-schema</id>
 						<goals>
 							<goal>common-schema-form-bundle</goal>
 						</goals>
+						<configuration>
+							<localSchemaFile>${project.basedir}/src/main/resources/cluster/kafka-cluster-connection-configuration-schema-form.json</localSchemaFile>
+							<outputFile>${project.build.outputDirectory}/cluster/kafka-cluster-connection-configuration-schema-form.json</outputFile>
+						</configuration>
+					</execution>
+					<execution>
+						<id>bundle-kafka-cluster-schema</id>
+						<goals>
+							<goal>common-schema-form-bundle</goal>
+						</goals>
+						<configuration>
+							<localSchemaFile>${project.basedir}/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json</localSchemaFile>
+							<outputFile>${project.build.outputDirectory}/cluster/kafka-cluster-configuration-schema-form.json</outputFile>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ClusterConfigurationSchemaService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ClusterConfigurationSchemaService.java
@@ -18,25 +18,46 @@ package io.gravitee.apim.core.cluster.domain_service;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @DomainService
 public class ClusterConfigurationSchemaService {
 
-    private static final String SCHEMA_PATH = "/cluster/kafka-cluster-configuration-schema-form.json";
+    private static final Map<ClusterType, String> SCHEMA_PATHS = Map.of(
+        ClusterType.KAFKA_CLUSTER_CONNECTION,
+        "/cluster/kafka-cluster-connection-configuration-schema-form.json",
+        ClusterType.KAFKA_CLUSTER,
+        "/cluster/kafka-cluster-configuration-schema-form.json"
+    );
 
-    private String cachedSchema;
+    private final Map<ClusterType, String> cachedSchemas = new ConcurrentHashMap<>();
 
+    public String getConfigurationSchema(ClusterType type) {
+        return cachedSchemas.computeIfAbsent(type, this::loadSchema);
+    }
+
+    /**
+     * @deprecated Use {@link #getConfigurationSchema(ClusterType)} instead.
+     */
+    @Deprecated
     public String getConfigurationSchema() {
-        if (cachedSchema == null) {
-            try (InputStream resourceAsStream = this.getClass().getResourceAsStream(SCHEMA_PATH)) {
-                cachedSchema = new String(resourceAsStream.readAllBytes(), UTF_8);
-            } catch (IOException e) {
-                throw new TechnicalManagementException("An error occurs while trying to load cluster configuration schema", e);
-            }
+        return getConfigurationSchema(ClusterType.KAFKA_CLUSTER_CONNECTION);
+    }
+
+    private String loadSchema(ClusterType type) {
+        String path = SCHEMA_PATHS.get(type);
+        if (path == null) {
+            throw new TechnicalManagementException("No configuration schema found for cluster type: " + type);
         }
-        return cachedSchema;
+        try (InputStream resourceAsStream = this.getClass().getResourceAsStream(path)) {
+            return new String(resourceAsStream.readAllBytes(), UTF_8);
+        } catch (IOException e) {
+            throw new TechnicalManagementException("An error occurs while trying to load cluster configuration schema", e);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterService.java
@@ -20,10 +20,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterType;
+import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
@@ -50,6 +52,27 @@ public class ValidateClusterService {
             jsonSchemaChecker.validate(schema, configJson);
         } catch (JsonProcessingException e) {
             throw new InvalidDataException("Configuration is not valid JSON.");
+        }
+
+        if (cluster.getType() == ClusterType.KAFKA_CLUSTER) {
+            validateUniqueConnectionNames(cluster);
+        }
+    }
+
+    private void validateUniqueConnectionNames(Cluster cluster) {
+        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        var duplicates = config
+            .connections()
+            .stream()
+            .collect(Collectors.groupingBy(c -> c.name(), Collectors.counting()))
+            .entrySet()
+            .stream()
+            .filter(e -> e.getValue() > 1)
+            .map(e -> e.getKey())
+            .toList();
+
+        if (!duplicates.isEmpty()) {
+            throw new InvalidDataException("Connection names must be unique. Duplicates found: " + duplicates);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterService.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
@@ -37,12 +38,15 @@ public class ValidateClusterService {
         if (StringUtils.isEmpty(cluster.getName())) {
             throw new InvalidDataException("Name is required.");
         }
+        if (Objects.isNull(cluster.getType())) {
+            throw new InvalidDataException("Type is required.");
+        }
         if (Objects.isNull(cluster.getConfiguration())) {
             throw new InvalidDataException("Configuration is required.");
         }
         try {
             String configJson = objectMapper.writeValueAsString(cluster.getConfiguration());
-            String schema = clusterConfigurationSchemaService.getConfigurationSchema();
+            String schema = clusterConfigurationSchemaService.getConfigurationSchema(cluster.getType());
             jsonSchemaChecker.validate(schema, configJson);
         } catch (JsonProcessingException e) {
             throw new InvalidDataException("Configuration is not valid JSON.");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/Cluster.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/Cluster.java
@@ -35,13 +35,14 @@ public class Cluster {
     private Instant updatedAt;
     private String environmentId;
     private String organizationId;
+    private ClusterType type;
     private String name;
     private String description;
     private Object configuration;
     private Set<String> groups;
 
-    public KafkaClusterConfiguration getKafkaClusterConfiguration(ObjectMapper objectMapper) {
-        return objectMapper.convertValue(this.configuration, KafkaClusterConfiguration.class);
+    public KafkaClusterConnectionConfiguration getKafkaClusterConnectionConfiguration(ObjectMapper objectMapper) {
+        return objectMapper.convertValue(this.configuration, KafkaClusterConnectionConfiguration.class);
     }
 
     public void update(UpdateCluster updateCluster) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/Cluster.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/Cluster.java
@@ -45,6 +45,10 @@ public class Cluster {
         return objectMapper.convertValue(this.configuration, KafkaClusterConnectionConfiguration.class);
     }
 
+    public KafkaClusterConfiguration getKafkaClusterConfiguration(ObjectMapper objectMapper) {
+        return objectMapper.convertValue(this.configuration, KafkaClusterConfiguration.class);
+    }
+
     public void update(UpdateCluster updateCluster) {
         this.updatedAt = TimeProvider.instantNow();
         if (updateCluster.getName() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/ClusterType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/ClusterType.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,17 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CreateCluster } from './CreateCluster';
+package io.gravitee.apim.core.cluster.model;
 
-export function fakeCreateCluster(overrides: Partial<CreateCluster> = {}): CreateCluster {
-  return {
-    type: 'KAFKA_CLUSTER_CONNECTION',
-    name: 'New Cluster Name',
-    description: 'A new test cluster',
-    configuration: {
-      bootstrapServers: 'kafka.example.com:9092',
-      security: 'none',
-    },
-    ...overrides,
-  };
+public enum ClusterType {
+    KAFKA_CLUSTER_CONNECTION,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/CreateCluster.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/CreateCluster.java
@@ -28,6 +28,7 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CreateCluster {
 
+    private ClusterType type;
     private String name;
     private String description;
     private Object configuration;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaClusterConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaClusterConfiguration.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.apim.core.cluster.model;
 
-public enum ClusterType {
-    KAFKA_CLUSTER_CONNECTION,
-    KAFKA_CLUSTER,
-}
+import java.util.List;
+
+public record KafkaClusterConfiguration(List<KafkaClusterConnection> connections) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaClusterConnection.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaClusterConnection.java
@@ -15,7 +15,4 @@
  */
 package io.gravitee.apim.core.cluster.model;
 
-public enum ClusterType {
-    KAFKA_CLUSTER_CONNECTION,
-    KAFKA_CLUSTER,
-}
+public record KafkaClusterConnection(String bootstrapServers, SecurityConfig security) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaClusterConnection.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaClusterConnection.java
@@ -15,4 +15,4 @@
  */
 package io.gravitee.apim.core.cluster.model;
 
-public record KafkaClusterConnection(String bootstrapServers, SecurityConfig security) {}
+public record KafkaClusterConnection(String name, String bootstrapServers, SecurityConfig security) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaClusterConnectionConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaClusterConnectionConfiguration.java
@@ -15,4 +15,4 @@
  */
 package io.gravitee.apim.core.cluster.model;
 
-public record KafkaClusterConfiguration(String bootstrapServers, SecurityConfig security) {}
+public record KafkaClusterConnectionConfiguration(String bootstrapServers, SecurityConfig security) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCase.java
@@ -54,6 +54,7 @@ public class CreateClusterUseCase {
     public Output execute(Input input) {
         Instant now = TimeProvider.instantNow();
         Cluster clusterToCreate = Cluster.builder()
+            .type(input.createCluster.getType())
             .name(input.createCluster.getName())
             .description(input.createCluster.getDescription())
             .configuration(input.createCluster.getConfiguration())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ClusterAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ClusterAdapter.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.adapter;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.apim.core.cluster.model.ClusterType;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
@@ -29,12 +30,19 @@ public abstract class ClusterAdapter {
     public static final ObjectMapper mapper = new ObjectMapper();
 
     @Mapping(target = "definition", source = "cluster", qualifiedByName = "mapDefinition")
+    @Mapping(target = "type", source = "type", qualifiedByName = "mapTypeToString")
     public abstract io.gravitee.repository.management.model.Cluster toRepository(Cluster cluster);
+
+    @Named("mapTypeToString")
+    public String mapTypeToString(ClusterType type) {
+        return type != null ? type.name() : null;
+    }
 
     @Named("mapDefinition")
     public String mapDefinition(Cluster cluster) throws JsonProcessingException {
         var clusterDefinition = io.gravitee.definition.model.cluster.Cluster.builder()
             .id(cluster.getId())
+            .type(cluster.getType() != null ? cluster.getType().name() : null)
             .name(cluster.getName())
             .configuration(cluster.getConfiguration())
             .build();
@@ -42,7 +50,13 @@ public abstract class ClusterAdapter {
     }
 
     @Mapping(target = "configuration", source = "cluster", qualifiedByName = "mapConfiguration")
+    @Mapping(target = "type", source = "type", qualifiedByName = "mapTypeFromString")
     public abstract Cluster fromRepository(io.gravitee.repository.management.model.Cluster cluster);
+
+    @Named("mapTypeFromString")
+    public ClusterType mapTypeFromString(String type) {
+        return type != null ? ClusterType.valueOf(type) : ClusterType.KAFKA_CLUSTER_CONNECTION;
+    }
 
     @Named("mapConfiguration")
     public Object mapConfiguration(io.gravitee.repository.management.model.Cluster cluster) throws JsonProcessingException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json
@@ -265,6 +265,11 @@
     "kafkaClusterConnection": {
       "type": "object",
       "properties": {
+        "name": {
+          "type": "string",
+          "title": "Connection name",
+          "description": "A name to identify this connection"
+        },
         "bootstrapServers": {
           "type": "string",
           "title": "Bootstrap servers",
@@ -294,7 +299,7 @@
           "required": ["protocol"]
         }
       },
-      "required": ["bootstrapServers", "security"],
+      "required": ["name", "bootstrapServers", "security"],
       "additionalProperties": false
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-connection-configuration-schema-form.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-connection-configuration-schema-form.json
@@ -261,54 +261,41 @@
           }
         }
       }
-    },
-    "kafkaClusterConnection": {
-      "type": "object",
-      "properties": {
-        "bootstrapServers": {
-          "type": "string",
-          "title": "Bootstrap servers",
-          "description": "The Kafka bootstrap server address (e.g., kafka.example.com:9092)"
-        },
-        "security": {
-          "type": "object",
-          "title": "Security",
-          "properties": {
-            "protocol": {
-              "$ref": "#/definitions/securityProtocol"
-            },
-            "sasl": {
-              "$ref": "#/definitions/securitySasl"
-            },
-            "ssl": {
-              "$ref": "#/gioExternalDefinitions/sslOptions",
-              "gioConfig": {
-                "displayIf": {
-                  "$eq": {
-                    "value.security.protocol": ["SASL_SSL", "SSL"]
-                  }
-                }
-              }
-            }
-          },
-          "required": ["protocol"]
-        }
-      },
-      "required": ["bootstrapServers", "security"],
-      "additionalProperties": false
     }
   },
   "properties": {
-    "connections": {
-      "type": "array",
-      "title": "Kafka Cluster Connections",
-      "description": "List of Kafka cluster connections",
-      "items": {
-        "$ref": "#/definitions/kafkaClusterConnection"
+    "bootstrapServers": {
+      "type": "string",
+      "title": "Bootstrap servers",
+      "description": "The Kafka bootstrap server address (e.g., kafka.example.com:9092)"
+    },
+    "security": {
+      "type": "object",
+      "title": "Security",
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/securityProtocol"
+        },
+        "sasl": {
+          "$ref": "#/definitions/securitySasl"
+        },
+        "ssl": {
+          "$ref": "#/gioExternalDefinitions/sslOptions",
+          "gioConfig": {
+            "displayIf": {
+              "$eq": {
+                "value.security.protocol": ["SASL_SSL", "SSL"]
+              }
+            }
+          }
+        }
       },
-      "minItems": 1
+      "required": ["protocol"]
     }
   },
-  "required": ["connections"],
+  "gioConfig": {
+    "uiBorder": "none"
+  },
+  "required": ["bootstrapServers", "security"],
   "additionalProperties": false
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterServiceTest.java
@@ -20,11 +20,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.cluster.model.Cluster;
+import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.infra.json.JsonSchemaCheckerImpl;
 import io.gravitee.json.validation.JsonSchemaValidatorImpl;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.impl.JsonSchemaServiceImpl;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -49,7 +51,7 @@ class ValidateClusterServiceTest {
 
     @Test
     void should_throw_when_name_is_empty() {
-        Cluster cluster = Cluster.builder().name("").configuration(validConfig()).build();
+        Cluster cluster = Cluster.builder().type(ClusterType.KAFKA_CLUSTER_CONNECTION).name("").configuration(validConfig()).build();
 
         assertThatThrownBy(() -> validateClusterService.validate(cluster))
             .isInstanceOf(InvalidDataException.class)
@@ -58,7 +60,7 @@ class ValidateClusterServiceTest {
 
     @Test
     void should_throw_when_name_is_null() {
-        Cluster cluster = Cluster.builder().name(null).configuration(validConfig()).build();
+        Cluster cluster = Cluster.builder().type(ClusterType.KAFKA_CLUSTER_CONNECTION).name(null).configuration(validConfig()).build();
 
         assertThatThrownBy(() -> validateClusterService.validate(cluster))
             .isInstanceOf(InvalidDataException.class)
@@ -66,8 +68,17 @@ class ValidateClusterServiceTest {
     }
 
     @Test
+    void should_throw_when_type_is_null() {
+        Cluster cluster = Cluster.builder().name("my-cluster").configuration(validConfig()).build();
+
+        assertThatThrownBy(() -> validateClusterService.validate(cluster))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessage("Type is required.");
+    }
+
+    @Test
     void should_throw_when_configuration_is_null() {
-        Cluster cluster = Cluster.builder().name("my-cluster").configuration(null).build();
+        Cluster cluster = Cluster.builder().type(ClusterType.KAFKA_CLUSTER_CONNECTION).name("my-cluster").configuration(null).build();
 
         assertThatThrownBy(() -> validateClusterService.validate(cluster))
             .isInstanceOf(InvalidDataException.class)
@@ -76,7 +87,11 @@ class ValidateClusterServiceTest {
 
     @Test
     void should_pass_with_valid_plaintext_configuration() {
-        Cluster cluster = Cluster.builder().name("my-cluster").configuration(validConfig()).build();
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("my-cluster")
+            .configuration(validConfig())
+            .build();
 
         assertThatCode(() -> validateClusterService.validate(cluster)).doesNotThrowAnyException();
     }
@@ -84,6 +99,7 @@ class ValidateClusterServiceTest {
     @Test
     void should_throw_when_protocol_has_invalid_value() {
         Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
             .name("my-cluster")
             .configuration(Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "INVALID_PROTOCOL")))
             .build();
@@ -93,7 +109,46 @@ class ValidateClusterServiceTest {
 
     @Test
     void should_throw_when_bootstrap_servers_is_missing() {
-        Cluster cluster = Cluster.builder().name("my-cluster").configuration(Map.of("security", Map.of("protocol", "PLAINTEXT"))).build();
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("my-cluster")
+            .configuration(Map.of("security", Map.of("protocol", "PLAINTEXT")))
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validate(cluster)).isInstanceOf(InvalidDataException.class);
+    }
+
+    @Test
+    void should_pass_with_valid_kafka_cluster_configuration() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER)
+            .name("my-kafka-cluster")
+            .configuration(
+                Map.of("connections", List.of(Map.of("bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT"))))
+            )
+            .build();
+
+        assertThatCode(() -> validateClusterService.validate(cluster)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_throw_when_kafka_cluster_has_no_connections() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER)
+            .name("my-kafka-cluster")
+            .configuration(Map.of("connections", List.of()))
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validate(cluster)).isInstanceOf(InvalidDataException.class);
+    }
+
+    @Test
+    void should_throw_when_kafka_cluster_connection_missing_bootstrap_servers() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER)
+            .name("my-kafka-cluster")
+            .configuration(Map.of("connections", List.of(Map.of("security", Map.of("protocol", "PLAINTEXT")))))
+            .build();
 
         assertThatThrownBy(() -> validateClusterService.validate(cluster)).isInstanceOf(InvalidDataException.class);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterServiceTest.java
@@ -124,7 +124,10 @@ class ValidateClusterServiceTest {
             .type(ClusterType.KAFKA_CLUSTER)
             .name("my-kafka-cluster")
             .configuration(
-                Map.of("connections", List.of(Map.of("bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT"))))
+                Map.of(
+                    "connections",
+                    List.of(Map.of("name", "conn-1", "bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT")))
+                )
             )
             .build();
 
@@ -147,9 +150,43 @@ class ValidateClusterServiceTest {
         Cluster cluster = Cluster.builder()
             .type(ClusterType.KAFKA_CLUSTER)
             .name("my-kafka-cluster")
-            .configuration(Map.of("connections", List.of(Map.of("security", Map.of("protocol", "PLAINTEXT")))))
+            .configuration(Map.of("connections", List.of(Map.of("name", "conn-1", "security", Map.of("protocol", "PLAINTEXT")))))
             .build();
 
         assertThatThrownBy(() -> validateClusterService.validate(cluster)).isInstanceOf(InvalidDataException.class);
+    }
+
+    @Test
+    void should_throw_when_kafka_cluster_connection_missing_name() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER)
+            .name("my-kafka-cluster")
+            .configuration(
+                Map.of("connections", List.of(Map.of("bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT"))))
+            )
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validate(cluster)).isInstanceOf(InvalidDataException.class);
+    }
+
+    @Test
+    void should_throw_when_kafka_cluster_has_duplicate_connection_names() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER)
+            .name("my-kafka-cluster")
+            .configuration(
+                Map.of(
+                    "connections",
+                    List.of(
+                        Map.of("name", "same-name", "bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT")),
+                        Map.of("name", "same-name", "bootstrapServers", "kafka2:9092", "security", Map.of("protocol", "PLAINTEXT"))
+                    )
+                )
+            )
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validate(cluster))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("Connection names must be unique");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/model/ClusterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/model/ClusterTest.java
@@ -18,8 +18,10 @@ package io.gravitee.apim.core.cluster.model;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -69,5 +71,35 @@ public class ClusterTest {
             () -> assertThat(cluster.getEnvironmentId()).isEqualTo(envId),
             () -> assertThat(cluster.getConfiguration()).isEqualTo(newConfiguration)
         );
+    }
+
+    @Test
+    public void should_deserialize_kafka_cluster_configuration() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Object configuration = Map.of(
+            "connections",
+            List.of(
+                Map.of("bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT")),
+                Map.of("bootstrapServers", "kafka2:9092", "security", Map.of("protocol", "SSL"))
+            )
+        );
+        Cluster cluster = Cluster.builder().type(ClusterType.KAFKA_CLUSTER).configuration(configuration).build();
+
+        KafkaClusterConfiguration kafkaConfig = cluster.getKafkaClusterConfiguration(objectMapper);
+
+        assertThat(kafkaConfig.connections()).hasSize(2);
+        assertThat(kafkaConfig.connections().get(0).bootstrapServers()).isEqualTo("kafka1:9092");
+        assertThat(kafkaConfig.connections().get(1).bootstrapServers()).isEqualTo("kafka2:9092");
+    }
+
+    @Test
+    public void should_deserialize_kafka_cluster_connection_configuration() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Object configuration = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        Cluster cluster = Cluster.builder().type(ClusterType.KAFKA_CLUSTER_CONNECTION).configuration(configuration).build();
+
+        KafkaClusterConnectionConfiguration connectionConfig = cluster.getKafkaClusterConnectionConfiguration(objectMapper);
+
+        assertThat(connectionConfig.bootstrapServers()).isEqualTo("localhost:9092");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/model/ClusterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/model/ClusterTest.java
@@ -79,8 +79,8 @@ public class ClusterTest {
         Object configuration = Map.of(
             "connections",
             List.of(
-                Map.of("bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT")),
-                Map.of("bootstrapServers", "kafka2:9092", "security", Map.of("protocol", "SSL"))
+                Map.of("name", "primary", "bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT")),
+                Map.of("name", "secondary", "bootstrapServers", "kafka2:9092", "security", Map.of("protocol", "SSL"))
             )
         );
         Cluster cluster = Cluster.builder().type(ClusterType.KAFKA_CLUSTER).configuration(configuration).build();
@@ -88,7 +88,9 @@ public class ClusterTest {
         KafkaClusterConfiguration kafkaConfig = cluster.getKafkaClusterConfiguration(objectMapper);
 
         assertThat(kafkaConfig.connections()).hasSize(2);
+        assertThat(kafkaConfig.connections().get(0).name()).isEqualTo("primary");
         assertThat(kafkaConfig.connections().get(0).bootstrapServers()).isEqualTo("kafka1:9092");
+        assertThat(kafkaConfig.connections().get(1).name()).isEqualTo("secondary");
         assertThat(kafkaConfig.connections().get(1).bootstrapServers()).isEqualTo("kafka2:9092");
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCaseTest.java
@@ -184,7 +184,7 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
         String name = "Kafka Cluster";
         Object configuration = Map.of(
             "connections",
-            List.of(Map.of("bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT")))
+            List.of(Map.of("name", "conn-1", "bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT")))
         );
         // Given
         var toCreate = CreateCluster.builder().type(ClusterType.KAFKA_CLUSTER).name(name).configuration(configuration).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCaseTest.java
@@ -30,6 +30,7 @@ import io.gravitee.apim.core.cluster.domain_service.ClusterConfigurationSchemaSe
 import io.gravitee.apim.core.cluster.domain_service.ValidateClusterService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterAuditEvent;
+import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.apim.core.cluster.model.CreateCluster;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.membership.crud_service.MembershipCrudService;
@@ -80,7 +81,7 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
         String name = "Cluster 1";
         Object configuration = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
         // Given
-        var toCreate = CreateCluster.builder().name(name).configuration(configuration).build();
+        var toCreate = CreateCluster.builder().type(ClusterType.KAFKA_CLUSTER_CONNECTION).name(name).configuration(configuration).build();
 
         // When
         var output = createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO));
@@ -88,6 +89,7 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
         // Then
         var expected = Cluster.builder()
             .id(GENERATED_UUID)
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
             .name(name)
             .createdAt(INSTANT_NOW)
             .updatedAt(INSTANT_NOW)
@@ -104,7 +106,7 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
         String name = "Cluster 1";
         Object configuration = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
         // Given
-        var toCreate = CreateCluster.builder().name(name).configuration(configuration).build();
+        var toCreate = CreateCluster.builder().type(ClusterType.KAFKA_CLUSTER_CONNECTION).name(name).configuration(configuration).build();
 
         // When
         createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO));
@@ -132,7 +134,7 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
         String name = "Cluster 1";
         Object configuration = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
         // Given
-        var toCreate = CreateCluster.builder().name(name).configuration(configuration).build();
+        var toCreate = CreateCluster.builder().type(ClusterType.KAFKA_CLUSTER_CONNECTION).name(name).configuration(configuration).build();
 
         // When
         createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO));
@@ -155,7 +157,7 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
     void should_throw_exception_when_name_is_null() {
         Object configuration = Map.of("protocol", "PLAINTEXT");
         // Given
-        var toCreate = CreateCluster.builder().configuration(configuration).build();
+        var toCreate = CreateCluster.builder().type(ClusterType.KAFKA_CLUSTER_CONNECTION).configuration(configuration).build();
 
         // When
         var throwable = Assertions.catchThrowable(() -> createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO)));
@@ -168,13 +170,32 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
     void should_throw_exception_when_configuration_is_null() {
         String name = "Cluster 1";
         // Given
-        var toCreate = CreateCluster.builder().name(name).build();
+        var toCreate = CreateCluster.builder().type(ClusterType.KAFKA_CLUSTER_CONNECTION).name(name).build();
 
         // When
         var throwable = Assertions.catchThrowable(() -> createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO)));
 
         // Then
         Assertions.assertThat(throwable).isInstanceOf(InvalidDataException.class).hasMessage("Configuration is required.");
+    }
+
+    @Test
+    void should_create_kafka_cluster() {
+        String name = "Kafka Cluster";
+        Object configuration = Map.of(
+            "connections",
+            List.of(Map.of("bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT")))
+        );
+        // Given
+        var toCreate = CreateCluster.builder().type(ClusterType.KAFKA_CLUSTER).name(name).configuration(configuration).build();
+
+        // When
+        var output = createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO));
+
+        // Then
+        assertThat(output.cluster().getType()).isEqualTo(ClusterType.KAFKA_CLUSTER);
+        assertThat(output.cluster().getName()).isEqualTo(name);
+        assertThat(output.cluster().getConfiguration()).isEqualTo(configuration);
     }
 
     private void initRoles() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCaseTest.java
@@ -31,6 +31,7 @@ import io.gravitee.apim.core.cluster.domain_service.ClusterConfigurationSchemaSe
 import io.gravitee.apim.core.cluster.domain_service.ValidateClusterService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterAuditEvent;
+import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.apim.core.cluster.model.UpdateCluster;
 import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.apim.infra.json.JsonSchemaCheckerImpl;
@@ -62,6 +63,7 @@ class UpdateClusterUseCaseTest extends AbstractUseCaseTest {
 
         existingCluster = Cluster.builder()
             .id(GENERATED_UUID)
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
             .name("Cluster 1")
             .createdAt(INSTANT_NOW)
             .description("The cluster no 1")


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13496
## Summary

- Add `ClusterType` enum (`KAFKA_CLUSTER_CONNECTION`, `KAFKA_CLUSTER`) and `type` field across all layers (repository, service, REST API, console)
- Rename `KafkaClusterConfiguration` → `KafkaClusterConnectionConfiguration` for the existing connection type
- Add new `KafkaClusterConnection` record (name, bootstrapServers, security) and `KafkaClusterConfiguration` record (List\<KafkaClusterConnection\>) for the new `KAFKA_CLUSTER` type
- Migrate existing DB data to `KAFKA_CLUSTER_CONNECTION` (MongoDB upgrader + JDBC Liquibase v4_12_0)
- Split JSON schema validation per cluster type with dedicated schema files
- Add `?type=` query param to `GET /clusters/schema/configuration` endpoint
- Validate unique connection names within a `KAFKA_CLUSTER`
- Default to `KAFKA_CLUSTER_CONNECTION` when type is null in adapter (backward compatibility)
