### PR TITLE
fix: trigger subscription form backend validation only for portal endpoints

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResource.java
@@ -302,6 +302,7 @@ public class ApiProductSubscriptionsResource extends AbstractResource {
             .generalConditionsAccepted(null)
             .generalConditionsContentRevision(null)
             .auditInfo(getAuditInfo())
+            .subscriptionFormMetadataValidationRequired(false)
             .build();
 
         CreateSubscriptionUseCase.Output output = createSubscriptionUseCase.execute(input);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductSubscriptionsResourceTest.java
@@ -468,6 +468,7 @@ class ApiProductSubscriptionsResourceTest extends AbstractResourceTest {
                 soft.assertThat(captor.getValue().planId()).isEqualTo("plan-1");
                 soft.assertThat(captor.getValue().applicationId()).isEqualTo("app-1");
                 soft.assertThat(captor.getValue().apiKeyMode()).isNull();
+                soft.assertThat(captor.getValue().subscriptionFormMetadataValidationRequired()).isFalse();
             });
             verify(acceptSubscriptionUseCase).execute(any());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewSubscriptionEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewSubscriptionEntity.java
@@ -15,9 +15,6 @@
  */
 package io.gravitee.rest.api.model;
 
-import com.fasterxml.jackson.annotation.JsonRawValue;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.rest.api.model.context.OriginContext;
 import java.util.Map;
 import lombok.Getter;
