### PR TITLE
fix(helm): support preinstalled JDBC drivers

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -4,7 +4,11 @@
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
 ### 4.11.2
-- Add support for `jdbc.driverSource=preinstalled` to use JDBC drivers already baked into custom API and Gateway runtime images, without JDBC runtime provisioning.
+- Improve JDBC driver delivery options in the Helm chart:
+  - `auto` uses bundled PostgreSQL, MariaDB, and SQL Server drivers, and uses startup download for MySQL and other custom JDBC families
+  - `image` allows using a dedicated customer-provided JDBC image instead of downloading the driver at startup
+  - `download` keeps the explicit startup download mode
+  - `preinstalled` allows using JDBC drivers already baked into custom API and Gateway runtime images, without JDBC runtime provisioning
 - Validate `jdbc.driverSource` values during chart rendering and fail on unsupported values.
 
 ### 4.10.0

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.11.2
+- Add support for `jdbc.driverSource=preinstalled` to use JDBC drivers already baked into custom API and Gateway runtime images, without JDBC runtime provisioning.
+- Validate `jdbc.driverSource` values during chart rendering and fail on unsupported values.
+
 ### 4.10.0
 - Allow to configure Expression Language whitelist.
 - Improve redis rate limit configuration to allow username for acl configuration [issues/10966](https://github.com/gravitee-io/issues/issues/10966).

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,4 +29,8 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - kind: added
+      description: 'Add support for jdbc.driverSource=preinstalled for custom APIM images with pre-baked JDBC drivers.'
+    - kind: fixed
+      description: 'Validate jdbc.driverSource values during chart rendering and fail on unsupported values.'

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -31,6 +31,6 @@ annotations:
   ###########
   artifacthub.io/changes: |
     - kind: added
-      description: 'Add support for jdbc.driverSource=preinstalled for custom APIM images with pre-baked JDBC drivers.'
+      description: 'Improve JDBC driver delivery options with auto, download, image, and preinstalled modes.'
     - kind: fixed
       description: 'Validate jdbc.driverSource values during chart rendering and fail on unsupported values.'

--- a/helm/README.adoc
+++ b/helm/README.adoc
@@ -272,6 +272,8 @@ The startup behavior is derived from `jdbc.url` and `jdbc.driverSource`:
 * `jdbc.driverSource=auto` uses bundled PostgreSQL, MariaDB, and SQL Server drivers, and uses startup download for MySQL and any other custom JDBC family
 * `jdbc.driverSource=download` always downloads the driver from `jdbc.driver` at startup
 * `jdbc.driverSource=image` copies the driver at startup from a dedicated customer-provided JDBC image
+* `jdbc.driverSource=preinstalled` uses a driver already baked into the final API and Gateway runtime images
+* any other value fails chart rendering
 
 When `jdbc.driverSource=auto`:
 
@@ -345,7 +347,24 @@ management:
   type: jdbc
 ----
 
-The API upgrader follows the same JDBC behavior automatically.
+For hardened immutable deployments, use preinstalled mode with custom API and Gateway images that already contain the driver in:
+
+* `/opt/graviteeio-management-api/plugins/ext/repository-jdbc`
+* `/opt/graviteeio-gateway/plugins/ext/repository-jdbc`
+
+In this mode, the chart does not create a JDBC initContainer, `emptyDir`, or JDBC volume mount.
+
+----
+jdbc:
+  driverSource: preinstalled
+  url: jdbc:mysql://mysql-apim-mysql:3306/graviteeapim
+  username: gravitee
+  password: P@ssw0rd
+management:
+  type: jdbc
+----
+
+The API upgrader follows the same behavior and expects the driver to be present in the API image as well.
 
 For MySQL fallback mode, keep the current startup download path:
 

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -217,7 +217,12 @@ other
 Configured JDBC driver source.
 */}}
 {{- define "apim.jdbcDriverSource" -}}
