### PR TITLE
fix(rest-api): return all groups for group admins in paginated search

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -286,9 +286,12 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     @Override
     public io.gravitee.common.data.domain.Page<GroupEntity> search(ExecutionContext executionContext, Pageable pageable, String query) {
         String environmentId = executionContext.getEnvironmentId();
-        GroupCriteria.GroupCriteriaBuilder groupCriteriaBuilder = GroupCriteria.builder().environmentId(environmentId).query(query);
+        GroupCriteria groupCriteria = GroupCriteria.builder().environmentId(environmentId).query(query).build();
+        io.gravitee.common.data.domain.Page<Group> groups = groupRepository.search(groupCriteria, convert(pageable));
+        io.gravitee.common.data.domain.Page<GroupEntity> result = groups.map(this::map);
+
         if (
-            !permissionService.hasPermission(
+            permissionService.hasPermission(
                 executionContext,
                 RolePermission.ENVIRONMENT_GROUP,
                 executionContext.getEnvironmentId(),
@@ -297,13 +300,15 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 DELETE
             )
         ) {
+            result.getContent().forEach(groupEntity -> groupEntity.setManageable(true));
+        } else {
             Optional<RoleEntity> optGroupAdminSystemRole = roleService.findByScopeAndName(
                 RoleScope.GROUP,
                 SystemRole.ADMIN.name(),
                 executionContext.getOrganizationId()
             );
             if (optGroupAdminSystemRole.isPresent()) {
-                Set<String> groupIds = membershipService
+                Set<String> manageableGroupIds = membershipService
                     .getMembershipsByMemberAndReferenceAndRole(
                         MembershipMemberType.USER,
                         getAuthenticatedUsername(),
@@ -313,11 +318,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                     .stream()
                     .map(MembershipEntity::getReferenceId)
                     .collect(Collectors.toSet());
-                groupCriteriaBuilder.idIn(groupIds);
+                result.getContent().forEach(groupEntity -> groupEntity.setManageable(manageableGroupIds.contains(groupEntity.getId())));
             }
         }
-        io.gravitee.common.data.domain.Page<Group> groups = groupRepository.search(groupCriteriaBuilder.build(), convert(pageable));
-        return groups.map(this::map);
+        return result;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupServiceImplTest.java
@@ -83,10 +83,10 @@ public class GroupServiceImplTest {
     private EventManager eventManager;
 
     @Test
-    public void search_hasNotPermissionCreateUpdateDelete() {
+    public void search_should_return_all_groups_and_mark_administered_as_manageable_when_user_is_group_admin() {
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         int pageNumber = 1;
-        int pageSize = 2;
+        int pageSize = 4;
         Pageable pageable = new PageableImpl(pageNumber, pageSize);
         String searchTerm = "test";
 
@@ -108,10 +108,7 @@ public class GroupServiceImplTest {
             Optional.of(roleEntity)
         );
 
-        Set<MembershipEntity> memberships = Set.of(
-            MembershipEntity.builder().id("m1").referenceId("gr1").build(),
-            MembershipEntity.builder().id("m2").referenceId("gr2").build()
-        );
+        Set<MembershipEntity> memberships = Set.of(MembershipEntity.builder().id("m1").referenceId("gr1").build());
         when(
             membershipService.getMembershipsByMemberAndReferenceAndRole(
                 eq(MembershipMemberType.USER),
@@ -121,27 +118,114 @@ public class GroupServiceImplTest {
             )
         ).thenReturn(memberships);
 
-        GroupCriteria groupCriteria = GroupCriteria.builder()
-            .environmentId(executionContext.getEnvironmentId())
-            .query(searchTerm)
-            .idIn(Set.of("gr1", "gr2"))
-            .build();
-        List<Group> groups = List.of(Group.builder().id("gr1").build(), Group.builder().id("gr2").build());
-        Page<Group> groupsPage = new Page<>(groups, pageNumber, pageSize, 13);
+        GroupCriteria groupCriteria = GroupCriteria.builder().environmentId(executionContext.getEnvironmentId()).query(searchTerm).build();
+        List<Group> groups = List.of(
+            Group.builder().id("gr1").build(),
+            Group.builder().id("gr2").build(),
+            Group.builder().id("gr3").build()
+        );
+        Page<Group> groupsPage = new Page<>(groups, pageNumber, pageSize, 3);
         when(groupRepository.search(groupCriteria, convert(pageable))).thenReturn(groupsPage);
 
-        Page<GroupEntity> searchResult = service.search(executionContext, pageable, "test");
+        Page<GroupEntity> searchResult = service.search(executionContext, pageable, searchTerm);
 
         assertAll(
-            () -> assertThat(searchResult.getContent()).isEqualTo(groups.stream().map(service::map).toList()),
-            () -> assertThat(searchResult.getTotalElements()).isEqualTo(13),
-            () -> assertThat(searchResult.getPageNumber()).isEqualTo(pageNumber),
-            () -> assertThat(searchResult.getPageElements()).isEqualTo(pageSize)
+            () -> assertThat(searchResult.getContent()).hasSize(3),
+            () -> assertThat(searchResult.getContent().stream().map(GroupEntity::getId).toList()).containsExactly("gr1", "gr2", "gr3"),
+            () -> assertThat(searchResult.getContent().get(0).isManageable()).isTrue(),
+            () -> assertThat(searchResult.getContent().get(1).isManageable()).isFalse(),
+            () -> assertThat(searchResult.getContent().get(2).isManageable()).isFalse()
         );
     }
 
     @Test
-    public void search_hasPermissionCreateUpdateDelete() {
+    public void search_should_return_all_groups_with_manageable_false_when_user_is_not_group_admin() {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        int pageNumber = 1;
+        int pageSize = 4;
+        Pageable pageable = new PageableImpl(pageNumber, pageSize);
+        String searchTerm = "test";
+
+        when(
+            permissionService.hasPermission(
+                executionContext,
+                RolePermission.ENVIRONMENT_GROUP,
+                executionContext.getEnvironmentId(),
+                CREATE,
+                UPDATE,
+                DELETE
+            )
+        ).thenReturn(false);
+
+        when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Set.of());
+
+        RoleEntity roleEntity = RoleEntity.builder().id("re1").build();
+        when(roleService.findByScopeAndName(RoleScope.GROUP, SystemRole.ADMIN.name(), executionContext.getOrganizationId())).thenReturn(
+            Optional.of(roleEntity)
+        );
+
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                eq(MembershipMemberType.USER),
+                any(),
+                eq(MembershipReferenceType.GROUP),
+                eq(roleEntity.getId())
+            )
+        ).thenReturn(Set.of());
+
+        GroupCriteria groupCriteria = GroupCriteria.builder().environmentId(executionContext.getEnvironmentId()).query(searchTerm).build();
+        List<Group> groups = List.of(Group.builder().id("gr1").build(), Group.builder().id("gr2").build());
+        Page<Group> groupsPage = new Page<>(groups, pageNumber, pageSize, 2);
+        when(groupRepository.search(groupCriteria, convert(pageable))).thenReturn(groupsPage);
+
+        Page<GroupEntity> searchResult = service.search(executionContext, pageable, searchTerm);
+
+        assertAll(
+            () -> assertThat(searchResult.getContent()).hasSize(2),
+            () -> assertThat(searchResult.getContent().stream().noneMatch(GroupEntity::isManageable)).isTrue()
+        );
+    }
+
+    @Test
+    public void search_should_return_all_groups_with_manageable_false_when_group_admin_role_does_not_exist() {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        int pageNumber = 1;
+        int pageSize = 4;
+        Pageable pageable = new PageableImpl(pageNumber, pageSize);
+        String searchTerm = "test";
+
+        when(
+            permissionService.hasPermission(
+                executionContext,
+                RolePermission.ENVIRONMENT_GROUP,
+                executionContext.getEnvironmentId(),
+                CREATE,
+                UPDATE,
+                DELETE
+            )
+        ).thenReturn(false);
+
+        when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Set.of());
+
+        when(roleService.findByScopeAndName(RoleScope.GROUP, SystemRole.ADMIN.name(), executionContext.getOrganizationId())).thenReturn(
+            Optional.empty()
+        );
+
+        GroupCriteria groupCriteria = GroupCriteria.builder().environmentId(executionContext.getEnvironmentId()).query(searchTerm).build();
+        List<Group> groups = List.of(Group.builder().id("gr1").build(), Group.builder().id("gr2").build());
+        Page<Group> groupsPage = new Page<>(groups, pageNumber, pageSize, 2);
+        when(groupRepository.search(groupCriteria, convert(pageable))).thenReturn(groupsPage);
+
+        Page<GroupEntity> searchResult = service.search(executionContext, pageable, searchTerm);
+
+        assertAll(
+            () -> assertThat(searchResult.getContent()).hasSize(2),
+            () -> assertThat(searchResult.getContent().stream().noneMatch(GroupEntity::isManageable)).isTrue()
+        );
+    }
+
+    @Test
+    public void search_should_return_all_groups_with_manageable_true_when_user_has_cud_permissions() {
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         int pageNumber = 1;
         int pageSize = 2;
@@ -161,16 +245,17 @@ public class GroupServiceImplTest {
 
         GroupCriteria groupCriteria = GroupCriteria.builder().environmentId(executionContext.getEnvironmentId()).query(searchTerm).build();
         List<Group> groups = List.of(Group.builder().id("gr1").build(), Group.builder().id("gr2").build());
-        Page<Group> groupsPage = new Page<>(groups, pageNumber, pageSize, 13);
+        Page<Group> groupsPage = new Page<>(groups, pageNumber, pageSize, 2);
         when(groupRepository.search(groupCriteria, convert(pageable))).thenReturn(groupsPage);
 
         when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Set.of());
 
-        Page<GroupEntity> searchResult = service.search(executionContext, pageable, "test");
+        Page<GroupEntity> searchResult = service.search(executionContext, pageable, searchTerm);
 
         assertAll(
-            () -> assertThat(searchResult.getContent()).isEqualTo(groups.stream().map(service::map).toList()),
-            () -> assertThat(searchResult.getTotalElements()).isEqualTo(13),
+            () -> assertThat(searchResult.getContent()).hasSize(2),
+            () -> assertThat(searchResult.getContent().stream().allMatch(GroupEntity::isManageable)).isTrue(),
+            () -> assertThat(searchResult.getTotalElements()).isEqualTo(2),
             () -> assertThat(searchResult.getPageNumber()).isEqualTo(pageNumber),
             () -> assertThat(searchResult.getPageElements()).isEqualTo(pageSize)
         );


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13497

## Description

Fix Group Admin users only seeing their administered groups in paginated search. `search()` now returns all groups and sets `manageable` flag per group, matching `findAll()` behavior.
