### PR TITLE
feat: add native-kafka-cluster endpoint type with crossId support

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/Cluster.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/Cluster.fixture.ts
@@ -18,6 +18,7 @@ import { Cluster } from './Cluster';
 export function fakeCluster(overrides: Partial<Cluster> = {}): Cluster {
   return {
     id: 'cluster-id',
+    crossId: 'cluster-name',
     type: 'KAFKA_CLUSTER_CONNECTION',
     name: 'Cluster Name',
     description: 'A test cluster',

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/Cluster.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/Cluster.ts
@@ -17,6 +17,7 @@ export type ClusterType = 'KAFKA_CLUSTER_CONNECTION' | 'KAFKA_CLUSTER';
 
 export interface Cluster {
   id: string;
+  crossId: string;
   type: ClusterType;
   name: string;
   description?: string;
@@ -32,6 +33,7 @@ export interface KafkaClusterConnectionConfiguration {
 }
 
 export interface KafkaClusterConnection {
+  crossId?: string;
   name: string;
   bootstrapServers?: string;
   security?: unknown;

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/CreateCluster.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/CreateCluster.ts
@@ -15,4 +15,4 @@
  */
 import { Cluster } from './Cluster';
 
-export type CreateCluster = Pick<Cluster, 'type' | 'name' | 'description' | 'configuration'>;
+export type CreateCluster = Pick<Cluster, 'type' | 'name' | 'description' | 'configuration'> & { crossId?: string };

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-stepper-helper.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4-spec-stepper-helper.ts
@@ -67,14 +67,6 @@ export class ApiCreationV4SpecStepperHelper {
           supportedListenerType: 'KAFKA',
         }),
       );
-      this.httpExpects.expectEndpointGetRequest(
-        fakeConnectorPlugin({
-          id: 'native-kafka',
-          supportedApiType: 'NATIVE',
-          name: 'Native Kafka Endpoint',
-          supportedListenerType: 'KAFKA',
-        }),
-      );
     }
   }
 

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.native-kafka.component.spec.ts
@@ -170,6 +170,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
       await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('KAFKA');
       await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(nativeKafkaEntrypoint);
+      await stepperHelper.fillAndValidateStep3_1_EndpointsList(nativeKafkaEndpoint);
       await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(nativeKafkaEndpoint);
       await stepperHelper.validateStep4_1_SecurityPlansList();
 
@@ -204,6 +205,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
       await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('KAFKA');
       await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(nativeKafkaEntrypoint);
+      await stepperHelper.fillAndValidateStep3_1_EndpointsList(nativeKafkaEndpoint);
       await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(nativeKafkaEndpoint);
       await stepperHelper.validateStep4_1_SecurityPlansList();
 
@@ -242,6 +244,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
       await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('KAFKA');
       await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(nativeKafkaEntrypoint);
+      await stepperHelper.fillAndValidateStep3_1_EndpointsList(nativeKafkaEndpoint);
       await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(nativeKafkaEndpoint);
 
       const plansList = await harnessLoader.getHarness(Step4Security1PlansHarness);
@@ -280,6 +283,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
       await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('KAFKA');
       await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(nativeKafkaEntrypoint);
+      await stepperHelper.fillAndValidateStep3_1_EndpointsList(nativeKafkaEndpoint);
       await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(nativeKafkaEndpoint);
       await stepperHelper.validateStep4_1_SecurityPlansList();
 