-{{- lower (default "auto" .Values.jdbc.driverSource) -}}
+{{- $source := lower (default "auto" .Values.jdbc.driverSource) -}}
+{{- if has $source (list "auto" "download" "image" "preinstalled") -}}
+{{- $source -}}
+{{- else -}}
+{{- fail (printf "jdbc.driverSource must be one of auto, download, image, preinstalled, got %q" .Values.jdbc.driverSource) -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/tests/api/deployment_test.yaml
+++ b/helm/tests/api/deployment_test.yaml
@@ -110,6 +110,35 @@ tests:
           path: spec.template.spec.volumes[1].name
           value: graviteeio-apim-repository-jdbc-ext
 
+  - it: Check deployment with preinstalled MySQL JDBC support
+    template: api/api-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        driverSource: "preinstalled"
+        url: "jdbc:mysql://db:3306/gravitee"
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[1]
+      - notExists:
+          path: spec.template.spec.volumes[1]
+
+  - it: Should fail for unsupported JDBC driver source
+    template: api/api-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        driverSource: "dupa"
+        url: "jdbc:mysql://db:3306/gravitee"
+        driver: "https://url/where/to/download/driver"
+    asserts:
+      - failedTemplate:
+          errorPattern: "jdbc\\.driverSource must be one of auto, download, image, preinstalled"
+
   - it: Set containerPort with custom port if core service is enabled
     template: api/api-deployment.yaml
     set:

--- a/helm/tests/api/job_upgrader_test.yaml
+++ b/helm/tests/api/job_upgrader_test.yaml
@@ -110,6 +110,24 @@ tests:
           content:
             name: get-repository-jdbc-ext
 
+  - it: Should use preinstalled MySQL JDBC driver without runtime provisioning
+    template: api/api-upgrader-job.yaml
+    set:
+      api:
+        upgrader: true
+      management:
+        type: "jdbc"
+      jdbc:
+        driverSource: "preinstalled"
+        url: "jdbc:mysql://db:3306/gravitee"
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[1]
+      - notExists:
+          path: spec.template.spec.volumes[1]
+
   - it: Check that cockpit has been disabled
     template: api/api-upgrader-job.yaml
     set:

--- a/helm/tests/gateway/deployment_jdbc_test.yaml
+++ b/helm/tests/gateway/deployment_jdbc_test.yaml
@@ -103,6 +103,39 @@ tests:
           content:
             name: get-repository-jdbc-ext
 
+  - it: Should use preinstalled MySQL JDBC driver without runtime provisioning
+    template: gateway/gateway-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        driverSource: "preinstalled"
+        url: "jdbc:mysql://db:3306/gravitee"
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: graviteeio-apim-repository-jdbc-ext
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: graviteeio-apim-repository-jdbc-ext
+
+  - it: Should fail for unsupported JDBC driver source
+    template: gateway/gateway-deployment.yaml
+    set:
+      management:
+        type: "jdbc"
+      jdbc:
+        driverSource: "dupa"
+        url: "jdbc:mysql://db:3306/gravitee"
+        driver: "https://url/where/to/download/driver"
+    asserts:
+      - failedTemplate:
+          errorPattern: "jdbc\\.driverSource must be one of auto, download, image, preinstalled"
+
   - it: Should not download bundled PostgreSQL JDBC driver
     template: gateway/gateway-deployment.yaml
     set:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -263,6 +263,8 @@ jdbc:
   # - auto: bundled PostgreSQL/MariaDB/SQL Server drivers, download for MySQL and other custom JDBC families
   # - download: always download the driver from jdbc.driver at startup
   # - image: copy the driver at startup from a dedicated customer-provided JDBC image
+  # - preinstalled: use a driver already baked into the final API and Gateway runtime images
+  # Any other value fails chart rendering.
   # In auto mode, MySQL still requires jdbc.driver and downloads the driver at startup.
   # PostgreSQL, MariaDB, and SQL Server ignore jdbc.driver in auto mode.
   driverSource: auto
@@ -271,7 +273,10 @@ jdbc:
   # For MySQL, the recommended path is jdbc.driverSource=image with a minimal JDBC image
   # containing /drivers/mysql-connector-j.jar.
   # The fallback path is jdbc.driverSource=download using jdbc.driver.
-  # mount-based MySQL delivery is not part of the documented recommendation.
+  # For hardened immutable images, jdbc.driverSource=preinstalled expects the driver to
+  # already exist in:
+  # - /opt/graviteeio-management-api/plugins/ext/repository-jdbc
+  # - /opt/graviteeio-gateway/plugins/ext/repository-jdbc
   url: jdbc:mysql://localhost:3306/gravitee
   # Set this URL for MySQL runtime download mode or any other non-bundled/custom JDBC driver.
   driver: https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.22/mysql-connector-java-8.0.22.jar


### PR DESCRIPTION
**Description**

This PR adds support for a new Helm JDBC delivery mode, `jdbc.driverSource=preinstalled,` for deployments where the JDBC driver is already baked into the final API and Gateway images.

In this mode, the chart no longer performs JDBC runtime provisioning: it does not create the JDBC initContainer, emptyDir, or plugin directory mount for API, Gateway, or the API upgrader job. The expected behavior is that the JDBC driver is already present in the standard plugin directory inside the custom runtime images.

The PR also updates the Helm documentation and adds regression coverage for the new mode, while preserving the existing behavior for auto, download, and image.

Additionally, it aligns Helm OpenShift security-context adaptation with global values support and applies the same adaptation to the API upgrader JDBC initContainer.

**Additional context**

Full Helm chart regression was executed with `helm unittest -f 'tests/**/*.yaml'` .
`Result: 116/116 test suites passed, 608/608 tests passed`
helm lint . also passed
For` jdbc.driverSource=preinstalled`, the expected driver locations are:
`/opt/graviteeio-management-api/plugins/ext/repository-jdbc`
`/opt/graviteeio-gateway/plugins/ext/repository-jdbc`
This mode disables JDBC runtime provisioning, but does not by itself enforce a read-only filesystem inside the running container