### PR TITLE
backport/APIM-13089-mtls-certificate-management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ gravitee-apim-e2e/ui-test/screenshots/
 # Claude configurations
 CLAUDE.md
 .claude
+
+.specs
+.c4

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -216,6 +216,9 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
       access: {
         enabled: true,
       },
+      mtls: {
+        enabled: false,
+      },
       banner: {
         enabled: true,
         title: 'testTitle',

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -242,6 +242,9 @@ export interface PortalSettingsPortalNext {
   access: {
     enabled: boolean;
   };
+  mtls?: {
+    enabled?: boolean;
+  };
   banner?: {
     title?: string;
     subtitle?: string;

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -447,6 +447,15 @@
                 aria-label="New Portal Enabled"
               ></mat-slide-toggle>
             </gio-form-slide-toggle>
+            <gio-form-slide-toggle formGroupName="mtls" class="portal__form__card__form-field">
+              <gio-form-label>Enable mTLS Certificate Management</gio-form-label>
+              <mat-slide-toggle
+                id="enable-portal-next-mtls"
+                formControlName="enabled"
+                gioFormSlideToggle
+                aria-label="mTLS Certificate Management Enabled"
+              ></mat-slide-toggle>
+            </gio-form-slide-toggle>
             @if (!!settings.portalNext?.access?.enabled) {
               <div class="new-developer-portal-actions">
                 @if (portalUrl) {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -198,6 +198,9 @@ describe('PortalSettingsComponent', () => {
           access: {
             enabled: false,
           },
+          mtls: {
+            enabled: false,
+          },
           banner: {
             ...portalSettingsMock.portalNext.banner,
             enabled: true,

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -107,6 +107,7 @@ interface PortalForm {
   }>;
   portalNext: FormGroup<{
     access: FormGroup<{ enabled: FormControl<boolean> }>;
+    mtls: FormGroup<{ enabled: FormControl<boolean> }>;
   }>;
   scheduler: FormGroup<{
     tasks: FormControl<number>;
@@ -387,6 +388,12 @@ export class PortalSettingsComponent implements OnInit {
             disabled: this.isReadonly('portalNext.access.enabled'),
           }),
         }),
+        mtls: new FormGroup({
+          enabled: new FormControl({
+            value: !!this.settings.portalNext?.mtls?.enabled,
+            disabled: this.isReadonly('portalNext.mtls.enabled'),
+          }),
+        }),
       }),
       scheduler: new FormGroup({
         tasks: new FormControl({
@@ -636,6 +643,7 @@ export class PortalSettingsComponent implements OnInit {
           ...this.settings.portalNext.access,
           ...this.portalForm.get('portalNext.access').value,
         },
+        mtls: this.portalForm.get('portalNext.mtls').value,
       },
     };
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.harness.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+export class AddCertificateDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-add-certificate-dialog';
+
+  private readonly getNameInput = this.locatorFor(MatInputHarness.with({ selector: '[data-testid="certificate-name-input"]' }));
+  private readonly getPemInput = this.locatorFor(MatInputHarness.with({ selector: '[data-testid="certificate-pem-input"]' }));
+  private readonly getContinueUploadButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="certificate-continue-upload-button"]' }),
+  );
+  private readonly getContinueConfigureButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="certificate-continue-configure-button"]' }),
+  );
+  private readonly getSubmitButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="certificate-submit-button"]' }));
+  private readonly getCancelButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="certificate-cancel-button"]' }));
+  private readonly getPreviousButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="certificate-previous-button"]' }),
+  );
+  private readonly getGracePeriodInput = this.locatorForOptional(
+    MatInputHarness.with({ selector: '[data-testid="certificate-grace-period-input"]' }),
+  );
+  private readonly getSubmitErrorEl = this.locatorForOptional('[data-testid="certificate-submit-error"]');
+
+  async nameInput(): Promise<MatInputHarness> {
+    return this.getNameInput();
+  }
+
+  async pemInput(): Promise<MatInputHarness> {
+    return this.getPemInput();
+  }
+
+  async clickContinueUpload(): Promise<void> {
+    return (await this.getContinueUploadButton()).click();
+  }
+
+  async clickContinueConfigure(): Promise<void> {
+    return (await this.getContinueConfigureButton()).click();
+  }
+
+  async clickSubmit(): Promise<void> {
+    return (await this.getSubmitButton()).click();
+  }
+
+  async clickCancel(): Promise<void> {
+    return (await this.getCancelButton()).click();
+  }
+
+  async previousButton(): Promise<MatButtonHarness | null> {
+    return this.getPreviousButton();
+  }
+
+  async gracePeriodInput(): Promise<MatInputHarness | null> {
+    return this.getGracePeriodInput();
+  }
+
+  async submitErrorText(): Promise<string | null> {
+    const el = await this.getSubmitErrorEl();
+    return el ? el.text() : null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.harness.ts
@@ -37,6 +37,7 @@ export class AddCertificateDialogHarness extends ComponentHarness {
     MatInputHarness.with({ selector: '[data-testid="certificate-grace-period-input"]' }),
   );
   protected locateSubmitErrorEl = this.locatorForOptional('[data-testid="certificate-submit-error"]');
+  protected locateValidateErrorEl = this.locatorForOptional('[data-testid="certificate-validate-error"]');
 
   public async nameInput(): Promise<MatInputHarness> {
     return this.locateNameInput();
@@ -72,6 +73,11 @@ export class AddCertificateDialogHarness extends ComponentHarness {
 
   public async submitErrorText(): Promise<string | null> {
     const el = await this.locateSubmitErrorEl();
+    return el ? el.text() : null;
+  }
+
+  public async validateErrorText(): Promise<string | null> {
+    const el = await this.locateValidateErrorEl();
     return el ? el.text() : null;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.harness.ts
@@ -20,58 +20,58 @@ import { MatInputHarness } from '@angular/material/input/testing';
 export class AddCertificateDialogHarness extends ComponentHarness {
   static readonly hostSelector = 'app-add-certificate-dialog';
 
-  private readonly getNameInput = this.locatorFor(MatInputHarness.with({ selector: '[data-testid="certificate-name-input"]' }));
-  private readonly getPemInput = this.locatorFor(MatInputHarness.with({ selector: '[data-testid="certificate-pem-input"]' }));
-  private readonly getContinueUploadButton = this.locatorFor(
+  protected locateNameInput = this.locatorFor(MatInputHarness.with({ selector: '[data-testid="certificate-name-input"]' }));
+  protected locatePemInput = this.locatorFor(MatInputHarness.with({ selector: '[data-testid="certificate-pem-input"]' }));
+  protected locateContinueUploadButton = this.locatorFor(
     MatButtonHarness.with({ selector: '[data-testid="certificate-continue-upload-button"]' }),
   );
-  private readonly getContinueConfigureButton = this.locatorFor(
+  protected locateContinueConfigureButton = this.locatorFor(
     MatButtonHarness.with({ selector: '[data-testid="certificate-continue-configure-button"]' }),
   );
-  private readonly getSubmitButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="certificate-submit-button"]' }));
-  private readonly getCancelButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="certificate-cancel-button"]' }));
-  private readonly getPreviousButton = this.locatorForOptional(
+  protected locateSubmitButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="certificate-submit-button"]' }));
+  protected locateCancelButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="certificate-cancel-button"]' }));
+  protected locatePreviousButton = this.locatorForOptional(
     MatButtonHarness.with({ selector: '[data-testid="certificate-previous-button"]' }),
   );
-  private readonly getGracePeriodInput = this.locatorForOptional(
+  protected locateGracePeriodInput = this.locatorForOptional(
     MatInputHarness.with({ selector: '[data-testid="certificate-grace-period-input"]' }),
   );
-  private readonly getSubmitErrorEl = this.locatorForOptional('[data-testid="certificate-submit-error"]');
+  protected locateSubmitErrorEl = this.locatorForOptional('[data-testid="certificate-submit-error"]');
 
-  async nameInput(): Promise<MatInputHarness> {
-    return this.getNameInput();
+  public async nameInput(): Promise<MatInputHarness> {
+    return this.locateNameInput();
   }
 
-  async pemInput(): Promise<MatInputHarness> {
-    return this.getPemInput();
+  public async pemInput(): Promise<MatInputHarness> {
+    return this.locatePemInput();
   }
 
-  async clickContinueUpload(): Promise<void> {
-    return (await this.getContinueUploadButton()).click();
+  public async clickContinueUpload(): Promise<void> {
+    return (await this.locateContinueUploadButton()).click();
   }
 
-  async clickContinueConfigure(): Promise<void> {
-    return (await this.getContinueConfigureButton()).click();
+  public async clickContinueConfigure(): Promise<void> {
+    return (await this.locateContinueConfigureButton()).click();
   }
 
-  async clickSubmit(): Promise<void> {
-    return (await this.getSubmitButton()).click();
+  public async clickSubmit(): Promise<void> {
+    return (await this.locateSubmitButton()).click();
   }
 
-  async clickCancel(): Promise<void> {
-    return (await this.getCancelButton()).click();
+  public async clickCancel(): Promise<void> {
+    return (await this.locateCancelButton()).click();
   }
 
-  async previousButton(): Promise<MatButtonHarness | null> {
-    return this.getPreviousButton();
+  public async previousButton(): Promise<MatButtonHarness | null> {
+    return this.locatePreviousButton();
   }
 
-  async gracePeriodInput(): Promise<MatInputHarness | null> {
-    return this.getGracePeriodInput();
+  public async gracePeriodInput(): Promise<MatInputHarness | null> {
+    return this.locateGracePeriodInput();
   }
 
-  async submitErrorText(): Promise<string | null> {
-    const el = await this.getSubmitErrorEl();
+  public async submitErrorText(): Promise<string | null> {
+    const el = await this.locateSubmitErrorEl();
     return el ? el.text() : null;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.html
@@ -1,0 +1,233 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title i18n="@@addCertificateDialogTitle">Add certificate</h2>
+
+<mat-dialog-content class="add-certificate-dialog__content">
+  <mat-stepper [linear]="false" animationDuration="0" #stepper>
+    <!-- Step 1: Upload -->
+    <mat-step>
+      <ng-template matStepLabel>
+        <span i18n="@@addCertificateStepUpload">Upload</span>
+      </ng-template>
+      <form [formGroup]="uploadForm" class="add-certificate-dialog__step">
+        <mat-form-field class="add-certificate-dialog__field">
+          <mat-label i18n="@@addCertificateNameLabel">Certificate Name</mat-label>
+          <input matInput formControlName="name" type="text" maxlength="256" data-testid="certificate-name-input" />
+          @if (uploadForm.controls.name.hasError('required') && uploadForm.controls.name.touched) {
+            <mat-error i18n="@@addCertificateNameRequired">Certificate name is required.</mat-error>
+          }
+        </mat-form-field>
+
+        <div class="add-certificate-dialog__certificate-input">
+          <div class="add-certificate-dialog__section">
+            <span class="next-gen-h4" i18n="@@addCertificatePasteLabel">Paste certificate</span>
+            <mat-form-field class="add-certificate-dialog__field">
+              <mat-label i18n="@@addCertificatePemLabel">Certificate (PEM)</mat-label>
+              <textarea
+                matInput
+                formControlName="certificate"
+                rows="6"
+                placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+                aria-label="PEM certificate"
+                i18n-aria-label="@@addCertificatePemAriaLabel"
+                data-testid="certificate-pem-input"
+              ></textarea>
+              @if (uploadForm.controls.certificate.hasError('required') && uploadForm.controls.certificate.touched) {
+                <mat-error i18n="@@addCertificatePemRequired">Certificate is required.</mat-error>
+              }
+            </mat-form-field>
+          </div>
+
+          <div class="add-certificate-dialog__section">
+            <span class="next-gen-h4" i18n="@@addCertificateUploadFileLabel">Upload file</span>
+            <label class="add-certificate-dialog__file-label">
+              <input
+                type="file"
+                accept=".pem,.crt,.cer"
+                class="add-certificate-dialog__file-input"
+                (change)="onFileSelected($event)"
+                aria-label="Upload certificate file"
+                i18n-aria-label="@@addCertificateFileInputAriaLabel"
+                data-testid="certificate-file-input"
+              />
+              <mat-icon aria-hidden="true">upload_file</mat-icon>
+              <span i18n="@@addCertificateChooseFile">Choose file (.pem, .crt, .cer)</span>
+            </label>
+          </div>
+        </div>
+      </form>
+    </mat-step>
+
+    <!-- Step 2: Configure -->
+    <mat-step>
+      <ng-template matStepLabel>
+        <span i18n="@@addCertificateStepConfigure">Configure</span>
+      </ng-template>
+      <form [formGroup]="configureForm" class="add-certificate-dialog__step">
+        <mat-form-field class="add-certificate-dialog__field">
+          <mat-label i18n="@@addCertificateEndsAtLabel">Active until (optional)</mat-label>
+          <input matInput [matDatepicker]="endsAtPicker" [min]="minDate" formControlName="endsAt" data-testid="certificate-ends-at-input" />
+          <mat-datepicker-toggle
+            matIconSuffix
+            [for]="endsAtPicker"
+            aria-label="Open calendar"
+            i18n-aria-label="@@addCertificateEndsAtCalendarAriaLabel"
+          />
+          <mat-datepicker #endsAtPicker />
+          <mat-hint i18n="@@addCertificateEndsAtHint">When this certificate should stop being active</mat-hint>
+        </mat-form-field>
+
+        @if (data.hasActiveCertificates) {
+          <div class="add-certificate-dialog__grace-period-info">
+            <mat-icon aria-hidden="true">info_outline</mat-icon>
+            <span class="next-gen-small" i18n="@@addCertificateGracePeriodInfo">
+              Both certificates will remain active during the grace period to avoid downtime.
+            </span>
+          </div>
+
+          <mat-form-field class="add-certificate-dialog__field">
+            <mat-label i18n="@@addCertificateGracePeriodLabel">Grace period end for current certificate</mat-label>
+            <input
+              matInput
+              [matDatepicker]="gracePicker"
+              [min]="minDate"
+              [max]="maxGracePeriodDate"
+              formControlName="gracePeriodEnd"
+              data-testid="certificate-grace-period-input"
+            />
+            <mat-datepicker-toggle
+              matIconSuffix
+              [for]="gracePicker"
+              aria-label="Open calendar"
+              i18n-aria-label="@@addCertificateGracePeriodCalendarAriaLabel"
+            />
+            <mat-datepicker #gracePicker />
+            <mat-hint i18n="@@addCertificateGracePeriodHint">When the currently active certificate should be revoked</mat-hint>
+            @if (configureForm.controls.gracePeriodEnd?.hasError('required') && configureForm.controls.gracePeriodEnd?.touched) {
+              <mat-error i18n="@@addCertificateGracePeriodRequired"
+                >Grace period end date is required when rotating certificates.</mat-error
+              >
+            }
+          </mat-form-field>
+        }
+      </form>
+    </mat-step>
+
+    <!-- Step 3: Confirm -->
+    <mat-step>
+      <ng-template matStepLabel>
+        <span i18n="@@addCertificateStepConfirm">Confirm</span>
+      </ng-template>
+      <div class="add-certificate-dialog__step">
+        <div class="add-certificate-dialog__summary" data-testid="certificate-summary">
+          <span class="next-gen-h5" i18n="@@addCertificateSummaryTitle">Certificate Summary</span>
+          <div class="add-certificate-dialog__summary-row">
+            <span class="next-gen-small add-certificate-dialog__summary-label" i18n="@@addCertificateSummaryNameLabel">Name:</span>
+            <span class="next-gen-small add-certificate-dialog__summary-value" data-testid="certificate-summary-name">{{
+              uploadForm.controls.name.value
+            }}</span>
+          </div>
+          @if (configureForm.controls.endsAt.value) {
+            <div class="add-certificate-dialog__summary-row">
+              <span class="next-gen-small add-certificate-dialog__summary-label" i18n="@@addCertificateSummaryEndsAtLabel"
+                >Active until:</span
+              >
+              <span class="next-gen-small add-certificate-dialog__summary-value" data-testid="certificate-summary-ends-at">{{
+                configureForm.controls.endsAt.value | date
+              }}</span>
+            </div>
+          }
+          @if (configureForm.controls.gracePeriodEnd?.value) {
+            <div class="add-certificate-dialog__summary-row">
+              <span class="next-gen-small add-certificate-dialog__summary-label" i18n="@@addCertificateSummaryGracePeriodLabel"
+                >Grace period ends:</span
+              >
+              <span class="next-gen-small add-certificate-dialog__summary-value" data-testid="certificate-summary-grace-period">{{
+                configureForm.controls.gracePeriodEnd.value | date
+              }}</span>
+            </div>
+          }
+        </div>
+
+        @if (submitError(); as submitError) {
+          <p class="add-certificate-dialog__error next-gen-small" data-testid="certificate-submit-error" role="alert">
+            {{ submitError }}
+          </p>
+        }
+      </div>
+    </mat-step>
+  </mat-stepper>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  @if (stepper.selectedIndex > 0) {
+    <button
+      mat-stroked-button
+      type="button"
+      (click)="stepper.previous()"
+      data-testid="certificate-previous-button"
+      i18n="@@addCertificatePreviousButton"
+    >
+      Previous
+    </button>
+  }
+  <button
+    mat-stroked-button
+    [mat-dialog-close]="undefined"
+    type="button"
+    data-testid="certificate-cancel-button"
+    i18n="@@addCertificateCancelButton"
+  >
+    Cancel
+  </button>
+  @if (stepper.selectedIndex === 0) {
+    <button
+      mat-flat-button
+      color="primary"
+      type="button"
+      (click)="continueStep(uploadForm)"
+      data-testid="certificate-continue-upload-button"
+      i18n="@@addCertificateContinueButton"
+    >
+      Continue
+    </button>
+  } @else if (stepper.selectedIndex === 1) {
+    <button
+      mat-flat-button
+      color="primary"
+      type="button"
+      (click)="continueStep(configureForm)"
+      data-testid="certificate-continue-configure-button"
+      i18n="@@addCertificateContinueButton"
+    >
+      Continue
+    </button>
+  } @else {
+    <button
+      mat-flat-button
+      color="primary"
+      type="button"
+      [disabled]="isSubmitting()"
+      (click)="onSubmit()"
+      data-testid="certificate-submit-button"
+      i18n="@@addCertificateSubmitButton"
+    >
+      Add Certificate
+    </button>
+  }
+</mat-dialog-actions>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.html
@@ -25,7 +25,7 @@
         <span i18n="@@addCertificateStepUpload">Upload</span>
       </ng-template>
       <form [formGroup]="uploadForm" class="add-certificate-dialog__step">
-        <mat-form-field class="add-certificate-dialog__field">
+        <mat-form-field appearance="outline" class="add-certificate-dialog__field">
           <mat-label i18n="@@addCertificateNameLabel">Certificate Name</mat-label>
           <input matInput formControlName="name" type="text" maxlength="256" data-testid="certificate-name-input" />
           @if (uploadForm.controls.name.hasError('required') && uploadForm.controls.name.touched) {
@@ -36,7 +36,7 @@
         <div class="add-certificate-dialog__certificate-input">
           <div class="add-certificate-dialog__section">
             <span class="next-gen-h4" i18n="@@addCertificatePasteLabel">Paste certificate</span>
-            <mat-form-field class="add-certificate-dialog__field">
+            <mat-form-field appearance="outline" class="add-certificate-dialog__field">
               <mat-label i18n="@@addCertificatePemLabel">Certificate (PEM)</mat-label>
               <textarea
                 matInput
@@ -70,6 +70,12 @@
             </label>
           </div>
         </div>
+
+        @if (validateError(); as validateError) {
+          <p class="add-certificate-dialog__error next-gen-small" data-testid="certificate-validate-error" role="alert">
+            {{ validateError }}
+          </p>
+        }
       </form>
     </mat-step>
 
@@ -79,7 +85,7 @@
         <span i18n="@@addCertificateStepConfigure">Configure</span>
       </ng-template>
       <form [formGroup]="configureForm" class="add-certificate-dialog__step">
-        <mat-form-field class="add-certificate-dialog__field">
+        <mat-form-field appearance="outline" class="add-certificate-dialog__field">
           <mat-label i18n="@@addCertificateEndsAtLabel">Active until (optional)</mat-label>
           <input matInput [matDatepicker]="endsAtPicker" [min]="minDate" formControlName="endsAt" data-testid="certificate-ends-at-input" />
           <mat-datepicker-toggle
@@ -100,7 +106,7 @@
             </span>
           </div>
 
-          <mat-form-field class="add-certificate-dialog__field">
+          <mat-form-field appearance="outline" class="add-certificate-dialog__field">
             <mat-label i18n="@@addCertificateGracePeriodLabel">Grace period end for current certificate</mat-label>
             <input
               matInput
@@ -200,7 +206,8 @@
       mat-flat-button
       color="primary"
       type="button"
-      (click)="continueStep(uploadForm)"
+      [disabled]="isValidating()"
+      (click)="validateAndContinue()"
       data-testid="certificate-continue-upload-button"
       i18n="@@addCertificateContinueButton"
     >

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.scss
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../../../scss/theme' as app-theme;
+
+.add-certificate-dialog {
+  &__content {
+    min-width: 480px;
+  }
+
+  &__step {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding-top: 16px;
+  }
+
+  &__field {
+    width: 100%;
+  }
+
+  &__certificate-input {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__section-title {
+    color: app-theme.$paragraph-color;
+  }
+
+  &__file-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    color: app-theme.$primary-main-color;
+    padding: 8px 12px;
+    border: app-theme.$border-width solid app-theme.$border-color;
+    border-radius: app-theme.$container-shape;
+    width: fit-content;
+
+    &:hover {
+      background-color: color-mix(in srgb, app-theme.$primary-main-color 8%, transparent);
+    }
+  }
+
+  &__file-input {
+    display: none;
+  }
+
+  &__grace-period-info {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 8px 12px;
+    background-color: color-mix(in srgb, app-theme.$primary-main-color 8%, app-theme.$background-color);
+    border-radius: app-theme.$container-shape;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__summary {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 16px;
+    background-color: app-theme.$background-color;
+    border-radius: app-theme.$container-shape;
+    border: app-theme.$border-width solid app-theme.$border-color;
+  }
+
+  &__summary-row {
+    display: flex;
+    gap: 8px;
+  }
+
+  &__summary-label {
+    color: app-theme.$paragraph-color;
+    min-width: 100px;
+  }
+
+  &__summary-value {
+    color: app-theme.$default-text-color;
+  }
+
+  &__error {
+    color: app-theme.$error-main-color;
+    margin: 0;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
@@ -122,7 +122,13 @@ describe('AddCertificateDialogComponent', () => {
     await harness.clickContinueUpload();
     fixture.detectChanges();
 
-    httpTestingController.expectOne(VALIDATE_URL).flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
+    httpTestingController.expectOne(VALIDATE_URL).flush(
+      { error: 'Invalid PEM' },
+      {
+        status: 400,
+        statusText: 'Bad Request',
+      },
+    );
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
@@ -169,7 +175,8 @@ describe('AddCertificateDialogComponent', () => {
 
   it('should also call update on old cert when gracePeriodEnd is set', async () => {
     const activeCertificateId = 'old-cert-id';
-    await init(makeData({ hasActiveCertificates: true, activeCertificateId }));
+    const activeCertificateName = 'Old Cert Name';
+    await init(makeData({ hasActiveCertificates: true, activeCertificateId, activeCertificateName }));
     await fillAndValidate();
 
     const graceDate = new Date('2026-12-31');
@@ -188,6 +195,36 @@ describe('AddCertificateDialogComponent', () => {
 
     const updateReq = httpTestingController.expectOne(`${CERTIFICATES_URL}/${activeCertificateId}`);
     expect(updateReq.request.method).toBe('PUT');
+    expect(updateReq.request.body).toMatchObject({ name: activeCertificateName, endsAt: graceDate.toISOString() });
+    updateReq.flush({ id: activeCertificateId, name: activeCertificateName, status: 'ACTIVE_WITH_END' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should not send name in update when activeCertificateName is missing', async () => {
+    const activeCertificateId = 'old-cert-id';
+    await init(makeData({ hasActiveCertificates: true, activeCertificateId, activeCertificateName: undefined }));
+    await fillAndValidate();
+
+    const graceDate = new Date('2026-12-31');
+    fixture.componentInstance.configureForm.controls.gracePeriodEnd.setValue(graceDate);
+    await harness.clickContinueConfigure();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    const createReq = httpTestingController.expectOne(CERTIFICATES_URL);
+    createReq.flush({ id: 'new-cert', name: 'My Cert', status: 'ACTIVE' });
+    fixture.detectChanges();
+
+    const updateReq = httpTestingController.expectOne(`${CERTIFICATES_URL}/${activeCertificateId}`);
+    expect(updateReq.request.method).toBe('PUT');
+    expect(updateReq.request.body).not.toHaveProperty('name');
     expect(updateReq.request.body).toMatchObject({ endsAt: graceDate.toISOString() });
     updateReq.flush({ id: activeCertificateId, name: 'Old Cert', status: 'ACTIVE_WITH_END' });
     fixture.detectChanges();
@@ -208,7 +245,13 @@ describe('AddCertificateDialogComponent', () => {
     await harness.clickSubmit();
     fixture.detectChanges();
 
-    httpTestingController.expectOne(CERTIFICATES_URL).flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
+    httpTestingController.expectOne(CERTIFICATES_URL).flush(
+      { error: 'Invalid PEM' },
+      {
+        status: 400,
+        statusText: 'Bad Request',
+      },
+    );
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { AddCertificateDialogComponent, AddCertificateDialogData } from './add-certificate-dialog.component';
+import { AddCertificateDialogHarness } from './add-certificate-dialog.component.harness';
+import { ConfigService } from '../../../../../../services/config.service';
+import { AppTestingModule, TESTING_BASE_URL } from '../../../../../../testing/app-testing.module';
+
+const APPLICATION_ID = 'app-1';
+
+function makeData(overrides: Partial<AddCertificateDialogData> = {}): AddCertificateDialogData {
+  return {
+    applicationId: APPLICATION_ID,
+    hasActiveCertificates: false,
+    ...overrides,
+  };
+}
+
+describe('AddCertificateDialogComponent', () => {
+  let fixture: ComponentFixture<AddCertificateDialogComponent>;
+  let harness: AddCertificateDialogHarness;
+  let httpTestingController: HttpTestingController;
+  let dialogRef: { close: jest.Mock };
+
+  async function init(data: AddCertificateDialogData = makeData()): Promise<void> {
+    dialogRef = { close: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [AddCertificateDialogComponent, AppTestingModule],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddCertificateDialogComponent);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AddCertificateDialogHarness);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  afterEach(() => httpTestingController.verify());
+
+  it('should show upload step initially', async () => {
+    await init();
+    expect(await harness.nameInput()).toBeTruthy();
+    expect(await harness.pemInput()).toBeTruthy();
+  });
+
+  it('should show validation errors when continuing with empty upload form', async () => {
+    await init();
+    await harness.clickContinueUpload();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.uploadForm.touched).toBe(true);
+    expect(fixture.componentInstance.uploadForm.invalid).toBe(true);
+  });
+
+  it('should advance to configure step when upload form is valid', async () => {
+    await init();
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    fixture.detectChanges();
+
+    await harness.clickContinueUpload();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.stepper().selectedIndex).toBe(1);
+  });
+
+  it('should not show grace period field when hasActiveCertificates is false', async () => {
+    await init(makeData({ hasActiveCertificates: false }));
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    await harness.clickContinueUpload();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.gracePeriodInput()).toBeNull();
+  });
+
+  it('should show grace period field when hasActiveCertificates is true', async () => {
+    await init(makeData({ hasActiveCertificates: true, activeCertificateId: 'old-cert' }));
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    await harness.clickContinueUpload();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.gracePeriodInput()).toBeTruthy();
+  });
+
+  it('should call create and close dialog on successful submit', async () => {
+    await init();
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    await harness.clickContinueUpload();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    await harness.clickContinueConfigure();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toMatchObject({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    req.flush({ id: 'new-cert', name: 'My Cert', status: 'ACTIVE' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should also call update on old cert when gracePeriodEnd is set', async () => {
+    const activeCertificateId = 'old-cert-id';
+    await init(makeData({ hasActiveCertificates: true, activeCertificateId }));
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    await harness.clickContinueUpload();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const graceDate = new Date('2026-12-31');
+    fixture.componentInstance.configureForm.controls.gracePeriodEnd.setValue(graceDate);
+    await harness.clickContinueConfigure();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    const createReq = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`);
+    createReq.flush({ id: 'new-cert', name: 'My Cert', status: 'ACTIVE' });
+    fixture.detectChanges();
+
+    const updateReq = httpTestingController.expectOne(
+      `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates/${activeCertificateId}`,
+    );
+    expect(updateReq.request.method).toBe('PUT');
+    expect(updateReq.request.body).toMatchObject({ endsAt: graceDate.toISOString() });
+    updateReq.flush({ id: activeCertificateId, name: 'Old Cert', status: 'ACTIVE_WITH_END' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should show validation error on 400 response', async () => {
+    await init();
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: 'INVALID PEM' });
+    await harness.clickContinueUpload();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    await harness.clickContinueConfigure();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    httpTestingController
+      .expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`)
+      .flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.submitErrorText()).toBeTruthy();
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.spec.ts
@@ -26,6 +26,8 @@ import { ConfigService } from '../../../../../../services/config.service';
 import { AppTestingModule, TESTING_BASE_URL } from '../../../../../../testing/app-testing.module';
 
 const APPLICATION_ID = 'app-1';
+const VALIDATE_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates/_validate`;
+const CERTIFICATES_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`;
 
 function makeData(overrides: Partial<AddCertificateDialogData> = {}): AddCertificateDialogData {
   return {
@@ -64,6 +66,23 @@ describe('AddCertificateDialogComponent', () => {
     fixture.detectChanges();
   }
 
+  function flushValidate(overrides: object = {}): void {
+    const req = httpTestingController.expectOne(VALIDATE_URL);
+    expect(req.request.method).toBe('POST');
+    req.flush({ certificateExpiration: '2027-06-01T00:00:00.000Z', subject: 'CN=test', issuer: 'CN=ca', ...overrides });
+  }
+
+  async function fillAndValidate(): Promise<void> {
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    fixture.detectChanges();
+    await harness.clickContinueUpload();
+    fixture.detectChanges();
+    flushValidate();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
   afterEach(() => httpTestingController.verify());
 
   it('should show upload step initially', async () => {
@@ -81,52 +100,54 @@ describe('AddCertificateDialogComponent', () => {
     expect(fixture.componentInstance.uploadForm.invalid).toBe(true);
   });
 
-  it('should advance to configure step when upload form is valid', async () => {
+  it('should advance to configure step after successful certificate validation', async () => {
     await init();
-
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    fixture.detectChanges();
-
-    await harness.clickContinueUpload();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await fillAndValidate();
 
     expect(fixture.componentInstance.stepper().selectedIndex).toBe(1);
   });
 
-  it('should not show grace period field when hasActiveCertificates is false', async () => {
-    await init(makeData({ hasActiveCertificates: false }));
+  it('should pre-fill endsAt from certificate expiration returned by validation', async () => {
+    await init();
+    await fillAndValidate();
 
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
+    expect(fixture.componentInstance.configureForm.controls.endsAt.value).toEqual(new Date('2027-06-01T00:00:00.000Z'));
+  });
+
+  it('should show validate error when certificate validation returns 400', async () => {
+    await init();
+
+    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: 'INVALID PEM' });
+    fixture.detectChanges();
     await harness.clickContinueUpload();
+    fixture.detectChanges();
+
+    httpTestingController.expectOne(VALIDATE_URL).flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
+
+    expect(await harness.validateErrorText()).toBeTruthy();
+    expect(fixture.componentInstance.stepper().selectedIndex).toBe(0);
+  });
+
+  it('should not show grace period field when hasActiveCertificates is false', async () => {
+    await init(makeData({ hasActiveCertificates: false }));
+    await fillAndValidate();
 
     expect(await harness.gracePeriodInput()).toBeNull();
   });
 
   it('should show grace period field when hasActiveCertificates is true', async () => {
     await init(makeData({ hasActiveCertificates: true, activeCertificateId: 'old-cert' }));
-
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    await harness.clickContinueUpload();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await fillAndValidate();
 
     expect(await harness.gracePeriodInput()).toBeTruthy();
   });
 
   it('should call create and close dialog on successful submit', async () => {
     await init();
-
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    await harness.clickContinueUpload();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await fillAndValidate();
 
     await harness.clickContinueConfigure();
     fixture.detectChanges();
@@ -136,7 +157,7 @@ describe('AddCertificateDialogComponent', () => {
     await harness.clickSubmit();
     fixture.detectChanges();
 
-    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`);
+    const req = httpTestingController.expectOne(CERTIFICATES_URL);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toMatchObject({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
     req.flush({ id: 'new-cert', name: 'My Cert', status: 'ACTIVE' });
@@ -149,12 +170,7 @@ describe('AddCertificateDialogComponent', () => {
   it('should also call update on old cert when gracePeriodEnd is set', async () => {
     const activeCertificateId = 'old-cert-id';
     await init(makeData({ hasActiveCertificates: true, activeCertificateId }));
-
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: '-----BEGIN CERTIFICATE-----' });
-    await harness.clickContinueUpload();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await fillAndValidate();
 
     const graceDate = new Date('2026-12-31');
     fixture.componentInstance.configureForm.controls.gracePeriodEnd.setValue(graceDate);
@@ -166,13 +182,11 @@ describe('AddCertificateDialogComponent', () => {
     await harness.clickSubmit();
     fixture.detectChanges();
 
-    const createReq = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`);
+    const createReq = httpTestingController.expectOne(CERTIFICATES_URL);
     createReq.flush({ id: 'new-cert', name: 'My Cert', status: 'ACTIVE' });
     fixture.detectChanges();
 
-    const updateReq = httpTestingController.expectOne(
-      `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates/${activeCertificateId}`,
-    );
+    const updateReq = httpTestingController.expectOne(`${CERTIFICATES_URL}/${activeCertificateId}`);
     expect(updateReq.request.method).toBe('PUT');
     expect(updateReq.request.body).toMatchObject({ endsAt: graceDate.toISOString() });
     updateReq.flush({ id: activeCertificateId, name: 'Old Cert', status: 'ACTIVE_WITH_END' });
@@ -182,14 +196,9 @@ describe('AddCertificateDialogComponent', () => {
     expect(dialogRef.close).toHaveBeenCalledWith(true);
   });
 
-  it('should show validation error on 400 response', async () => {
+  it('should show submit error on 400 response from create', async () => {
     await init();
-
-    fixture.componentInstance.uploadForm.setValue({ name: 'My Cert', certificate: 'INVALID PEM' });
-    await harness.clickContinueUpload();
-    fixture.detectChanges();
-    await fixture.whenStable();
-    fixture.detectChanges();
+    await fillAndValidate();
 
     await harness.clickContinueConfigure();
     fixture.detectChanges();
@@ -199,14 +208,36 @@ describe('AddCertificateDialogComponent', () => {
     await harness.clickSubmit();
     fixture.detectChanges();
 
-    httpTestingController
-      .expectOne(`${TESTING_BASE_URL}/applications/${APPLICATION_ID}/certificates`)
-      .flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
+    httpTestingController.expectOne(CERTIFICATES_URL).flush({ error: 'Invalid PEM' }, { status: 400, statusText: 'Bad Request' });
     fixture.detectChanges();
     await fixture.whenStable();
     fixture.detectChanges();
 
     expect(await harness.submitErrorText()).toBeTruthy();
     expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('should fill certificate name from uploaded file name', async () => {
+    await init();
+
+    const file = new File(['-----BEGIN CERTIFICATE-----'], 'my-server.crt', { type: 'application/x-x509-ca-cert' });
+    const mockEvent = { target: { files: [file], value: '' } } as unknown as Event;
+    await fixture.componentInstance.onFileSelected(mockEvent);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.uploadForm.controls.name.value).toBe('my-server');
+  });
+
+  it('should not overwrite an existing certificate name when uploading a file', async () => {
+    await init();
+
+    fixture.componentInstance.uploadForm.controls.name.setValue('already-set');
+
+    const file = new File(['-----BEGIN CERTIFICATE-----'], 'my-server.crt', { type: 'application/x-x509-ca-cert' });
+    const mockEvent = { target: { files: [file], value: '' } } as unknown as Event;
+    await fixture.componentInstance.onFileSelected(mockEvent);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.uploadForm.controls.name.value).toBe('already-set');
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
@@ -35,6 +35,7 @@ export interface AddCertificateDialogData {
   applicationId: string;
   hasActiveCertificates: boolean;
   activeCertificateId?: string;
+  activeCertificateName?: string;
   activeCertificateExpiration?: string;
 }
 
@@ -157,6 +158,7 @@ export class AddCertificateDialogComponent {
         switchMap(() => {
           if (gracePeriodEnd && this.data.activeCertificateId) {
             return this.certService.update(this.data.applicationId, this.data.activeCertificateId!, {
+              ...(this.data.activeCertificateName ? { name: this.data.activeCertificateName } : {}),
               endsAt: gracePeriodEnd.toISOString(),
             });
           }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, DestroyRef, inject, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DATE_FORMATS, MAT_NATIVE_DATE_FORMATS, provideNativeDateAdapter } from '@angular/material/core';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatStepper, MatStepperModule } from '@angular/material/stepper';
+import { of, switchMap } from 'rxjs';
+
+import { ApplicationCertificateService } from '../../../../../../services/application-certificate.service';
+
+export interface AddCertificateDialogData {
+  applicationId: string;
+  hasActiveCertificates: boolean;
+  activeCertificateId?: string;
+  activeCertificateExpiration?: string;
+}
+
+@Component({
+  selector: 'app-add-certificate-dialog',
+  imports: [
+    DatePipe,
+    MatDialogModule,
+    MatButtonModule,
+    MatStepperModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatDatepickerModule,
+    ReactiveFormsModule,
+  ],
+  providers: [provideNativeDateAdapter(), { provide: MAT_DATE_FORMATS, useValue: MAT_NATIVE_DATE_FORMATS }],
+  templateUrl: './add-certificate-dialog.component.html',
+  styleUrl: './add-certificate-dialog.component.scss',
+})
+export class AddCertificateDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<AddCertificateDialogComponent>);
+  readonly data: AddCertificateDialogData = inject(MAT_DIALOG_DATA);
+  private readonly certService = inject(ApplicationCertificateService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly stepper = viewChild.required<MatStepper>('stepper');
+
+  readonly minDate = new Date();
+  readonly maxGracePeriodDate: Date | undefined = this.data.activeCertificateExpiration
+    ? new Date(this.data.activeCertificateExpiration)
+    : undefined;
+
+  isSubmitting = signal(false);
+  submitError = signal<string | null>(null);
+
+  readonly uploadForm = new FormGroup({
+    name: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    certificate: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+  });
+
+  readonly configureForm = new FormGroup({
+    endsAt: new FormControl<Date | null>(null),
+    gracePeriodEnd: new FormControl<Date | null>(null, this.data.hasActiveCertificates ? [Validators.required] : []),
+  });
+
+  continueStep(group: FormGroup): void {
+    group.markAllAsTouched();
+    if (group.invalid) return;
+    this.stepper().next();
+  }
+
+  async onFileSelected(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    const content = await this.readFileAsText(file);
+    this.uploadForm.controls.certificate.setValue(content);
+    input.value = '';
+  }
+
+  onSubmit(): void {
+    if (this.uploadForm.invalid || this.configureForm.invalid) return;
+
+    const { name, certificate } = this.uploadForm.value;
+    const { endsAt, gracePeriodEnd } = this.configureForm.value;
+
+    this.isSubmitting.set(true);
+    this.submitError.set(null);
+
+    this.certService
+      .create(this.data.applicationId, {
+        name: name!,
+        certificate: certificate!,
+        ...(endsAt ? { endsAt: endsAt.toISOString() } : {}),
+      })
+      .pipe(
+        switchMap(() => {
+          if (gracePeriodEnd && this.data.activeCertificateId) {
+            return this.certService.update(this.data.applicationId, this.data.activeCertificateId!, {
+              endsAt: gracePeriodEnd.toISOString(),
+            });
+          }
+          return of(null);
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: () => {
+          this.isSubmitting.set(false);
+          this.dialogRef.close(true);
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isSubmitting.set(false);
+          if (err.status === 400) {
+            this.submitError.set($localize`:@@addCertificateValidationError:Validation failed for Certificate uploaded. Please try again`);
+          } else {
+            this.submitError.set($localize`:@@addCertificateSubmitError:An error occurred. Please try again`);
+          }
+        },
+      });
+  }
+
+  private readFileAsText(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsText(file);
+    });
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/add-certificate-dialog/add-certificate-dialog.component.ts
@@ -26,9 +26,10 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatStepper, MatStepperModule } from '@angular/material/stepper';
-import { of, switchMap } from 'rxjs';
+import { of, switchMap, tap } from 'rxjs';
 
 import { ApplicationCertificateService } from '../../../../../../services/application-certificate.service';
+import { fileNameWithoutExtension } from '../../../../../../utils/common.utils';
 
 export interface AddCertificateDialogData {
   applicationId: string;
@@ -69,6 +70,8 @@ export class AddCertificateDialogComponent {
 
   isSubmitting = signal(false);
   submitError = signal<string | null>(null);
+  isValidating = signal(false);
+  validateError = signal<string | null>(null);
 
   readonly uploadForm = new FormGroup({
     name: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
@@ -86,12 +89,52 @@ export class AddCertificateDialogComponent {
     this.stepper().next();
   }
 
+  validateAndContinue(): void {
+    this.uploadForm.markAllAsTouched();
+    if (this.uploadForm.invalid) return;
+
+    this.isValidating.set(true);
+    this.validateError.set(null);
+
+    this.certService
+      .validate(this.data.applicationId, this.uploadForm.controls.certificate.value)
+      .pipe(
+        tap(response => {
+          if (response.certificateExpiration) {
+            this.configureForm.controls.endsAt.setValue(new Date(response.certificateExpiration));
+          }
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: () => {
+          this.isValidating.set(false);
+          this.stepper().next();
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isValidating.set(false);
+          if (err.status === 400) {
+            this.validateError.set(
+              $localize`:@@addCertificateValidationError:Validation failed for Certificate uploaded. Please try again`,
+            );
+          } else {
+            this.validateError.set(
+              $localize`:@@addCertificateValidateError:An error occurred while validating the certificate. Please try again`,
+            );
+          }
+        },
+      });
+  }
+
   async onFileSelected(event: Event): Promise<void> {
     const input = event.target as HTMLInputElement;
     const file = input.files?.[0];
     if (!file) return;
     const content = await this.readFileAsText(file);
     this.uploadForm.controls.certificate.setValue(content);
+    if (!this.uploadForm.controls.name.value) {
+      this.uploadForm.controls.name.setValue(fileNameWithoutExtension(file.name));
+    }
     input.value = '';
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.html
@@ -23,6 +23,20 @@
         Manage mTLS certificates for this application
       </p>
     </div>
+    @if (canManage()) {
+      <button
+        mat-flat-button
+        color="primary"
+        type="button"
+        (click)="openUploadDialog()"
+        data-testid="upload-certificate-button"
+        aria-label="Upload certificate"
+        i18n-aria-label="@@uploadCertificateAriaLabel"
+      >
+        <mat-icon aria-hidden="true">upload</mat-icon>
+        <span i18n="@@uploadCertificateButton">Upload certificate</span>
+      </button>
+    }
   </div>
 
   @if (loadError()) {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.html
@@ -39,9 +39,11 @@
     }
   </div>
 
-  @if (loadError()) {
-    <p class="next-gen-small certificates__error" i18n="@@certificatesLoadError">Failed to load certificates. Please try again.</p>
-  } @else if (certificates().length === 0) {
+  @if (error(); as errorText) {
+    <p class="certificates__error next-gen-small" data-testid="certificate-error" role="alert">{{ errorText }}</p>
+  }
+
+  @if (certificates().length === 0 && !error()) {
     <div class="certificates__empty">
       <span class="material-icons icon-with-background" aria-hidden="true">workspace_premium</span>
       <span class="next-gen-h5" i18n="@@noCertificatesTitle">No mTLS certificates added</span>
@@ -49,7 +51,7 @@
         Add your first certificate to enable mTLS authentication for this application
       </span>
     </div>
-  } @else {
+  } @else if (certificates().length > 0) {
     <mat-tab-group (selectedTabChange)="onTabChange()">
       <mat-tab>
         <ng-template mat-tab-label>
@@ -62,7 +64,10 @@
           [totalElements]="totalElements()"
           [currentPage]="currentPage()"
           [pageSize]="pageSize"
+          [navigable]="false"
+          [actions]="canManage() ? activeActions : []"
           (pageChange)="onPageChange($event)"
+          (actionClick)="onActiveAction($event)"
         />
       </mat-tab>
       <mat-tab>
@@ -76,7 +81,10 @@
           [totalElements]="totalElements()"
           [currentPage]="currentPage()"
           [pageSize]="pageSize"
+          [navigable]="false"
+          [actions]="canManage() ? historyActions : []"
           (pageChange)="onPageChange($event)"
+          (actionClick)="onHistoryAction($event)"
         />
       </mat-tab>
     </mat-tab-group>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.html
@@ -1,0 +1,70 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="certificates">
+  <div class="certificates__header">
+    <div class="certificates__header__info">
+      <span class="next-gen-h5" i18n="@@certificatesSectionTitle">Certificates</span>
+      <p class="next-gen-small certificates__header__subtitle" i18n="@@certificatesSectionDescription">
+        Manage mTLS certificates for this application
+      </p>
+    </div>
+  </div>
+
+  @if (loadError()) {
+    <p class="next-gen-small certificates__error" i18n="@@certificatesLoadError">Failed to load certificates. Please try again.</p>
+  } @else if (certificates().length === 0) {
+    <div class="certificates__empty">
+      <span class="material-icons icon-with-background" aria-hidden="true">workspace_premium</span>
+      <span class="next-gen-h5" i18n="@@noCertificatesTitle">No mTLS certificates added</span>
+      <span class="next-gen-small" i18n="@@noCertificatesDescription">
+        Add your first certificate to enable mTLS authentication for this application
+      </span>
+    </div>
+  } @else {
+    <mat-tab-group (selectedTabChange)="onTabChange()">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span i18n="@@activeCertificatesTab">Active certificates</span>
+          <span class="certificates__tab-count next-gen-caption">{{ activeCertificates().length }}</span>
+        </ng-template>
+        <app-paginated-table
+          [columns]="tableColumns"
+          [rows]="activeRows()"
+          [totalElements]="totalElements()"
+          [currentPage]="currentPage()"
+          [pageSize]="pageSize"
+          (pageChange)="onPageChange($event)"
+        />
+      </mat-tab>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <span i18n="@@historyCertificatesTab">Certificate history</span>
+          <span class="certificates__tab-count next-gen-caption">{{ historyCertificates().length }}</span>
+        </ng-template>
+        <app-paginated-table
+          [columns]="tableColumns"
+          [rows]="historyRows()"
+          [totalElements]="totalElements()"
+          [currentPage]="currentPage()"
+          [pageSize]="pageSize"
+          (pageChange)="onPageChange($event)"
+        />
+      </mat-tab>
+    </mat-tab-group>
+  }
+</div>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.scss
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../../scss/theme';
+
+.certificates {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background-color: theme.$background-color;
+  border-radius: 8px;
+  outline: theme.$border-width solid theme.$border-color;
+  padding: 16px;
+
+  &__header {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding-bottom: 16px;
+    border-bottom: 1px solid theme.$border-color;
+
+    &__info {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    &__subtitle {
+      margin: 0;
+      color: theme.$paragraph-color;
+    }
+  }
+
+  &__error {
+    color: theme.$error-main-color;
+  }
+
+  &__empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 32px 16px;
+    text-align: center;
+  }
+
+  &__tab-count {
+    margin-left: 6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    border-radius: 10px;
+    background-color: theme.$chip-background;
+    color: theme.$chip-label-text-color;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.spec.ts
@@ -17,6 +17,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
@@ -152,5 +153,28 @@ describe('ApplicationTabSettingsCertificatesComponent', () => {
       .forEach(req => req.flush({ data: [], metadata: { paginateMetaData: { totalElements: 0 } } }));
 
     expect(fixture.componentInstance.currentPage()).toBe(2);
+  });
+
+  it('should show upload button when user has UPDATE permission', async () => {
+    const harness = await initWithCertificates([fakeCertificate()]);
+    expect(await harness.getUploadButton()).toBeTruthy();
+  });
+
+  it('should not show upload button when user lacks UPDATE permission', async () => {
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ DEFINITION: ['R'] }));
+    const harness = await initWithCertificates([fakeCertificate()]);
+    expect(await harness.getUploadButton()).toBeNull();
+  });
+
+  it('should open upload dialog when upload button is clicked', async () => {
+    const harness = await initWithCertificates([fakeCertificate()]);
+    const dialog = TestBed.inject(MatDialog);
+    const openSpy = jest
+      .spyOn(dialog, 'open')
+      .mockReturnValue({ afterClosed: () => ({ pipe: () => ({ subscribe: () => ({}) }) }) } as never);
+
+    await harness.clickUploadButton();
+
+    expect(openSpy).toHaveBeenCalled();
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.spec.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
@@ -23,6 +25,7 @@ import { provideRouter } from '@angular/router';
 
 import { ApplicationTabSettingsCertificatesComponent } from './application-tab-settings-certificates.component';
 import { ApplicationTabSettingsCertificatesHarness } from './application-tab-settings-certificates.harness';
+import { ConfirmDialogHarness } from '../../../../../components/confirm-dialog/confirm-dialog.harness';
 import { ClientCertificate } from '../../../../../entities/application/client-certificate';
 import { fakeUserApplicationPermissions } from '../../../../../entities/permission/permission.fixtures';
 import { ConfigService } from '../../../../../services/config.service';
@@ -39,6 +42,7 @@ const fakeCertificate = (overrides: Partial<ClientCertificate> = {}): ClientCert
 describe('ApplicationTabSettingsCertificatesComponent', () => {
   let fixture: ComponentFixture<ApplicationTabSettingsCertificatesComponent>;
   let httpTestingController: HttpTestingController;
+  let rootLoader: HarnessLoader;
   const applicationId = 'app-1';
 
   beforeEach(async () => {
@@ -51,10 +55,17 @@ describe('ApplicationTabSettingsCertificatesComponent', () => {
         provideRouter([]),
         { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
       ],
-    }).compileComponents();
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true,
+        },
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(ApplicationTabSettingsCertificatesComponent);
     httpTestingController = TestBed.inject(HttpTestingController);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     fixture.componentRef.setInput('applicationId', applicationId);
     fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ DEFINITION: ['U'] }));
   });
@@ -177,4 +188,248 @@ describe('ApplicationTabSettingsCertificatesComponent', () => {
 
     expect(openSpy).toHaveBeenCalled();
   });
+
+  it('should keep certificate untouched when first delete confirmation is cancelled', async () => {
+    const certificate = fakeCertificate();
+    await initWithCertificates([certificate]);
+
+    await clickDeleteButton();
+
+    const confirmDialog = await getConfirmDialog();
+    expect(confirmDialog).not.toBeNull();
+    expect(await confirmDialog?.getTitle()).toBe('Delete certificate');
+    await confirmDialog?.cancel();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(await getConfirmDialog()).toBeNull();
+    httpTestingController.expectNone(req => req.method === 'DELETE');
+    expect(fixture.componentInstance.activeCertificates().map(cert => cert.id)).toEqual([certificate.id]);
+  });
+
+  it('should delete a non-last-active certificate after the initial confirmation', async () => {
+    const certificates = [
+      fakeCertificate({ id: 'cert-1', name: 'Certificate 1' }),
+      fakeCertificate({ id: 'cert-2', name: 'Certificate 2' }),
+    ];
+    await initWithCertificates(certificates, 2);
+
+    await clickDeleteButton();
+
+    const confirmDialog = await getConfirmDialog();
+    await confirmDialog?.confirm();
+
+    expect(await getConfirmDialog()).toBeNull();
+    httpTestingController.expectNone(`${TESTING_BASE_URL}/applications/${applicationId}/certificates?page=1&size=${certificates.length}`);
+
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates/cert-1`,
+        method: 'DELETE',
+      })
+      .flush(null);
+
+    flushCertificatesRequest([certificates[1]], 1);
+
+    expect(fixture.componentInstance.activeCertificates().map(cert => cert.id)).toEqual(['cert-2']);
+  });
+
+  it('should require a final warning confirmation before deleting the last active certificate', async () => {
+    const certificate = fakeCertificate();
+    await initWithCertificates([certificate]);
+
+    await clickDeleteButton();
+
+    const firstConfirmDialog = await getConfirmDialog();
+    expect(await firstConfirmDialog?.getTitle()).toBe('Delete certificate');
+    await firstConfirmDialog?.confirm();
+
+    httpTestingController.expectNone(req => req.method === 'DELETE');
+    flushCertificatesRequest([certificate], 1);
+
+    const warningDialog = await getConfirmDialog();
+    expect(warningDialog).not.toBeNull();
+    expect(await warningDialog?.getTitle()).toBe('Warning');
+    expect(await warningDialog?.getContent()).toContain(
+      'There is no active certificate in case you proceed with the deletion. Do you want to proceed?',
+    );
+    httpTestingController.expectNone(req => req.method === 'DELETE');
+
+    await warningDialog?.confirm();
+
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates/${certificate.id}`,
+        method: 'DELETE',
+      })
+      .flush(null);
+
+    flushCertificatesRequest([], 0);
+
+    expect(fixture.componentInstance.activeCertificates()).toEqual([]);
+  });
+
+  it('should keep the last active certificate untouched when the warning is cancelled', async () => {
+    const certificate = fakeCertificate();
+    await initWithCertificates([certificate]);
+
+    await clickDeleteButton();
+
+    const firstConfirmDialog = await getConfirmDialog();
+    await firstConfirmDialog?.confirm();
+
+    flushCertificatesRequest([certificate], 1);
+
+    const warningDialog = await getConfirmDialog();
+    expect(warningDialog).not.toBeNull();
+    await warningDialog?.cancel();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(await getConfirmDialog()).toBeNull();
+    httpTestingController.expectNone(req => req.method === 'DELETE');
+    expect(fixture.componentInstance.activeCertificates().map(cert => cert.id)).toEqual([certificate.id]);
+  });
+
+  it('should delete a certificate from history after confirmation', async () => {
+    const activeCertificate = fakeCertificate({ id: 'cert-active', status: 'ACTIVE' });
+    const historyCertificate = fakeCertificate({ id: 'cert-history', status: 'REVOKED', name: 'Revoked certificate' });
+    await initWithCertificates([activeCertificate, historyCertificate], 2);
+
+    await clickHistoryTab();
+    await clickHistoryDeleteButton();
+
+    const confirmDialog = await getConfirmDialog();
+    expect(confirmDialog).not.toBeNull();
+    expect(await confirmDialog?.getTitle()).toBe('Delete certificate');
+    await confirmDialog?.confirm();
+
+    expect(await getConfirmDialog()).toBeNull();
+    httpTestingController.expectNone(`${TESTING_BASE_URL}/applications/${applicationId}/certificates?page=1&size=2`);
+
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates/${historyCertificate.id}`,
+        method: 'DELETE',
+      })
+      .flush(null);
+
+    flushCertificatesRequest([activeCertificate], 1);
+
+    expect(fixture.componentInstance.historyCertificates()).toEqual([]);
+  });
+
+  it('should show a persistent inline error when certificate deletion fails', async () => {
+    const certificates = [fakeCertificate({ id: 'cert-1' }), fakeCertificate({ id: 'cert-2' })];
+    await initWithCertificates(certificates, 2);
+
+    await clickDeleteButton();
+
+    const confirmDialog = await getConfirmDialog();
+    await confirmDialog?.confirm();
+    httpTestingController.expectNone(`${TESTING_BASE_URL}/applications/${applicationId}/certificates?page=1&size=${certificates.length}`);
+
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates/${certificates[0].id}`,
+        method: 'DELETE',
+      })
+      .flush({ error: 'Delete failed' }, { status: 500, statusText: 'Internal Server Error' });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(getErrorMessage()?.textContent).toContain('An error occurred while deleting the certificate. Please try again');
+    expect(fixture.componentInstance.activeCertificates().map(cert => cert.id)).toEqual(['cert-1', 'cert-2']);
+  });
+
+  it('should clear delete error when retrying certificate deletion', async () => {
+    const certificates = [fakeCertificate({ id: 'cert-1' }), fakeCertificate({ id: 'cert-2' })];
+    await initWithCertificates(certificates, 2);
+
+    await failDeleteAttempt(certificates[0]);
+    expect(getErrorMessage()?.textContent).toContain('An error occurred while deleting the certificate. Please try again');
+
+    await clickDeleteButton();
+
+    expect(getErrorMessage()).toBeNull();
+
+    const confirmDialog = await getConfirmDialog();
+    await confirmDialog?.cancel();
+  });
+
+  it('should clear delete error after a successful certificates reload', async () => {
+    const certificates = [fakeCertificate({ id: 'cert-1' }), fakeCertificate({ id: 'cert-2' })];
+    await initWithCertificates(certificates, 2);
+
+    await failDeleteAttempt(certificates[0]);
+    expect(getErrorMessage()?.textContent).toContain('An error occurred while deleting the certificate. Please try again');
+
+    fixture.componentInstance.loadCertificates();
+    flushCertificatesRequest(certificates, 2);
+
+    expect(getErrorMessage()).toBeNull();
+  });
+
+  function flushCertificatesRequest(data: ClientCertificate[] = [], totalElements = data.length, page = 1, size = 10): void {
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates?page=${page}&size=${size}`,
+        method: 'GET',
+      })
+      .flush({
+        data,
+        metadata: { paginateMetaData: { totalElements } },
+      });
+    fixture.detectChanges();
+  }
+
+  async function clickDeleteButton(index = 0): Promise<void> {
+    const deleteButtons = fixture.nativeElement.querySelectorAll('[data-testid="paginated-table-action-delete-certificate-button"]');
+    (deleteButtons[index] as HTMLButtonElement | undefined)?.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  async function clickHistoryDeleteButton(index = 0): Promise<void> {
+    const deleteButtons = fixture.nativeElement.querySelectorAll(
+      '[data-testid="paginated-table-action-delete-history-certificate-button"]',
+    );
+    (deleteButtons[index] as HTMLButtonElement | undefined)?.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  async function clickHistoryTab(): Promise<void> {
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationTabSettingsCertificatesHarness);
+    await harness.clickTab('history');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    flushCertificatesRequest(fixture.componentInstance.certificates(), fixture.componentInstance.totalElements());
+  }
+
+  async function getConfirmDialog(): Promise<ConfirmDialogHarness | null> {
+    return rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+  }
+
+  async function failDeleteAttempt(certificate: ClientCertificate): Promise<void> {
+    await clickDeleteButton();
+
+    const confirmDialog = await getConfirmDialog();
+    await confirmDialog?.confirm();
+
+    httpTestingController
+      .expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}/certificates/${certificate.id}`,
+        method: 'DELETE',
+      })
+      .flush({ error: 'Delete failed' }, { status: 500, statusText: 'Internal Server Error' });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  function getErrorMessage(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('[data-testid="certificate-error"]');
+  }
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.spec.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+
+import { ApplicationTabSettingsCertificatesComponent } from './application-tab-settings-certificates.component';
+import { ApplicationTabSettingsCertificatesHarness } from './application-tab-settings-certificates.harness';
+import { ClientCertificate } from '../../../../../entities/application/client-certificate';
+import { fakeUserApplicationPermissions } from '../../../../../entities/permission/permission.fixtures';
+import { ConfigService } from '../../../../../services/config.service';
+import { AppTestingModule, TESTING_BASE_URL } from '../../../../../testing/app-testing.module';
+
+const fakeCertificate = (overrides: Partial<ClientCertificate> = {}): ClientCertificate => ({
+  id: 'cert-1',
+  name: 'My Certificate',
+  status: 'ACTIVE',
+  createdAt: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('ApplicationTabSettingsCertificatesComponent', () => {
+  let fixture: ComponentFixture<ApplicationTabSettingsCertificatesComponent>;
+  let httpTestingController: HttpTestingController;
+  const applicationId = 'app-1';
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApplicationTabSettingsCertificatesComponent, AppTestingModule],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationTabSettingsCertificatesComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.componentRef.setInput('applicationId', applicationId);
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ DEFINITION: ['U'] }));
+  });
+
+  afterEach(() => httpTestingController.verify());
+
+  async function initWithCertificates(
+    data: ClientCertificate[] = [],
+    totalElements = data.length,
+  ): Promise<ApplicationTabSettingsCertificatesHarness> {
+    fixture.detectChanges();
+    httpTestingController
+      .match(req => req.url.includes(`/applications/${applicationId}/certificates`))
+      .forEach(req =>
+        req.flush({
+          data,
+          metadata: { paginateMetaData: { totalElements } },
+        }),
+      );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationTabSettingsCertificatesHarness);
+  }
+
+  it('should show empty state when no certificates', async () => {
+    const harness = await initWithCertificates([]);
+    expect(await harness.getEmptyState()).toBeTruthy();
+    expect(await harness.getPaginatedTable()).toBeNull();
+  });
+
+  it('should show paginated table when certificates exist', async () => {
+    const harness = await initWithCertificates([fakeCertificate()]);
+    expect(await harness.getEmptyState()).toBeNull();
+    expect(await harness.getPaginatedTable()).toBeTruthy();
+  });
+
+  it('should set totalElements from metadata', async () => {
+    await initWithCertificates([fakeCertificate()], 42);
+    expect(fixture.componentInstance.totalElements()).toBe(42);
+  });
+
+  it('should show error message when loading fails', async () => {
+    fixture.detectChanges();
+    httpTestingController
+      .match(req => req.url.includes(`/applications/${applicationId}/certificates`))
+      .forEach(req => req.flush({ error: 'Server error' }, { status: 500, statusText: 'Internal Server Error' }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationTabSettingsCertificatesHarness);
+    expect(await harness.getErrorMessage()).toBeTruthy();
+  });
+
+  it('should filter active tab correctly', async () => {
+    const certs = [
+      fakeCertificate({ id: 'c1', status: 'ACTIVE' }),
+      fakeCertificate({ id: 'c2', status: 'ACTIVE_WITH_END' }),
+      fakeCertificate({ id: 'c3', status: 'REVOKED' }),
+    ];
+    await initWithCertificates(certs);
+
+    expect(fixture.componentInstance.activeCertificates()).toHaveLength(2);
+    expect(fixture.componentInstance.activeCertificates().map(c => c.id)).toEqual(['c1', 'c2']);
+  });
+
+  it('should filter history tab correctly', async () => {
+    const certs = [fakeCertificate({ id: 'c1', status: 'ACTIVE' }), fakeCertificate({ id: 'c2', status: 'REVOKED' })];
+    await initWithCertificates(certs);
+
+    expect(fixture.componentInstance.historyCertificates()).toHaveLength(1);
+    expect(fixture.componentInstance.historyCertificates()[0].id).toBe('c2');
+  });
+
+  it('should format expired cert as "Expired"', () => {
+    const past = new Date(Date.now() - 86400000).toISOString();
+    expect(fixture.componentInstance.formatDaysRemaining(past)).toBe('Expired');
+  });
+
+  it('should format no-expiry cert as "—"', () => {
+    expect(fixture.componentInstance.formatDaysRemaining(undefined)).toBe('—');
+  });
+
+  it('should format future expiry as days remaining', () => {
+    const future = new Date(Date.now() + 2 * 86400000).toISOString();
+    const result = fixture.componentInstance.formatDaysRemaining(future);
+    expect(Number(result)).toBeGreaterThan(0);
+  });
+
+  it('should reload certificates on page change', async () => {
+    await initWithCertificates([fakeCertificate()]);
+
+    fixture.componentInstance.onPageChange(2);
+
+    httpTestingController
+      .match(req => req.url.includes(`/applications/${applicationId}/certificates`) && req.url.includes('page=2'))
+      .forEach(req => req.flush({ data: [], metadata: { paginateMetaData: { totalElements: 0 } } }));
+
+    expect(fixture.componentInstance.currentPage()).toBe(2);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
@@ -135,6 +135,7 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
       applicationId: this.applicationId(),
       hasActiveCertificates: activeCerts.length > 0,
       activeCertificateId: activeCert?.id,
+      activeCertificateName: activeCert?.name,
       activeCertificateExpiration: activeCert?.endsAt,
     };
     this.dialog

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
@@ -15,9 +15,13 @@
  */
 import { Component, computed, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { differenceInCalendarDays } from 'date-fns';
 
+import { AddCertificateDialogComponent, AddCertificateDialogData } from './add-certificate-dialog/add-certificate-dialog.component';
 import { PaginatedTableComponent, TableColumn } from '../../../../../components/paginated-table/paginated-table.component';
 import { ClientCertificate } from '../../../../../entities/application/client-certificate';
 import { UserApplicationPermissions } from '../../../../../entities/permission/permission';
@@ -25,12 +29,13 @@ import { ApplicationCertificateService } from '../../../../../services/applicati
 
 @Component({
   selector: 'app-application-tab-settings-certificates',
-  imports: [MatTabsModule, PaginatedTableComponent],
+  imports: [MatTabsModule, MatButtonModule, MatIconModule, PaginatedTableComponent],
   templateUrl: './application-tab-settings-certificates.component.html',
   styleUrl: './application-tab-settings-certificates.component.scss',
 })
 export class ApplicationTabSettingsCertificatesComponent implements OnInit {
   private readonly certService = inject(ApplicationCertificateService);
+  private readonly dialog = inject(MatDialog);
   private readonly destroyRef = inject(DestroyRef);
 
   applicationId = input.required<string>();
@@ -94,6 +99,24 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
     if (!endsAt) return '—';
     const days = differenceInCalendarDays(new Date(endsAt), new Date());
     return days <= 0 ? 'Expired' : String(days);
+  }
+
+  openUploadDialog(): void {
+    const activeCerts = this.activeCertificates();
+    const activeCert = activeCerts[0];
+    const data: AddCertificateDialogData = {
+      applicationId: this.applicationId(),
+      hasActiveCertificates: activeCerts.length > 0,
+      activeCertificateId: activeCert?.id,
+      activeCertificateExpiration: activeCert?.endsAt,
+    };
+    this.dialog
+      .open(AddCertificateDialogComponent, { data, width: '560px' })
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(needsRefresh => {
+        if (needsRefresh) this.loadCertificates();
+      });
   }
 
   private toRows(certs: ClientCertificate[]) {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
@@ -20,12 +20,24 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { differenceInCalendarDays } from 'date-fns';
+import { EMPTY, map, Observable, of, switchMap, tap } from 'rxjs';
 
 import { AddCertificateDialogComponent, AddCertificateDialogData } from './add-certificate-dialog/add-certificate-dialog.component';
-import { PaginatedTableComponent, TableColumn } from '../../../../../components/paginated-table/paginated-table.component';
+import { ConfirmDialogComponent, ConfirmDialogData } from '../../../../../components/confirm-dialog/confirm-dialog.component';
+import { PaginatedTableComponent, TableAction, TableColumn } from '../../../../../components/paginated-table/paginated-table.component';
 import { ClientCertificate } from '../../../../../entities/application/client-certificate';
 import { UserApplicationPermissions } from '../../../../../entities/permission/permission';
 import { ApplicationCertificateService } from '../../../../../services/application-certificate.service';
+
+interface CertificateTableRow {
+  certificate: ClientCertificate;
+  id: string;
+  name: string;
+  createdAt: string;
+  endsAt: string;
+  status: string;
+  daysRemaining: string;
+}
 
 @Component({
   selector: 'app-application-tab-settings-certificates',
@@ -46,13 +58,13 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
   certificates = signal<ClientCertificate[]>([]);
   currentPage = signal(1);
   totalElements = signal(0);
-  loadError = signal(false);
+  error = signal<string | null>(null);
   readonly pageSize = 10;
 
-  activeCertificates = computed(() =>
-    this.certificates().filter(c => c.status === 'ACTIVE' || c.status === 'ACTIVE_WITH_END' || c.status === 'SCHEDULED'),
-  );
+  activeCertificates = computed(() => this.certificates().filter(cert => this.isActiveCertificate(cert)));
   historyCertificates = computed(() => this.certificates().filter(c => c.status === 'REVOKED'));
+  activeRows = computed(() => this.activeCertificates().map(cert => this.toTableRow(cert)));
+  historyRows = computed(() => this.historyCertificates().map(cert => this.toTableRow(cert)));
 
   tableColumns: TableColumn[] = [
     { id: 'name', label: 'Name' },
@@ -62,8 +74,23 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
     { id: 'daysRemaining', label: 'Days Remaining' },
   ];
 
-  activeRows = computed(() => this.toRows(this.activeCertificates()));
-  historyRows = computed(() => this.toRows(this.historyCertificates()));
+  activeActions: TableAction<CertificateTableRow>[] = [
+    {
+      id: 'delete-certificate-button',
+      icon: 'delete',
+      ariaLabel: $localize`:@@deleteCertificateAriaLabel:Delete certificate`,
+      color: 'warn',
+    },
+  ];
+
+  historyActions: TableAction<CertificateTableRow>[] = [
+    {
+      id: 'delete-history-certificate-button',
+      icon: 'delete',
+      ariaLabel: $localize`:@@deleteCertificateAriaLabel:Delete certificate`,
+      color: 'warn',
+    },
+  ];
 
   ngOnInit(): void {
     this.loadCertificates();
@@ -75,12 +102,12 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: res => {
-          this.loadError.set(false);
+          this.error.set(null);
           this.certificates.set(res.data ?? []);
           this.totalElements.set(res.metadata?.paginateMetaData?.totalElements ?? 0);
         },
         error: () => {
-          this.loadError.set(true);
+          this.error.set($localize`:@@certificatesLoadError:Failed to load certificates. Please try again.`);
         },
       });
   }
@@ -119,18 +146,116 @@ export class ApplicationTabSettingsCertificatesComponent implements OnInit {
       });
   }
 
-  private toRows(certs: ClientCertificate[]) {
-    return certs.map(cert => ({
-      id: cert.id,
-      name: cert.name,
-      createdAt: cert.createdAt ?? '',
-      endsAt: cert.endsAt ? new Date(cert.endsAt).toLocaleDateString() : '—',
-      status: this.formatStatus(cert.status),
-      daysRemaining: this.formatDaysRemaining(cert.endsAt),
-    }));
+  deleteCertificate(cert: ClientCertificate): void {
+    this.error.set(null);
+
+    this.openConfirmDialog(this.buildDeleteDialogData(cert), 'confirmCertificateDeleteDialog')
+      .pipe(
+        switchMap(confirmed => (confirmed ? this.loadCertificatesForDeleteCheck(cert) : EMPTY)),
+        switchMap(certificates => this.confirmAndDeleteCertificate(cert, certificates)),
+        tap(() => this.loadCertificates()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        error: () => {
+          this.error.set($localize`:@@deleteCertificateError:An error occurred while deleting the certificate. Please try again`);
+        },
+      });
+  }
+
+  onActiveAction(event: { actionId: string; row: CertificateTableRow }): void {
+    this.handleCertificateAction(event);
+  }
+
+  onHistoryAction(event: { actionId: string; row: CertificateTableRow }): void {
+    this.handleCertificateAction(event);
+  }
+
+  private formatEndsAtDisplay(endsAt: string | undefined): string {
+    return endsAt ? new Date(endsAt).toLocaleDateString() : '—';
   }
 
   private formatStatus(status: string): string {
     return status.charAt(0) + status.slice(1).toLowerCase().replace(/_/g, ' ');
+  }
+
+  private openConfirmDialog(dialogData: ConfirmDialogData, id: string): Observable<boolean | undefined> {
+    return this.dialog
+      .open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
+        role: 'alertdialog',
+        id,
+        data: dialogData,
+      })
+      .afterClosed();
+  }
+
+  private buildDeleteDialogData(cert: ClientCertificate): ConfirmDialogData {
+    return {
+      title: $localize`:@@titleDeleteCertificateDialog:Delete certificate`,
+      content: $localize`:@@contentDeleteCertificateDialog:Are you sure you want to delete the certificate "${cert.name}:certificateName:"?`,
+      confirmLabel: $localize`:@@confirmDeleteCertificateDialog:Delete`,
+      cancelLabel: $localize`:@@cancelDeleteCertificateDialog:Cancel`,
+    };
+  }
+
+  private buildLastActiveWarningDialogData(): ConfirmDialogData {
+    return {
+      title: $localize`:@@titleDeleteLastCertificateDialog:Warning`,
+      content: $localize`:@@contentDeleteLastCertificateDialog:There is no active certificate in case you proceed with the deletion. Do you want to proceed?`,
+      confirmLabel: $localize`:@@confirmDeleteCertificateDialog:Delete`,
+      cancelLabel: $localize`:@@cancelDeleteCertificateDialog:Cancel`,
+    };
+  }
+
+  private loadCertificatesForDeleteCheck(cert: ClientCertificate): Observable<ClientCertificate[]> {
+    if (!this.isActiveCertificate(cert)) {
+      return of(this.certificates());
+    }
+
+    const currentPageActiveCertificates = this.certificates().filter(candidate => this.isActiveCertificate(candidate));
+    if (currentPageActiveCertificates.some(candidate => candidate.id !== cert.id)) {
+      return of(this.certificates());
+    }
+
+    const pageSize = Math.max(this.totalElements(), this.pageSize);
+
+    return this.certService.list(this.applicationId(), 1, pageSize).pipe(map(response => response.data ?? []));
+  }
+
+  private handleCertificateAction(event: { actionId: string; row: CertificateTableRow }): void {
+    if (event.actionId === 'delete-certificate-button' || event.actionId === 'delete-history-certificate-button') {
+      this.deleteCertificate(event.row.certificate);
+    }
+  }
+
+  private confirmAndDeleteCertificate(cert: ClientCertificate, certificates: ClientCertificate[]): Observable<unknown> {
+    if (!this.isLastActiveCertificate(cert, certificates)) {
+      return this.certService.delete(this.applicationId(), cert.id);
+    }
+
+    return this.openConfirmDialog(this.buildLastActiveWarningDialogData(), 'confirmLastActiveCertificateDeleteDialog').pipe(
+      switchMap(confirmed => (confirmed ? this.certService.delete(this.applicationId(), cert.id) : EMPTY)),
+    );
+  }
+
+  private isLastActiveCertificate(cert: ClientCertificate, certificates: ClientCertificate[]): boolean {
+    const activeCertificates = certificates.filter(candidate => this.isActiveCertificate(candidate));
+    return activeCertificates.length === 1 && activeCertificates[0].id === cert.id;
+  }
+
+  private isActiveCertificate(cert: ClientCertificate): boolean {
+    return cert.status === 'ACTIVE' || cert.status === 'ACTIVE_WITH_END' || cert.status === 'SCHEDULED';
+  }
+
+  private toTableRow(cert: ClientCertificate): CertificateTableRow {
+    return {
+      certificate: cert,
+      id: cert.id,
+      name: cert.name,
+      createdAt: cert.createdAt ?? '',
+      endsAt: this.formatEndsAtDisplay(cert.endsAt),
+      status: this.formatStatus(cert.status),
+      daysRemaining: this.formatDaysRemaining(cert.endsAt),
+    };
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.component.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatTabsModule } from '@angular/material/tabs';
+import { differenceInCalendarDays } from 'date-fns';
+
+import { PaginatedTableComponent, TableColumn } from '../../../../../components/paginated-table/paginated-table.component';
+import { ClientCertificate } from '../../../../../entities/application/client-certificate';
+import { UserApplicationPermissions } from '../../../../../entities/permission/permission';
+import { ApplicationCertificateService } from '../../../../../services/application-certificate.service';
+
+@Component({
+  selector: 'app-application-tab-settings-certificates',
+  imports: [MatTabsModule, PaginatedTableComponent],
+  templateUrl: './application-tab-settings-certificates.component.html',
+  styleUrl: './application-tab-settings-certificates.component.scss',
+})
+export class ApplicationTabSettingsCertificatesComponent implements OnInit {
+  private readonly certService = inject(ApplicationCertificateService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  applicationId = input.required<string>();
+  userApplicationPermissions = input.required<UserApplicationPermissions>();
+
+  canManage = computed(() => this.userApplicationPermissions().DEFINITION?.includes('U') ?? false);
+
+  certificates = signal<ClientCertificate[]>([]);
+  currentPage = signal(1);
+  totalElements = signal(0);
+  loadError = signal(false);
+  readonly pageSize = 10;
+
+  activeCertificates = computed(() =>
+    this.certificates().filter(c => c.status === 'ACTIVE' || c.status === 'ACTIVE_WITH_END' || c.status === 'SCHEDULED'),
+  );
+  historyCertificates = computed(() => this.certificates().filter(c => c.status === 'REVOKED'));
+
+  tableColumns: TableColumn[] = [
+    { id: 'name', label: 'Name' },
+    { id: 'createdAt', label: 'Uploaded', type: 'date' },
+    { id: 'endsAt', label: 'Expiry date' },
+    { id: 'status', label: 'Status' },
+    { id: 'daysRemaining', label: 'Days Remaining' },
+  ];
+
+  activeRows = computed(() => this.toRows(this.activeCertificates()));
+  historyRows = computed(() => this.toRows(this.historyCertificates()));
+
+  ngOnInit(): void {
+    this.loadCertificates();
+  }
+
+  loadCertificates(): void {
+    this.certService
+      .list(this.applicationId(), this.currentPage(), this.pageSize)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: res => {
+          this.loadError.set(false);
+          this.certificates.set(res.data ?? []);
+          this.totalElements.set(res.metadata?.paginateMetaData?.totalElements ?? 0);
+        },
+        error: () => {
+          this.loadError.set(true);
+        },
+      });
+  }
+
+  onPageChange(page: number): void {
+    this.currentPage.set(page);
+    this.loadCertificates();
+  }
+
+  onTabChange(): void {
+    this.currentPage.set(1);
+    this.loadCertificates();
+  }
+
+  formatDaysRemaining(endsAt: string | undefined): string {
+    if (!endsAt) return '—';
+    const days = differenceInCalendarDays(new Date(endsAt), new Date());
+    return days <= 0 ? 'Expired' : String(days);
+  }
+
+  private toRows(certs: ClientCertificate[]) {
+    return certs.map(cert => ({
+      id: cert.id,
+      name: cert.name,
+      createdAt: cert.createdAt ?? '',
+      endsAt: cert.endsAt ? new Date(cert.endsAt).toLocaleDateString() : '—',
+      status: this.formatStatus(cert.status),
+      daysRemaining: this.formatDaysRemaining(cert.endsAt),
+    }));
+  }
+
+  private formatStatus(status: string): string {
+    return status.charAt(0) + status.slice(1).toLowerCase().replace(/_/g, ' ');
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
@@ -21,8 +21,8 @@ export class ApplicationTabSettingsCertificatesHarness extends ComponentHarness 
   protected locateEmptyState = this.locatorForOptional('.certificates__empty');
   protected locatePaginatedTable = this.locatorForOptional('app-paginated-table');
   protected locateErrorMessage = this.locatorForOptional('.certificates__error');
-  protected locateTabButtons = this.locatorForAll('.certificates__tabs__tab');
-  protected locateActiveTabButton = this.locatorForOptional('.certificates__tabs__tab--active');
+  protected locateTabButtons = this.locatorForAll('[role="tab"]');
+  protected locateActiveTabButton = this.locatorForOptional('[role="tab"][aria-selected="true"]');
   protected locateUploadButton = this.locatorForOptional('[data-testid="upload-certificate-button"]');
 
   public async getEmptyState(): Promise<TestElement | null> {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
@@ -13,25 +13,45 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentHarness } from '@angular/cdk/testing';
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
 
 export class ApplicationTabSettingsCertificatesHarness extends ComponentHarness {
   public static readonly hostSelector = 'app-application-tab-settings-certificates';
 
-  getEmptyState = this.locatorForOptional('.certificates__empty');
-  getPaginatedTable = this.locatorForOptional('app-paginated-table');
-  getErrorMessage = this.locatorForOptional('.certificates__error');
-  getTabButtons = this.locatorForAll('.certificates__tabs__tab');
-  getActiveTabButton = this.locatorForOptional('.certificates__tabs__tab--active');
-  getUploadButton = this.locatorForOptional('[data-testid="upload-certificate-button"]');
+  protected locateEmptyState = this.locatorForOptional('.certificates__empty');
+  protected locatePaginatedTable = this.locatorForOptional('app-paginated-table');
+  protected locateErrorMessage = this.locatorForOptional('.certificates__error');
+  protected locateTabButtons = this.locatorForAll('.certificates__tabs__tab');
+  protected locateActiveTabButton = this.locatorForOptional('.certificates__tabs__tab--active');
+  protected locateUploadButton = this.locatorForOptional('[data-testid="upload-certificate-button"]');
 
-  async clickUploadButton(): Promise<void> {
-    const btn = await this.getUploadButton();
+  public async getEmptyState(): Promise<TestElement | null> {
+    return this.locateEmptyState();
+  }
+
+  public async getPaginatedTable(): Promise<TestElement | null> {
+    return this.locatePaginatedTable();
+  }
+
+  public async getErrorMessage(): Promise<TestElement | null> {
+    return this.locateErrorMessage();
+  }
+
+  public async getActiveTabButton(): Promise<TestElement | null> {
+    return this.locateActiveTabButton();
+  }
+
+  public async getUploadButton(): Promise<TestElement | null> {
+    return this.locateUploadButton();
+  }
+
+  public async clickUploadButton(): Promise<void> {
+    const btn = await this.locateUploadButton();
     await btn?.click();
   }
 
-  async clickTab(label: 'active' | 'history'): Promise<void> {
-    const tabs = await this.getTabButtons();
+  public async clickTab(label: 'active' | 'history'): Promise<void> {
+    const tabs = await this.locateTabButtons();
     const index = label === 'active' ? 0 : 1;
     await tabs[index].click();
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
@@ -23,6 +23,12 @@ export class ApplicationTabSettingsCertificatesHarness extends ComponentHarness 
   getErrorMessage = this.locatorForOptional('.certificates__error');
   getTabButtons = this.locatorForAll('.certificates__tabs__tab');
   getActiveTabButton = this.locatorForOptional('.certificates__tabs__tab--active');
+  getUploadButton = this.locatorForOptional('[data-testid="upload-certificate-button"]');
+
+  async clickUploadButton(): Promise<void> {
+    const btn = await this.getUploadButton();
+    await btn?.click();
+  }
 
   async clickTab(label: 'active' | 'history'): Promise<void> {
     const tabs = await this.getTabButtons();

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-certificates/application-tab-settings-certificates.harness.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ApplicationTabSettingsCertificatesHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-application-tab-settings-certificates';
+
+  getEmptyState = this.locatorForOptional('.certificates__empty');
+  getPaginatedTable = this.locatorForOptional('app-paginated-table');
+  getErrorMessage = this.locatorForOptional('.certificates__error');
+  getTabButtons = this.locatorForAll('.certificates__tabs__tab');
+  getActiveTabButton = this.locatorForOptional('.certificates__tabs__tab--active');
+
+  async clickTab(label: 'active' | 'history'): Promise<void> {
+    const tabs = await this.getTabButtons();
+    const index = label === 'active' ? 0 : 1;
+    await tabs[index].click();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
@@ -133,10 +133,16 @@
           }
         </div>
 
-        <app-application-tab-settings-certificates
-          [applicationId]="applicationId()"
-          [userApplicationPermissions]="userApplicationPermissions()"
-        />
+        @if (mtlsEnabled) {
+          @if (certificates.isLoading()) {
+            <app-loader />
+          } @else if (showCertificates()) {
+            <app-application-tab-settings-certificates
+              [applicationId]="applicationId()"
+              [userApplicationPermissions]="userApplicationPermissions()"
+            />
+          }
+        }
 
         <div class="settings-edit__form__actions">
           <button

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
@@ -58,7 +58,7 @@
               <p class="next-gen-body" i18n="@@applicationTypeApplicationSettings">Application type</p>
               <mat-form-field appearance="outline">
                 <input matInput formControlName="appType" aria-label="Application type" data-testId="simple-type" />
-                <mat-hint i18n="@@hintApplicationTypeApplicationSettings">Type of the application (mobile, web, ...)</mat-hint>
+                <mat-hint i18n="@@hintApplicationTypeApplicationSettings">Type of the application (mobile, web, ...) </mat-hint>
               </mat-form-field>
             </div>
             <div class="settings-edit__form__field">
@@ -66,8 +66,8 @@
               <mat-form-field appearance="outline">
                 <input matInput formControlName="appClientId" aria-label="Client ID" data-testId="simple-clientId" />
                 <mat-hint i18n="@@hintClientIdApplicationSettings"
-                  >This field is required to subscribe to certain types of API Plan (OAuth2, JWT)</mat-hint
-                >
+                  >This field is required to subscribe to certain types of API Plan (OAuth2, JWT)
+                </mat-hint>
               </mat-form-field>
             </div>
           } @else if (application.settings.oauth) {
@@ -110,9 +110,9 @@
                     />
                   </mat-chip-grid>
                   <mat-hint i18n="@@hintRedirectUrisApplicationSettings"
-                    >URIs where the authorization server will send OAuth responses</mat-hint
-                  >
-                  <mat-error i18n="@@redirectUrisRequiredApplicationSettings">At least one redirect URI is required</mat-error>
+                    >URIs where the authorization server will send OAuth responses
+                  </mat-hint>
+                  <mat-error i18n="@@redirectUrisRequiredApplicationSettings">At least one redirect URI is required </mat-error>
                 </mat-form-field>
               </div>
             }
@@ -121,27 +121,23 @@
               <mat-form-field appearance="outline">
                 <mat-select formControlName="oauthGrantTypes" multiple aria-label="Grant types" data-testId="grantTypes">
                   @for (grantType of grantTypesList; track grantType) {
-                    <mat-option [value]="grantType.type" [disabled]="grantType.isDisabled">{{ grantType.name }}</mat-option>
+                    <mat-option [value]="grantType.type" [disabled]="grantType.isDisabled">{{ grantType.name }} </mat-option>
                   }
                 </mat-select>
                 <mat-hint i18n="@@hintGrantTypesApplicationSettings"
-                  >Grant types allowed for the client. Please set only grant types you need for security reasons</mat-hint
-                >
-                <mat-error i18n="@@grantTypesRequiredApplicationSettings">At least one grant type is required</mat-error>
+                  >Grant types allowed for the client. Please set only grant types you need for security reasons
+                </mat-hint>
+                <mat-error i18n="@@grantTypesRequiredApplicationSettings">At least one grant type is required </mat-error>
               </mat-form-field>
             </div>
           }
         </div>
 
         @if (mtlsEnabled) {
-          @if (certificates.isLoading()) {
-            <app-loader />
-          } @else if (showCertificates()) {
-            <app-application-tab-settings-certificates
-              [applicationId]="applicationId()"
-              [userApplicationPermissions]="userApplicationPermissions()"
-            />
-          }
+          <app-application-tab-settings-certificates
+            [applicationId]="applicationId()"
+            [userApplicationPermissions]="userApplicationPermissions()"
+          />
         }
 
         <div class="settings-edit__form__actions">

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
@@ -133,6 +133,11 @@
           }
         </div>
 
+        <app-application-tab-settings-certificates
+          [applicationId]="applicationId()"
+          [userApplicationPermissions]="userApplicationPermissions()"
+        />
+
         <div class="settings-edit__form__actions">
           <button
             mat-flat-button

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.spec.ts
@@ -16,7 +16,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
-import { of, Subject, throwError } from 'rxjs';
+import { of } from 'rxjs';
 
 import { ApplicationTabSettingsEditComponent } from './application-tab-settings-edit.component';
 import { fakeApplication, fakeSimpleApplicationType } from '../../../../../entities/application/application.fixture';
@@ -29,14 +29,13 @@ describe('ApplicationTabSettingsEditComponent', () => {
   const APPLICATION_ID = 'test-app-id';
   let fixture: ComponentFixture<ApplicationTabSettingsEditComponent>;
   let component: ApplicationTabSettingsEditComponent;
-  const mockList = jest.fn();
 
   async function init(configuration: object) {
     await TestBed.configureTestingModule({
       imports: [ApplicationTabSettingsEditComponent, NoopAnimationsModule],
       providers: [
         { provide: ConfigService, useValue: { configuration } },
-        { provide: ApplicationCertificateService, useValue: { list: mockList } },
+        { provide: ApplicationCertificateService, useValue: { list: jest.fn().mockReturnValue(of({ data: [] })) } },
         { provide: ApplicationService, useValue: { get: () => of(fakeApplication()), save: jest.fn() } },
         { provide: Router, useValue: { url: '/', navigate: jest.fn() } },
       ],
@@ -51,33 +50,8 @@ describe('ApplicationTabSettingsEditComponent', () => {
     await fixture.whenStable();
   }
 
-  async function initForLoadingState() {
-    await TestBed.configureTestingModule({
-      imports: [ApplicationTabSettingsEditComponent, NoopAnimationsModule],
-      providers: [
-        { provide: ConfigService, useValue: { configuration: { portalNext: { mtls: { enabled: true } } } } },
-        { provide: ApplicationCertificateService, useValue: { list: mockList } },
-        { provide: ApplicationService, useValue: { get: () => of(fakeApplication()), save: jest.fn() } },
-        { provide: Router, useValue: { url: '/', navigate: jest.fn() } },
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(ApplicationTabSettingsEditComponent);
-    component = fixture.componentInstance;
-    fixture.componentRef.setInput('applicationId', APPLICATION_ID);
-    fixture.componentRef.setInput('applicationTypeConfiguration', fakeSimpleApplicationType());
-    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions());
-    // Do NOT call whenStable() — rxResource with a never-emitting Subject keeps the zone unstable
-    fixture.detectChanges();
-  }
-
-  beforeEach(() => {
-    mockList.mockReset();
-  });
-
   describe('mtlsEnabled', () => {
     it('should return true when mtls is enabled', async () => {
-      mockList.mockReturnValue(of({}));
       await init({ portalNext: { mtls: { enabled: true } } });
 
       expect((component as unknown as { mtlsEnabled: boolean }).mtlsEnabled).toBe(true);
@@ -93,58 +67,6 @@ describe('ApplicationTabSettingsEditComponent', () => {
       await init({});
 
       expect((component as unknown as { mtlsEnabled: boolean }).mtlsEnabled).toBe(false);
-    });
-  });
-
-  describe('certificates', () => {
-    it('should not call certService.list when mtls is disabled', async () => {
-      await init({});
-
-      expect(mockList).not.toHaveBeenCalled();
-    });
-
-    it('should call certService.list with applicationId when mtls is enabled', async () => {
-      mockList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 0 } } }));
-      await init({ portalNext: { mtls: { enabled: true } } });
-
-      expect(mockList).toHaveBeenCalledWith(APPLICATION_ID, 1, 1);
-    });
-  });
-
-  describe('showCertificates', () => {
-    it('should return false when mtls is disabled', async () => {
-      await init({});
-
-      expect(component.showCertificates()).toBe(false);
-    });
-
-    it('should return false when certificate list is empty', async () => {
-      mockList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 0 } } }));
-      await init({ portalNext: { mtls: { enabled: true } } });
-
-      expect(component.showCertificates()).toBe(false);
-    });
-
-    it('should return true when certificates exist', async () => {
-      mockList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 2 } } }));
-      await init({ portalNext: { mtls: { enabled: true } } });
-
-      expect(component.showCertificates()).toBe(true);
-    });
-
-    it('should return true when certificate API fails (fail-open)', async () => {
-      mockList.mockReturnValue(throwError(() => new Error('API error')));
-      await init({ portalNext: { mtls: { enabled: true } } });
-
-      expect(component.showCertificates()).toBe(true);
-    });
-
-    it('should return false while certificates are still loading', async () => {
-      mockList.mockReturnValue(new Subject());
-      await initForLoadingState();
-
-      expect((component as unknown as { certificates: { isLoading: () => boolean } }).certificates.isLoading()).toBe(true);
-      expect(component.showCertificates()).toBe(false);
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.spec.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Router } from '@angular/router';
+import { of, Subject, throwError } from 'rxjs';
+
+import { ApplicationTabSettingsEditComponent } from './application-tab-settings-edit.component';
+import { fakeApplication, fakeSimpleApplicationType } from '../../../../../entities/application/application.fixture';
+import { fakeUserApplicationPermissions } from '../../../../../entities/permission/permission.fixtures';
+import { ApplicationCertificateService } from '../../../../../services/application-certificate.service';
+import { ApplicationService } from '../../../../../services/application.service';
+import { ConfigService } from '../../../../../services/config.service';
+
+describe('ApplicationTabSettingsEditComponent', () => {
+  const APPLICATION_ID = 'test-app-id';
+  let fixture: ComponentFixture<ApplicationTabSettingsEditComponent>;
+  let component: ApplicationTabSettingsEditComponent;
+  const mockList = jest.fn();
+
+  async function init(configuration: object) {
+    await TestBed.configureTestingModule({
+      imports: [ApplicationTabSettingsEditComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ConfigService, useValue: { configuration } },
+        { provide: ApplicationCertificateService, useValue: { list: mockList } },
+        { provide: ApplicationService, useValue: { get: () => of(fakeApplication()), save: jest.fn() } },
+        { provide: Router, useValue: { url: '/', navigate: jest.fn() } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationTabSettingsEditComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('applicationId', APPLICATION_ID);
+    fixture.componentRef.setInput('applicationTypeConfiguration', fakeSimpleApplicationType());
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions());
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  async function initForLoadingState() {
+    await TestBed.configureTestingModule({
+      imports: [ApplicationTabSettingsEditComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ConfigService, useValue: { configuration: { portalNext: { mtls: { enabled: true } } } } },
+        { provide: ApplicationCertificateService, useValue: { list: mockList } },
+        { provide: ApplicationService, useValue: { get: () => of(fakeApplication()), save: jest.fn() } },
+        { provide: Router, useValue: { url: '/', navigate: jest.fn() } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationTabSettingsEditComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('applicationId', APPLICATION_ID);
+    fixture.componentRef.setInput('applicationTypeConfiguration', fakeSimpleApplicationType());
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions());
+    // Do NOT call whenStable() — rxResource with a never-emitting Subject keeps the zone unstable
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    mockList.mockReset();
+  });
+
+  describe('mtlsEnabled', () => {
+    it('should return true when mtls is enabled', async () => {
+      mockList.mockReturnValue(of({}));
+      await init({ portalNext: { mtls: { enabled: true } } });
+
+      expect((component as unknown as { mtlsEnabled: boolean }).mtlsEnabled).toBe(true);
+    });
+
+    it('should return false when mtls is disabled', async () => {
+      await init({ portalNext: { mtls: { enabled: false } } });
+
+      expect((component as unknown as { mtlsEnabled: boolean }).mtlsEnabled).toBe(false);
+    });
+
+    it('should return false when mtls config is absent', async () => {
+      await init({});
+
+      expect((component as unknown as { mtlsEnabled: boolean }).mtlsEnabled).toBe(false);
+    });
+  });
+
+  describe('certificates', () => {
+    it('should not call certService.list when mtls is disabled', async () => {
+      await init({});
+
+      expect(mockList).not.toHaveBeenCalled();
+    });
+
+    it('should call certService.list with applicationId when mtls is enabled', async () => {
+      mockList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 0 } } }));
+      await init({ portalNext: { mtls: { enabled: true } } });
+
+      expect(mockList).toHaveBeenCalledWith(APPLICATION_ID, 1, 1);
+    });
+  });
+
+  describe('showCertificates', () => {
+    it('should return false when mtls is disabled', async () => {
+      await init({});
+
+      expect(component.showCertificates()).toBe(false);
+    });
+
+    it('should return false when certificate list is empty', async () => {
+      mockList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 0 } } }));
+      await init({ portalNext: { mtls: { enabled: true } } });
+
+      expect(component.showCertificates()).toBe(false);
+    });
+
+    it('should return true when certificates exist', async () => {
+      mockList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 2 } } }));
+      await init({ portalNext: { mtls: { enabled: true } } });
+
+      expect(component.showCertificates()).toBe(true);
+    });
+
+    it('should return true when certificate API fails (fail-open)', async () => {
+      mockList.mockReturnValue(throwError(() => new Error('API error')));
+      await init({ portalNext: { mtls: { enabled: true } } });
+
+      expect(component.showCertificates()).toBe(true);
+    });
+
+    it('should return false while certificates are still loading', async () => {
+      mockList.mockReturnValue(new Subject());
+      await initForLoadingState();
+
+      expect((component as unknown as { certificates: { isLoading: () => boolean } }).certificates.isLoading()).toBe(true);
+      expect(component.showCertificates()).toBe(false);
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 import { AsyncPipe } from '@angular/common';
-import { Component, computed, inject, input, OnInit } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
+import { Component, inject, input, OnInit } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -30,9 +29,7 @@ import { isEqual } from 'lodash';
 import { map, Observable, of, startWith, Subject, take, takeUntil, tap } from 'rxjs';
 
 import { CopyCodeComponent } from '../../../../../components/copy-code/copy-code.component';
-import { LoaderComponent } from '../../../../../components/loader/loader.component';
 import { Application, ApplicationGrantType, ApplicationType } from '../../../../../entities/application/application';
-import { ClientCertificatesResponse } from '../../../../../entities/application/client-certificate';
 import { UserApplicationPermissions } from '../../../../../entities/permission/permission';
 import { ApplicationCertificateService } from '../../../../../services/application-certificate.service';
 import { ApplicationService } from '../../../../../services/application.service';
@@ -70,7 +67,6 @@ interface ApplicationGrantTypeVM {
   imports: [
     ApplicationTabSettingsCertificatesComponent,
     CopyCodeComponent,
-    LoaderComponent,
     MatButtonModule,
     MatCardModule,
     MatDivider,
@@ -96,18 +92,6 @@ export class ApplicationTabSettingsEditComponent implements OnInit {
   protected get mtlsEnabled(): boolean {
     return this.configService.configuration?.portalNext?.mtls?.enabled === true;
   }
-
-  protected readonly certificates = rxResource<ClientCertificatesResponse | undefined, string | null>({
-    params: () => (this.mtlsEnabled ? this.applicationId() : null),
-    stream: ({ params }) => (params ? this.certService.list(params, 1, 1) : of(undefined)),
-  });
-
-  showCertificates = computed(() => {
-    if (this.certificates.error()) return true;
-    const response = this.certificates.value();
-    if (!response) return false;
-    return (response.metadata?.paginateMetaData?.totalElements ?? 0) > 0;
-  });
 
   application$!: Observable<Application>;
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
@@ -31,7 +31,9 @@ import { of } from 'rxjs/internal/observable/of';
 
 import { CopyCodeComponent } from '../../../../../components/copy-code/copy-code.component';
 import { Application, ApplicationGrantType, ApplicationType } from '../../../../../entities/application/application';
+import { UserApplicationPermissions } from '../../../../../entities/permission/permission';
 import { ApplicationService } from '../../../../../services/application.service';
+import { ApplicationTabSettingsCertificatesComponent } from '../application-tab-settings-certificates/application-tab-settings-certificates.component';
 
 interface ApplicationSettingsVM {
   name: string;
@@ -62,6 +64,7 @@ interface ApplicationGrantTypeVM {
 @Component({
   selector: 'app-application-tab-settings-edit',
   imports: [
+    ApplicationTabSettingsCertificatesComponent,
     CopyCodeComponent,
     MatButtonModule,
     MatCardModule,
@@ -80,6 +83,7 @@ interface ApplicationGrantTypeVM {
 export class ApplicationTabSettingsEditComponent implements OnInit {
   applicationId = input.required<string>();
   applicationTypeConfiguration = input.required<ApplicationType>();
+  userApplicationPermissions = input.required<UserApplicationPermissions>();
 
   application$!: Observable<Application>;
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import { AsyncPipe } from '@angular/common';
-import { Component, input, OnInit } from '@angular/core';
+import { Component, computed, inject, input, OnInit } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -26,13 +27,16 @@ import { MatInput } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { Router } from '@angular/router';
 import { isEqual } from 'lodash';
-import { map, Observable, startWith, Subject, take, takeUntil, tap } from 'rxjs';
-import { of } from 'rxjs/internal/observable/of';
+import { map, Observable, of, startWith, Subject, take, takeUntil, tap } from 'rxjs';
 
 import { CopyCodeComponent } from '../../../../../components/copy-code/copy-code.component';
+import { LoaderComponent } from '../../../../../components/loader/loader.component';
 import { Application, ApplicationGrantType, ApplicationType } from '../../../../../entities/application/application';
+import { ClientCertificatesResponse } from '../../../../../entities/application/client-certificate';
 import { UserApplicationPermissions } from '../../../../../entities/permission/permission';
+import { ApplicationCertificateService } from '../../../../../services/application-certificate.service';
 import { ApplicationService } from '../../../../../services/application.service';
+import { ConfigService } from '../../../../../services/config.service';
 import { ApplicationTabSettingsCertificatesComponent } from '../application-tab-settings-certificates/application-tab-settings-certificates.component';
 
 interface ApplicationSettingsVM {
@@ -66,6 +70,7 @@ interface ApplicationGrantTypeVM {
   imports: [
     ApplicationTabSettingsCertificatesComponent,
     CopyCodeComponent,
+    LoaderComponent,
     MatButtonModule,
     MatCardModule,
     MatDivider,
@@ -81,9 +86,28 @@ interface ApplicationGrantTypeVM {
   styleUrl: './application-tab-settings-edit.component.scss',
 })
 export class ApplicationTabSettingsEditComponent implements OnInit {
+  protected readonly configService = inject(ConfigService);
+  private readonly certService = inject(ApplicationCertificateService);
+
   applicationId = input.required<string>();
   applicationTypeConfiguration = input.required<ApplicationType>();
   userApplicationPermissions = input.required<UserApplicationPermissions>();
+
+  protected get mtlsEnabled(): boolean {
+    return this.configService.configuration?.portalNext?.mtls?.enabled === true;
+  }
+
+  protected readonly certificates = rxResource<ClientCertificatesResponse | undefined, string | null>({
+    params: () => (this.mtlsEnabled ? this.applicationId() : null),
+    stream: ({ params }) => (params ? this.certService.list(params, 1, 1) : of(undefined)),
+  });
+
+  showCertificates = computed(() => {
+    if (this.certificates.error()) return true;
+    const response = this.certificates.value();
+    if (!response) return false;
+    return (response.metadata?.paginateMetaData?.totalElements ?? 0) > 0;
+  });
 
   application$!: Observable<Application>;
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.harness.ts
@@ -13,16 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ContentContainerComponentHarness, parallel, TestKey } from '@angular/cdk/testing';
+import { ContentContainerComponentHarness, parallel, TestElement, TestKey } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatChipGridHarness } from '@angular/material/chips/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 
 import { CopyCodeHarness } from '../../../../../components/copy-code/copy-code.harness';
+import { ApplicationTabSettingsCertificatesHarness } from '../application-tab-settings-certificates/application-tab-settings-certificates.harness';
 
 export class ApplicationTabSettingsEditHarness extends ContentContainerComponentHarness {
   public static hostSelector = 'app-application-tab-settings-edit';
+  protected locateCertificatesSection = this.locatorForOptional(ApplicationTabSettingsCertificatesHarness);
+  protected locateCertificatesLoader = this.locatorForOptional('app-loader');
   protected locateAppName = this.getHarness(MatInputHarness.with({ selector: '[data-testId="name"]' }));
   protected locateAppDescription = this.getHarness(MatInputHarness.with({ selector: '[data-testId="description"]' }));
   protected locateAppDomain = this.getHarnessOrNull(MatInputHarness.with({ selector: '[data-testId="domain"]' }));
@@ -34,6 +37,14 @@ export class ApplicationTabSettingsEditHarness extends ContentContainerComponent
   protected locateGrantTypes = this.getHarnessOrNull(MatSelectHarness.with({ selector: '[data-testId="grantTypes"]' }));
   protected locateSaveButton = this.getHarness(MatButtonHarness.with({ selector: '[data-testId="save"]' }));
   protected locateDiscardButton = this.getHarness(MatButtonHarness.with({ selector: '[data-testId="discard"]' }));
+  public async getCertificatesSection(): Promise<ApplicationTabSettingsCertificatesHarness | null> {
+    return this.locateCertificatesSection();
+  }
+
+  public async getCertificatesLoader(): Promise<TestElement | null> {
+    return this.locateCertificatesLoader();
+  }
+
   public async getName(): Promise<string> {
     return this.locateAppName.then(input => input.getValue());
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.html
@@ -17,7 +17,11 @@
 -->
 @if (application(); as application) {
   @if (isEditing() && canUpdate()) {
-    <app-application-tab-settings-edit [applicationId]="application.id" [applicationTypeConfiguration]="applicationTypeConfiguration()" />
+    <app-application-tab-settings-edit
+      [applicationId]="application.id"
+      [applicationTypeConfiguration]="applicationTypeConfiguration()"
+      [userApplicationPermissions]="userApplicationPermissions()"
+    />
   } @else {
     <app-application-tab-settings-read
       [applicationId]="application.id"

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.update.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.update.spec.ts
@@ -78,6 +78,15 @@ describe('ApplicationTabSettingsComponent', () => {
     });
   }
 
+  function flushCertificatesRequest() {
+    const certificatesUrl = `${TESTING_BASE_URL}/applications/${applicationId}/certificates`;
+    httpTestingController
+      .match(req => req.url.startsWith(certificatesUrl))
+      .forEach(req => {
+        req.flush({ data: [], metadata: { pagination: { totalCount: 0 } } });
+      });
+  }
+
   async function initRestCalls(application: Application, applicationType: ApplicationType) {
     fixture.componentRef.setInput('applicationTypeConfiguration', applicationType);
     fixture.detectChanges();
@@ -93,6 +102,7 @@ describe('ApplicationTabSettingsComponent', () => {
     await fixture.whenStable();
 
     flushGetRequests(application);
+    flushCertificatesRequest();
     await fixture.whenStable();
 
     updateHarness = await loader.getHarness(ApplicationTabSettingsEditHarness);

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.update.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.update.spec.ts
@@ -18,6 +18,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of, Subject, throwError } from 'rxjs';
 
 import { ApplicationTabSettingsEditHarness } from './application-tab-settings-edit/application-tab-settings-edit.harness';
 import { ApplicationTabSettingsComponent } from './application-tab-settings.component';
@@ -32,6 +33,7 @@ import {
   fakeWebApplicationType,
 } from '../../../../entities/application/application.fixture';
 import { fakeUserApplicationPermissions } from '../../../../entities/permission/permission.fixtures';
+import { ApplicationCertificateService } from '../../../../services/application-certificate.service';
 import { ConfigService } from '../../../../services/config.service';
 import { AppTestingModule, TESTING_BASE_URL } from '../../../../testing/app-testing.module';
 
@@ -461,6 +463,131 @@ describe('ApplicationTabSettingsComponent', () => {
       await updateHarness.discardChanges();
       expect(await updateHarness.getName()).toEqual('Native application');
       expect(await updateHarness.isDiscardButtonDisabled()).toBeTruthy();
+    });
+  });
+});
+
+describe('ApplicationTabSettingsComponent - Certificates section visibility', () => {
+  let fixture: ComponentFixture<ApplicationTabSettingsComponent>;
+  let httpTestingController: HttpTestingController;
+  let loader: HarnessLoader;
+  let updateHarness: ApplicationTabSettingsEditHarness;
+  const applicationId = 'id1';
+  const simpleApplication = fakeApplication({ id: applicationId });
+  const mockCertList = jest.fn();
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApplicationTabSettingsComponent, ConfirmDialogComponent, HttpClientTestingModule, NoopAnimationsModule, AppTestingModule],
+      providers: [
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL, configuration: { portalNext: { mtls: { enabled: true } } } } },
+        { provide: ApplicationCertificateService, useValue: { list: mockCertList } },
+      ],
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  function flushGetRequests(application: Application) {
+    const applicationUrl = `${TESTING_BASE_URL}/applications/${applicationId}`;
+    httpTestingController.match(applicationUrl).forEach(req => {
+      expect(req.request.method).toBe('GET');
+      req.flush(application);
+      fixture.detectChanges();
+    });
+  }
+
+  async function init(application: Application, applicationType: ApplicationType) {
+    fixture = TestBed.createComponent(ApplicationTabSettingsComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.componentRef.setInput('applicationId', applicationId);
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ DEFINITION: ['U'] }));
+    fixture.componentRef.setInput('applicationTypeConfiguration', applicationType);
+    fixture.detectChanges();
+
+    flushGetRequests(application);
+    await fixture.whenStable();
+    flushGetRequests(application);
+    await fixture.whenStable();
+
+    fixture.componentRef.instance.isEditing.set(true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    flushGetRequests(application);
+    await fixture.whenStable();
+
+    updateHarness = await loader.getHarness(ApplicationTabSettingsEditHarness);
+  }
+
+  async function initForLoadingState(application: Application, applicationType: ApplicationType) {
+    fixture = TestBed.createComponent(ApplicationTabSettingsComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.componentRef.setInput('applicationId', applicationId);
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ DEFINITION: ['U'] }));
+    fixture.componentRef.setInput('applicationTypeConfiguration', applicationType);
+    fixture.detectChanges();
+
+    flushGetRequests(application);
+    await fixture.whenStable();
+    flushGetRequests(application);
+    await fixture.whenStable();
+
+    fixture.componentRef.instance.isEditing.set(true);
+    fixture.detectChanges();
+
+    // Do NOT call whenStable() here — rxResource with a never-emitting Subject
+    // keeps the zone unstable indefinitely. Flush the app GET from ngOnInit directly.
+    flushGetRequests(application);
+    fixture.detectChanges();
+  }
+
+  describe('when application has no certificates', () => {
+    beforeEach(async () => {
+      mockCertList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 0 } } }));
+      await init(simpleApplication, fakeSimpleApplicationType());
+    });
+
+    it('should hide certificates section', async () => {
+      expect(await updateHarness.getCertificatesSection()).toBeNull();
+    });
+  });
+
+  describe('when application has certificates', () => {
+    beforeEach(async () => {
+      mockCertList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 1 } } }));
+      await init(simpleApplication, fakeSimpleApplicationType());
+    });
+
+    it('should show certificates section', async () => {
+      expect(await updateHarness.getCertificatesSection()).not.toBeNull();
+    });
+  });
+
+  describe('when certificate count is still loading', () => {
+    beforeEach(async () => {
+      mockCertList.mockReturnValue(new Subject());
+      await initForLoadingState(simpleApplication, fakeSimpleApplicationType());
+    });
+
+    it('should show loader and hide certificates section', () => {
+      expect(fixture.nativeElement.querySelector('app-loader')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('app-application-tab-settings-certificates')).toBeNull();
+    });
+  });
+
+  describe('when certificate count API fails', () => {
+    beforeEach(async () => {
+      mockCertList.mockReturnValue(throwError(() => new Error('API error')));
+      await init(simpleApplication, fakeSimpleApplicationType());
+    });
+
+    it('should show certificates section as fallback', async () => {
+      expect(await updateHarness.getCertificatesLoader()).toBeNull();
+      expect(await updateHarness.getCertificatesSection()).not.toBeNull();
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.update.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.update.spec.ts
@@ -18,7 +18,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { of, Subject, throwError } from 'rxjs';
+import { of } from 'rxjs';
 
 import { ApplicationTabSettingsEditHarness } from './application-tab-settings-edit/application-tab-settings-edit.harness';
 import { ApplicationTabSettingsComponent } from './application-tab-settings.component';
@@ -159,7 +159,10 @@ describe('ApplicationTabSettingsComponent', () => {
         settings: { app: { client_id: 'New custom client ID', type: '' } },
       };
 
-      const req = httpTestingController.expectOne({ url: `${TESTING_BASE_URL}/applications/${applicationId}`, method: 'PUT' });
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
       expect(req.request.body).toEqual(updatedApplication);
       req.flush(updatedApplication);
     });
@@ -216,7 +219,10 @@ describe('ApplicationTabSettingsComponent', () => {
         description: 'New b2b description',
       };
 
-      const req = httpTestingController.expectOne({ url: `${TESTING_BASE_URL}/applications/${applicationId}`, method: 'PUT' });
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
       expect(req.request.body).toEqual(updatedApplication);
       req.flush(updatedApplication);
     });
@@ -285,7 +291,10 @@ describe('ApplicationTabSettingsComponent', () => {
         },
       };
 
-      const req = httpTestingController.expectOne({ url: `${TESTING_BASE_URL}/applications/${applicationId}`, method: 'PUT' });
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
       expect(req.request.body).toEqual(updatedApplication);
       req.flush(updatedApplication);
     });
@@ -354,7 +363,10 @@ describe('ApplicationTabSettingsComponent', () => {
         },
       };
 
-      const req = httpTestingController.expectOne({ url: `${TESTING_BASE_URL}/applications/${applicationId}`, method: 'PUT' });
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
       expect(req.request.body).toEqual(updatedApplication);
       req.flush(updatedApplication);
     });
@@ -424,7 +436,10 @@ describe('ApplicationTabSettingsComponent', () => {
         },
       };
 
-      const req = httpTestingController.expectOne({ url: `${TESTING_BASE_URL}/applications/${applicationId}`, method: 'PUT' });
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
       expect(req.request.body).toEqual(updatedApplication);
       req.flush(updatedApplication);
     });
@@ -474,13 +489,16 @@ describe('ApplicationTabSettingsComponent - Certificates section visibility', ()
   let updateHarness: ApplicationTabSettingsEditHarness;
   const applicationId = 'id1';
   const simpleApplication = fakeApplication({ id: applicationId });
-  const mockCertList = jest.fn();
+  const mockCertList = jest.fn().mockReturnValue(of({ data: [] }));
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ApplicationTabSettingsComponent, ConfirmDialogComponent, HttpClientTestingModule, NoopAnimationsModule, AppTestingModule],
       providers: [
-        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL, configuration: { portalNext: { mtls: { enabled: true } } } } },
+        {
+          provide: ConfigService,
+          useValue: { baseURL: TESTING_BASE_URL, configuration: { portalNext: { mtls: { enabled: true } } } },
+        },
         { provide: ApplicationCertificateService, useValue: { list: mockCertList } },
       ],
     }).compileComponents();
@@ -523,70 +541,12 @@ describe('ApplicationTabSettingsComponent - Certificates section visibility', ()
     updateHarness = await loader.getHarness(ApplicationTabSettingsEditHarness);
   }
 
-  async function initForLoadingState(application: Application, applicationType: ApplicationType) {
-    fixture = TestBed.createComponent(ApplicationTabSettingsComponent);
-    httpTestingController = TestBed.inject(HttpTestingController);
-    fixture.componentRef.setInput('applicationId', applicationId);
-    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ DEFINITION: ['U'] }));
-    fixture.componentRef.setInput('applicationTypeConfiguration', applicationType);
-    fixture.detectChanges();
-
-    flushGetRequests(application);
-    await fixture.whenStable();
-    flushGetRequests(application);
-    await fixture.whenStable();
-
-    fixture.componentRef.instance.isEditing.set(true);
-    fixture.detectChanges();
-
-    // Do NOT call whenStable() here — rxResource with a never-emitting Subject
-    // keeps the zone unstable indefinitely. Flush the app GET from ngOnInit directly.
-    flushGetRequests(application);
-    fixture.detectChanges();
-  }
-
-  describe('when application has no certificates', () => {
+  describe('when mTLS is enabled', () => {
     beforeEach(async () => {
-      mockCertList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 0 } } }));
-      await init(simpleApplication, fakeSimpleApplicationType());
-    });
-
-    it('should hide certificates section', async () => {
-      expect(await updateHarness.getCertificatesSection()).toBeNull();
-    });
-  });
-
-  describe('when application has certificates', () => {
-    beforeEach(async () => {
-      mockCertList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 1 } } }));
       await init(simpleApplication, fakeSimpleApplicationType());
     });
 
     it('should show certificates section', async () => {
-      expect(await updateHarness.getCertificatesSection()).not.toBeNull();
-    });
-  });
-
-  describe('when certificate count is still loading', () => {
-    beforeEach(async () => {
-      mockCertList.mockReturnValue(new Subject());
-      await initForLoadingState(simpleApplication, fakeSimpleApplicationType());
-    });
-
-    it('should show loader and hide certificates section', () => {
-      expect(fixture.nativeElement.querySelector('app-loader')).not.toBeNull();
-      expect(fixture.nativeElement.querySelector('app-application-tab-settings-certificates')).toBeNull();
-    });
-  });
-
-  describe('when certificate count API fails', () => {
-    beforeEach(async () => {
-      mockCertList.mockReturnValue(throwError(() => new Error('API error')));
-      await init(simpleApplication, fakeSimpleApplicationType());
-    });
-
-    it('should show certificates section as fallback', async () => {
-      expect(await updateHarness.getCertificatesLoader()).toBeNull();
       expect(await updateHarness.getCertificatesSection()).not.toBeNull();
     });
   });

--- a/gravitee-apim-portal-webui-next/src/components/confirm-dialog/confirm-dialog.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/confirm-dialog/confirm-dialog.harness.ts
@@ -21,6 +21,8 @@ export class ConfirmDialogHarness extends ComponentHarness {
 
   private readonly getConfirmButtonHarness = this.locatorFor(MatButtonHarness.with({ selector: '.confirm-dialog__confirm-button' }));
   private readonly getCancelButtonHarness = this.locatorFor(MatButtonHarness.with({ selector: '.confirm-dialog__cancel-button' }));
+  private readonly getTitleText = this.locatorFor('.confirm-dialog__title');
+  private readonly getContentText = this.locatorFor('.confirm-dialog__content');
 
   public async confirm(): Promise<void> {
     await this.getConfirmButtonHarness().then(button => button.click());
@@ -36,5 +38,13 @@ export class ConfirmDialogHarness extends ComponentHarness {
 
   public async getCancelText(): Promise<string> {
     return await this.getCancelButtonHarness().then(button => button.getText());
+  }
+
+  public async getTitle(): Promise<string> {
+    return await this.getTitleText().then(title => title.text());
+  }
+
+  public async getContent(): Promise<string> {
+    return await this.getContentText().then(content => content.text());
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
@@ -19,7 +19,7 @@
   <table mat-table [dataSource]="rows()" class="paginated-table">
     @for (column of columns(); track column.id) {
       <ng-container [matColumnDef]="column.id">
-        <th mat-header-cell *matHeaderCellDef>{{ column.label }}</th>
+        <th mat-header-cell *matHeaderCellDef class="next-gen-small-bold">{{ column.label }}</th>
         <td mat-cell *matCellDef="let element">
           @switch (column.type) {
             @case ('date') {
@@ -33,15 +33,46 @@
       </ng-container>
     }
 
-    <ng-container matColumnDef="expand">
-      <th mat-header-cell *matHeaderCellDef></th>
-      <td mat-cell *matCellDef="let element" class="paginated-table__column-expand">
-        <mat-icon>chevron_right</mat-icon>
-      </td>
-    </ng-container>
+    @if (actions().length > 0) {
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let element" class="paginated-table__actions">
+          @for (action of actions(); track action.id) {
+            @if (!action.isVisible || action.isVisible(element)) {
+              <button
+                mat-icon-button
+                type="button"
+                [color]="action.color ?? 'primary'"
+                [disabled]="action.isDisabled?.(element) ?? false"
+                [attr.aria-label]="action.ariaLabel"
+                [attr.data-testid]="'paginated-table-action-' + action.id"
+                (click)="onActionClick($event, action.id, element)"
+              >
+                <mat-icon aria-hidden="true">{{ action.icon }}</mat-icon>
+              </button>
+            }
+          }
+        </td>
+      </ng-container>
+    }
+
+    @if (navigable()) {
+      <ng-container matColumnDef="expand">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let element" class="paginated-table__column-expand">
+          <mat-icon>chevron_right</mat-icon>
+        </td>
+      </ng-container>
+    }
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns()"></tr>
-    <tr mat-row class="paginated-table__row" *matRowDef="let row; columns: displayedColumns()" [routerLink]="[row.id]"></tr>
+    <tr
+      mat-row
+      class="paginated-table__row"
+      [class.paginated-table__row--navigable]="navigable()"
+      *matRowDef="let row; columns: displayedColumns()"
+      [routerLink]="navigable() ? [row.id] : null"
+    ></tr>
   </table>
 </div>
 

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.scss
@@ -35,11 +35,19 @@
   }
 
   &__row {
-    cursor: pointer;
-
     &:last-child td {
       border-bottom: none;
     }
+  }
+
+  &__row--navigable {
+    cursor: pointer;
+  }
+
+  &__actions,
+  &__column-expand {
+    width: 1%;
+    white-space: nowrap;
   }
 
   &__column-expand {

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.spec.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+
+import { PaginatedTableComponent, TableAction, TableColumn } from './paginated-table.component';
+import { PaginatedTableHarness } from './paginated-table.harness';
+
+type TestRow = {
+  id: string;
+  name: string;
+  createdAt: string;
+};
+
+@Component({
+  standalone: true,
+  imports: [PaginatedTableComponent],
+  template: `
+    <app-paginated-table
+      [columns]="columns"
+      [rows]="rows"
+      [totalElements]="totalElements"
+      [currentPage]="currentPage"
+      [pageSize]="pageSize"
+      [navigable]="navigable"
+      [actions]="actions"
+      (actionClick)="onActionClick($event)"
+    />
+  `,
+})
+class TestHostComponent {
+  columns: TableColumn[] = [
+    { id: 'name', label: 'Name' },
+    { id: 'createdAt', label: 'Created', type: 'date' },
+  ];
+  rows: TestRow[] = [{ id: 'row-1', name: 'First row', createdAt: '2026-01-01T00:00:00Z' }];
+  totalElements = 1;
+  currentPage = 1;
+  pageSize = 10;
+  navigable = true;
+  actions: TableAction<TestRow>[] = [];
+  receivedAction: { actionId: string; row: TestRow } | null = null;
+
+  onActionClick(event: { actionId: string; row: TestRow }): void {
+    this.receivedAction = event;
+  }
+}
+
+describe('PaginatedTableComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let harness: PaginatedTableHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideNoopAnimations(), provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+  });
+
+  it('should render navigable rows with expand column by default', async () => {
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, PaginatedTableHarness);
+
+    expect((await harness.getNavigableRows()).length).toBeGreaterThan(0);
+    expect((await harness.getExpandColumns()).length).toBeGreaterThan(0);
+    expect((await harness.getActionButtons()).length).toBe(0);
+  });
+
+  it('should render action buttons and disable navigation when configured', async () => {
+    host.navigable = false;
+    host.actions = [
+      {
+        id: 'delete',
+        icon: 'delete',
+        ariaLabel: 'Delete row',
+        color: 'warn',
+      },
+    ];
+
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, PaginatedTableHarness);
+
+    expect((await harness.getNavigableRows()).length).toBe(0);
+    expect((await harness.getExpandColumns()).length).toBe(0);
+
+    const deleteButton = await harness.getActionButton('delete');
+    expect(deleteButton).toBeTruthy();
+
+    await deleteButton!.click();
+
+    expect(host.receivedAction).toEqual({
+      actionId: 'delete',
+      row: host.rows[0],
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.ts
@@ -15,6 +15,7 @@
  */
 import { DatePipe } from '@angular/common';
 import { Component, computed, input, output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
@@ -27,10 +28,19 @@ export interface TableColumn {
   type?: 'text' | 'date';
 }
 
+export interface TableAction<T> {
+  id: string;
+  icon: string;
+  ariaLabel: string;
+  color?: 'primary' | 'accent' | 'warn';
+  isVisible?: (row: T) => boolean;
+  isDisabled?: (row: T) => boolean;
+}
+
 @Component({
   selector: 'app-paginated-table',
   standalone: true,
-  imports: [DatePipe, MatTableModule, MatIcon, RouterLink, PaginationComponent],
+  imports: [DatePipe, MatTableModule, MatIcon, RouterLink, PaginationComponent, MatButtonModule],
   templateUrl: './paginated-table.component.html',
   styleUrl: './paginated-table.component.scss',
 })
@@ -41,13 +51,25 @@ export class PaginatedTableComponent<T> {
   currentPage = input.required<number>();
   pageSize = input.required<number>();
   pageSizeOptions = input<number[]>(DEFAULT_PAGE_SIZE_OPTIONS);
+  navigable = input(true);
+  actions = input<TableAction<T>[]>([]);
 
   pageChange = output<number>();
   pageSizeChange = output<number>();
+  actionClick = output<{ actionId: string; row: T }>();
 
-  displayedColumns = computed(() => [...this.columns().map(c => c.id as string), 'expand']);
+  displayedColumns = computed(() => [
+    ...this.columns().map(c => c.id as string),
+    ...(this.actions().length > 0 ? ['actions'] : []),
+    ...(this.navigable() ? ['expand'] : []),
+  ]);
 
   onPageChange(page: number): void {
     this.pageChange.emit(page);
+  }
+
+  onActionClick(event: Event, actionId: string, row: T): void {
+    event.stopPropagation();
+    this.actionClick.emit({ actionId, row });
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.harness.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class PaginatedTableHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-paginated-table';
+
+  protected locateNavigableRows = this.locatorForAll('.paginated-table__row--navigable');
+  protected locateExpandColumns = this.locatorForAll('.paginated-table__column-expand');
+  protected locateActionButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[data-testid^="paginated-table-action-"]' }));
+
+  async getNavigableRows(): Promise<TestElement[]> {
+    return this.locateNavigableRows();
+  }
+
+  async getExpandColumns(): Promise<TestElement[]> {
+    return this.locateExpandColumns();
+  }
+
+  async getActionButtons(): Promise<MatButtonHarness[]> {
+    return this.locateActionButtons();
+  }
+
+  async getActionButton(actionId: string): Promise<MatButtonHarness | null> {
+    return this.locatorForOptional(MatButtonHarness.with({ selector: `[data-testid="paginated-table-action-${actionId}"]` }))();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/entities/application/client-certificate.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/client-certificate.fixture.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ClientCertificate } from './client-certificate';
+
+export function fakeClientCertificate(overrides: Partial<ClientCertificate> = {}): ClientCertificate {
+  return {
+    id: 'cert-1',
+    name: 'My Certificate',
+    status: 'ACTIVE',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/entities/application/client-certificate.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/client-certificate.ts
@@ -35,6 +35,12 @@ export interface CreateClientCertificateInput {
   endsAt?: string;
 }
 
+export interface ValidateCertificateResponse {
+  certificateExpiration?: string;
+  subject?: string;
+  issuer?: string;
+}
+
 export interface UpdateClientCertificateInput {
   name?: string;
   startsAt?: string;

--- a/gravitee-apim-portal-webui-next/src/entities/application/client-certificate.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/client-certificate.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ClientCertificateStatus = 'ACTIVE' | 'ACTIVE_WITH_END' | 'SCHEDULED' | 'REVOKED';
+
+export interface ClientCertificate {
+  id: string;
+  name: string;
+  status: ClientCertificateStatus;
+  subject?: string;
+  issuer?: string;
+  fingerprint?: string;
+  createdAt?: string;
+  startsAt?: string;
+  endsAt?: string;
+}
+
+export interface CreateClientCertificateInput {
+  name: string;
+  certificate: string;
+  startsAt?: string;
+  endsAt?: string;
+}
+
+export interface UpdateClientCertificateInput {
+  name?: string;
+  startsAt?: string;
+  endsAt?: string;
+}
+
+export interface PaginateMetaData {
+  totalElements: number;
+}
+
+export interface ClientCertificatesResponse {
+  data?: ClientCertificate[];
+  metadata?: {
+    paginateMetaData?: PaginateMetaData;
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
@@ -18,6 +18,9 @@ export class ConfigurationPortalNext {
   access?: {
     enabled?: boolean;
   };
+  mtls?: {
+    enabled?: boolean;
+  };
   banner?: {
     enabled?: boolean;
     title?: string;

--- a/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
+++ b/gravitee-apim-portal-webui-next/src/scss/material-design-overrides.scss
@@ -68,6 +68,14 @@ mat-expansion-panel {
   --mat-expansion-container-background-color: #{theme.$card-background-color};
 }
 
+mat-stepper {
+  @include mat.stepper-overrides(
+    (
+      container-color: #{theme.$card-background-color},
+    )
+  );
+}
+
 .mat-mdc-select-panel {
   --mat-select-panel-background-color: #{theme.$select-panel-background-color};
 }

--- a/gravitee-apim-portal-webui-next/src/services/application-certificate.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-certificate.service.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApplicationCertificateService } from './application-certificate.service';
+import { fakeClientCertificate } from '../entities/application/client-certificate.fixture';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
+
+describe('ApplicationCertificateService', () => {
+  let service: ApplicationCertificateService;
+  let httpTestingController: HttpTestingController;
+  const appId = 'app-1';
+  const certId = 'cert-1';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    service = TestBed.inject(ApplicationCertificateService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should GET application certificates with pagination', done => {
+    const response = { data: [fakeClientCertificate()], metadata: { paginateMetaData: { totalElements: 1 } } };
+
+    service.list(appId, 1, 10).subscribe(res => {
+      expect(res).toMatchObject(response);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${appId}/certificates?page=1&size=10`);
+    expect(req.request.method).toEqual('GET');
+    req.flush(response);
+  });
+
+  it('should POST a new application certificate', done => {
+    const input = { name: 'New Cert', certificate: '-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----' };
+    const created = fakeClientCertificate({ id: 'cert-new', name: 'New Cert' });
+
+    service.create(appId, input).subscribe(res => {
+      expect(res).toMatchObject(created);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${appId}/certificates`);
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toEqual(input);
+    req.flush(created);
+  });
+
+  it('should PUT updated application certificate', done => {
+    const input = { name: 'Updated Cert' };
+    const updated = fakeClientCertificate({ id: certId, name: 'Updated Cert' });
+
+    service.update(appId, certId, input).subscribe(res => {
+      expect(res).toMatchObject(updated);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${appId}/certificates/${certId}`);
+    expect(req.request.method).toEqual('PUT');
+    expect(req.request.body).toEqual(input);
+    req.flush(updated);
+  });
+
+  it('should DELETE an application certificate', done => {
+    service.delete(appId, certId).subscribe(() => {
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${appId}/certificates/${certId}`);
+    expect(req.request.method).toEqual('DELETE');
+    req.flush(null);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/application-certificate.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-certificate.service.spec.ts
@@ -90,4 +90,19 @@ describe('ApplicationCertificateService', () => {
     expect(req.request.method).toEqual('DELETE');
     req.flush(null);
   });
+
+  it('should POST to _validate and return certificate metadata', done => {
+    const certificate = '-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpE...\n-----END CERTIFICATE-----';
+    const response = { certificateExpiration: '2027-06-01T00:00:00.000Z', subject: 'CN=test', issuer: 'CN=ca' };
+
+    service.validate(appId, certificate).subscribe(res => {
+      expect(res).toMatchObject(response);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${appId}/certificates/_validate`);
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toEqual({ certificate });
+    req.flush(response);
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/application-certificate.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-certificate.service.ts
@@ -23,6 +23,7 @@ import {
   ClientCertificatesResponse,
   CreateClientCertificateInput,
   UpdateClientCertificateInput,
+  ValidateCertificateResponse,
 } from '../entities/application/client-certificate';
 
 @Injectable({
@@ -46,6 +47,13 @@ export class ApplicationCertificateService {
 
   update(applicationId: string, certId: string, body: UpdateClientCertificateInput): Observable<ClientCertificate> {
     return this.http.put<ClientCertificate>(`${this.configService.baseURL}/applications/${applicationId}/certificates/${certId}`, body);
+  }
+
+  validate(applicationId: string, certificate: string): Observable<ValidateCertificateResponse> {
+    return this.http.post<ValidateCertificateResponse>(
+      `${this.configService.baseURL}/applications/${applicationId}/certificates/_validate`,
+      { certificate },
+    );
   }
 
   delete(applicationId: string, certId: string): Observable<void> {

--- a/gravitee-apim-portal-webui-next/src/services/application-certificate.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-certificate.service.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ConfigService } from './config.service';
+import {
+  ClientCertificate,
+  ClientCertificatesResponse,
+  CreateClientCertificateInput,
+  UpdateClientCertificateInput,
+} from '../entities/application/client-certificate';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApplicationCertificateService {
+  constructor(
+    private readonly http: HttpClient,
+    private readonly configService: ConfigService,
+  ) {}
+
+  list(applicationId: string, page = 1, size = 10): Observable<ClientCertificatesResponse> {
+    return this.http.get<ClientCertificatesResponse>(
+      `${this.configService.baseURL}/applications/${applicationId}/certificates?page=${page}&size=${size}`,
+    );
+  }
+
+  create(applicationId: string, body: CreateClientCertificateInput): Observable<ClientCertificate> {
+    return this.http.post<ClientCertificate>(`${this.configService.baseURL}/applications/${applicationId}/certificates`, body);
+  }
+
+  update(applicationId: string, certId: string, body: UpdateClientCertificateInput): Observable<ClientCertificate> {
+    return this.http.put<ClientCertificate>(`${this.configService.baseURL}/applications/${applicationId}/certificates/${certId}`, body);
+  }
+
+  delete(applicationId: string, certId: string): Observable<void> {
+    return this.http.delete<void>(`${this.configService.baseURL}/applications/${applicationId}/certificates/${certId}`);
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/utils/common.utils.ts
+++ b/gravitee-apim-portal-webui-next/src/utils/common.utils.ts
@@ -63,6 +63,14 @@ export function toTitleCase(value: string): string {
 }
 
 /**
+ * Returns the file name without its last extension (`cert.pem` → `cert`).
+ * If there is no `.suffix`, returns `fileName` unchanged.
+ */
+export function fileNameWithoutExtension(fileName: string): string {
+  return fileName.replace(/\.[^.]+$/, '');
+}
+
+/**
  * Compares two filter objects for equality.
  * Compares arrays and primitive values within the filter objects.
  */

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import lombok.AccessLevel;
 import lombok.Getter;
 
 /**
@@ -144,7 +143,7 @@ public enum Key {
     PORTAL_NEXT_THEME_CUSTOM_CSS("portal.next.theme.customCss", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_THEME_FONT_FAMILY("portal.next.theme.font.family", "\"Roboto\", sans-serif", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_CATALOG_VIEW_MODE("portal.next.catalog.viewMode", new HashSet<>(singletonList(ENVIRONMENT))),
-    PORTAL_NEXT_MTLS_ENABLED("portal.next.feature.mtlsEnabled", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_MTLS_ENABLED("portal.next.mtls.enabled", new HashSet<>(singletonList(ENVIRONMENT))),
 
     MANAGEMENT_TITLE("management.title", "Gravitee.io Management", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     MANAGEMENT_URL("management.url", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -144,6 +144,7 @@ public enum Key {
     PORTAL_NEXT_THEME_CUSTOM_CSS("portal.next.theme.customCss", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_THEME_FONT_FAMILY("portal.next.theme.font.family", "\"Roboto\", sans-serif", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_CATALOG_VIEW_MODE("portal.next.catalog.viewMode", new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_MTLS_ENABLED("portal.next.feature.mtlsEnabled", new HashSet<>(singletonList(ENVIRONMENT))),
 
     MANAGEMENT_TITLE("management.title", "Gravitee.io Management", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     MANAGEMENT_URL("management.url", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
@@ -37,6 +37,9 @@ public class PortalNext {
     @ParameterKey(Key.PORTAL_NEXT_ACCESS_ENABLED)
     private Enabled access;
 
+    @ParameterKey(Key.PORTAL_NEXT_MTLS_ENABLED)
+    private Enabled mtls;
+
     private Banner banner;
 
     private Catalog catalog;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -53,6 +53,9 @@ public class ConfigurationMapper {
         configuration.setAccess(convert(portalNext.getAccess()));
         configuration.setBanner(convert(portalNext.getBanner()));
         configuration.setCatalog(convert(portalNext.getCatalog()));
+        if (portalNext.getMtls() != null) {
+            configuration.setMtls(convert(portalNext.getMtls()));
+        }
         return configuration;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalClientCertificateMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalClientCertificateMapper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.rest.api.portal.rest.model.CreatePortalClientCertificateInput;
+import io.gravitee.rest.api.portal.rest.model.PortalClientCertificate;
+import io.gravitee.rest.api.portal.rest.model.PortalClientCertificateStatus;
+import io.gravitee.rest.api.portal.rest.model.UpdatePortalClientCertificateInput;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper for converting between domain ClientCertificate and portal REST DTOs.
+ *
+ * @author GraviteeSource Team
+ */
+@Mapper(uses = DateMapper.class)
+public interface PortalClientCertificateMapper {
+    PortalClientCertificateMapper INSTANCE = Mappers.getMapper(PortalClientCertificateMapper.class);
+    PortalClientCertificate toDto(ClientCertificate domain);
+
+    List<PortalClientCertificate> toDto(List<ClientCertificate> domain);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "crossId", ignore = true)
+    @Mapping(target = "applicationId", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "certificateExpiration", ignore = true)
+    @Mapping(target = "subject", ignore = true)
+    @Mapping(target = "issuer", ignore = true)
+    @Mapping(target = "fingerprint", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    @Mapping(target = "status", ignore = true)
+    ClientCertificate toDomain(CreatePortalClientCertificateInput input);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "crossId", ignore = true)
+    @Mapping(target = "applicationId", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "certificate", ignore = true)
+    @Mapping(target = "certificateExpiration", ignore = true)
+    @Mapping(target = "subject", ignore = true)
+    @Mapping(target = "issuer", ignore = true)
+    @Mapping(target = "fingerprint", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    @Mapping(target = "status", ignore = true)
+    ClientCertificate toDomain(UpdatePortalClientCertificateInput input);
+
+    default PortalClientCertificateStatus toPortalStatus(ClientCertificateStatus status) {
+        if (status == null) return null;
+        return PortalClientCertificateStatus.fromValue(status.name());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
@@ -234,4 +234,9 @@ public class ApplicationResource extends AbstractResource {
     public ApplicationKeysResource getApplicationKeysResource() {
         return resourceContext.getResource(ApplicationKeysResource.class);
     }
+
+    @Path("certificates")
+    public PortalApplicationClientCertificatesResource getApplicationCertificatesResource() {
+        return resourceContext.getResource(PortalApplicationClientCertificatesResource.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificateResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificateResource.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertificateUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.portal.rest.mapper.PortalClientCertificateMapper;
+import io.gravitee.rest.api.portal.rest.model.PortalClientCertificate;
+import io.gravitee.rest.api.portal.rest.model.UpdatePortalClientCertificateInput;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import java.util.Optional;
+
+/**
+ * Resource for managing a single client certificate of an application via the portal API.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Application Client Certificates")
+public class PortalApplicationClientCertificateResource extends AbstractResource {
+
+    @Inject
+    private GetClientCertificateUseCase getClientCertificateUseCase;
+
+    @Inject
+    private UpdateClientCertificateUseCase updateClientCertificateUseCase;
+
+    @Inject
+    private DeleteClientCertificateUseCase deleteClientCertificateUseCase;
+
+    private final PortalClientCertificateMapper mapper = PortalClientCertificateMapper.INSTANCE;
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("applicationId")
+    @Parameter(name = "applicationId", hidden = true)
+    private String applicationId;
+
+    @PathParam("certId")
+    @Parameter(name = "certId", required = true, description = "Client certificate identifier")
+    private String certId;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "Get a client certificate",
+        description = "User must have the APPLICATION_DEFINITION[READ] permission to use this service"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Client certificate",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PortalClientCertificate.class))
+    )
+    @ApiResponse(responseCode = "403", description = "Forbidden")
+    @ApiResponse(responseCode = "404", description = "Client certificate not found")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
+    public Response getCertificate() {
+        var cert = getClientCertificateUseCase
+            .execute(new GetClientCertificateUseCase.Input(Optional.of(applicationId), certId))
+            .clientCertificate();
+        return Response.ok(mapper.toDto(cert)).build();
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "Update a client certificate",
+        description = "User must have the APPLICATION_DEFINITION[UPDATE] permission to use this service"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Updated client certificate",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PortalClientCertificate.class))
+    )
+    @ApiResponse(responseCode = "403", description = "Forbidden")
+    @ApiResponse(responseCode = "404", description = "Client certificate not found")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response updateCertificate(@Valid @NotNull final UpdatePortalClientCertificateInput input) {
+        var updated = updateClientCertificateUseCase
+            .execute(new UpdateClientCertificateUseCase.Input(Optional.of(applicationId), certId, mapper.toDomain(input)))
+            .clientCertificate();
+        return Response.ok(mapper.toDto(updated)).build();
+    }
+
+    @DELETE
+    @Operation(
+        summary = "Delete a client certificate",
+        description = "User must have the APPLICATION_DEFINITION[UPDATE] permission to use this service"
+    )
+    @ApiResponse(responseCode = "204", description = "Client certificate successfully deleted")
+    @ApiResponse(responseCode = "400", description = "Cannot delete last certificate with active mTLS subscriptions")
+    @ApiResponse(responseCode = "403", description = "Forbidden")
+    @ApiResponse(responseCode = "404", description = "Client certificate not found")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response deleteCertificate() {
+        // ClientCertificateLastRemovalException (HTTP 400) is mapped automatically by ManagementExceptionMapper
+        deleteClientCertificateUseCase.execute(new DeleteClientCertificateUseCase.Input(Optional.of(applicationId), certId));
+        return Response.noContent().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResource.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.portal.rest.mapper.PortalClientCertificateMapper;
+import io.gravitee.rest.api.portal.rest.model.CreatePortalClientCertificateInput;
+import io.gravitee.rest.api.portal.rest.model.PortalClientCertificate;
+import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resource for listing and creating client certificates of an application via the portal API.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag(name = "Application Client Certificates")
+public class PortalApplicationClientCertificatesResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private GetClientCertificatesUseCase getClientCertificatesUseCase;
+
+    @Inject
+    private CreateClientCertificateUseCase createClientCertificateUseCase;
+
+    private final PortalClientCertificateMapper mapper = PortalClientCertificateMapper.INSTANCE;
+
+    @PathParam("applicationId")
+    @Parameter(name = "applicationId", hidden = true)
+    private String applicationId;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "List client certificates for an application",
+        description = "User must have the APPLICATION_DEFINITION[READ] permission to use this service"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Paginated list of client certificates",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PortalClientCertificate.class))
+    )
+    @ApiResponse(responseCode = "403", description = "Forbidden")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
+    public Response listCertificates(@Valid @BeanParam PaginationParam paginationParam) {
+        var output = getClientCertificatesUseCase.execute(
+            new GetClientCertificatesUseCase.Input(applicationId, new PageableImpl(paginationParam.getPage(), paginationParam.getSize()))
+        );
+
+        List<PortalClientCertificate> certs = mapper.toDto(output.clientCertificates().getContent());
+
+        Map<String, Object> paginateMetadata = new HashMap<>();
+        paginateMetadata.put("totalElements", output.clientCertificates().getTotalElements());
+        Map<String, Map<String, Object>> metadata = new HashMap<>();
+        metadata.put("paginateMetaData", paginateMetadata);
+
+        return createListResponse(GraviteeContext.getExecutionContext(), certs, paginationParam, metadata);
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "Create a client certificate for an application",
+        description = "User must have the APPLICATION_DEFINITION[UPDATE] permission to use this service"
+    )
+    @ApiResponse(
+        responseCode = "201",
+        description = "Client certificate successfully created",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PortalClientCertificate.class))
+    )
+    @ApiResponse(responseCode = "403", description = "Forbidden")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response createCertificate(@Valid @NotNull final CreatePortalClientCertificateInput input) {
+        var created = createClientCertificateUseCase
+            .execute(new CreateClientCertificateUseCase.Input(applicationId, mapper.toDomain(input)))
+            .clientCertificate();
+        return Response.created(this.getLocationHeader(created.id())).entity(mapper.toDto(created)).build();
+    }
+
+    @Path("{certId}")
+    public PortalApplicationClientCertificateResource getCertificateResource() {
+        return resourceContext.getResource(PortalApplicationClientCertificateResource.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResource.java
@@ -17,7 +17,10 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.ValidateClientCertificateUseCase;
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.clientcertificate.ValidateCertificateRequest;
+import io.gravitee.rest.api.model.clientcertificate.ValidateCertificateResponse;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
@@ -67,6 +70,9 @@ public class PortalApplicationClientCertificatesResource extends AbstractResourc
 
     @Inject
     private CreateClientCertificateUseCase createClientCertificateUseCase;
+
+    @Inject
+    private ValidateClientCertificateUseCase validateClientCertificateUseCase;
 
     private final PortalClientCertificateMapper mapper = PortalClientCertificateMapper.INSTANCE;
 
@@ -123,6 +129,30 @@ public class PortalApplicationClientCertificatesResource extends AbstractResourc
             .execute(new CreateClientCertificateUseCase.Input(applicationId, mapper.toDomain(input)))
             .clientCertificate();
         return Response.created(this.getLocationHeader(created.id())).entity(mapper.toDto(created)).build();
+    }
+
+    @POST
+    @Path("_validate")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "Validate a PEM-encoded client certificate",
+        description = "Parses the certificate and returns its metadata without persisting it. User must have the APPLICATION_DEFINITION[READ] permission to use this service."
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Certificate is valid",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ValidateCertificateResponse.class))
+    )
+    @ApiResponse(responseCode = "400", description = "Certificate is invalid, empty, or is a CA certificate")
+    @ApiResponse(responseCode = "403", description = "Forbidden")
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
+    public Response validateCertificate(@Valid @NotNull final ValidateCertificateRequest request) {
+        var result = validateClientCertificateUseCase.execute(new ValidateClientCertificateUseCase.Input(request.certificate()));
+        var certificateInfo = result.certificateInfo();
+        return Response.ok(
+            new ValidateCertificateResponse(certificateInfo.certificateExpiration(), certificateInfo.subject(), certificateInfo.issuer())
+        ).build();
     }
 
     @Path("{certId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -1856,6 +1856,143 @@ paths:
                 500:
                     $ref: "#/components/responses/InternalServerError"
 
+    /applications/{applicationId}/certificates:
+        parameters:
+            - $ref: "#/components/parameters/applicationIdParam"
+        get:
+            tags:
+                - Application Client Certificates
+            parameters:
+                - $ref: "#/components/parameters/pageNumberParam"
+                - $ref: "#/components/parameters/pageSizeParam"
+            summary: List client certificates for an application
+            description: |
+                List all client certificates for an application.
+
+                User must have the APPLICATION_DEFINITION[READ] permission.
+            operationId: listApplicationCertificates
+            responses:
+                200:
+                    description: Paginated list of client certificates
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PortalClientCertificatesResponse"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                404:
+                    $ref: "#/components/responses/ApplicationNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+        post:
+            tags:
+                - Application Client Certificates
+            requestBody:
+                description: Use to create a client certificate.
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/CreatePortalClientCertificateInput"
+            summary: Create a client certificate for an application
+            description: |
+                Create a client certificate for an application.
+
+                User must have the APPLICATION_DEFINITION[UPDATE] permission.
+            operationId: createApplicationCertificate
+            responses:
+                201:
+                    description: Created client certificate
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PortalClientCertificate"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                404:
+                    $ref: "#/components/responses/ApplicationNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+    /applications/{applicationId}/certificates/{certId}:
+        parameters:
+            - $ref: "#/components/parameters/applicationIdParam"
+            - $ref: "#/components/parameters/certIdParam"
+        get:
+            tags:
+                - Application Client Certificates
+            summary: Get a client certificate
+            description: |
+                Get a client certificate by id.
+
+                User must have the APPLICATION_DEFINITION[READ] permission.
+            operationId: getApplicationCertificate
+            responses:
+                200:
+                    description: Client certificate
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PortalClientCertificate"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                404:
+                    $ref: "#/components/responses/ApplicationNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+        put:
+            tags:
+                - Application Client Certificates
+            requestBody:
+                description: Use to update a client certificate.
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/UpdatePortalClientCertificateInput"
+            summary: Update a client certificate
+            description: |
+                Update a client certificate.
+
+                User must have the APPLICATION_DEFINITION[UPDATE] permission.
+            operationId: updateApplicationCertificate
+            responses:
+                200:
+                    description: Updated client certificate
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PortalClientCertificate"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                404:
+                    $ref: "#/components/responses/ApplicationNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+        delete:
+            tags:
+                - Application Client Certificates
+            summary: Delete a client certificate
+            description: |
+                Delete a client certificate.
+
+                User must have the APPLICATION_DEFINITION[UPDATE] permission.
+            operationId: deleteApplicationCertificate
+            responses:
+                204:
+                    description: No-Content
+                400:
+                    description: Cannot delete last certificate with active mTLS subscriptions
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ErrorResponse"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                404:
+                    $ref: "#/components/responses/ApplicationNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+
     /groups:
         get:
             tags:
@@ -3374,6 +3511,13 @@ components:
             in: path
             required: true
             description: Id of a log.
+            schema:
+                type: string
+        certIdParam:
+            name: certId
+            in: path
+            required: true
+            description: Id of a client certificate.
             schema:
                 type: string
         memberIdParam:
@@ -6623,6 +6767,79 @@ components:
             enum:
                 - GRAVITEE_MARKDOWN
                 - OPENAPI
+
+        PortalClientCertificate:
+            type: object
+            properties:
+                id:
+                    type: string
+                name:
+                    type: string
+                status:
+                    $ref: "#/components/schemas/PortalClientCertificateStatus"
+                subject:
+                    type: string
+                issuer:
+                    type: string
+                fingerprint:
+                    type: string
+                createdAt:
+                    type: string
+                    format: date-time
+                startsAt:
+                    type: string
+                    format: date-time
+                endsAt:
+                    type: string
+                    format: date-time
+        PortalClientCertificateStatus:
+            type: string
+            description: Status of a client certificate.
+            enum:
+                - ACTIVE
+                - ACTIVE_WITH_END
+                - SCHEDULED
+                - REVOKED
+        CreatePortalClientCertificateInput:
+            type: object
+            required:
+                - name
+                - certificate
+            properties:
+                name:
+                    type: string
+                certificate:
+                    type: string
+                    description: PEM-encoded certificate
+                startsAt:
+                    type: string
+                    format: date-time
+                endsAt:
+                    type: string
+                    format: date-time
+        UpdatePortalClientCertificateInput:
+            type: object
+            properties:
+                name:
+                    type: string
+                startsAt:
+                    type: string
+                    format: date-time
+                endsAt:
+                    type: string
+                    format: date-time
+        PortalClientCertificatesResponse:
+            type: object
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/PortalClientCertificate"
+                metadata:
+                    type: object
+                    additionalProperties: true
+                links:
+                    $ref: "#/components/schemas/Links"
 
     responses:
         InternalServerError:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -5601,6 +5601,8 @@ components:
                     $ref: "#/components/schemas/Enabled"
                 catalog:
                     $ref: "#/components/schemas/ConfigurationPortalNextCatalog"
+                mtls:
+                    $ref: "#/components/schemas/Enabled"
         ConfigurationPortalNextBanner:
             type: object
             description: Configuration of the banner for Portal Next

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -1913,6 +1913,40 @@ paths:
                     $ref: "#/components/responses/ApplicationNotFoundError"
                 500:
                     $ref: "#/components/responses/InternalServerError"
+    /applications/{applicationId}/certificates/_validate:
+        parameters:
+            - $ref: "#/components/parameters/applicationIdParam"
+        post:
+            tags:
+                - Application Client Certificates
+            requestBody:
+                description: Use to validate a client certificate.
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ValidateCertificateRequest"
+            summary: Validate a PEM-encoded client certificate
+            description: |
+                Parses the certificate and returns its metadata without persisting it.
+
+                User must have the APPLICATION_DEFINITION[READ] permission.
+            operationId: validateApplicationCertificate
+            responses:
+                200:
+                    description: Certificate is valid
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ValidateCertificateResponse"
+                400:
+                    $ref: "#/components/responses/BadRequestError"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                404:
+                    $ref: "#/components/responses/ApplicationNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
     /applications/{applicationId}/certificates/{certId}:
         parameters:
             - $ref: "#/components/parameters/applicationIdParam"
@@ -6770,6 +6804,27 @@ components:
                 - GRAVITEE_MARKDOWN
                 - OPENAPI
 
+        ValidateCertificateRequest:
+            type: object
+            required:
+                - certificate
+            properties:
+                certificate:
+                    type: string
+                    description: The certificate in PEM format to validate.
+        ValidateCertificateResponse:
+            type: object
+            properties:
+                certificateExpiration:
+                    type: string
+                    format: date-time
+                    description: Expiration date extracted from the certificate.
+                subject:
+                    type: string
+                    description: Subject of the certificate.
+                issuer:
+                    type: string
+                    description: Issuer of the certificate.
         PortalClientCertificate:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
@@ -190,4 +190,24 @@ public class ConfigurationMapperTest {
         String configurationAsJSON = mapper.writeValueAsString(configuration);
         assertEquals(mapper.readTree(expected), mapper.readTree(configurationAsJSON));
     }
+
+    @Test
+    public void convertPortalNextShouldMapMtlsEnabled() {
+        PortalNext portalNext = new PortalNext();
+        portalNext.setAccess(new Enabled(false));
+
+        portalNext.setMtls(new Enabled(true));
+        ConfigurationPortalNext result = configurationMapper.convert(portalNext);
+        Assertions.assertNotNull(result.getMtls());
+        Assertions.assertEquals(Boolean.TRUE, result.getMtls().getEnabled());
+
+        portalNext.setMtls(new Enabled(false));
+        result = configurationMapper.convert(portalNext);
+        Assertions.assertNotNull(result.getMtls());
+        Assertions.assertEquals(Boolean.FALSE, result.getMtls().getEnabled());
+
+        portalNext.setMtls(null);
+        result = configurationMapper.convert(portalNext);
+        Assertions.assertNull(result.getMtls());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertif
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.ValidateClientCertificateUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.rest.api.portal.rest.JerseySpringTest;
@@ -137,6 +138,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected DeleteClientCertificateUseCase deleteClientCertificateUseCase;
+
+    @Autowired
+    protected ValidateClientCertificateUseCase validateClientCertificateUseCase;
 
     @Autowired
     protected CustomUserFieldService customUserFieldService;
@@ -371,6 +375,7 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
             createClientCertificateUseCase,
             updateClientCertificateUseCase,
             deleteClientCertificateUseCase,
+            validateClientCertificateUseCase,
             apiService,
             apiSearchService,
             apiAuthorizationService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
@@ -17,6 +17,11 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.mockito.Mockito.reset;
 
+import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertificateUseCase;
 import io.gravitee.apim.core.subscription.use_case.CreateSubscriptionUseCase;
 import io.gravitee.apim.core.subscription_form.domain_service.SubscriptionFormSchemaGenerator;
 import io.gravitee.rest.api.portal.rest.JerseySpringTest;
@@ -117,6 +122,21 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected CreateSubscriptionUseCase createSubscriptionUseCase;
+
+    @Autowired
+    protected GetClientCertificatesUseCase getClientCertificatesUseCase;
+
+    @Autowired
+    protected GetClientCertificateUseCase getClientCertificateUseCase;
+
+    @Autowired
+    protected CreateClientCertificateUseCase createClientCertificateUseCase;
+
+    @Autowired
+    protected UpdateClientCertificateUseCase updateClientCertificateUseCase;
+
+    @Autowired
+    protected DeleteClientCertificateUseCase deleteClientCertificateUseCase;
 
     @Autowired
     protected CustomUserFieldService customUserFieldService;
@@ -346,6 +366,11 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     protected void resetAllMocks() {
         reset(
             createSubscriptionUseCase,
+            getClientCertificatesUseCase,
+            getClientCertificateUseCase,
+            createClientCertificateUseCase,
+            updateClientCertificateUseCase,
+            deleteClientCertificateUseCase,
             apiService,
             apiSearchService,
             apiAuthorizationService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificateResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificateResourceTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertificateUseCase;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.portal.rest.model.PortalClientCertificate;
+import io.gravitee.rest.api.portal.rest.model.UpdatePortalClientCertificateInput;
+import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import java.util.Date;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PortalApplicationClientCertificateResourceTest extends AbstractResourceTest {
+
+    private static final String APPLICATION_ID = "my-application";
+    private static final String CERT_ID = "my-cert-id";
+
+    @Override
+    protected String contextPath() {
+        return "applications/" + APPLICATION_ID + "/certificates/" + CERT_ID;
+    }
+
+    @BeforeEach
+    public void init() {
+        resetAllMocks();
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+    }
+
+    @Test
+    public void should_get_client_certificate() {
+        var certificate = createClientCertificate(CERT_ID, "My Certificate");
+
+        when(getClientCertificateUseCase.execute(any(GetClientCertificateUseCase.Input.class))).thenReturn(
+            new GetClientCertificateUseCase.Output(certificate)
+        );
+
+        final Response response = target().request().get();
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            var result = response.readEntity(PortalClientCertificate.class);
+            soft.assertThat(result.getId()).isEqualTo(CERT_ID);
+            soft.assertThat(result.getName()).isEqualTo("My Certificate");
+        });
+        verify(getClientCertificateUseCase).execute(any(GetClientCertificateUseCase.Input.class));
+    }
+
+    @Test
+    public void should_return_404_when_certificate_not_found() {
+        when(getClientCertificateUseCase.execute(any(GetClientCertificateUseCase.Input.class))).thenThrow(
+            new ClientCertificateNotFoundException(CERT_ID)
+        );
+
+        final Response response = target().request().get();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+    }
+
+    @Test
+    public void should_update_client_certificate() {
+        var updateRequest = new UpdatePortalClientCertificateInput();
+        updateRequest.setName("Updated Certificate Name");
+
+        ClientCertificate updated = createClientCertificate(CERT_ID, "Updated Certificate Name");
+
+        when(updateClientCertificateUseCase.execute(any(UpdateClientCertificateUseCase.Input.class))).thenReturn(
+            new UpdateClientCertificateUseCase.Output(updated)
+        );
+
+        final Response response = target().request().put(Entity.json(updateRequest));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            var result = response.readEntity(PortalClientCertificate.class);
+            soft.assertThat(result.getName()).isEqualTo("Updated Certificate Name");
+        });
+        verify(updateClientCertificateUseCase).execute(any(UpdateClientCertificateUseCase.Input.class));
+    }
+
+    @Test
+    public void should_return_404_when_updating_non_existent_certificate() {
+        var updateRequest = new UpdatePortalClientCertificateInput();
+        updateRequest.setName("Updated Certificate Name");
+
+        when(updateClientCertificateUseCase.execute(any(UpdateClientCertificateUseCase.Input.class))).thenThrow(
+            new ClientCertificateNotFoundException(CERT_ID)
+        );
+
+        final Response response = target().request().put(Entity.json(updateRequest));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+    }
+
+    @Test
+    public void should_delete_client_certificate() {
+        doNothing().when(deleteClientCertificateUseCase).execute(any(DeleteClientCertificateUseCase.Input.class));
+
+        final Response response = target().request().delete();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NO_CONTENT_204);
+        verify(deleteClientCertificateUseCase).execute(any(DeleteClientCertificateUseCase.Input.class));
+    }
+
+    @Test
+    public void should_return_404_when_deleting_non_existent_certificate() {
+        doThrow(new ClientCertificateNotFoundException(CERT_ID))
+            .when(deleteClientCertificateUseCase)
+            .execute(any(DeleteClientCertificateUseCase.Input.class));
+
+        final Response response = target().request().delete();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+    }
+
+    private ClientCertificate createClientCertificate(String id, String name) {
+        return new ClientCertificate(
+            id,
+            null,
+            APPLICATION_ID,
+            name,
+            null,
+            null,
+            new Date(),
+            new Date(),
+            "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpE...\n-----END CERTIFICATE-----",
+            null,
+            null,
+            null,
+            null,
+            null,
+            ClientCertificateStatus.ACTIVE
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResourceTest.java
@@ -20,12 +20,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService.CertificateInfo;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
 import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.ValidateClientCertificateUseCase;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.clientcertificate.ValidateCertificateRequest;
+import io.gravitee.rest.api.model.clientcertificate.ValidateCertificateResponse;
 import io.gravitee.rest.api.portal.rest.model.CreatePortalClientCertificateInput;
 import io.gravitee.rest.api.portal.rest.model.PortalClientCertificate;
 import io.gravitee.rest.api.portal.rest.model.PortalClientCertificatesResponse;
@@ -113,6 +117,34 @@ public class PortalApplicationClientCertificatesResourceTest extends AbstractRes
         createRequest.setName("My Certificate");
 
         final Response response = target().request().post(Entity.json(createRequest));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+    }
+
+    @Test
+    public void should_validate_certificate_and_return_metadata() {
+        var expiration = new Date();
+        var certInfo = new CertificateInfo(expiration, "CN=test", "CN=ca", "abc123");
+        when(validateClientCertificateUseCase.execute(any(ValidateClientCertificateUseCase.Input.class))).thenReturn(
+            new ValidateClientCertificateUseCase.Output(certInfo)
+        );
+
+        var request = new ValidateCertificateRequest("-----BEGIN CERTIFICATE-----\nMIIBkTCB...\n-----END CERTIFICATE-----");
+        final Response response = target("/_validate").request().post(Entity.json(request));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            var result = response.readEntity(ValidateCertificateResponse.class);
+            soft.assertThat(result.certificateExpiration()).isEqualTo(expiration);
+            soft.assertThat(result.subject()).isEqualTo("CN=test");
+            soft.assertThat(result.issuer()).isEqualTo("CN=ca");
+        });
+        verify(validateClientCertificateUseCase).execute(any(ValidateClientCertificateUseCase.Input.class));
+    }
+
+    @Test
+    public void should_return_400_when_certificate_is_missing_in_validate_request() {
+        final Response response = target("/_validate").request().post(Entity.json("{}"));
 
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalApplicationClientCertificatesResourceTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.apim.core.application_certificate.model.ClientCertificateStatus;
+import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.portal.rest.model.CreatePortalClientCertificateInput;
+import io.gravitee.rest.api.portal.rest.model.PortalClientCertificate;
+import io.gravitee.rest.api.portal.rest.model.PortalClientCertificatesResponse;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import java.util.Date;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PortalApplicationClientCertificatesResourceTest extends AbstractResourceTest {
+
+    private static final String APPLICATION_ID = "my-application";
+
+    @Override
+    protected String contextPath() {
+        return "applications/" + APPLICATION_ID + "/certificates";
+    }
+
+    @BeforeEach
+    public void init() {
+        resetAllMocks();
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+    }
+
+    @Test
+    public void should_list_client_certificates() {
+        ClientCertificate cert1 = createClientCertificate("cert-1", "Certificate 1");
+        ClientCertificate cert2 = createClientCertificate("cert-2", "Certificate 2");
+        Page<ClientCertificate> page = new Page<>(List.of(cert1, cert2), 1, 2, 2);
+
+        when(getClientCertificatesUseCase.execute(any(GetClientCertificatesUseCase.Input.class))).thenReturn(
+            new GetClientCertificatesUseCase.Output(page)
+        );
+
+        final Response response = target().request().get();
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            var result = response.readEntity(PortalClientCertificatesResponse.class);
+            soft.assertThat(result.getData()).hasSize(2);
+            soft.assertThat(result.getData().get(0).getId()).isEqualTo("cert-1");
+        });
+        verify(getClientCertificatesUseCase).execute(any(GetClientCertificatesUseCase.Input.class));
+    }
+
+    @Test
+    public void should_create_client_certificate() {
+        var createRequest = new CreatePortalClientCertificateInput();
+        createRequest.setName("My Certificate");
+        createRequest.setCertificate("-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpE...\n-----END CERTIFICATE-----");
+
+        ClientCertificate created = createClientCertificate("new-cert-id", "My Certificate");
+
+        when(createClientCertificateUseCase.execute(any(CreateClientCertificateUseCase.Input.class))).thenReturn(
+            new CreateClientCertificateUseCase.Output(created)
+        );
+
+        final Response response = target().request().post(Entity.json(createRequest));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(response.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+            soft.assertThat(response.getHeaderString("Location")).contains("new-cert-id");
+            var result = response.readEntity(PortalClientCertificate.class);
+            soft.assertThat(result.getId()).isEqualTo("new-cert-id");
+            soft.assertThat(result.getName()).isEqualTo("My Certificate");
+        });
+        verify(createClientCertificateUseCase).execute(any(CreateClientCertificateUseCase.Input.class));
+    }
+
+    @Test
+    public void should_not_create_client_certificate_without_name() {
+        var createRequest = new CreatePortalClientCertificateInput();
+        createRequest.setCertificate("-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpE...\n-----END CERTIFICATE-----");
+
+        final Response response = target().request().post(Entity.json(createRequest));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+    }
+
+    @Test
+    public void should_not_create_client_certificate_without_certificate() {
+        var createRequest = new CreatePortalClientCertificateInput();
+        createRequest.setName("My Certificate");
+
+        final Response response = target().request().post(Entity.json(createRequest));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+    }
+
+    private ClientCertificate createClientCertificate(String id, String name) {
+        return new ClientCertificate(
+            id,
+            null,
+            APPLICATION_ID,
+            name,
+            null,
+            null,
+            new Date(),
+            new Date(),
+            "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpE...\n-----END CERTIFICATE-----",
+            null,
+            null,
+            null,
+            null,
+            null,
+            ClientCertificateStatus.ACTIVE
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -69,6 +69,7 @@ import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertif
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
 import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.ValidateClientCertificateUseCase;
 import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
 import io.gravitee.apim.core.audit.query_service.AuditMetadataQueryService;
 import io.gravitee.apim.core.audit.query_service.AuditQueryService;
@@ -1248,6 +1249,11 @@ public class ResourceContextConfiguration {
     @Bean
     public DeleteClientCertificateUseCase deleteClientCertificateUseCase() {
         return mock(DeleteClientCertificateUseCase.class);
+    }
+
+    @Bean
+    public ValidateClientCertificateUseCase validateClientCertificateUseCase() {
+        return mock(ValidateClientCertificateUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -64,6 +64,11 @@ import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
+import io.gravitee.apim.core.application_certificate.use_case.CreateClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.DeleteClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificateUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.GetClientCertificatesUseCase;
+import io.gravitee.apim.core.application_certificate.use_case.UpdateClientCertificateUseCase;
 import io.gravitee.apim.core.audit.domain_service.SearchAuditDomainService;
 import io.gravitee.apim.core.audit.query_service.AuditMetadataQueryService;
 import io.gravitee.apim.core.audit.query_service.AuditQueryService;
@@ -1218,6 +1223,31 @@ public class ResourceContextConfiguration {
     @Bean
     public ClientCertificateValidationDomainService clientCertificateValidationDomainService() {
         return mock(ClientCertificateValidationDomainService.class);
+    }
+
+    @Bean
+    public GetClientCertificatesUseCase getClientCertificatesUseCase() {
+        return mock(GetClientCertificatesUseCase.class);
+    }
+
+    @Bean
+    public GetClientCertificateUseCase getClientCertificateUseCase() {
+        return mock(GetClientCertificateUseCase.class);
+    }
+
+    @Bean
+    public CreateClientCertificateUseCase createClientCertificateUseCase() {
+        return mock(CreateClientCertificateUseCase.class);
+    }
+
+    @Bean
+    public UpdateClientCertificateUseCase updateClientCertificateUseCase() {
+        return mock(UpdateClientCertificateUseCase.class);
+    }
+
+    @Bean
+    public DeleteClientCertificateUseCase deleteClientCertificateUseCase() {
+        return mock(DeleteClientCertificateUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCase.java
@@ -19,6 +19,8 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -30,10 +32,17 @@ public class DeleteClientCertificateUseCase {
 
     public void execute(Input input) {
         ClientCertificate certificate = clientCertificateCrudService.findById(input.clientCertificateId());
+        if (input.applicationId().isPresent() && !input.applicationId().get().equals(certificate.applicationId())) {
+            throw new ClientCertificateNotFoundException(input.clientCertificateId());
+        }
         applicationCertificatesUpdateDomainService.validateCertificateRemoval(certificate.applicationId(), input.clientCertificateId());
         clientCertificateCrudService.delete(input.clientCertificateId());
         applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(certificate.applicationId());
     }
 
-    public record Input(String clientCertificateId) {}
+    public record Input(Optional<String> applicationId, String clientCertificateId) {
+        public Input(String clientCertificateId) {
+            this(Optional.empty(), clientCertificateId);
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/GetClientCertificateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/GetClientCertificateUseCase.java
@@ -18,6 +18,8 @@ package io.gravitee.apim.core.application_certificate.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -28,10 +30,17 @@ public class GetClientCertificateUseCase {
 
     public Output execute(Input input) {
         ClientCertificate certificate = clientCertificateCrudService.findById(input.clientCertificateId());
+        if (input.applicationId().isPresent() && !input.applicationId().get().equals(certificate.applicationId())) {
+            throw new ClientCertificateNotFoundException(input.clientCertificateId());
+        }
         return new Output(certificate);
     }
 
-    public record Input(String clientCertificateId) {}
+    public record Input(Optional<String> applicationId, String clientCertificateId) {
+        public Input(String clientCertificateId) {
+            this(Optional.empty(), clientCertificateId);
+        }
+    }
 
     public record Output(ClientCertificate clientCertificate) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCase.java
@@ -19,6 +19,8 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.domain_service.ApplicationCertificatesUpdateDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
+import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -29,12 +31,22 @@ public class UpdateClientCertificateUseCase {
     private final ApplicationCertificatesUpdateDomainService applicationCertificatesUpdateDomainService;
 
     public Output execute(Input input) {
+        if (input.applicationId().isPresent()) {
+            ClientCertificate existing = clientCertificateCrudService.findById(input.clientCertificateId());
+            if (!input.applicationId().get().equals(existing.applicationId())) {
+                throw new ClientCertificateNotFoundException(input.clientCertificateId());
+            }
+        }
         ClientCertificate certificate = clientCertificateCrudService.update(input.clientCertificateId(), input.toUpdate());
         applicationCertificatesUpdateDomainService.updateActiveMTLSSubscriptions(certificate.applicationId());
         return new Output(certificate);
     }
 
-    public record Input(String clientCertificateId, ClientCertificate toUpdate) {}
+    public record Input(Optional<String> applicationId, String clientCertificateId, ClientCertificate toUpdate) {
+        public Input(String clientCertificateId, ClientCertificate toUpdate) {
+            this(Optional.empty(), clientCertificateId, toUpdate);
+        }
+    }
 
     public record Output(ClientCertificate clientCertificate) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/DeleteClientCertificateUseCaseTest.java
@@ -30,6 +30,7 @@ import io.gravitee.rest.api.service.exceptions.ClientCertificateLastRemovalExcep
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -129,5 +130,35 @@ class DeleteClientCertificateUseCaseTest {
         var input = new DeleteClientCertificateUseCase.Input("non-existent-id");
 
         assertThatThrownBy(() -> deleteClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_exception_when_applicationId_does_not_match() {
+        var certId = "cert-id";
+        var appId = "app-id";
+        var certificate = new ClientCertificate(
+            certId,
+            "cross-id",
+            appId,
+            "Test Certificate",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            new Date(),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
+        clientCertificateCrudService.initWith(List.of(certificate));
+
+        var input = new DeleteClientCertificateUseCase.Input(Optional.of("other-app-id"), certId);
+
+        assertThatThrownBy(() -> deleteClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateNotFoundException.class);
+
+        assertThat(clientCertificateCrudService.storage()).hasSize(1);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/GetClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/GetClientCertificateUseCaseTest.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.application_certificate.model.ClientCertificateStat
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,5 +73,59 @@ class GetClientCertificateUseCaseTest {
         var input = new GetClientCertificateUseCase.Input("non-existent-id");
 
         assertThatThrownBy(() -> getClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_exception_when_applicationId_does_not_match() {
+        var certId = "cert-id";
+        var certificate = new ClientCertificate(
+            certId,
+            "cross-id",
+            "app-id",
+            "Test Certificate",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            new Date(),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
+        clientCertificateCrudService.initWith(List.of(certificate));
+
+        var input = new GetClientCertificateUseCase.Input(Optional.of("other-app-id"), certId);
+
+        assertThatThrownBy(() -> getClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateNotFoundException.class);
+    }
+
+    @Test
+    void should_return_certificate_when_applicationId_matches() {
+        var certId = "cert-id";
+        var certificate = new ClientCertificate(
+            certId,
+            "cross-id",
+            "app-id",
+            "Test Certificate",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            new Date(),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
+        clientCertificateCrudService.initWith(List.of(certificate));
+
+        var result = getClientCertificateUseCase.execute(new GetClientCertificateUseCase.Input(Optional.of("app-id"), certId));
+
+        assertThat(result.clientCertificate().id()).isEqualTo(certId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application_certificate/use_case/UpdateClientCertificateUseCaseTest.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.application_certificate.model.ClientCertificateStat
 import io.gravitee.rest.api.service.exceptions.ClientCertificateNotFoundException;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,6 +91,34 @@ class UpdateClientCertificateUseCaseTest {
         var updateRequest = new ClientCertificate("Updated Name", new Date(), new Date());
 
         var input = new UpdateClientCertificateUseCase.Input("non-existent-id", updateRequest);
+
+        assertThatThrownBy(() -> updateClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_exception_when_applicationId_does_not_match() {
+        var certId = "cert-id";
+        var certificate = new ClientCertificate(
+            certId,
+            "cross-id",
+            "app-id",
+            "Original Name",
+            new Date(),
+            new Date(),
+            new Date(),
+            new Date(),
+            "PEM_CONTENT",
+            new Date(),
+            "CN=Test",
+            "CN=Issuer",
+            "fingerprint",
+            "env-id",
+            ClientCertificateStatus.ACTIVE
+        );
+        clientCertificateCrudService.initWith(List.of(certificate));
+
+        var updateRequest = new ClientCertificate("Updated Name", new Date(), new Date());
+        var input = new UpdateClientCertificateUseCase.Input(Optional.of("other-app-id"), certId, updateRequest);
 
         assertThatThrownBy(() -> updateClientCertificateUseCase.execute(input)).isInstanceOf(ClientCertificateNotFoundException.class);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ApplicationCertificatesUpdateDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/application_certificates/ApplicationCertificatesUpdateDomainServiceImplTest.java
@@ -223,29 +223,6 @@ class ApplicationCertificatesUpdateDomainServiceImplTest {
     }
 
     @Test
-    void should_clear_certificate_when_no_active_certificates() {
-        // Given: an mTLS plan
-        Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());
-        planCrudService.initWith(List.of(mtlsPlan));
-
-        String existingEncodedCert = Base64.getEncoder().encodeToString(PEM_CERTIFICATE_1.getBytes(StandardCharsets.UTF_8));
-        SubscriptionEntity subscription = buildSubscription(SUBSCRIPTION_ID, APPLICATION_ID, PLAN_ID, existingEncodedCert);
-        subscriptionCrudService.initWith(List.of(subscription));
-
-        // No active certificates (only revoked)
-        ClientCertificate revokedCertificate = buildClientCertificate("cert-1", ClientCertificateStatus.REVOKED, PEM_CERTIFICATE_1);
-        clientCertificateCrudService.initWith(List.of(revokedCertificate));
-
-        // When
-        service.updateActiveMTLSSubscriptions(APPLICATION_ID);
-
-        // Then: subscription should be updated with empty string
-        SubscriptionEntity result = subscriptionCrudService.get(SUBSCRIPTION_ID);
-        assertThat(result.getClientCertificate()).isEmpty();
-        assertThat(result.getCreatedAt()).isNotEqualTo(result.getUpdatedAt());
-    }
-
-    @Test
     void should_update_ActiveMTLSSubscriptions_multiple_subscriptions() {
         // Given: an mTLS plan
         Plan mtlsPlan = buildPlan(PlanSecurityType.MTLS.name());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13089

## Description

Backport of Self-Service mTLS Certificate Management (APIM-13089) to 4.11.x.

- **APIM-13259** — Added portal-next certificates tab to application settings and papi endpoints (`GET`/`POST`/`DELETE /applications/{id}/certificates/{certId}`)
- **APIM-13260** — Added 3-step certificate upload dialog (upload → configure grace period → confirm) with pre-flight validation against the papi endpoint before step 2
- **APIM-13258** — Added per-environment mTLS feature toggle to portal-next configuration (papi + console settings UI); certificates section is conditionally shown based on toggle and existing certificate presence
- **APIM-13262** — Added deletion confirmation dialogs with last-certificate warning; backend guard (`validateCertificateRemoval`) prevents removing the final active certificate on a live mTLS subscription
- **APIM-13502** — Fixed: uploading a second certificate was overwriting the name of the previous one; `activeCertificateName` is now included in update payloads

## Additional context

- Cherry-picked from `master` (9 commits: `b36f7fd5`…`15838d08`).
- One conflict resolved in `DeleteClientCertificateUseCase` / `ApplicationCertificatesUpdateDomainServiceImpl`: ownership check from 4.11.x preserved alongside the new `validateCertificateRemoval` guard; early-return behavior adopted (safe because the guard prevents reaching that code path with no
  certs).