@@ -295,6 +299,7 @@ describe('ApiCreationV4Component - Native Kafka', () => {
       await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
       await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('KAFKA');
       await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(nativeKafkaEntrypoint);
+      await stepperHelper.fillAndValidateStep3_1_EndpointsList(nativeKafkaEndpoint);
       await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(nativeKafkaEndpoint);
 
       const plansList = await harnessLoader.getHarness(Step4Security1PlansHarness);

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-0-architecture.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-0-architecture.component.ts
@@ -15,7 +15,7 @@
  */
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { combineLatest, Observable, Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { GioConfirmDialogComponent, GioConfirmDialogData, GioLicenseService, License } from '@gravitee/ui-particles-angular';
 import { MatDialog } from '@angular/material/dialog';
 import { takeUntil, tap } from 'rxjs/operators';
@@ -165,12 +165,10 @@ export class Step2Entrypoints0ArchitectureComponent implements OnInit, OnDestroy
   }
 
   private doSaveKafka() {
-    combineLatest([
-      this.connectorPluginsV2Service.getEntrypointPlugin('native-kafka'),
-      this.connectorPluginsV2Service.getEndpointPlugin('native-kafka'),
-    ])
+    this.connectorPluginsV2Service
+      .getEntrypointPlugin('native-kafka')
       .pipe(
-        tap(([nativeKafkaEntrypoint, nativeKafkaEndpoint]) => {
+        tap(nativeKafkaEntrypoint => {
           this.stepService.validStep(previousPayload => ({
             ...previousPayload,
             selectedEntrypoints: [
@@ -180,15 +178,6 @@ export class Step2Entrypoints0ArchitectureComponent implements OnInit, OnDestroy
                 icon: this.iconService.registerSvg(nativeKafkaEntrypoint.id, nativeKafkaEntrypoint.icon),
                 supportedListenerType: nativeKafkaEntrypoint.supportedListenerType,
                 deployed: nativeKafkaEntrypoint.deployed,
-              },
-            ],
-            selectedEndpoints: [
-              {
-                id: nativeKafkaEndpoint.id,
-                name: nativeKafkaEndpoint.name,
-                icon: this.iconService.registerSvg(nativeKafkaEndpoint.id, nativeKafkaEndpoint.icon),
-                supportedListenerType: nativeKafkaEndpoint.supportedListenerType,
-                deployed: nativeKafkaEndpoint.deployed,
               },
             ],
             architecture: 'KAFKA',

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
@@ -192,6 +192,7 @@ export class Step2Entrypoints2ConfigComponent implements OnInit, OnDestroy {
 
     switch (this.apiType) {
       case 'MESSAGE':
+      case 'NATIVE':
         this.stepService.goToNextStep({
           groupNumber: 3,
           component: Step3Endpoints1ListComponent,
@@ -201,7 +202,6 @@ export class Step2Entrypoints2ConfigComponent implements OnInit, OnDestroy {
       case 'MCP_PROXY':
       case 'LLM_PROXY':
       case 'A2A_PROXY':
-      case 'NATIVE':
         this.stepService.goToNextStep({
           groupNumber: 3,
           component: Step3Endpoints2ConfigComponent,

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-3-endpoints/step-3-endpoints-1-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/steps/step-3-endpoints/step-3-endpoints-1-list.component.ts
@@ -76,11 +76,14 @@ export class Step3Endpoints1ListComponent implements OnInit, OnDestroy {
       selectedEndpointsIds: this.formBuilder.control(currentSelectedEndpointIds, [Validators.required]),
     });
 
+    const apiType = this.stepService.payload.type ?? 'MESSAGE';
+
     this.connectorPluginsV2Service
-      .listEndpointPluginsByApiType('MESSAGE')
+      .listEndpointPluginsByApiType(apiType)
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe(endpointPlugins => {
-        const requiredQoS = this.stepService.payload.selectedEntrypoints.map(e => e.selectedQos);
+        const requiredQoS =
+          apiType === 'NATIVE' ? [] : (this.stepService.payload.selectedEntrypoints ?? []).map(e => e.selectedQos).filter(qos => !!qos);
         this.endpoints = mapAndFilterBySupportedQos(endpointPlugins, requiredQoS, this.iconService);
         this.shouldUpgrade = this.connectorPluginsV2Service.selectedPluginsNotAvailable(currentSelectedEndpointIds, this.endpoints);
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.html
@@ -19,7 +19,7 @@
   <mat-card>
     <mat-card-content>
       <mat-stepper [linear]="true">
-        <mat-step *ngIf="apiType === 'MESSAGE'" state="type" [stepControl]="createForm.get('type')">
+        <mat-step *ngIf="apiType === 'MESSAGE' || apiType === 'NATIVE'" state="type" [stepControl]="createForm.get('type')">
           <ng-template matStepperIcon="type">
             <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
           </ng-template>
@@ -47,7 +47,7 @@
             <ng-container *ngIf="apiType === 'PROXY' || apiType === 'LLM_PROXY'">
               <ng-container *ngTemplateOutlet="exitButton"></ng-container>
             </ng-container>
-            <button *ngIf="apiType === 'MESSAGE'" mat-stroked-button type="button" matStepperPrevious>Back</button>
+            <button *ngIf="apiType === 'MESSAGE' || apiType === 'NATIVE'" mat-stroked-button type="button" matStepperPrevious>Back</button>
             <button mat-raised-button type="button" color="primary" [disabled]="createForm.get('general').invalid" matStepperNext>
               Validate general information
             </button>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.spec.ts
@@ -181,6 +181,24 @@ const ENDPOINT_LIST = [
     supportedApiType: 'MESSAGE',
     supportedQos: ['AT_MOST_ONCE', 'NONE', 'AT_LEAST_ONCE', 'AUTO'],
   },
+  {
+    id: 'native-kafka',
+    name: 'Broker',
+    description: 'Native Kafka endpoint using inline bootstrap servers',
+    icon: 'kafka-icon',
+    deployed: true,
+    supportedApiType: 'NATIVE',
+    supportedQos: [],
+  },
+  {
+    id: 'native-kafka-cluster',
+    name: 'Cluster',
+    description: 'Native Kafka endpoint referencing a Kafka Cluster by crossId',
+    icon: 'kafka-icon',
+    deployed: true,
+    supportedApiType: 'NATIVE',
+    supportedQos: [],
+  },
 ];
 const ENTRYPOINT_LIST: ConnectorPlugin[] = [
   {
@@ -243,7 +261,7 @@ describe('ApiEndpointGroupCreateComponent', () => {
     expectApiGet();
     fixture.detectChanges();
 
-    if (api.type === 'MESSAGE') {
+    if (api.type === 'MESSAGE' || api.type === 'NATIVE') {
       expectEndpointListGet();
     }
   };
@@ -589,17 +607,17 @@ describe('ApiEndpointGroupCreateComponent', () => {
   describe('V4 API - Native Kafka', () => {
     beforeEach(async () => {
       await initComponent(fakeNativeKafkaApiV4({ id: API_ID }));
-
-      expectConfigurationSchemaGet('native-kafka', fakeKafkaSchema);
-      expectSharedConfigurationSchemaGet('native-kafka', {
-        $schema: 'http://json-schema.org/draft-07/schema#',
-        type: 'object',
-        properties: {},
-      });
     });
 
     describe('When creating a native-kafka endpoint group', () => {
       it('should be possible', async () => {
+        // Select endpoint type
+        await fillOutAndValidateEndpointSelection('native-kafka', fakeKafkaSchema, {
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'object',
+          properties: {},
+        });
+
         // Fill General information
         expect(await harness.isGeneralStepSelected()).toEqual(true);
         await harness.setNameValue(ENDPOINT_GROUP_NAME);
@@ -689,12 +707,12 @@ describe('ApiEndpointGroupCreateComponent', () => {
     return step.then(foundStep => foundStep.isSelected());
   }
 
-  async function fillOutAndValidateEndpointSelection(type = 'kafka'): Promise<void> {
+  async function fillOutAndValidateEndpointSelection(type = 'kafka', schema?: any, sharedSchema?: any): Promise<void> {
     expect(await harness.isEndpointGroupTypeStepSelected()).toEqual(true);
     await harness.selectEndpointGroup(type);
     if (type !== 'mock') {
-      expectConfigurationSchemaGet(type);
-      expectSharedConfigurationSchemaGet(type);
+      expectConfigurationSchemaGet(type, schema);
+      expectSharedConfigurationSchemaGet(type, sharedSchema);
     }
     await harness.validateEndpointGroupSelection();
     expect(await harness.isEndpointGroupTypeStepSelected()).toEqual(false);

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-group/create/api-endpoint-group-create.component.ts
@@ -88,7 +88,10 @@ export class ApiEndpointGroupCreateComponent implements OnInit {
           this.generalForm.get('name').addValidators([isEndpointNameUnique(apiV4)]);
           this.apiType = apiV4.type;
           this.isNativeKafka = apiV4.type === 'NATIVE' && apiV4.listeners.some(listener => listener.type === 'KAFKA');
-          this.requiredQos = apiV4.listeners.flatMap(listener => listener.entrypoints).flatMap(entrypoint => entrypoint.qos);
+          this.requiredQos = apiV4.listeners
+            .flatMap(listener => listener.entrypoints)
+            .flatMap(entrypoint => entrypoint.qos)
+            .filter(qos => !!qos);
           if (this.apiType === 'PROXY') {
             this.endpointGroupTypeForm.get('endpointGroupType').setValue('http-proxy');
           }
@@ -96,8 +99,8 @@ export class ApiEndpointGroupCreateComponent implements OnInit {
             this.endpointGroupTypeForm.get('endpointGroupType').setValue('llm-proxy');
           }
           if (this.isNativeKafka) {
-            this.endpointGroupTypeForm.get('endpointGroupType').setValue('native-kafka');
             this.generalForm.get('loadBalancerType').removeValidators(Validators.required);
+            this.generalForm.get('loadBalancerType').updateValueAndValidity();
           }
           this.changeDetectorRef.detectChanges();
         },

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.adapter.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.adapter.ts
@@ -117,6 +117,8 @@ const toGeneralColumnName = (api: ApiV4, endpointGroup: EndpointGroupV4): string
       return 'Target URL';
     case 'NATIVE.native-kafka':
       return 'Bootstrap Servers';
+    case 'NATIVE.native-kafka-cluster':
+      return 'Cluster';
     case 'MESSAGE.kafka':
       return 'Bootstrap Servers';
   }
@@ -128,6 +130,13 @@ const toGeneralInfo = (api: ApiV4, endpoint: EndpointV4): string | undefined => 
       return get(endpoint.configuration, 'target', '');
     case 'NATIVE.native-kafka':
       return get(endpoint.configuration, 'bootstrapServers', '');
+    case 'NATIVE.native-kafka-cluster': {
+      const cluster = get(endpoint.configuration, 'clusterCrossId', '');
+      const connection = get(endpoint.configuration, 'connectionCrossId', '');
+      // TODO: maybe retrieve and display cluster and connection names instead of ids for better readability
+      // And display warning if cluster or connection is not found
+      return connection ? `${cluster} / ${connection}` : cluster;
+    }
     case 'MESSAGE.kafka':
       return get(endpoint.configuration, 'bootstrapServers', '');
   }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.html
@@ -26,7 +26,7 @@
               <mat-icon [svgIcon]="plugins?.get(group.type)?.icon"></mat-icon>
               {{ plugins?.get(group.type)?.name }}
             </span>
-            @if (group.type !== 'native-kafka') {
+            @if (group.type !== 'native-kafka' && group.type !== 'native-kafka-cluster') {
               <span class="gio-badge-accent">
                 <mat-icon svgIcon="gio:share-2"></mat-icon>
                 {{ group.loadBalancerType }}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.component.spec.ts
@@ -121,6 +121,24 @@ describe('ApiEndpointGroupsStandardComponent', () => {
     ],
   };
 
+  const kafkaClusterGroup: EndpointGroupV4 = {
+    name: 'cluster-group',
+    type: 'native-kafka-cluster',
+    loadBalancer: { type: 'WEIGHTED_RANDOM' },
+    endpoints: [
+      {
+        name: 'cluster endpoint',
+        type: 'native-kafka-cluster',
+        weight: 1,
+        inheritConfiguration: true,
+        configuration: {
+          clusterCrossId: 'my-kafka-cluster',
+          connectionCrossId: 'primary',
+        },
+      },
+    ],
+  };
+
   const a2aGroup: EndpointGroupV4 = {
     name: 'A2A Proxy',
     type: 'a2a-proxy',
@@ -209,6 +227,17 @@ describe('ApiEndpointGroupsStandardComponent', () => {
       expect(await warningFailoverBanner[0].getText()).toContain(
         'Failover is enabled but it is not supported for Kafka endpoints. Use the native Kafka Failover by providing multiple bootstrap servers.',
       );
+    });
+
+    it('should display native-kafka-cluster endpoint with cluster and connection crossIds', async () => {
+      const apiV4 = fakeApiV4({
+        id: API_ID,
+        type: 'NATIVE',
+        endpointGroups: [kafkaClusterGroup],
+      });
+      await initComponent(apiV4);
+
+      expect(await componentHarness.getTableRows(0)).toEqual([['', 'cluster endpoint', 'my-kafka-cluster / primary', '']]);
     });
 
     it('should allow to create another endpoint group for a NATIVE api', async () => {

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/add-dialog/kafka-clusters-add-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/add-dialog/kafka-clusters-add-dialog.component.html
@@ -29,6 +29,12 @@
     </mat-form-field>
 
     <mat-form-field class="form-field">
+      <mat-label>Cross ID</mat-label>
+      <input #crossIdInput type="text" aria-label="Cross ID" matInput formControlName="crossId" [maxLength]="256" />
+      <mat-hint>Auto-generated from name if left empty</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field class="form-field">
       <mat-label>Description</mat-label>
       <textarea #descriptionInput matInput formControlName="description" [maxLength]="1024"></textarea>
       <mat-hint align="end">{{ descriptionInput.value.length }}/1024</mat-hint>

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/add-dialog/kafka-clusters-add-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/add-dialog/kafka-clusters-add-dialog.component.ts
@@ -25,7 +25,7 @@ import { map, startWith } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
 export type KafkaClustersAddDialogData = undefined;
-export type KafkaClustersAddDialogResult = undefined | { name: string; description?: string };
+export type KafkaClustersAddDialogResult = undefined | { name: string; crossId?: string; description?: string };
 
 @Component({
   selector: 'kafka-clusters-add-dialog',
@@ -37,6 +37,7 @@ export type KafkaClustersAddDialogResult = undefined | { name: string; descripti
 export class KafkaClustersAddDialogComponent {
   protected formGroup: FormGroup<{
     name: FormControl<string>;
+    crossId: FormControl<string>;
     description: FormControl<string>;
   }>;
   protected isValid$: Observable<boolean>;
@@ -44,6 +45,7 @@ export class KafkaClustersAddDialogComponent {
   constructor(public dialogRef: MatDialogRef<KafkaClustersAddDialogComponent, KafkaClustersAddDialogResult>) {
     this.formGroup = new FormGroup({
       name: new FormControl('', Validators.required),
+      crossId: new FormControl(''),
       description: new FormControl(''),
     });
 
@@ -59,6 +61,7 @@ export class KafkaClustersAddDialogComponent {
     }
     this.dialogRef.close({
       name: this.formGroup.get('name').value,
+      crossId: this.formGroup.get('crossId').value || undefined,
       description: this.formGroup.get('description').value,
     });
   }

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/add-dialog/kafka-clusters-add-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/add-dialog/kafka-clusters-add-dialog.harness.ts
@@ -29,6 +29,7 @@ export class KafkaClustersAddDialogHarness extends ComponentHarness {
 
   protected _title = this.locatorForOptional(MatDialogSection.TITLE);
   protected nameInput = this.locatorForOptional(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+  protected crossIdInput = this.locatorForOptional(MatInputHarness.with({ selector: '[formControlName="crossId"]' }));
   protected descriptionInput = this.locatorForOptional(MatInputHarness.with({ selector: '[formControlName="description"]' }));
 
   public async cancel(): Promise<void> {
@@ -41,6 +42,13 @@ export class KafkaClustersAddDialogHarness extends ComponentHarness {
   }
   public async getName() {
     return await this.nameInput().then(input => input.getValue());
+  }
+
+  public async setCrossId(text: string) {
+    await this.crossIdInput().then(input => input.setValue(text));
+  }
+  public async getCrossId() {
+    return await this.crossIdInput().then(input => input.getValue());
   }
 
   public async setDescription(text: string) {

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/list/kafka-cluster-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/list/kafka-cluster-list.component.spec.ts
@@ -166,6 +166,29 @@ describe('KafkaClusterListComponent', () => {
       type: 'KAFKA_CLUSTER',
       name: 'New Kafka Cluster',
       description: 'A new kafka cluster',
+      crossId: undefined,
+      configuration: {
+        connections: [],
+      },
+    });
+  });
+
+  it('should create a new kafka cluster with explicit crossId', async () => {
+    await componentHarness.clickAddButton();
+
+    const dialogHarness = await rootLoader.getHarness(KafkaClustersAddDialogHarness);
+
+    await dialogHarness.setName('New Kafka Cluster');
+    await dialogHarness.setCrossId('my-custom-cross-id');
+    await dialogHarness.setDescription('A new kafka cluster');
+
+    await dialogHarness.create();
+
+    expectCreateClusterRequest(httpTestingController, {
+      type: 'KAFKA_CLUSTER',
+      crossId: 'my-custom-cross-id',
+      name: 'New Kafka Cluster',
+      description: 'A new kafka cluster',
       configuration: {
         connections: [],
       },

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/list/kafka-cluster-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/list/kafka-cluster-list.component.ts
@@ -164,6 +164,7 @@ export class KafkaClusterListComponent implements OnInit {
 
           return this.clusterService.create({
             type: 'KAFKA_CLUSTER',
+            crossId: result.crossId,
             name: result.name,
             description: result.description,
             configuration: {

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-connections/details/general/cluster-general.component.html
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-connections/details/general/cluster-general.component.html
@@ -39,6 +39,8 @@
         <div class="details-card__header__right-coll">
           <div class="details-card__header__right-coll__info">
             <dl class="gio-description-list">
+              <dt>Cross ID</dt>
+              <dd>{{ initialCluster.crossId }}</dd>
               <dt>Created</dt>
               <dd>{{ initialCluster.createdAt | date: 'medium' }}</dd>
               <dt>Updated</dt>

--- a/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-connection-type.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-connection-type.component.html
@@ -1,0 +1,49 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<mat-form-field appearance="outline">
+  <mat-label>{{ props.label }}</mat-label>
+
+  <input
+    matInput
+    [matAutocomplete]="connectionAutocomplete"
+    [formControl]="formControl"
+    [formlyAttributes]="field"
+    [placeholder]="props.placeholder"
+    [required]="props.required"
+  />
+
+  <mat-error>
+    <formly-validation-message [field]="field"></formly-validation-message>
+  </mat-error>
+
+  <mat-hint *ngIf="!(connectionNotFound$ | async) && props.description">
+    {{ props.description }}
+  </mat-hint>
+
+  <mat-hint *ngIf="connectionNotFound$ | async" class="cluster-connection-type__warning">
+    Connection not found! The API will not work on the gateway until a valid connection is configured.
+  </mat-hint>
+</mat-form-field>
+
+<mat-autocomplete #connectionAutocomplete="matAutocomplete">
+  <mat-option *ngFor="let connection of filteredConnections$ | async" [value]="connection.crossId">
+    <span>{{ connection.name }}</span>
+    <small> ({{ connection.crossId }})</small>
+  </mat-option>
+</mat-autocomplete>

--- a/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-connection-type.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-connection-type.component.scss
@@ -1,0 +1,15 @@
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+:host {
+  display: block;
+  width: 100%;
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+.cluster-connection-type__warning {
+  color: mat.m2-get-color-from-palette(gio.$mat-warning-palette, 'default');
+}

--- a/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-connection-type.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-connection-type.component.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, OnInit } from '@angular/core';
+import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
+import { combineLatest, Observable, of } from 'rxjs';
+import { catchError, map, shareReplay, startWith, switchMap } from 'rxjs/operators';
+
+import { ClusterService } from '../../../services-ngx/cluster.service';
+import { KafkaClusterConnection } from '../../../entities/management-api-v2';
+
+@Component({
+  selector: 'cluster-connection-type',
+  templateUrl: './cluster-connection-type.component.html',
+  styleUrls: ['./cluster-connection-type.component.scss'],
+  standalone: false,
+})
+export class ClusterConnectionTypeComponent extends FieldType<FieldTypeConfig> implements OnInit {
+  filteredConnections$: Observable<KafkaClusterConnection[]>;
+  connectionNotFound$: Observable<boolean>;
+
+  constructor(private readonly clusterService: ClusterService) {
+    super();
+  }
+
+  ngOnInit() {
+    const clusterCrossIdControl = this.form.get('clusterCrossId');
+    if (!clusterCrossIdControl) {
+      this.filteredConnections$ = of([]);
+      this.connectionNotFound$ = of(false);
+      return;
+    }
+
+    this.filteredConnections$ = clusterCrossIdControl.valueChanges.pipe(
+      startWith(clusterCrossIdControl.value),
+      switchMap(crossId => {
+        if (!crossId) {
+          return of([]);
+        }
+        return this.clusterService.list(crossId, undefined, 1, 50, 'KAFKA_CLUSTER').pipe(
+          map(result => {
+            const cluster = result.data?.find(c => c.crossId === crossId);
+            if (!cluster || !cluster.configuration) return [];
+            const config = cluster.configuration as { connections?: KafkaClusterConnection[] };
+            return config.connections ?? [];
+          }),
+          catchError(() => of([])),
+        );
+      }),
+      shareReplay(1),
+    );
+
+    const currentValue$ = this.formControl.valueChanges.pipe(startWith(this.formControl.value ?? ''));
+
+    this.connectionNotFound$ = combineLatest([currentValue$, this.filteredConnections$]).pipe(
+      map(([term, connections]) => {
+        if (!term) return false;
+        return !connections.some(c => c.crossId === term);
+      }),
+      shareReplay(1),
+    );
+  }
+}

--- a/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-type.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-type.component.html
@@ -1,0 +1,49 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<mat-form-field appearance="outline">
+  <mat-label>{{ props.label }}</mat-label>
+
+  <input
+    matInput
+    [matAutocomplete]="clusterAutocomplete"
+    [formControl]="formControl"
+    [formlyAttributes]="field"
+    [placeholder]="props.placeholder"
+    [required]="props.required"
+  />
+
+  <mat-error>
+    <formly-validation-message [field]="field"></formly-validation-message>
+  </mat-error>
+
+  <mat-hint *ngIf="!(clusterNotFound$ | async) && props.description">
+    {{ props.description }}
+  </mat-hint>
+
+  <mat-hint *ngIf="clusterNotFound$ | async" class="cluster-type__warning">
+    Cluster not found! The API will not work on the gateway until a valid cluster is configured.
+  </mat-hint>
+</mat-form-field>
+
+<mat-autocomplete #clusterAutocomplete="matAutocomplete">
+  <mat-option *ngFor="let cluster of filteredClusters$ | async" [value]="cluster.crossId">
+    <span>{{ cluster.name }}</span>
+    <small> ({{ cluster.crossId }})</small>
+  </mat-option>
+</mat-autocomplete>

--- a/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-type.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-type.component.scss
@@ -1,0 +1,15 @@
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+:host {
+  display: block;
+  width: 100%;
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+.cluster-type__warning {
+  color: mat.m2-get-color-from-palette(gio.$mat-warning-palette, 'default');
+}

--- a/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-type.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-type.component.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, OnInit } from '@angular/core';
+import { FieldType, FieldTypeConfig } from '@ngx-formly/core';
+import { Observable, of } from 'rxjs';
+import { catchError, map, shareReplay, startWith, switchMap } from 'rxjs/operators';
+
+import { ClusterService } from '../../../services-ngx/cluster.service';
+import { Cluster, ClusterType } from '../../../entities/management-api-v2';
+
+@Component({
+  selector: 'cluster-type',
+  templateUrl: './cluster-type.component.html',
+  styleUrls: ['./cluster-type.component.scss'],
+  standalone: false,
+})
+export class ClusterTypeComponent extends FieldType<FieldTypeConfig> implements OnInit {
+  filteredClusters$: Observable<Cluster[]>;
+  clusterNotFound$: Observable<boolean>;
+
+  constructor(private readonly clusterService: ClusterService) {
+    super();
+  }
+
+  ngOnInit() {
+    const clusterType: ClusterType = this.props?.clusterType ?? this.field?.props?.clusterType ?? 'KAFKA_CLUSTER';
+
+    // All clusters of this type (for validation)
+    const allClusters$ = this.clusterService.list('', undefined, 1, 9999, clusterType).pipe(
+      map(result => result.data ?? []),
+      catchError(() => of([])),
+      shareReplay(1),
+    );
+
+    // Filtered clusters for autocomplete dropdown
+    this.filteredClusters$ = this.formControl.valueChanges.pipe(
+      startWith(this.formControl.value ?? ''),
+      switchMap(term => {
+        if (!term) return allClusters$;
+        return allClusters$.pipe(
+          map(clusters =>
+            clusters.filter(c => c.name.toLowerCase().includes(term.toLowerCase()) || c.crossId.toLowerCase().includes(term.toLowerCase())),
+          ),
+        );
+      }),
+    );
+
+    // Validation: check if current value matches a known crossId
+    this.clusterNotFound$ = this.formControl.valueChanges.pipe(
+      startWith(this.formControl.value ?? ''),
+      switchMap(term => {
+        if (!term) return of(false);
+        return allClusters$.pipe(map(clusters => !clusters.some(c => c.crossId === term)));
+      }),
+      shareReplay(1),
+    );
+  }
+}

--- a/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/form-json-schema-extended.module.ts
+++ b/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/form-json-schema-extended.module.ts
@@ -25,13 +25,15 @@ import { GioFormJsonSchemaModule, GioIconsModule } from '@gravitee/ui-particles-
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { FORMLY_CONFIG, FormlyModule } from '@ngx-formly/core';
 
+import { ClusterConnectionTypeComponent } from './cluster-connection-type.component';
+import { ClusterTypeComponent } from './cluster-type.component';
 import { ResourceTypeComponent } from './resource-type.component';
 import { ResourceTypeService } from './resource-type.service';
 
 import { GioSafePipeModule } from '../../utils/safe.pipe.module';
 
 @NgModule({
-  declarations: [ResourceTypeComponent],
+  declarations: [ResourceTypeComponent, ClusterTypeComponent, ClusterConnectionTypeComponent],
   imports: [
     CommonModule,
     ReactiveFormsModule,
@@ -58,6 +60,14 @@ import { GioSafePipeModule } from '../../utils/safe.pipe.module';
           {
             name: 'resource-type',
             component: ResourceTypeComponent,
+          },
+          {
+            name: 'cluster-type',
+            component: ClusterTypeComponent,
+          },
+          {
+            name: 'cluster-connection-type',
+            component: ClusterConnectionTypeComponent,
           },
         ],
       },

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/cluster/Cluster.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/cluster/Cluster.java
@@ -27,6 +27,7 @@ import lombok.NoArgsConstructor;
 public class Cluster {
 
     private String id;
+    private String crossId;
     private String type;
     private String name;
     private Object configuration;

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1538,6 +1538,19 @@
                     </exclusions>
                 </dependency>
                 <dependency>
+                    <groupId>com.graviteesource.connector</groupId>
+                    <artifactId>gravitee-endpoint-native-kafka-cluster</artifactId>
+                    <version>${gravitee-reactor-native-kafka.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
                     <groupId>com.graviteesource.endpoint</groupId>
                     <artifactId>gravitee-endpoint-agent-to-agent</artifactId>
                     <version>${gravitee-endpoint-agent-to-agent.version}</version>

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ClusterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ClusterRepository.java
@@ -27,6 +27,8 @@ import java.util.Set;
 public interface ClusterRepository extends CrudRepository<Cluster, String> {
     Page<Cluster> search(ClusterCriteria criteria, Pageable pageable, Optional<Sortable> sortable);
 
+    Optional<Cluster> findByCrossIdAndEnvironmentId(String crossId, String environmentId);
+
     void updateGroups(String clusterId, Set<String> groups);
 
     void deleteByEnvironmentId(String environmentId) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Cluster.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Cluster.java
@@ -31,6 +31,7 @@ import lombok.Setter;
 public class Cluster {
 
     private String id;
+    private String crossId;
     private Instant createdAt;
     private Instant updatedAt;
     private String environmentId;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClusterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClusterRepository.java
@@ -203,6 +203,13 @@ public class JdbcClusterRepository extends JdbcAbstractCrudRepository<Cluster, S
     }
 
     @Override
+    public Set<Cluster> findAll() throws TechnicalException {
+        Set<Cluster> clusters = super.findAll();
+        clusters.forEach(this::addGroups);
+        return clusters;
+    }
+
+    @Override
     public Optional<Cluster> findById(String id) throws io.gravitee.repository.exceptions.TechnicalException {
         Optional<Cluster> opt = super.findById(id);
         opt.ifPresent(this::addGroups);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClusterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcClusterRepository.java
@@ -61,6 +61,7 @@ public class JdbcClusterRepository extends JdbcAbstractCrudRepository<Cluster, S
     protected JdbcObjectMapper<Cluster> buildOrm() {
         return JdbcObjectMapper.builder(Cluster.class, this.tableName, "id")
             .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("cross_id", Types.NVARCHAR, String.class)
             .addColumn("created_at", Types.TIMESTAMP, Instant.class)
             .addColumn("updated_at", Types.TIMESTAMP, Instant.class)
             .addColumn("environment_id", Types.NVARCHAR, String.class)
@@ -117,6 +118,23 @@ public class JdbcClusterRepository extends JdbcAbstractCrudRepository<Cluster, S
             log.error("Failed to update cluster:", ex);
             throw new TechnicalException("Failed to update cluster", ex);
         }
+    }
+
+    @Override
+    public Optional<Cluster> findByCrossIdAndEnvironmentId(String crossId, String environmentId) {
+        log.debug("JdbcClusterRepository.findByCrossIdAndEnvironmentId({}, {})", crossId, environmentId);
+        var result = jdbcTemplate.query(
+            getOrm().getSelectAllSql() + " WHERE cross_id = ? AND environment_id = ?",
+            getOrm().getRowMapper(),
+            crossId,
+            environmentId
+        );
+        if (result.isEmpty()) {
+            return Optional.empty();
+        }
+        Cluster cluster = result.get(0);
+        addGroups(cluster);
+        return Optional.of(cluster);
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/04_add_cross_id_to_clusters_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/04_add_cross_id_to_clusters_table.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_04_add_cross_id_to_clusters_table
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}clusters
+            columns:
+              - column:
+                  name: cross_id
+                  type: nvarchar(256)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -335,3 +335,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/03_add_lock_api_product_role_to_groups.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/02_add_type_to_clusters_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/04_add_cross_id_to_clusters_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClusterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoClusterRepository.java
@@ -90,7 +90,13 @@ public class MongoClusterRepository implements ClusterRepository {
 
     @Override
     public Set<Cluster> findAll() throws TechnicalException {
-        throw new IllegalStateException("Not implemented");
+        return internalClusterMongoRepo.findAll().stream().map(mapper::map).collect(java.util.stream.Collectors.toSet());
+    }
+
+    @Override
+    public Optional<Cluster> findByCrossIdAndEnvironmentId(String crossId, String environmentId) {
+        log.debug("Find cluster by crossId [{}] and environmentId [{}]", crossId, environmentId);
+        return Optional.ofNullable(internalClusterMongoRepo.findByCrossIdAndEnvironmentId(crossId, environmentId)).map(mapper::map);
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clusters/ClusterMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clusters/ClusterMongoRepository.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ClusterMongoRepository extends MongoRepository<ClusterMongo, String>, ClusterMongoRepositoryCustom {
+    ClusterMongo findByCrossIdAndEnvironmentId(String crossId, String environmentId);
+
     @Query(value = "{ 'environmentId': ?0 }", delete = true)
     void deleteByEnvironmentId(String environmentId);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ClusterMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ClusterMongo.java
@@ -29,6 +29,7 @@ public class ClusterMongo extends Auditable {
     @Id
     private String id;
 
+    private String crossId;
     private String environmentId;
     private String organizationId;
     private String type;

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClusterRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClusterRepositoryTest.java
@@ -41,6 +41,33 @@ public class ClusterRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void should_find_all() throws Exception {
+        Set<Cluster> clusters = clusterRepository.findAll();
+        assertThat(clusters).hasSize(10);
+        assertThat(clusters)
+            .extracting(Cluster::getId)
+            .containsExactlyInAnyOrder(
+                "cluster-id-1",
+                "cluster-id-2",
+                "cluster-id-3",
+                "cluster-id-4",
+                "cluster-id-5",
+                "cluster-id-6",
+                "cluster-id-7",
+                "cluster-id-8",
+                "cluster-id-9",
+                "cluster-id-10"
+            );
+        // Verify groups are populated
+        Cluster clusterWithGroups = clusters
+            .stream()
+            .filter(c -> "cluster-id-1".equals(c.getId()))
+            .findFirst()
+            .orElseThrow();
+        assertThat(clusterWithGroups.getGroups()).isEqualTo(Set.of("group-1", "group-2"));
+    }
+
+    @Test
     public void should_find_by_id() throws Exception {
         Cluster cluster = clusterRepository.findById("cluster-id-1").orElseThrow();
         assertAll(

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClusterRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ClusterRepositoryTest.java
@@ -45,6 +45,7 @@ public class ClusterRepositoryTest extends AbstractManagementRepositoryTest {
         Cluster cluster = clusterRepository.findById("cluster-id-1").orElseThrow();
         assertAll(
             () -> assertThat(cluster.getId()).isEqualTo("cluster-id-1"),
+            () -> assertThat(cluster.getCrossId()).isEqualTo("cluster-1"),
             () -> assertThat(cluster.getCreatedAt()).isEqualTo(Instant.ofEpochSecond(1753711100)),
             () -> assertThat(cluster.getUpdatedAt()).isNull(),
             () -> assertThat(cluster.getEnvironmentId()).isEqualTo("env-1"),
@@ -60,6 +61,7 @@ public class ClusterRepositoryTest extends AbstractManagementRepositoryTest {
     public void should_create() throws Exception {
         final Cluster cluster = Cluster.builder()
             .id("cluster-id")
+            .crossId("my-cluster")
             // Because by default, PostgreSQL's timestamp type (without with time zone) supports up to 6 digits of fractional seconds (microsecond precision),
             // while Java's Instant supports up to nanoseconds (9 digits).
             .createdAt(Instant.now().truncatedTo(ChronoUnit.MICROS))
@@ -75,6 +77,7 @@ public class ClusterRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertAll(
             () -> assertThat(createdCluster.getId()).isEqualTo(cluster.getId()),
+            () -> assertThat(createdCluster.getCrossId()).isEqualTo(cluster.getCrossId()),
             () -> assertThat(createdCluster.getCreatedAt()).isEqualTo(cluster.getCreatedAt()),
             () -> assertThat(createdCluster.getUpdatedAt()).isNull(),
             () -> assertThat(createdCluster.getEnvironmentId()).isEqualTo(cluster.getEnvironmentId()),
@@ -214,6 +217,27 @@ public class ClusterRepositoryTest extends AbstractManagementRepositoryTest {
 
         Cluster updatedCluster = clusterRepository.findById(clusterId).orElseThrow();
         assertThat(updatedCluster.getGroups()).isEqualTo(Set.of("group-3", "group-4"));
+    }
+
+    @Test
+    public void should_find_by_crossId_and_environment_id() throws Exception {
+        Optional<Cluster> found = clusterRepository.findByCrossIdAndEnvironmentId("cluster-1", "env-1");
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo("cluster-id-1");
+        assertThat(found.get().getCrossId()).isEqualTo("cluster-1");
+        assertThat(found.get().getEnvironmentId()).isEqualTo("env-1");
+    }
+
+    @Test
+    public void should_return_empty_when_crossId_not_found() throws Exception {
+        Optional<Cluster> found = clusterRepository.findByCrossIdAndEnvironmentId("non-existing", "env-1");
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    public void should_return_empty_when_crossId_exists_in_different_environment() throws Exception {
+        Optional<Cluster> found = clusterRepository.findByCrossIdAndEnvironmentId("cluster-1", "env-2");
+        assertThat(found).isEmpty();
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/cluster-tests/clusters.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/cluster-tests/clusters.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "cluster-id-1",
+    "crossId": "cluster-1",
     "createdAt": 1753711100,
     "environmentId": "env-1",
     "organizationId": "org-1",
@@ -11,6 +12,7 @@
   },
   {
     "id": "cluster-id-2",
+    "crossId": "cluster-no-2",
     "createdAt": 1753711100,
     "environmentId": "env-1",
     "organizationId": "org-1",
@@ -20,6 +22,7 @@
   },
   {
     "id": "cluster-id-3",
+    "crossId": "3-cluster",
     "createdAt": 1753711100,
     "environmentId": "env-2",
     "organizationId": "org-1",
@@ -29,6 +32,7 @@
   },
   {
     "id": "cluster-id-4",
+    "crossId": "cluster-4",
     "createdAt": 1753711100,
     "environmentId": "env-2",
     "organizationId": "org-1",
@@ -38,6 +42,7 @@
   },
   {
     "id": "cluster-id-5",
+    "crossId": "no-5-cluster",
     "createdAt": 1753711100,
     "environmentId": "env-3",
     "organizationId": "org-2",
@@ -47,6 +52,7 @@
   },
   {
     "id": "cluster-id-6",
+    "crossId": "cluster-6",
     "createdAt": 1753711100,
     "environmentId": "env-3",
     "organizationId": "org-2",
@@ -56,6 +62,7 @@
   },
   {
     "id": "cluster-id-7",
+    "crossId": "cluster-7",
     "createdAt": 1753711100,
     "environmentId": "env-2",
     "organizationId": "org-1",
@@ -65,6 +72,7 @@
   },
   {
     "id": "cluster-id-8",
+    "crossId": "8-cluster",
     "createdAt": 1753711100,
     "environmentId": "env-1",
     "organizationId": "org-1",
@@ -74,6 +82,7 @@
   },
   {
     "id": "cluster-id-9",
+    "crossId": "cluster-9",
     "createdAt": 1753711100,
     "environmentId": "env-2",
     "organizationId": "org-1",
@@ -83,6 +92,7 @@
   },
   {
     "id": "cluster-id-10",
+    "crossId": "cluster-10",
     "createdAt": 1753711100,
     "environmentId": "env-1",
     "organizationId": "org-1",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1394,6 +1394,9 @@ components:
       properties:
         type:
           $ref: "#/components/schemas/ClusterType"
+        crossId:
+          type: string
+          description: Portable identifier for cross-environment references. Auto-generated from name if not provided.
         name:
           type: string
         description:
@@ -1406,6 +1409,9 @@ components:
       properties:
         id:
           type: string
+        crossId:
+          type: string
+          description: Portable identifier for cross-environment references. Immutable after creation.
         type:
           $ref: "#/components/schemas/ClusterType"
         createdAt:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterService.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
+import io.gravitee.apim.core.cluster.query_service.ClusterQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
@@ -35,6 +36,7 @@ public class ValidateClusterService {
     private final JsonSchemaChecker jsonSchemaChecker;
     private final ClusterConfigurationSchemaService clusterConfigurationSchemaService;
     private final ObjectMapper objectMapper;
+    private final ClusterQueryService clusterQueryService;
 
     public void validate(Cluster cluster) {
         if (StringUtils.isEmpty(cluster.getName())) {
@@ -56,6 +58,29 @@ public class ValidateClusterService {
 
         if (cluster.getType() == ClusterType.KAFKA_CLUSTER) {
             validateUniqueConnectionNames(cluster);
+            validateUniqueConnectionCrossIds(cluster);
+        }
+    }
+
+    public void validateForCreate(Cluster cluster) {
+        validate(cluster);
+        validateCrossIdUniqueness(cluster);
+    }
+
+    public void validateForUpdate(Cluster existingCluster, Cluster updatedCluster) {
+        validate(updatedCluster);
+        if (existingCluster.getCrossId() != null && !existingCluster.getCrossId().equals(updatedCluster.getCrossId())) {
+            throw new InvalidDataException("CrossId is immutable and cannot be changed after creation.");
+        }
+    }
+
+    private void validateCrossIdUniqueness(Cluster cluster) {
+        if (StringUtils.isEmpty(cluster.getCrossId())) {
+            throw new InvalidDataException("CrossId is required.");
+        }
+        var existing = clusterQueryService.findByCrossIdAndEnvironmentId(cluster.getCrossId(), cluster.getEnvironmentId());
+        if (existing.isPresent() && !existing.get().getId().equals(cluster.getId())) {
+            throw new InvalidDataException("A cluster with crossId '" + cluster.getCrossId() + "' already exists in this environment.");
         }
     }
 
@@ -73,6 +98,27 @@ public class ValidateClusterService {
 
         if (!duplicates.isEmpty()) {
             throw new InvalidDataException("Connection names must be unique. Duplicates found: " + duplicates);
+        }
+    }
+
+    private void validateUniqueConnectionCrossIds(Cluster cluster) {
+        var config = cluster.getKafkaClusterConfiguration(objectMapper);
+        if (config.connections() == null || config.connections().isEmpty()) {
+            return;
+        }
+        var duplicates = config
+            .connections()
+            .stream()
+            .filter(c -> c.crossId() != null)
+            .collect(Collectors.groupingBy(c -> c.crossId(), Collectors.counting()))
+            .entrySet()
+            .stream()
+            .filter(e -> e.getValue() > 1)
+            .map(e -> e.getKey())
+            .toList();
+
+        if (!duplicates.isEmpty()) {
+            throw new InvalidDataException("Connection crossIds must be unique within a cluster. Duplicates found: " + duplicates);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/Cluster.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/Cluster.java
@@ -31,6 +31,7 @@ import lombok.Setter;
 public class Cluster {
 
     private String id;
+    private String crossId;
     private Instant createdAt;
     private Instant updatedAt;
     private String environmentId;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/CreateCluster.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/CreateCluster.java
@@ -29,6 +29,7 @@ import lombok.Setter;
 public class CreateCluster {
 
     private ClusterType type;
+    private String crossId;
     private String name;
     private String description;
     private Object configuration;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaClusterConnection.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaClusterConnection.java
@@ -15,4 +15,4 @@
  */
 package io.gravitee.apim.core.cluster.model;
 
-public record KafkaClusterConnection(String name, String bootstrapServers, SecurityConfig security) {}
+public record KafkaClusterConnection(String crossId, String name, String bootstrapServers, SecurityConfig security) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/query_service/ClusterQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/query_service/ClusterQueryService.java
@@ -24,4 +24,5 @@ import java.util.Optional;
 
 public interface ClusterQueryService {
     Page<Cluster> search(ClusterSearchCriteria criteria, Pageable pageable, Optional<Sortable> sortable);
+    Optional<Cluster> findByCrossIdAndEnvironmentId(String crossId, String environmentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCase.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.cluster.use_case;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
@@ -24,16 +25,21 @@ import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
 import io.gravitee.apim.core.cluster.domain_service.ValidateClusterService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterAuditEvent;
+import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.apim.core.cluster.model.CreateCluster;
+import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
+import io.gravitee.apim.core.cluster.model.KafkaClusterConnection;
 import io.gravitee.apim.core.membership.crud_service.MembershipCrudService;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.membership.query_service.RoleQueryService;
+import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 
@@ -46,6 +52,7 @@ public class CreateClusterUseCase {
     private final AuditDomainService auditService;
     private final MembershipCrudService membershipCrudService;
     private final RoleQueryService roleQueryService;
+    private final ObjectMapper objectMapper;
 
     public record Input(CreateCluster createCluster, AuditInfo auditInfo) {}
 
@@ -53,11 +60,21 @@ public class CreateClusterUseCase {
 
     public Output execute(Input input) {
         Instant now = TimeProvider.instantNow();
+        String crossId = StringUtils.isEmpty(input.createCluster.getCrossId())
+            ? StringUtils.slugify(input.createCluster.getName())
+            : input.createCluster.getCrossId();
+
+        Object configuration = input.createCluster.getConfiguration();
+        if (input.createCluster.getType() == ClusterType.KAFKA_CLUSTER && configuration != null) {
+            configuration = generateConnectionCrossIds(configuration);
+        }
+
         Cluster clusterToCreate = Cluster.builder()
             .type(input.createCluster.getType())
+            .crossId(crossId)
             .name(input.createCluster.getName())
             .description(input.createCluster.getDescription())
-            .configuration(input.createCluster.getConfiguration())
+            .configuration(configuration)
             .id(UuidString.generateRandom())
             .createdAt(now)
             .updatedAt(now)
@@ -65,7 +82,7 @@ public class CreateClusterUseCase {
             .organizationId(input.auditInfo().organizationId())
             .build();
 
-        validateClusterService.validate(clusterToCreate);
+        validateClusterService.validateForCreate(clusterToCreate);
 
         Cluster createdCluster = clusterCrudService.create(clusterToCreate);
 
@@ -96,6 +113,26 @@ public class CreateClusterUseCase {
             .updatedAt(createdAtZonedDateTime)
             .build();
         return membershipCrudService.create(membership);
+    }
+
+    private Object generateConnectionCrossIds(Object configuration) {
+        var config = objectMapper.convertValue(configuration, KafkaClusterConfiguration.class);
+        if (config.connections() == null || config.connections().isEmpty()) {
+            return configuration;
+        }
+        List<KafkaClusterConnection> updatedConnections = config
+            .connections()
+            .stream()
+            .map(conn ->
+                new KafkaClusterConnection(
+                    StringUtils.isEmpty(conn.crossId()) ? StringUtils.slugify(conn.name()) : conn.crossId(),
+                    conn.name(),
+                    conn.bootstrapServers(),
+                    conn.security()
+                )
+            )
+            .toList();
+        return objectMapper.convertValue(new KafkaClusterConfiguration(updatedConnections), Object.class);
     }
 
     private void createAuditLog(Cluster cluster, AuditInfo auditInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCase.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.cluster.use_case;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
@@ -24,12 +25,17 @@ import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
 import io.gravitee.apim.core.cluster.domain_service.ValidateClusterService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterAuditEvent;
+import io.gravitee.apim.core.cluster.model.ClusterType;
+import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
+import io.gravitee.apim.core.cluster.model.KafkaClusterConnection;
 import io.gravitee.apim.core.cluster.model.UpdateCluster;
 import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
+import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 
@@ -41,6 +47,7 @@ public class UpdateClusterUseCase {
     private final ValidateClusterService validateClusterService;
     private final AuditDomainService auditService;
     private final PermissionDomainService permissionDomainService;
+    private final ObjectMapper objectMapper;
 
     public record Input(String clusterId, UpdateCluster updateCluster, AuditInfo auditInfo) {}
 
@@ -61,15 +68,48 @@ public class UpdateClusterUseCase {
             input.updateCluster().setConfiguration(null);
         }
 
+        if (input.updateCluster().getConfiguration() != null && clusterToUpdate.getType() == ClusterType.KAFKA_CLUSTER) {
+            input.updateCluster().setConfiguration(generateConnectionCrossIds(input.updateCluster().getConfiguration()));
+        }
+
+        Cluster existingClusterSnapshot = Cluster.builder()
+            .id(clusterToUpdate.getId())
+            .crossId(clusterToUpdate.getCrossId())
+            .type(clusterToUpdate.getType())
+            .name(clusterToUpdate.getName())
+            .environmentId(clusterToUpdate.getEnvironmentId())
+            .organizationId(clusterToUpdate.getOrganizationId())
+            .build();
+
         clusterToUpdate.update(input.updateCluster());
 
-        validateClusterService.validate(clusterToUpdate);
+        validateClusterService.validateForUpdate(existingClusterSnapshot, clusterToUpdate);
 
         Cluster updatedCluster = clusterCrudService.update(clusterToUpdate);
 
         createAuditLog(clusterToUpdate, updatedCluster, input.auditInfo());
 
         return new Output(updatedCluster);
+    }
+
+    private Object generateConnectionCrossIds(Object configuration) {
+        var config = objectMapper.convertValue(configuration, KafkaClusterConfiguration.class);
+        if (config.connections() == null || config.connections().isEmpty()) {
+            return configuration;
+        }
+        List<KafkaClusterConnection> updatedConnections = config
+            .connections()
+            .stream()
+            .map(conn ->
+                new KafkaClusterConnection(
+                    StringUtils.isEmpty(conn.crossId()) ? StringUtils.slugify(conn.name()) : conn.crossId(),
+                    conn.name(),
+                    conn.bootstrapServers(),
+                    conn.security()
+                )
+            )
+            .toList();
+        return objectMapper.convertValue(new KafkaClusterConfiguration(updatedConnections), Object.class);
     }
 
     private void createAuditLog(Cluster clusterBeforeUpdate, Cluster updatedCluster, AuditInfo auditInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/utils/StringUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/utils/StringUtils.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.utils;
 
+import java.text.Normalizer;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.jspecify.annotations.Nullable;
@@ -32,6 +34,18 @@ public final class StringUtils {
 
     public static boolean isNotEmpty(@Nullable CharSequence cs) {
         return !isEmpty(cs);
+    }
+
+    private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^a-z0-9-]");
+    private static final Pattern MULTIPLE_DASHES = Pattern.compile("-{2,}");
+
+    public static String slugify(@Nullable String input) {
+        if (input == null) return null;
+        String normalized = Normalizer.normalize(input, Normalizer.Form.NFD).replaceAll("\\p{M}", "");
+        String slug = NON_ALPHANUMERIC.matcher(normalized.toLowerCase().replace(' ', '-')).replaceAll("");
+        slug = MULTIPLE_DASHES.matcher(slug).replaceAll("-");
+        slug = slug.replaceAll("^-|-$", "");
+        return slug;
     }
 
     public static String appendCurlyBraces(String selectionRule) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ClusterAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ClusterAdapter.java
@@ -42,6 +42,7 @@ public abstract class ClusterAdapter {
     public String mapDefinition(Cluster cluster) throws JsonProcessingException {
         var clusterDefinition = io.gravitee.definition.model.cluster.Cluster.builder()
             .id(cluster.getId())
+            .crossId(cluster.getCrossId())
             .type(cluster.getType() != null ? cluster.getType().name() : null)
             .name(cluster.getName())
             .configuration(cluster.getConfiguration())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/cluster/ClusterQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/cluster/ClusterQueryServiceImpl.java
@@ -51,4 +51,9 @@ public class ClusterQueryServiceImpl implements ClusterQueryService {
 
         return result.map(clusterAdapter::fromRepository);
     }
+
+    @Override
+    public Optional<Cluster> findByCrossIdAndEnvironmentId(String crossId, String environmentId) {
+        return clusterRepository.findByCrossIdAndEnvironmentId(crossId, environmentId).map(clusterAdapter::fromRepository);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClusterCrossIdUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClusterCrossIdUpgrader.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import io.gravitee.apim.core.utils.StringUtils;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.repository.management.api.ClusterRepository;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@CustomLog
+@Component
+public class ClusterCrossIdUpgrader implements Upgrader {
+
+    @Lazy
+    @Autowired
+    private ClusterRepository clusterRepository;
+
+    @Override
+    public boolean upgrade() {
+        try {
+            clusterRepository
+                .findAll()
+                .forEach(cluster -> {
+                    if (cluster.getCrossId() != null && !cluster.getCrossId().isEmpty()) {
+                        return;
+                    }
+                    log.info("Generating crossId for cluster {}", cluster.getName());
+                    cluster.setCrossId(StringUtils.slugify(cluster.getName() != null ? cluster.getName() : cluster.getId()));
+                    try {
+                        clusterRepository.update(cluster);
+                    } catch (Exception e) {
+                        log.error("Failed to update crossId for cluster {}", cluster.getName(), e);
+                    }
+                });
+            return true;
+        } catch (Exception ex) {
+            log.error("ClusterCrossIdUpgrader failed", ex);
+            return false;
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.CLUSTER_CROSS_ID_UPGRADER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -66,6 +66,7 @@ public class UpgraderOrder {
     public static final int TENANT_KEY_UPGRADER = 717;
     public static final int SUBSCRIPTION_FORM_CONSTRAINTS_UPGRADER = 718;
     public static final int CLUSTER_ROLES_UPGRADER = 900;
+    public static final int CLUSTER_CROSS_ID_UPGRADER = 901;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;
     public static final int API_PRODUCT_ROLES_UPGRADER = 950;
     public static final int API_PRODUCT_MEMBER_PERMISSION_UPGRADER = 951;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json
@@ -265,6 +265,11 @@
     "kafkaClusterConnection": {
       "type": "object",
       "properties": {
+        "crossId": {
+          "type": "string",
+          "title": "Cross ID",
+          "description": "Portable identifier for cross-environment references. Auto-generated from name if not provided."
+        },
         "name": {
           "type": "string",
           "title": "Connection name",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json
@@ -265,15 +265,15 @@
     "kafkaClusterConnection": {
       "type": "object",
       "properties": {
-        "crossId": {
-          "type": "string",
-          "title": "Cross ID",
-          "description": "Portable identifier for cross-environment references. Auto-generated from name if not provided."
-        },
         "name": {
           "type": "string",
           "title": "Connection name",
           "description": "A name to identify this connection"
+        },
+        "crossId": {
+          "type": "string",
+          "title": "Cross ID",
+          "description": "Portable identifier for cross-environment references. Auto-generated from name if not provided."
         },
         "bootstrapServers": {
           "type": "string",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClusterCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClusterCrudServiceInMemory.java
@@ -63,6 +63,7 @@ public class ClusterCrudServiceInMemory extends AbstractCrudServiceInMemory<Clus
             Cluster cluster = storage.get(index.getAsInt());
             Cluster updatedCluster = Cluster.builder()
                 .id(cluster.getId())
+                .crossId(cluster.getCrossId())
                 .name(cluster.getName())
                 .description(cluster.getDescription())
                 .environmentId(cluster.getEnvironmentId())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClusterQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ClusterQueryServiceInMemory.java
@@ -48,6 +48,14 @@ public class ClusterQueryServiceInMemory extends AbstractQueryServiceInMemory<Cl
     }
 
     @Override
+    public Optional<Cluster> findByCrossIdAndEnvironmentId(String crossId, String environmentId) {
+        return storage
+            .stream()
+            .filter(cluster -> crossId.equals(cluster.getCrossId()) && environmentId.equals(cluster.getEnvironmentId()))
+            .findFirst();
+    }
+
+    @Override
     public Page<Cluster> search(ClusterSearchCriteria criteria, Pageable pageable, Optional<Sortable> sortable) {
         var pageNumber = pageable.getPageNumber();
         var pageSize = pageable.getPageSize();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -572,4 +572,9 @@ public class InMemoryConfiguration {
     public SubscriptionFormElResolverInMemory subscriptionFormElResolver() {
         return new SubscriptionFormElResolverInMemory();
     }
+
+    @Bean
+    public ClusterQueryServiceInMemory clusterQueryService() {
+        return new ClusterQueryServiceInMemory();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterServiceTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import inmemory.ClusterQueryServiceInMemory;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterType;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
@@ -37,12 +38,19 @@ import org.junit.jupiter.api.Test;
 class ValidateClusterServiceTest {
 
     private ValidateClusterService validateClusterService;
+    private final ClusterQueryServiceInMemory clusterQueryService = new ClusterQueryServiceInMemory();
 
     @BeforeEach
     void setUp() {
         JsonSchemaChecker jsonSchemaChecker = new JsonSchemaCheckerImpl(new JsonSchemaServiceImpl(new JsonSchemaValidatorImpl()));
         ClusterConfigurationSchemaService clusterConfigurationSchemaService = new ClusterConfigurationSchemaService();
-        validateClusterService = new ValidateClusterService(jsonSchemaChecker, clusterConfigurationSchemaService, new ObjectMapper());
+        validateClusterService = new ValidateClusterService(
+            jsonSchemaChecker,
+            clusterConfigurationSchemaService,
+            new ObjectMapper(),
+            clusterQueryService
+        );
+        clusterQueryService.reset();
     }
 
     private static Map<String, Object> validConfig() {
@@ -188,5 +196,182 @@ class ValidateClusterServiceTest {
         assertThatThrownBy(() -> validateClusterService.validate(cluster))
             .isInstanceOf(InvalidDataException.class)
             .hasMessageContaining("Connection names must be unique");
+    }
+
+    @Test
+    void should_throw_when_crossId_is_not_unique_in_environment() {
+        Cluster existingCluster = Cluster.builder()
+            .id("existing-id")
+            .crossId("my-cluster")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Cluster")
+            .environmentId("env-1")
+            .configuration(validConfig())
+            .build();
+        clusterQueryService.initWith(List.of(existingCluster));
+
+        Cluster newCluster = Cluster.builder()
+            .id("new-id")
+            .crossId("my-cluster")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Cluster 2")
+            .environmentId("env-1")
+            .configuration(validConfig())
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validateForCreate(newCluster))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("A cluster with crossId 'my-cluster' already exists");
+    }
+
+    @Test
+    void should_pass_when_crossId_is_unique_in_environment() {
+        Cluster existingCluster = Cluster.builder()
+            .id("existing-id")
+            .crossId("my-cluster")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Cluster")
+            .environmentId("env-1")
+            .configuration(validConfig())
+            .build();
+        clusterQueryService.initWith(List.of(existingCluster));
+
+        Cluster newCluster = Cluster.builder()
+            .id("new-id")
+            .crossId("my-other-cluster")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Other Cluster")
+            .environmentId("env-1")
+            .configuration(validConfig())
+            .build();
+
+        assertThatCode(() -> validateClusterService.validateForCreate(newCluster)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_pass_when_same_crossId_in_different_environment() {
+        Cluster existingCluster = Cluster.builder()
+            .id("existing-id")
+            .crossId("my-cluster")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Cluster")
+            .environmentId("env-1")
+            .configuration(validConfig())
+            .build();
+        clusterQueryService.initWith(List.of(existingCluster));
+
+        Cluster newCluster = Cluster.builder()
+            .id("new-id")
+            .crossId("my-cluster")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Cluster")
+            .environmentId("env-2")
+            .configuration(validConfig())
+            .build();
+
+        assertThatCode(() -> validateClusterService.validateForCreate(newCluster)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_throw_when_crossId_is_empty() {
+        Cluster cluster = Cluster.builder()
+            .id("new-id")
+            .crossId("")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Cluster")
+            .environmentId("env-1")
+            .configuration(validConfig())
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validateForCreate(cluster))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("CrossId is required.");
+    }
+
+    @Test
+    void should_throw_when_kafka_cluster_has_duplicate_connection_crossIds() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER)
+            .name("my-kafka-cluster")
+            .configuration(
+                Map.of(
+                    "connections",
+                    List.of(
+                        Map.of(
+                            "crossId",
+                            "same-cross-id",
+                            "name",
+                            "conn-1",
+                            "bootstrapServers",
+                            "kafka1:9092",
+                            "security",
+                            Map.of("protocol", "PLAINTEXT")
+                        ),
+                        Map.of(
+                            "crossId",
+                            "same-cross-id",
+                            "name",
+                            "conn-2",
+                            "bootstrapServers",
+                            "kafka2:9092",
+                            "security",
+                            Map.of("protocol", "PLAINTEXT")
+                        )
+                    )
+                )
+            )
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validate(cluster))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("Connection crossIds must be unique within a cluster");
+    }
+
+    @Test
+    void should_throw_when_crossId_is_changed_on_update() {
+        Cluster existingCluster = Cluster.builder()
+            .id("cluster-id")
+            .crossId("original-cross-id")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Cluster")
+            .environmentId("env-1")
+            .configuration(validConfig())
+            .build();
+
+        Cluster updatedCluster = Cluster.builder()
+            .id("cluster-id")
+            .crossId("modified-cross-id")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Cluster")
+            .environmentId("env-1")
+            .configuration(validConfig())
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validateForUpdate(existingCluster, updatedCluster))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("CrossId is immutable");
+    }
+
+    @Test
+    void should_pass_when_crossId_is_unchanged_on_update() {
+        Cluster existingCluster = Cluster.builder()
+            .id("cluster-id")
+            .crossId("my-cross-id")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Cluster")
+            .environmentId("env-1")
+            .configuration(validConfig())
+            .build();
+
+        Cluster updatedCluster = Cluster.builder()
+            .id("cluster-id")
+            .crossId("my-cross-id")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("Updated Name")
+            .environmentId("env-1")
+            .configuration(validConfig())
+            .build();
+
+        assertThatCode(() -> validateClusterService.validateForUpdate(existingCluster, updatedCluster)).doesNotThrowAnyException();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCaseTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inmemory.AbstractUseCaseTest;
 import inmemory.ClusterCrudServiceInMemory;
+import inmemory.ClusterQueryServiceInMemory;
 import inmemory.MembershipCrudServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
@@ -55,8 +56,10 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
     private final String ROLE_ID = "role-id";
 
     private final ClusterCrudServiceInMemory clusterCrudService = new ClusterCrudServiceInMemory();
+    private final ClusterQueryServiceInMemory clusterQueryService = new ClusterQueryServiceInMemory();
     private final MembershipCrudService membershipCrudService = new MembershipCrudServiceInMemory();
     private final RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private CreateClusterUseCase createClusterUseCase;
 
@@ -64,15 +67,22 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
     void setUp() {
         var jsonSchemaChecker = new JsonSchemaCheckerImpl(new JsonSchemaServiceImpl(new JsonSchemaValidatorImpl()));
         var clusterConfigurationSchemaService = new ClusterConfigurationSchemaService();
-        var validateClusterService = new ValidateClusterService(jsonSchemaChecker, clusterConfigurationSchemaService, new ObjectMapper());
+        var validateClusterService = new ValidateClusterService(
+            jsonSchemaChecker,
+            clusterConfigurationSchemaService,
+            objectMapper,
+            clusterQueryService
+        );
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
         createClusterUseCase = new CreateClusterUseCase(
             clusterCrudService,
             validateClusterService,
             auditService,
             membershipCrudService,
-            roleQueryService
+            roleQueryService,
+            objectMapper
         );
+        clusterQueryService.reset();
         initRoles();
     }
 
@@ -89,6 +99,7 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
         // Then
         var expected = Cluster.builder()
             .id(GENERATED_UUID)
+            .crossId("cluster-1")
             .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
             .name(name)
             .createdAt(INSTANT_NOW)
@@ -195,7 +206,82 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
         // Then
         assertThat(output.cluster().getType()).isEqualTo(ClusterType.KAFKA_CLUSTER);
         assertThat(output.cluster().getName()).isEqualTo(name);
-        assertThat(output.cluster().getConfiguration()).isEqualTo(configuration);
+        assertThat(output.cluster().getCrossId()).isEqualTo("kafka-cluster");
+        var config = objectMapper.convertValue(output.cluster().getConfiguration(), Map.class);
+        var connections = (List<Map<String, Object>>) config.get("connections");
+        assertThat(connections).hasSize(1);
+        assertThat(connections.get(0).get("crossId")).isEqualTo("conn-1");
+        assertThat(connections.get(0).get("name")).isEqualTo("conn-1");
+    }
+
+    @Test
+    void should_create_with_explicit_crossId() {
+        String name = "Cluster 1";
+        Object configuration = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        var toCreate = CreateCluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .crossId("custom-cross-id")
+            .name(name)
+            .configuration(configuration)
+            .build();
+
+        var output = createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO));
+
+        assertThat(output.cluster().getCrossId()).isEqualTo("custom-cross-id");
+    }
+
+    @Test
+    void should_generate_crossId_from_name_when_not_provided() {
+        Object configuration = Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT"));
+        var toCreate = CreateCluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Super Cluster!!")
+            .configuration(configuration)
+            .build();
+
+        var output = createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO));
+
+        assertThat(output.cluster().getCrossId()).isEqualTo("my-super-cluster");
+    }
+
+    @Test
+    void should_throw_when_crossId_already_exists_in_environment() {
+        Cluster existingCluster = Cluster.builder()
+            .id("existing-id")
+            .crossId("my-cluster")
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .name("My Cluster")
+            .environmentId(ENV_ID)
+            .organizationId(ORG_ID)
+            .configuration(Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT")))
+            .build();
+        clusterQueryService.initWith(List.of(existingCluster));
+
+        var toCreate = CreateCluster.builder()
+            .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
+            .crossId("my-cluster")
+            .name("Another Cluster")
+            .configuration(Map.of("bootstrapServers", "localhost:9092", "security", Map.of("protocol", "PLAINTEXT")))
+            .build();
+
+        Assertions.assertThatThrownBy(() -> createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO)))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("A cluster with crossId 'my-cluster' already exists");
+    }
+
+    @Test
+    void should_generate_connection_crossIds_for_kafka_cluster() {
+        Object configuration = Map.of(
+            "connections",
+            List.of(Map.of("name", "Primary Connection", "bootstrapServers", "kafka1:9092", "security", Map.of("protocol", "PLAINTEXT")))
+        );
+        var toCreate = CreateCluster.builder().type(ClusterType.KAFKA_CLUSTER).name("Kafka Cluster").configuration(configuration).build();
+
+        var output = createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO));
+
+        var config = objectMapper.convertValue(output.cluster().getConfiguration(), Map.class);
+        var connections = (List<Map<String, Object>>) config.get("connections");
+        assertThat(connections.get(0).get("crossId")).isEqualTo("primary-connection");
     }
 
     private void initRoles() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/UpdateClusterUseCaseTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inmemory.AbstractUseCaseTest;
 import inmemory.ClusterCrudServiceInMemory;
+import inmemory.ClusterQueryServiceInMemory;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.model.AuditProperties;
@@ -50,19 +51,34 @@ class UpdateClusterUseCaseTest extends AbstractUseCaseTest {
 
     private UpdateClusterUseCase updateClusterUseCase;
     private final ClusterCrudService clusterCrudService = new ClusterCrudServiceInMemory();
+    private final ClusterQueryServiceInMemory clusterQueryService = new ClusterQueryServiceInMemory();
     private final PermissionDomainService permissionDomainService = mock(PermissionDomainService.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private Cluster existingCluster;
 
     @BeforeEach
     void setUp() {
         var jsonSchemaChecker = new JsonSchemaCheckerImpl(new JsonSchemaServiceImpl(new JsonSchemaValidatorImpl()));
         var clusterConfigurationSchemaService = new ClusterConfigurationSchemaService();
-        var validateClusterService = new ValidateClusterService(jsonSchemaChecker, clusterConfigurationSchemaService, new ObjectMapper());
+        var validateClusterService = new ValidateClusterService(
+            jsonSchemaChecker,
+            clusterConfigurationSchemaService,
+            objectMapper,
+            clusterQueryService
+        );
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
-        updateClusterUseCase = new UpdateClusterUseCase(clusterCrudService, validateClusterService, auditService, permissionDomainService);
+        updateClusterUseCase = new UpdateClusterUseCase(
+            clusterCrudService,
+            validateClusterService,
+            auditService,
+            permissionDomainService,
+            objectMapper
+        );
+        clusterQueryService.reset();
 
         existingCluster = Cluster.builder()
             .id(GENERATED_UUID)
+            .crossId("cluster-1")
             .type(ClusterType.KAFKA_CLUSTER_CONNECTION)
             .name("Cluster 1")
             .createdAt(INSTANT_NOW)
@@ -160,6 +176,18 @@ class UpdateClusterUseCaseTest extends AbstractUseCaseTest {
                     .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
                     .build()
             );
+    }
+
+    @Test
+    void should_preserve_crossId_on_update() {
+        // Given
+        var toUpdate = UpdateCluster.builder().name("New Name").build();
+
+        // When
+        var updatedCluster = updateClusterUseCase.execute(new UpdateClusterUseCase.Input(GENERATED_UUID, toUpdate, AUDIT_INFO));
+
+        // Then - crossId remains unchanged
+        assertThat(updatedCluster.cluster().getCrossId()).isEqualTo("cluster-1");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClusterCrossIdUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ClusterCrossIdUpgraderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.management.api.ClusterRepository;
+import io.gravitee.repository.management.model.Cluster;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterCrossIdUpgraderTest {
+
+    @Mock
+    private ClusterRepository clusterRepository;
+
+    @InjectMocks
+    private ClusterCrossIdUpgrader upgrader;
+
+    @Test
+    public void should_generate_crossId_for_cluster_without_one() throws Exception {
+        var cluster = Cluster.builder().id("cluster-id-1").name("My Cluster Name").build();
+
+        when(clusterRepository.findAll()).thenReturn(Set.of(cluster));
+        assertThat(upgrader.upgrade()).isTrue();
+
+        var captor = ArgumentCaptor.forClass(Cluster.class);
+        verify(clusterRepository).update(captor.capture());
+
+        assertThat(captor.getValue().getCrossId()).isEqualTo("my-cluster-name");
+    }
+
+    @Test
+    public void should_use_id_when_name_is_null() throws Exception {
+        var cluster = Cluster.builder().id("cluster-id-1").build();
+
+        when(clusterRepository.findAll()).thenReturn(Set.of(cluster));
+        assertThat(upgrader.upgrade()).isTrue();
+
+        var captor = ArgumentCaptor.forClass(Cluster.class);
+        verify(clusterRepository).update(captor.capture());
+
+        assertThat(captor.getValue().getCrossId()).isEqualTo("cluster-id-1");
+    }
+
+    @Test
+    public void should_skip_cluster_with_existing_crossId() throws Exception {
+        var cluster = Cluster.builder().id("cluster-id-1").name("My Cluster").crossId("existing-cross-id").build();
+
+        when(clusterRepository.findAll()).thenReturn(Set.of(cluster));
+        assertThat(upgrader.upgrade()).isTrue();
+
+        verify(clusterRepository, never()).update(any());
+    }
+
+    @Test
+    public void should_return_false_on_exception() throws Exception {
+        when(clusterRepository.findAll()).thenThrow(new RuntimeException());
+        assertThat(upgrader.upgrade()).isFalse();
+    }
+
+    @Test
+    public void should_continue_on_update_failure() throws Exception {
+        var cluster1 = Cluster.builder().id("cluster-1").name("Cluster 1").build();
+        var cluster2 = Cluster.builder().id("cluster-2").name("Cluster 2").build();
+
+        when(clusterRepository.findAll()).thenReturn(Set.of(cluster1, cluster2));
+        when(clusterRepository.update(any())).thenThrow(new RuntimeException("update failed")).thenReturn(cluster2);
+
+        assertThat(upgrader.upgrade()).isTrue();
+        verify(clusterRepository, times(2)).update(any());
+    }
+
+    @Test
+    public void should_have_correct_order() {
+        assertThat(upgrader.getOrder()).isEqualTo(UpgraderOrder.CLUSTER_CROSS_ID_UPGRADER);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0-alpha.2</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>7.0.0-alpha.1</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>7.0.0-alpha.3</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.2</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>2.7.3</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary

[APIM-13496](https://gravitee.atlassian.net/browse/APIM-13496)

- Add portable `crossId` identifier to Clusters (unique per environment) and Kafka Cluster Connections (unique per cluster), auto-generated from name slug, immutable after creation
- Add custom form components (`cluster-type`, `cluster-connection-type`) for endpoint schema forms with autocomplete and validation warnings
- Support `native-kafka-cluster` endpoint type in API creation flow, endpoint group creation, and endpoint groups display
- Add endpoint type selection step for Native Kafka APIs (Broker vs Cluster)
- Add `native-kafka-cluster` plugin to APIM distribution (reactor `7.0.0-alpha.3`)
- DB migrations (Liquibase + upgrader) to populate crossId on existing clusters

## Changes

- **Backend**: crossId on Cluster/KafkaClusterConnection models, validation, repository, OpenAPI, upgrader
- **Frontend**: Kafka Cluster creation dialog + detail page crossId field, custom formly components, API creation flow with endpoint selection, endpoint groups adapter
- **Distribution**: bump reactor version, add new endpoint plugin

[APIM-13496]: https://gravitee.atlassian.net/browse/APIM-13496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

https://github.com/user-attachments/assets/faabcc40-52ae-4336-973a-cff3252960d2



