### PR TITLE
refactor(portal): simplify certificate handling and remove unused code

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.html
@@ -58,7 +58,7 @@
               <p class="next-gen-body" i18n="@@applicationTypeApplicationSettings">Application type</p>
               <mat-form-field appearance="outline">
                 <input matInput formControlName="appType" aria-label="Application type" data-testId="simple-type" />
-                <mat-hint i18n="@@hintApplicationTypeApplicationSettings">Type of the application (mobile, web, ...)</mat-hint>
+                <mat-hint i18n="@@hintApplicationTypeApplicationSettings">Type of the application (mobile, web, ...) </mat-hint>
               </mat-form-field>
             </div>
             <div class="settings-edit__form__field">
@@ -66,8 +66,8 @@
               <mat-form-field appearance="outline">
                 <input matInput formControlName="appClientId" aria-label="Client ID" data-testId="simple-clientId" />
                 <mat-hint i18n="@@hintClientIdApplicationSettings"
-                  >This field is required to subscribe to certain types of API Plan (OAuth2, JWT)</mat-hint
-                >
+                  >This field is required to subscribe to certain types of API Plan (OAuth2, JWT)
+                </mat-hint>
               </mat-form-field>
             </div>
           } @else if (application.settings.oauth) {
@@ -110,9 +110,9 @@
                     />
                   </mat-chip-grid>
                   <mat-hint i18n="@@hintRedirectUrisApplicationSettings"
-                    >URIs where the authorization server will send OAuth responses</mat-hint
-                  >
-                  <mat-error i18n="@@redirectUrisRequiredApplicationSettings">At least one redirect URI is required</mat-error>
+                    >URIs where the authorization server will send OAuth responses
+                  </mat-hint>
+                  <mat-error i18n="@@redirectUrisRequiredApplicationSettings">At least one redirect URI is required </mat-error>
                 </mat-form-field>
               </div>
             }
@@ -121,27 +121,23 @@
               <mat-form-field appearance="outline">
                 <mat-select formControlName="oauthGrantTypes" multiple aria-label="Grant types" data-testId="grantTypes">
                   @for (grantType of grantTypesList; track grantType) {
-                    <mat-option [value]="grantType.type" [disabled]="grantType.isDisabled">{{ grantType.name }}</mat-option>
+                    <mat-option [value]="grantType.type" [disabled]="grantType.isDisabled">{{ grantType.name }} </mat-option>
                   }
                 </mat-select>
                 <mat-hint i18n="@@hintGrantTypesApplicationSettings"
-                  >Grant types allowed for the client. Please set only grant types you need for security reasons</mat-hint
-                >
-                <mat-error i18n="@@grantTypesRequiredApplicationSettings">At least one grant type is required</mat-error>
+                  >Grant types allowed for the client. Please set only grant types you need for security reasons
+                </mat-hint>
+                <mat-error i18n="@@grantTypesRequiredApplicationSettings">At least one grant type is required </mat-error>
               </mat-form-field>
             </div>
           }
         </div>
 
         @if (mtlsEnabled) {
-          @if (certificates.isLoading()) {
-            <app-loader />
-          } @else if (showCertificates()) {
-            <app-application-tab-settings-certificates
-              [applicationId]="applicationId()"
-              [userApplicationPermissions]="userApplicationPermissions()"
-            />
-          }
+          <app-application-tab-settings-certificates
+            [applicationId]="applicationId()"
+            [userApplicationPermissions]="userApplicationPermissions()"
+          />
         }
 
         <div class="settings-edit__form__actions">

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.spec.ts
@@ -16,7 +16,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
-import { of, Subject, throwError } from 'rxjs';
+import { of } from 'rxjs';
 
 import { ApplicationTabSettingsEditComponent } from './application-tab-settings-edit.component';
 import { fakeApplication, fakeSimpleApplicationType } from '../../../../../entities/application/application.fixture';
