### PR TITLE
fix: handle DASHBOARD audit reference type to prevent NPE in audit log UI

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditReferenceType.java
@@ -27,4 +27,5 @@ public enum AuditReferenceType {
     APPLICATION,
     API,
     API_PRODUCT,
+    DASHBOARD,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -66,7 +66,8 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
         entry(Audit.AuditReferenceType.ENVIRONMENT, AuditReferenceType.ENVIRONMENT),
         entry(Audit.AuditReferenceType.APPLICATION, AuditReferenceType.APPLICATION),
         entry(Audit.AuditReferenceType.API, AuditReferenceType.API),
-        entry(Audit.AuditReferenceType.API_PRODUCT, AuditReferenceType.API_PRODUCT)
+        entry(Audit.AuditReferenceType.API_PRODUCT, AuditReferenceType.API_PRODUCT),
+        entry(Audit.AuditReferenceType.DASHBOARD, AuditReferenceType.DASHBOARD)
     );
 
     @Lazy


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/11338.

## Description

DASHBOARD was added to the repository-layer Audit.AuditReferenceType enum but was never propagated to the service-layer AuditReferenceType enum or the conversion map in AuditServiceImpl. This caused Map.get() to return null for any DASHBOARD audit record, which then triggered a NPE in getMetadata() where getReferenceType().name() was called without a null guard, making the entire audit log page fail to load.

## Additional context

the issue has all the context

