### PR TITLE
chore(deps): bump gravitee-resource-cache-provider-api to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <gravitee-reporter-api.version>1.35.1</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
-        <gravitee-resource-cache-provider-api.version>2.0.0</gravitee-resource-cache-provider-api.version>
+        <gravitee-resource-cache-provider-api.version>2.1.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-content-provider-api.version>1.0.0</gravitee-resource-content-provider-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.4.1</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-storage-api.version>1.1.0</gravitee-resource-storage-api.version>


### PR DESCRIPTION
## Summary
- Bumps `gravitee-resource-cache-provider-api` from 2.0.0 to 2.1.0
- 2.1.0 adds async `Future`-based cache methods (`getAsync`, `putAsync`, `evictAsync`, `clearAsync`) needed by the Vert.x Redis cache resource rewrite (APIM-13556)

## Test plan
- [ ] CI green — no breaking changes, only additive default methods on the `Cache` interface