### PR TITLE
Write apiProductId to gateway metrics and log in SubscriptionProcessor and ReporterProcessor

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
@@ -144,6 +144,7 @@ public class SubscriptionProcessor implements Processor {
             }
             if (subscription.getApiProductId() != null) {
                 ctx.setAttribute(ATTR_API_PRODUCT, subscription.getApiProductId());
+                metrics.setApiProductId(subscription.getApiProductId());
             }
             ctx
                 .getTemplateEngine()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessorTest.java
@@ -162,6 +162,32 @@ class SubscriptionProcessorTest extends AbstractProcessorTest {
     }
 
     @Nested
+    class ApiProduct {
+
+        @Test
+        void should_set_api_product_id_on_metrics_when_subscription_has_api_product() {
+            var subscription = new Subscription();
+            subscription.setApiProductId("api-product-id");
+            spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SUBSCRIPTION, subscription);
+
+            cut.execute(spyCtx).test().assertComplete();
+
+            assertThat(spyCtx.metrics().getApiProductId()).isEqualTo("api-product-id");
+            assertThat(spyCtx.<String>getAttribute(SubscriptionProcessor.ATTR_API_PRODUCT)).isEqualTo("api-product-id");
+        }
+
+        @Test
+        void should_not_overwrite_api_product_id_on_metrics_when_subscription_has_no_api_product() {
+            spyCtx.metrics().setApiProductId("pre-existing");
+            spyCtx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SUBSCRIPTION, new Subscription());
+
+            cut.execute(spyCtx).test().assertComplete();
+
+            assertThat(spyCtx.metrics().getApiProductId()).isEqualTo("pre-existing");
+        }
+    }
+
+    @Nested
     class ClientIdentifier {
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessor.java
@@ -82,6 +82,7 @@ public class ReporterProcessor implements Processor {
                         if (log != null) {
                             log.setApiId(metrics.getApiId());
                             log.setApiName(metrics.getApiName());
+                            log.setApiProductId(metrics.getApiProductId());
                             log.setRequestEnded(metrics.isRequestEnded());
                             reporterService.report(log);
                         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/reporter/ReporterProcessorTest.java
@@ -128,6 +128,21 @@ class ReporterProcessorTest extends AbstractProcessorTest {
         }
 
         @Test
+        void should_set_api_product_id_on_log_when_metrics_has_api_product_id() {
+            // Given
+            when(reactableApi.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
+            ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_REACTABLE_API, reactableApi);
+            ctx.metrics().setApiProductId("product-id");
+            ctx.metrics().setLog(Log.builder().build());
+
+            // When
+            reporterProcessor.execute(ctx).test().assertResult();
+
+            // Then
+            assertThat(ctx.metrics().getLog().getApiProductId()).isEqualTo("product-id");
+        }
+
+        @Test
         void should_execute_report_actions_when_analytics_and_log_are_enabled() {
             // Given
             when(reactableApi.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <gravitee-plugin.version>5.0.0</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.1.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>2.1.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>2.2.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
         <gravitee-resource-cache-provider-api.version>2.1.0</gravitee-resource-cache-provider-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13544

## Changes

- `SubscriptionProcessor`: writes `apiProductId` to `Metrics` when `subscription.getApiProductId()` is non-null
- `ReporterProcessor`: forwards `apiProductId` from `Metrics` to the `Log` object before reporting, so it appears in all v4 access log entries (Elasticsearch, File/CSV)

Without the second fix, `apiProductId` is always null in `Log` regardless of whether the request goes through an API product plan.

## Testing

- `SubscriptionProcessorTest`: product subscription path sets `apiProductId` on metrics; direct API subscription leaves it null
- `ReporterProcessorTest`: non-null `metrics.getApiProductId()` is propagated to the reported `Log`

For manual testing details, see description in https://github.com/gravitee-io/gravitee-api-management/pull/16394 

