### PR TITLE
feat: Add and display api product members

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.harness.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+
+import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
+
+export class ApiProductMembersComponentHarness extends ComponentHarness {
+  static hostSelector = 'api-product-members';
+
+  async getTitle(): Promise<string> {
+    const el = await this.locatorFor('[data-testid="api_product_members_title"]')();
+    return (await el.text()).trim();
+  }
+
+  async getDescription(): Promise<string> {
+    const el = await this.locatorFor('[data-testid="api_product_members_description"]')();
+    return el.text();
+  }
+
+  async getEmptyMessage(): Promise<string> {
+    const el = await this.locatorFor('[data-testid="api_product_members_table_empty"]')();
+    return (await el.text()).trim();
+  }
+
+  async getMembersTable(): Promise<MatTableHarness> {
+    return this.locatorFor(MatTableHarness)();
+  }
+
+  async getAddMemberButton(): Promise<MatButtonHarness | null> {
+    return this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="api_product_members_add_button"]' }))();
+  }
+
+  async getDeleteMemberButton(): Promise<MatButtonHarness> {
+    return this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="api_product_members_delete_button"]' }))();
+  }
+
+  async getTableWrapper(): Promise<GioTableWrapperHarness> {
+    return this.locatorFor(GioTableWrapperHarness)();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.html
@@ -15,65 +15,120 @@
     limitations under the License.
 
 -->
-<mat-card>
-  <mat-card-content>
-    <div class="card__header">
-      <div class="card__header__title">
-        <h3 data-testid="api_product_members_title">Members</h3>
-        <p data-testid="api_product_members_description">
-          Manage who can interact with your API Product through the API Management console
-        </p>
-      </div>
-      <div class="card__header__actions">
-        <button class="card__header__actions__button" mat-stroked-button color="basic" type="button" disabled>Transfer ownership</button>
-        <button class="card__header__actions__button" mat-raised-button type="button" disabled aria-label="Manage groups">
-          Manage groups
-        </button>
-        <button class="card__header__actions__button" mat-raised-button color="primary" type="button" disabled>
-          <mat-icon svgIcon="gio:plus"></mat-icon> Add members
-        </button>
-      </div>
-    </div>
+<form [formGroup]="form">
+  @if (membersLoadState(); as state) {
+    <mat-card>
+      <mat-card-content>
+        <div class="card__header">
+          <div class="card__header__title">
+            <h3 data-testid="api_product_members_title">Members</h3>
+            <p data-testid="api_product_members_description">
+              Manage who can interact with your API Product through the API Management console
+            </p>
+          </div>
+          <div class="card__header__actions">
+            <button class="card__header__actions__button" mat-raised-button type="button" disabled>Transfer ownership</button>
+            <button class="card__header__actions__button" mat-raised-button type="button" disabled aria-label="Manage groups">
+              Manage groups
+            </button>
+            <button
+              *gioPermission="{ anyOf: ['api_product-member-c'] }"
+              class="card__header__actions__button"
+              mat-raised-button
+              color="primary"
+              type="button"
+              data-testid="api_product_members_add_button"
+              [disabled]="isReadOnly"
+              (click)="openAddMemberDialog()"
+            >
+              <mat-icon svgIcon="gio:plus"></mat-icon> Add members
+            </button>
+          </div>
+        </div>
 
-    <form [formGroup]="notifyForm">
-      <gio-form-slide-toggle class="card__enable-notification-toggle">
-        Notify members when they are added to the API Product
-        <mat-slide-toggle
-          gioFormSlideToggle
-          formControlName="isNotificationsEnabled"
-          aria-label="Enable notifications when members are added to this API Product"
-        ></mat-slide-toggle>
-      </gio-form-slide-toggle>
-    </form>
+        <gio-form-slide-toggle class="card__enable-notification-toggle">
+          Notify members when they are added to the API Product
+          <mat-slide-toggle
+            gioFormSlideToggle
+            formControlName="isNotificationsEnabled"
+            aria-label="Enable notifications when members are added to this API Product"
+          ></mat-slide-toggle>
+        </gio-form-slide-toggle>
+      </mat-card-content>
+      <gio-table-wrapper
+        [disableSearchInput]="true"
+        [length]="state.totalCount"
+        [filters]="tableFilters()"
+        (filtersChange)="onFiltersChanged($event)"
+        [paginationPageSizeOptions]="[10, 20, 50, 100]"
+      >
+        <table mat-table [dataSource]="allRows()" class="card__table" formGroupName="members" aria-label="Direct members table">
+          <ng-container matColumnDef="picture">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let member">
+              <gio-avatar [src]="member.picture" [name]="member.displayName" [size]="24" [roundedBorder]="true"></gio-avatar>
+            </td>
+          </ng-container>
 
-    <gio-table-wrapper
-      [disableSearchInput]="true"
-      [length]="membersTableDSUnpaginatedLength"
-      [filters]="filters"
-      (filtersChange)="onFiltersChanged($event)"
-      [paginationPageSizeOptions]="[10, 20, 50, 100]"
-    >
-      <table mat-table [dataSource]="[]" class="card__table" aria-label="Direct members table">
-        <ng-container matColumnDef="picture">
-          <th mat-header-cell *matHeaderCellDef></th>
-          <td mat-cell *matCellDef="let member">
-            <gio-avatar [src]="member.picture" [name]="member.displayName" [size]="24" [roundedBorder]="true"></gio-avatar>
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="displayName">
-          <th mat-header-cell *matHeaderCellDef>Name</th>
-          <td mat-cell *matCellDef="let member">{{ member.displayName }}</td>
-        </ng-container>
-        <ng-container matColumnDef="role">
-          <th mat-header-cell *matHeaderCellDef>Role</th>
-          <td mat-cell *matCellDef="let member">{{ member.role }}</td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-        <tr class="mat-mdc-no-data-row" *matNoDataRow>
-          <td [attr.colspan]="displayedColumns.length">No members found</td>
-        </tr>
-      </table>
-    </gio-table-wrapper>
-  </mat-card-content>
-</mat-card>
+          <ng-container matColumnDef="displayName">
+            <th mat-header-cell *matHeaderCellDef>Name</th>
+            <td mat-cell *matCellDef="let member" [class.primary-owner-name]="member.isPrimaryOwner">
+              {{ member.displayName }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="role">
+            <th mat-header-cell *matHeaderCellDef>Role</th>
+            <td mat-cell *matCellDef="let member">
+              <mat-form-field>
+                <mat-select [formControlName]="member.id">
+                  @for (roleName of roleNames(); track roleName) {
+                    <mat-option [value]="roleName" [disabled]="roleName === 'PRIMARY_OWNER' && !member.isPrimaryOwner">{{
+                      roleName
+                    }}</mat-option>
+                  }
+                </mat-select>
+                @if (roleFieldShowsRequiredError()[member.id]) {
+                  <mat-error>Role is required.</mat-error>
+                }
+              </mat-form-field>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="delete">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let member">
+              @if (!member.isPrimaryOwner && !member.isPending) {
+                <div class="action-cell">
+                  <button
+                    type="button"
+                    mat-icon-button
+                    aria-label="Remove member"
+                    data-testid="api_product_members_delete_button"
+                    (click)="removeMember(member)"
+                  >
+                    <mat-icon svgIcon="gio:trash"></mat-icon>
+                  </button>
+                </div>
+              }
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+          <tr class="mat-mdc-no-data-row" *matNoDataRow>
+            <td [attr.colspan]="displayedColumns.length">
+              @if (state.isLoading) {
+                <span data-testid="api_product_members_table_loading">Loading members…</span>
+              } @else {
+                <span data-testid="api_product_members_table_empty">No members found</span>
+              }
+            </td>
+          </tr>
+        </table>
+      </gio-table-wrapper>
+    </mat-card>
+
+    <gio-save-bar [form]="form" (resetClicked)="onReset()" (submitted)="onSave()"></gio-save-bar>
+  }
+</form>

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.scss
@@ -16,49 +16,29 @@
 @use '../../../scss/gio-layout' as gio-layout;
 
 :host {
-  @include gio-layout.gio-responsive-margin-container;
-  display: block;
-  max-width: 100%;
-}
-
-mat-card {
-  max-width: 100%;
-  box-sizing: border-box;
+  @include gio-layout.gio-responsive-content-container;
 }
 
 .card {
   &__header {
     display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
     justify-content: space-between;
-    gap: 1rem;
-    max-width: 100%;
+    align-items: flex-start;
+    min-width: max-content;
 
     &__title {
-      flex: 1 1 0;
-      min-width: 0;
-      text-align: start;
-
-      h3 {
-        margin: 0;
-        padding: 0;
-      }
-
-      p {
-        margin: 0.25rem 0 0;
-        padding: 0;
-      }
+      width: 50%;
     }
 
     &__actions {
       display: flex;
-      flex: 0 0 auto;
-      flex-wrap: wrap;
+      width: 50%;
       justify-content: flex-end;
-      align-items: center;
       align-self: center;
-      gap: 0.375rem;
+
+      &__button {
+        margin: 0 0.375rem;
+      }
     }
   }
 
@@ -68,12 +48,21 @@ mat-card {
 
   &__table {
     width: 100%;
-    max-width: 100%;
 
     .mat-column-picture {
       text-align: center;
       width: 1.5rem;
       padding-right: 0.5rem;
+    }
+
+    .primary-owner-name {
+      font-weight: bold;
+    }
+
+    .action-cell {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
     }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.spec.ts
@@ -13,51 +13,270 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { HarnessLoader } from '@angular/cdk/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { MatTableHarness } from '@angular/material/table/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
 
 import { ApiProductMembersComponent } from './api-product-members.component';
+import { ApiProductMembersComponentHarness } from './api-product-members.component.harness';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { fakeMember } from '../../../entities/management-api-v2/member/member.fixture';
 
 describe('ApiProductMembersComponent', () => {
-  let fixture: ComponentFixture<ApiProductMembersComponent>;
-  let loader: HarnessLoader;
+  const API_PRODUCT_ID = 'test-api-product-id';
+  const MEMBERS_URL = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/members`;
+  const ROLES_URL = `${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/API_PRODUCT/roles`;
 
-  beforeEach(async () => {
+  let fixture: ComponentFixture<ApiProductMembersComponent>;
+  let harness: ApiProductMembersComponentHarness;
+  let httpTestingController: HttpTestingController;
+  const snackBarService = { error: jest.fn(), success: jest.fn() };
+
+  const queryParams$ = new BehaviorSubject<Record<string, string>>({});
+
+  async function init(
+    permissions: string[] = ['api_product-member-r', 'api_product-member-c'],
+    initialQueryParams: Record<string, string> = {},
+  ) {
     await TestBed.configureTestingModule({
-      imports: [ApiProductMembersComponent, MatIconTestingModule, NoopAnimationsModule],
+      imports: [ApiProductMembersComponent, NoopAnimationsModule, GioTestingModule, MatIconTestingModule],
+      providers: [
+        { provide: GioTestingPermissionProvider, useValue: permissions },
+        { provide: SnackBarService, useValue: snackBarService },
+        {
+          provide: InteractivityChecker,
+          useValue: { isFocusable: () => true },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: new BehaviorSubject(convertToParamMap({ apiProductId: API_PRODUCT_ID })),
+            queryParams: queryParams$,
+            snapshot: {
+              paramMap: convertToParamMap({ apiProductId: API_PRODUCT_ID }),
+              queryParams: initialQueryParams,
+            },
+          },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ApiProductMembersComponent);
-    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiProductMembersComponentHarness);
     fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.clearAllMocks();
+    queryParams$.next({});
   });
 
-  it('should render the Members section with title and description', () => {
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('[data-testid="api_product_members_title"]')?.textContent?.trim()).toBe('Members');
-    expect(compiled.querySelector('[data-testid="api_product_members_description"]')?.textContent).toContain(
-      'Manage who can interact with your API Product',
-    );
-  });
+  function expectMembersRequest(members = [fakeMember()], totalCount = members.length, page = 1, perPage = 10) {
+    const req = httpTestingController.expectOne(r => r.url === MEMBERS_URL);
+    expect(req.request.params.get('page')).toEqual(page.toString());
+    expect(req.request.params.get('perPage')).toEqual(perPage.toString());
+    req.flush({ data: members, pagination: { totalCount, page, perPage } });
+  }
 
-  it('should render picture, Name and Role column headers in the members table', async () => {
-    const table = await loader.getHarness(MatTableHarness);
+  function expectRolesRequest() {
+    const req = httpTestingController.expectOne(ROLES_URL);
+    req.flush([
+      { id: 'PRIMARY_OWNER', name: 'PRIMARY_OWNER', default: false, scope: 'API_PRODUCT' },
+      { id: 'USER', name: 'USER', default: true, scope: 'API_PRODUCT' },
+      { id: 'OWNER', name: 'OWNER', default: false, scope: 'API_PRODUCT' },
+    ]);
+  }
+
+  it('should render the Members section with title and description', fakeAsync(async () => {
+    await init();
+    expectMembersRequest([]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    expect(await harness.getTitle()).toBe('Members');
+    expect(await harness.getDescription()).toContain('Manage who can interact with your API Product');
+  }));
+
+  it('should render picture, Name and Role column headers', fakeAsync(async () => {
+    await init();
+    expectMembersRequest([]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    const table = await harness.getMembersTable();
     const headerRows = await table.getHeaderRows();
     const cells = await headerRows[0].getCells();
     const headerTexts = await Promise.all(cells.map(c => c.getText()));
     expect(headerTexts).toEqual(['', 'Name', 'Role']);
-  });
+  }));
 
-  it('should show an empty state when there are no members', async () => {
-    const table = await loader.getHarness(MatTableHarness);
+  it('should render delete column when user has delete permission', fakeAsync(async () => {
+    await init(['api_product-member-r', 'api_product-member-c', 'api_product-member-d', 'api_product-member-u']);
+    expectMembersRequest([]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    const table = await harness.getMembersTable();
+    const headerRows = await table.getHeaderRows();
+    const cells = await headerRows[0].getCells();
+    const headerTexts = await Promise.all(cells.map(c => c.getText()));
+    expect(headerTexts).toEqual(['', 'Name', 'Role', '']);
+  }));
+
+  it('should display existing members in the table', fakeAsync(async () => {
+    await init();
+    const member = fakeMember({ id: 'user-1', displayName: 'Alice', roles: [{ name: 'USER' }] });
+    expectMembersRequest([member]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    const table = await harness.getMembersTable();
     const rows = await table.getRows();
-    expect(rows.length).toBe(0);
+    expect(rows.length).toBe(1);
+    const cells = await rows[0].getCells();
+    const texts = await Promise.all(cells.map(c => c.getText()));
+    expect(texts[1]).toBe('Alice');
+    expect(texts[2]).toContain('USER');
+  }));
 
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('.mat-mdc-no-data-row')?.textContent).toContain('No members found');
-  });
+  it('should show Primary Owner role in the Role column', fakeAsync(async () => {
+    await init();
+    const owner = fakeMember({ id: 'owner-1', displayName: 'Admin', roles: [{ name: 'PRIMARY_OWNER' }] });
+    expectMembersRequest([owner]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    const table = await harness.getMembersTable();
+    const rows = await table.getRows();
+    const cells = await rows[0].getCells();
+    expect(await cells[2].getText()).toContain('PRIMARY_OWNER');
+  }));
+
+  it('should show "No members found" when there are no members', fakeAsync(async () => {
+    await init();
+    expectMembersRequest([]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    expect(await harness.getEmptyMessage()).toBe('No members found');
+  }));
+
+  it('should show "Add members" button when user has create permission', fakeAsync(async () => {
+    await init(['api_product-member-r', 'api_product-member-c']);
+    expectMembersRequest([]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    expect(await harness.getAddMemberButton()).not.toBeNull();
+  }));
+
+  it('should hide "Add members" button when user lacks create permission', fakeAsync(async () => {
+    await init(['api_product-member-r']);
+    expectMembersRequest([]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    expect(await harness.getAddMemberButton()).toBeNull();
+  }));
+
+  it('should update URL query params when pagination changes', fakeAsync(async () => {
+    await init();
+    const router = TestBed.inject(Router);
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    expectMembersRequest([fakeMember({ id: 'm1', roles: [{ name: 'USER' }] })], 50, 1, 10);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    const tableWrapper = await harness.getTableWrapper();
+    const paginator = await tableWrapper.getPaginator('header');
+    await paginator!.setPageSize(20);
+    await paginator!.goToNextPage();
+    tick(300);
+    fixture.detectChanges();
+
+    expect(navigateSpy).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({ queryParams: { page: 2, size: 20 }, queryParamsHandling: 'merge' }),
+    );
+  }));
+
+  it('should remove member and reload from server', fakeAsync(async () => {
+    await init(['api_product-member-r', 'api_product-member-c', 'api_product-member-d']);
+
+    const onlyMember = fakeMember({ id: 'last-member', displayName: 'Last Member', roles: [{ name: 'USER' }] });
+    expectMembersRequest([onlyMember], 11, 1, 10);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    await (await harness.getDeleteMemberButton()).click();
+    tick();
+    fixture.detectChanges();
+
+    const confirmDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(GioConfirmDialogHarness);
+    await confirmDialog.confirm();
+    tick();
+    fixture.detectChanges();
+
+    httpTestingController.expectOne(r => r.url === `${MEMBERS_URL}/last-member` && r.method === 'DELETE').flush({});
+    tick();
+    fixture.detectChanges();
+
+    expectMembersRequest([], 10, 1, 10);
+    tick();
+    fixture.detectChanges();
+
+    expect(await (await harness.getMembersTable()).getRows()).toHaveLength(0);
+  }));
+
+  it('should navigate to the last valid page (not page 1) when deleting the only member on a deeper page', fakeAsync(async () => {
+    queryParams$.next({ page: '3', size: '10' });
+
+    await init(['api_product-member-r', 'api_product-member-c', 'api_product-member-d'], { page: '3', size: '10' });
+    const router = TestBed.inject(Router);
+    const navigateSpy = jest.spyOn(router, 'navigate');
+
+    const onlyMember = fakeMember({ id: 'page3-member', displayName: 'Page 3 Member', roles: [{ name: 'USER' }] });
+    expectMembersRequest([onlyMember], 21, 3, 10);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    await (await harness.getDeleteMemberButton()).click();
+    tick();
+    fixture.detectChanges();
+
+    const confirmDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(GioConfirmDialogHarness);
+    await confirmDialog.confirm();
+    tick();
+    fixture.detectChanges();
+
+    httpTestingController.expectOne(r => r.url === `${MEMBERS_URL}/page3-member` && r.method === 'DELETE').flush({});
+    tick();
+    fixture.detectChanges();
+
+    httpTestingController.expectNone(r => r.url === MEMBERS_URL && r.method === 'GET');
+    expect(navigateSpy).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { page: 2 }, queryParamsHandling: 'merge' }));
+  }));
 });

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.ts
@@ -13,17 +13,68 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { AbstractControl, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { HttpErrorResponse } from '@angular/common/http';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatDialog } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTableModule } from '@angular/material/table';
-import { GioAvatarModule, GioFormSlideToggleModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { ActivatedRoute, Router } from '@angular/router';
+import {
+  GioAvatarModule,
+  GioConfirmDialogComponent,
+  GioConfirmDialogData,
+  GioFormSlideToggleModule,
+  GioIconsModule,
+  GioSaveBarModule,
+} from '@gravitee/ui-particles-angular';
+import { combineLatest, EMPTY, forkJoin, merge, Observable, of, Subject } from 'rxjs';
+import { catchError, distinctUntilChanged, filter, map, shareReplay, startWith, switchMap, take, tap } from 'rxjs/operators';
+import { isEqual, uniqueId } from 'lodash';
 
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
+import { GioUsersSelectorModule } from '../../../shared/components/gio-users-selector/gio-users-selector.module';
+import {
+  GioUsersSelectorComponent,
+  GioUsersSelectorData,
+} from '../../../shared/components/gio-users-selector/gio-users-selector.component';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { RoleService } from '../../../services-ngx/role.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { UsersService } from '../../../services-ngx/users.service';
+import { Member } from '../../../entities/management-api-v2';
+import { SearchableUser } from '../../../entities/user/searchableUser';
+
+export interface MemberRow {
+  id: string;
+  displayName: string;
+  picture: string;
+  role: string;
+  isPrimaryOwner: boolean;
+  isPending: boolean;
+}
+
+interface MembersState {
+  isLoading: boolean;
+  rows: MemberRow[];
+  totalCount: number;
+}
+
+const LOADING_STATE: MembersState = { isLoading: true, rows: [], totalCount: 0 };
+
+function effectiveRoleName(member: Member): string {
+  const roles = member.roles ?? [];
+  return roles.find(r => r.name === 'PRIMARY_OWNER')?.name ?? roles[0]?.name ?? '';
+}
 
 @Component({
   selector: 'api-product-members',
@@ -34,28 +85,325 @@ import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrap
     ReactiveFormsModule,
     MatCardModule,
     MatButtonModule,
+    MatFormFieldModule,
     MatIconModule,
+    MatSelectModule,
     MatSlideToggleModule,
     MatTableModule,
-    GioIconsModule,
     GioAvatarModule,
     GioFormSlideToggleModule,
+    GioIconsModule,
+    GioPermissionModule,
+    GioSaveBarModule,
     GioTableWrapperModule,
+    GioUsersSelectorModule,
   ],
 })
 export class ApiProductMembersComponent {
-  protected readonly displayedColumns = ['picture', 'displayName', 'role'] as const;
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
+  private readonly roleService = inject(RoleService);
+  private readonly usersService = inject(UsersService);
+  private readonly permissionService = inject(GioPermissionService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly destroyRef = inject(DestroyRef);
 
-  protected readonly notifyForm = new FormGroup({
+  private readonly reloadMembers$ = new Subject<void>();
+  private readonly pendingUsers = signal<Array<SearchableUser & { viewId: string; userPicture: string }>>([]);
+  protected readonly isReadOnly = !this.permissionService.hasAnyMatching(['api_product-member-u']);
+  protected readonly displayedColumns = this.permissionService.hasAnyMatching(['api_product-member-d'])
+    ? ['picture', 'displayName', 'role', 'delete']
+    : ['picture', 'displayName', 'role'];
+  protected readonly form = new FormGroup({
     isNotificationsEnabled: new FormControl(true),
+    members: new FormGroup({}),
+  });
+  protected readonly roleFieldShowsRequiredError = signal<Readonly<Record<string, boolean>>>({});
+
+  private readonly paginationFromRoute$ = this.activatedRoute.queryParams.pipe(
+    map(params => ({ page: +(params['page'] ?? 1), size: +(params['size'] ?? 10) })),
+    distinctUntilChanged(isEqual),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+
+  private readonly roles = toSignal(this.roleService.list('API_PRODUCT').pipe(take(1)));
+
+  protected readonly roleNames = computed(() => (this.roles() ?? []).map(r => r.name));
+
+  protected readonly defaultRole = computed(() => {
+    const roles = this.roles() ?? [];
+    return (roles.find(r => r.default) ?? roles[0])?.name ?? null;
   });
 
-  protected readonly filters: GioTableWrapperFilters = {
-    pagination: { index: 1, size: 10 },
-    searchTerm: '',
-  };
+  protected readonly membersLoadState = toSignal(
+    combineLatest([
+      this.activatedRoute.paramMap.pipe(
+        map(p => p.get('apiProductId') ?? ''),
+        filter(id => id !== ''),
+        distinctUntilChanged(),
+      ),
+      this.paginationFromRoute$,
+      merge(of(null), this.reloadMembers$),
+    ]).pipe(
+      switchMap(([apiProductId, { page, size }]) =>
+        this.apiProductV2Service.getPagedMembers(apiProductId, page, size).pipe(
+          map(res => ({
+            isLoading: false,
+            rows: (res.data ?? []).map(m => this.mapMemberToRow(m)),
+            totalCount: res.pagination?.totalCount ?? 0,
+          })),
+          catchError(() => of({ ...LOADING_STATE, isLoading: false })),
+        ),
+      ),
+      tap(state => this.syncMembersFormGroup(state.rows)),
+    ),
+    { initialValue: LOADING_STATE },
+  );
 
-  protected membersTableDSUnpaginatedLength = 0;
+  protected readonly tableFilters = toSignal(
+    this.paginationFromRoute$.pipe(
+      map(({ page, size }) => ({ pagination: { index: page, size }, searchTerm: '' }) satisfies GioTableWrapperFilters),
+    ),
+    { initialValue: { pagination: { index: 1, size: 10 }, searchTerm: '' } satisfies GioTableWrapperFilters },
+  );
 
-  protected onFiltersChanged(_filters: GioTableWrapperFilters): void {}
+  private readonly pendingRows = computed<MemberRow[]>(() =>
+    this.pendingUsers().map(user => ({
+      id: user.viewId,
+      displayName: user.displayName ?? '',
+      picture: user.userPicture,
+      role: this.defaultRole() ?? '',
+      isPrimaryOwner: false,
+      isPending: true,
+    })),
+  );
+
+  protected readonly allRows = computed<MemberRow[]>(() => [...this.pendingRows(), ...this.membersLoadState().rows]);
+
+  private readonly roleValidationSubscription = merge(this.membersForm.statusChanges, this.membersForm.valueChanges)
+    .pipe(startWith(null), takeUntilDestroyed())
+    .subscribe(() => this.refreshRoleFieldRequiredErrors());
+
+  protected onFiltersChanged(filters: GioTableWrapperFilters): void {
+    this.router.navigate([], {
+      relativeTo: this.activatedRoute,
+      queryParams: { page: filters.pagination.index, size: filters.pagination.size },
+      queryParamsHandling: 'merge',
+    });
+  }
+
+  protected openAddMemberDialog(): void {
+    const apiProductId = this.apiProductId;
+    const { totalCount, rows } = this.membersLoadState();
+    const pendingIds = this.pendingUsers()
+      .map(u => u.id ?? '')
+      .filter(Boolean);
+
+    const allMemberIds$: Observable<string[]> =
+      totalCount <= rows.length
+        ? of(rows.map(m => m.id))
+        : this.apiProductV2Service.getPagedMembers(apiProductId, 1, totalCount).pipe(
+            map(res => (res.data ?? []).map(m => m.id ?? '').filter(Boolean)),
+            catchError(() => of(rows.map(m => m.id))),
+          );
+
+    allMemberIds$
+      .pipe(
+        take(1),
+        switchMap(memberIds => {
+          const existingIds = new Set([...memberIds, ...pendingIds]);
+          return this.matDialog
+            .open<GioUsersSelectorComponent, GioUsersSelectorData, SearchableUser[]>(GioUsersSelectorComponent, {
+              width: '500px',
+              data: {
+                userFilterPredicate: user => !existingIds.has(user.id ?? ''),
+              },
+              role: 'alertdialog',
+              id: 'addApiProductMemberDialog',
+            })
+            .afterClosed();
+        }),
+        filter((selected): selected is SearchableUser[] => !!selected && selected.length > 0),
+        take(1),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(selectedUsers => selectedUsers.forEach(u => this.addPendingUser(u)));
+  }
+
+  protected removeMember(member: MemberRow): void {
+    if (!member.id || member.isPending || member.isPrimaryOwner) {
+      return;
+    }
+    const apiProductId = this.apiProductId;
+    const confirm = this.matDialog.open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
+      data: {
+        title: 'Remove API Product member',
+        content: `Are you sure you want to remove "<b>${member.displayName}</b>" from this API Product members? <br>This action cannot be undone!`,
+        confirmButton: 'Remove',
+      },
+      role: 'alertdialog',
+      id: 'confirmApiProductMemberDeleteDialog',
+    });
+
+    confirm
+      .afterClosed()
+      .pipe(
+        filter(Boolean),
+        switchMap(() => this.apiProductV2Service.deleteMember(apiProductId, member.id)),
+        tap(() => {
+          this.snackBarService.success(`Member ${member.displayName} has been removed.`);
+          this.membersForm.get(member.id)?.disable({ emitEvent: false });
+          const { pagination } = this.tableFilters();
+          const totalCount = this.membersLoadState().totalCount - 1;
+          if (pagination.index > 1 && totalCount <= (pagination.index - 1) * pagination.size) {
+            const lastValidPage = Math.max(1, Math.ceil(totalCount / pagination.size));
+            this.router.navigate([], {
+              relativeTo: this.activatedRoute,
+              queryParams: { page: lastValidPage },
+              queryParamsHandling: 'merge',
+            });
+          } else {
+            this.reloadMembers$.next();
+          }
+        }),
+        catchError(this.memberHttpErrorHandler('Could not remove member.')),
+        take(1),
+      )
+      .subscribe();
+  }
+
+  protected onSave(): void {
+    const apiProductId = this.apiProductId;
+    const controls = this.membersForm.controls as Record<string, AbstractControl>;
+    const dirtyEntries = Object.entries(controls).filter(([, c]) => c.dirty) as [string, FormControl<string>][];
+
+    const requests: Observable<unknown>[] = [];
+    for (const [key, ctrl] of dirtyEntries) {
+      if (key.startsWith('pending-')) {
+        const user = this.pendingUsers().find(u => u.viewId === key);
+        if (!user) {
+          continue;
+        }
+        const roleName = ctrl.value;
+        const payload = user.id != null && user.id !== '' ? { userId: user.id, roleName } : { externalReference: user.reference, roleName };
+        requests.push(this.apiProductV2Service.addMember(apiProductId, payload));
+      } else {
+        requests.push(this.apiProductV2Service.updateMember(apiProductId, { memberId: key, roleName: ctrl.value }));
+      }
+    }
+
+    if (requests.length === 0) {
+      return;
+    }
+
+    forkJoin(requests)
+      .pipe(
+        tap(() => {
+          this.snackBarService.success('Changes successfully saved!');
+          this.clearPendingUsers();
+          this.form.markAsPristine();
+          this.reloadMembers$.next();
+        }),
+        catchError(this.memberHttpErrorHandler('Could not save member changes.')),
+      )
+      .subscribe();
+  }
+
+  protected onReset(): void {
+    this.clearPendingUsers();
+    this.form.markAsPristine();
+    this.syncMembersFormGroup(this.membersLoadState().rows);
+    this.reloadMembers$.next();
+  }
+
+  private get membersForm(): FormGroup {
+    return this.form.get('members') as FormGroup;
+  }
+
+  private get apiProductId(): string {
+    return this.activatedRoute.snapshot.paramMap.get('apiProductId') ?? '';
+  }
+
+  private memberHttpErrorHandler(fallbackMessage: string) {
+    return (err: HttpErrorResponse) => {
+      this.snackBarService.error(err.error?.message ?? fallbackMessage);
+      return EMPTY;
+    };
+  }
+
+  private refreshRoleFieldRequiredErrors(): void {
+    const next: Record<string, boolean> = {};
+    for (const id of Object.keys(this.membersForm.controls)) {
+      next[id] = this.membersForm.controls[id].hasError('required');
+    }
+    this.roleFieldShowsRequiredError.set(next);
+  }
+
+  private mapMemberToRow(member: Member): MemberRow {
+    return {
+      id: member.id ?? '',
+      displayName: member.displayName ?? '',
+      picture: this.usersService.getUserAvatar(member.id),
+      role: effectiveRoleName(member),
+      isPrimaryOwner: (member.roles ?? []).some(r => r.name === 'PRIMARY_OWNER'),
+      isPending: false,
+    };
+  }
+
+  private syncMembersFormGroup(rows: MemberRow[]): void {
+    const serverIds = new Set(rows.map(r => r.id).filter(Boolean));
+
+    for (const key of Object.keys(this.membersForm.controls)) {
+      if (key.startsWith('pending-')) {
+        continue;
+      }
+      if (!serverIds.has(key)) {
+        this.membersForm.removeControl(key);
+      }
+    }
+
+    for (const row of rows) {
+      if (!row.id) {
+        continue;
+      }
+      const disabled = row.isPrimaryOwner || this.isReadOnly;
+      const existing = this.membersForm.get(row.id) as FormControl<string> | null;
+      if (!existing) {
+        this.membersForm.addControl(
+          row.id,
+          new FormControl({ value: row.role, disabled }, { nonNullable: true, validators: [Validators.required] }),
+        );
+      } else if (!existing.dirty) {
+        existing.patchValue(row.role, { emitEvent: false });
+        if (disabled) {
+          existing.disable({ emitEvent: false });
+        } else {
+          existing.enable({ emitEvent: false });
+        }
+      }
+    }
+    this.refreshRoleFieldRequiredErrors();
+  }
+
+  private addPendingUser(user: SearchableUser): void {
+    const viewId = `pending-${uniqueId()}`;
+    this.pendingUsers.update(current => [...current, { ...user, viewId, userPicture: this.usersService.getUserAvatar(user.id) }]);
+    const control = new FormControl<string>(this.defaultRole() ?? '', { nonNullable: true, validators: [Validators.required] });
+    control.markAsDirty();
+    this.membersForm.addControl(viewId, control);
+    this.form.markAsDirty();
+    this.refreshRoleFieldRequiredErrors();
+  }
+
+  private clearPendingUsers(): void {
+    this.pendingUsers.set([]);
+    for (const key of Object.keys(this.membersForm.controls)) {
+      if (key.startsWith('pending-')) {
+        this.membersForm.removeControl(key);
+      }
+    }
+    this.refreshRoleFieldRequiredErrors();
+  }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.spec.ts
@@ -19,6 +19,7 @@ import { TestBed } from '@angular/core/testing';
 import { ApiProductV2Service } from './api-product-v2.service';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
+import { AddMember, Member, MembersResponse, UpdateMember } from '../entities/management-api-v2';
 import { ApiProduct, CreateApiProduct, UpdateApiProduct } from '../entities/management-api-v2/api-product';
 
 function fakeApiProduct(overrides?: Partial<ApiProduct>): ApiProduct {
@@ -370,6 +371,118 @@ describe('ApiProductV2Service', () => {
       });
 
       req.flush({ ok: false, reason: 'Name already exists' });
+    });
+  });
+
+  describe('getPermissions', () => {
+    it('should GET members/permissions for the API Product', done => {
+      const permissions = { MEMBER: 'CRUD', PLAN: 'R' };
+
+      apiProductV2Service.getPermissions('product-abc').subscribe(result => {
+        expect(result).toEqual(permissions);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/product-abc/members/permissions`,
+        method: 'GET',
+      });
+      req.flush(permissions);
+    });
+  });
+
+  describe('getPagedMembers', () => {
+    it('should GET members with default pagination', done => {
+      const response: MembersResponse = {
+        data: [{ id: 'm1', displayName: 'Alice', roles: [{ name: 'USER' }] } as Member],
+        pagination: { totalCount: 1, page: 1, perPage: 10 },
+      };
+
+      apiProductV2Service.getPagedMembers('product-abc').subscribe(result => {
+        expect(result.data).toHaveLength(1);
+        expect(result.pagination?.totalCount).toBe(1);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/product-abc/members?page=1&perPage=10`,
+        method: 'GET',
+      });
+      req.flush(response);
+    });
+
+    it('should GET members with custom page and perPage', done => {
+      const response: MembersResponse = { data: [], pagination: { totalCount: 0, page: 3, perPage: 25 } };
+
+      apiProductV2Service.getPagedMembers('product-abc', 3, 25).subscribe(result => {
+        expect(result.data).toEqual([]);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/product-abc/members?page=3&perPage=25`,
+        method: 'GET',
+      });
+      req.flush(response);
+    });
+  });
+
+  describe('addMember', () => {
+    it('should POST with userId and roleName', done => {
+      const membership: AddMember = { userId: 'user-1', roleName: 'USER' };
+      const created: Member = { id: 'mem-1', displayName: 'Alice', roles: [{ name: 'USER' }] } as Member;
+
+      apiProductV2Service.addMember('product-abc', membership).subscribe(member => {
+        expect(member.id).toEqual('mem-1');
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/product-abc/members`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(membership);
+      req.flush(created);
+    });
+
+    it('should POST with externalReference when no Gravitee user id', done => {
+      const membership: AddMember = { externalReference: 'idp-subject-99', roleName: 'USER' };
+
+      apiProductV2Service.addMember('product-abc', membership).subscribe(() => done());
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/product-abc/members`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(membership);
+      req.flush({ id: 'mem-ext', roles: [{ name: 'USER' }] } as Member);
+    });
+  });
+
+  describe('updateMember', () => {
+    it('should PUT roleName to members/{memberId}', done => {
+      const membership: UpdateMember = { memberId: 'mem-99', roleName: 'OWNER' };
+
+      apiProductV2Service.updateMember('product-abc', membership).subscribe(() => done());
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/product-abc/members/mem-99`,
+        method: 'PUT',
+      });
+      expect(req.request.body).toEqual({ roleName: 'OWNER' });
+      req.flush({ id: 'mem-99', roles: [{ name: 'OWNER' }] } as Member);
+    });
+  });
+
+  describe('deleteMember', () => {
+    it('should DELETE members/{memberId}', done => {
+      apiProductV2Service.deleteMember('product-abc', 'mem-1').subscribe(() => done());
+
+      const req = httpTestingController.expectOne({
+        url: `${baseURL}/api-products/product-abc/members/mem-1`,
+        method: 'DELETE',
+      });
+      req.flush(null);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-product-v2.service.ts
@@ -30,6 +30,7 @@ import {
   UpdateApiProduct,
   VerifyApiProductDeployResponse,
 } from '../entities/management-api-v2/api-product';
+import { AddMember, Member, MembersResponse, UpdateMember } from '../entities/management-api-v2';
 
 @Injectable({
   providedIn: 'root',
@@ -257,5 +258,40 @@ export class ApiProductV2Service {
    */
   getPermissions(apiProductId: string): Observable<Record<string, string>> {
     return this.http.get<Record<string, string>>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/members/permissions`);
+  }
+
+  /**
+   * Get paginated list of members for an API Product
+   * Calls GET /environments/{envId}/api-products/{apiProductId}/members
+   */
+  getPagedMembers(apiProductId: string, page = 1, perPage = 10): Observable<MembersResponse> {
+    const params = new HttpParams().set('page', page.toString()).set('perPage', perPage.toString());
+    return this.http.get<MembersResponse>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/members`, { params });
+  }
+
+  /**
+   * Add a member to an API Product
+   * Calls POST /environments/{envId}/api-products/{apiProductId}/members
+   */
+  addMember(apiProductId: string, membership: AddMember): Observable<Member> {
+    return this.http.post<Member>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/members`, membership);
+  }
+
+  /**
+   * Update a member's role on an API Product
+   * Calls PUT /environments/{envId}/api-products/{apiProductId}/members/{memberId}
+   */
+  updateMember(apiProductId: string, membership: UpdateMember): Observable<Member> {
+    return this.http.put<Member>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/members/${membership.memberId}`, {
+      roleName: membership.roleName,
+    });
+  }
+
+  /**
+   * Remove a member from an API Product
+   * Calls DELETE /environments/{envId}/api-products/{apiProductId}/members/{memberId}
+   */
+  deleteMember(apiProductId: string, memberId: string): Observable<void> {
+    return this.http.delete<void>(`${this.constants.env.v2BaseURL}/api-products/${apiProductId}/members/${memberId}`);
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -105,8 +105,11 @@ import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
 import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryService;
 import io.gravitee.apim.core.logs_engine.use_case.GetLogsFilterDefinitionsUseCase;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
+import io.gravitee.apim.core.member.domain_service.MemberDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
+import io.gravitee.apim.core.member.query_service.MemberQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
 import io.gravitee.apim.core.membership.domain_service.PublishPlanDomainService;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
 import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
@@ -797,6 +800,21 @@ public class ResourceContextConfiguration {
     @Bean
     public GroupCrudServiceInMemory groupCrudService() {
         return new GroupCrudServiceInMemory();
+    }
+
+    @Bean
+    public MembershipDomainService membershipDomainService() {
+        return mock(MembershipDomainService.class);
+    }
+
+    @Bean
+    public MemberDomainService memberDomainService() {
+        return mock(MemberDomainService.class);
+    }
+
+    @Bean
+    public MemberQueryService memberQueryService() {
+        return mock(MemberQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResource.java
@@ -15,18 +15,42 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.api_product;
 
+import io.gravitee.apim.core.api_product.use_case.VerifyApiProductExistsUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.AddApiProductMemberUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.DeleteApiProductMemberUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.GetApiProductMembersUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.UpdateApiProductMemberUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.MemberMapper;
+import io.gravitee.rest.api.management.v2.rest.model.AddMember;
+import io.gravitee.rest.api.management.v2.rest.model.Member;
+import io.gravitee.rest.api.management.v2.rest.model.MembersResponse;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateMember;
+import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
+import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.CustomLog;
 
@@ -36,10 +60,80 @@ public class ApiProductMembersResource extends AbstractResource {
     @PathParam("apiProductId")
     private String apiProductId;
 
+    @Inject
+    private VerifyApiProductExistsUseCase verifyApiProductExistsUseCase;
+
+    @Inject
+    private GetApiProductMembersUseCase getApiProductMembersUseCase;
+
+    @Inject
+    private AddApiProductMemberUseCase addApiProductMemberUseCase;
+
+    @Inject
+    private UpdateApiProductMemberUseCase updateApiProductMemberUseCase;
+
+    @Inject
+    private DeleteApiProductMemberUseCase deleteApiProductMemberUseCase;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_MEMBER, acls = { RolePermissionAction.READ }) })
+    public Response getApiProductMembers(@BeanParam @Valid PaginationParam paginationParam) {
+        verifyApiProductInCurrentEnvironment();
+        var output = getApiProductMembersUseCase.execute(new GetApiProductMembersUseCase.Input(apiProductId));
+        var members = output.members().stream().map(MemberMapper.INSTANCE::map).toList();
+
+        List<Member> membersSubList = computePaginationData(members, paginationParam);
+
+        return Response.ok(
+            new MembersResponse()
+                .data(membersSubList)
+                .pagination(PaginationInfo.computePaginationInfo(members.size(), membersSubList.size(), paginationParam))
+                .links(computePaginationLinks(members.size(), paginationParam))
+        ).build();
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_MEMBER, acls = RolePermissionAction.CREATE) })
+    public Response createApiProductMembership(@Valid @NotNull AddMember apiProductMembership) {
+        verifyApiProductInCurrentEnvironment();
+
+        var output = addApiProductMemberUseCase.execute(
+            new AddApiProductMemberUseCase.Input(MemberMapper.INSTANCE.map(apiProductMembership), apiProductId)
+        );
+        return Response.status(Response.Status.CREATED).entity(MemberMapper.INSTANCE.map(output.createdMember())).build();
+    }
+
+    @PUT
+    @Path("/{memberId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_MEMBER, acls = RolePermissionAction.UPDATE) })
+    public Response updateApiProductMembership(@PathParam("memberId") String memberId, @Valid @NotNull UpdateMember updateMember) {
+        verifyApiProductInCurrentEnvironment();
+
+        var output = updateApiProductMemberUseCase.execute(
+            new UpdateApiProductMemberUseCase.Input(updateMember.getRoleName(), memberId, apiProductId)
+        );
+        return Response.ok().entity(MemberMapper.INSTANCE.map(output.updatedMember())).build();
+    }
+
+    @Path("/{memberId}")
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_MEMBER, acls = RolePermissionAction.DELETE) })
+    public Response deleteApiProductMembership(@PathParam("memberId") String memberId) {
+        verifyApiProductInCurrentEnvironment();
+        deleteApiProductMemberUseCase.execute(new DeleteApiProductMemberUseCase.Input(apiProductId, memberId));
+        return Response.noContent().build();
+    }
+
     @GET
     @Path("/permissions")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getApiProductMemberPermissions() {
+        verifyApiProductInCurrentEnvironment();
         Map<String, char[]> permissions = new HashMap<>();
         if (isAuthenticated()) {
             final String userId = getAuthenticatedUser();
@@ -63,5 +157,10 @@ public class ApiProductMembersResource extends AbstractResource {
             }
         }
         return Response.ok(permissions).build();
+    }
+
+    private void verifyApiProductInCurrentEnvironment() {
+        var ctx = GraviteeContext.getExecutionContext();
+        verifyApiProductExistsUseCase.execute(new VerifyApiProductExistsUseCase.Input(ctx.getEnvironmentId(), apiProductId));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -494,6 +494,144 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /environments/{envId}/api-products/{apiProductId}/members:
+    parameters:
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/apiProductIdParam"
+    get:
+      parameters:
+        - $ref: "#/components/parameters/pageParam"
+        - $ref: "#/components/parameters/perPageParam"
+      tags:
+        - API Product Members
+      summary: List API Product members
+      description: |-
+        List user members for an API Product.
+
+        User must have the API_PRODUCT_MEMBER[READ] permission.
+      operationId: listApiProductMembers
+      responses:
+        "200":
+          $ref: "./openapi-environments.yaml#/components/responses/MembersResponse"
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "403":
+          $ref: '#/components/responses/ForbiddenError'
+        "404":
+          description: API Product not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - API Product Members
+      summary: Add a member to an API Product
+      description: |-
+        Add a new member to an API Product with the given role. PRIMARY_OWNER cannot be assigned through this API.
+
+        Returns 400 when the user is already a member, or when PRIMARY_OWNER is requested.
+
+        User must have the API_PRODUCT_MEMBER[CREATE] permission.
+      operationId: addApiProductMember
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "./openapi-environments.yaml#/components/schemas/AddMember"
+        required: true
+      responses:
+        "201":
+          description: Member successfully added
+          content:
+            application/json:
+              schema:
+                $ref: "./openapi-environments.yaml#/components/schemas/Member"
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "403":
+          $ref: '#/components/responses/ForbiddenError'
+        "404":
+          description: API Product not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
+  /environments/{envId}/api-products/{apiProductId}/members/{memberId}:
+    parameters:
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/apiProductIdParam"
+      - $ref: "./openapi-environments.yaml#/components/parameters/memberId"
+    put:
+      tags:
+        - API Product Members
+      summary: Update an API Product member
+      description: |-
+        Edit a member for an API Product.
+
+        Returns 400 when PRIMARY_OWNER is requested.
+
+        User must have the API_PRODUCT_MEMBER[UPDATE] permission.
+      operationId: updateApiProductMember
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "./openapi-environments.yaml#/components/schemas/UpdateMember"
+        required: true
+      responses:
+        "200":
+          description: Membership successfully edited
+          content:
+            application/json:
+              schema:
+                $ref: "./openapi-environments.yaml#/components/schemas/Member"
+        "400":
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "403":
+          $ref: '#/components/responses/ForbiddenError'
+        "404":
+          description: API Product not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - API Product Members
+      summary: Remove an API Product member
+      description: |-
+        Remove one API Product member.
+
+        User must have the API_PRODUCT_MEMBER[DELETE] permission.
+      operationId: deleteApiProductMember
+      responses:
+        "204":
+          description: Membership successfully deleted
+        "401":
+          $ref: '#/components/responses/UnauthorizedError'
+        "403":
+          $ref: '#/components/responses/ForbiddenError'
+        "404":
+          description: API Product not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
+
   /environments/{envId}/api-products/{apiProductId}/members/permissions:
     parameters:
       - $ref: "#/components/parameters/envIdParam"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResourceTest.java
@@ -15,19 +15,56 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.api_product;
 
+import static assertions.MAPIAssertions.assertThat;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.NO_CONTENT_204;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.use_case.VerifyApiProductExistsUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.AddApiProductMemberUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.DeleteApiProductMemberUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.GetApiProductMembersUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.UpdateApiProductMemberUseCase;
+import io.gravitee.rest.api.management.v2.rest.mapper.MemberMapper;
+import io.gravitee.rest.api.management.v2.rest.model.AddMember;
+import io.gravitee.rest.api.management.v2.rest.model.Links;
+import io.gravitee.rest.api.management.v2.rest.model.Member;
+import io.gravitee.rest.api.management.v2.rest.model.MembersResponse;
+import io.gravitee.rest.api.management.v2.rest.model.Pagination;
+import io.gravitee.rest.api.management.v2.rest.model.Role;
+import io.gravitee.rest.api.management.v2.rest.model.UpdateMember;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.permissions.ApiProductPermission;
+import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -37,6 +74,21 @@ class ApiProductMembersResourceTest extends AbstractResourceTest {
 
     private static final String ENV_ID = "my-env";
     private static final String API_PRODUCT_ID = "c45b8e66-4d2a-47ad-9b8e-664d2a97ad88";
+
+    @Inject
+    private VerifyApiProductExistsUseCase verifyApiProductExistsUseCase;
+
+    @Inject
+    private GetApiProductMembersUseCase getApiProductMembersUseCase;
+
+    @Inject
+    private AddApiProductMemberUseCase addApiProductMemberUseCase;
+
+    @Inject
+    private UpdateApiProductMemberUseCase updateApiProductMemberUseCase;
+
+    @Inject
+    private DeleteApiProductMemberUseCase deleteApiProductMemberUseCase;
 
     @Override
     protected String contextPath() {
@@ -62,11 +114,31 @@ class ApiProductMembersResourceTest extends AbstractResourceTest {
     public void tearDown() {
         super.tearDown();
         GraviteeContext.cleanContext();
-        reset(membershipService);
+        reset(
+            membershipService,
+            verifyApiProductExistsUseCase,
+            getApiProductMembersUseCase,
+            addApiProductMemberUseCase,
+            updateApiProductMemberUseCase,
+            deleteApiProductMemberUseCase
+        );
+    }
+
+    private void givenApiProductExists() {
+        doNothing().when(verifyApiProductExistsUseCase).execute(any());
+    }
+
+    private void givenApiProductMissing() {
+        doThrow(new ApiProductNotFoundException(API_PRODUCT_ID)).when(verifyApiProductExistsUseCase).execute(any());
     }
 
     @Nested
     class GetApiProductMemberPermissionsTest {
+
+        @BeforeEach
+        void setUp() {
+            givenApiProductExists();
+        }
 
         /**
          * JerseySpringTest.AuthenticationFilter always returns {@code true} for {@code isUserInRole},
@@ -77,15 +149,24 @@ class ApiProductMembersResourceTest extends AbstractResourceTest {
          * without replacing the underlying JAX-RS security filter.
          */
         @Test
+        void should_return_404_when_api_product_not_found() {
+            givenApiProductMissing();
+
+            Response response = rootTarget("permissions").request().get();
+
+            assertThat(response).hasStatus(NOT_FOUND_404);
+        }
+
+        @Test
         void should_return_200_with_all_api_product_permissions_for_admin() {
             Response response = rootTarget("permissions").request().get();
 
-            assertThat(response.getStatus()).isEqualTo(OK_200);
+            Assertions.assertThat(response.getStatus()).isEqualTo(OK_200);
 
             @SuppressWarnings("unchecked")
             Map<String, String> permissions = response.readEntity(Map.class);
 
-            assertThat(permissions).isNotNull().hasSize(ApiProductPermission.values().length);
+            Assertions.assertThat(permissions).isNotNull().hasSize(ApiProductPermission.values().length);
 
             // Each permission key maps to a string serialised from char[] — verify CRUD chars present
             final String expectedRights = new String(
@@ -98,9 +179,254 @@ class ApiProductMembersResourceTest extends AbstractResourceTest {
             );
 
             Arrays.stream(ApiProductPermission.values()).forEach(perm ->
-                assertThat(permissions)
+                Assertions.assertThat(permissions)
                     .as("Permission map should contain '%s' with full CRUD rights", perm.getName())
                     .containsEntry(perm.getName(), expectedRights)
+            );
+        }
+    }
+
+    @Nested
+    class ListApiProductMembers {
+
+        @BeforeEach
+        void setUp() {
+            givenApiProductExists();
+        }
+
+        @Test
+        void should_return_404_when_api_product_not_found() {
+            givenApiProductMissing();
+
+            Response response = rootTarget().request().get();
+
+            assertThat(response).hasStatus(NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_when_user_not_permitted_to_list_members() {
+            shouldReturn403(RolePermission.API_PRODUCT_MEMBER, API_PRODUCT_ID, RolePermissionAction.READ, () ->
+                rootTarget().request().get()
+            );
+        }
+
+        @Test
+        void should_list_one_member() {
+            var member = io.gravitee.apim.core.member.model.Member.builder()
+                .id("memberId")
+                .displayName("John Doe")
+                .roles(List.of(io.gravitee.apim.core.member.model.Member.Role.builder().name("API_PRODUCT_USER").build()))
+                .type(MembershipMemberType.USER)
+                .build();
+
+            when(getApiProductMembersUseCase.execute(any())).thenReturn(new GetApiProductMembersUseCase.Output(List.of(member)));
+
+            Response response = rootTarget().request().get();
+
+            assertThat(response).hasStatus(OK_200);
+            Assertions.assertThat(response.readEntity(MembersResponse.class)).isEqualTo(
+                new MembersResponse()
+                    .pagination(new Pagination().page(1).pageCount(1).perPage(10).totalCount(1L).pageItemsCount(1))
+                    .data(Stream.of(member).map(MemberMapper.INSTANCE::map).toList())
+                    .links(new Links().self(rootTarget().getUri().toString()))
+            );
+        }
+    }
+
+    @Nested
+    class CreateApiProductMember {
+
+        @BeforeEach
+        void setUp() {
+            givenApiProductExists();
+            when(addApiProductMemberUseCase.execute(any())).thenAnswer(invocation -> {
+                var input = invocation.getArgument(0, AddApiProductMemberUseCase.Input.class);
+                if ("PRIMARY_OWNER".equals(input.addMember().getRoleName())) {
+                    throw new SinglePrimaryOwnerException(RoleScope.API_PRODUCT);
+                }
+                return new AddApiProductMemberUseCase.Output(
+                    MemberEntity.builder()
+                        .id(input.addMember().getUserId())
+                        .referenceId(input.apiProductId())
+                        .displayName("John Doe")
+                        .roles(List.of(RoleEntity.builder().name(input.addMember().getRoleName()).build()))
+                        .build()
+                );
+            });
+        }
+
+        @Test
+        void should_return_404_when_api_product_not_found() {
+            givenApiProductMissing();
+
+            Response response = rootTarget().request().post(Entity.json(new AddMember().roleName("API_PRODUCT_USER").userId("userId")));
+
+            assertThat(response).hasStatus(NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_when_user_not_permitted_to_create_members() {
+            when(
+                permissionService.hasPermission(
+                    eq(GraviteeContext.getExecutionContext()),
+                    eq(RolePermission.API_PRODUCT_MEMBER),
+                    eq(API_PRODUCT_ID),
+                    eq(RolePermissionAction.CREATE)
+                )
+            ).thenReturn(false);
+
+            Response response = rootTarget().request().post(Entity.json(new AddMember()));
+
+            assertThat(response).hasStatus(FORBIDDEN_403);
+        }
+
+        @Test
+        void should_return_400_when_role_is_primary_owner() {
+            var body = new AddMember().roleName("PRIMARY_OWNER").userId("userId");
+            Response response = rootTarget().request().post(Entity.json(body));
+            assertThat(response)
+                .hasStatus(BAD_REQUEST_400)
+                .asError()
+                .hasMessage("An API_PRODUCT must always have only one PRIMARY_OWNER !");
+        }
+
+        @Test
+        void should_create_api_product_member() {
+            var body = new AddMember().roleName("API_PRODUCT_USER").userId("userId");
+            Response response = rootTarget().request().post(Entity.json(body));
+
+            assertThat(response)
+                .hasStatus(CREATED_201)
+                .asEntity(Member.class)
+                .isEqualTo(new Member().id("userId").displayName("John Doe").roles(List.of(new Role().name("API_PRODUCT_USER"))));
+
+            verify(addApiProductMemberUseCase).execute(
+                argThat(
+                    input ->
+                        "userId".equals(input.addMember().getUserId()) &&
+                        "API_PRODUCT_USER".equals(input.addMember().getRoleName()) &&
+                        API_PRODUCT_ID.equals(input.apiProductId())
+                )
+            );
+        }
+    }
+
+    @Nested
+    class UpdateApiProductMember {
+
+        private static final String MEMBER_ID = "memberId";
+
+        @BeforeEach
+        void setUp() {
+            givenApiProductExists();
+            when(updateApiProductMemberUseCase.execute(any())).thenAnswer(invocation -> {
+                var input = invocation.getArgument(0, UpdateApiProductMemberUseCase.Input.class);
+                if ("PRIMARY_OWNER".equals(input.newRole())) {
+                    throw new SinglePrimaryOwnerException(RoleScope.API_PRODUCT);
+                }
+                return new UpdateApiProductMemberUseCase.Output(
+                    io.gravitee.apim.core.member.model.Member.builder()
+                        .id(input.memberId())
+                        .referenceId(input.apiProductId())
+                        .referenceType(MembershipReferenceType.API_PRODUCT)
+                        .type(MembershipMemberType.USER)
+                        .displayName("John Doe")
+                        .roles(
+                            List.of(
+                                io.gravitee.apim.core.member.model.Member.Role.builder()
+                                    .name(input.newRole())
+                                    .scope(RoleScope.API_PRODUCT)
+                                    .build()
+                            )
+                        )
+                        .build()
+                );
+            });
+        }
+
+        @Test
+        void should_return_404_when_api_product_not_found() {
+            givenApiProductMissing();
+
+            Response response = rootTarget(MEMBER_ID).request().put(Entity.json(new UpdateMember().roleName("API_PRODUCT_USER")));
+
+            assertThat(response).hasStatus(NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_when_user_not_permitted_to_edit_members() {
+            shouldReturn403(RolePermission.API_PRODUCT_MEMBER, API_PRODUCT_ID, RolePermissionAction.UPDATE, () ->
+                rootTarget(MEMBER_ID).request().put(Entity.json(new UpdateMember()))
+            );
+        }
+
+        @Test
+        void should_return_400_when_editing_with_role_primary_owner() {
+            var update = new UpdateMember().roleName("PRIMARY_OWNER");
+            Response response = rootTarget(MEMBER_ID).request().put(Entity.json(update));
+
+            assertThat(response)
+                .hasStatus(BAD_REQUEST_400)
+                .asError()
+                .hasMessage("An API_PRODUCT must always have only one PRIMARY_OWNER !");
+        }
+
+        @Test
+        void should_edit_a_membership() {
+            var update = new UpdateMember().roleName("API_PRODUCT_USER");
+            Response response = rootTarget(MEMBER_ID).request().put(Entity.json(update));
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(Member.class)
+                .isEqualTo(
+                    new Member()
+                        .id(MEMBER_ID)
+                        .displayName("John Doe")
+                        .roles(
+                            List.of(
+                                new Role()
+                                    .name("API_PRODUCT_USER")
+                                    .scope(io.gravitee.rest.api.management.v2.rest.model.RoleScope.API_PRODUCT)
+                            )
+                        )
+                );
+        }
+    }
+
+    @Nested
+    class DeleteApiProductMember {
+
+        private static final String MEMBER_ID = "memberId";
+
+        @BeforeEach
+        void setUp() {
+            givenApiProductExists();
+        }
+
+        @Test
+        void should_return_404_when_api_product_not_found() {
+            givenApiProductMissing();
+
+            Response response = rootTarget(MEMBER_ID).request().delete();
+
+            assertThat(response).hasStatus(NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_when_user_not_permitted_to_delete_members() {
+            shouldReturn403(RolePermission.API_PRODUCT_MEMBER, API_PRODUCT_ID, RolePermissionAction.DELETE, () ->
+                rootTarget(MEMBER_ID).request().delete()
+            );
+        }
+
+        @Test
+        void should_delete_a_membership() {
+            Response response = rootTarget(MEMBER_ID).request().delete();
+
+            assertThat(response).hasStatus(NO_CONTENT_204);
+            verify(deleteApiProductMemberUseCase).execute(
+                argThat(input -> API_PRODUCT_ID.equals(input.apiProductId()) && MEMBER_ID.equals(input.memberId()))
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -76,7 +76,12 @@ import io.gravitee.apim.core.api_product.use_case.GetApiProductApisUseCase;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.SearchApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.UpdateApiProductUseCase;
+import io.gravitee.apim.core.api_product.use_case.VerifyApiProductExistsUseCase;
 import io.gravitee.apim.core.api_product.use_case.VerifyApiProductNameUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.AddApiProductMemberUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.DeleteApiProductMemberUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.GetApiProductMembersUseCase;
+import io.gravitee.apim.core.api_product.use_case.members.UpdateApiProductMemberUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
@@ -990,6 +995,32 @@ public class ResourceContextConfiguration {
     @Bean
     public VerifyApiProductNameUseCase verifyApiProductNameUseCase() {
         return mock(VerifyApiProductNameUseCase.class);
+    }
+
+    @Bean
+    @Primary
+    public VerifyApiProductExistsUseCase verifyApiProductExistsUseCase() {
+        return mock(VerifyApiProductExistsUseCase.class);
+    }
+
+    @Bean
+    public GetApiProductMembersUseCase getApiProductMembersUseCase() {
+        return mock(GetApiProductMembersUseCase.class);
+    }
+
+    @Bean
+    public AddApiProductMemberUseCase addApiProductMemberUseCase() {
+        return mock(AddApiProductMemberUseCase.class);
+    }
+
+    @Bean
+    public UpdateApiProductMemberUseCase updateApiProductMemberUseCase() {
+        return mock(UpdateApiProductMemberUseCase.class);
+    }
+
+    @Bean
+    public DeleteApiProductMemberUseCase deleteApiProductMemberUseCase() {
+        return mock(DeleteApiProductMemberUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -101,8 +101,11 @@ import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
 import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryService;
 import io.gravitee.apim.core.logs_engine.use_case.GetLogsFilterDefinitionsUseCase;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
+import io.gravitee.apim.core.member.domain_service.MemberDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
+import io.gravitee.apim.core.member.query_service.MemberQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
 import io.gravitee.apim.core.membership.domain_service.PublishPlanDomainService;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
 import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
@@ -994,6 +997,21 @@ public class ResourceContextConfiguration {
     @Bean
     public ApplicationPrimaryOwnerDomainService applicationPrimaryOwnerDomainService() {
         return mock(ApplicationPrimaryOwnerDomainService.class);
+    }
+
+    @Bean
+    public MembershipDomainService membershipDomainService() {
+        return mock(MembershipDomainService.class);
+    }
+
+    @Bean
+    public MemberDomainService memberDomainService() {
+        return mock(MemberDomainService.class);
+    }
+
+    @Bean
+    public MemberQueryService memberQueryService() {
+        return mock(MemberQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -101,8 +101,11 @@ import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
 import io.gravitee.apim.core.logs_engine.query_service.LogsDefinitionQueryService;
 import io.gravitee.apim.core.logs_engine.use_case.GetLogsFilterDefinitionsUseCase;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
+import io.gravitee.apim.core.member.domain_service.MemberDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
+import io.gravitee.apim.core.member.query_service.MemberQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
 import io.gravitee.apim.core.membership.domain_service.PublishPlanDomainService;
 import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
@@ -912,6 +915,21 @@ public class ResourceContextConfiguration {
     @Bean
     public GroupCrudServiceInMemory groupCrudService() {
         return new GroupCrudServiceInMemory();
+    }
+
+    @Bean
+    public MembershipDomainService membershipDomainService() {
+        return mock(MembershipDomainService.class);
+    }
+
+    @Bean
+    public MemberDomainService memberDomainService() {
+        return mock(MemberDomainService.class);
+    }
+
+    @Bean
+    public MemberQueryService memberQueryService() {
+        return mock(MemberQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/VerifyApiProductExistsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/VerifyApiProductExistsUseCase.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+
+@UseCase
+@AllArgsConstructor
+public class VerifyApiProductExistsUseCase {
+
+    private final ApiProductQueryService apiProductQueryService;
+
+    public void execute(Input input) {
+        Optional<ApiProduct> product = apiProductQueryService.findById(input.apiProductId());
+        if (product.isEmpty() || !input.environmentId().equals(product.get().getEnvironmentId())) {
+            throw new ApiProductNotFoundException(input.apiProductId());
+        }
+    }
+
+    public record Input(String environmentId, String apiProductId) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/AddApiProductMemberUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/AddApiProductMemberUseCase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case.members;
+
+import static io.gravitee.rest.api.model.permissions.SystemRole.PRIMARY_OWNER;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.member.model.MembershipReferenceType;
+import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
+import io.gravitee.apim.core.membership.model.AddMember;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
+import lombok.AllArgsConstructor;
+
+@UseCase
+@AllArgsConstructor
+public class AddApiProductMemberUseCase {
+
+    private final MembershipDomainService membershipDomainService;
+
+    public record Input(AddMember addMember, String apiProductId) {}
+
+    public record Output(MemberEntity createdMember) {}
+
+    public Output execute(Input input) {
+        validateMembership(input.addMember);
+
+        MemberEntity created = membershipDomainService.createNewMembership(
+            GraviteeContext.getExecutionContext(),
+            MembershipReferenceType.API_PRODUCT,
+            input.apiProductId,
+            input.addMember.getUserId(),
+            input.addMember.getExternalReference(),
+            input.addMember.getRoleName()
+        );
+
+        return new Output(created);
+    }
+
+    private void validateMembership(AddMember addMember) {
+        if (PRIMARY_OWNER.name().equals(addMember.getRoleName())) {
+            throw new SinglePrimaryOwnerException(RoleScope.API_PRODUCT);
+        }
+        if (addMember.getUserId() == null && addMember.getExternalReference() == null) {
+            throw new InvalidDataException("Request must specify either userId or externalReference");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/DeleteApiProductMemberUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/DeleteApiProductMemberUseCase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case.members;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.member.model.MembershipMemberType;
+import io.gravitee.apim.core.member.model.MembershipReferenceType;
+import io.gravitee.apim.core.member.query_service.MemberQueryService;
+import lombok.AllArgsConstructor;
+
+@UseCase
+@AllArgsConstructor
+public class DeleteApiProductMemberUseCase {
+
+    private final MemberQueryService memberQueryService;
+
+    public record Input(String apiProductId, String memberId) {}
+
+    public record Output() {}
+
+    public Output execute(Input input) {
+        memberQueryService.deleteReferenceMember(
+            MembershipReferenceType.API_PRODUCT,
+            input.apiProductId,
+            MembershipMemberType.USER,
+            input.memberId
+        );
+        return new Output();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/GetApiProductMembersUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/GetApiProductMembersUseCase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case.members;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.member.model.Member;
+import io.gravitee.apim.core.member.model.MembershipReferenceType;
+import io.gravitee.apim.core.member.query_service.MemberQueryService;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import java.util.Comparator;
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+@UseCase
+public class GetApiProductMembersUseCase {
+
+    private final MemberQueryService memberQueryService;
+
+    public record Input(String apiProductId) {}
+
+    public record Output(List<Member> members) {}
+
+    public Output execute(Input input) {
+        var members = memberQueryService
+            .getMembersByReference(MembershipReferenceType.API_PRODUCT, input.apiProductId)
+            .stream()
+            .filter(member -> member.getType() == MembershipMemberType.USER)
+            .sorted(Comparator.comparing(Member::getId, Comparator.nullsLast(String::compareTo)))
+            .toList();
+        return new Output(members);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/UpdateApiProductMemberUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/UpdateApiProductMemberUseCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case.members;
+
+import static io.gravitee.rest.api.model.permissions.SystemRole.PRIMARY_OWNER;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.member.model.Member;
+import io.gravitee.apim.core.member.model.MembershipMember;
+import io.gravitee.apim.core.member.model.MembershipMemberType;
+import io.gravitee.apim.core.member.model.MembershipReference;
+import io.gravitee.apim.core.member.model.MembershipReferenceType;
+import io.gravitee.apim.core.member.model.MembershipRole;
+import io.gravitee.apim.core.member.query_service.MemberQueryService;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
+import lombok.AllArgsConstructor;
+
+@UseCase
+@AllArgsConstructor
+public class UpdateApiProductMemberUseCase {
+
+    private final MemberQueryService memberQueryService;
+
+    public record Input(String newRole, String memberId, String apiProductId) {}
+
+    public record Output(Member updatedMember) {}
+
+    public Output execute(Input input) {
+        if (PRIMARY_OWNER.name().equals(input.newRole)) {
+            throw new SinglePrimaryOwnerException(RoleScope.API_PRODUCT);
+        }
+
+        var reference = new MembershipReference(MembershipReferenceType.API_PRODUCT, input.apiProductId);
+        var member = MembershipMember.builder().memberId(input.memberId).memberType(MembershipMemberType.USER).build();
+        var role = MembershipRole.builder().scope(io.gravitee.apim.core.member.model.RoleScope.API_PRODUCT).name(input.newRole).build();
+        Member updatedMember = memberQueryService.updateRoleToMemberOnReference(reference, member, role);
+
+        return new Output(updatedMember);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/exception/MemberNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/exception/MemberNotFoundException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.membership.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+
+public class MemberNotFoundException extends NotFoundDomainException {
+
+    public MemberNotFoundException(String memberId) {
+        super("Member not found.", memberId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -95,6 +95,10 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
 
     @Lazy
     @Autowired
+    private ApiProductsRepository apiProductsRepository;
+
+    @Lazy
+    @Autowired
     private EnvironmentRepository environmentRepository;
 
     @Lazy
@@ -230,9 +234,7 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
                     }
                 }
             } else if (
-                auditEntity.getReferenceId() != null &&
-                (Audit.AuditReferenceType.API.name().equals(auditEntity.getReferenceType().name()) ||
-                    Audit.AuditReferenceType.API_PRODUCT.name().equals(auditEntity.getReferenceType().name()))
+                auditEntity.getReferenceId() != null && Audit.AuditReferenceType.API.name().equals(auditEntity.getReferenceType().name())
             ) {
                 metadataKey = "API:" + auditEntity.getReferenceId() + ":name";
                 if (!metadata.containsKey(metadataKey)) {
@@ -240,6 +242,24 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
                         Optional<Api> optApi = apiRepository.findById(auditEntity.getReferenceId());
                         if (optApi.isPresent()) {
                             metadata.put(metadataKey, optApi.get().getName());
+                        }
+                    } catch (TechnicalException e) {
+                        log.error("Error finding metadata {}", metadataKey);
+                        metadata.put(metadataKey, auditEntity.getReferenceId());
+                    }
+                }
+            } else if (
+                auditEntity.getReferenceId() != null &&
+                Audit.AuditReferenceType.API_PRODUCT.name().equals(auditEntity.getReferenceType().name())
+            ) {
+                metadataKey = "API_PRODUCT:" + auditEntity.getReferenceId() + ":name";
+                if (!metadata.containsKey(metadataKey)) {
+                    try {
+                        Optional<io.gravitee.repository.management.model.ApiProduct> optApiProduct = apiProductsRepository.findById(
+                            auditEntity.getReferenceId()
+                        );
+                        if (optApiProduct.isPresent()) {
+                            metadata.put(metadataKey, optApiProduct.get().getName());
                         }
                     } catch (TechnicalException e) {
                         log.error("Error finding metadata {}", metadataKey);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -511,6 +511,19 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                     referenceId
                 );
                 break;
+            case API_PRODUCT:
+                auditService.createApiProductAuditLog(
+                    executionContext,
+                    AuditService.AuditLogData.builder()
+                        .properties(properties)
+                        .event(event)
+                        .createdAt(date)
+                        .oldValue(oldValue)
+                        .newValue(newValue)
+                        .build(),
+                    referenceId
+                );
+                break;
             case APPLICATION:
                 auditService.createApplicationAuditLog(
                     executionContext,
@@ -856,6 +869,9 @@ public class MembershipServiceImpl extends AbstractService implements Membership
             RoleEntity integrationPORole = roleService
                 .findByScopeAndName(RoleScope.INTEGRATION, PRIMARY_OWNER.name(), executionContext.getOrganizationId())
                 .orElseThrow(() -> new TechnicalManagementException("Unable to find Application Primary Owner role"));
+            RoleEntity apiProductPORole = roleService
+                .findByScopeAndName(RoleScope.API_PRODUCT, PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+                .orElseThrow(() -> new TechnicalManagementException("Unable to find API Product Primary Owner role"));
             Set<io.gravitee.repository.management.model.Membership> memberships =
                 membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
                     memberId,
@@ -872,6 +888,9 @@ public class MembershipServiceImpl extends AbstractService implements Membership
             }
             if (MembershipReferenceType.INTEGRATION.equals(referenceType)) {
                 assertNoPrimaryOwnerRemoval(integrationPORole, memberships);
+            }
+            if (MembershipReferenceType.API_PRODUCT.equals(referenceType)) {
+                assertNoPrimaryOwnerRemoval(apiProductPORole, memberships);
             }
 
             for (io.gravitee.repository.management.model.Membership membership : memberships) {
@@ -2013,6 +2032,9 @@ public class MembershipServiceImpl extends AbstractService implements Membership
             RoleEntity appPORole = roleService
                 .findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), executionContext.getOrganizationId())
                 .orElseThrow(() -> new TechnicalManagementException("Unable to find APPLICATION Primary Owner role"));
+            RoleEntity apiProductPORole = roleService
+                .findByScopeAndName(RoleScope.API_PRODUCT, PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+                .orElseThrow(() -> new TechnicalManagementException("Unable to find API Product Primary Owner role"));
 
             Set<io.gravitee.repository.management.model.Membership> existingMemberships =
                 this.membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
@@ -2033,6 +2055,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 assertNoPrimaryOwnerRemoval(apiPORole, existingMemberships);
                 assertNoPrimaryOwnerRemoval(appPORole, existingMemberships);
                 assertNoPrimaryOwnerRemoval(integrationPORole, existingMemberships);
+                assertNoPrimaryOwnerRemoval(apiProductPORole, existingMemberships);
             }
 
             if (existingMemberships != null && !existingMemberships.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/VerifyApiProductExistsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/VerifyApiProductExistsUseCaseTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.AbstractUseCaseTest;
+import inmemory.ApiProductQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class VerifyApiProductExistsUseCaseTest extends AbstractUseCaseTest {
+
+    private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    private VerifyApiProductExistsUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new VerifyApiProductExistsUseCase(apiProductQueryService);
+    }
+
+    @Test
+    void should_pass_when_product_exists_in_environment() {
+        ApiProduct product = ApiProduct.builder().id("p1").name("P").environmentId(ENV_ID).build();
+        apiProductQueryService.initWith(Collections.singletonList(product));
+
+        assertThatCode(() -> cut.execute(new VerifyApiProductExistsUseCase.Input(ENV_ID, "p1"))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_throw_when_product_missing() {
+        assertThatThrownBy(() -> cut.execute(new VerifyApiProductExistsUseCase.Input(ENV_ID, "missing"))).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+    }
+
+    @Test
+    void should_throw_when_product_belongs_to_another_environment() {
+        ApiProduct product = ApiProduct.builder().id("p1").name("P").environmentId("other-env").build();
+        apiProductQueryService.initWith(Collections.singletonList(product));
+
+        assertThatThrownBy(() -> cut.execute(new VerifyApiProductExistsUseCase.Input(ENV_ID, "p1"))).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/AddApiProductMemberUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/AddApiProductMemberUseCaseTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case.members;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import inmemory.AbstractUseCaseTest;
+import inmemory.MembershipDomainServiceInMemory;
+import io.gravitee.apim.core.membership.model.AddMember;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AddApiProductMemberUseCaseTest extends AbstractUseCaseTest {
+
+    private AddApiProductMemberUseCase addApiProductMemberUseCase;
+    private final MembershipDomainServiceInMemory membershipDomainService = new MembershipDomainServiceInMemory();
+
+    @BeforeEach
+    void setUp() {
+        addApiProductMemberUseCase = new AddApiProductMemberUseCase(membershipDomainService);
+    }
+
+    @Test
+    void should_add_api_product_member() {
+        AddMember addMember = AddMember.builder().roleName("API_PRODUCT_USER").userId("user-1").build();
+
+        addApiProductMemberUseCase.execute(new AddApiProductMemberUseCase.Input(addMember, "ap-1"));
+
+        var membership = membershipDomainService.storage().stream().findFirst().orElseThrow();
+        assertAll(() ->
+            assertThat(membership)
+                .usingRecursiveComparison()
+                .isEqualTo(
+                    MemberEntity.builder()
+                        .referenceType(MembershipReferenceType.API_PRODUCT)
+                        .referenceId("ap-1")
+                        .roles(List.of(RoleEntity.builder().name("API_PRODUCT_USER").build()))
+                        .type(MembershipMemberType.USER)
+                        .id("user-1")
+                        .build()
+                )
+        );
+    }
+
+    @Test
+    void should_throw_validation_error_when_role_is_primary_owner() {
+        AddMember addMember = AddMember.builder().roleName("PRIMARY_OWNER").userId("u1").build();
+
+        assertThrows(SinglePrimaryOwnerException.class, () ->
+            addApiProductMemberUseCase.execute(new AddApiProductMemberUseCase.Input(addMember, "ap-1"))
+        );
+    }
+
+    @Test
+    void should_throw_when_user_id_and_external_reference_missing() {
+        AddMember addMember = AddMember.builder().roleName("API_PRODUCT_USER").build();
+
+        assertThrows(InvalidDataException.class, () ->
+            addApiProductMemberUseCase.execute(new AddApiProductMemberUseCase.Input(addMember, "ap-1"))
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/DeleteApiProductMemberUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/DeleteApiProductMemberUseCaseTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case.members;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.MemberQueryServiceInMemory;
+import io.gravitee.apim.core.member.model.Member;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DeleteApiProductMemberUseCaseTest {
+
+    private DeleteApiProductMemberUseCase deleteApiProductMemberUseCase;
+    private final MemberQueryServiceInMemory memberQueryService = new MemberQueryServiceInMemory();
+
+    @BeforeEach
+    void setUp() {
+        deleteApiProductMemberUseCase = new DeleteApiProductMemberUseCase(memberQueryService);
+        initMembers();
+    }
+
+    @Test
+    void should_delete_member() {
+        assertThat(memberQueryService.storage()).hasSize(3);
+        deleteApiProductMemberUseCase.execute(new DeleteApiProductMemberUseCase.Input("ap-1", "member-1"));
+        assertThat(memberQueryService.storage()).hasSize(2);
+        assertThat(memberQueryService.storage()).map(Member::getId).containsExactlyInAnyOrder("member-2", "member-3");
+    }
+
+    private void initMembers() {
+        memberQueryService.initWith(
+            List.of(
+                Member.builder()
+                    .id("member-1")
+                    .referenceType(MembershipReferenceType.API_PRODUCT)
+                    .referenceId("ap-1")
+                    .type(MembershipMemberType.USER)
+                    .roles(List.of())
+                    .build(),
+                Member.builder()
+                    .id("member-2")
+                    .referenceType(MembershipReferenceType.API_PRODUCT)
+                    .referenceId("ap-1")
+                    .type(MembershipMemberType.USER)
+                    .roles(List.of())
+                    .build(),
+                Member.builder()
+                    .id("member-3")
+                    .referenceType(MembershipReferenceType.API_PRODUCT)
+                    .referenceId("ap-1")
+                    .type(MembershipMemberType.USER)
+                    .roles(List.of())
+                    .build()
+            )
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/GetApiProductMembersUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/GetApiProductMembersUseCaseTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case.members;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.MemberQueryServiceInMemory;
+import io.gravitee.apim.core.member.model.Member;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class GetApiProductMembersUseCaseTest {
+
+    private GetApiProductMembersUseCase getApiProductMembersUseCase;
+    private final MemberQueryServiceInMemory memberQueryService = new MemberQueryServiceInMemory();
+
+    @BeforeEach
+    void setUp() {
+        getApiProductMembersUseCase = new GetApiProductMembersUseCase(memberQueryService);
+        initMembers();
+    }
+
+    @Test
+    void should_return_api_product_members_sorted_by_id_with_nulls_last() {
+        var result = getApiProductMembersUseCase.execute(new GetApiProductMembersUseCase.Input("ap-1"));
+
+        assertThat(result.members()).map(Member::getId).containsExactly("member-1", "member-2", "member-5", null);
+    }
+
+    @Test
+    void should_return_empty_list_when_no_members_for_product() {
+        var result = getApiProductMembersUseCase.execute(new GetApiProductMembersUseCase.Input("ap-unknown"));
+
+        assertThat(result.members()).isEmpty();
+    }
+
+    @Test
+    void should_exclude_non_user_members() {
+        var result = getApiProductMembersUseCase.execute(new GetApiProductMembersUseCase.Input("ap-1"));
+
+        assertThat(result.members()).allMatch(m -> m.getType() == MembershipMemberType.USER);
+    }
+
+    private void initMembers() {
+        List<Member> members = List.of(
+            Member.builder()
+                .id("member-5")
+                .referenceType(MembershipReferenceType.API_PRODUCT)
+                .referenceId("ap-1")
+                .type(MembershipMemberType.USER)
+                .build(),
+            Member.builder()
+                .id("member-2")
+                .referenceType(MembershipReferenceType.API_PRODUCT)
+                .referenceId("ap-1")
+                .type(MembershipMemberType.USER)
+                .build(),
+            Member.builder()
+                .id(null)
+                .referenceType(MembershipReferenceType.API_PRODUCT)
+                .referenceId("ap-1")
+                .type(MembershipMemberType.USER)
+                .build(),
+            Member.builder()
+                .id("member-3")
+                .referenceType(MembershipReferenceType.API_PRODUCT)
+                .referenceId("ap-2")
+                .type(MembershipMemberType.USER)
+                .build(),
+            Member.builder()
+                .id("member-1")
+                .referenceType(MembershipReferenceType.API_PRODUCT)
+                .referenceId("ap-1")
+                .type(MembershipMemberType.USER)
+                .build(),
+            Member.builder()
+                .id("group-1")
+                .referenceType(MembershipReferenceType.API_PRODUCT)
+                .referenceId("ap-1")
+                .type(MembershipMemberType.GROUP)
+                .build()
+        );
+        memberQueryService.initWith(members);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/UpdateApiProductMemberUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/UpdateApiProductMemberUseCaseTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case.members;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.MemberQueryServiceInMemory;
+import io.gravitee.apim.core.member.model.Member;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UpdateApiProductMemberUseCaseTest {
+
+    private UpdateApiProductMemberUseCase updateApiProductMemberUseCase;
+    private final MemberQueryServiceInMemory memberQueryService = new MemberQueryServiceInMemory();
+
+    @BeforeEach
+    void setUp() {
+        updateApiProductMemberUseCase = new UpdateApiProductMemberUseCase(memberQueryService);
+        initMembers();
+    }
+
+    @Test
+    void should_update_api_product_member() {
+        Member member = memberQueryService.storage().get(0);
+        assertThat(member.getRoles().get(0).getName()).isEqualTo("OWNER");
+
+        updateApiProductMemberUseCase.execute(new UpdateApiProductMemberUseCase.Input("API_PRODUCT_USER", "member-1", "ap-1"));
+
+        member = memberQueryService.storage().get(0);
+        assertThat(member.getRoles().get(0).getName()).isEqualTo("API_PRODUCT_USER");
+        assertThat(member.getRoles().get(0).getScope()).isEqualTo(RoleScope.API_PRODUCT);
+    }
+
+    @Test
+    void should_throw_validation_error_when_role_is_primary_owner() {
+        assertThatThrownBy(() ->
+            updateApiProductMemberUseCase.execute(new UpdateApiProductMemberUseCase.Input("PRIMARY_OWNER", "member-1", "ap-1"))
+        ).isInstanceOf(SinglePrimaryOwnerException.class);
+    }
+
+    private void initMembers() {
+        List<Member> members = List.of(
+            Member.builder()
+                .referenceType(MembershipReferenceType.API_PRODUCT)
+                .referenceId("ap-1")
+                .type(MembershipMemberType.USER)
+                .id("member-1")
+                .roles(List.of(Member.Role.builder().name("OWNER").build()))
+                .build()
+        );
+        memberQueryService.initWith(members);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiProductTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiProductTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.DELETE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.node.api.Node;
+import io.gravitee.repository.management.api.CommandRepository;
+import io.gravitee.repository.management.api.MembershipRepository;
+import io.gravitee.repository.management.model.Membership;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.permissions.OrganizationPermission;
+import io.gravitee.rest.api.model.permissions.Permission;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.providers.User;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.IdentityService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.MembershipAlreadyExistsException;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
+import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MembershipService_CreateNewMembershipForApiProductTest {
+
+    private static final String API_PRODUCT_ID = "api-product-id-1";
+
+    private MembershipServiceImpl membershipService;
+
+    @Mock
+    private MembershipRepository membershipRepository;
+
+    @Mock
+    private ApiSearchService apiSearchService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private IdentityService identityService;
+
+    @Mock
+    private Node node;
+
+    @Mock
+    private CommandRepository commandRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private PrimaryOwnerService primaryOwnerService;
+
+    @BeforeEach
+    void setUp() {
+        reset(membershipRepository, apiSearchService, userService, auditService, roleService, identityService);
+
+        membershipService = new MembershipServiceImpl(
+            identityService,
+            userService,
+            null,
+            null,
+            primaryOwnerService,
+            null,
+            membershipRepository,
+            roleService,
+            null,
+            null,
+            apiSearchService,
+            null,
+            null,
+            null,
+            auditService,
+            null,
+            null,
+            node,
+            objectMapper,
+            commandRepository,
+            null,
+            null
+        );
+
+        mockRole();
+    }
+
+    @Test
+    void should_create_membership_and_write_api_product_audit_log() throws Exception {
+        String existingUserId = "existing-user-id";
+        mockExistingUser(existingUserId);
+
+        Membership newMembership = new Membership();
+        newMembership.setReferenceType(io.gravitee.repository.management.model.MembershipReferenceType.API_PRODUCT);
+        newMembership.setRoleId("API_PRODUCT_OWNER");
+        newMembership.setReferenceId(API_PRODUCT_ID);
+        newMembership.setMemberId(existingUserId);
+        newMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.USER);
+
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
+                existingUserId,
+                io.gravitee.repository.management.model.MembershipMemberType.USER,
+                io.gravitee.repository.management.model.MembershipReferenceType.API_PRODUCT,
+                API_PRODUCT_ID
+            )
+        ).thenReturn(Collections.emptySet(), Set.of(newMembership));
+
+        MemberEntity createdMember = membershipService.createNewMembership(
+            GraviteeContext.getExecutionContext(),
+            MembershipReferenceType.API_PRODUCT,
+            API_PRODUCT_ID,
+            existingUserId,
+            null,
+            "OWNER"
+        );
+
+        assertThat(createdMember).isNotNull();
+        verify(auditService).createApiProductAuditLog(any(), any(), eq(API_PRODUCT_ID));
+    }
+
+    private void mockExistingUser(String existingUserId) {
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(existingUserId);
+        when(userService.findById(GraviteeContext.getExecutionContext(), existingUserId)).thenReturn(userEntity);
+    }
+
+    private void mockRole() {
+        RoleEntity role = role("API_PRODUCT_OWNER");
+        lenient()
+            .when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, "OWNER", GraviteeContext.getCurrentOrganization()))
+            .thenReturn(Optional.of(role));
+        when(roleService.findByIds(Set.of("API_PRODUCT_OWNER"))).thenReturn(Map.of("API_PRODUCT_OWNER", role));
+    }
+
+    private static RoleEntity role(String roleId) {
+        Map<String, char[]> perms = new HashMap<>();
+        for (Permission perm : OrganizationPermission.values()) {
+            perms.put(perm.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() });
+        }
+        RoleEntity role = new RoleEntity();
+        role.setScope(RoleScope.API_PRODUCT);
+        role.setName("OWNER");
+        role.setId(roleId);
+        role.setPermissions(perms);
+        return role;
+    }
+
+    private void mockExternalUser(String externalReference) {
+        User externalUser = new User();
+        externalUser.setSource("source");
+        externalUser.setSourceId(externalReference);
+        externalUser.setId("external-user-id");
+        when(identityService.findByReference(externalReference)).thenReturn(Optional.of(externalUser));
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId("external-user-id");
+        userEntity.setSource("source");
+        userEntity.setSourceId(externalReference);
+        when(userService.findBySource(anyString(), anyString(), anyString(), eq(false))).thenReturn(userEntity);
+
+        mockExistingUser("external-user-id");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
@@ -49,6 +49,7 @@ public class MembershipService_DeleteMemberTest {
     private static final String API_PO_ROLE_ID = "123";
     private static final String APPLICATION_PO_ROLE_ID = "222";
     private static final String INTEGRATION_PO_ROLE_ID = "333";
+    private static final String API_PRODUCT_PO_ROLE_ID = "444";
     private static final String MEMBER_ID = "456";
     private static final String API_ID = "789";
     private static final String APPLICATION_ID = "app#1";
@@ -95,6 +96,9 @@ public class MembershipService_DeleteMemberTest {
         );
         when(roleService.findByScopeAndName(RoleScope.INTEGRATION, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(
             primaryOwnerRole(RoleScope.INTEGRATION, INTEGRATION_PO_ROLE_ID)
+        );
+        when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(
+            primaryOwnerRole(RoleScope.API_PRODUCT, API_PRODUCT_PO_ROLE_ID)
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
@@ -95,6 +95,7 @@ public class MembershipService_EditMemberTest {
         when(roleService.findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(apiPrimaryOwnerRole());
         when(roleService.findByScopeAndName(RoleScope.INTEGRATION, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(Optional.of(new RoleEntity()));
         when(roleService.findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(appPrimaryOwnerRole());
+        when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(Optional.of(new RoleEntity()));
 
         Membership membership = new Membership();
         membership.setRoleId(API_PO_ROLE_ID);
@@ -127,6 +128,7 @@ public class MembershipService_EditMemberTest {
         when(roleService.findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(apiPrimaryOwnerRole());
         when(roleService.findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(appPrimaryOwnerRole());
         when(roleService.findByScopeAndName(RoleScope.INTEGRATION, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(Optional.of(new RoleEntity()));
+        when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(Optional.of(new RoleEntity()));
 
         Membership membership = new Membership();
         membership.setRoleId(APP_PO_ROLE_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_IntegrationMembershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_IntegrationMembershipTest.java
@@ -311,6 +311,9 @@ public class MembershipService_IntegrationMembershipTest {
             when(
                 roleService.findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
             ).thenReturn(Optional.of(new RoleEntity()));
+            when(
+                roleService.findByScopeAndName(RoleScope.API_PRODUCT, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
+            ).thenReturn(Optional.of(new RoleEntity()));
             when(integrationRepository.findByIntegrationId(INTEGRATION_ID)).thenReturn(Optional.of(new Integration()));
 
             MemberEntity updatedMember = membershipService.updateMembershipForIntegration(
@@ -368,6 +371,9 @@ public class MembershipService_IntegrationMembershipTest {
                 roleService.findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
             ).thenReturn(Optional.of(new RoleEntity()));
             when(
+                roleService.findByScopeAndName(RoleScope.API_PRODUCT, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
+            ).thenReturn(Optional.of(new RoleEntity()));
+            when(
                 membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
                     EXISTING_USER_ID,
                     MembershipMemberType.USER,
@@ -400,6 +406,9 @@ public class MembershipService_IntegrationMembershipTest {
             ).thenReturn(Optional.of(new RoleEntity()));
             when(
                 roleService.findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
+            ).thenReturn(Optional.of(new RoleEntity()));
+            when(
+                roleService.findByScopeAndName(RoleScope.API_PRODUCT, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
             ).thenReturn(Optional.of(new RoleEntity()));
             when(
                 membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
@@ -160,6 +160,9 @@ public class MembershipService_UpdateMembershipForApiTest {
         when(
             roleService.findByScopeAndName(RoleScope.APPLICATION, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
         ).thenReturn(Optional.of(new RoleEntity()));
+        when(
+            roleService.findByScopeAndName(RoleScope.API_PRODUCT, PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
+        ).thenReturn(Optional.of(new RoleEntity()));
 
         MemberEntity updatedMember = membershipService.updateMembershipForApi(
             GraviteeContext.getExecutionContext(),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13373
https://gravitee.atlassian.net/browse/APIM-13372

## Description

This PR adds API Product members in the backend and console: you can see who has access to an API Product and add, change, or remove their roles, using the same kind of flow as other member screens.

<img width="1511" height="709" alt="image" src="https://github.com/user-attachments/assets/89296a04-65d4-488f-bf60-fadc28e2e3d0" />