@@ -46,6 +43,13 @@ public class NewSubscriptionEntity {
     private OriginContext.Origin origin = OriginContext.Origin.MANAGEMENT;
 
     private Map<String, String> metadata;
+
+    /**
+     * <strong>Temporary:</strong> remove once the Console supports the subscription form flow.
+     * Until then, {@code true} runs the subscription-form metadata validation (portal); {@code false}
+     * skips it for mAPI/Console requests.
+     */
+    private Boolean subscriptionFormMetadataValidationRequired = false;
 
     public NewSubscriptionEntity(String plan, String application) {
         this.application = application;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateSubscriptionConfigurationEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateSubscriptionConfigurationEntity.java
@@ -39,4 +39,11 @@ public class UpdateSubscriptionConfigurationEntity {
     private SubscriptionConfigurationEntity configuration;
 
     private Map<String, String> metadata;
+
+    /**
+     * <strong>Temporary:</strong> remove once the Console supports the subscription form flow.
+     * Until then, {@code true} runs the subscription-form metadata validation (portal); {@code false}
+     * skips it for mAPI/Console requests.
+     */
+    private Boolean subscriptionFormMetadataValidationRequired = false;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateSubscriptionEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateSubscriptionEntity.java
@@ -52,4 +52,11 @@ public class UpdateSubscriptionEntity {
     private SubscriptionConfigurationEntity configuration;
 
     private Map<String, String> metadata;
+
+    /**
+     * <strong>Temporary:</strong> remove once the Console supports the subscription form flow.
+     * Until then, {@code true} runs the subscription-form metadata validation (portal); {@code false}
+     * skips it for mAPI/Console requests.
+     */
+    private Boolean subscriptionFormMetadataValidationRequired = false;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResource.java
@@ -136,6 +136,7 @@ public class SubscriptionResource extends AbstractResource {
 
         UpdateSubscriptionConfigurationEntity updateSubscriptionConfigurationEntity = new UpdateSubscriptionConfigurationEntity();
         updateSubscriptionConfigurationEntity.setSubscriptionId(subscriptionId);
+        updateSubscriptionConfigurationEntity.setSubscriptionFormMetadataValidationRequired(true);
         SubscriptionConfigurationInput subscriptionConfigurationInput = updateSubscriptionInput.getConfiguration();
 
         if (updateSubscriptionInput.getMetadata() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
@@ -130,6 +130,7 @@ public class SubscriptionsResource extends AbstractResource {
                     .generalConditionsAccepted(subscriptionInput.getGeneralConditionsAccepted())
                     .generalConditionsContentRevision(getPageRevisionId(subscriptionInput))
                     .auditInfo(auditInfo)
+                    .subscriptionFormMetadataValidationRequired(true)
                     .build()
             );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionResourceTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doReturn;
@@ -335,6 +336,7 @@ class SubscriptionResourceTest extends AbstractResourceTest {
             );
             verify(subscriptionService).update(eq(GraviteeContext.getExecutionContext()), subscriptionCaptor.capture());
             assertEquals(SUBSCRIPTION, subscriptionCaptor.getValue().getSubscriptionId());
+            assertTrue(Boolean.TRUE.equals(subscriptionCaptor.getValue().getSubscriptionFormMetadataValidationRequired()));
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
@@ -22,6 +22,7 @@ import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -212,6 +213,7 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
         assertEquals("{\"url\":\"my-url\"}", useCaseInput.configuration().getEntrypointConfiguration());
         assertEquals(ApiKeyMode.EXCLUSIVE, useCaseInput.apiKeyMode());
         assertEquals(API, useCaseInput.referenceId());
+        assertTrue(Boolean.TRUE.equals(useCaseInput.subscriptionFormMetadataValidationRequired()));
 
         final Subscription subscriptionResponse = response.readEntity(Subscription.class);
         assertNotNull(subscriptionResponse);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/CreateSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/CreateSubscriptionDomainService.java
@@ -50,6 +50,7 @@ public interface CreateSubscriptionDomainService {
         java.util.Map<String, String> metadata,
         io.gravitee.rest.api.model.ApiKeyMode apiKeyMode,
         Boolean generalConditionsAccepted,
-        io.gravitee.rest.api.model.PageEntity.PageRevisionId generalConditionsContentRevision
+        io.gravitee.rest.api.model.PageEntity.PageRevisionId generalConditionsContentRevision,
+        Boolean subscriptionFormMetadataValidationRequired
     );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/use_case/CreateSubscriptionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/use_case/CreateSubscriptionUseCase.java
@@ -71,7 +71,8 @@ public class CreateSubscriptionUseCase {
             input.metadata,
             input.apiKeyMode,
             input.generalConditionsAccepted,
-            input.generalConditionsContentRevision
+            input.generalConditionsContentRevision,
+            input.subscriptionFormMetadataValidationRequired
         );
 
         SubscriptionEntity createdSubscription = subscriptionCrudService.get(createdSubscriptionEntity.getId());
@@ -115,7 +116,8 @@ public class CreateSubscriptionUseCase {
         io.gravitee.rest.api.model.ApiKeyMode apiKeyMode,
         Boolean generalConditionsAccepted,
         io.gravitee.rest.api.model.PageEntity.PageRevisionId generalConditionsContentRevision,
-        AuditInfo auditInfo
+        AuditInfo auditInfo,
+        Boolean subscriptionFormMetadataValidationRequired
     ) {}
 
     public record Output(SubscriptionEntity subscription) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/CreateSubscriptionDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/CreateSubscriptionDomainServiceImpl.java
@@ -46,7 +46,8 @@ public class CreateSubscriptionDomainServiceImpl implements CreateSubscriptionDo
         java.util.Map<String, String> metadata,
         io.gravitee.rest.api.model.ApiKeyMode apiKeyMode,
         Boolean generalConditionsAccepted,
-        io.gravitee.rest.api.model.PageEntity.PageRevisionId generalConditionsContentRevision
+        io.gravitee.rest.api.model.PageEntity.PageRevisionId generalConditionsContentRevision,
+        Boolean subscriptionFormMetadataValidationRequired
     ) {
         ExecutionContext executionContext = new ExecutionContext(auditInfo.organizationId(), auditInfo.environmentId());
 
@@ -73,6 +74,9 @@ public class CreateSubscriptionDomainServiceImpl implements CreateSubscriptionDo
         }
         if (generalConditionsContentRevision != null) {
             newSubscriptionEntity.setGeneralConditionsContentRevision(generalConditionsContentRevision);
+        }
+        if (subscriptionFormMetadataValidationRequired != null) {
+            newSubscriptionEntity.setSubscriptionFormMetadataValidationRequired(subscriptionFormMetadataValidationRequired);
         }
 
         return subscriptionService.create(executionContext, newSubscriptionEntity, customApiKey);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImpl.java
@@ -54,10 +54,49 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
     @Override
     public void validateAndSanitize(final GenericPlanEntity genericPlanEntity, final NewSubscriptionEntity subscription) {
         subscription.setConfiguration(validateAndSanitizeSubscriptionConfiguration(genericPlanEntity, subscription.getConfiguration()));
-        if (subscription.getMetadata() != null) {
-            subscription.setMetadata(subscriptionMetadataSanitizer.sanitizeAndValidate(subscription.getMetadata()));
+        var metadata = subscription.getMetadata();
+        if (metadata != null) {
+            metadata = subscriptionMetadataSanitizer.sanitizeAndValidate(metadata);
+            subscription.setMetadata(metadata);
         }
-        validateSubscriptionFormMetadataIfApplicable(genericPlanEntity, subscription.getMetadata());
+        if (Boolean.TRUE.equals(subscription.getSubscriptionFormMetadataValidationRequired())) {
+            validateSubscriptionFormMetadataIfApplicable(genericPlanEntity, metadata);
+        }
+    }
+
+    @Override
+    public void validateAndSanitize(
+        final GenericPlanEntity genericPlanEntity,
+        final UpdateSubscriptionEntity subscription,
+        String applicationId
+    ) {
+        subscription.setConfiguration(validateAndSanitizeSubscriptionConfiguration(genericPlanEntity, subscription.getConfiguration()));
+        var metadata = subscription.getMetadata();
+        if (metadata != null) {
+            metadata = subscriptionMetadataSanitizer.sanitizeAndValidate(metadata);
+            subscription.setMetadata(metadata);
+        }
+        if (Boolean.TRUE.equals(subscription.getSubscriptionFormMetadataValidationRequired())) {
+            validateSubscriptionFormMetadataIfApplicable(genericPlanEntity, metadata);
+        }
+    }
+
+    @Override
+    public void validateAndSanitize(
+        final GenericPlanEntity genericPlanEntity,
+        final UpdateSubscriptionConfigurationEntity subscriptionConfiguration
+    ) {
+        subscriptionConfiguration.setConfiguration(
+            validateAndSanitizeSubscriptionConfiguration(genericPlanEntity, subscriptionConfiguration.getConfiguration())
+        );
+        var metadata = subscriptionConfiguration.getMetadata();
+        if (metadata != null) {
+            metadata = subscriptionMetadataSanitizer.sanitizeAndValidate(metadata);
+            subscriptionConfiguration.setMetadata(metadata);
+        }
+        if (Boolean.TRUE.equals(subscriptionConfiguration.getSubscriptionFormMetadataValidationRequired())) {
+            validateSubscriptionFormMetadataIfApplicable(genericPlanEntity, metadata);
+        }
     }
 
     private void validateSubscriptionFormMetadataIfApplicable(
@@ -82,35 +121,6 @@ public class SubscriptionValidationServiceImpl extends TransactionalService impl
             )
             .map(SubscriptionFormSubmissionValidator::new)
             .ifPresent(validator -> validator.validate(submitted));
-    }
-
-    @Override
-    public void validateAndSanitize(
-        final GenericPlanEntity genericPlanEntity,
-        final UpdateSubscriptionEntity subscription,
-        String applicationId
-    ) {
-        subscription.setConfiguration(validateAndSanitizeSubscriptionConfiguration(genericPlanEntity, subscription.getConfiguration()));
-        if (subscription.getMetadata() != null) {
-            subscription.setMetadata(subscriptionMetadataSanitizer.sanitizeAndValidate(subscription.getMetadata()));
-        }
-        validateSubscriptionFormMetadataIfApplicable(genericPlanEntity, subscription.getMetadata());
-    }
-
-    @Override
-    public void validateAndSanitize(
-        final GenericPlanEntity genericPlanEntity,
-        final UpdateSubscriptionConfigurationEntity subscriptionConfiguration
-    ) {
-        subscriptionConfiguration.setConfiguration(
-            validateAndSanitizeSubscriptionConfiguration(genericPlanEntity, subscriptionConfiguration.getConfiguration())
-        );
-        if (subscriptionConfiguration.getMetadata() != null) {
-            subscriptionConfiguration.setMetadata(
-                subscriptionMetadataSanitizer.sanitizeAndValidate(subscriptionConfiguration.getMetadata())
-            );
-        }
-        validateSubscriptionFormMetadataIfApplicable(genericPlanEntity, subscriptionConfiguration.getMetadata());
     }
 
     private SubscriptionConfigurationEntity validateAndSanitizeSubscriptionConfiguration(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/CreateSubscriptionDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/CreateSubscriptionDomainServiceImplTest.java
@@ -71,6 +71,7 @@ class CreateSubscriptionDomainServiceImplTest {
             Map.of("k", "v"),
             ApiKeyMode.EXCLUSIVE,
             null,
+            null,
             null
         );
 
@@ -97,7 +98,7 @@ class CreateSubscriptionDomainServiceImplTest {
             .build();
         when(subscriptionService.create(any(), any(), any())).thenReturn(new SubscriptionEntity());
 
-        cut.create(auditInfo, PLAN_ID, APP_ID, null, null, config, null, null, null, null);
+        cut.create(auditInfo, PLAN_ID, APP_ID, null, null, config, null, null, null, null, null);
 
         ArgumentCaptor<NewSubscriptionEntity> entityCaptor = ArgumentCaptor.forClass(NewSubscriptionEntity.class);
         verify(subscriptionService).create(any(), entityCaptor.capture(), any());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/SubscriptionValidationServiceImplTest.java
@@ -18,7 +18,10 @@ package io.gravitee.rest.api.service.v4.impl.validation;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.SubscriptionFormFixtures;
@@ -295,6 +298,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var subscription = new NewSubscriptionEntity();
+            subscription.setSubscriptionFormMetadataValidationRequired(true);
             subscription.setMetadata(Map.of());
 
             assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, subscription)).isInstanceOf(
@@ -315,6 +319,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var subscription = new NewSubscriptionEntity();
+            subscription.setSubscriptionFormMetadataValidationRequired(true);
             subscription.setMetadata(Map.of("email", "user@example.com"));
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
@@ -335,6 +340,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var subscription = new NewSubscriptionEntity();
+            subscription.setSubscriptionFormMetadataValidationRequired(true);
             subscription.setMetadata(Map.of());
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
@@ -353,6 +359,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var subscription = new NewSubscriptionEntity();
+            subscription.setSubscriptionFormMetadataValidationRequired(true);
             subscription.setMetadata(Map.of());
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
@@ -371,6 +378,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var subscription = new NewSubscriptionEntity();
+            subscription.setSubscriptionFormMetadataValidationRequired(true);
             subscription.setMetadata(Map.of());
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
@@ -381,6 +389,7 @@ public class SubscriptionValidationServiceImplTest {
             // storage is empty — no form registered for any environment
 
             var subscription = new NewSubscriptionEntity();
+            subscription.setSubscriptionFormMetadataValidationRequired(true);
             subscription.setMetadata(Map.of());
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
@@ -399,6 +408,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var subscription = new NewSubscriptionEntity();
+            subscription.setSubscriptionFormMetadataValidationRequired(true);
             subscription.setMetadata(null);
 
             assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, subscription)).isInstanceOf(
@@ -434,6 +444,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setSubscriptionFormMetadataValidationRequired(true);
             subscriptionConfig.setMetadata(Map.of());
 
             assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).isInstanceOf(
@@ -454,6 +465,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setSubscriptionFormMetadataValidationRequired(true);
             subscriptionConfig.setMetadata(Map.of("email", "user@example.com"));
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).doesNotThrowAnyException();
@@ -472,6 +484,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setSubscriptionFormMetadataValidationRequired(true);
             subscriptionConfig.setMetadata(Map.of());
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).doesNotThrowAnyException();
@@ -480,6 +493,7 @@ public class SubscriptionValidationServiceImplTest {
         @Test
         void should_not_validate_when_no_form_for_environment() {
             var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setSubscriptionFormMetadataValidationRequired(true);
             subscriptionConfig.setMetadata(Map.of());
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).doesNotThrowAnyException();
@@ -498,6 +512,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setSubscriptionFormMetadataValidationRequired(true);
             subscriptionConfig.setMetadata(null);
 
             assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).isInstanceOf(
@@ -533,6 +548,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setSubscriptionFormMetadataValidationRequired(true);
             updateSubscription.setMetadata(Map.of());
 
             assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).isInstanceOf(
@@ -553,6 +569,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setSubscriptionFormMetadataValidationRequired(true);
             updateSubscription.setMetadata(Map.of("email", "user@example.com"));
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).doesNotThrowAnyException();
@@ -571,6 +588,7 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setSubscriptionFormMetadataValidationRequired(true);
             updateSubscription.setMetadata(Map.of());
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).doesNotThrowAnyException();
@@ -579,6 +597,7 @@ public class SubscriptionValidationServiceImplTest {
         @Test
         void should_not_validate_when_no_form_for_environment() {
             var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setSubscriptionFormMetadataValidationRequired(true);
             updateSubscription.setMetadata(Map.of());
 
             assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).doesNotThrowAnyException();
@@ -597,11 +616,67 @@ public class SubscriptionValidationServiceImplTest {
             );
 
             var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setSubscriptionFormMetadataValidationRequired(true);
             updateSubscription.setMetadata(null);
 
             assertThatThrownBy(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).isInstanceOf(
                 SubscriptionFormValidationException.class
             );
+        }
+    }
+
+    @Nested
+    class When_subscription_form_metadata_validation_disabled {
+
+        @BeforeEach
+        void beforeEach() {
+            clearInvocations(subscriptionMetadataSanitizer);
+            planEntity.setEnvironmentId(SubscriptionFormFixtures.ENVIRONMENT_ID);
+            subscriptionFormQueryService.initWith(
+                List.of(
+                    SubscriptionFormFixtures.aSubscriptionFormBuilder()
+                        .enabled(true)
+                        .validationConstraints(
+                            SubscriptionFormConstraintsFactory.fromSchema(
+                                new SubscriptionFormSchema(
+                                    List.of(new SubscriptionFormSchema.InputField("email", true, null, null, null, null))
+                                )
+                            )
+                        )
+                        .gmdContent(GraviteeMarkdown.of("<p/>"))
+                        .build()
+                )
+            );
+        }
+
+        @Test
+        void should_invoke_metadata_sanitizer_for_new_subscription_without_form_validation() {
+            var subscription = new NewSubscriptionEntity();
+            subscription.setSubscriptionFormMetadataValidationRequired(false);
+            subscription.setMetadata(Map.of("note", "v"));
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, subscription)).doesNotThrowAnyException();
+            verify(subscriptionMetadataSanitizer, times(1)).sanitizeAndValidate(any());
+        }
+
+        @Test
+        void should_invoke_metadata_sanitizer_for_update_subscription_without_form_validation() {
+            var updateSubscription = new UpdateSubscriptionEntity();
+            updateSubscription.setSubscriptionFormMetadataValidationRequired(false);
+            updateSubscription.setMetadata(Map.of("note", "v"));
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, updateSubscription, APP_ID)).doesNotThrowAnyException();
+            verify(subscriptionMetadataSanitizer, times(1)).sanitizeAndValidate(any());
+        }
+
+        @Test
+        void should_invoke_metadata_sanitizer_for_update_configuration_without_form_validation() {
+            var subscriptionConfig = new UpdateSubscriptionConfigurationEntity();
+            subscriptionConfig.setSubscriptionFormMetadataValidationRequired(false);
+            subscriptionConfig.setMetadata(Map.of("note", "v"));
+
+            assertThatCode(() -> cut.validateAndSanitize(planEntity, subscriptionConfig)).doesNotThrowAnyException();
+            verify(subscriptionMetadataSanitizer, times(1)).sanitizeAndValidate(any());
         }
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13609

