### PR TITLE
feat: add API Product role management in User details

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.html
@@ -49,6 +49,16 @@
           </mat-form-field>
 
           <mat-form-field>
+            <mat-label>API Product Role</mat-label>
+            <mat-select formControlName="apiProductRole" aria-label="API Product role">
+              <mat-option>-- None --</mat-option>
+              @for (apiProductRole of apiProductRoles(); track apiProductRole.name) {
+                <mat-option [disabled]="apiProductRole.system" [value]="apiProductRole.name">{{ apiProductRole.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field>
             <mat-label>Application Role</mat-label>
             <mat-select formControlName="applicationRole" aria-label="Application role">
               <mat-option>-- None --</mat-option>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.spec.ts
@@ -83,6 +83,10 @@ describe('OrgSettingsUserDetailAddGroupDialogComponent', () => {
       fakeRole({ id: 'roleOrgUserId', name: 'ROLE_INTEGRATION_USER' }),
       fakeRole({ id: 'roleOrgAdminId', name: 'ROLE_INTEGRATION_ADMIN' }),
     ]);
+    expectRolesListRequest('API_PRODUCT', [
+      fakeRole({ id: 'roleApiProductUserId', name: 'ROLE_API_PRODUCT_USER' }),
+      fakeRole({ id: 'roleApiProductAdminId', name: 'ROLE_API_PRODUCT_ADMIN' }),
+    ]);
 
     const submitButton = await loader.getHarness(MatButtonHarness.with({ selector: 'button[type=submit]' }));
     expect(await submitButton.isDisabled()).toBeTruthy();
@@ -99,12 +103,16 @@ describe('OrgSettingsUserDetailAddGroupDialogComponent', () => {
     const integrationRoleSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName=integrationRole' }));
     await integrationRoleSelect.clickOptions({ text: 'ROLE_INTEGRATION_ADMIN' });
 
+    const apiProductRoleSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName=apiProductRole' }));
+    await apiProductRoleSelect.clickOptions({ text: 'ROLE_API_PRODUCT_USER' });
+
     await submitButton.click();
 
     expect(matDialogRefMock.close).toHaveBeenCalledWith({
       apiRole: 'ROLE_API_USER',
       applicationRole: 'ROLE_APPLICATION_ADMIN',
       integrationRole: 'ROLE_INTEGRATION_ADMIN',
+      apiProductRole: 'ROLE_API_PRODUCT_USER',
       groupId: 'group-a',
       groupName: 'Group A',
       isAdmin: null,

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-add-group-dialog.component.ts
@@ -31,6 +31,7 @@ export type OrgSettingsUserDetailAddGroupDialogReturn = {
   apiRole: string;
   applicationRole?: string;
   integrationRole?: string;
+  apiProductRole?: string;
   isAdmin?: boolean;
 };
 
@@ -64,6 +65,7 @@ export class OrgSettingsUserDetailAddGroupDialogComponent {
   readonly apiRoles = toSignal(this.roleService.list('API').pipe(shareReplay(1)), { initialValue: [] });
   readonly applicationRoles = toSignal(this.roleService.list('APPLICATION').pipe(shareReplay(1)), { initialValue: [] });
   readonly integrationRoles = toSignal(this.roleService.list('INTEGRATION').pipe(shareReplay(1)), { initialValue: [] });
+  readonly apiProductRoles = toSignal(this.roleService.list('API_PRODUCT').pipe(shareReplay(1)), { initialValue: [] });
 
   constructor() {
     this.addGroupForm = new UntypedFormGroup(
@@ -73,6 +75,7 @@ export class OrgSettingsUserDetailAddGroupDialogComponent {
         apiRole: new UntypedFormControl(null),
         applicationRole: new UntypedFormControl(null),
         integrationRole: new UntypedFormControl(null),
+        apiProductRole: new UntypedFormControl(null),
       },
       [leastOneGroupRoleIsRequiredValidator],
     );

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.html
@@ -85,6 +85,22 @@
                   </td>
                 </ng-container>
 
+                <!-- API Product Role Column -->
+                <ng-container matColumnDef="apiProductRole">
+                  <th mat-header-cell *matHeaderCellDef id="apiProductRole">API Product Role</th>
+                  <td mat-cell *matCellDef="let group" [formGroupName]="group.id">
+                    <mat-form-field>
+                      <mat-label>API Product role</mat-label>
+                      <mat-select [id]="group.id" [aria-label]="'API Product roles for ' + group.id" formControlName="API_PRODUCT">
+                        <mat-option>-- None --</mat-option>
+                        @for (role of apiProductRoles(); track role.name) {
+                          <mat-option [disabled]="role.system" [value]="role.name">{{ role.name }}</mat-option>
+                        }
+                      </mat-select>
+                    </mat-form-field>
+                  </td>
+                </ng-container>
+
                 <!-- Application Role Column -->
                 <ng-container matColumnDef="applicationRole">
                   <th mat-header-cell *matHeaderCellDef id="applicationRole">Application Role</th>

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.scss
@@ -47,6 +47,7 @@ $border-color: mat.m2-get-color-from-palette($foreground, divider);
     }
 
     .mat-mdc-cell.mat-column-apiRoles,
+    .mat-mdc-cell.mat-column-apiProductRole,
     .mat-mdc-cell.mat-column-applicationRole,
     .mat-mdc-cell.mat-column-integrationRole {
       mat-form-field {

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.ts
@@ -101,9 +101,10 @@ export class OrgSettingsUserDetailMembershipsComponent {
   readonly apiRoles = toSignal(this.roleService.list('API').pipe(shareReplay(1)), { initialValue: [] });
   readonly applicationRoles = toSignal(this.roleService.list('APPLICATION').pipe(shareReplay(1)), { initialValue: [] });
   readonly integrationRoles = toSignal(this.roleService.list('INTEGRATION').pipe(shareReplay(1)), { initialValue: [] });
+  readonly apiProductRoles = toSignal(this.roleService.list('API_PRODUCT').pipe(shareReplay(1)), { initialValue: [] });
 
   groupsRolesFormGroup: UntypedFormGroup;
-  groupsTableDisplayedColumns = ['name', 'groupAdmin', 'apiRoles', 'applicationRole', 'integrationRole', 'delete'];
+  groupsTableDisplayedColumns = ['name', 'groupAdmin', 'apiRoles', 'apiProductRole', 'applicationRole', 'integrationRole', 'delete'];
   apisTableDisplayedColumns = [...DEFAULT_RESOURCE_TABLE_COLUMNS];
   apiProductsTableDisplayedColumns = [...DEFAULT_RESOURCE_TABLE_COLUMNS];
   applicationsTableDisplayedColumns = ['name'];
@@ -134,7 +135,8 @@ export class OrgSettingsUserDetailMembershipsComponent {
   private initialGroups: MembershipGroupDS[] = [];
 
   // Store initial group roles to compare changes
-  initialGroupRoles: Record<string, { GROUP?: string; API?: string; APPLICATION?: string; INTEGRATION?: string }> = {};
+  initialGroupRoles: Record<string, { GROUP?: string; API?: string; APPLICATION?: string; INTEGRATION?: string; API_PRODUCT?: string }> =
+    {};
 
   constructor() {
     effect(() => {
@@ -247,6 +249,7 @@ export class OrgSettingsUserDetailMembershipsComponent {
                   { scope: 'API' as const, name: groupeAdded.apiRole },
                   { scope: 'APPLICATION' as const, name: groupeAdded.applicationRole },
                   { scope: 'INTEGRATION' as const, name: groupeAdded.integrationRole },
+                  { scope: 'API_PRODUCT' as const, name: groupeAdded.apiProductRole },
                 ],
               },
             ],
@@ -376,6 +379,7 @@ export class OrgSettingsUserDetailMembershipsComponent {
           API: group.roles['API'],
           APPLICATION: group.roles['APPLICATION'],
           INTEGRATION: group.roles['INTEGRATION'],
+          API_PRODUCT: group.roles['API_PRODUCT'],
         };
 
         return {
@@ -414,6 +418,10 @@ export class OrgSettingsUserDetailMembershipsComponent {
         }),
         INTEGRATION: new UntypedFormControl({
           value: group.roles['INTEGRATION'],
+          disabled: this.userStatus() !== 'ACTIVE' || this.isReadOnly(),
+        }),
+        API_PRODUCT: new UntypedFormControl({
+          value: group.roles['API_PRODUCT'],
           disabled: this.userStatus() !== 'ACTIVE' || this.isReadOnly(),
         }),
       },

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -516,7 +516,13 @@ describe('OrgSettingsUserDetailComponent', () => {
               name: 'Group A',
               environmentId: 'envAlphaId',
               environmentName: 'Environment Alpha',
-              roles: { GROUP: 'ADMIN', API: 'ROLE_API', APPLICATION: 'ROLE_APP_OWNER', INTEGRATION: 'ROLE_INTEGRATION_OWNER' },
+              roles: {
+                GROUP: 'ADMIN',
+                API: 'ROLE_API',
+                APPLICATION: 'ROLE_APP_OWNER',
+                INTEGRATION: 'ROLE_INTEGRATION_OWNER',
+                API_PRODUCT: 'ROLE_API_PRODUCT_USER',
+              },
             },
           ],
         },
@@ -526,6 +532,7 @@ describe('OrgSettingsUserDetailComponent', () => {
         api: [fakeRole({ id: 'roleApiId', name: 'ROLE_API' })],
         application: [fakeRole({ id: 'roleAppOwnerId', name: 'ROLE_APP_OWNER' }), fakeRole({ id: 'roleAppUserId', name: 'ROLE_APP_USER' })],
         integration: [fakeRole({ id: 'roleIntegrationOwnerId', name: 'ROLE_INTEGRATION_OWNER' })],
+        apiProduct: [fakeRole({ id: 'roleApiProductUserId', name: 'ROLE_API_PRODUCT_USER' })],
       },
     );
 
@@ -534,11 +541,13 @@ describe('OrgSettingsUserDetailComponent', () => {
 
     const groupAdminCheckbox = await (await (await groupsTable.getRows())[0].getCells())[1].getHarness(MatCheckboxHarness);
     const apiRoleSelect = await (await (await groupsTable.getRows())[0].getCells())[2].getHarness(MatSelectHarness);
-    const applicationRoleSelect = await (await (await groupsTable.getRows())[0].getCells())[3].getHarness(MatSelectHarness);
-    const integrationRoleSelect = await (await (await groupsTable.getRows())[0].getCells())[4].getHarness(MatSelectHarness);
+    const apiProductRoleSelect = await (await (await groupsTable.getRows())[0].getCells())[3].getHarness(MatSelectHarness);
+    const applicationRoleSelect = await (await (await groupsTable.getRows())[0].getCells())[4].getHarness(MatSelectHarness);
+    const integrationRoleSelect = await (await (await groupsTable.getRows())[0].getCells())[5].getHarness(MatSelectHarness);
 
     expect(await groupAdminCheckbox.isChecked()).toBe(true);
     expect(await apiRoleSelect.getValueText()).toBe('ROLE_API');
+    expect(await apiProductRoleSelect.getValueText()).toBe('ROLE_API_PRODUCT_USER');
     expect(await applicationRoleSelect.getValueText()).toBe('ROLE_APP_OWNER');
     expect(await integrationRoleSelect.getValueText()).toBe('ROLE_INTEGRATION_OWNER');
 
@@ -548,12 +557,22 @@ describe('OrgSettingsUserDetailComponent', () => {
     const saveBar = await loader.getHarness(GioSaveBarHarness);
     await saveBar.clickSubmit();
 
-    expectAddOrUpdateGroupMembershipRequest('groupA', [
-      fakeGroupMembership({
-        id: user.id,
-        roles: [{ scope: 'APPLICATION', name: 'ROLE_APP_USER' }],
-      }),
-    ]);
+    expectAddOrUpdateGroupMembershipRequest(
+      'groupA',
+      [fakeGroupMembership({ id: user.id, roles: [{ scope: 'APPLICATION', name: 'ROLE_APP_USER' }] })],
+      [
+        {
+          id: user.id,
+          roles: [
+            { scope: 'GROUP', name: '' },
+            { scope: 'API', name: 'ROLE_API' },
+            { scope: 'APPLICATION', name: 'ROLE_APP_USER' },
+            { scope: 'INTEGRATION', name: 'ROLE_INTEGRATION_OWNER' },
+            { scope: 'API_PRODUCT', name: 'ROLE_API_PRODUCT_USER' },
+          ],
+        },
+      ],
+    );
   });
 
   it('should delete user from group after confirm dialog', async () => {
@@ -572,7 +591,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     const membershipsCard = await loader.getHarness(MatCardHarness.with({ selector: '.org-settings-user-detail__memberships-card' }));
     const groupsTable = await membershipsCard.getHarness(MatTableHarness.with({ selector: '[aria-label="Groups table"]' }));
 
-    const deleteUserGroupButton = await (await (await groupsTable.getRows())[0].getCells())[5].getHarness(MatButtonHarness);
+    const deleteUserGroupButton = await (await (await groupsTable.getRows())[0].getCells())[6].getHarness(MatButtonHarness);
 
     await deleteUserGroupButton.click();
 
@@ -611,6 +630,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     expectRolesListRequest('API');
     expectRolesListRequest('APPLICATION');
     expectRolesListRequest('INTEGRATION');
+    expectRolesListRequest('API_PRODUCT');
 
     const groupIdSelect = await dialog.getHarness(MatSelectHarness.with({ selector: '[formControlName="groupId"]' }));
     await groupIdSelect.open();
@@ -637,6 +657,7 @@ describe('OrgSettingsUserDetailComponent', () => {
           { name: null, scope: 'API' },
           { name: null, scope: 'APPLICATION' },
           { name: null, scope: 'INTEGRATION' },
+          { name: null, scope: 'API_PRODUCT' },
         ],
       },
     ]);
@@ -824,6 +845,7 @@ describe('OrgSettingsUserDetailComponent', () => {
       api?: Role[];
       application?: Role[];
       integration?: Role[];
+      apiProduct?: Role[];
     } = {},
   ) {
     expectUserTokensGetRequest(user, tokens);
@@ -845,6 +867,7 @@ describe('OrgSettingsUserDetailComponent', () => {
     expectRolesListRequest('API', roles.api || []);
     expectRolesListRequest('APPLICATION', roles.application || []);
     expectRolesListRequest('INTEGRATION', roles.integration || []);
+    expectRolesListRequest('API_PRODUCT', roles.apiProduct || []);
     expectRolesListRequest('ENVIRONMENT', roles.environment || []);
   }
 
@@ -885,9 +908,12 @@ describe('OrgSettingsUserDetailComponent', () => {
     fixture.detectChanges();
   }
 
-  function expectAddOrUpdateGroupMembershipRequest(groupId: string, groupMembership: GroupMembership[] = []) {
+  function expectAddOrUpdateGroupMembershipRequest(groupId: string, groupMembership: GroupMembership[] = [], expectedBody?: unknown) {
     const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${groupId}/members`);
     expect(req.request.method).toEqual('POST');
+    if (expectedBody) {
+      expect(req.request.body).toEqual(expectedBody);
+    }
     req.flush(groupMembership);
     fixture.detectChanges();
   }

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.ts
@@ -91,7 +91,10 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
   private groupsRolesFormGroup: UntypedFormGroup;
 
   // Store initial group roles from the memberships sub-component
-  private membershipInitialGroupRoles: Record<string, { GROUP?: string; API?: string; APPLICATION?: string; INTEGRATION?: string }> = {};
+  private membershipInitialGroupRoles: Record<
+    string,
+    { GROUP?: string; API?: string; APPLICATION?: string; INTEGRATION?: string; API_PRODUCT?: string }
+  > = {};
 
   tokensTableDS: TokenDS[];
   tokensTableDisplayedColumns = ['name', 'createdAt', 'lastUseAt', 'action'];
@@ -225,7 +228,7 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
           mergeMap(groupId => {
             const groupRolesFormGroup = this.groupsRolesFormGroup.get(groupId) as UntypedFormGroup;
             if (groupRolesFormGroup.dirty) {
-              const { GROUP, API, APPLICATION, INTEGRATION } = groupRolesFormGroup.getRawValue();
+              const { GROUP, API, APPLICATION, INTEGRATION, API_PRODUCT } = groupRolesFormGroup.getRawValue();
 
               return this.groupService.addOrUpdateMemberships(groupId, [
                 {
@@ -235,6 +238,7 @@ export class OrgSettingsUserDetailComponent implements OnInit, OnDestroy {
                     { scope: 'API' as const, name: API },
                     { scope: 'APPLICATION' as const, name: APPLICATION },
                     { scope: 'INTEGRATION' as const, name: INTEGRATION },
+                    { scope: 'API_PRODUCT' as const, name: API_PRODUCT },
                   ],
                 },
               ]);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -207,9 +207,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
             List<String> allGroupIds = all.stream().map(Group::getId).toList();
 
-            // Batch-fetch GROUP->API and GROUP->APPLICATION memberships (2 queries instead of 3*N)
+            // Batch-fetch GROUP->API, GROUP->APPLICATION, and GROUP->API_PRODUCT memberships
             Set<MembershipEntity> apiMemberships = Set.of();
             Set<MembershipEntity> appMemberships = Set.of();
+            Set<MembershipEntity> apiProductMemberships = Set.of();
             if (!allGroupIds.isEmpty()) {
                 apiMemberships = membershipService.getMembershipsByMembersAndReference(
                     MembershipMemberType.GROUP,
@@ -221,6 +222,11 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                     allGroupIds,
                     MembershipReferenceType.APPLICATION
                 );
+                apiProductMemberships = membershipService.getMembershipsByMembersAndReference(
+                    MembershipMemberType.GROUP,
+                    allGroupIds,
+                    MembershipReferenceType.API_PRODUCT
+                );
             }
 
             // Build default role maps (memberships where referenceId is null)
@@ -229,6 +235,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 .filter(m -> m.getReferenceId() == null)
                 .collect(Collectors.toMap(MembershipEntity::getMemberId, MembershipEntity::getRoleId, (a, b) -> a));
             Map<String, String> defaultAppRoleByGroup = appMemberships
+                .stream()
+                .filter(m -> m.getReferenceId() == null)
+                .collect(Collectors.toMap(MembershipEntity::getMemberId, MembershipEntity::getRoleId, (a, b) -> a));
+            Map<String, String> defaultApiProductRoleByGroup = apiProductMemberships
                 .stream()
                 .filter(m -> m.getReferenceId() == null)
                 .collect(Collectors.toMap(MembershipEntity::getMemberId, MembershipEntity::getRoleId, (a, b) -> a));
@@ -247,7 +257,9 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
             final List<GroupEntity> groups = all
                 .stream()
-                .map(group -> mapWithBatchData(group, defaultApiRoleByGroup, defaultAppRoleByGroup, poGroupIds))
+                .map(group ->
+                    mapWithBatchData(group, defaultApiRoleByGroup, defaultAppRoleByGroup, defaultApiProductRoleByGroup, poGroupIds)
+                )
                 .sorted(Comparator.comparing(GroupEntity::getName))
                 .collect(Collectors.toList());
 
@@ -482,7 +494,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         Map<RoleScope, String> formerRoles,
         Map<RoleScope, String> newRoles
     ) throws TechnicalException {
-        RoleScope[] groupRoleScopes = { RoleScope.API, RoleScope.APPLICATION };
+        RoleScope[] groupRoleScopes = { RoleScope.API, RoleScope.APPLICATION, RoleScope.API_PRODUCT };
         for (RoleScope roleScope : groupRoleScopes) {
             if (
                 formerRoles != null &&
@@ -721,6 +733,15 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             membershipService.deleteReferenceMember(
                 executionContext,
                 MembershipReferenceType.APPLICATION,
+                null,
+                MembershipMemberType.GROUP,
+                groupId
+            );
+
+            //remove default group API_PRODUCT role
+            membershipService.deleteReferenceMember(
+                executionContext,
+                MembershipReferenceType.API_PRODUCT,
                 null,
                 MembershipMemberType.GROUP,
                 groupId
@@ -1149,6 +1170,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         if (defaultApiRole != null) {
             roles.put(RoleScope.API, defaultApiRole.getName());
         }
+        RoleEntity defaultApiProductRole = getDefaultRole(group.getId(), RoleScope.API_PRODUCT);
+        if (defaultApiProductRole != null) {
+            roles.put(RoleScope.API_PRODUCT, defaultApiProductRole.getName());
+        }
         RoleEntity defaultApplicationRole = getDefaultRole(group.getId(), RoleScope.APPLICATION);
         if (defaultApplicationRole != null) {
             roles.put(RoleScope.APPLICATION, defaultApplicationRole.getName());
@@ -1177,6 +1202,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         Group group,
         Map<String, String> defaultApiRoleIdByGroup,
         Map<String, String> defaultAppRoleIdByGroup,
+        Map<String, String> defaultApiProductRoleIdByGroup,
         Set<String> poGroupIds
     ) {
         if (group == null) {
@@ -1209,6 +1235,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         String appRoleId = defaultAppRoleIdByGroup.get(group.getId());
         if (appRoleId != null) {
             roles.put(RoleScope.APPLICATION, roleService.findById(appRoleId).getName());
+        }
+        String apiProductRoleId = defaultApiProductRoleIdByGroup.get(group.getId());
+        if (apiProductRoleId != null) {
+            roles.put(RoleScope.API_PRODUCT, roleService.findById(apiProductRoleId).getName());
         }
         entity.setRoles(roles);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
@@ -241,6 +241,14 @@ public class GroupService_DeleteTest {
             eq(GROUP_ID)
         );
 
+        verify(membershipService, times(1)).deleteReferenceMember(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(MembershipReferenceType.API_PRODUCT),
+            eq(null),
+            eq(MembershipMemberType.GROUP),
+            eq(GROUP_ID)
+        );
+
         verify(eventManager, times(1)).publishEvent(
             eq(ApplicationAlertEventType.APPLICATION_MEMBERSHIP_UPDATE),
             any(ApplicationAlertMembershipEvent.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_UpdateTest.java
@@ -237,6 +237,46 @@ public class GroupService_UpdateTest {
     }
 
     @Test
+    public void shouldUpdateGroupWithApiProductDefaultRole() throws Exception {
+        UpdateGroupEntity updatedGroupEntity = new UpdateGroupEntity();
+        updatedGroupEntity.setName("my-group-name");
+        updatedGroupEntity.setRoles(Maps.<RoleScope, String>builder().put(RoleScope.API_PRODUCT, "USER").build());
+
+        final Group group = new Group();
+        group.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.ENVIRONMENT_GROUP),
+                eq("DEFAULT"),
+                eq(CREATE),
+                eq(UPDATE),
+                eq(DELETE)
+            )
+        ).thenReturn(true);
+        when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Collections.emptySet());
+
+        groupService.update(GraviteeContext.getExecutionContext(), GROUP_ID, updatedGroupEntity);
+
+        verify(membershipService).addRoleToMemberOnReference(
+            eq(GraviteeContext.getExecutionContext()),
+            argThat(
+                membershipReference ->
+                    membershipReference.getType() == MembershipReferenceType.API_PRODUCT && membershipReference.getId() == null
+            ),
+            argThat(
+                membershipMember ->
+                    membershipMember.getMemberId().equals(GROUP_ID) &&
+                    membershipMember.getReference() == null &&
+                    membershipMember.getMemberType() == MembershipMemberType.GROUP
+            ),
+            argThat(membershipRole -> membershipRole.getScope() == RoleScope.API_PRODUCT && membershipRole.getName().equals("USER"))
+        );
+    }
+
+    @Test
     public void shouldNotReindexApisIfGroupIsNotPrimaryOwner() throws Exception {
         UpdateGroupEntity updateGroup = new UpdateGroupEntity();
         updateGroup.setName("Updated Name");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13596

## Description

Display API Product role in user assignments
- Add 'API Product Role' column to the user-detail group memberships table
  alongside API, Application, and Integration role columns
- Load API_PRODUCT roles via roleService and populate the column dropdown
- Apply max-width: 160px to mat-column-apiProductRole so it matches the
  width of the other role columns

Allow assigning API Product role from User page
- Add apiProductRole form control to the 'Add group' dialog so admins can
  set the API Product role when adding a group to a user
- Include API_PRODUCT scope in the membership payload sent on save so the
  selected role is persisted correctly

Fix default API Product role not persisted on Group Settings save (backend)
- Add RoleScope.API_PRODUCT to the iterated scopes in updateDefaultRoles()
  so the default role is written/removed when a group is updated
- Add API_PRODUCT default role lookup in map() (findById path) so the role
  is returned in single-group responses
- Add batch fetch of API_PRODUCT memberships in findAll() and thread the
  result through mapWithBatchData() to cover the group-list path
- Add deleteReferenceMember call for MembershipReferenceType.API_PRODUCT in
  delete() to clean up the default role membership when a group is deleted

Tests
- Add shouldUpdateGroupWithApiProductDefaultRole to GroupService_UpdateTest
  to verify the API_PRODUCT role is written via addRoleToMemberOnReference
- Update shouldDeleteGroup in GroupService_DeleteTest to verify
  deleteReferenceMember is called for MembershipReferenceType.API_PRODUCT
  
  
  
<img width="1728" height="865" alt="Screenshot 2026-04-12 at 2 54 36 PM" src="https://github.com/user-attachments/assets/f824f2ca-8dee-4e26-9571-456845e12167" />
<img width="1728" height="865" alt="Screenshot 2026-04-12 at 2 54 44 PM" src="https://github.com/user-attachments/assets/1d8c0cc5-f6aa-468f-af2e-3c670a3dd892" />
<img width="1728" height="865" alt="Screenshot 2026-04-12 at 2 56 23 PM" src="https://github.com/user-attachments/assets/c0eb6c03-680e-41c0-89ec-03861bced5ba" />

  

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

