### PR TITLE
test: fix flaky tests

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/vertx/DebugHttpProtocolVerticleTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/vertx/DebugHttpProtocolVerticleTest.java
@@ -36,7 +36,6 @@ import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import io.vertx.rxjava3.core.http.HttpServer;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -82,7 +81,6 @@ class DebugHttpProtocolVerticleTest {
     @DisplayName("Check that the verticle is still there")
     void lastChecks(Vertx vertx) {
         assertThat(vertx.deploymentIDs()).isNotEmpty().hasSize(1);
-        vertxHttpServer.instances().forEach(HttpServer::close);
     }
 
     @Test


### PR DESCRIPTION
## Description

Root cause by CircleCI agent:
The @AfterEach method in DebugHttpProtocolVerticleTest called vertxHttpServer.instances().forEach(HttpServer::close) after each test. In Vert.x 5, HttpServer::close is asynchronous (fire-and-forget), which created a race condition: the server's connection pool was being closed while the http_server_should_listen test's HttpClient still had an in- flight request, resulting in io.vertx.core.VertxException: Pool closed.

Fix approach:
Removed the manual vertxHttpServer.instances().forEach(HttpServer::close) call from @AfterEach. The verticle's rxStop() method already handles server shutdown correctly when the Vert.x extension undeploys the verticle during test teardown. The manual close was redundant and conflicted with the normal Vert.x lifecycle cleanup.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

