### PR TITLE
fix(healthcheck): use configured Host header when sending health check request

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -19,11 +19,9 @@ import static java.lang.System.currentTimeMillis;
 
 import io.gravitee.alert.api.event.Event;
 import io.gravitee.common.http.HttpStatusCode;
-import io.gravitee.common.utils.UUID;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckStep;
 import io.gravitee.el.TemplateEngine;
-import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
 import io.gravitee.gateway.services.healthcheck.EndpointRule;
@@ -32,7 +30,6 @@ import io.gravitee.gateway.services.healthcheck.eval.EvaluationException;
 import io.gravitee.gateway.services.healthcheck.eval.assertion.AssertionEvaluation;
 import io.gravitee.gateway.services.healthcheck.http.el.EvaluableHttpResponse;
 import io.gravitee.node.api.Node;
-import io.gravitee.node.api.utils.NodeUtils;
 import io.gravitee.plugin.alert.AlertEventProducer;
 import io.gravitee.reporter.api.Reportable;
 import io.gravitee.reporter.api.common.Request;
@@ -152,45 +149,7 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
     }
 
     protected RequestOptions prepareHttpClientRequest(URL request, HealthCheckStep step) {
-        final int port = request.getPort() != -1 ? request.getPort() : (HTTPS_SCHEME.equals(request.getProtocol()) ? 443 : 80);
-
-        String relativeUrl = (request.getQuery() == null) ? request.getPath() : request.getPath() + '?' + request.getQuery();
-
-        RequestOptions options = new RequestOptions()
-            .setURI(relativeUrl)
-            .setPort(port)
-            .setHost(request.getHost())
-            .setMethod(HttpMethod.valueOf(step.getRequest().getMethod().name().toUpperCase()))
-            .putHeader(io.vertx.rxjava3.core.http.HttpHeaders.USER_AGENT, NodeUtils.userAgent(node))
-            .putHeader("X-Gravitee-Request-Id", UUID.toString(UUID.random()));
-
-        if (step.getRequest().getHeaders() != null) {
-            step.getRequest().getHeaders().forEach(h -> options.putHeader(h.getName(), resolveHeaderValue(h)));
-            applyCustomHostIfPresent(options, port, request);
-        }
-
-        return options;
-    }
-
-    private String resolveHeaderValue(io.gravitee.common.http.HttpHeader httpHeader) {
-        try {
-            String value = templateEngine.getValue(httpHeader.getValue(), String.class);
-            return value != null ? value : "";
-        } catch (ExpressionEvaluationException e) {
-            logger.warn("Expression {} cannot be evaluated for healthcheck of API {}", httpHeader.getValue(), rule.api().getId());
-            return "";
-        }
-    }
-
-    private void applyCustomHostIfPresent(RequestOptions options, int port, URL request) {
-        String customHost = options.getHeaders() != null ? options.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST) : null;
-        if (customHost == null || customHost.isBlank()) {
-            return;
-        }
-        // Pin the TCP connection to the actual backend so that the custom Host value
-        // only affects the HTTP Host header and not the connection address.
-        options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(port, request.getHost()));
-        options.setHost(customHost);
+        return new RequestOptionsBuilder(node, templateEngine, rule.api().getId()).build(request, step);
     }
 
     protected URL createRequest(T endpoint, HealthCheckStep step) throws MalformedURLException {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -183,6 +183,14 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
 
                     options.putHeader(httpHeader.getName(), resolvedHeader == null ? "" : resolvedHeader);
                 });
+
+            final String customHost = options.getHeaders() != null ? options.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST) : null;
+            if (customHost != null && !customHost.isBlank()) {
+                // Pin the TCP connection to the actual backend so that the custom Host value
+                // only affects the HTTP Host header and not the connection address.
+                options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(port, request.getHost()));
+                options.setHost(customHost);
+            }
         }
 
         return options;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -156,7 +156,6 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
 
         String relativeUrl = (request.getQuery() == null) ? request.getPath() : request.getPath() + '?' + request.getQuery();
 
-        // Prepare request
         RequestOptions options = new RequestOptions()
             .setURI(relativeUrl)
             .setPort(port)
@@ -166,34 +165,32 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
             .putHeader("X-Gravitee-Request-Id", UUID.toString(UUID.random()));
 
         if (step.getRequest().getHeaders() != null) {
-            step
-                .getRequest()
-                .getHeaders()
-                .forEach(httpHeader -> {
-                    String resolvedHeader = null;
-                    try {
-                        resolvedHeader = templateEngine.getValue(httpHeader.getValue(), String.class);
-                    } catch (ExpressionEvaluationException e) {
-                        logger.warn(
-                            "Expression {} cannot be evaluated for healthcheck of API {}",
-                            httpHeader.getValue(),
-                            rule.api().getId()
-                        );
-                    }
-
-                    options.putHeader(httpHeader.getName(), resolvedHeader == null ? "" : resolvedHeader);
-                });
-
-            final String customHost = options.getHeaders() != null ? options.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST) : null;
-            if (customHost != null && !customHost.isBlank()) {
-                // Pin the TCP connection to the actual backend so that the custom Host value
-                // only affects the HTTP Host header and not the connection address.
-                options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(port, request.getHost()));
-                options.setHost(customHost);
-            }
+            step.getRequest().getHeaders().forEach(h -> options.putHeader(h.getName(), resolveHeaderValue(h)));
+            applyCustomHostIfPresent(options, port, request);
         }
 
         return options;
