### PR TITLE
feat: implement backend members read path for application

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -109,6 +109,7 @@ import io.gravitee.apim.core.member.query_service.MemberQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
 import io.gravitee.apim.core.membership.domain_service.PublishPlanDomainService;
+import io.gravitee.apim.core.membership.domain_service.SearchApplicationMembersDomainService;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
 import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
 import io.gravitee.apim.core.parameters.query_service.ParametersQueryService;
@@ -324,6 +325,14 @@ public class ResourceContextConfiguration {
     @Bean
     public PublishPlanDomainService planOperationsDomainService() {
         return mock(PublishPlanDomainService.class);
+    }
+
+    /**
+     * Required by SearchApplicationMembersUseCase.
+     */
+    @Bean
+    public SearchApplicationMembersDomainService searchApplicationMembersDomainService() {
+        return mock(SearchApplicationMembersDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -128,6 +128,7 @@ import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.SearchApplicationMembersDomainService;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
 import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
 import io.gravitee.apim.core.notification.domain_service.ValidatePortalNotificationDomainService;
@@ -840,6 +841,11 @@ public class ResourceContextConfiguration {
     @Bean
     public ApplicationPrimaryOwnerDomainService applicationPrimaryOwnerDomainService() {
         return mock(ApplicationPrimaryOwnerDomainService.class);
+    }
+
+    @Bean
+    public SearchApplicationMembersDomainService searchApplicationMembersDomainService() {
+        return mock(SearchApplicationMembersDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -105,6 +105,7 @@ import io.gravitee.apim.core.member.query_service.MemberQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
 import io.gravitee.apim.core.membership.domain_service.PublishPlanDomainService;
+import io.gravitee.apim.core.membership.domain_service.SearchApplicationMembersDomainService;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
 import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
 import io.gravitee.apim.core.parameters.domain_service.ParametersDomainService;
@@ -523,6 +524,11 @@ public class ResourceContextConfiguration {
     @Bean
     public PublishPlanDomainService planOperationsDomainService() {
         return mock(PublishPlanDomainService.class);
+    }
+
+    @Bean
+    public SearchApplicationMembersDomainService searchApplicationMembersDomainService() {
+        return mock(SearchApplicationMembersDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMembersSearchCriteriaMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMembersSearchCriteriaMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.application.model.SearchApplicationMembersCriteria;
+import io.gravitee.rest.api.portal.rest.model.ApplicationMembersSearchInput;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ApplicationMembersSearchCriteriaMapper {
+    ApplicationMembersSearchCriteriaMapper INSTANCE = Mappers.getMapper(ApplicationMembersSearchCriteriaMapper.class);
+
+    @Mapping(target = "displayName", source = "filters.displayName")
+    SearchApplicationMembersCriteria toSearchCriteria(ApplicationMembersSearchInput input);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/MemberMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/MemberMapper.java
@@ -17,7 +17,10 @@ package io.gravitee.rest.api.portal.rest.mapper;
 
 import static io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper.usersURL;
 
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.portal.rest.model.Member;
 import io.gravitee.rest.api.portal.rest.model.User;
@@ -25,6 +28,11 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import jakarta.ws.rs.core.UriInfo;
 import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -44,6 +52,7 @@ public class MemberMapper {
     public Member convert(ExecutionContext executionContext, MemberEntity member, UriInfo uriInfo) {
         final Member memberItem = new Member();
 
+        memberItem.setId(member.getId());
         memberItem.setCreatedAt(member.getCreatedAt().toInstant().atOffset(ZoneOffset.UTC));
 
         UserEntity userEntity = userService.findById(executionContext, member.getId());
@@ -58,5 +67,54 @@ public class MemberMapper {
         }
         memberItem.setUpdatedAt(member.getUpdatedAt().toInstant().atOffset(ZoneOffset.UTC));
         return memberItem;
+    }
+
+    public List<Member> convert(
+        List<Membership> memberships,
+        List<BaseUserEntity> users,
+        Map<String, RoleEntity> rolesById,
+        UriInfo uriInfo
+    ) {
+        var usersById = users.stream().collect(Collectors.toMap(BaseUserEntity::getId, Function.identity(), (left, right) -> left));
+
+        return memberships
+            .stream()
+            .map(membership -> convert(membership, usersById.get(membership.getMemberId()), rolesById, uriInfo))
+            .toList();
+    }
+
+    private Member convert(Membership membership, BaseUserEntity user, Map<String, RoleEntity> rolesById, UriInfo uriInfo) {
+        var memberItem = new Member();
+        memberItem.setId(membership.getMemberId());
+        if (membership.getCreatedAt() != null) {
+            memberItem.setCreatedAt(membership.getCreatedAt().toInstant().atOffset(ZoneOffset.UTC));
+        }
+        if (membership.getUpdatedAt() != null) {
+            memberItem.setUpdatedAt(membership.getUpdatedAt().toInstant().atOffset(ZoneOffset.UTC));
+        }
+
+        var memberUser = new User();
+        memberUser.setId(membership.getMemberId());
+        if (user != null) {
+            memberUser.setDisplayName(user.displayName());
+            memberUser.setEmail(user.getEmail());
+        }
+        memberUser.setLinks(
+            userMapper.computeUserLinks(usersURL(uriInfo.getBaseUriBuilder(), membership.getMemberId()), userUpdatedAt(user))
+        );
+        memberItem.setUser(memberUser);
+
+        var role = rolesById.get(membership.getRoleId());
+        if (role != null) {
+            memberItem.setRole(role.getName());
+        }
+        return memberItem;
+    }
+
+    private Date userUpdatedAt(BaseUserEntity user) {
+        if (user == null) {
+            return null;
+        }
+        return user.getUpdatedAt();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResource.java
@@ -15,16 +15,21 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.apim.core.application.use_case.SearchApplicationMembersUseCase;
+import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.MemberEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.portal.rest.mapper.ApplicationMembersSearchCriteriaMapper;
 import io.gravitee.rest.api.portal.rest.mapper.MemberMapper;
+import io.gravitee.rest.api.portal.rest.model.ApplicationMembersSearchInput;
 import io.gravitee.rest.api.portal.rest.model.Member;
 import io.gravitee.rest.api.portal.rest.model.MemberInput;
 import io.gravitee.rest.api.portal.rest.model.TransferOwnershipInput;
@@ -45,7 +50,9 @@ import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -67,6 +74,9 @@ public class ApplicationMembersResource extends AbstractResource {
     @Inject
     private MemberMapper memberMapper;
 
+    @Inject
+    private SearchApplicationMembersUseCase searchApplicationMembersUseCase;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.APPLICATION_MEMBER, acls = RolePermissionAction.READ) })
@@ -85,6 +95,42 @@ public class ApplicationMembersResource extends AbstractResource {
             .collect(Collectors.toList());
 
         return createListResponse(executionContext, membersList, paginationParam);
+    }
+
+    @POST
+    @Path("/_search")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_MEMBER, acls = RolePermissionAction.READ) })
+    public Response searchMembersByApplicationId(
+        @PathParam("applicationId") String applicationId,
+        @Valid @BeanParam PaginationParam paginationParam,
+        @Valid @NotNull(message = "Input must not be null.") ApplicationMembersSearchInput input
+    ) {
+        var executionContext = GraviteeContext.getExecutionContext();
+        var result = searchApplicationMembersUseCase.execute(
+            new SearchApplicationMembersUseCase.Input(
+                executionContext,
+                applicationId,
+                ApplicationMembersSearchCriteriaMapper.INSTANCE.toSearchCriteria(input),
+                new PageableImpl(paginationParam.getPage(), paginationParam.getSize())
+            )
+        );
+
+        var roleIds = result
+            .memberships()
+            .getContent()
+            .stream()
+            .map(Membership::getRoleId)
+            .filter(id -> id != null && !id.isBlank())
+            .collect(Collectors.toSet());
+        Map<String, RoleEntity> rolesById = roleIds.isEmpty() ? Map.of() : roleService.findByIds(roleIds);
+        List<Member> membersList = memberMapper.convert(result.memberships().getContent(), result.users(), rolesById, uriInfo);
+        Map<String, Map<String, Object>> metadata = new HashMap<>(
+            Map.of("paginateMetaData", new HashMap<>(Map.of("totalElements", result.memberships().getTotalElements())))
+        );
+
+        return createListResponse(executionContext, membersList, paginationParam, metadata);
     }
 
     @POST

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMembersSearchCriteriaMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMembersSearchCriteriaMapperTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.gravitee.rest.api.portal.rest.model.ApplicationMembersSearchFilters;
+import io.gravitee.rest.api.portal.rest.model.ApplicationMembersSearchInput;
+import org.junit.Test;
+
+public class ApplicationMembersSearchCriteriaMapperTest {
+
+    private final ApplicationMembersSearchCriteriaMapper mapper = ApplicationMembersSearchCriteriaMapper.INSTANCE;
+
+    @Test
+    public void should_map_display_name_filter() {
+        var input = new ApplicationMembersSearchInput().filters(new ApplicationMembersSearchFilters().displayName("john"));
+
+        var criteria = mapper.toSearchCriteria(input);
+
+        assertEquals("john", criteria.displayName());
+    }
+
+    @Test
+    public void should_map_null_filters() {
+        var input = new ApplicationMembersSearchInput();
+
+        var criteria = mapper.toSearchCriteria(input);
+
+        assertNull(criteria.displayName());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/MemberMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/MemberMapperTest.java
@@ -20,6 +20,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.rest.api.model.MemberEntity;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UserEntity;
@@ -30,8 +32,11 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -98,7 +103,7 @@ public class MemberMapperTest {
         Member responseMember = memberMapper.convert(GraviteeContext.getExecutionContext(), memberEntity, uriInfo);
         assertNotNull(responseMember);
         assertEquals(now.toEpochMilli(), responseMember.getCreatedAt().toInstant().toEpochMilli());
-        assertNull(responseMember.getId());
+        assertEquals(MEMBER_ID, responseMember.getId());
         assertEquals("OWNER", responseMember.getRole());
         assertEquals(now.toEpochMilli(), responseMember.getUpdatedAt().toInstant().toEpochMilli());
 
@@ -108,5 +113,53 @@ public class MemberMapperTest {
         assertEquals(MEMBER_EMAIL, user.getEmail());
         assertEquals(MEMBER_ID, user.getId());
         assertEquals("environments/DEFAULT/users/" + MEMBER_ID + "/avatar?", user.getLinks().getAvatar());
+    }
+
+    @Test
+    public void testConvertMemberships() {
+        Instant now = Instant.now();
+        Date nowDate = Date.from(now.minusSeconds(60));
+        Date userUpdatedAt = Date.from(now);
+
+        Membership membership = Membership.builder()
+            .id("00000000-0000-0000-0000-000000000001")
+            .memberId(MEMBER_ID)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.APPLICATION)
+            .referenceId("application-id")
+            .roleId("role-id")
+            .createdAt(nowDate.toInstant().atZone(ZoneId.systemDefault()))
+            .updatedAt(nowDate.toInstant().atZone(ZoneId.systemDefault()))
+            .build();
+        BaseUserEntity baseUser = BaseUserEntity.builder()
+            .id(MEMBER_ID)
+            .firstname("my-member")
+            .lastname("display-name")
+            .email(MEMBER_EMAIL)
+            .updatedAt(userUpdatedAt)
+            .build();
+        RoleEntity role = new RoleEntity();
+        role.setName("OWNER");
+
+        when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromPath(""));
+        when(userMapper.computeUserLinks(anyString(), any())).thenCallRealMethod();
+
+        Member responseMember = memberMapper.convert(List.of(membership), List.of(baseUser), Map.of("role-id", role), uriInfo).get(0);
+
+        assertNotNull(responseMember);
+        assertEquals(nowDate.toInstant().toEpochMilli(), responseMember.getCreatedAt().toInstant().toEpochMilli());
+        assertEquals(MEMBER_ID, responseMember.getId());
+        assertEquals("OWNER", responseMember.getRole());
+        assertEquals(nowDate.toInstant().toEpochMilli(), responseMember.getUpdatedAt().toInstant().toEpochMilli());
+
+        User responseUser = responseMember.getUser();
+        assertNotNull(responseUser);
+        assertEquals("my-member display-name", responseUser.getDisplayName());
+        assertEquals(MEMBER_EMAIL, responseUser.getEmail());
+        assertEquals(MEMBER_ID, responseUser.getId());
+        assertEquals(
+            "environments/DEFAULT/users/" + MEMBER_ID + "/avatar?" + userUpdatedAt.toInstant().toEpochMilli(),
+            responseUser.getLinks().getAvatar()
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResourceTest.java
@@ -17,9 +17,16 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.membership.domain_service.SearchApplicationMembersDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.MemberEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
@@ -36,12 +43,14 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.internal.util.collections.Sets;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -55,6 +64,12 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
     private static final String MEMBER_2 = "my-member-2";
     private static final String UNKNOWN_MEMBER = "unknown-member";
 
+    @Autowired
+    private SearchApplicationMembersDomainService searchApplicationMembersDomainService;
+
+    @Autowired
+    private UserCrudServiceInMemory userCrudService;
+
     @Override
     protected String contextPath() {
         return "applications/";
@@ -63,6 +78,8 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
     @BeforeEach
     public void init() {
         resetAllMocks();
+        reset(searchApplicationMembersDomainService);
+        userCrudService.reset();
 
         MemberEntity memberEntity1 = new MemberEntity();
         memberEntity1.setId(MEMBER_1);
@@ -84,8 +101,18 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
         doThrow(ApplicationNotFoundException.class)
             .when(applicationService)
             .findById(GraviteeContext.getExecutionContext(), UNKNOWN_APPLICATION);
+        doThrow(new ApplicationNotFoundException(UNKNOWN_APPLICATION))
+            .when(searchApplicationMembersDomainService)
+            .searchApplicationMembers(anyString(), eq(UNKNOWN_APPLICATION));
         doThrow(UserNotFoundException.class).when(userService).findById(GraviteeContext.getExecutionContext(), UNKNOWN_MEMBER);
         when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+        doAnswer(invocation ->
+            ((List<Membership>) invocation.getArgument(0)).stream()
+                .map(membership -> new Member().id(membership.getMemberId()))
+                .toList()
+        )
+            .when(memberMapper)
+            .convert(anyList(), anyList(), anyMap(), any());
     }
 
     @Test
@@ -102,6 +129,46 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         Links links = membersResponse.getLinks();
         assertNotNull(links);
+    }
+
+    @Test
+    public void shouldSearchMembers() {
+        initSearchContext();
+
+        final Response response = target(APPLICATION)
+            .path("members")
+            .path("_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json("{}"));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        MembersResponse membersResponse = response.readEntity(MembersResponse.class);
+        assertEquals(2, membersResponse.getData().size());
+        assertTrue(
+            (MEMBER_1.equals(membersResponse.getData().get(0).getId()) && MEMBER_2.equals(membersResponse.getData().get(1).getId())) ||
+                (MEMBER_1.equals(membersResponse.getData().get(1).getId()) && MEMBER_2.equals(membersResponse.getData().get(0).getId()))
+        );
+        assertNotNull(membersResponse.getLinks());
+    }
+
+    @Test
+    public void shouldSearchMembersByDisplayName() {
+        initSearchContext();
+
+        final Response response = target(APPLICATION)
+            .path("members")
+            .path("_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json("{\"filters\":{\"displayName\":\"-2\"}}"));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        MembersResponse membersResponse = response.readEntity(MembersResponse.class);
+        assertEquals(1, membersResponse.getData().size());
+        assertEquals(MEMBER_2, membersResponse.getData().get(0).getId());
     }
 
     @Test
@@ -303,6 +370,12 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
     }
 
+    @Test
+    public void shouldHaveNotFoundWhileSearchingMembers() {
+        final Response response = target(UNKNOWN_APPLICATION).path("members").path("_search").request().post(Entity.json("{}"));
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
     //404 POST /members
     @Test
     public void shouldHaveNotFoundWhileCreatingNewMemberUnknonwnApplication() {
@@ -422,5 +495,41 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         Error error = errors.get(0);
         assertEquals("An APPLICATION must always have only one PRIMARY_OWNER !", error.getMessage());
+    }
+
+    private void initSearchContext() {
+        var allMemberships = List.of(
+            Membership.builder()
+                .id("00000000-0000-0000-0000-000000000001")
+                .memberId(MEMBER_1)
+                .memberType(Membership.Type.USER)
+                .referenceType(Membership.ReferenceType.APPLICATION)
+                .referenceId(APPLICATION)
+                .roleId("role-1")
+                .build(),
+            Membership.builder()
+                .id("00000000-0000-0000-0000-000000000002")
+                .memberId(MEMBER_2)
+                .memberType(Membership.Type.USER)
+                .referenceType(Membership.ReferenceType.APPLICATION)
+                .referenceId(APPLICATION)
+                .roleId("role-2")
+                .build()
+        );
+        userCrudService.initWith(
+            List.of(
+                BaseUserEntity.builder().id(MEMBER_1).firstname(MEMBER_1).build(),
+                BaseUserEntity.builder().id(MEMBER_2).firstname(MEMBER_2).build()
+            )
+        );
+        when(roleService.findByIds(any())).thenReturn(Map.of("role-1", role("USER"), "role-2", role("OWNER")));
+
+        when(searchApplicationMembersDomainService.searchApplicationMembers(anyString(), eq(APPLICATION))).thenReturn(allMemberships);
+    }
+
+    private RoleEntity role(String name) {
+        var role = new RoleEntity();
+        role.setName(name);
+        return role;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -105,6 +105,7 @@ import io.gravitee.apim.core.member.query_service.MemberQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
 import io.gravitee.apim.core.membership.domain_service.PublishPlanDomainService;
+import io.gravitee.apim.core.membership.domain_service.SearchApplicationMembersDomainService;
 import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
 import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
@@ -427,6 +428,14 @@ public class ResourceContextConfiguration {
     @Bean
     public PublishPlanDomainService planOperationsDomainService() {
         return mock(PublishPlanDomainService.class);
+    }
+
+    /**
+     * Required by SearchApplicationMembersUseCase.
+     */
+    @Bean
+    public SearchApplicationMembersDomainService searchApplicationMembersDomainService() {
+        return mock(SearchApplicationMembersDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/model/SearchApplicationMembersCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/model/SearchApplicationMembersCriteria.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application.model;
+
+import lombok.Builder;
+
+@Builder
+public record SearchApplicationMembersCriteria(String displayName) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/use_case/SearchApplicationMembersUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/use_case/SearchApplicationMembersUseCase.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.application.model.SearchApplicationMembersCriteria;
+import io.gravitee.apim.core.membership.domain_service.SearchApplicationMembersDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.PaginationInvalidException;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@UseCase
+public class SearchApplicationMembersUseCase {
+
+    private final SearchApplicationMembersDomainService searchApplicationMembersDomainService;
+    private final UserCrudService userCrudService;
+
+    public SearchApplicationMembersUseCase(
+        SearchApplicationMembersDomainService searchApplicationMembersDomainService,
+        UserCrudService userCrudService
+    ) {
+        this.searchApplicationMembersDomainService = searchApplicationMembersDomainService;
+        this.userCrudService = userCrudService;
+    }
+
+    public Output execute(Input input) {
+        var memberships = searchApplicationMembersDomainService.searchApplicationMembers(
+            input.executionContext().getEnvironmentId(),
+            input.applicationId()
+        );
+
+        var userIds = memberships
+            .stream()
+            .filter(membership -> membership.getMemberType() == Membership.Type.USER)
+            .map(Membership::getMemberId)
+            .distinct()
+            .toList();
+        var usersById = findUsersById(userIds);
+
+        var sortedAndFilteredMemberships = sortAndFilterMemberships(memberships, usersById, input.criteria());
+        var page = paginate(sortedAndFilteredMemberships, input.pageable());
+        var usersInPage = page
+            .getContent()
+            .stream()
+            .filter(membership -> membership.getMemberType() == Membership.Type.USER)
+            .map(Membership::getMemberId)
+            .map(usersById::get)
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList();
+
+        return new Output(page, usersInPage);
+    }
+
+    private Map<String, BaseUserEntity> findUsersById(List<String> userIds) {
+        if (userIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return userCrudService.findBaseUsersByIds(userIds).stream().collect(Collectors.toMap(BaseUserEntity::getId, Function.identity()));
+    }
+
+    private List<Membership> sortAndFilterMemberships(
+        Collection<Membership> memberships,
+        Map<String, BaseUserEntity> usersById,
+        SearchApplicationMembersCriteria criteria
+    ) {
+        var searchedDisplayName = criteria != null ? criteria.displayName() : null;
+
+        return memberships
+            .stream()
+            .filter(membership -> displayNameMatches(membership, searchedDisplayName, usersById))
+            .sorted(Comparator.comparing(membership -> normalizedDisplayName(membership, usersById)))
+            .toList();
+    }
+
+    private boolean displayNameMatches(Membership membership, String searchedDisplayName, Map<String, BaseUserEntity> usersById) {
+        if (searchedDisplayName == null || searchedDisplayName.isBlank()) {
+            return true;
+        }
+
+        if (membership.getMemberType() != Membership.Type.USER) {
+            return false;
+        }
+
+        var user = usersById.get(membership.getMemberId());
+        if (user == null) {
+            return false;
+        }
+
+        var displayName = user.displayName();
+        if (displayName == null) {
+            return false;
+        }
+
+        return displayName.toLowerCase(Locale.ROOT).contains(searchedDisplayName.toLowerCase(Locale.ROOT));
+    }
+
+    private String normalizedDisplayName(Membership membership, Map<String, BaseUserEntity> usersById) {
+        if (membership.getMemberType() != Membership.Type.USER) {
+            return "";
+        }
+
+        var user = usersById.get(membership.getMemberId());
+        if (user == null) {
+            return "";
+        }
+
+        var displayName = user.displayName();
+        return displayName != null ? displayName.toLowerCase(Locale.ROOT) : "";
+    }
+
+    private Page<Membership> paginate(Collection<Membership> memberships, Pageable pageable) {
+        var resolvedPageable = Optional.ofNullable(pageable).orElseGet(() -> new PageableImpl(1, Integer.MAX_VALUE));
+
+        var totalCount = memberships.size();
+        var startIndex = (resolvedPageable.getPageNumber() - 1) * resolvedPageable.getPageSize();
+        if (resolvedPageable.getPageNumber() < 1 || (totalCount > 0 && startIndex >= totalCount)) {
+            throw new PaginationInvalidException();
+        }
+
+        var pageContent = memberships.stream().skip(startIndex).limit(resolvedPageable.getPageSize()).toList();
+        return new Page<>(pageContent, resolvedPageable.getPageNumber(), resolvedPageable.getPageSize(), totalCount);
+    }
+
+    public record Input(
+        ExecutionContext executionContext,
+        String applicationId,
+        SearchApplicationMembersCriteria criteria,
+        Pageable pageable
+    ) {}
+
+    public record Output(Page<Membership> memberships, List<BaseUserEntity> users) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/SearchApplicationMembersDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/SearchApplicationMembersDomainService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.membership.domain_service;
+
+import io.gravitee.apim.core.membership.model.Membership;
+import java.util.Collection;
+
+public interface SearchApplicationMembersDomainService {
+    Collection<Membership> searchApplicationMembers(String environmentId, String applicationId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/membership/SearchApplicationMembersDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/membership/SearchApplicationMembersDomainServiceImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.membership;
+
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.membership.domain_service.SearchApplicationMembersDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SearchApplicationMembersDomainServiceImpl implements SearchApplicationMembersDomainService {
+
+    private final MembershipQueryService membershipQueryService;
+    private final ApplicationCrudService applicationCrudService;
+
+    @Override
+    public Collection<Membership> searchApplicationMembers(String environmentId, String applicationId) {
+        applicationCrudService.findById(applicationId, environmentId);
+        try {
+            return membershipQueryService.findByReference(Membership.ReferenceType.APPLICATION, applicationId);
+        } catch (TechnicalDomainException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurs while trying to search members for application %s", applicationId),
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/MembershipFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/MembershipFixtures.java
@@ -25,6 +25,8 @@ import java.util.function.Supplier;
 
 public class MembershipFixtures {
 
+    private static final String APPLICATION_MEMBERSHIP_UUID = "00000000-0000-0000-0000-000000000001";
+
     private static final Supplier<Membership.MembershipBuilder> BASE = () ->
         Membership.builder()
             .id("membership-id")
@@ -41,6 +43,26 @@ public class MembershipFixtures {
 
     public static Membership anApiMembership(String apiId) {
         return BASE.get().referenceType(Membership.ReferenceType.API).referenceId(apiId).build();
+    }
+
+    public static Membership anApplicationMembership(String applicationId, String memberId, String roleId) {
+        return BASE.get()
+            .id(APPLICATION_MEMBERSHIP_UUID)
+            .referenceType(Membership.ReferenceType.APPLICATION)
+            .referenceId(applicationId)
+            .memberId(memberId)
+            .roleId(roleId)
+            .build();
+    }
+
+    public static Membership anApplicationMembership(String membershipId, String applicationId, String memberId, String roleId) {
+        return BASE.get()
+            .id(membershipId)
+            .referenceType(Membership.ReferenceType.APPLICATION)
+            .referenceId(applicationId)
+            .memberId(memberId)
+            .roleId(roleId)
+            .build();
     }
 
     public static Membership anApiPrimaryOwnerUserMembership(String apiId, String userId, String organizationId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/RoleFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/RoleFixtures.java
@@ -125,6 +125,10 @@ public class RoleFixtures {
             .build();
     }
 
+    public static Role anApplicationRole(String roleId, String name) {
+        return Role.builder().id(roleId).name(name).scope(Role.Scope.APPLICATION).build();
+    }
+
     private static Role.RoleBuilder systemRoleBuilder() {
         return Role.builder()
             .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/use_case/SearchApplicationMembersUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/use_case/SearchApplicationMembersUseCaseTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.application.use_case;
+
+import static fixtures.core.model.BaseUserEntityFixtures.aBaseUserEntity;
+import static fixtures.core.model.MembershipFixtures.anApplicationMembership;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application.model.SearchApplicationMembersCriteria;
+import io.gravitee.apim.core.membership.domain_service.SearchApplicationMembersDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.PaginationInvalidException;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SearchApplicationMembersUseCaseTest {
+
+    private static final String APPLICATION_ID = "application-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+
+    @Mock
+    private SearchApplicationMembersDomainService searchApplicationMembersDomainService;
+
+    @Mock
+    private UserCrudService userCrudService;
+
+    private SearchApplicationMembersUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new SearchApplicationMembersUseCase(searchApplicationMembersDomainService, userCrudService);
+    }
+
+    @Test
+    void should_throw_when_application_is_not_found() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var pageable = new PageableImpl(1, 10);
+        var criteria = SearchApplicationMembersCriteria.builder().build();
+
+        when(searchApplicationMembersDomainService.searchApplicationMembers(ENVIRONMENT_ID, APPLICATION_ID)).thenThrow(
+            new ApplicationNotFoundException(APPLICATION_ID)
+        );
+
+        Throwable throwable = catchThrowable(() ->
+            cut.execute(new SearchApplicationMembersUseCase.Input(executionContext, APPLICATION_ID, criteria, pageable))
+        );
+
+        assertThat(throwable).isInstanceOf(ApplicationNotFoundException.class).hasMessageContaining(APPLICATION_ID);
+    }
+
+    @Test
+    void should_search_filter_sort_paginate_and_return_users_for_page() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var pageable = new PageableImpl(1, 1);
+        var criteria = SearchApplicationMembersCriteria.builder().displayName("a").build();
+        var membership1 = anApplicationMembership("00000000-0000-0000-0000-000000000001", APPLICATION_ID, "user-1", "role-1");
+        var membership2 = anApplicationMembership("00000000-0000-0000-0000-000000000002", APPLICATION_ID, "user-2", "role-2");
+        var groupMembership = anApplicationMembership(
+            "00000000-0000-0000-0000-000000000003",
+            APPLICATION_ID,
+            "group-1",
+            "role-3"
+        ).withMemberType(Membership.Type.GROUP);
+        var user1 = aBaseUserEntity("user-1");
+        user1.setFirstname("Alice");
+        user1.setLastname("");
+        var user2 = aBaseUserEntity("user-2");
+        user2.setFirstname("Bob");
+        user2.setLastname("");
+
+        when(searchApplicationMembersDomainService.searchApplicationMembers(ENVIRONMENT_ID, APPLICATION_ID)).thenReturn(
+            List.of(membership2, groupMembership, membership1)
+        );
+        when(userCrudService.findBaseUsersByIds(List.of("user-2", "user-1"))).thenReturn(Set.of(user1, user2));
+
+        var result = cut.execute(new SearchApplicationMembersUseCase.Input(executionContext, APPLICATION_ID, criteria, pageable));
+
+        assertThat(result.memberships().getTotalElements()).isEqualTo(1);
+        assertThat(result.memberships().getContent()).containsExactly(membership1);
+        assertThat(result.users()).containsExactly(user1);
+        verify(searchApplicationMembersDomainService).searchApplicationMembers(eq(ENVIRONMENT_ID), eq(APPLICATION_ID));
+        verify(userCrudService).findBaseUsersByIds(eq(List.of("user-2", "user-1")));
+    }
+
+    @Test
+    void should_throw_when_page_is_invalid() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var pageable = new PageableImpl(2, 10);
+        var membership = anApplicationMembership("00000000-0000-0000-0000-000000000001", APPLICATION_ID, "user-1", "role-1");
+        var user = aBaseUserEntity("user-1");
+
+        when(searchApplicationMembersDomainService.searchApplicationMembers(ENVIRONMENT_ID, APPLICATION_ID)).thenReturn(
+            List.of(membership)
+        );
+        when(userCrudService.findBaseUsersByIds(List.of("user-1"))).thenReturn(Set.of(user));
+
+        Throwable throwable = catchThrowable(() ->
+            cut.execute(
+                new SearchApplicationMembersUseCase.Input(
+                    executionContext,
+                    APPLICATION_ID,
+                    SearchApplicationMembersCriteria.builder().build(),
+                    pageable
+                )
+            )
+        );
+
+        assertThat(throwable).isInstanceOf(PaginationInvalidException.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/membership/SearchApplicationMembersDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/membership/SearchApplicationMembersDomainServiceImplTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.membership;
+
+import static fixtures.core.model.MembershipFixtures.anApplicationMembership;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SearchApplicationMembersDomainServiceImplTest {
+
+    private static final String ENVIRONMENT_ID = "env-id";
+    private static final String APPLICATION_ID = "app-id";
+
+    MembershipQueryService membershipQueryService;
+    ApplicationCrudService applicationCrudService;
+
+    SearchApplicationMembersDomainServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        membershipQueryService = mock(MembershipQueryService.class);
+        applicationCrudService = mock(ApplicationCrudService.class);
+        service = new SearchApplicationMembersDomainServiceImpl(membershipQueryService, applicationCrudService);
+    }
+
+    @Test
+    void should_return_memberships_for_application() {
+        var membership1 = anApplicationMembership("00000000-0000-0000-0000-000000000001", APPLICATION_ID, "user-1", "role-1");
+        var membership2 = anApplicationMembership(
+            "00000000-0000-0000-0000-000000000002",
+            APPLICATION_ID,
+            "user-2",
+            "role-2"
+        ).withMemberType(Membership.Type.GROUP);
+
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(
+            BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build()
+        );
+        when(membershipQueryService.findByReference(eq(Membership.ReferenceType.APPLICATION), eq(APPLICATION_ID))).thenReturn(
+            Set.of(membership1, membership2)
+        );
+
+        var result = service.searchApplicationMembers(ENVIRONMENT_ID, APPLICATION_ID);
+
+        assertThat(result).containsExactlyInAnyOrder(membership1, membership2);
+    }
+
+    @Test
+    void should_throw_when_query_service_fails() {
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(
+            BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build()
+        );
+        when(membershipQueryService.findByReference(eq(Membership.ReferenceType.APPLICATION), eq(APPLICATION_ID))).thenThrow(
+            new TechnicalDomainException("query failed")
+        );
+
+        Throwable throwable = catchThrowable(() -> service.searchApplicationMembers(ENVIRONMENT_ID, APPLICATION_ID));
+
+        assertThat(throwable)
+            .isInstanceOf(TechnicalDomainException.class)
+            .hasMessage("An error occurs while trying to search members for application app-id");
+    }
+
+    @Test
+    void should_throw_when_application_does_not_exist() {
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenThrow(new ApplicationNotFoundException(APPLICATION_ID));
+
+        Throwable throwable = catchThrowable(() -> service.searchApplicationMembers(ENVIRONMENT_ID, APPLICATION_ID));
+
+        assertThat(throwable).isInstanceOf(ApplicationNotFoundException.class);
+        verifyNoInteractions(membershipQueryService);
+    }
+}


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-13465


## Description

Add portal members listing for applications with pagination and permission checks, map membership data to the Member contract (including member.id), and cover empty/populated responses in resource tests (including links = null for empty list).


