### PR TITLE
chore: bump gravitee-resource-oauth2-provider-api version to 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
         <gravitee-resource-cache-provider-api.version>2.1.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-content-provider-api.version>1.0.0</gravitee-resource-content-provider-api.version>
-        <gravitee-resource-oauth2-provider-api.version>1.5.0</gravitee-resource-oauth2-provider-api.version>
+        <gravitee-resource-oauth2-provider-api.version>1.5.1</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-storage-api.version>1.1.0</gravitee-resource-storage-api.version>
         <gravitee-scoring-api.version>0.7.0</gravitee-scoring-api.version>
         <gravitee-secret-api.version>3.0.0</gravitee-secret-api.version>


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13671