### PR TITLE
refactor(redis): migrate rate-limit and distributed-sync to VertxRedisClientFactory

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-redis/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/pom.xml
@@ -50,6 +50,24 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>io.gravitee.node</groupId>
+			<artifactId>gravitee-node-vertx</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.gravitee.node</groupId>
+			<artifactId>gravitee-node-logging</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>io.gravitee.plugin</groupId>
+			<artifactId>gravitee-plugin-common-configurations</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- Runtime scope -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/common/RedisConnectionFactory.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/common/RedisConnectionFactory.java
@@ -15,21 +15,26 @@
  */
 package io.gravitee.repository.redis.common;
 
+import io.gravitee.node.vertx.client.redis.VertxRedisClientFactory;
+import io.gravitee.plugin.configurations.redis.HostAndPort;
+import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.plugin.configurations.redis.RedisSentinelOptions;
+import io.gravitee.plugin.configurations.ssl.KeyStore;
+import io.gravitee.plugin.configurations.ssl.SslOptions;
+import io.gravitee.plugin.configurations.ssl.TrustStore;
+import io.gravitee.plugin.configurations.ssl.jks.JKSKeyStore;
+import io.gravitee.plugin.configurations.ssl.jks.JKSTrustStore;
+import io.gravitee.plugin.configurations.ssl.none.NoneKeyStore;
+import io.gravitee.plugin.configurations.ssl.none.NoneTrustStore;
+import io.gravitee.plugin.configurations.ssl.pem.PEMKeyStore;
+import io.gravitee.plugin.configurations.ssl.pem.PEMTrustStore;
+import io.gravitee.plugin.configurations.ssl.pkcs12.PKCS12KeyStore;
+import io.gravitee.plugin.configurations.ssl.pkcs12.PKCS12TrustStore;
 import io.gravitee.repository.redis.vertx.RedisClient;
 import io.vertx.core.Vertx;