## Description

### Summary
This change fixes subscription creation from the Console (Management API) when a plan has a subscription form with required fields. Backend validation for that form was running for every subscription request, so Console users—who never see the form—could not satisfy required fields and requests failed.

We now treat Portal and Management (Console / mAPI) subscription flows differently: subscription form backend validation runs only when the request is known to come from the Portal. Management-originated requests skip that validation so publishers and admins can still create or manage subscriptions as before.

Sanitization of subscription metadata (keys, stripping unsafe markup, etc.) remains global for all origins so we do not weaken stored-data safety for Console-created subscriptions.

### Problem
Subscription form backend validation was applied regardless of who created the subscription.
The Console does not expose the subscription form UI for that flow, so required fields from the form could never be submitted → validation errors and blocked subscriptions.
There was no reliable signal in the subscription pipeline to mean “the user actually went through the Portal form.”
### Approach (this PR)
Introduce an internal flag on the subscription-related payloads (e.g. create / update paths) that indicates whether subscription form backend validation should run.
Portal REST resources set this flag when building the subscription so validation runs when the form is shown to the consumer.
Management API / Console paths set it so validation is not run for that origin.
Keep metadata sanitization separate: it continues to run for all requests; only the form constraint validation is conditional on the flag.


## Additional context

**Important limitation — shared Portal API (pAPI)**

The Portal API is shared between the **Classic Portal** and the **Next Gen Portal**, so the backend **cannot tell** which portal a request came from.
**Implication**: if Subscription Form is enabled globally and includes fields with required constraints, **subscription-form backend validation also runs for Classic Portal flows**. Classic Portal does not surface that form in the subscription journey, so users cannot supply those values — in practice this blocks subscription creation on the old portal.
This PR does not add classic-vs-next detection on pAPI; that remains a known constraint of the current architecture while both portals use the same endpoints.

