### PR TITLE
Api Product : Backend implementation for transfer of PO ownership

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -28,6 +28,7 @@ import inmemory.CRDMembersDomainServiceInMemory;
 import inmemory.EventLatestCrudInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
+import inmemory.MembershipDomainServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/MembershipMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/MembershipMapper.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import io.gravitee.rest.api.management.v2.rest.model.ApiProductTransferOwnership;
 import io.gravitee.rest.api.management.v2.rest.model.ClusterTransferOwnership;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -24,4 +26,7 @@ public interface MembershipMapper {
     MembershipMapper INSTANCE = Mappers.getMapper(MembershipMapper.class);
 
     io.gravitee.apim.core.membership.model.TransferOwnership map(ClusterTransferOwnership transferOwnership);
+
+    @Mapping(source = "userType", target = "memberType")
+    io.gravitee.apim.core.membership.model.TransferOwnership map(ApiProductTransferOwnership transferOwnership);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.api_product;
 
+import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.api_product.use_case.VerifyApiProductExistsUseCase;
 import io.gravitee.apim.core.api_product.use_case.members.AddApiProductMemberUseCase;
 import io.gravitee.apim.core.api_product.use_case.members.DeleteApiProductMemberUseCase;
@@ -22,7 +23,9 @@ import io.gravitee.apim.core.api_product.use_case.members.GetApiProductMembersUs
 import io.gravitee.apim.core.api_product.use_case.members.UpdateApiProductMemberUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.MemberMapper;
+import io.gravitee.rest.api.management.v2.rest.mapper.MembershipMapper;
 import io.gravitee.rest.api.management.v2.rest.model.AddMember;
+import io.gravitee.rest.api.management.v2.rest.model.ApiProductTransferOwnership;
 import io.gravitee.rest.api.management.v2.rest.model.Member;
 import io.gravitee.rest.api.management.v2.rest.model.MembersResponse;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateMember;
@@ -74,6 +77,9 @@ public class ApiProductMembersResource extends AbstractResource {
 
     @Inject
     private DeleteApiProductMemberUseCase deleteApiProductMemberUseCase;
+
+    @Inject
+    private TransferApiProductOwnershipUseCase transferApiProductOwnershipUseCase;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -157,6 +163,18 @@ public class ApiProductMembersResource extends AbstractResource {
             }
         }
         return Response.ok(permissions).build();
+    }
+
+    @POST
+    @Path("/_transfer-ownership")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_PRODUCT_MEMBER, acls = RolePermissionAction.UPDATE) })
+    public Response transferApiProductOwnership(@Valid @NotNull ApiProductTransferOwnership transferOwnership) {
+        verifyApiProductInCurrentEnvironment();
+        transferApiProductOwnershipUseCase.execute(
+            new TransferApiProductOwnershipUseCase.Input(MembershipMapper.INSTANCE.map(transferOwnership), apiProductId)
+        );
+        return Response.noContent().build();
     }
 
     private void verifyApiProductInCurrentEnvironment() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -668,6 +668,31 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /environments/{envId}/api-products/{apiProductId}/members/_transfer-ownership:
+    parameters:
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/apiProductIdParam"
+    post:
+      tags:
+        - API Product Members
+      summary: Transfer API Product ownership
+      description: |-
+        Transfer the ownership of the API Product to a user, group, or an existing member.
+        Return a 404 HTTP Error if API Product cannot be found.
+        User must have the API_PRODUCT_MEMBER[UPDATE] permission.
+      operationId: transferApiProductOwnership
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApiProductTransferOwnership"
+        required: true
+      responses:
+        "204":
+          description: Ownership has been transferred successfully
+        default:
+          $ref: "#/components/responses/Error"
+
   /environments/{envId}/api-products/{apiProductId}/deployments/_verify:
     parameters:
       - $ref: "#/components/parameters/envIdParam"
@@ -2090,6 +2115,21 @@ components:
       enum:
         - USER
         - GROUP
