### PR TITLE
feat: implement members search by displayName in portal API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/MemberMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/MemberMapper.java
@@ -44,6 +44,7 @@ public class MemberMapper {
     public Member convert(ExecutionContext executionContext, MemberEntity member, UriInfo uriInfo) {
         final Member memberItem = new Member();
 
+        memberItem.setId(member.getId());
         memberItem.setCreatedAt(member.getCreatedAt().toInstant().atOffset(ZoneOffset.UTC));
 
         UserEntity userEntity = userService.findById(executionContext, member.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResource.java
@@ -46,6 +46,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -72,19 +73,44 @@ public class ApplicationMembersResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.APPLICATION_MEMBER, acls = RolePermissionAction.READ) })
     public Response getMembersByApplicationId(
         @PathParam("applicationId") String applicationId,
+        @QueryParam("q") String query,
         @BeanParam PaginationParam paginationParam
     ) {
         //Does application exist ?
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         applicationService.findById(executionContext, applicationId);
 
+        String searchTerm = normalizeSearchTerm(query);
         List<Member> membersList = membershipService
             .getMembersByReference(executionContext, MembershipReferenceType.APPLICATION, applicationId)
             .stream()
+            .filter(member -> isMatchingDisplayName(member, searchTerm))
             .map(membership -> memberMapper.convert(executionContext, membership, uriInfo))
             .collect(Collectors.toList());
 
         return createListResponse(executionContext, membersList, paginationParam);
+    }
+
+    private String normalizeSearchTerm(String query) {
+        if (query == null) {
+            return null;
+        }
+
+        String trimmedQuery = query.trim();
+        if (trimmedQuery.isEmpty()) {
+            return null;
+        }
+
+        return trimmedQuery.toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isMatchingDisplayName(MemberEntity member, String searchTerm) {
+        if (searchTerm == null) {
+            return true;
+        }
+
+        String displayName = member.getDisplayName();
+        return displayName != null && displayName.toLowerCase(Locale.ROOT).contains(searchTerm);
     }
 
     @POST

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -1168,19 +1168,28 @@ paths:
             parameters:
                 - $ref: "#/components/parameters/pageNumberParam"
                 - $ref: "#/components/parameters/pageSizeParam"
-            summary: List application members
+                - $ref: "#/components/parameters/applicationMembersQueryParam"
+            summary: List and search application members
             description: |
-                List application members.
+                List and search application members.
 
                 User must have the APPLICATION_MEMBER[READ] permission.
+                Pagination controls are always provided in the `links` object.
+                Search starts when `q` contains at least one character.
             operationId: getMembersByApplicationId
             responses:
                 200:
-                    description: List of members
+                    description: List of members with pagination links
                     content:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/MembersResponse"
+                400:
+                    description: Invalid pagination or search query parameter.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ErrorResponse"
                 403:
                     $ref: "#/components/responses/PermissionError"
                 404:
@@ -4073,6 +4082,14 @@ components:
             description: query string to be used in the search engine
             schema:
                 type: string
+        applicationMembersQueryParam:
+            name: q
+            in: query
+            required: false
+            description: Search phrase applied to the member Name field. Search starts when at least one character is provided.
+            schema:
+                type: string
+                minLength: 1
 
         # Connectors Expand
         connectorQueryParam:
@@ -6899,6 +6916,12 @@ components:
                     $ref: "#/components/schemas/Links"
 
     responses:
+        BadRequestError:
+            description: Bad Request
+            content:
+                application/json:
+                    schema:
+                        $ref: "#/components/schemas/ErrorResponse"
         InternalServerError:
             description: Internal Server Error
             content:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -4086,7 +4086,7 @@ components:
             name: q
             in: query
             required: false
-            description: Search phrase applied to the member Name field. Search starts when at least one character is provided.
+            description: Search phrase applied to the member displayName field. Search starts when at least one character is provided.
             schema:
                 type: string
                 minLength: 1

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/MemberMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/MemberMapperTest.java
@@ -98,7 +98,7 @@ public class MemberMapperTest {
         Member responseMember = memberMapper.convert(GraviteeContext.getExecutionContext(), memberEntity, uriInfo);
         assertNotNull(responseMember);
         assertEquals(now.toEpochMilli(), responseMember.getCreatedAt().toInstant().toEpochMilli());
-        assertNull(responseMember.getId());
+        assertEquals(MEMBER_ID, responseMember.getId());
         assertEquals("OWNER", responseMember.getRole());
         assertEquals(now.toEpochMilli(), responseMember.getUpdatedAt().toInstant().toEpochMilli());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResourceTest.java
@@ -54,6 +54,10 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
     private static final String MEMBER_1 = "my-member";
     private static final String MEMBER_2 = "my-member-2";
     private static final String UNKNOWN_MEMBER = "unknown-member";
+    private static final String MEMBER_1_DISPLAY_NAME = "John Smith";
+    private static final String MEMBER_2_DISPLAY_NAME = "Alice Brown";
+    private static final String MEMBER_1_EMAIL = "john.smith@example.com";
+    private static final String MEMBER_2_EMAIL = "alice.brown@example.com";
 
     @Override
     protected String contextPath() {
@@ -66,9 +70,13 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         MemberEntity memberEntity1 = new MemberEntity();
         memberEntity1.setId(MEMBER_1);
+        memberEntity1.setDisplayName(MEMBER_1_DISPLAY_NAME);
+        memberEntity1.setEmail(MEMBER_1_EMAIL);
 
         MemberEntity memberEntity2 = new MemberEntity();
         memberEntity2.setId(MEMBER_2);
+        memberEntity2.setDisplayName(MEMBER_2_DISPLAY_NAME);
+        memberEntity2.setEmail(MEMBER_2_EMAIL);
         doReturn(new Member().id(MEMBER_2)).when(memberMapper).convert(eq(GraviteeContext.getExecutionContext()), eq(memberEntity2), any());
         doReturn(new Member().id(MEMBER_1)).when(memberMapper).convert(eq(GraviteeContext.getExecutionContext()), eq(memberEntity1), any());
         doReturn(Sets.newSet(memberEntity1, memberEntity2))
@@ -115,6 +123,38 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         Links links = membersResponse.getLinks();
         assertNotNull(links);
+    }
+
+    @Test
+    public void shouldGetMembersFilteredByDisplayName() {
+        final Response response = target(APPLICATION).path("members").queryParam("q", "john").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        MembersResponse membersResponse = response.readEntity(MembersResponse.class);
+        assertEquals(1, membersResponse.getData().size());
+        assertEquals(MEMBER_1, membersResponse.getData().get(0).getId());
+    }
+
+    @Test
+    public void shouldGetMembersFilteredByDisplayNameIgnoringCase() {
+        final Response response = target(APPLICATION).path("members").queryParam("q", "ALICE").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        MembersResponse membersResponse = response.readEntity(MembersResponse.class);
+        assertEquals(1, membersResponse.getData().size());
+        assertEquals(MEMBER_2, membersResponse.getData().get(0).getId());
+    }
+
+    @Test
+    public void shouldNotFilterMembersByEmail() {
+        final Response response = target(APPLICATION).path("members").queryParam("q", "example.com").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        MembersResponse membersResponse = response.readEntity(MembersResponse.class);
+        assertEquals(0, membersResponse.getData().size());
+
+        Links links = membersResponse.getLinks();
+        assertNull(links);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

- add q filtering in GET /applications/{applicationId}/members (displayName only, case-insensitive)
- update OpenAPI param description to reflect displayName scope
- extend ApplicationMembersResourceTest with search scenarios, including non-matching email case



