### PR TITLE
fix(rest-api): clean stale group refs from page accessControls on group deletion (APIM-13541)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PageCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PageCriteria.java
@@ -34,6 +34,7 @@ public class PageCriteria {
     private String parent;
     private Boolean rootParent;
     private Boolean useAutoFetch;
+    private String accessControlGroupId;
 
     private PageCriteria() {}
 
@@ -67,6 +68,10 @@ public class PageCriteria {
 
     public Boolean getUseAutoFetch() {
         return useAutoFetch;
+    }
+
+    public String getAccessControlGroupId() {
+        return accessControlGroupId;
     }
 
     public String getReferenceType() {
@@ -113,6 +118,10 @@ public class PageCriteria {
         this.useAutoFetch = useAutoFetch;
     }
 
+    private void setAccessControlGroupId(String accessControlGroupId) {
+        this.accessControlGroupId = accessControlGroupId;
+    }
+
     public void setVisibility(String visibility) {
         this.visibility = visibility;
     }
@@ -131,13 +140,25 @@ public class PageCriteria {
             Objects.equals(published, that.published) &&
             Objects.equals(visibility, that.visibility) &&
             Objects.equals(parent, that.parent) &&
-            Objects.equals(rootParent, that.rootParent)
+            Objects.equals(rootParent, that.rootParent) &&
+            Objects.equals(accessControlGroupId, that.accessControlGroupId)
         );
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(referenceId, referenceType, name, type, homepage, published, visibility, parent, rootParent);
+        return Objects.hash(
+            referenceId,
+            referenceType,
+            name,
+            type,
+            homepage,
+            published,
+            visibility,
+            parent,
+            rootParent,
+            accessControlGroupId
+        );
     }
 
     public static class Builder {
@@ -199,6 +220,11 @@ public class PageCriteria {
 
         public Builder withAutoFetch() {
             this.query.setUseAutoFetch(Boolean.TRUE);
+            return this;
+        }
+
+        public Builder accessControlGroupId(String groupId) {
+            this.query.setAccessControlGroupId(groupId);
             return this;
         }
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPageRepository.java
@@ -659,6 +659,13 @@ public class JdbcPageRepository extends JdbcAbstractCrudRepository<Page, String>
                     where.add("p.use_auto_fetch = ?");
                     params.add(criteria.getUseAutoFetch());
                 }
+                if (criteria.getAccessControlGroupId() != null) {
+                    select += "inner join " + PAGE_ACL + " acl on p.id = acl.page_id ";
+                    where.add("acl.reference_id = ?");
+                    params.add(criteria.getAccessControlGroupId());
+                    where.add("acl.reference_type = ?");
+                    params.add("GROUP");
+                }
             }
 
             if (!where.toString().trim().isEmpty()) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryImpl.java
@@ -101,6 +101,16 @@ public class PageMongoRepositoryImpl implements PageMongoRepositoryCustom {
             if (criteria.getUseAutoFetch() != null) {
                 q.addCriteria(where("useAutoFetch").is(criteria.getUseAutoFetch().booleanValue()));
             }
+            if (criteria.getAccessControlGroupId() != null) {
+                q.addCriteria(
+                    where("accessControls").elemMatch(
+                        new Criteria().andOperator(
+                            where("referenceId").is(criteria.getAccessControlGroupId()),
+                            where("referenceType").is("GROUP")
+                        )
+                    )
+                );
+            }
         }
 
         q.with(Sort.by(ASC, "order"));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryImplTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryImplTest.java
@@ -16,13 +16,17 @@
 package io.gravitee.repository.mongodb.management.internal.page;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.PageMongo;
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
@@ -72,6 +76,27 @@ class PageMongoRepositoryImplTest {
             MAPPER.readTree(
                 """
                 {"$set":{"homepage":false}}
+                """
+            )
+        );
+    }
+
+    @Test
+    @SneakyThrows
+    void searchByAccessControlGroupId() {
+        PageMongoRepositoryImpl repository = buildRepository();
+        when(mongoTemplate.find(any(Query.class), eq(PageMongo.class))).thenReturn(Collections.emptyList());
+
+        PageCriteria criteria = new PageCriteria.Builder().referenceType("API").accessControlGroupId("my-group").build();
+        repository.search(criteria);
+
+        verify(mongoTemplate).find(queryCaptor.capture(), eq(PageMongo.class));
+
+        JsonNode jsonQuery = MAPPER.readTree(queryCaptor.getValue().getQueryObject().toJson());
+        assertThat(jsonQuery).isEqualTo(
+            MAPPER.readTree(
+                """
+                {"referenceType":"API","accessControls":{"$elemMatch":{"$and":[{"referenceId":"my-group"},{"referenceType":"GROUP"}]}}}
                 """
             )
         );

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PageRepository_searchTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PageRepository_searchTest.java
@@ -156,4 +156,35 @@ public class PageRepository_searchTest extends AbstractManagementRepositoryTest 
         assertEquals(1, pages.size());
         assertEquals("FindApiPage", pages.iterator().next().getId());
     }
+
+    @Test
+    public void shouldFindPagesByAccessControlGroupId() throws Exception {
+        List<Page> pages = pageRepository.search(new PageCriteria.Builder().accessControlGroupId("grp1").build());
+        assertNotNull(pages);
+        assertEquals(1, pages.size());
+        assertEquals("FindApiPage", pages.get(0).getId());
+    }
+
+    @Test
+    public void shouldFindPagesByAccessControlGroupIdAndReferenceType() throws Exception {
+        List<Page> pages = pageRepository.search(new PageCriteria.Builder().referenceType("API").accessControlGroupId("grp2").build());
+        assertNotNull(pages);
+        assertEquals(1, pages.size());
+        assertEquals("FindApiPage", pages.get(0).getId());
+    }
+
+    @Test
+    public void shouldReturnEmptyWhenAccessControlGroupIdNotFound() throws Exception {
+        List<Page> pages = pageRepository.search(new PageCriteria.Builder().accessControlGroupId("non-existent-group").build());
+        assertNotNull(pages);
+        assertEquals(0, pages.size());
+    }
+
+    @Test
+    public void shouldNotMatchRoleAccessControlWhenSearchingByGroupId() throws Exception {
+        // "role1" exists as a ROLE access control on FindApiPage, not as a GROUP
+        List<Page> pages = pageRepository.search(new PageCriteria.Builder().accessControlGroupId("role1").build());
+        assertNotNull(pages);
+        assertEquals(0, pages.size());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -753,16 +753,17 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                     //remove from API plans
                     removeFromAPIPlans(groupId, updatedDate, api.getId());
 
-                    //remove from API pages
-                    PageCriteria apiPageCriteria = new PageCriteria.Builder()
-                        .referenceId(api.getId())
-                        .referenceType(PageReferenceType.API.name())
-                        .build();
-                    removeGroupFromPages(groupId, updatedDate, apiPageCriteria);
-
                     //remove idp group mapping using this group
                     removeIDPGroupMapping(groupId, updatedDate);
                 });