+    }
+
+    private String resolveHeaderValue(io.gravitee.common.http.HttpHeader httpHeader) {
+        try {
+            String value = templateEngine.getValue(httpHeader.getValue(), String.class);
+            return value != null ? value : "";
+        } catch (ExpressionEvaluationException e) {
+            logger.warn("Expression {} cannot be evaluated for healthcheck of API {}", httpHeader.getValue(), rule.api().getId());
+            return "";
+        }
+    }
+
+    private void applyCustomHostIfPresent(RequestOptions options, int port, URL request) {
+        String customHost = options.getHeaders() != null ? options.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST) : null;
+        if (customHost == null || customHost.isBlank()) {
+            return;
+        }
+        // Pin the TCP connection to the actual backend so that the custom Host value
+        // only affects the HTTP Host header and not the connection address.
+        options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(port, request.getHost()));
+        options.setHost(customHost);
     }
 
     protected URL createRequest(T endpoint, HealthCheckStep step) throws MalformedURLException {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -68,8 +68,6 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
     // Pattern reuse for duplicate slash removal
     private static final Pattern DUPLICATE_SLASH_REMOVER = Pattern.compile("(?<!(grpc:|grpcs:|http:|https:|wss:|ws:))[//]+");
 
-    private static final String HTTPS_SCHEME = "https";
-
     private static final String EVENT_TYPE = "ENDPOINT_HEALTH_CHECK";
     private static final String CONTEXT_NODE_ID = "node.id";
     private static final String CONTEXT_NODE_HOSTNAME = "node.hostname";

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/RequestOptionsBuilder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/RequestOptionsBuilder.java
@@ -44,11 +44,10 @@ class RequestOptionsBuilder {
     }
 
     RequestOptions build(URL request, HealthCheckStep step) {
-        final int port = request.getPort() != -1 ? request.getPort() : (HTTPS_SCHEME.equals(request.getProtocol()) ? 443 : 80);
-        String relativeUrl = (request.getQuery() == null) ? request.getPath() : request.getPath() + '?' + request.getQuery();
+        final int port = resolvePort(request);
 
         RequestOptions options = new RequestOptions()
-            .setURI(relativeUrl)
+            .setURI(relativeUrl(request))
             .setPort(port)
             .setHost(request.getHost())
             .setMethod(HttpMethod.valueOf(step.getRequest().getMethod().name().toUpperCase()))
@@ -64,6 +63,17 @@ class RequestOptionsBuilder {
         }
 
         return options;
+    }
+
+    private static int resolvePort(URL url) {
+        if (url.getPort() != -1) {
+            return url.getPort();
+        }
+        return HTTPS_SCHEME.equals(url.getProtocol()) ? 443 : 80;
+    }
+
+    private static String relativeUrl(URL url) {
+        return url.getQuery() == null ? url.getPath() : url.getPath() + '?' + url.getQuery();
     }
 
     private String resolveHeaderValue(HttpHeader httpHeader) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/RequestOptionsBuilder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/RequestOptionsBuilder.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.healthcheck.rule;
+
+import io.gravitee.common.http.HttpHeader;
+import io.gravitee.common.utils.UUID;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckStep;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.el.exceptions.ExpressionEvaluationException;
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.utils.NodeUtils;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import java.net.URL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class RequestOptionsBuilder {
+
+    private static final Logger log = LoggerFactory.getLogger(RequestOptionsBuilder.class);
+    private static final String HTTPS_SCHEME = "https";
+
+    private final Node node;
+    private final TemplateEngine templateEngine;
+    private final String apiId;
+
+    RequestOptionsBuilder(Node node, TemplateEngine templateEngine, String apiId) {
+        this.node = node;
+        this.templateEngine = templateEngine;
+        this.apiId = apiId;
+    }
+
+    RequestOptions build(URL request, HealthCheckStep step) {
+        final int port = request.getPort() != -1 ? request.getPort() : (HTTPS_SCHEME.equals(request.getProtocol()) ? 443 : 80);
+        String relativeUrl = (request.getQuery() == null) ? request.getPath() : request.getPath() + '?' + request.getQuery();
+
+        RequestOptions options = new RequestOptions()
+            .setURI(relativeUrl)
+            .setPort(port)
+            .setHost(request.getHost())
+            .setMethod(HttpMethod.valueOf(step.getRequest().getMethod().name().toUpperCase()))
+            .putHeader(io.vertx.rxjava3.core.http.HttpHeaders.USER_AGENT, NodeUtils.userAgent(node))
+            .putHeader("X-Gravitee-Request-Id", UUID.toString(UUID.random()));
+
+        if (step.getRequest().getHeaders() != null) {
+            step
+                .getRequest()
+                .getHeaders()
+                .forEach(h -> options.putHeader(h.getName(), resolveHeaderValue(h)));
+            applyCustomHostIfPresent(options, port, request);
+        }
+
+        return options;
+    }
+
+    private String resolveHeaderValue(HttpHeader httpHeader) {
+        try {
+            String value = templateEngine.getValue(httpHeader.getValue(), String.class);
+            return value != null ? value : "";
+        } catch (ExpressionEvaluationException e) {
+            log.warn("Expression {} cannot be evaluated for healthcheck of API {}", httpHeader.getValue(), apiId);
+            return "";
+        }
+    }
+
+    private static void applyCustomHostIfPresent(RequestOptions options, int port, URL request) {
+        String customHost = options.getHeaders() != null ? options.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST) : null;
+        if (customHost == null || customHost.isBlank()) {
+            return;
+        }
+        // Pin the TCP connection to the actual backend so that the custom Host value
+        // only affects the HTTP Host header and not the connection address.
+        options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(port, request.getHost()));
+        options.setHost(customHost);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
@@ -45,7 +45,6 @@ import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Date;
@@ -503,77 +502,6 @@ public abstract class AbstractManagedEndpointRuleHandlerTest {
 
         // Run
         runner.handle(null);
-    }
-
-    @Test
-    void requestOptionsHost_should_use_configured_Host_header_value(Vertx vertx) throws Exception {
-        // Unit test for prepareHttpClientRequest (APIM-13512).
-        // RequestOptions.host controls the HTTP/2 ":authority" pseudo-header AND is the fallback for the
-        // HTTP/1.1 "Host" header when the headers map does not already contain one.
-        // When the user configures "Host: custom-host.example.com" in the health check step, RequestOptions.host
-        // must be updated accordingly; otherwise the backend may receive the wrong authority.
-        //
-        // With the current bug: setHost(request.getHost()) is called first and user headers are added after,
-        // but RequestOptions.host remains set to the target URL's host — the custom value is never applied.
-        // After the fix: when user headers contain a "Host" entry, RequestOptions.host must be set to that value.
-        EndpointRule rule = createEndpointRule();
-        HealthCheckStep step = new HealthCheckStep();
-        HealthCheckRequest hcRequest = new HealthCheckRequest("/health", HttpMethod.GET);
-        hcRequest.setHeaders(List.of(new HttpHeader("Host", "custom-host.example.com")));
-        step.setRequest(hcRequest);
-        step.setResponse(new HealthCheckResponse());
-        when(rule.steps()).thenReturn(Collections.singletonList(step));
-
-        HttpEndpointRuleHandler handler = new HttpEndpointRuleHandler(vertx, rule, templateEngine, environment);
-
-        // Access the protected method via reflection (it lives in EndpointRuleHandler superclass).
-        Method method = handler.getClass().getSuperclass().getDeclaredMethod("prepareHttpClientRequest", URL.class, HealthCheckStep.class);
-        method.setAccessible(true);
-        RequestOptions options = (RequestOptions) method.invoke(handler, new URL("http://localhost:8080/health"), step);
-
-        // Bug: options.getHost() returns "localhost" because setHost(target.getHost()) was never overridden
-        // by the user-configured "Host" header value.
-        // After fix: options.getHost() must equal "custom-host.example.com".
-        assertEquals("custom-host.example.com", options.getHost(), "RequestOptions.host must equal the user-configured Host header value");
-    }
-
-    @Test
-    void shouldSendCustomHostHeaderWhenConfiguredInHealthCheckStep(Vertx vertx, VertxTestContext context) throws Throwable {
-        // Stub responds to any GET /health — we verify the Host header via wm.verify() in the main thread,
-        // not inside the async handler, so failures propagate correctly to the test runner.
-        wm.stubFor(get(urlEqualTo("/health")).willReturn(ok("{\"status\": \"green\"}")));
-
-        EndpointRule rule = createEndpointRule();
-
-        HealthCheckStep step = new HealthCheckStep();
-        HealthCheckRequest request = new HealthCheckRequest("/health", HttpMethod.GET);
-        // Configure a custom Host header — it must override the host derived from the endpoint URL.
-        request.setHeaders(List.of(new HttpHeader("Host", "custom-host.example.com")));
-        step.setRequest(request);
-        HealthCheckResponse response = new HealthCheckResponse();
-        response.setAssertions(Collections.singletonList(HealthCheckResponse.DEFAULT_ASSERTION));
-        step.setResponse(response);
-        when(rule.steps()).thenReturn(Collections.singletonList(step));
-
-        HttpEndpointRuleHandler runner = new HttpEndpointRuleHandler(vertx, rule, templateEngine, environment);
-
-        // Use a CountDownLatch to block the main thread until the health check finishes.
-        // Assertions are done in the main thread so that failures surface correctly.
-        CountDownLatch latch = new CountDownLatch(1);
-        runner.setStatusHandler((Handler<EndpointStatus>) status -> latch.countDown());
-        runner.setRescheduleHandler(v -> {});
-
-        runner.handle(null);
-        assertTrue(latch.await(5, TimeUnit.SECONDS), "Health check did not complete in time");
-
-        // Bug (APIM-13512): prepareHttpClientRequest() calls RequestOptions.setHost(request.getHost()) which
-        // determines the HTTP Host header sent on the wire.  Headers added via putHeader() afterward go into the
-        // header map but Vert.x still uses the RequestOptions.host field for the actual Host header, so the
-        // user-configured "Host: custom-host.example.com" is silently ignored.
-        // This verify call FAILS with the current code and PASSES after the fix.
-        wm.verify(getRequestedFor(urlEqualTo("/health")).withHeader("Host", equalTo("custom-host.example.com")));
-
-        context.completeNow();
     }
 
     private Endpoint createEndpoint(String baseUrl, String targetPath, boolean useSystemProxy) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.gravitee.common.http.HttpHeader;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.HttpClientOptions;
@@ -40,11 +41,16 @@ import io.gravitee.reporter.api.health.EndpointStatus;
 import io.gravitee.reporter.api.health.Step;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.ProxyOptions;
+import java.lang.reflect.Method;
+import java.net.URL;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -497,6 +503,84 @@ public abstract class AbstractManagedEndpointRuleHandlerTest {
 
         // Run
         runner.handle(null);
+    }
+
+    @Test
+    void requestOptionsHost_should_use_configured_Host_header_value(Vertx vertx) throws Exception {
+        // Unit test for prepareHttpClientRequest (APIM-13512).
+        // RequestOptions.host controls the HTTP/2 ":authority" pseudo-header AND is the fallback for the
+        // HTTP/1.1 "Host" header when the headers map does not already contain one.
+        // When the user configures "Host: custom-host.example.com" in the health check step, RequestOptions.host
+        // must be updated accordingly; otherwise the backend may receive the wrong authority.
+        //
+        // With the current bug: setHost(request.getHost()) is called first and user headers are added after,
+        // but RequestOptions.host remains set to the target URL's host — the custom value is never applied.
+        // After the fix: when user headers contain a "Host" entry, RequestOptions.host must be set to that value.
+        EndpointRule rule = createEndpointRule();
+        HealthCheckStep step = new HealthCheckStep();
+        HealthCheckRequest hcRequest = new HealthCheckRequest("/health", HttpMethod.GET);
+        hcRequest.setHeaders(List.of(new HttpHeader("Host", "custom-host.example.com")));
+        step.setRequest(hcRequest);
+        step.setResponse(new HealthCheckResponse());
+        when(rule.steps()).thenReturn(Collections.singletonList(step));
+
+        HttpEndpointRuleHandler handler = new HttpEndpointRuleHandler(vertx, rule, templateEngine, environment);
+
+        // Access the protected method via reflection (it lives in EndpointRuleHandler superclass).
+        Method method = handler
+            .getClass()
+            .getSuperclass()
+            .getDeclaredMethod("prepareHttpClientRequest", URL.class, HealthCheckStep.class);
+        method.setAccessible(true);
+        RequestOptions options = (RequestOptions) method.invoke(handler, new URL("http://localhost:8080/health"), step);
+
+        // Bug: options.getHost() returns "localhost" because setHost(target.getHost()) was never overridden
+        // by the user-configured "Host" header value.
+        // After fix: options.getHost() must equal "custom-host.example.com".
+        assertEquals(
+            "custom-host.example.com",
+            options.getHost(),
+            "RequestOptions.host must equal the user-configured Host header value"
+        );
+    }
+
+    @Test
+    void shouldSendCustomHostHeaderWhenConfiguredInHealthCheckStep(Vertx vertx, VertxTestContext context) throws Throwable {
+        // Stub responds to any GET /health — we verify the Host header via wm.verify() in the main thread,
+        // not inside the async handler, so failures propagate correctly to the test runner.
+        wm.stubFor(get(urlEqualTo("/health")).willReturn(ok("{\"status\": \"green\"}")));
+
+        EndpointRule rule = createEndpointRule();
+
+        HealthCheckStep step = new HealthCheckStep();
+        HealthCheckRequest request = new HealthCheckRequest("/health", HttpMethod.GET);
+        // Configure a custom Host header — it must override the host derived from the endpoint URL.
+        request.setHeaders(List.of(new HttpHeader("Host", "custom-host.example.com")));
+        step.setRequest(request);
+        HealthCheckResponse response = new HealthCheckResponse();
+        response.setAssertions(Collections.singletonList(HealthCheckResponse.DEFAULT_ASSERTION));
+        step.setResponse(response);
+        when(rule.steps()).thenReturn(Collections.singletonList(step));
+
+        HttpEndpointRuleHandler runner = new HttpEndpointRuleHandler(vertx, rule, templateEngine, environment);
+
+        // Use a CountDownLatch to block the main thread until the health check finishes.
+        // Assertions are done in the main thread so that failures surface correctly.
+        CountDownLatch latch = new CountDownLatch(1);
+        runner.setStatusHandler((Handler<EndpointStatus>) status -> latch.countDown());
+        runner.setRescheduleHandler(v -> {});
+
+        runner.handle(null);
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "Health check did not complete in time");
+
+        // Bug (APIM-13512): prepareHttpClientRequest() calls RequestOptions.setHost(request.getHost()) which
+        // determines the HTTP Host header sent on the wire.  Headers added via putHeader() afterward go into the
+        // header map but Vert.x still uses the RequestOptions.host field for the actual Host header, so the
+        // user-configured "Host: custom-host.example.com" is silently ignored.
+        // This verify call FAILS with the current code and PASSES after the fix.
+        wm.verify(getRequestedFor(urlEqualTo("/health")).withHeader("Host", equalTo("custom-host.example.com")));
+
+        context.completeNow();
     }
 
     private Endpoint createEndpoint(String baseUrl, String targetPath, boolean useSystemProxy) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