@@ -29,14 +29,13 @@ describe('ApplicationTabSettingsEditComponent', () => {
   const APPLICATION_ID = 'test-app-id';
   let fixture: ComponentFixture<ApplicationTabSettingsEditComponent>;
   let component: ApplicationTabSettingsEditComponent;
-  const mockList = jest.fn();
 
   async function init(configuration: object) {
     await TestBed.configureTestingModule({
       imports: [ApplicationTabSettingsEditComponent, NoopAnimationsModule],
       providers: [
         { provide: ConfigService, useValue: { configuration } },
-        { provide: ApplicationCertificateService, useValue: { list: mockList } },
+        { provide: ApplicationCertificateService, useValue: { list: jest.fn().mockReturnValue(of({ data: [] })) } },
         { provide: ApplicationService, useValue: { get: () => of(fakeApplication()), save: jest.fn() } },
         { provide: Router, useValue: { url: '/', navigate: jest.fn() } },
       ],
@@ -51,33 +50,8 @@ describe('ApplicationTabSettingsEditComponent', () => {
     await fixture.whenStable();
   }
 
-  async function initForLoadingState() {
-    await TestBed.configureTestingModule({
-      imports: [ApplicationTabSettingsEditComponent, NoopAnimationsModule],
-      providers: [
-        { provide: ConfigService, useValue: { configuration: { portalNext: { mtls: { enabled: true } } } } },
-        { provide: ApplicationCertificateService, useValue: { list: mockList } },
-        { provide: ApplicationService, useValue: { get: () => of(fakeApplication()), save: jest.fn() } },
-        { provide: Router, useValue: { url: '/', navigate: jest.fn() } },
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(ApplicationTabSettingsEditComponent);
-    component = fixture.componentInstance;
-    fixture.componentRef.setInput('applicationId', APPLICATION_ID);
-    fixture.componentRef.setInput('applicationTypeConfiguration', fakeSimpleApplicationType());
-    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions());
-    // Do NOT call whenStable() — rxResource with a never-emitting Subject keeps the zone unstable
-    fixture.detectChanges();
-  }
-
-  beforeEach(() => {
-    mockList.mockReset();
-  });
-
   describe('mtlsEnabled', () => {
     it('should return true when mtls is enabled', async () => {
-      mockList.mockReturnValue(of({}));
       await init({ portalNext: { mtls: { enabled: true } } });
 
       expect((component as unknown as { mtlsEnabled: boolean }).mtlsEnabled).toBe(true);
@@ -93,58 +67,6 @@ describe('ApplicationTabSettingsEditComponent', () => {
       await init({});
 
       expect((component as unknown as { mtlsEnabled: boolean }).mtlsEnabled).toBe(false);
-    });
-  });
-
-  describe('certificates', () => {
-    it('should not call certService.list when mtls is disabled', async () => {
-      await init({});
-
-      expect(mockList).not.toHaveBeenCalled();
-    });
-
-    it('should call certService.list with applicationId when mtls is enabled', async () => {
-      mockList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 0 } } }));
-      await init({ portalNext: { mtls: { enabled: true } } });
-
-      expect(mockList).toHaveBeenCalledWith(APPLICATION_ID, 1, 1);
-    });
-  });
-
-  describe('showCertificates', () => {
-    it('should return false when mtls is disabled', async () => {
-      await init({});
-
-      expect(component.showCertificates()).toBe(false);
-    });
-
-    it('should return false when certificate list is empty', async () => {
-      mockList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 0 } } }));
-      await init({ portalNext: { mtls: { enabled: true } } });
-
-      expect(component.showCertificates()).toBe(false);
-    });
-
-    it('should return true when certificates exist', async () => {
-      mockList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 2 } } }));
-      await init({ portalNext: { mtls: { enabled: true } } });
-
-      expect(component.showCertificates()).toBe(true);
-    });
-
-    it('should return true when certificate API fails (fail-open)', async () => {
-      mockList.mockReturnValue(throwError(() => new Error('API error')));
-      await init({ portalNext: { mtls: { enabled: true } } });
-
-      expect(component.showCertificates()).toBe(true);
-    });
-
-    it('should return false while certificates are still loading', async () => {
-      mockList.mockReturnValue(new Subject());
-      await initForLoadingState();
-
-      expect((component as unknown as { certificates: { isLoading: () => boolean } }).certificates.isLoading()).toBe(true);
-      expect(component.showCertificates()).toBe(false);
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings-edit/application-tab-settings-edit.component.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 import { AsyncPipe } from '@angular/common';
-import { Component, computed, inject, input, OnInit } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
+import { Component, inject, input, OnInit } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -30,9 +29,7 @@ import { isEqual } from 'lodash';
 import { map, Observable, of, startWith, Subject, take, takeUntil, tap } from 'rxjs';
 
 import { CopyCodeComponent } from '../../../../../components/copy-code/copy-code.component';
-import { LoaderComponent } from '../../../../../components/loader/loader.component';
 import { Application, ApplicationGrantType, ApplicationType } from '../../../../../entities/application/application';
-import { ClientCertificatesResponse } from '../../../../../entities/application/client-certificate';
 import { UserApplicationPermissions } from '../../../../../entities/permission/permission';
 import { ApplicationCertificateService } from '../../../../../services/application-certificate.service';
 import { ApplicationService } from '../../../../../services/application.service';
@@ -70,7 +67,6 @@ interface ApplicationGrantTypeVM {
   imports: [
     ApplicationTabSettingsCertificatesComponent,
     CopyCodeComponent,
-    LoaderComponent,
     MatButtonModule,
     MatCardModule,
     MatDivider,
@@ -96,18 +92,6 @@ export class ApplicationTabSettingsEditComponent implements OnInit {
   protected get mtlsEnabled(): boolean {
     return this.configService.configuration?.portalNext?.mtls?.enabled === true;
   }
-
-  protected readonly certificates = rxResource<ClientCertificatesResponse | undefined, string | null>({
-    params: () => (this.mtlsEnabled ? this.applicationId() : null),
-    stream: ({ params }) => (params ? this.certService.list(params, 1, 1) : of(undefined)),
-  });
-
-  showCertificates = computed(() => {
-    if (this.certificates.error()) return true;
-    const response = this.certificates.value();
-    if (!response) return false;
-    return (response.metadata?.paginateMetaData?.totalElements ?? 0) > 0;
-  });
 
   application$!: Observable<Application>;
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.update.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-settings/application-tab-settings.component.update.spec.ts
@@ -18,7 +18,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { of, Subject, throwError } from 'rxjs';
+import { of } from 'rxjs';
 
 import { ApplicationTabSettingsEditHarness } from './application-tab-settings-edit/application-tab-settings-edit.harness';
 import { ApplicationTabSettingsComponent } from './application-tab-settings.component';
@@ -159,7 +159,10 @@ describe('ApplicationTabSettingsComponent', () => {
         settings: { app: { client_id: 'New custom client ID', type: '' } },
       };
 
-      const req = httpTestingController.expectOne({ url: `${TESTING_BASE_URL}/applications/${applicationId}`, method: 'PUT' });
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
       expect(req.request.body).toEqual(updatedApplication);
       req.flush(updatedApplication);
     });
@@ -216,7 +219,10 @@ describe('ApplicationTabSettingsComponent', () => {
         description: 'New b2b description',
       };
 
-      const req = httpTestingController.expectOne({ url: `${TESTING_BASE_URL}/applications/${applicationId}`, method: 'PUT' });
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
       expect(req.request.body).toEqual(updatedApplication);
       req.flush(updatedApplication);
     });
@@ -285,7 +291,10 @@ describe('ApplicationTabSettingsComponent', () => {
         },
       };
 
-      const req = httpTestingController.expectOne({ url: `${TESTING_BASE_URL}/applications/${applicationId}`, method: 'PUT' });
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
       expect(req.request.body).toEqual(updatedApplication);
       req.flush(updatedApplication);
     });
@@ -354,7 +363,10 @@ describe('ApplicationTabSettingsComponent', () => {
         },
       };
 
-      const req = httpTestingController.expectOne({ url: `${TESTING_BASE_URL}/applications/${applicationId}`, method: 'PUT' });
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
       expect(req.request.body).toEqual(updatedApplication);
       req.flush(updatedApplication);
     });