+
+            // Clean page accessControls on every API page referencing this group, regardless of whether
+            // the API is still in the group's membership — covers stale refs that the loop above misses.
+            PageCriteria apiPagesWithGroupCriteria = new PageCriteria.Builder()
+                .referenceType(PageReferenceType.API.name())
+                .accessControlGroupId(groupId)
+                .build();
+            removeGroupFromPages(groupId, updatedDate, apiPagesWithGroupCriteria);
 
             Set<String> applicationIds = new HashSet<>();
             applicationRepository

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
@@ -233,7 +233,7 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
                         .collect(Collectors.toList());
                 }
 
-                // Replace group id by group name in access control list
+                // Replace group id by group name in access control list, skipping stale refs to deleted groups
                 pages.forEach(pageEntity -> {
                     if (pageEntity.getAccessControls() != null) {
                         pageEntity.setAccessControls(
@@ -243,13 +243,15 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
                                 .filter(accessControlEntity ->
                                     accessControlEntity.getReferenceType().equals(AccessControlReferenceType.GROUP.name())
                                 )
-                                .peek(accessControlEntity ->
-                                    accessControlEntity.setReferenceId(
-                                        groupIdNameMap.computeIfAbsent(accessControlEntity.getReferenceId(), key ->
-                                            groupService.findById(GraviteeContext.getExecutionContext(), key).getName()
-                                        )
-                                    )
-                                )
+                                .map(accessControlEntity -> {
+                                    String groupName = resolveGroupName(groupService, groupIdNameMap, accessControlEntity.getReferenceId());
+                                    if (groupName == null) {
+                                        return null;
+                                    }
+                                    accessControlEntity.setReferenceId(groupName);
+                                    return accessControlEntity;
+                                })
+                                .filter(Objects::nonNull)
                                 .collect(Collectors.toSet())
                         );
                     }
@@ -279,16 +281,7 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
                             p
                                 .getExcludedGroups()
                                 .stream()
-                                .map(groupId ->
-                                    groupIdNameMap.computeIfAbsent(groupId, key -> {
-                                        try {
-                                            return groupService.findById(GraviteeContext.getExecutionContext(), key).getName();
-                                        } catch (GroupNotFoundException e) {
-                                            log.warn("Unable to find group {}", key);
-                                            return null;
-                                        }
-                                    })
-                                )
+                                .map(groupId -> resolveGroupName(groupService, groupIdNameMap, groupId))
                                 .filter(Objects::nonNull)
                                 .collect(Collectors.toList())
                         );
@@ -307,6 +300,26 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
                 }
             }
         }
