### PR TITLE
feat(gateway): init TCP connection metrics

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/subscription/SubscriptionProcessor.java
@@ -47,6 +47,7 @@ public class SubscriptionProcessor implements Processor {
 
     public static final String ID = "processor-subscription";
     public static final String ATTR_API_PRODUCT = ExecutionContext.ATTR_PREFIX + "apiProduct";
+    public static final String CLIENT_IDENTIFIER_HEADER_PROPERTY = "handlers.request.client.header";
     public static final String DEFAULT_CLIENT_IDENTIFIER_HEADER = "X-Gravitee-Client-Identifier";
     static final String APPLICATION_ANONYMOUS = "1";
     static final String PLAN_ANONYMOUS = "1";

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactor.java
@@ -21,9 +21,12 @@ import static io.gravitee.gateway.reactive.api.context.ContextAttributes.ATTR_CO
 import static io.gravitee.gateway.reactive.api.context.ContextAttributes.ATTR_REQUEST_METHOD;
 import static io.gravitee.gateway.reactive.api.context.ContextAttributes.ATTR_SNI;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_SERVER_ID;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.CLIENT_IDENTIFIER_HEADER_PROPERTY;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.DEFAULT_CLIENT_IDENTIFIER_HEADER;
 
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
@@ -40,6 +43,7 @@ import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.gravitee.gateway.reactive.core.v4.endpoint.EndpointManager;
 import io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver;
 import io.gravitee.gateway.reactive.core.v4.invoker.TcpEndpointInvoker;
+import io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LoggingHook;
 import io.gravitee.gateway.reactor.handler.Acceptor;
 import io.gravitee.gateway.reactor.handler.DefaultTcpAcceptor;
@@ -48,6 +52,8 @@ import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.logging.LogEntry;
 import io.gravitee.node.logging.LogEntryFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.gravitee.reporter.api.v4.metric.NoopMetrics;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.List;
 import java.util.Optional;
@@ -76,6 +82,8 @@ public class TcpApiReactor extends AbstractApiReactor {
     private Lifecycle.State lifecycleState;
     private AnalyticsContext analyticsContext;
     private final TcpInvoker defaultInvoker;
+    private final GatewayConfiguration gatewayConfiguration;
+    private final String clientIdentifierHeader;
 
     public TcpApiReactor(
         Api api,
@@ -85,7 +93,8 @@ public class TcpApiReactor extends AbstractApiReactor {
         EntrypointConnectorPluginManager entrypointConnectorPluginManager,
         EndpointManager endpointManager,
         RequestTimeoutConfiguration requestTimeoutConfiguration,
-        TracingContext tracingContext
+        TracingContext tracingContext,
+        GatewayConfiguration gatewayConfiguration
     ) {
         super(
             configuration,
@@ -104,6 +113,12 @@ public class TcpApiReactor extends AbstractApiReactor {
             null
         );
         this.loggingMaxSize = configuration.getProperty(REPORTERS_LOGGING_MAX_SIZE_PROPERTY, String.class, null);
+        this.gatewayConfiguration = gatewayConfiguration;
+        this.clientIdentifierHeader = configuration.getProperty(
+            CLIENT_IDENTIFIER_HEADER_PROPERTY,
+            String.class,
+            DEFAULT_CLIENT_IDENTIFIER_HEADER
+        );
     }
 
     @Override
@@ -122,12 +137,13 @@ public class TcpApiReactor extends AbstractApiReactor {
         ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ENABLED, analyticsContext.isTracingEnabled());
         ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED, tracingContext.isVerbose());
         ctx.logEntries(DEFAULT_EXECUTION_CONTEXT_LOG_ENTRIES);
+        initMetrics(ctx);
+        prepareMetrics(ctx);
 
         // TODO specific Tcp API Request processor chain factory that contains SubscriptionProcessor in beforeApi chain
         return new CompletableReactorChain(handleEntrypointRequest(ctx))
-            // configure backend call
+            .chainWith(SubscriptionProcessor.instance(clientIdentifierHeader).execute(ctx))
             .chainWith(defaultInvoker.invoke(ctx))
-            // setup timeout
             .chainWith(upstream -> timeout(upstream, ctx))
             // handle response
             .chainWith(handleEntrypointResponse(ctx))
@@ -135,6 +151,36 @@ public class TcpApiReactor extends AbstractApiReactor {
             .chainWith(ctx.response().end(ctx))
             .doOnSubscribe(disposable -> pendingRequests.incrementAndGet())
             .doFinally(pendingRequests::decrementAndGet);
+    }
+
+    private void initMetrics(MutableExecutionContext ctx) {
+        if (!analyticsContext.isEnabled()) {
+            ctx.metrics(new NoopMetrics());
+            return;
+        }
+        var request = ctx.request();
+        Metrics.MetricsBuilder<?, ?> builder = Metrics.builder()
+            .timestamp(request.timestamp())
+            .requestId(request.id())
+            .transactionId(request.transactionId())
+            .remoteAddress(request.remoteAddress())
+            .localAddress(request.localAddress())
+            .host(request.host());
+        gatewayConfiguration.tenant().ifPresent(builder::tenant);
+        gatewayConfiguration.zone().ifPresent(builder::zone);
+        ctx.metrics(builder.enabled(true).build());
+    }
+
+    private void prepareMetrics(MutableExecutionContext ctx) {
+        Metrics metrics = ctx.metrics();
+        if (!metrics.isEnabled()) {
+            return;
+        }
+        metrics.setApiId(api.getId());
+        metrics.setApiName(api.getName());
+        metrics.setApiType(api.getDefinition().getType().getLabel());
+        metrics.setOrganizationId(api.getOrganizationId());
+        metrics.setEnvironmentId(api.getEnvironmentId());
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactorFactory.java
@@ -88,7 +88,8 @@ public class TcpApiReactorFactory implements ReactorFactory<Api> {
             entrypointConnectorPluginManager,
             endpointManager,
             requestTimeoutConfiguration,
-            createTracingContext(api)
+            createTracingContext(api),
+            gatewayConfiguration
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.v4.processor;
 
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.CLIENT_IDENTIFIER_HEADER_PROPERTY;
 import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.DEFAULT_CLIENT_IDENTIFIER_HEADER;
 
 import io.gravitee.definition.model.Cors;
@@ -69,7 +70,7 @@ public class ApiProcessorChainFactory {
         this.configuration = configuration;
         this.overrideXForwardedPrefix = configuration.getProperty("handlers.request.headers.x-forwarded-prefix", Boolean.class, false);
         this.clientIdentifierHeader = configuration.getProperty(
-            "handlers.request.client.header",
+            CLIENT_IDENTIFIER_HEADER_PROPERTY,
             String.class,
             DEFAULT_CLIENT_IDENTIFIER_HEADER
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactorTest.java
@@ -16,8 +16,13 @@
 package io.gravitee.gateway.reactive.handlers.api.v4;
 
 import static io.gravitee.common.component.Lifecycle.State.STOPPED;
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_APPLICATION;
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_PLAN;
+import static io.gravitee.gateway.api.ExecutionContext.ATTR_SUBSCRIPTION_ID;
 import static io.gravitee.gateway.handlers.api.ApiReactorHandlerFactory.REPORTERS_LOGGING_EXCLUDED_RESPONSE_TYPES_PROPERTY;
 import static io.gravitee.gateway.handlers.api.ApiReactorHandlerFactory.REPORTERS_LOGGING_MAX_SIZE_PROPERTY;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.CLIENT_IDENTIFIER_HEADER_PROPERTY;
+import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.DEFAULT_CLIENT_IDENTIFIER_HEADER;
 import static io.gravitee.gateway.reactive.handlers.api.v4.DefaultApiReactor.PENDING_REQUESTS_TIMEOUT_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,8 +36,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.component.Lifecycle;
+import io.gravitee.common.util.LinkedMultiValueMap;
+import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.el.TemplateContext;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.reactive.api.ApiType;
@@ -42,6 +53,7 @@ import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.tcp.TcpExecutionContext;
 import io.gravitee.gateway.reactive.core.context.DefaultDeploymentContext;
 import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
+import io.gravitee.gateway.reactive.core.context.MutableRequest;
 import io.gravitee.gateway.reactive.core.context.MutableResponse;
 import io.gravitee.gateway.reactive.core.v4.endpoint.EndpointManager;
 import io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver;
@@ -51,12 +63,15 @@ import io.gravitee.gateway.reactor.handler.TcpAcceptor;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.gravitee.reporter.api.v4.metric.NoopMetrics;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.CompletableObserver;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,10 +79,12 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.helpers.NOPLogger;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -75,6 +92,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 class TcpApiReactorTest {
 
     public static final String API_ID = "api-id";
+    public static final String API_NAME = "api-name";
     public static final String ORGANIZATION_ID = "organization-id";
     public static final String ENVIRONMENT_ID = "environment-id";
 
@@ -126,6 +144,24 @@ class TcpApiReactorTest {
     @Mock
     private RequestTimeoutConfiguration requestTimeoutConfiguration;
 
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
+    @Mock
+    private MutableRequest request;
+
+    @Mock
+    private HttpHeaders requestHeaders;
+
+    @Mock
+    private HttpHeaders responseHeaders;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @Mock
+    private TemplateContext templateContext;
+
     private TestScheduler testScheduler;
 
     private TracingContext tracingContext = TracingContext.noop();
@@ -139,7 +175,7 @@ class TcpApiReactorTest {
 
         lenient().when(api.getDefinition()).thenReturn(apiDefinition);
         lenient().when(api.getId()).thenReturn(API_ID);
-        lenient().when(api.getName()).thenReturn(API_ID);
+        lenient().when(api.getName()).thenReturn(API_NAME);
         lenient().when(api.getDeployedAt()).thenReturn(new Date());
         lenient().when(api.getOrganizationId()).thenReturn(ORGANIZATION_ID);
         lenient().when(api.getEnvironmentId()).thenReturn(ENVIRONMENT_ID);
@@ -156,9 +192,23 @@ class TcpApiReactorTest {
             .thenReturn(entrypointConnector);
         lenient().when(entrypointConnector.supportedApi()).thenReturn(ApiType.PROXY);
 
+        lenient().when(ctx.withLogger(any())).thenReturn(NOPLogger.NOP_LOGGER);
+        lenient().when(ctx.request()).thenReturn(request);
+        lenient().when(request.headers()).thenReturn(requestHeaders);
+        lenient().when(request.parameters()).thenReturn(new LinkedMultiValueMap<>());
+        lenient().when(response.headers()).thenReturn(responseHeaders);
+        lenient().when(ctx.metrics()).thenReturn(org.mockito.Mockito.mock(Metrics.class));
+        lenient().when(ctx.getTemplateEngine()).thenReturn(templateEngine);
+        lenient().when(templateEngine.getTemplateContext()).thenReturn(templateContext);
+        lenient().when(gatewayConfiguration.tenant()).thenReturn(Optional.empty());
+        lenient().when(gatewayConfiguration.zone()).thenReturn(Optional.empty());
+
         when(configuration.getProperty(REPORTERS_LOGGING_EXCLUDED_RESPONSE_TYPES_PROPERTY, String.class, null)).thenReturn(null);
         when(configuration.getProperty(REPORTERS_LOGGING_MAX_SIZE_PROPERTY, String.class, null)).thenReturn(null);
         when(configuration.getProperty(PENDING_REQUESTS_TIMEOUT_PROPERTY, Long.class, 10_000L)).thenReturn(10_000L);
+        lenient()
+            .when(configuration.getProperty(CLIENT_IDENTIFIER_HEADER_PROPERTY, String.class, DEFAULT_CLIENT_IDENTIFIER_HEADER))
+            .thenReturn(DEFAULT_CLIENT_IDENTIFIER_HEADER);
 
         lenient().when(requestTimeoutConfiguration.getRequestTimeout()).thenReturn(0L);
         lenient().when(requestTimeoutConfiguration.getRequestTimeoutGraceDelay()).thenReturn(10000L);
@@ -183,7 +233,8 @@ class TcpApiReactorTest {
                 entrypointConnectorPluginManager,
                 endpointManager,
                 requestTimeoutConfiguration,
-                tracingContext
+                tracingContext,
+                gatewayConfiguration
             );
             ReflectionTestUtils.setField(tcpApiReactor, "entrypointConnectorResolver", entrypointConnectorResolver);
             ReflectionTestUtils.setField(tcpApiReactor, "defaultInvoker", defaultInvoker);
@@ -199,7 +250,7 @@ class TcpApiReactorTest {
         cut.handle(ctx).test().assertComplete();
 
         verify(ctx).setAttribute(ContextAttributes.ATTR_API, API_ID);
-        verify(ctx).setAttribute(ContextAttributes.ATTR_API_NAME, API_ID);
+        verify(ctx).setAttribute(ContextAttributes.ATTR_API_NAME, API_NAME);
         verify(ctx).setAttribute(ContextAttributes.ATTR_API_DEPLOYED_AT, api.getDeployedAt().getTime());
         verify(ctx).setAttribute(ContextAttributes.ATTR_ORGANIZATION, ORGANIZATION_ID);
         verify(ctx).setAttribute(ContextAttributes.ATTR_ENVIRONMENT, ENVIRONMENT_ID);
@@ -318,6 +369,101 @@ class TcpApiReactorTest {
         verify(entrypointConnectorResolver).stop();
         verify(endpointManager).preStop();
         verify(endpointManager, never()).stop();
+    }
+
+    @Test
+    void should_set_api_fields_on_metrics_when_analytics_enabled() {
+        when(apiDefinition.getAnalytics()).thenReturn(new Analytics());
+        Metrics enabledMetrics = Metrics.builder().enabled(true).build();
+        lenient().when(ctx.metrics()).thenReturn(enabledMetrics);
+        cut = buildApiReactor();
+
+        cut.handle(ctx).test().assertComplete();
+
+        ArgumentCaptor<Metrics> captor = ArgumentCaptor.forClass(Metrics.class);
+        verify(ctx).metrics(captor.capture());
+        assertThat(captor.getValue().isEnabled()).isTrue();
+        assertThat(enabledMetrics.getApiId()).isEqualTo(API_ID);
+        assertThat(enabledMetrics.getApiName()).isEqualTo(API_NAME);
+        assertThat(enabledMetrics.getApiType()).isEqualTo("proxy");
+        assertThat(enabledMetrics.getOrganizationId()).isEqualTo(ORGANIZATION_ID);
+        assertThat(enabledMetrics.getEnvironmentId()).isEqualTo(ENVIRONMENT_ID);
+    }
+
+    @Test
+    void should_set_noop_metrics_when_analytics_disabled() {
+        // apiDefinition.getAnalytics() returns null by default — analytics disabled
+        cut = buildApiReactor();
+
+        cut.handle(ctx).test().assertComplete();
+
+        ArgumentCaptor<Metrics> captor = ArgumentCaptor.forClass(Metrics.class);
+        verify(ctx).metrics(captor.capture());
+        assertThat(captor.getValue()).isInstanceOf(NoopMetrics.class);
+    }
+
+    @Test
+    void should_populate_subscription_fields_on_metrics() {
+        when(apiDefinition.getAnalytics()).thenReturn(new Analytics());
+        when(ctx.getAttribute(ATTR_PLAN)).thenReturn("plan-123");
+        when(ctx.getAttribute(ATTR_APPLICATION)).thenReturn("app-456");
+        when(ctx.getAttribute(ATTR_SUBSCRIPTION_ID)).thenReturn("sub-789");
+        Metrics enabledMetrics = Metrics.builder().enabled(true).build();
+        lenient().when(ctx.metrics()).thenReturn(enabledMetrics);
+        cut = buildApiReactor();
+
+        cut.handle(ctx).test().assertComplete();
+
+        assertThat(enabledMetrics.getPlanId()).isEqualTo("plan-123");
+        assertThat(enabledMetrics.getApplicationId()).isEqualTo("app-456");
+        assertThat(enabledMetrics.getSubscriptionId()).isEqualTo("sub-789");
+    }
+
+    @Test
+    void should_build_metrics_from_request_fields() {
+        when(apiDefinition.getAnalytics()).thenReturn(new Analytics());
+        when(request.id()).thenReturn("req-id");
+        when(request.transactionId()).thenReturn("tx-id");
+        when(request.remoteAddress()).thenReturn("1.2.3.4");
+        when(request.localAddress()).thenReturn("5.6.7.8");
+        when(request.host()).thenReturn("myhost");
+        when(request.timestamp()).thenReturn(12345L);
+        cut = buildApiReactor();
+
+        cut.handle(ctx).test().assertComplete();
+
+        ArgumentCaptor<Metrics> captor = ArgumentCaptor.forClass(Metrics.class);
+        verify(ctx).metrics(captor.capture());
+        Metrics built = captor.getValue();
+        assertThat(built.getRequestId()).isEqualTo("req-id");
+        assertThat(built.getTransactionId()).isEqualTo("tx-id");
+        assertThat(built.getRemoteAddress()).isEqualTo("1.2.3.4");
+        assertThat(built.getLocalAddress()).isEqualTo("5.6.7.8");
+        assertThat(built.getHost()).isEqualTo("myhost");
+        assertThat(built.getTimestamp()).isEqualTo(12345L);
+        assertThat(built.isEnabled()).isTrue();
+    }
+
+    @Test
+    void should_populate_tenant_and_zone_on_metrics_when_configured() {
+        when(apiDefinition.getAnalytics()).thenReturn(new Analytics());
+        when(request.id()).thenReturn("req-id");
+        when(request.transactionId()).thenReturn("tx-id");
+        when(request.remoteAddress()).thenReturn("1.2.3.4");
+        when(request.localAddress()).thenReturn("5.6.7.8");
+        when(request.host()).thenReturn("myhost");
+        when(request.timestamp()).thenReturn(12345L);
+        when(gatewayConfiguration.tenant()).thenReturn(Optional.of("my-tenant"));
+        when(gatewayConfiguration.zone()).thenReturn(Optional.of("my-zone"));
+        cut = buildApiReactor();
+
+        cut.handle(ctx).test().assertComplete();
+
+        ArgumentCaptor<Metrics> captor = ArgumentCaptor.forClass(Metrics.class);
+        verify(ctx).metrics(captor.capture());
+        Metrics built = captor.getValue();
+        assertThat(built.getTenant()).isEqualTo("my-tenant");
+        assertThat(built.getZone()).isEqualTo("my-zone");
     }
 
     private InOrder getInOrder() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13586

## Description

Wires TCP connection metrics initialisation into `TcpApiReactor` so that downstream processors (specifically `SubscriptionProcessor`) have a `Metrics` object to write into.

Before this change, no metrics object was initialised for TCP connections — `MetricsProcessor` does not run for TCP (tracked as a TODO in `DefaultTcpSocketDispatcher`).

**What this PR adds:**
- `initMetrics()` — initialises a `Metrics` object from the incoming TCP connection (timestamp, request/transaction IDs, remote/local address, host, tenant, zone). Falls back to `NoopMetrics` when analytics is disabled.
- `prepareMetrics()` — stamps API context fields (`apiId`, `apiName`, `apiType`, `organizationId`, `environmentId`) onto the metrics object.
- `SubscriptionProcessor` wired into the TCP handler chain, populating `planId`, `applicationId`, `subscriptionId`, and `clientIdentifier` on the metrics object.
- `GatewayConfiguration` injected into `TcpApiReactor` / `TcpApiReactorFactory` for tenant/zone fields (already used by `DefaultEndpointManager` in the factory).

Connection metrics emission is out of scope for this PR and will be handled in APIM-13587.

## Testing

- Unit tests updated in `TcpApiReactorTest` and `TcpApiReactorFactoryTest`.