### PR TITLE
docs(gateway): add Kafka OTel tracedApiKeys config to gravitee.yml

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -740,6 +740,13 @@ services:
 #    exporter:
 #      endpoint: http://localhost:4317
 #      protocol: grpc
+#    # Kafka Native API tracing configuration
+#    # tracedApiKeys restricts per-request spans to specific Kafka protocol types.
+#    # When omitted or empty, all protocol types are traced.
+#    # Recommended: trace only meaningful data-path operations to reduce noise
+#    # from housekeeping requests (METADATA, HEARTBEAT, FIND_COORDINATOR, etc.).
+#    kafka:
+#      tracedApiKeys: [PRODUCE, FETCH]
 
 #handlers:
 #  request:

--- a/helm/tests/gateway/configmap_tracing_test.yaml
+++ b/helm/tests/gateway/configmap_tracing_test.yaml
@@ -84,3 +84,24 @@ tests:
             \s         type: pem
             \s       verifyHostname: true
             \s     type: grpc
+  - it: Enable opentelemetry tracing with kafka tracedApiKeys
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        services:
+          opentelemetry:
+            enabled: true
+            kafka:
+              tracedApiKeys:
+                - PRODUCE
+                - FETCH
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s opentelemetry:
+            \s   enabled: true
+            \s   kafka:
+            \s     tracedApiKeys:
+            \s     - PRODUCE
+            \s     - FETCH

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1744,6 +1744,10 @@ gateway:
 #        compression: none
 #        headers:
 #          - X-Custom-Header: value
+#      kafka:
+#        tracedApiKeys:
+#          - PRODUCE
+#          - FETCH
 #        timeout: 10000
 #        ssl:
 #          trustall: false


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-13485

https://gravitee.atlassian.net/browse/APIM-13634

## Description

Adds Kafka Native API tracing configuration under the opentelemetry section in gravitee.yml and Helm chart values.

- gravitee.yml: documents kafka.tracedApiKeys with a recommended default of [PRODUCE, FETCH] to reduce noise from housekeeping requests (METADATA, HEARTBEAT, FIND_COORDINATOR, etc.).
- helm/values.yaml: adds corresponding kafka.tracedApiKeys under the opentelemetry commented block.
- helm/tests: adds a configmap test for the Kafka tracing configuration.

Introduced by: https://gravitee.atlassian.net/browse/APIM-13485

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