+    }
+
+    /**
+     * Resolve a group ID to its name, caching results (including misses) in the provided map.
+     * Returns null if the group no longer exists. computeIfAbsent is unsafe here because it
+     * does not memoize null mappings, which would re-trigger findById for every stale ref.
+     */
+    private static String resolveGroupName(GroupService groupService, Map<String, String> groupIdNameMap, String groupId) {
+        if (groupIdNameMap.containsKey(groupId)) {
+            return groupIdNameMap.get(groupId);
+        }
+        String name;
+        try {
+            name = groupService.findById(GraviteeContext.getExecutionContext(), groupId).getName();
+        } catch (GroupNotFoundException e) {
+            log.warn("Group [{}] no longer exists, skipping from export", groupId);
+            name = null;
+        }
+        groupIdNameMap.put(groupId, name);
+        return name;
     }
 
     public void setApplicationContext(ApplicationContext applicationContext) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
@@ -202,6 +202,12 @@ public class GroupService_DeleteTest {
 
         when(
             pageRepository.search(
+                new PageCriteria.Builder().referenceType(PageReferenceType.API.name()).accessControlGroupId(GROUP_ID).build()
+            )
+        ).thenReturn(Collections.emptyList());
+
+        when(
+            pageRepository.search(
                 new PageCriteria.Builder()
                     .referenceId(GraviteeContext.getExecutionContext().getEnvironmentId())
                     .referenceType(PageReferenceType.ENVIRONMENT.name())
@@ -311,6 +317,13 @@ public class GroupService_DeleteTest {
         accessControlToRemove.setReferenceId(GROUP_ID);
         AccessControl accessControlToKeep = new AccessControl();
         page.setAccessControls(new HashSet<>(Set.of(accessControlToRemove, accessControlToKeep)));
+
+        when(
+            pageRepository.search(
+                new PageCriteria.Builder().referenceType(PageReferenceType.API.name()).accessControlGroupId(GROUP_ID).build()
+            )
+        ).thenReturn(Collections.emptyList());
+
         when(
             pageRepository.search(
                 new PageCriteria.Builder()
@@ -329,5 +342,93 @@ public class GroupService_DeleteTest {
         verify(applicationRepository).update(
             argThat(app -> app.getGroups().size() == 1 && !app.getGroups().contains(GROUP_ID) && app.getGroups().contains(ANOTHER_GROUP_ID))
         );
+    }
+
+    @Test
+    public void shouldDeleteGroupAccessControlFromPagesOnApisNotInGroup() throws Exception {
+        // This tests the exact bug from APIM-13541: API is NOT in the group's membership
+        // (not found by apiRepository.search(groups(groupId))), but has a page with
+        // accessControl referencing the group. The new cleanup pass should handle this.
+
+        final Group group = new Group();
+        group.setId(GROUP_ID);
+        group.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+
+        RoleEntity role = new RoleEntity();
+        role.setId("API_PRIMARY_OWNER_ID");
+        when(
+            roleService.findByScopeAndName(
+                RoleScope.API,
+                SystemRole.PRIMARY_OWNER.name(),
+                GraviteeContext.getExecutionContext().getOrganizationId()
+            )
+        ).thenReturn(Optional.of(role));
+
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                GROUP_ID,
+                MembershipReferenceType.API,
+                "API_PRIMARY_OWNER_ID"
+            )
+        ).thenReturn(Collections.emptySet());
+
+        // No APIs found by group membership search (the API is NOT in the group's groups[])
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).groups(GROUP_ID).build(),
+                null,
+                new PageableBuilder().pageSize(100).pageNumber(0).build(),
+                ApiFieldFilter.allFields()
+            )
+        ).thenReturn(new io.gravitee.common.data.domain.Page<>(List.of(), 0, 0, 0));
+
+        when(applicationRepository.findByGroups(Collections.singletonList(GROUP_ID))).thenReturn(Collections.emptySet());
+
+        // But there IS a page on some API that references this group in accessControls
+        Page apiPageWithStaleRef = new Page();
+        apiPageWithStaleRef.setId("PAGE_ON_UNRELATED_API");
+        apiPageWithStaleRef.setReferenceId("UNRELATED_API_ID");
+        apiPageWithStaleRef.setReferenceType(PageReferenceType.API);
+        AccessControl staleAccessControl = new AccessControl();
+        staleAccessControl.setReferenceType("GROUP");
+        staleAccessControl.setReferenceId(GROUP_ID);
+        AccessControl validAccessControl = new AccessControl();
+        validAccessControl.setReferenceType("GROUP");
+        validAccessControl.setReferenceId("other-group-id");
+        apiPageWithStaleRef.setAccessControls(new HashSet<>(Set.of(staleAccessControl, validAccessControl)));
+
+        when(
+            pageRepository.search(
+                new PageCriteria.Builder().referenceType(PageReferenceType.API.name()).accessControlGroupId(GROUP_ID).build()
+            )
+        ).thenReturn(List.of(apiPageWithStaleRef));
+
+        when(
+            pageRepository.search(
+                new PageCriteria.Builder()
+                    .referenceId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                    .referenceType(PageReferenceType.ENVIRONMENT.name())
+                    .build()
+            )
+        ).thenReturn(Collections.emptyList());
+
+        groupService.delete(GraviteeContext.getExecutionContext(), GROUP_ID);
+
+        // Verify the stale accessControl was removed from the page, keeping the valid one
+        verify(pageRepository).update(
+            argThat(
+                p ->
+                    "PAGE_ON_UNRELATED_API".equals(p.getId()) &&
+                    p.getAccessControls().size() == 1 &&
+                    p
+                        .getAccessControls()
+                        .stream()
+                        .noneMatch(ac -> GROUP_ID.equals(ac.getReferenceId()))
+            )
+        );
+
+        verify(groupRepository, times(1)).delete(eq(GROUP_ID));
     }
 }