@@ -424,7 +436,10 @@ describe('ApplicationTabSettingsComponent', () => {
         },
       };
 
-      const req = httpTestingController.expectOne({ url: `${TESTING_BASE_URL}/applications/${applicationId}`, method: 'PUT' });
+      const req = httpTestingController.expectOne({
+        url: `${TESTING_BASE_URL}/applications/${applicationId}`,
+        method: 'PUT',
+      });
       expect(req.request.body).toEqual(updatedApplication);
       req.flush(updatedApplication);
     });
@@ -474,13 +489,16 @@ describe('ApplicationTabSettingsComponent - Certificates section visibility', ()
   let updateHarness: ApplicationTabSettingsEditHarness;
   const applicationId = 'id1';
   const simpleApplication = fakeApplication({ id: applicationId });
-  const mockCertList = jest.fn();
+  const mockCertList = jest.fn().mockReturnValue(of({ data: [] }));
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ApplicationTabSettingsComponent, ConfirmDialogComponent, HttpClientTestingModule, NoopAnimationsModule, AppTestingModule],
       providers: [
-        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL, configuration: { portalNext: { mtls: { enabled: true } } } } },
+        {
+          provide: ConfigService,
+          useValue: { baseURL: TESTING_BASE_URL, configuration: { portalNext: { mtls: { enabled: true } } } },
+        },
         { provide: ApplicationCertificateService, useValue: { list: mockCertList } },
       ],
     }).compileComponents();