-import io.vertx.core.net.JksOptions;
-import io.vertx.core.net.NetClientOptions;
-import io.vertx.core.net.OpenSSLEngineOptions;
-import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.PemTrustOptions;
-import io.vertx.core.net.PfxOptions;
-import io.vertx.redis.client.RedisClientType;
-import io.vertx.redis.client.RedisOptions;
-import io.vertx.redis.client.RedisRole;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
@@ -47,7 +52,6 @@ public class RedisConnectionFactory {
     private final Map<String, String> scripts;
 
     private static final String SENTINEL_PARAMETER_PREFIX = "sentinel.";
-
     private static final String PASSWORD_PARAMETER = "password";
 
     private static final String STORE_FORMAT_JKS = "JKS";
@@ -67,27 +71,26 @@ public class RedisConnectionFactory {
     }
 
     public RedisClient createRedisClient() {
-        return new RedisClient(vertx, buildRedisOptions(), scripts);
+        RedisClientOptions options = buildRedisClientOptions();
+        VertxRedisClientFactory factory = new VertxRedisClientFactory(vertx);
+        return new RedisClient(vertx, factory, options, scripts);
     }
 
-    protected RedisOptions buildRedisOptions() {
-        final RedisOptions options = new RedisOptions();
+    protected RedisClientOptions buildRedisClientOptions() {
+        RedisClientOptions.RedisClientOptionsBuilder builder = RedisClientOptions.builder();
 
         boolean ssl = readPropertyValue(propertyPrefix + "ssl", boolean.class, false);
         String username = readPropertyValue(propertyPrefix + "username", String.class, null);
+        String password = readPropertyValue(propertyPrefix + PASSWORD_PARAMETER, String.class);
+
+        builder.host(readPropertyValue(propertyPrefix + "host", String.class, "localhost"));
+        builder.port(readPropertyValue(propertyPrefix + "port", int.class, 6379));
+        builder.username(username);
+        builder.password(password);
+        builder.useSsl(ssl);
 
         if (isSentinelEnabled()) {
-            // Sentinels + Redis master / replicas
             log.debug("Redis repository configured to use Sentinel connection");
-
-            options.setType(RedisClientType.SENTINEL);
-            List<HostAndPort> sentinelNodes = getSentinelNodes();
-
-            // Redis Password
-            String password = readPropertyValue(propertyPrefix + PASSWORD_PARAMETER, String.class);
-            sentinelNodes.forEach(hostAndPort ->
-                options.addConnectionString(hostAndPort.withPassword(password).withSsl(ssl).toConnectionString())
-            );
 
             String redisMaster = readPropertyValue(propertyPrefix + SENTINEL_PARAMETER_PREFIX + "master", String.class);
             if (!StringUtils.hasText(redisMaster)) {
@@ -95,149 +98,110 @@ public class RedisConnectionFactory {
                     "Incorrect Sentinel configuration : parameter '" + propertyPrefix + SENTINEL_PARAMETER_PREFIX + "master' is mandatory!"
                 );
             }
-            options.setMasterName(redisMaster).setRole(RedisRole.MASTER);
 
-            // Sentinel Password
             String sentinelPassword = readPropertyValue(
                 propertyPrefix + SENTINEL_PARAMETER_PREFIX + PASSWORD_PARAMETER,
                 String.class,
                 null
             );
-            options.setPassword(sentinelPassword);
+
+            builder.sentinel(
+                RedisSentinelOptions.builder().masterId(redisMaster).password(sentinelPassword).nodes(getSentinelNodes()).build()
+            );
         } else {
-            // Standalone Redis
             log.debug("Redis repository configured to use standalone connection");
-
-            options.setType(RedisClientType.STANDALONE);
-
-            HostAndPort hostAndPort = HostAndPort.of(
-                readPropertyValue(propertyPrefix + "host", String.class, "localhost"),
-                readPropertyValue(propertyPrefix + "port", int.class, 6379)
-            )
-                .withUsername(username)
-                .withPassword(readPropertyValue(propertyPrefix + PASSWORD_PARAMETER, String.class))
-                .withSsl(ssl);
-
-            options.setConnectionString(hostAndPort.toConnectionString());
         }
 
-        // SSL
         if (ssl) {
             log.debug("Redis repository configured with ssl enabled");
-
-            boolean trustAll = readPropertyValue(propertyPrefix + "trustAll", boolean.class, true);
-            options.getNetClientOptions().setSsl(true);
-            options.getNetClientOptions().setTrustAll(trustAll);
-
-            String hostnameVerificationAlgorithm = readPropertyValue(
-                propertyPrefix + "hostnameVerificationAlgorithm",
-                String.class,
-                "NONE"
-            );
-            if ("NONE".equals(hostnameVerificationAlgorithm)) {
-                options.getNetClientOptions().setHostnameVerificationAlgorithm("");
-            } else {
-                options.getNetClientOptions().setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
-            }
-
-            // TLS Protocols
-            options
-                .getNetClientOptions()
-                .setEnabledSecureTransportProtocols(
-                    StringUtils.commaDelimitedListToSet(
-                        StringUtils.trimAllWhitespace(readPropertyValue(propertyPrefix + "tlsProtocols", String.class, ""))
-                    )
-                );
-
-            // TLS Ciphers
-            StringUtils.commaDelimitedListToSet(readPropertyValue(propertyPrefix + "tlsCiphers", String.class, "")).forEach(cipherSuite ->
-                options.getNetClientOptions().addEnabledCipherSuite(cipherSuite.strip())
-            );
-
-            options.getNetClientOptions().setUseAlpn(readPropertyValue(propertyPrefix + "alpn", boolean.class, false));
-
-            if (readPropertyValue(propertyPrefix + "openssl", boolean.class, false)) {
-                options.getNetClientOptions().setSslEngineOptions(new OpenSSLEngineOptions());
-            }
-
-            if (!trustAll) {
-                // Client truststore configuration (trust server certificate).
-                configureTrustStore(options.getNetClientOptions());
-            } else {
-                log.warn("Redis repository configured with ssl and trustAll which is not a good practice for security");
-            }
-
-            // Client keystore configuration (client certificate for mtls).
-            configureKeyStore(options.getNetClientOptions());
+            builder.ssl(buildSslOptions());
         }
 
-        // Set max waiting handlers high enough to manage high throughput since we are not using the pooled mode
-        options.setMaxWaitingHandlers(1024);
+        builder.connectTimeout(readPropertyValue(propertyPrefix + "tcp.connectTimeout", int.class, 5000));
+        builder.idleTimeout(readPropertyValue(propertyPrefix + "tcp.idleTimeout", int.class, 0));
 
-        // Enforce timeouts with default ones if not defined.
-        options
-            .getNetClientOptions()
-            .setConnectTimeout(readPropertyValue(propertyPrefix + "tcp.connectTimeout", int.class, 5000))
-            .setIdleTimeout(readPropertyValue(propertyPrefix + "tcp.idleTimeout", int.class, 0))
-            .setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
-
-        return options;
+        return builder.build();
     }
 
-    private void configureTrustStore(NetClientOptions netClientOptions) {
+    private SslOptions buildSslOptions() {
+        SslOptions sslOptions = new SslOptions();
+        boolean trustAll = readPropertyValue(propertyPrefix + "trustAll", boolean.class, true);
+        sslOptions.setTrustAll(trustAll);
+
+        String hostnameVerificationAlgorithm = readPropertyValue(propertyPrefix + "hostnameVerificationAlgorithm", String.class, "NONE");
+        sslOptions.setHostnameVerificationAlgorithm(hostnameVerificationAlgorithm);
+        sslOptions.setHostnameVerifier(!"NONE".equalsIgnoreCase(hostnameVerificationAlgorithm));
+
+        String tlsProtocols = readPropertyValue(propertyPrefix + "tlsProtocols", String.class, "");
+        if (StringUtils.hasText(tlsProtocols)) {
+            sslOptions.setTlsProtocols(StringUtils.commaDelimitedListToSet(StringUtils.trimAllWhitespace(tlsProtocols)));
+        }
+
+        String tlsCiphers = readPropertyValue(propertyPrefix + "tlsCiphers", String.class, "");
+        if (StringUtils.hasText(tlsCiphers)) {
+            sslOptions.setTlsCiphers(new java.util.ArrayList<>(StringUtils.commaDelimitedListToSet(tlsCiphers)));
+        }
+
+        sslOptions.setAlpn(readPropertyValue(propertyPrefix + "alpn", boolean.class, false));
+        sslOptions.setOpenSsl(readPropertyValue(propertyPrefix + "openssl", boolean.class, false));
+
+        if (!trustAll) {
+            sslOptions.setTrustStore(buildTrustStore());
+        }
+
+        sslOptions.setKeyStore(buildKeyStore());
+
+        return sslOptions;
+    }
+
+    private TrustStore buildTrustStore() {
         String truststorePropertyPrefix = propertyPrefix + "truststore.";
         String truststorePath = readPropertyValue(truststorePropertyPrefix + "path", String.class);
         String truststoreType = readPropertyValue(truststorePropertyPrefix + "type", String.class);
         String truststorePassword = readPropertyValue(truststorePropertyPrefix + "password", String.class);
         String truststoreAlias = readPropertyValue(truststorePropertyPrefix + "alias", String.class);
 
-        if (StringUtils.hasText(truststoreType)) {
-            switch (truststoreType.toUpperCase()) {
-                case STORE_FORMAT_PEM:
-                    final PemTrustOptions pemTrustOptions = new PemTrustOptions();
-
-                    if (StringUtils.hasText(truststorePath)) {
-                        pemTrustOptions.addCertPath(truststorePath);
-                    } else {
-                        throw new IllegalArgumentException("Missing PEM truststore value");
-                    }
-
-                    netClientOptions.setTrustOptions(pemTrustOptions);
-                    break;
-                case STORE_FORMAT_PKCS12:
-                    final PfxOptions pfxOptions = new PfxOptions();
-
-                    if (StringUtils.hasText(truststorePath)) {
-                        pfxOptions.setPath(truststorePath);
-                    } else {
-                        throw new IllegalArgumentException("Missing PKCS12 truststore value");
-                    }
-
-                    pfxOptions.setAlias(truststoreAlias);
-                    pfxOptions.setPassword(truststorePassword);
-                    netClientOptions.setTrustOptions(pfxOptions);
-                    break;
-                case STORE_FORMAT_JKS:
-                    final JksOptions jksOptions = new JksOptions();
-
-                    if (StringUtils.hasText(truststorePath)) {
-                        jksOptions.setPath(truststorePath);
-                    } else {
-                        throw new IllegalArgumentException("Missing JKS truststore value");
-                    }
-
-                    jksOptions.setAlias(truststoreAlias);
-                    jksOptions.setPassword(truststorePassword);
-                    netClientOptions.setTrustOptions(jksOptions);
-                    break;
-                default:
-                    log.error("Unknown type of Truststore provided {}", truststoreType);
-                    break;
-            }
+        if (!StringUtils.hasText(truststoreType)) {
+            return new NoneTrustStore();
         }
+
+        return switch (truststoreType.toUpperCase()) {
+            case STORE_FORMAT_PEM -> {
+                if (!StringUtils.hasText(truststorePath)) {
+                    throw new IllegalArgumentException("Missing PEM truststore value");
+                }
+                PEMTrustStore pemTrustStore = new PEMTrustStore();
+                pemTrustStore.setPath(truststorePath);
+                yield pemTrustStore;
+            }
+            case STORE_FORMAT_PKCS12 -> {
+                if (!StringUtils.hasText(truststorePath)) {
+                    throw new IllegalArgumentException("Missing PKCS12 truststore value");
+                }
+                PKCS12TrustStore pkcs12TrustStore = new PKCS12TrustStore();
+                pkcs12TrustStore.setPath(truststorePath);
+                pkcs12TrustStore.setAlias(truststoreAlias);
+                pkcs12TrustStore.setPassword(truststorePassword);
+                yield pkcs12TrustStore;
+            }
+            case STORE_FORMAT_JKS -> {
+                if (!StringUtils.hasText(truststorePath)) {
+                    throw new IllegalArgumentException("Missing JKS truststore value");
+                }
+                JKSTrustStore jksTrustStore = new JKSTrustStore();
+                jksTrustStore.setPath(truststorePath);
+                jksTrustStore.setAlias(truststoreAlias);
+                jksTrustStore.setPassword(truststorePassword);
+                yield jksTrustStore;
+            }
+            default -> {
+                log.error("Unknown type of Truststore provided {}", truststoreType);
+                yield new NoneTrustStore();
+            }
+        };
     }
 
-    private void configureKeyStore(NetClientOptions netClientOptions) {
+    private KeyStore buildKeyStore() {
         String keystorePropertyPrefix = propertyPrefix + "keystore.";
         String keystorePath = readPropertyValue(keystorePropertyPrefix + "path", String.class);
         String keystorePassword = readPropertyValue(keystorePropertyPrefix + "password", String.class);
@@ -245,63 +209,62 @@ public class RedisConnectionFactory {
         String keystoreType = readPropertyValue(keystorePropertyPrefix + "type", String.class);
         String keystoreAlias = readPropertyValue(keystorePropertyPrefix + "alias", String.class);
 
-        if (StringUtils.hasText(keystoreType)) {
-            switch (keystoreType.toUpperCase()) {
-                case STORE_FORMAT_PEM:
-                    final PemKeyCertOptions pemKeyCertOptions = new PemKeyCertOptions();
-
-                    for (
-                        int idx = 0;
-                        StringUtils.hasText(readPropertyValue(keystorePropertyPrefix + "certificates[" + idx + "].cert", String.class));
-                        idx++
-                    ) {
-                        pemKeyCertOptions.addCertPath(
-                            readPropertyValue(keystorePropertyPrefix + "certificates[" + idx + "].cert", String.class)
-                        );
-                        pemKeyCertOptions.addKeyPath(
-                            readPropertyValue(keystorePropertyPrefix + "certificates[" + idx + "].key", String.class)
-                        );
-                    }
-
-                    if (pemKeyCertOptions.getCertPaths().isEmpty()) {
-                        throw new IllegalArgumentException("Missing PEM keystore value");
-                    }
-
-                    netClientOptions.setKeyCertOptions(pemKeyCertOptions);
-                    break;
-                case STORE_FORMAT_PKCS12:
-                    final PfxOptions pfxOptions = new PfxOptions();
-
-                    if (StringUtils.hasText(keystorePath)) {
-                        pfxOptions.setPath(keystorePath);
-                    } else {
-                        throw new IllegalArgumentException("Missing PKCS12 keystore value");
-                    }
-
-                    pfxOptions.setAlias(keystoreAlias);
-                    pfxOptions.setAliasPassword(keyPassword);
-                    pfxOptions.setPassword(keystorePassword);
-                    netClientOptions.setKeyCertOptions(pfxOptions);
-                    break;
-                case STORE_FORMAT_JKS:
-                    final JksOptions jksOptions = new JksOptions();
-
-                    if (StringUtils.hasText(keystorePath)) {
-                        jksOptions.setPath(keystorePath);
-                    } else {
-                        throw new IllegalArgumentException("Missing JKS keystore value");
-                    }
-
-                    jksOptions.setAlias(keystoreAlias);
-                    jksOptions.setAliasPassword(keyPassword);
-                    jksOptions.setPassword(keystorePassword);
-                    netClientOptions.setKeyCertOptions(jksOptions);
-                    break;
-                default:
-                    log.error("Unknown type of Keystore provided {}", keystoreType);
-                    break;
-            }
+        if (!StringUtils.hasText(keystoreType)) {
+            return new NoneKeyStore();
         }
+
+        return switch (keystoreType.toUpperCase()) {
+            case STORE_FORMAT_PEM -> {
+                List<String> certPaths = new ArrayList<>();
+                List<String> keyPaths = new ArrayList<>();
+                for (
+                    int idx = 0;
+                    StringUtils.hasText(readPropertyValue(keystorePropertyPrefix + "certificates[" + idx + "].cert", String.class));
+                    idx++
+                ) {
+                    certPaths.add(readPropertyValue(keystorePropertyPrefix + "certificates[" + idx + "].cert", String.class));
+                    keyPaths.add(readPropertyValue(keystorePropertyPrefix + "certificates[" + idx + "].key", String.class));
+                }
+                if (certPaths.isEmpty()) {
+                    throw new IllegalArgumentException("Missing PEM keystore value");
+                }
+                PEMKeyStore pemKeyStore = new PEMKeyStore();
+                if (certPaths.size() == 1) {
+                    pemKeyStore.setCertPath(certPaths.get(0));
+                    pemKeyStore.setKeyPath(keyPaths.get(0));
+                } else {
+                    pemKeyStore.setCertPaths(certPaths);
+                    pemKeyStore.setKeyPaths(keyPaths);
+                }
+                yield pemKeyStore;
+            }
+            case STORE_FORMAT_PKCS12 -> {
+                if (!StringUtils.hasText(keystorePath)) {
+                    throw new IllegalArgumentException("Missing PKCS12 keystore value");
+                }
+                PKCS12KeyStore pkcs12KeyStore = new PKCS12KeyStore();
+                pkcs12KeyStore.setPath(keystorePath);
+                pkcs12KeyStore.setAlias(keystoreAlias);
+                pkcs12KeyStore.setKeyPassword(keyPassword);
+                pkcs12KeyStore.setPassword(keystorePassword);
+                yield pkcs12KeyStore;
+            }
+            case STORE_FORMAT_JKS -> {
+                if (!StringUtils.hasText(keystorePath)) {
+                    throw new IllegalArgumentException("Missing JKS keystore value");
+                }
+                JKSKeyStore jksKeyStore = new JKSKeyStore();
+                jksKeyStore.setPath(keystorePath);
+                jksKeyStore.setAlias(keystoreAlias);
+                jksKeyStore.setKeyPassword(keyPassword);
+                jksKeyStore.setPassword(keystorePassword);
+                yield jksKeyStore;
+            }
+            default -> {
+                log.error("Unknown type of Keystore provided {}", keystoreType);
+                yield new NoneKeyStore();
+            }
+        };
     }
 
     private <T> T readPropertyValue(String propertyName, Class<T> propertyType) {
@@ -327,59 +290,8 @@ public class RedisConnectionFactory {
         ) {
             String host = readPropertyValue(propertyPrefix + SENTINEL_PARAMETER_PREFIX + "nodes[" + idx + "].host", String.class);
             int port = readPropertyValue(propertyPrefix + SENTINEL_PARAMETER_PREFIX + "nodes[" + idx + "].port", int.class);
-            nodes.add(HostAndPort.of(host, port));
+            nodes.add(HostAndPort.builder().host(host).port(port).build());
         }
         return nodes;
-    }
-
-    private static class HostAndPort {
-
-        private final String host;
-        private final int port;
-        private String password;
-        private boolean useSsl;
-        private String username;
-
-        private HostAndPort(String host, int port) {
-            this.host = host;
-            this.port = port;
-        }
-
-        static HostAndPort of(String host, int port) {
-            return new HostAndPort(host, port);
-        }
-
-        public HostAndPort withPassword(String password) {
-            this.password = password;
-
-            return this;
-        }
-
-        public HostAndPort withUsername(String username) {
-            this.username = username;
-            return this;
-        }
-
-        public HostAndPort withSsl(boolean useSsl) {
-            this.useSsl = useSsl;
-
-            return this;
-        }
-
-        public String toConnectionString() {
-            String connectionType = "redis";
-
-            if (useSsl) {
-                connectionType = "rediss";
-            }
-            if (StringUtils.hasText(username) && StringUtils.hasText(password)) {
-                log.debug("Redis repository configured with username and password");
-                return connectionType + "://" + username + ":" + password + '@' + host + ':' + port;
-            } else if (StringUtils.hasText(password)) {
-                return connectionType + "://:" + password + '@' + host + ':' + port;
-            } else {
-                return connectionType + "://" + host + ':' + port;
-            }
-        }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
@@ -15,12 +15,13 @@
  */
 package io.gravitee.repository.redis.vertx;
 
+import io.gravitee.node.vertx.client.redis.VertxRedisClientFactory;
+import io.gravitee.plugin.configurations.redis.RedisClientOptions;
 import io.gravitee.repository.redis.ratelimit.RedisRateLimitRepository;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.redis.client.Redis;
 import io.vertx.redis.client.RedisAPI;
-import io.vertx.redis.client.RedisOptions;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -41,7 +42,8 @@ public class RedisClient {
     private static final String SCRIPT_LOAD_COMMAND = "LOAD";
 
     private final Vertx vertx;
-    private final RedisOptions options;
+    private final VertxRedisClientFactory factory;
+    private final RedisClientOptions clientOptions;
     private final Map<String, String> scripts;
     private final Map<String, String> scriptsSha = new HashMap<>();
     private Future<RedisAPI> redisAPIFuture;
@@ -50,9 +52,15 @@ public class RedisClient {
     private final AtomicBoolean connecting = new AtomicBoolean(false);
     private Redis redis;
 
-    public RedisClient(final Vertx vertx, final RedisOptions options, final Map<String, String> scripts) {
+    public RedisClient(
+        final Vertx vertx,
+        final VertxRedisClientFactory factory,
+        final RedisClientOptions clientOptions,
+        final Map<String, String> scripts
+    ) {
         this.vertx = vertx;
-        this.options = options;
+        this.factory = factory;
+        this.clientOptions = clientOptions;
         this.scripts = scripts;
         this.connect(0);
     }
@@ -62,7 +70,6 @@ public class RedisClient {
     }
 
     private void connect(final int retry) {
-        // Cleanup any already existing connection.
         if (redis != null) {
             redis.close();
             redis = null;
@@ -70,18 +77,12 @@ public class RedisClient {
         }
 
         if (connecting.compareAndSet(false, true)) {
-            redis = Redis.createClient(vertx, options);
+            redis = factory.createClient(clientOptions);
             this.redisAPIFuture = redis
                 .connect()
                 .onSuccess(conn -> {
                     log.debug("Connected to Redis");
-                    // make sure the client is reconnected on error
-                    conn.exceptionHandler(e ->
-                        // attempt to reconnect,
-                        // if there is an unrecoverable error
-                        attemptReconnect(0)
-                    );
-                    // make sure the client is reconnected on connection close
+                    conn.exceptionHandler(e -> attemptReconnect(0));
                     conn.endHandler(v -> attemptReconnect(0));
                 })
                 .flatMap(redisConnection -> {
@@ -93,7 +94,7 @@ public class RedisClient {
                     connecting.set(false);
                     connected.set(true);
                 })
-                .timeout(options.getNetClientOptions().getConnectTimeout(), TimeUnit.MILLISECONDS)
+                .timeout(clientOptions.getConnectTimeout(), TimeUnit.MILLISECONDS)
                 .onFailure(t -> {
                     log.error("Unable to connect to Redis", t);
                     connected.set(false);
@@ -102,13 +103,8 @@ public class RedisClient {
         }
     }
 
-    /**
-     * Attempt to reconnect
-     */
     private void attemptReconnect(int retry) {
         connecting.set(false);
-
-        // retry with backoff up to 10240 ms
         long backoff = (long) (Math.pow(2, Math.min(retry, 10)) * 10);
         vertx.setTimer(backoff, timer -> connect(retry + 1));
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/common/RedisConnectionFactoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/common/RedisConnectionFactoryTest.java
@@ -19,13 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
-import io.vertx.core.net.JksOptions;
-import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.PemTrustOptions;
-import io.vertx.core.net.PfxOptions;
-import io.vertx.redis.client.RedisOptions;
-import java.util.ArrayList;
-import java.util.List;
+import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.plugin.configurations.ssl.jks.JKSKeyStore;
+import io.gravitee.plugin.configurations.ssl.jks.JKSTrustStore;
+import io.gravitee.plugin.configurations.ssl.pem.PEMKeyStore;
+import io.gravitee.plugin.configurations.ssl.pem.PEMTrustStore;
+import io.gravitee.plugin.configurations.ssl.pkcs12.PKCS12KeyStore;
+import io.gravitee.plugin.configurations.ssl.pkcs12.PKCS12TrustStore;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,48 +51,52 @@ public class RedisConnectionFactoryTest {
     }
 
     @Test
-    void shouldReturnRedisOptionsWithSecuredEndpoint() {
+    void shouldReturnRedisClientOptionsWithSslEnabled() {
         environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
         environment.setProperty(PROPERTY_PREFIX + ".redis.port", "6379");
         environment.setProperty(PROPERTY_PREFIX + ".redis.ssl", "true");
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
         assertThat(options).isNotNull();
-        assertThat(options.getEndpoint()).isEqualTo("rediss://redis:6379");
+        assertThat(options.getHost()).isEqualTo("redis");
+        assertThat(options.getPort()).isEqualTo(6379);
+        assertThat(options.isUseSsl()).isTrue();
     }
 
     @Test
-    void shouldReturnRedisOptionsWithoutSecuredEndpoint() {
+    void shouldReturnRedisClientOptionsWithoutSsl() {
         environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
         environment.setProperty(PROPERTY_PREFIX + ".redis.port", "6379");
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
         assertThat(options).isNotNull();
-        assertThat(options.getEndpoint()).isEqualTo("redis://redis:6379");
+        assertThat(options.getHost()).isEqualTo("redis");
+        assertThat(options.getPort()).isEqualTo(6379);
+        assertThat(options.isUseSsl()).isFalse();
     }
 
     @Test
-    public void shouldReturnRedisOptionsWithSentinelsEndpoints() {
+    public void shouldReturnRedisClientOptionsWithSentinel() {
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.master", "redis-master");
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.nodes[0].host", "sent1");
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.nodes[0].port", "26379");
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.nodes[1].host", "sent2");
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.nodes[1].port", "26379");
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
-
-        List<String> sentinelEndpoints = new ArrayList<>();
-        sentinelEndpoints.add("redis://sent1:26379");
-        sentinelEndpoints.add("redis://sent2:26379");
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
         assertThat(options).isNotNull();
-        assertThat(options.getEndpoints()).containsAll(sentinelEndpoints);
+        assertThat(options.getSentinel()).isNotNull();
+        assertThat(options.getSentinel().getMasterId()).isEqualTo("redis-master");
+        assertThat(options.getSentinel().getNodes()).hasSize(2);
+        assertThat(options.getSentinel().getNodes().get(0).getHost()).isEqualTo("sent1");
+        assertThat(options.getSentinel().getNodes().get(1).getHost()).isEqualTo("sent2");
     }
 
     @Test
-    void shouldReturnRedisOptionsWithSentinelsSecuredEndpoints() {
+    void shouldReturnRedisClientOptionsWithSentinelAndSsl() {
         environment.setProperty(PROPERTY_PREFIX + ".redis.ssl", "true");
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.master", "redis-master");
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.nodes[0].host", "sent1");
@@ -100,15 +104,49 @@ public class RedisConnectionFactoryTest {
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.nodes[1].host", "sent2");
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.nodes[1].port", "26379");
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
-
-        List<String> sentinelEndpoints = new ArrayList<>();
-        sentinelEndpoints.add("rediss://sent1:26379");
-        sentinelEndpoints.add("rediss://sent2:26379");
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
         assertThat(options).isNotNull();
-        assertThat(options.getNetClientOptions().getHostnameVerificationAlgorithm()).isEqualTo("");
-        assertThat(options.getEndpoints()).containsAll(sentinelEndpoints);
+        assertThat(options.isUseSsl()).isTrue();
+        assertThat(options.getSsl()).isNotNull();
+        assertThat(options.getSsl().isHostnameVerifier()).isFalse();
+        assertThat(options.getSsl().getHostnameVerificationAlgorithm()).isEqualTo("NONE");
+        assertThat(options.getSentinel()).isNotNull();
+        assertThat(options.getSentinel().getMasterId()).isEqualTo("redis-master");
+        assertThat(options.getSentinel().getNodes()).hasSize(2);
+    }
+
+    @Test
+    void shouldPreserveLdapsHostnameVerificationAlgorithm() {
+        environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.port", "6379");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.ssl", "true");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.hostnameVerificationAlgorithm", "LDAPS");
+
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
+
+        assertThat(options.getSsl().getHostnameVerificationAlgorithm()).isEqualTo("LDAPS");
+        assertThat(options.getSsl().isHostnameVerifier()).isTrue();
+    }
+
+    @Test
+    void shouldReturnRedisClientOptionsWithMultiCertPemKeystore() {
+        environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.port", "6379");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.ssl", "true");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.trustAll", "true");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.type", "pem");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.certificates[0].cert", "/path/cert0.pem");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.certificates[0].key", "/path/key0.pem");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.certificates[1].cert", "/path/cert1.pem");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.certificates[1].key", "/path/key1.pem");
+
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
+
+        assertThat(options.getSsl().getKeyStore()).isInstanceOf(PEMKeyStore.class);
+        PEMKeyStore pemKeyStore = (PEMKeyStore) options.getSsl().getKeyStore();
+        assertThat(pemKeyStore.getCertPaths()).containsExactly("/path/cert0.pem", "/path/cert1.pem");
+        assertThat(pemKeyStore.getKeyPaths()).containsExactly("/path/key0.pem", "/path/key1.pem");
     }
 
     @Test
@@ -119,12 +157,12 @@ public class RedisConnectionFactoryTest {
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.nodes[1].port", "26379");
 
         assertThatIllegalStateException()
-            .isThrownBy(() -> redisConnectionFactory.buildRedisOptions())
+            .isThrownBy(() -> redisConnectionFactory.buildRedisClientOptions())
             .withMessageContaining("Incorrect Sentinel configuration");
     }
 
     @Test
-    void shouldReturnRedisOptionsWithPemTruststoreAndKeystore() {
+    void shouldReturnRedisClientOptionsWithPemTruststoreAndKeystore() {
         String keystoreCertPath = "/path/to/client.crt";
         String keystoreKeyPath = "/path/to/client.key";
         String truststorePath = "/path/to/ca.crt";
@@ -136,27 +174,27 @@ public class RedisConnectionFactoryTest {
         environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.type", "pem");
         environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.certificates[0].cert", keystoreCertPath);
         environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.certificates[0].key", keystoreKeyPath);
-
         environment.setProperty(PROPERTY_PREFIX + ".redis.truststore.type", "pem");
         environment.setProperty(PROPERTY_PREFIX + ".redis.truststore.path", truststorePath);
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
-
-        PemKeyCertOptions pemKeyCertOptions = new PemKeyCertOptions();
-        pemKeyCertOptions.addCertPath(keystoreCertPath);
-        pemKeyCertOptions.addKeyPath(keystoreKeyPath);
-
-        PemTrustOptions pemTrustOptions = new PemTrustOptions();
-        pemTrustOptions.addCertPath(truststorePath);
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
         assertThat(options).isNotNull();
-        assertThat(options.getNetClientOptions().getHostnameVerificationAlgorithm()).isEqualTo("HTTPS");
-        assertThat(options.getNetClientOptions().getKeyCertOptions()).usingRecursiveComparison().isEqualTo(pemKeyCertOptions);
-        assertThat(options.getNetClientOptions().getTrustOptions()).usingRecursiveComparison().isEqualTo(pemTrustOptions);
+        assertThat(options.getSsl()).isNotNull();
+        assertThat(options.getSsl().isHostnameVerifier()).isTrue();
+
+        assertThat(options.getSsl().getKeyStore()).isInstanceOf(PEMKeyStore.class);
+        PEMKeyStore pemKeyStore = (PEMKeyStore) options.getSsl().getKeyStore();
+        assertThat(pemKeyStore.getCertPath()).isEqualTo(keystoreCertPath);
+        assertThat(pemKeyStore.getKeyPath()).isEqualTo(keystoreKeyPath);
+
+        assertThat(options.getSsl().getTrustStore()).isInstanceOf(PEMTrustStore.class);
+        PEMTrustStore pemTrustStore = (PEMTrustStore) options.getSsl().getTrustStore();
+        assertThat(pemTrustStore.getPath()).isEqualTo(truststorePath);
     }
 
     @Test
-    void shouldReturnRedisOptionsWithPKCS12TruststoreAndKeystore() {
+    void shouldReturnRedisClientOptionsWithPKCS12TruststoreAndKeystore() {
         String keystorePath = "/path/to/client.pkcs12";
         String truststorePath = "/path/to/ca.pkcs12";
         environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
@@ -165,25 +203,20 @@ public class RedisConnectionFactoryTest {
         environment.setProperty(PROPERTY_PREFIX + ".redis.trustAll", "false");
         environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.type", "pkcs12");
         environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.path", keystorePath);
-
         environment.setProperty(PROPERTY_PREFIX + ".redis.truststore.type", "pkcs12");
         environment.setProperty(PROPERTY_PREFIX + ".redis.truststore.path", truststorePath);
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
-
-        PfxOptions keystorePfxOptions = new PfxOptions();
-        keystorePfxOptions.setPath(keystorePath);
-
-        PfxOptions truststorePfxOptions = new PfxOptions();
-        truststorePfxOptions.setPath(truststorePath);
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
         assertThat(options).isNotNull();
-        assertThat(options.getNetClientOptions().getKeyCertOptions()).usingRecursiveComparison().isEqualTo(keystorePfxOptions);
-        assertThat(options.getNetClientOptions().getTrustOptions()).usingRecursiveComparison().isEqualTo(truststorePfxOptions);
+        assertThat(options.getSsl().getKeyStore()).isInstanceOf(PKCS12KeyStore.class);
+        assertThat(((PKCS12KeyStore) options.getSsl().getKeyStore()).getPath()).isEqualTo(keystorePath);
+        assertThat(options.getSsl().getTrustStore()).isInstanceOf(PKCS12TrustStore.class);
+        assertThat(((PKCS12TrustStore) options.getSsl().getTrustStore()).getPath()).isEqualTo(truststorePath);
     }
 
     @Test
-    void shouldReturnRedisOptionsWithJKSTruststoreAndKeystore() {
+    void shouldReturnRedisClientOptionsWithJKSTruststoreAndKeystore() {
         String keystorePath = "/path/to/client.jks";
         String truststorePath = "/path/to/ca.jks";
         environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
@@ -192,21 +225,16 @@ public class RedisConnectionFactoryTest {
         environment.setProperty(PROPERTY_PREFIX + ".redis.trustAll", "false");
         environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.type", "jks");
         environment.setProperty(PROPERTY_PREFIX + ".redis.keystore.path", keystorePath);
-
         environment.setProperty(PROPERTY_PREFIX + ".redis.truststore.type", "jks");
         environment.setProperty(PROPERTY_PREFIX + ".redis.truststore.path", truststorePath);
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
-
-        JksOptions keystoreJksOptions = new JksOptions();
-        keystoreJksOptions.setPath(keystorePath);
-
-        JksOptions truststoreJksOptions = new JksOptions();
-        truststoreJksOptions.setPath(truststorePath);
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
         assertThat(options).isNotNull();
-        assertThat(options.getNetClientOptions().getKeyCertOptions()).usingRecursiveComparison().isEqualTo(keystoreJksOptions);
-        assertThat(options.getNetClientOptions().getTrustOptions()).usingRecursiveComparison().isEqualTo(truststoreJksOptions);
+        assertThat(options.getSsl().getKeyStore()).isInstanceOf(JKSKeyStore.class);
+        assertThat(((JKSKeyStore) options.getSsl().getKeyStore()).getPath()).isEqualTo(keystorePath);
+        assertThat(options.getSsl().getTrustStore()).isInstanceOf(JKSTrustStore.class);
+        assertThat(((JKSTrustStore) options.getSsl().getTrustStore()).getPath()).isEqualTo(truststorePath);
     }
 
     @ParameterizedTest
@@ -221,7 +249,7 @@ public class RedisConnectionFactoryTest {
         environment.setProperty(PROPERTY_PREFIX + ".redis.truststore.path", "truststorePath");
 
         assertThatIllegalArgumentException()
-            .isThrownBy(() -> redisConnectionFactory.buildRedisOptions())
+            .isThrownBy(() -> redisConnectionFactory.buildRedisClientOptions())
             .withMessageContaining("Missing " + keystoreType + " keystore value");
     }
 
@@ -237,56 +265,58 @@ public class RedisConnectionFactoryTest {
         environment.setProperty(PROPERTY_PREFIX + ".redis.truststore.type", truststoreType);
 
         assertThatIllegalArgumentException()
-            .isThrownBy(() -> redisConnectionFactory.buildRedisOptions())
+            .isThrownBy(() -> redisConnectionFactory.buildRedisClientOptions())
             .withMessageContaining("Missing " + truststoreType + " truststore value");
     }
 
     @Test
-    void shouldReturnRedisOptionsWithTrustAllEnabledToAvoidBreakingChangeWhenOnlySslConfigured() {
+    void shouldReturnRedisClientOptionsWithTrustAllEnabledByDefault() {
         environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
         environment.setProperty(PROPERTY_PREFIX + ".redis.port", "6379");
         environment.setProperty(PROPERTY_PREFIX + ".redis.ssl", "true");
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
-        assertThat(options.getNetClientOptions()).isNotNull();
-        assertThat(options.getNetClientOptions().isTrustAll()).isTrue();
+        assertThat(options.getSsl()).isNotNull();
+        assertThat(options.getSsl().isTrustAll()).isTrue();
     }
 
     @Test
-    void shouldReturnRedisOptionsWithTCPTimeouts() {
+    void shouldReturnRedisClientOptionsWithTCPTimeouts() {
         environment.setProperty(PROPERTY_PREFIX + ".redis.tcp.connectTimeout", "1234");
         environment.setProperty(PROPERTY_PREFIX + ".redis.tcp.idleTimeout", "5678");
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
-        assertThat(options.getNetClientOptions()).isNotNull();
-        assertThat(options.getNetClientOptions().getConnectTimeout()).isEqualTo(1234);
-        assertThat(options.getNetClientOptions().getIdleTimeout()).isEqualTo(5678);
+        assertThat(options).isNotNull();
+        assertThat(options.getConnectTimeout()).isEqualTo(1234);
+        assertThat(options.getIdleTimeout()).isEqualTo(5678);
     }
 
     @Test
-    void shouldReturnRedisOptionsWithUsernameAndPassword() {
+    void shouldReturnRedisClientOptionsWithUsernameAndPassword() {
         environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
         environment.setProperty(PROPERTY_PREFIX + ".redis.port", "6379");
         environment.setProperty(PROPERTY_PREFIX + ".redis.username", "testuser");
         environment.setProperty(PROPERTY_PREFIX + ".redis.password", "testpass");
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
         assertThat(options).isNotNull();
-        assertThat(options.getEndpoint()).isEqualTo("redis://testuser:testpass@redis:6379");
+        assertThat(options.getUsername()).isEqualTo("testuser");
+        assertThat(options.getPassword()).isEqualTo("testpass");
     }
 
     @Test
-    void shouldReturnRedisOptionsWithOnlyPassword() {
+    void shouldReturnRedisClientOptionsWithOnlyPassword() {
         environment.setProperty(PROPERTY_PREFIX + ".redis.host", "redis");
         environment.setProperty(PROPERTY_PREFIX + ".redis.port", "6379");
         environment.setProperty(PROPERTY_PREFIX + ".redis.password", "testpass");
 
-        RedisOptions options = redisConnectionFactory.buildRedisOptions();
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
 
         assertThat(options).isNotNull();
-        assertThat(options.getEndpoint()).isEqualTo("redis://:testpass@redis:6379");
+        assertThat(options.getPassword()).isEqualTo("testpass");
+        assertThat(options.getUsername()).isNull();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/mapper/V2ToV4MigrationOperatorTest.java
@@ -491,7 +491,7 @@ class V2ToV4MigrationOperatorTest {
             v2Endpoint2.setWeight(5);
             v2Endpoint2.setInherit(false);
             String configJsonForEndpoint =
-                "{\"http\":{\"idleTimeout\":2000,\"keepAliveTimeout\":6,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":false,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/d/e/f\",\"content\":\"def\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/d/e/f\",\"keyContent\":\"def\",\"certPath\":null,\"certContent\":null}},\"headers\":[{\"name\":\"X-Test1\",\"value\":\"no\"}]}";
+                "{\"http\":{\"idleTimeout\":2000,\"keepAliveTimeout\":6,\"connectTimeout\":2000,\"keepAlive\":true,\"readTimeout\":3000,\"pipelining\":false,\"maxConcurrentConnections\":5,\"useCompression\":true,\"propagateClientAcceptEncoding\":false,\"propagateClientHost\":false,\"followRedirects\":true,\"version\":\"HTTP_1_1\"},\"ssl\":{\"trustAll\":false,\"hostnameVerifier\":false,\"openSsl\":false,\"alpn\":false,\"trustStore\":{\"type\":\"PEM\",\"path\":\"/d/e/f\",\"content\":\"def\"},\"keyStore\":{\"type\":\"PEM\",\"keyPath\":\"/d/e/f\",\"keyContent\":\"def\",\"certPath\":null,\"certContent\":null}},\"headers\":[{\"name\":\"X-Test1\",\"value\":\"no\"}]}";
             v2Endpoint2.setConfiguration(configJsonForEndpoint);
             // Setup EndpointGroup
             EndpointGroup v2Group = new EndpointGroup();

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-alpha.10</gravitee-node.version>
+        <gravitee-node.version>9.0.0-wba-fix-tcp-hostname-null-SNAPSHOT</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,11 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-alpha.8</gravitee-node.version>
+        <gravitee-node.version>9.0.0-alpha.10</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>
-        <gravitee-plugin-common-configurations.version>1.2.3</gravitee-plugin-common-configurations.version>
+        <gravitee-plugin-common-configurations.version>1.3.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>2.2.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-wba-fix-tcp-hostname-null-SNAPSHOT</gravitee-node.version>
+        <gravitee-node.version>9.0.0-alpha.11</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>


### PR DESCRIPTION
## Summary

- Migrates `RedisConnectionFactory` to build `RedisClientOptions` (from `gravitee-plugin-common-configurations`) instead of Vert.x `RedisOptions` directly.
- `RedisClient` now takes `VertxRedisClientFactory` + `RedisClientOptions`, using the factory for both initial connection and reconnection — SSL/sentinel/keystore option-building routes through the factory's shared plumbing.
- Removes duplicated SSL/truststore/keystore code (PEM/PKCS12/JKS handling moved to plugin-common-configurations types, applied by factory via `SslOptionsMapper` + node SSL classes).
- No config changes — same `ratelimit.redis.*` / `distributed-sync.redis.*` YAML properties (including `tlsProtocols`, `tlsCiphers`, `alpn`, `openssl`, `hostnameVerificationAlgorithm`).

## Depends on / tracks

- Fix for: [APIM-13779](https://gravitee.atlassian.net/browse/APIM-13779)
- Epic: [APIM-13553](https://gravitee.atlassian.net/browse/APIM-13553)
- Requires upstream releases:
  - [gravitee-io/gravitee-node#551](https://github.com/gravitee-io/gravitee-node/pull/551) — fixes `VertxRedisClientFactory.configureSsl` hostname algorithm + adds `tlsProtocols`/`tlsCiphers`/`alpn` on node-vertx `SslOptions`. Needs release after merge (will be > 9.0.0-alpha.4).
  - [gravitee-io/gravitee-plugin-common-configurations#19](https://github.com/gravitee-io/gravitee-plugin-common-configurations/pull/19) — surfaces the 4 new SSL fields on `common-configurations.SslOptions`. Needs release after merge (will be > 1.2.1).
- After both releases: bump `gravitee-node.version` and `gravitee-plugin-common-configurations.version` in this PR's `pom.xml` to the new releases.

## Integration test matrix

Verified locally on a real Redis (standalone+password :6401, standalone+password+TLS/PEM :6402, host-based sentinel master:6501 + replica:6502 + sentinels :26501-26503) with patched SNAPSHOTs of the two upstream PRs installed:

| Scenario | Result |
|---|---|
| standalone + password | PASS — 2 ready clients, keys present |
| standalone + TLS + PEM + `trustAll=false` + `hostnameVerificationAlgorithm=HTTPS` + `tlsProtocols=TLSv1.2,TLSv1.3` | PASS — no `Missing hostname verification algorithm` error |
| sentinel + master/sentinel auth | PASS — sentinel cluster resolves master, keys replicated to replica |

Reference docker-compose setups: `docker/quick-setup/distributed-sync/`, `docker/quick-setup/redis-rate-limit/`.

## Known CI state

CI will be red on this PR until the two upstream PRs merge and release:

- PR compile references `SslOptions.setTlsProtocols()` / `setTlsCiphers()` / `setAlpn()` / `setOpenSsl()`, which don't exist in stock `common-configurations 1.2.1`. Compiles against the patched SNAPSHOT installed locally.
- Stock `node-vertx 9.0.0-alpha.4` has the `VertxRedisClientFactory.configureSsl` bug (no `HTTPS` branch for `hostnameVerifier=true`), so runtime TLS with non-trustAll fails until the fix ships.

## Test plan

- [x] `RedisConnectionFactoryTest` — 18/18 pass (standalone, sentinel, SSL with PEM/PKCS12/JKS, timeouts, username/password, error cases)
- [x] Integration: gateway with `ratelimit.type: redis` + `distributed-sync.type: redis` — rate-limit repo healthy, 1 connection per gateway per repo, `Repository [RATE_LIMIT] loaded by redis` and `Repository [DISTRIBUTED_SYNC] loaded by redis`, keys `distributed_sync_state:*`, `distributed_event::NODE_METADATA:*` present.
- [x] Integration with TLS (PEM truststore, `hostnameVerificationAlgorithm=HTTPS`) — previously regressed, now works after upstream fix.
- [x] Integration with sentinel (master auth + sentinel auth) — works; factory log `sentinel=mymaster(3 nodes)`.
- [ ] CI green — blocked on upstream PR merges + releases + version bumps here.

[APIM-13779]: https://gravitee.atlassian.net/browse/APIM-13779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-13553]: https://gravitee.atlassian.net/browse/APIM-13553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