### PR DESCRIPTION
## Summary

- Group deletion left stale refs in page `accessControls` for APIs not in the group's `groups[]` field. v2 export then crashed silently (HTTP 200 with empty body).
- Added cleanup pass in `GroupServiceImpl.delete()` that queries API pages referencing the group (via the new `accessControlGroupId` filter on `PageCriteria`) and removes stale access controls — covers pages on APIs outside the group's membership.
- Made v2 serializer resilient to missing groups (skip stale refs with warning instead of crashing).

Fixes https://gravitee.atlassian.net/browse/APIM-13541

## Review feedback addressed

- **Mongo `\$elemMatch` clarity** (Aikido): switched to explicit `Criteria.andOperator(...)` so it's unambiguous that both criteria target the same array element. Updated `PageMongoRepositoryImplTest` accordingly.
- **Redundant per-API page cleanup** (Gemini): removed the per-API `removeGroupFromPages` call inside the membership loop. The single global call with `accessControlGroupId` filter is a strict superset and pushes filtering into the repo query (no full-table scan).
- **`resolveGroupName` null-cache regression** (Aikido): replaced `computeIfAbsent` with explicit `containsKey`/`put`. `computeIfAbsent` does not memoize null returns, so every stale group ref re-hit `groupService.findById`.
- **Side-effect-in-`filter()`** (Gemini, prior): page access-control transformation now uses `map(...) → filter(Objects::nonNull)`.
- **Shared `groupId → name` resolver** (Aikido): extracted `resolveGroupName(...)` helper used by both pages and plans paths.

`exportAsJson()` was intentionally left as-is in this PR — broadening its catch behavior (currently log-and-return-empty) is out of scope here. Will track separately.

## Test plan

- [x] New test: API not in group membership, page has accessControl referencing group, verify cleanup on deletion (`shouldDeleteGroupAccessControlFromPagesOnApisNotInGroup`)
- [x] Existing tests pass: `GroupService_DeleteTest` (6/6), `ApiExportService_ExportAsJsonTest` (8/8), `ApiExportService_gRPC_ExportAsJsonTest` (1/1), `PageMongoRepositoryImplTest` (2/2), full `GroupService*` suite (43/43)
- [x] Manual verification: export returns valid JSON after group deletion (per @carlos-andres-osorio, see APIM-13541 comment 82420)