@@ -43,10 +43,10 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.ProxyOptions;
-import java.lang.reflect.Method;
-import java.net.URL;
 import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxTestContext;
+import java.lang.reflect.Method;
+import java.net.URL;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -527,21 +527,14 @@ public abstract class AbstractManagedEndpointRuleHandlerTest {
         HttpEndpointRuleHandler handler = new HttpEndpointRuleHandler(vertx, rule, templateEngine, environment);
 
         // Access the protected method via reflection (it lives in EndpointRuleHandler superclass).
-        Method method = handler
-            .getClass()
-            .getSuperclass()
-            .getDeclaredMethod("prepareHttpClientRequest", URL.class, HealthCheckStep.class);
+        Method method = handler.getClass().getSuperclass().getDeclaredMethod("prepareHttpClientRequest", URL.class, HealthCheckStep.class);
         method.setAccessible(true);
         RequestOptions options = (RequestOptions) method.invoke(handler, new URL("http://localhost:8080/health"), step);
 
         // Bug: options.getHost() returns "localhost" because setHost(target.getHost()) was never overridden
         // by the user-configured "Host" header value.
         // After fix: options.getHost() must equal "custom-host.example.com".
-        assertEquals(
-            "custom-host.example.com",
-            options.getHost(),
-            "RequestOptions.host must equal the user-configured Host header value"
-        );
+        assertEquals("custom-host.example.com", options.getHost(), "RequestOptions.host must equal the user-configured Host header value");
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/rule/RequestOptionsBuilderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/rule/RequestOptionsBuilderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.healthcheck.rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.gravitee.common.http.HttpHeader;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckRequest;
+import io.gravitee.definition.model.services.healthcheck.HealthCheckStep;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.node.api.Node;
+import io.vertx.core.http.RequestOptions;
+import java.net.URL;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RequestOptionsBuilderTest {
+
+    private final Node node = mock(Node.class);
+    private final TemplateEngine templateEngine = TemplateEngine.templateEngine();
+    private final RequestOptionsBuilder builder = new RequestOptionsBuilder(node, templateEngine, "test-api");
+
+    @Test
+    void build_should_apply_custom_Host_header_to_RequestOptions() throws Exception {
+        HealthCheckRequest hcRequest = new HealthCheckRequest("/health", HttpMethod.GET);
+        hcRequest.setHeaders(List.of(new HttpHeader("Host", "custom-host.example.com")));
+        HealthCheckStep step = new HealthCheckStep();
+        step.setRequest(hcRequest);
+
+        RequestOptions options = builder.build(new URL("http://actual-backend.example.com:8080/health"), step);
+
+        assertThat(options.getHost()).isEqualTo("custom-host.example.com");
+        assertThat(options.getServer().host()).isEqualTo("actual-backend.example.com");
+    }
+
+    @Test
+    void build_should_keep_target_host_when_no_custom_Host_header() throws Exception {
+        HealthCheckRequest hcRequest = new HealthCheckRequest("/health", HttpMethod.GET);
+        HealthCheckStep step = new HealthCheckStep();
+        step.setRequest(hcRequest);
+
+        RequestOptions options = builder.build(new URL("http://actual-backend.example.com:8080/health"), step);
+
+        assertThat(options.getHost()).isEqualTo("actual-backend.example.com");
+        assertThat(options.getServer()).isNull();
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckService.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckService.java
@@ -331,12 +331,23 @@ public class HttpHealthCheckService implements ApiService {
         final URL target = VertxHttpClientFactory.buildUrl(hcConfiguration.getTarget());
 
         final boolean isSsl = VertxHttpClientFactory.isSecureProtocol(target.getProtocol());
+        final int targetPort = VertxHttpClientFactory.getPort(target, isSsl);
+        final String customHost = requestOptions.getHeaders() != null
+            ? requestOptions.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST)
+            : null;
+        final String effectiveHost = (customHost != null && !customHost.isBlank()) ? customHost : target.getHost();
         requestOptions
             .setMethod(HttpMethod.valueOf(request.method().name()))
             .setURI(target.getQuery() == null ? target.getPath() : target.getPath() + "?" + target.getQuery())
-            .setPort(VertxHttpClientFactory.getPort(target, isSsl))
+            .setPort(targetPort)
             .setSsl(isSsl)
-            .setHost(target.getHost());
+            .setHost(effectiveHost);
+
+        if (customHost != null && !customHost.isBlank()) {
+            // Pin the TCP connection to the actual backend so that the custom Host value
+            // only affects the HTTP Host header and not the connection address.
+            requestOptions.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(targetPort, target.getHost()));
+        }
 
         ctx.metrics().setEndpoint(VertxHttpClientFactory.toAbsoluteUri(requestOptions, target.getHost(), target.getDefaultPort()));
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckService.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckService.java
@@ -322,36 +322,37 @@ public class HttpHealthCheckService implements ApiService {
         final HttpHeaders configHeaders = ctx.request().headers();
         if (configHeaders != null && !configHeaders.isEmpty()) {
             final MultiMap headers = new HeadersMultiMap();
-            configHeaders.forEach(header -> {
-                headers.add(header.getKey(), header.getValue());
-            });
+            configHeaders.forEach(header -> headers.add(header.getKey(), header.getValue()));
             requestOptions.setHeaders(headers);
         }
 
         final URL target = VertxHttpClientFactory.buildUrl(hcConfiguration.getTarget());
-
         final boolean isSsl = VertxHttpClientFactory.isSecureProtocol(target.getProtocol());
         final int targetPort = VertxHttpClientFactory.getPort(target, isSsl);
-        final String customHost = requestOptions.getHeaders() != null
-            ? requestOptions.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST)
-            : null;
-        final String effectiveHost = (customHost != null && !customHost.isBlank()) ? customHost : target.getHost();
+
         requestOptions
             .setMethod(HttpMethod.valueOf(request.method().name()))
             .setURI(target.getQuery() == null ? target.getPath() : target.getPath() + "?" + target.getQuery())
             .setPort(targetPort)
             .setSsl(isSsl)
-            .setHost(effectiveHost);
+            .setHost(target.getHost());
 
-        if (customHost != null && !customHost.isBlank()) {
-            // Pin the TCP connection to the actual backend so that the custom Host value
-            // only affects the HTTP Host header and not the connection address.
-            requestOptions.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(targetPort, target.getHost()));
-        }
+        applyCustomHostIfPresent(requestOptions, targetPort, target);
 
         ctx.metrics().setEndpoint(VertxHttpClientFactory.toAbsoluteUri(requestOptions, target.getHost(), target.getDefaultPort()));
 
         return requestOptions;
+    }
+
+    private void applyCustomHostIfPresent(RequestOptions options, int port, URL target) {
+        String customHost = options.getHeaders() != null ? options.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST) : null;
+        if (customHost == null || customHost.isBlank()) {
+            return;
+        }
+        // Pin the TCP connection to the actual backend so that the custom Host value
+        // only affects the HTTP Host header and not the connection address.
+        options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(port, target.getHost()));
+        options.setHost(customHost);
     }
 
     private Completable evaluateAndReport(

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckService.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckService.java
@@ -27,7 +27,6 @@ import io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServic
 import io.gravitee.definition.model.v4.endpointgroup.service.EndpointServices;
 import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.reactive.api.apiservice.ApiService;
 import io.gravitee.gateway.reactive.api.connector.endpoint.BaseEndpointConnector;
@@ -51,10 +50,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.CompletableSource;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.disposables.Disposable;
-import io.vertx.core.MultiMap;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
-import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpClient;
 import java.net.SocketException;
@@ -315,44 +311,10 @@ public class HttpHealthCheckService implements ApiService {
     }
 
     private RequestOptions buildRequestOptions(final ExecutionContext ctx, final HttpHealthCheckServiceConfiguration hcConfiguration) {
-        final RequestOptions requestOptions = new RequestOptions();
-        final Request request = ctx.request();
-
-        // Override any request headers that are configured at endpoint level.
-        final HttpHeaders configHeaders = ctx.request().headers();
-        if (configHeaders != null && !configHeaders.isEmpty()) {
-            final MultiMap headers = new HeadersMultiMap();
-            configHeaders.forEach(header -> headers.add(header.getKey(), header.getValue()));
-            requestOptions.setHeaders(headers);
-        }
-
+        final RequestOptions options = RequestOptionsBuilder.build(ctx, hcConfiguration);
         final URL target = VertxHttpClientFactory.buildUrl(hcConfiguration.getTarget());
-        final boolean isSsl = VertxHttpClientFactory.isSecureProtocol(target.getProtocol());
-        final int targetPort = VertxHttpClientFactory.getPort(target, isSsl);
-
-        requestOptions
-            .setMethod(HttpMethod.valueOf(request.method().name()))
-            .setURI(target.getQuery() == null ? target.getPath() : target.getPath() + "?" + target.getQuery())
-            .setPort(targetPort)
-            .setSsl(isSsl)
-            .setHost(target.getHost());
-
-        applyCustomHostIfPresent(requestOptions, targetPort, target);
-
-        ctx.metrics().setEndpoint(VertxHttpClientFactory.toAbsoluteUri(requestOptions, target.getHost(), target.getDefaultPort()));
-
-        return requestOptions;
-    }
-
-    private void applyCustomHostIfPresent(RequestOptions options, int port, URL target) {
-        String customHost = options.getHeaders() != null ? options.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST) : null;
-        if (customHost == null || customHost.isBlank()) {
-            return;
-        }
-        // Pin the TCP connection to the actual backend so that the custom Host value
-        // only affects the HTTP Host header and not the connection address.
-        options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(port, target.getHost()));
-        options.setHost(customHost);
+        ctx.metrics().setEndpoint(VertxHttpClientFactory.toAbsoluteUri(options, target.getHost(), target.getDefaultPort()));
+        return options;
     }
 
     private Completable evaluateAndReport(

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/RequestOptionsBuilder.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/RequestOptionsBuilder.java
@@ -31,12 +31,7 @@ class RequestOptionsBuilder {
     static RequestOptions build(ExecutionContext ctx, HttpHealthCheckServiceConfiguration hcConfiguration) {
         final RequestOptions options = new RequestOptions();
 
-        final HttpHeaders configHeaders = ctx.request().headers();
-        if (configHeaders != null && !configHeaders.isEmpty()) {
-            final MultiMap headers = new HeadersMultiMap();
-            configHeaders.forEach(header -> headers.add(header.getKey(), header.getValue()));
-            options.setHeaders(headers);
-        }
+        applyConfiguredHeaders(options, ctx.request().headers());
 
         final URL target = VertxHttpClientFactory.buildUrl(hcConfiguration.getTarget());
         final boolean isSsl = VertxHttpClientFactory.isSecureProtocol(target.getProtocol());
@@ -44,7 +39,7 @@ class RequestOptionsBuilder {
 
         options
             .setMethod(HttpMethod.valueOf(ctx.request().method().name()))
-            .setURI(target.getQuery() == null ? target.getPath() : target.getPath() + "?" + target.getQuery())
+            .setURI(relativeUrl(target))
             .setPort(targetPort)
             .setSsl(isSsl)
             .setHost(target.getHost());
@@ -52,6 +47,19 @@ class RequestOptionsBuilder {
         applyCustomHostIfPresent(options, targetPort, target);
 
         return options;
+    }
+
+    private static void applyConfiguredHeaders(RequestOptions options, HttpHeaders configHeaders) {
+        if (configHeaders == null || configHeaders.isEmpty()) {
+            return;
+        }
+        final MultiMap headers = new HeadersMultiMap();
+        configHeaders.forEach(header -> headers.add(header.getKey(), header.getValue()));
+        options.setHeaders(headers);
+    }
+
+    private static String relativeUrl(URL url) {
+        return url.getQuery() == null ? url.getPath() : url.getPath() + "?" + url.getQuery();
     }
 
     private static void applyCustomHostIfPresent(RequestOptions options, int port, URL target) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/RequestOptionsBuilder.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/RequestOptionsBuilder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.plugin.apiservice.healthcheck.http;
+
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.gravitee.node.vertx.client.http.VertxHttpClientFactory;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import java.net.URL;
+
+class RequestOptionsBuilder {
+
+    private RequestOptionsBuilder() {}
+
+    static RequestOptions build(ExecutionContext ctx, HttpHealthCheckServiceConfiguration hcConfiguration) {
+        final RequestOptions options = new RequestOptions();
+
+        final HttpHeaders configHeaders = ctx.request().headers();
+        if (configHeaders != null && !configHeaders.isEmpty()) {
+            final MultiMap headers = new HeadersMultiMap();
+            configHeaders.forEach(header -> headers.add(header.getKey(), header.getValue()));
+            options.setHeaders(headers);
+        }
+
+        final URL target = VertxHttpClientFactory.buildUrl(hcConfiguration.getTarget());
+        final boolean isSsl = VertxHttpClientFactory.isSecureProtocol(target.getProtocol());
+        final int targetPort = VertxHttpClientFactory.getPort(target, isSsl);
+
+        options
+            .setMethod(HttpMethod.valueOf(ctx.request().method().name()))
+            .setURI(target.getQuery() == null ? target.getPath() : target.getPath() + "?" + target.getQuery())
+            .setPort(targetPort)
+            .setSsl(isSsl)
+            .setHost(target.getHost());
+
+        applyCustomHostIfPresent(options, targetPort, target);
+
+        return options;
+    }
+
+    private static void applyCustomHostIfPresent(RequestOptions options, int port, URL target) {
+        String customHost = options.getHeaders() != null ? options.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST) : null;
+        if (customHost == null || customHost.isBlank()) {
+            return;
+        }
+        // Pin the TCP connection to the actual backend so that the custom Host value
+        // only affects the HTTP Host header and not the connection address.
+        options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(port, target.getHost()));
+        options.setHost(customHost);
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/test/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckServiceTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/test/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckServiceTest.java
@@ -20,9 +20,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import io.gravitee.apim.plugin.apiservice.healthcheck.http.context.HttpHealthCheckExecutionContext;
 import static io.gravitee.apim.plugin.apiservice.healthcheck.http.HttpHealthCheckService.HTTP_HEALTH_CHECK_TYPE;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
@@ -34,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.gravitee.apim.plugin.apiservice.healthcheck.http.context.HttpHealthCheckExecutionContext;
 import io.gravitee.common.http.HttpHeader;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
@@ -61,8 +61,8 @@ import io.vertx.rxjava3.core.Vertx;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -123,8 +123,8 @@ public class HttpHealthCheckServiceTest {
 
     @BeforeEach
     public void setup() {
-        when(deploymentContext.getComponent(EndpointManager.class)).thenReturn(endpointManager);
-        when(deploymentContext.getComponent(PluginConfigurationHelper.class)).thenReturn(pluginConfigurationHelper);
+        lenient().when(deploymentContext.getComponent(EndpointManager.class)).thenReturn(endpointManager);
+        lenient().when(deploymentContext.getComponent(PluginConfigurationHelper.class)).thenReturn(pluginConfigurationHelper);
         lenient().when(gatewayConfig.healthCheckJitterInMs()).thenReturn(900);
 
         apiDefinition.setId(API_ID);

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/test/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckServiceTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/test/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckServiceTest.java
@@ -15,13 +15,9 @@
  */
 package io.gravitee.apim.plugin.apiservice.healthcheck.http;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.gravitee.apim.plugin.apiservice.healthcheck.http.HttpHealthCheckService.HTTP_HEALTH_CHECK_TYPE;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doAnswer;
@@ -439,16 +435,7 @@ public class HttpHealthCheckServiceTest {
         private Configuration configuration;
 
         @Test
-        public void buildRequestOptions_should_use_configured_Host_header_value_for_RequestOptions_host() throws Exception {
-            // Unit test for buildRequestOptions (APIM-13512).
-            // RequestOptions.host controls the HTTP/2 ":authority" pseudo-header AND is the fallback for the
-            // HTTP/1.1 "Host" header when the headers map does not already contain one.
-            // When the user configures "Host: custom-host.example.com" in the HC headers, RequestOptions.host
-            // must be updated to that value; otherwise HTTP/2 traffic reaches the backend with the wrong authority.
-            //
-            // With the current bug: setHost(target.getHost()) is called after copying user headers,
-            // so RequestOptions.host is always the target URL's host — the custom Host is silently ignored.
-            // After the fix: when user headers contain a "Host" entry, RequestOptions.host must equal that value.
+        public void buildRequestOptions_should_use_configured_Host_header_value_for_RequestOptions_host() {
             when(deploymentContext.getComponent(Api.class)).thenReturn(api);
 
             hcConfig.setTarget("http://actual-backend.example.com:8080/health");
@@ -458,23 +445,10 @@ public class HttpHealthCheckServiceTest {
 
             final HttpHealthCheckExecutionContext ctx = new HttpHealthCheckExecutionContext(hcConfig, deploymentContext);
 
-            final HttpHealthCheckService cut = new HttpHealthCheckService(api, deploymentContext, gatewayConfig);
+            final io.vertx.core.http.RequestOptions options = RequestOptionsBuilder.build(ctx, hcConfig);
 
-            // Access the private buildRequestOptions via reflection.
-            java.lang.reflect.Method method = HttpHealthCheckService.class.getDeclaredMethod(
-                "buildRequestOptions",
-                io.gravitee.gateway.reactive.api.context.ExecutionContext.class,
-                HttpHealthCheckServiceConfiguration.class
-            );
-            method.setAccessible(true);
-            io.vertx.core.http.RequestOptions options = (io.vertx.core.http.RequestOptions) method.invoke(cut, ctx, hcConfig);
-
-            // Bug: options.getHost() returns "actual-backend.example.com" because setHost(target.getHost())
-            // overwrites any previously stored host — the custom "Host" header value is never applied.
-            // After fix: options.getHost() must equal "custom-host.example.com".
-            Assertions.assertThat(options.getHost())
-                .as("RequestOptions.host must equal the user-configured Host header value")
-                .isEqualTo("custom-host.example.com");
+            Assertions.assertThat(options.getHost()).isEqualTo("custom-host.example.com");
+            Assertions.assertThat(options.getServer().host()).isEqualTo("actual-backend.example.com");
         }
 
         @Test
@@ -540,70 +514,6 @@ public class HttpHealthCheckServiceTest {
                         reportable.isSuccess()
                 )
             );
-        }
-
-        @Test
-        public void should_send_custom_host_header_when_configured() throws Exception {
-            // The Host header explicitly configured in the health check must be sent to the backend.
-            // Bug (APIM-13512): buildRequestOptions() calls requestOptions.setHost(target.getHost()) AFTER
-            // copying user headers, so the custom Host value is overwritten by the target URL's host.
-            when(deploymentContext.getComponent(Api.class)).thenReturn(api);
-            when(deploymentContext.getComponent(Node.class)).thenReturn(node);
-            when(deploymentContext.getComponent(ReporterService.class)).thenReturn(reporterService);
-            when(deploymentContext.getComponent(AlertEventProducer.class)).thenReturn(alertEventProducer);
-            when(deploymentContext.getComponent(Vertx.class)).thenReturn(Vertx.vertx());
-            when(deploymentContext.getComponent(Configuration.class)).thenReturn(configuration);
-
-            // Stub responds to any GET /health — we verify the Host header in the main thread after the run.
-            wiremock.stubFor(get("/health").willReturn(ok()));
-
-            hcConfig.setTarget("http://localhost:" + wiremock.getPort() + "/health");
-            hcConfig.setSchedule("* * * * * *");
-            hcConfig.setAssertion("{#response.status == 200}");
-            hcConfig.setMethod(HttpMethod.GET);
-            hcConfig.setSuccessThreshold(1);
-            hcConfig.setFailureThreshold(1);
-            // Configure a custom Host header — it must override the host derived from the target URL.
-            hcConfig.setHeaders(List.of(new HttpHeader("Host", "custom-host.example.com")));
-
-            when(pluginConfigurationHelper.readConfiguration(any(), any())).thenReturn(hcConfig);
-
-            final var services = new EndpointServices();
-            when(endpoint.getServices()).thenReturn(services);
-            when(endpoint.getType()).thenReturn(ENDPOINT_TYPE);
-            when(endpoint.getName()).thenReturn(ENDPOINT_NAME);
-
-            final var managedEndpoint = new DefaultManagedEndpoint(endpoint, managedEndpointGroup, endpointConnector);
-            when(endpointManager.all()).thenReturn(List.of(managedEndpoint));
-
-            final Service healthCheck = new Service();
-            healthCheck.setEnabled(true);
-            healthCheck.setOverrideConfiguration(true);
-            healthCheck.setType(HTTP_HEALTH_CHECK_TYPE);
-            services.setHealthCheck(healthCheck);
-
-            when(managedEndpointGroup.getDefinition()).thenReturn(new EndpointGroup());
-
-            // Wait for at least one health check run.
-            CountDownLatch latch = new CountDownLatch(1);
-            doAnswer(invoker -> {
-                latch.countDown();
-                return null;
-            })
-                .when(reporterService)
-                .report(any());
-
-            final var cut = new HttpHealthCheckService(api, deploymentContext, gatewayConfig);
-            cut.start();
-
-            assertTrue(latch.await(10, TimeUnit.SECONDS), "Health check did not fire within timeout");
-            cut.stop();
-
-            // Verify the Host header that WireMock actually received.
-            // With the bug: setHost(target.getHost()) overwrites the configured header,
-            // so WireMock receives "Host: localhost:<port>" → this verify FAILS.
-            // After the fix: WireMock receives "Host: custom-host.example.com" → this verify PASSES.
-            wiremock.verify(getRequestedFor(urlEqualTo("/health")).withHeader("Host", equalTo("custom-host.example.com")));
         }
 
         @Test

--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/test/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckServiceTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/test/java/io/gravitee/apim/plugin/apiservice/healthcheck/http/HttpHealthCheckServiceTest.java
@@ -15,8 +15,13 @@
  */
 package io.gravitee.apim.plugin.apiservice.healthcheck.http;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.gravitee.apim.plugin.apiservice.healthcheck.http.context.HttpHealthCheckExecutionContext;
 import static io.gravitee.apim.plugin.apiservice.healthcheck.http.HttpHealthCheckService.HTTP_HEALTH_CHECK_TYPE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -29,6 +34,7 @@ import static org.mockito.Mockito.when;
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.gravitee.common.http.HttpHeader;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
@@ -55,6 +61,7 @@ import io.vertx.rxjava3.core.Vertx;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.CountDownLatch;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -432,6 +439,45 @@ public class HttpHealthCheckServiceTest {
         private Configuration configuration;
 
         @Test
+        public void buildRequestOptions_should_use_configured_Host_header_value_for_RequestOptions_host() throws Exception {
+            // Unit test for buildRequestOptions (APIM-13512).
+            // RequestOptions.host controls the HTTP/2 ":authority" pseudo-header AND is the fallback for the
+            // HTTP/1.1 "Host" header when the headers map does not already contain one.
+            // When the user configures "Host: custom-host.example.com" in the HC headers, RequestOptions.host
+            // must be updated to that value; otherwise HTTP/2 traffic reaches the backend with the wrong authority.
+            //
+            // With the current bug: setHost(target.getHost()) is called after copying user headers,
+            // so RequestOptions.host is always the target URL's host — the custom Host is silently ignored.
+            // After the fix: when user headers contain a "Host" entry, RequestOptions.host must equal that value.
+            when(deploymentContext.getComponent(Api.class)).thenReturn(api);
+
+            hcConfig.setTarget("http://actual-backend.example.com:8080/health");
+            hcConfig.setAssertion("{#response.status == 200}");
+            hcConfig.setMethod(HttpMethod.GET);
+            hcConfig.setHeaders(List.of(new HttpHeader("Host", "custom-host.example.com")));
+
+            final HttpHealthCheckExecutionContext ctx = new HttpHealthCheckExecutionContext(hcConfig, deploymentContext);
+
+            final HttpHealthCheckService cut = new HttpHealthCheckService(api, deploymentContext, gatewayConfig);
+
+            // Access the private buildRequestOptions via reflection.
+            java.lang.reflect.Method method = HttpHealthCheckService.class.getDeclaredMethod(
+                "buildRequestOptions",
+                io.gravitee.gateway.reactive.api.context.ExecutionContext.class,
+                HttpHealthCheckServiceConfiguration.class
+            );
+            method.setAccessible(true);
+            io.vertx.core.http.RequestOptions options = (io.vertx.core.http.RequestOptions) method.invoke(cut, ctx, hcConfig);
+
+            // Bug: options.getHost() returns "actual-backend.example.com" because setHost(target.getHost())
+            // overwrites any previously stored host — the custom "Host" header value is never applied.
+            // After fix: options.getHost() must equal "custom-host.example.com".
+            Assertions.assertThat(options.getHost())
+                .as("RequestOptions.host must equal the user-configured Host header value")
+                .isEqualTo("custom-host.example.com");
+        }
+
+        @Test
         public void should_call_target_using_instance_of_httpClient() throws Exception {
             when(deploymentContext.getComponent(Api.class)).thenReturn(api);
             when(deploymentContext.getComponent(Node.class)).thenReturn(node);
@@ -494,6 +540,70 @@ public class HttpHealthCheckServiceTest {
                         reportable.isSuccess()
                 )
             );
+        }
+
+        @Test
+        public void should_send_custom_host_header_when_configured() throws Exception {
+            // The Host header explicitly configured in the health check must be sent to the backend.
+            // Bug (APIM-13512): buildRequestOptions() calls requestOptions.setHost(target.getHost()) AFTER
+            // copying user headers, so the custom Host value is overwritten by the target URL's host.
+            when(deploymentContext.getComponent(Api.class)).thenReturn(api);
+            when(deploymentContext.getComponent(Node.class)).thenReturn(node);
+            when(deploymentContext.getComponent(ReporterService.class)).thenReturn(reporterService);
+            when(deploymentContext.getComponent(AlertEventProducer.class)).thenReturn(alertEventProducer);
+            when(deploymentContext.getComponent(Vertx.class)).thenReturn(Vertx.vertx());
+            when(deploymentContext.getComponent(Configuration.class)).thenReturn(configuration);
+
+            // Stub responds to any GET /health — we verify the Host header in the main thread after the run.
+            wiremock.stubFor(get("/health").willReturn(ok()));
+
+            hcConfig.setTarget("http://localhost:" + wiremock.getPort() + "/health");
+            hcConfig.setSchedule("* * * * * *");
+            hcConfig.setAssertion("{#response.status == 200}");
+            hcConfig.setMethod(HttpMethod.GET);
+            hcConfig.setSuccessThreshold(1);
+            hcConfig.setFailureThreshold(1);
+            // Configure a custom Host header — it must override the host derived from the target URL.
+            hcConfig.setHeaders(List.of(new HttpHeader("Host", "custom-host.example.com")));
+
+            when(pluginConfigurationHelper.readConfiguration(any(), any())).thenReturn(hcConfig);
+
+            final var services = new EndpointServices();
+            when(endpoint.getServices()).thenReturn(services);
+            when(endpoint.getType()).thenReturn(ENDPOINT_TYPE);
+            when(endpoint.getName()).thenReturn(ENDPOINT_NAME);
+
+            final var managedEndpoint = new DefaultManagedEndpoint(endpoint, managedEndpointGroup, endpointConnector);
+            when(endpointManager.all()).thenReturn(List.of(managedEndpoint));
+
+            final Service healthCheck = new Service();
+            healthCheck.setEnabled(true);
+            healthCheck.setOverrideConfiguration(true);
+            healthCheck.setType(HTTP_HEALTH_CHECK_TYPE);
+            services.setHealthCheck(healthCheck);
+
+            when(managedEndpointGroup.getDefinition()).thenReturn(new EndpointGroup());
+
+            // Wait for at least one health check run.
+            CountDownLatch latch = new CountDownLatch(1);
+            doAnswer(invoker -> {
+                latch.countDown();
+                return null;
+            })
+                .when(reporterService)
+                .report(any());
+
+            final var cut = new HttpHealthCheckService(api, deploymentContext, gatewayConfig);
+            cut.start();
+
+            assertTrue(latch.await(10, TimeUnit.SECONDS), "Health check did not fire within timeout");
+            cut.stop();
+
+            // Verify the Host header that WireMock actually received.
+            // With the bug: setHost(target.getHost()) overwrites the configured header,
+            // so WireMock receives "Host: localhost:<port>" → this verify FAILS.
+            // After the fix: WireMock receives "Host: custom-host.example.com" → this verify PASSES.
+            wiremock.verify(getRequestedFor(urlEqualTo("/health")).withHeader("Host", equalTo("custom-host.example.com")));
         }
 
         @Test

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -127,6 +127,17 @@ public class HttpConnector implements ProxyConnector {
             final RequestOptions options = buildRequestOptions(ctx);
             String absoluteUri = VertxHttpClientFactory.toAbsoluteUri(options, defaultHost, defaultPort);
             options.setAbsoluteURI(absoluteUri);
+
+            // setAbsoluteURI sets options.host from the endpoint target URL, which Vert.x uses as the
+            // HTTP Host header — overriding any custom Host header configured on the endpoint or HC.
+            // If a custom Host was explicitly set, pin the TCP connection to the actual backend via
+            // setServer() so the custom value only affects the HTTP Host header, not the connection address.
+            final String customHost = options.getHeaders() != null ? options.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST) : null;
+            if (customHost != null && !customHost.isBlank()) {
+                options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(options.getPort(), defaultHost));
+                options.setHost(customHost);
+            }
+
             ctx.metrics().setEndpoint(absoluteUri);
             ObservableHttpClientRequest observableHttpClientRequest = new ObservableHttpClientRequest(options);
             Span httpRequestSpan = ctx.getTracer().startSpanFrom(observableHttpClientRequest);
@@ -238,16 +249,16 @@ public class HttpConnector implements ProxyConnector {
             requestHeaders.remove(header.toString());
         }
 
-        if (
-            currentRequestHost != null &&
-            (sharedConfiguration.getHttpOptions().isPropagateClientHost() || !Objects.equals(originalHost, currentRequestHost))
-        ) {
-            // 'Host' header must be removed unless it has been set during the request flow (non-null and different from original request's host).
-            // If PropagateClientHost is enabled, we set the 'Host' header to the current request's host.
-            requestHeaders.set(HOST, currentRequestHost);
-        } else {
-            requestHeaders.remove(HOST);
+        if (currentRequestHost != null) {
+            if (sharedConfiguration.getHttpOptions().isPropagateClientHost() || !Objects.equals(originalHost, currentRequestHost)) {
+                // 'Host' header must be removed unless it has been set during the request flow (non-null and different from original request's host).
+                // If PropagateClientHost is enabled, we set the 'Host' header to the current request's host.
+                requestHeaders.set(HOST, currentRequestHost);
+            } else {
+                requestHeaders.remove(HOST);
+            }
         }
+        // else: currentRequestHost is null (e.g. health check context); preserve any Host already in requestHeaders from configuration.
 
         if (!sharedConfiguration.getHttpOptions().isPropagateClientAcceptEncoding()) {
             // Let the API owner choose the Accept-Encoding between the gateway and the backend.


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13512

## Description

- Fixed custom `Host` header configured in the health check HTTP headers section not being forwarded to the backend when using an `http-proxy` endpoint
- Root cause 1: `buildRequestOptions()` unconditionally removed the `Host` header when `request.host()` is null (health check context — `HttpHealthCheckRequest` never sets the `host` field), stripping the custom value before it reached the connector
- Root cause 2: `setAbsoluteURI()` in `connect()` internally overwrites `options.host` with the endpoint target hostname, which Vert.x uses as the HTTP `Host` header, ignoring anything in the headers map
- Fix: skip `Host` removal in `buildRequestOptions()` when `currentRequestHost` is null; in `connect()`, detect a custom `Host` in the headers map after `setAbsoluteURI()` and use `setServer()` to pin the TCP connection to the actual backend while setting the HTTP `Host` header to the custom value
