### PR TITLE
feat(portal-next): define application members read/search contract

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -1173,14 +1173,17 @@ paths:
                 List application members.
 
                 User must have the APPLICATION_MEMBER[READ] permission.
+                Pagination controls are always provided in the `links` object.
             operationId: getMembersByApplicationId
             responses:
                 200:
-                    description: List of members
+                    description: List of members with pagination links
                     content:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/MembersResponse"
+                400:
+                    $ref: "#/components/responses/BadRequestError"
                 403:
                     $ref: "#/components/responses/PermissionError"
                 404:
@@ -1209,6 +1212,44 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Member"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                404:
+                    $ref: "#/components/responses/ApplicationNotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+    /applications/{applicationId}/members/_search:
+        parameters:
+            - $ref: "#/components/parameters/applicationIdParam"
+        post:
+            tags:
+                - Application
+            parameters:
+                - $ref: "#/components/parameters/pageNumberParam"
+                - $ref: "#/components/parameters/pageSizeParam"
+            requestBody:
+                description: Use to search application members
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ApplicationMembersSearchInput"
+            summary: Search application members
+            description: |
+                Search application members.
+
+                User must have the APPLICATION_MEMBER[READ] permission.
+                Pagination controls are always provided in the `links` object.
+            operationId: searchMembersByApplicationId
+            responses:
+                200:
+                    description: List of members with pagination links
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/MembersResponse"
+                400:
+                    $ref: "#/components/responses/BadRequestError"
                 403:
                     $ref: "#/components/responses/PermissionError"
                 404:
@@ -4161,6 +4202,19 @@ components:
                     $ref: "#/components/schemas/MetadataMap"
                 links:
                     $ref: "#/components/schemas/Links"
+        ApplicationMembersSearchInput:
+            type: object
+            description: Search input for application members. The filters object is extensible for future search attributes.
+            properties:
+                filters:
+                    $ref: "#/components/schemas/ApplicationMembersSearchFilters"
+        ApplicationMembersSearchFilters:
+            type: object
+            description: Search filters for application members.
+            properties:
+                displayName:
+                    type: string
+                    description: Search phrase applied to member display name. Search starts when at least one character is provided.
         SearchApplicationsLogsParams:
             type: object
             description: Search filters for application logs
@@ -6899,6 +6953,12 @@ components:
                     $ref: "#/components/schemas/Links"
 
     responses:
+        BadRequestError:
+            description: Bad Request
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/ErrorResponse"
         InternalServerError:
             description: Internal Server Error
             content:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12280

https://gravitee.atlassian.net/browse/APIM-13464

## Description

Updated the Portal OpenAPI contract for APIM-12280 on GET /applications/{applicationId}/members: added member search support (q, minLength: 1), clarified pagination behavior, and documented 400 for invalid query/pagination inputs.
Also fixed a pre-existing spec inconsistency by adding the missing components.responses.BadRequestError definition, which was already referenced and causing IDE/validation errors.