+
+    ApiProductTransferOwnership:
+      type: object
+      properties:
+        newPrimaryOwnerId:
+          type: string
+          description: The new primary owner ID (user's or group's technical identifier). Can be null if userReference is defined.
+        userReference:
+          type: string
+          description: The new primary owner reference from an identity provider. Can be null if newPrimaryOwnerId is defined.
+        userType:
+          $ref: "#/components/schemas/MembershipMemberType"
+        currentPrimaryOwnerNewRole:
+          type: string
+          description: The name of the role that will be assigned to the current primary owner after the transfer.
 
     Error:
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResourceTest.java
@@ -22,6 +22,8 @@ import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
 import static io.gravitee.common.http.HttpStatusCode.NO_CONTENT_204;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static jakarta.ws.rs.client.Entity.json;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,6 +34,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.api_product.use_case.VerifyApiProductExistsUseCase;
 import io.gravitee.apim.core.api_product.use_case.members.AddApiProductMemberUseCase;
 import io.gravitee.apim.core.api_product.use_case.members.DeleteApiProductMemberUseCase;
@@ -39,6 +42,7 @@ import io.gravitee.apim.core.api_product.use_case.members.GetApiProductMembersUs
 import io.gravitee.apim.core.api_product.use_case.members.UpdateApiProductMemberUseCase;
 import io.gravitee.rest.api.management.v2.rest.mapper.MemberMapper;
 import io.gravitee.rest.api.management.v2.rest.model.AddMember;
+import io.gravitee.rest.api.management.v2.rest.model.ApiProductTransferOwnership;
 import io.gravitee.rest.api.management.v2.rest.model.Links;
 import io.gravitee.rest.api.management.v2.rest.model.Member;
 import io.gravitee.rest.api.management.v2.rest.model.MembersResponse;