@@ -523,70 +541,12 @@ describe('ApplicationTabSettingsComponent - Certificates section visibility', ()
     updateHarness = await loader.getHarness(ApplicationTabSettingsEditHarness);
   }
 
-  async function initForLoadingState(application: Application, applicationType: ApplicationType) {
-    fixture = TestBed.createComponent(ApplicationTabSettingsComponent);
-    httpTestingController = TestBed.inject(HttpTestingController);
-    fixture.componentRef.setInput('applicationId', applicationId);
-    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ DEFINITION: ['U'] }));
-    fixture.componentRef.setInput('applicationTypeConfiguration', applicationType);
-    fixture.detectChanges();
-
-    flushGetRequests(application);
-    await fixture.whenStable();
-    flushGetRequests(application);
-    await fixture.whenStable();
-
-    fixture.componentRef.instance.isEditing.set(true);
-    fixture.detectChanges();
-
-    // Do NOT call whenStable() here — rxResource with a never-emitting Subject
-    // keeps the zone unstable indefinitely. Flush the app GET from ngOnInit directly.
-    flushGetRequests(application);
-    fixture.detectChanges();
-  }
-
-  describe('when application has no certificates', () => {
+  describe('when mTLS is enabled', () => {
     beforeEach(async () => {
-      mockCertList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 0 } } }));
-      await init(simpleApplication, fakeSimpleApplicationType());
-    });
-
-    it('should hide certificates section', async () => {
-      expect(await updateHarness.getCertificatesSection()).toBeNull();
-    });
-  });
-
-  describe('when application has certificates', () => {
-    beforeEach(async () => {
-      mockCertList.mockReturnValue(of({ metadata: { paginateMetaData: { totalElements: 1 } } }));
       await init(simpleApplication, fakeSimpleApplicationType());
     });
 
     it('should show certificates section', async () => {
-      expect(await updateHarness.getCertificatesSection()).not.toBeNull();
-    });
-  });
-
-  describe('when certificate count is still loading', () => {
-    beforeEach(async () => {
-      mockCertList.mockReturnValue(new Subject());
-      await initForLoadingState(simpleApplication, fakeSimpleApplicationType());
-    });
-
-    it('should show loader and hide certificates section', () => {
-      expect(fixture.nativeElement.querySelector('app-loader')).not.toBeNull();
-      expect(fixture.nativeElement.querySelector('app-application-tab-settings-certificates')).toBeNull();
-    });
-  });
-
-  describe('when certificate count API fails', () => {
-    beforeEach(async () => {
-      mockCertList.mockReturnValue(throwError(() => new Error('API error')));
-      await init(simpleApplication, fakeSimpleApplicationType());
-    });
-
-    it('should show certificates section as fallback', async () => {
-      expect(await updateHarness.getCertificatesLoader()).toBeNull();
       expect(await updateHarness.getCertificatesSection()).not.toBeNull();
     });
   });


### PR DESCRIPTION
Streamline mTLS certificate feature by removing unused loader and related RxJs-based logic. Refactor templates and tests to align with the simplified behavior.

## Issue

https://gravitee.atlassian.net/browse/APIM-13262

- Simplified the logic for displaying the mTLS certificate section in the Portal.
- The "mTLS Certificate Upload" option is now visible for all applications when the feature is enabled globally, regardless of whether they already have certificates.

- In `ApplicationTabSettingsEditComponent`, removed the `certificates` `rxResource` and `showCertificates` computed property that were used to determine visibility.
- Updated `application-tab-settings-edit.component.html` to remove conditional checks (`isLoading`, `showCertificates`) and always show the certificates component if `mtlsEnabled` is true.
- Updated `application-tab-settings-edit.component.spec.ts` and `application-tab-settings.component.update.spec.ts` to reflect the removal of the pre-fetching logic and ensure tests pass with the new behavior.


https://github.com/user-attachments/assets/78610502-b2c2-4702-8ab8-eb92d7fd6100


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