@@ -59,6 +63,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.List;
@@ -69,6 +74,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class ApiProductMembersResourceTest extends AbstractResourceTest {
 
@@ -89,6 +95,9 @@ class ApiProductMembersResourceTest extends AbstractResourceTest {
 
     @Inject
     private DeleteApiProductMemberUseCase deleteApiProductMemberUseCase;
+
+    @Inject
+    private TransferApiProductOwnershipUseCase transferApiProductOwnershipUseCase;
 
     @Override
     protected String contextPath() {
@@ -120,7 +129,8 @@ class ApiProductMembersResourceTest extends AbstractResourceTest {
             getApiProductMembersUseCase,
             addApiProductMemberUseCase,
             updateApiProductMemberUseCase,
-            deleteApiProductMemberUseCase
+            deleteApiProductMemberUseCase,
+            transferApiProductOwnershipUseCase
         );
     }
 
@@ -427,6 +437,61 @@ class ApiProductMembersResourceTest extends AbstractResourceTest {
             assertThat(response).hasStatus(NO_CONTENT_204);
             verify(deleteApiProductMemberUseCase).execute(
                 argThat(input -> API_PRODUCT_ID.equals(input.apiProductId()) && MEMBER_ID.equals(input.memberId()))
+            );
+        }
+    }
+
+    @Nested
+    class TransferOwnershipTest {
+
+        private WebTarget target;
+
+        @BeforeEach
+        void setup() {
+            target = rootTarget("_transfer-ownership");
+            givenApiProductExists();
+        }
+
+        @Test
+        void should_return_204_on_successful_transfer() {
+            when(transferApiProductOwnershipUseCase.execute(any())).thenReturn(new TransferApiProductOwnershipUseCase.Output());
+
+            Response response = target.request().post(json(new ApiProductTransferOwnership()));
+
+            assertThat(response.getStatus()).isEqualTo(NO_CONTENT_204);
+        }
+
+        @Test
+        void should_return_204_on_successful_group_transfer() {
+            when(transferApiProductOwnershipUseCase.execute(any())).thenReturn(new TransferApiProductOwnershipUseCase.Output());
+
+            // Send userType=GROUP via raw map — the generated model gains this field after regeneration
+            var body = Map.of("newPrimaryOwnerId", "group-1", "userType", "GROUP", "currentPrimaryOwnerNewRole", "USER");
+
+            Response response = target.request().post(json(body));
+
+            assertThat(response.getStatus()).isEqualTo(NO_CONTENT_204);
+
+            var captor = ArgumentCaptor.forClass(TransferApiProductOwnershipUseCase.Input.class);
+            verify(transferApiProductOwnershipUseCase).execute(captor.capture());
+            assertThat(captor.getValue().transferOwnership().getMemberType()).isEqualTo(
+                io.gravitee.apim.core.member.model.MembershipMemberType.GROUP
+            );
+        }
+
+        @Test
+        void should_return_404_when_api_product_not_found() {
+            givenApiProductMissing();
+
+            Response response = target.request().post(json(new ApiProductTransferOwnership()));
+
+            assertThat(response).hasStatus(NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_403_if_incorrect_permissions() {
+            shouldReturn403(RolePermission.API_PRODUCT_MEMBER, API_PRODUCT_ID, RolePermissionAction.UPDATE, () ->
+                target.request().post(json(new ApiProductTransferOwnership()))
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -78,6 +78,7 @@ import io.gravitee.apim.core.api_product.use_case.DeployApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductApisUseCase;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.SearchApiProductsUseCase;
+import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.api_product.use_case.UpdateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.VerifyApiProductExistsUseCase;
 import io.gravitee.apim.core.api_product.use_case.VerifyApiProductNameUseCase;
@@ -1034,6 +1035,11 @@ public class ResourceContextConfiguration {
     @Bean
     public DeleteApiProductMemberUseCase deleteApiProductMemberUseCase() {
         return mock(DeleteApiProductMemberUseCase.class);
+    }
+
+    @Bean
+    public TransferApiProductOwnershipUseCase transferApiProductOwnershipUseCase() {
+        return mock(TransferApiProductOwnershipUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -61,6 +61,7 @@ import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
+import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
@@ -1090,6 +1091,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SearchClusterUseCase searchClusterUseCase() {
         return mock(SearchClusterUseCase.class);
+    }
+
+    @Bean
+    public TransferApiProductOwnershipUseCase transferApiProductOwnershipUseCase() {
+        return mock(TransferApiProductOwnershipUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -60,6 +60,7 @@ import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
@@ -993,6 +994,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SearchClusterUseCase searchClusterUseCase() {
         return mock(SearchClusterUseCase.class);
+    }
+
+    @Bean
+    public TransferApiProductOwnershipUseCase transferApiProductOwnershipUseCase() {
+        return mock(TransferApiProductOwnershipUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/TransferApiProductOwnershipUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/TransferApiProductOwnershipUseCase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
+import io.gravitee.apim.core.membership.model.TransferOwnership;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+@UseCase
+public class TransferApiProductOwnershipUseCase {
+
+    private final MembershipDomainService membershipDomainService;
+
+    public record Input(TransferOwnership transferOwnership, String apiProductId) {}
+
+    public record Output() {}
+
+    public Output execute(Input input) {
+        membershipDomainService.transferOwnership(input.transferOwnership(), RoleScope.API_PRODUCT, input.apiProductId());
+        return new Output();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/TransferOwnership.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/model/TransferOwnership.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.membership.model;
 
+import io.gravitee.apim.core.member.model.MembershipMemberType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,4 +32,5 @@ public class TransferOwnership {
     private String newPrimaryOwnerId;
     private String userReference;
     private String currentPrimaryOwnerNewRole;
+    private MembershipMemberType memberType;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/membership/MembershipDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/membership/MembershipDomainServiceLegacyWrapper.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.TransferOwnershipNotAllowedException;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +40,6 @@ public class MembershipDomainServiceLegacyWrapper implements MembershipDomainSer
 
     private final MembershipService legacyService;
     private final RoleService roleService;
-    private final MembershipService membershipService;
 
     @Override
     public Map<String, char[]> getUserMemberPermissions(
@@ -62,10 +62,13 @@ public class MembershipDomainServiceLegacyWrapper implements MembershipDomainSer
                 GraviteeContext.getExecutionContext().getOrganizationId()
             )
             .ifPresent(newRoles::add);
+        MembershipMemberType memberType = transferOwnership.getMemberType() != null
+            ? MembershipMemberType.valueOf(transferOwnership.getMemberType().name())
+            : MembershipMemberType.USER;
         MembershipService.MembershipMember membershipMember = new MembershipService.MembershipMember(
             transferOwnership.getNewPrimaryOwnerId(),
             transferOwnership.getUserReference(),
-            MembershipMemberType.USER
+            memberType
         );
         legacyService.transferOwnership(
             GraviteeContext.getExecutionContext(),
@@ -86,7 +89,7 @@ public class MembershipDomainServiceLegacyWrapper implements MembershipDomainSer
         String externalReference,
         String roleName
     ) {
-        return membershipService.createNewMembership(
+        return legacyService.createNewMembership(
             executionContext,
             MembershipReferenceType.valueOf(referenceType.name()),
             referenceId,
@@ -99,6 +102,11 @@ public class MembershipDomainServiceLegacyWrapper implements MembershipDomainSer
     private void validateTransferOwnership(TransferOwnership transferOwnership) {
         if ("PRIMARY_OWNER".equals(transferOwnership.getCurrentPrimaryOwnerNewRole())) {
             throw new TransferOwnershipNotAllowedException(transferOwnership.getCurrentPrimaryOwnerNewRole());
+        }
+        boolean hasOwnerId = transferOwnership.getNewPrimaryOwnerId() != null && !transferOwnership.getNewPrimaryOwnerId().isBlank();
+        boolean hasUserRef = transferOwnership.getUserReference() != null && !transferOwnership.getUserReference().isBlank();
+        if (!hasOwnerId && !hasUserRef) {
+            throw new InvalidDataException("Transfer ownership requires either newPrimaryOwnerId or userReference to be provided.");
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -1993,8 +1993,10 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                     }
                 }
             } else if (previousPrimaryOwner.getMemberType() == MembershipMemberType.GROUP) {
-                // remove this group from the api's group list
-                apiGroupService.removeGroup(executionContext, itemId, previousPrimaryOwner.getMemberId());
+                // remove this group from the api's group list (only relevant for API references)
+                if (membershipReferenceType == MembershipReferenceType.API) {
+                    apiGroupService.removeGroup(executionContext, itemId, previousPrimaryOwner.getMemberId());
+                }
             }
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MembershipDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MembershipDomainServiceInMemory.java
@@ -89,6 +89,8 @@ public class MembershipDomainServiceInMemory extends AbstractServiceInMemory<Mem
             newPrimaryOwner.setReferenceType(MembershipReferenceType.valueOf(roleScope.name()));
             newPrimaryOwner.setReferenceId(itemId);
             newPrimaryOwner.setRoles(List.of(RoleEntity.builder().name("PRIMARY_OWNER").build()));
+            io.gravitee.apim.core.member.model.MembershipMemberType coreType = transferOwnership.getMemberType();
+            newPrimaryOwner.setType(coreType != null ? MembershipMemberType.valueOf(coreType.name()) : MembershipMemberType.USER);
             storage.add(newPrimaryOwner);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/TransferApiProductOwnershipUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/TransferApiProductOwnershipUseCaseTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import inmemory.AbstractUseCaseTest;
+import inmemory.MembershipDomainServiceInMemory;
+import io.gravitee.apim.core.member.model.MembershipMemberType;
+import io.gravitee.apim.core.membership.model.TransferOwnership;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TransferApiProductOwnershipUseCaseTest extends AbstractUseCaseTest {
+
+    private static final String API_PRODUCT_ID = "my-api-product";
+
+    private TransferApiProductOwnershipUseCase transferApiProductOwnershipUseCase;
+    private final MembershipDomainServiceInMemory membershipDomainService = new MembershipDomainServiceInMemory();
+
+    @BeforeEach
+    void setUp() {
+        transferApiProductOwnershipUseCase = new TransferApiProductOwnershipUseCase(membershipDomainService);
+        initData();
+    }
+
+    @Test
+    void should_transfer_ownership_to_existing_api_product_member() {
+        assertAll(
+            () -> assertThat(currentRoleOf("user-1")).isEqualTo("PRIMARY_OWNER"),
+            () -> assertThat(currentRoleOf("user-2")).isEqualTo("USER")
+        );
+
+        transferApiProductOwnershipUseCase.execute(
+            new TransferApiProductOwnershipUseCase.Input(
+                TransferOwnership.builder().currentPrimaryOwnerNewRole("USER").newPrimaryOwnerId("user-2").build(),
+                API_PRODUCT_ID
+            )
+        );
+
+        assertAll(
+            () -> assertThat(currentRoleOf("user-1")).isEqualTo("USER"),
+            () -> assertThat(currentRoleOf("user-2")).isEqualTo("PRIMARY_OWNER")
+        );
+    }
+
+    @Test
+    void should_transfer_ownership_to_new_user_not_yet_a_member() {
+        assertThat(currentRoleOf("user-1")).isEqualTo("PRIMARY_OWNER");
+
+        transferApiProductOwnershipUseCase.execute(
+            new TransferApiProductOwnershipUseCase.Input(
+                TransferOwnership.builder().currentPrimaryOwnerNewRole("OWNER").newPrimaryOwnerId("user-new").build(),
+                API_PRODUCT_ID
+            )
+        );
+
+        assertAll(
+            () -> assertThat(currentRoleOf("user-1")).isEqualTo("OWNER"),
+            () -> assertThat(currentRoleOf("user-new")).isEqualTo("PRIMARY_OWNER")
+        );
+    }
+
+    @Test
+    void should_transfer_ownership_to_group() {
+        assertThat(currentRoleOf("user-1")).isEqualTo("PRIMARY_OWNER");
+
+        transferApiProductOwnershipUseCase.execute(
+            new TransferApiProductOwnershipUseCase.Input(
+                TransferOwnership.builder()
+                    .currentPrimaryOwnerNewRole("USER")
+                    .newPrimaryOwnerId("group-1")
+                    .memberType(MembershipMemberType.GROUP)
+                    .build(),
+                API_PRODUCT_ID
+            )
+        );
+
+        assertAll(
+            () -> assertThat(currentRoleOf("user-1")).isEqualTo("USER"),
+            () -> assertThat(currentRoleOf("group-1")).isEqualTo("PRIMARY_OWNER"),
+            () -> assertThat(memberTypeOf("group-1")).isEqualTo(io.gravitee.rest.api.model.MembershipMemberType.GROUP)
+        );
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private String currentRoleOf(String userId) {
+        var member = membershipDomainService
+            .storage()
+            .stream()
+            .filter(m -> m.getId().equals(userId))
+            .findFirst();
+        assertThat(member).as("No member found with id: " + userId).isPresent();
+        var role = member.get().getRoles().stream().findFirst();
+        assertThat(role).as("Member '" + userId + "' has no roles assigned").isPresent();
+        return role.get().getName();
+    }
+
+    private io.gravitee.rest.api.model.MembershipMemberType memberTypeOf(String memberId) {
+        var member = membershipDomainService
+            .storage()
+            .stream()
+            .filter(m -> m.getId().equals(memberId))
+            .findFirst();
+        assertThat(member).as("No member found with id: " + memberId).isPresent();
+        return member.get().getType();
+    }
+
+    private void initData() {
+        membershipDomainService.initWith(
+            List.of(
+                MemberEntity.builder()
+                    .id("user-1")
+                    .referenceId(API_PRODUCT_ID)
+                    .referenceType(MembershipReferenceType.API_PRODUCT)
+                    .roles(List.of(RoleEntity.builder().name("PRIMARY_OWNER").scope(RoleScope.API_PRODUCT).build()))
+                    .build(),
+                MemberEntity.builder()
+                    .id("user-2")
+                    .referenceId(API_PRODUCT_ID)
+                    .referenceType(MembershipReferenceType.API_PRODUCT)
+                    .roles(List.of(RoleEntity.builder().name("USER").scope(RoleScope.API_PRODUCT).build()))
+                    .build()
+            )
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_TransferOwnershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_TransferOwnershipTest.java
@@ -408,6 +408,61 @@ public class MembershipService_TransferOwnershipTest {
     }
 
     @Test
+    public void shouldNotRemoveGroupFromApiProductWhenTransferringOwnershipFromGroup() throws TechnicalException {
+        String apiProductId = "api-product-id-1";
+        String apiProductPoRoleId = "API_PRODUCT_PRIMARY_OWNER";
+
+        RoleEntity poRole = new RoleEntity();
+        poRole.setId(apiProductPoRoleId);
+        poRole.setScope(RoleScope.API_PRODUCT);
+        poRole.setName(SystemRole.PRIMARY_OWNER.name());
+
+        lenient()
+            .when(roleService.findScopeByMembershipReferenceType(io.gravitee.rest.api.model.MembershipReferenceType.API_PRODUCT))
+            .thenReturn(RoleScope.API_PRODUCT);
+        lenient().when(roleService.findPrimaryOwnerRoleByOrganization(ORGANIZATION_ID, RoleScope.API_PRODUCT)).thenReturn(poRole);
+        lenient()
+            .when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID))
+            .thenReturn(Optional.of(poRole));
+
+        // Group is the current primary owner of the API Product
+        Membership groupPoMembership = new Membership();
+        groupPoMembership.setId("ap-membership-id-1");
+        groupPoMembership.setReferenceType(MembershipReferenceType.API_PRODUCT);
+        groupPoMembership.setRoleId(apiProductPoRoleId);
+        groupPoMembership.setReferenceId(apiProductId);
+        groupPoMembership.setMemberId(GROUP_ID);
+        groupPoMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.GROUP);
+
+        lenient()
+            .when(membershipRepository.findByReferenceAndRoleId(MembershipReferenceType.API_PRODUCT, apiProductId, apiProductPoRoleId))
+            .thenReturn(Set.of(groupPoMembership));
+        // Allow repository lookups for role assignment/removal to return empty (no pre-existing roles)
+        lenient()
+            .when(
+                membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceIdAndRoleId(any(), any(), any(), any(), any())
+            )
+            .thenReturn(Set.of());
+
+        RoleEntity fallbackRole = new RoleEntity();
+        fallbackRole.setId("API_PRODUCT_USER");
+        fallbackRole.setName("USER");
+        fallbackRole.setScope(RoleScope.API_PRODUCT);
+
+        membershipService.transferOwnership(
+            EXECUTION_CONTEXT,
+            io.gravitee.rest.api.model.MembershipReferenceType.API_PRODUCT,
+            RoleScope.API_PRODUCT,
+            apiProductId,
+            new MembershipService.MembershipMember(USER_ID, null, MembershipMemberType.USER),
+            List.of(fallbackRole)
+        );
+
+        // removeGroup must NOT be called for API_PRODUCT — only API references trigger the group cleanup
+        verify(apiGroupService, never()).removeGroup(any(), any(), any());
+    }
+
+    @Test
     public void shouldDoNothingWhenTransferringOwnershipToSameOwner() throws TechnicalException {
         RoleEntity poRole = new RoleEntity();
         poRole.setId(API_PRIMARY_OWNER_ROLE_ID);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13377

## Description

Adds backend support for transferring PRIMARY_OWNER of an API Product to another user or group, mirroring the existing feature available for APIs, Applications, and Clusters.

**New endpoint:**
`POST /v2/environments/{envId}/api-products/{apiProductId}/members/_transfer-ownership`

**Key changes:**
- New use case `TransferApiProductOwnershipUseCase` (existence check + ownership delegation)
- `TransferOwnership` domain model extended with `memberType` to support GROUP as new owner
- `MembershipDomainServiceLegacyWrapper` updated: dynamic member type resolution + empty-ID validation
- fixed approach in `MembershipServiceImpl`: `removeGroup` was called unconditionally for GROUP owners, causing `ApiNotFoundException` on non-API references — now guarded to fire only for `API` reference type

<details>
<summary>Architecture flow — API Product transfer ownership</summary>

```
POST /members/_transfer-ownership
  → ApiProductMembersResource  [@Permission API_PRODUCT_MEMBER[UPDATE]]
  → MembershipMapper           [userType → memberType]
  → TransferApiProductOwnershipUseCase
      ├── ApiProductQueryService.findById()       → 404 if missing
  → MembershipDomainServiceLegacyWrapper
      ├── validateTransferOwnership()             → 400 (bad role / empty owner)
      ├── roleService.findByScopeAndName()
  → MembershipService.transferOwnership()
      ├── assign PRIMARY_OWNER to new owner (USER or GROUP)
      ├── assign fallback role to old owner
      └── removeGroup → only if referenceType == API  [bug fix]
  → MongoDB memberships
  → 204 No Content
```

</details>

<details>
<summary>Architecture flow — API transfer ownership (for comparison)</summary>

```
POST /apis/{apiId}/_transfer-ownership
  → ApiMembersResource  [@Permission API_MEMBER[UPDATE]]
  → TransferApiOwnershipUseCase
  → MembershipDomainServiceLegacyWrapper  [same path]
  → MembershipService.transferOwnership()
      └── removeGroup / addGroup → always fires (API only, so correct)
  → 204 No Content
```

</details>

### Endpoint scenarios

Request body example:
```json
{
  "newPrimaryOwnerId": "user-uuid-or-group-id",
  "userReference": null,
  "currentPrimaryOwnerNewRole": "OWNER",
  "userType": "USER"
}
```

| Scenario | `userType` | Expected | Notes |
|---|---|---|---|
| USER → USER | `USER` (or omit) | `204` | Standard transfer between users |
| USER → GROUP | `GROUP` | `204` | Group becomes new PRIMARY_OWNER |
| GROUP → GROUP | `GROUP` | `204` | Transfer between two groups |
| GROUP → USER | `USER` | `204` | Group gives ownership to a user |
| API Product not found | any | `404` | AP ID is wrong |
| `currentPrimaryOwnerNewRole: PRIMARY_OWNER` | any | `400` | Cannot assign PRIMARY_OWNER as fallback |
| Empty `newPrimaryOwnerId` + no `userReference` | any | `400` | New owner must be identified |

### Notes — API vs API Product contract

**API request body:**
```json
{
  "userId": "6e4518ce-...",
  "userReference": null,
  "poRole": "USER",
  "userType": "USER"
}
```

**API Product request body:**
```json
{
  "newPrimaryOwnerId": "6e4518ce-...",
  "userReference": null,
  "currentPrimaryOwnerNewRole": "OWNER",
  "userType": "USER"
}
```

| Field | API | API Product |
|---|---|---|
| New owner ID | `userId` | `newPrimaryOwnerId` |
| Fallback role | `poRole` | `currentPrimaryOwnerNewRole` |
| New owner type | `userType` | `userType` |
| Identity ref | `userReference` | `userReference` |
| `If-Match` header | required | not required |

Field names differ because API Product follows the **Cluster pattern** (newer contract), while API uses the original legacy naming.

**`/members` in path:**
- **API**: `…/apis/{apiId}/_transfer-ownership` — transfer sits directly on the resource (legacy, pre-Cluster era)
- **Cluster**: `…/clusters/{clusterId}/members/_transfer-ownership` — correctly scoped under `/members`
- **API Product**: `…/api-products/{apiProductId}/members/_transfer-ownership` — same as Cluster; semantically correct since transfer ownership is a membership operation

### Video : 

https://github.com/user-attachments/assets/5b7c36f8-7e5a-4dbf-a3da-2140ad5aa1c1

