### PR TITLE
Application Members table for next-gen portal

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -34,6 +34,7 @@ import { SubscribeToApiComponent } from './api/subscribe-to-api/subscribe-to-api
 import { ApplicationLogComponent } from './dashboard/application-details/application-tab-logs/application-log/application-log.component';
 import { ApplicationLogTableComponent } from './dashboard/application-details/application-tab-logs/application-log-table/application-log-table.component';
 import { ApplicationTabLogsComponent } from './dashboard/application-details/application-tab-logs/application-tab-logs.component';
+import { ApplicationTabMembersComponent } from './dashboard/application-details/application-tab-members/application-tab-members.component';
 import { ApplicationTabSettingsComponent } from './dashboard/application-details/application-tab-settings/application-tab-settings.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { RegistrationConfirmationComponent } from './registration/registration-confirmation/registration-confirmation.component';
@@ -201,6 +202,10 @@ export const routes: Routes = [
             path: 'settings',
             component: ApplicationTabSettingsComponent,
             resolve: { applicationTypeConfiguration: applicationTypeResolver },
+          },
+          {
+            path: 'members',
+            component: ApplicationTabMembersComponent,
           },
         ],
       },

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.harness.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+import { LoaderHarness } from '../../../../components/loader/loader.harness';
+import { PaginatedTableHarness } from '../../../../components/paginated-table/paginated-table.harness';
+import { UserCellHarness } from '../../../../components/user-cell/user-cell.harness';
+
+export class ApplicationTabMembersComponentHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-application-tab-members';
+
+  private readonly locateLoader = this.locatorForOptional(LoaderHarness);
+  private readonly locateErrorMessage = this.locatorForOptional('[data-testid="members-list-error"]');
+  private readonly locateEmptyState = this.locatorForOptional('[data-testid="members-empty-state"]');
+  private readonly locatePaginatedTable = this.locatorForOptional(PaginatedTableHarness);
+  private readonly locateUserCells = this.locatorForAll(UserCellHarness);
+  private readonly locatePrimaryOwnerRoleCell = this.locatorForOptional('[data-testid="members-role-primary-owner"]');
+
+  public async getLoader(): Promise<LoaderHarness | null> {
+    return this.locateLoader();
+  }
+
+  public async getErrorMessage(): Promise<TestElement | null> {
+    return this.locateErrorMessage();
+  }
+
+  public async getEmptyState(): Promise<TestElement | null> {
+    return this.locateEmptyState();
+  }
+
+  public async getPaginatedTable(): Promise<PaginatedTableHarness | null> {
+    return this.locatePaginatedTable();
+  }
+
+  public async getUserCells(): Promise<UserCellHarness[]> {
+    return this.locateUserCells();
+  }
+
+  public async getFirstUserCell(): Promise<UserCellHarness> {
+    const cells = await this.locateUserCells();
+    if (cells.length === 0) {
+      throw new Error('Expected at least one app-user-cell to be rendered');
+    }
+    return cells[0];
+  }
+
+  public async isPrimaryOwnerRoleVisible(): Promise<boolean> {
+    return !!(await this.locatePrimaryOwnerRoleCell());
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.html
@@ -1,0 +1,54 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@if (canRead()) {
+  @if (membersResource.isLoading()) {
+    <app-loader />
+  } @else if (membersResource.error()) {
+    <div class="members__error next-gen-body" role="alert" data-testid="members-list-error" i18n="@@membersListError">
+      An error occurred while loading members. Try again later or contact your Portal administrator.
+    </div>
+  } @else if (totalElements() === 0) {
+    <div class="members__empty-state" data-testid="members-empty-state">
+      <p class="next-gen-body" i18n="@@membersEmptyState">No members found.</p>
+    </div>
+  } @else {
+    <app-paginated-table
+      [columns]="tableColumns"
+      [rows]="rows()"
+      [totalElements]="totalElements()"
+      [currentPage]="currentPage()"
+      [pageSize]="pageSize()"
+      [navigable]="false"
+      [actions]="actions"
+      (pageChange)="onPageChange($event)"
+      (pageSizeChange)="onPageSizeChange($event)"
+    >
+      <ng-template appTableCell="name" let-row>
+        <app-user-cell [user]="row.user" [isCurrentUser]="row.isCurrentUser" />
+      </ng-template>
+      <ng-template appTableCell="role" let-row>
+        <span
+          class="next-gen-small"
+          [class.members__role--primary-owner]="row.isPrimaryOwner"
+          [attr.data-testid]="row.isPrimaryOwner ? 'members-role-primary-owner' : 'members-role'"
+          >{{ row.role }}</span
+        >
+      </ng-template>
+    </app-paginated-table>
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.scss
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/theme/index' as app-theme;
+
+.members {
+  &__empty-state {
+    padding: 24px 0;
+    text-align: center;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__error {
+    padding: 24px 0;
+    color: app-theme.$error-main-color;
+  }
+
+  &__role--primary-owner {
+    color: app-theme.$primary-main-color;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+
+import { ApplicationTabMembersComponent } from './application-tab-members.component';
+import { ApplicationTabMembersComponentHarness } from './application-tab-members.component.harness';
+import { MembersResponse } from '../../../../entities/member/member';
+import { fakeMember, fakeMembersResponse } from '../../../../entities/member/member.fixtures';
+import { fakeUserApplicationPermissions } from '../../../../entities/permission/permission.fixtures';
+import { ConfigService } from '../../../../services/config.service';
+import { CurrentUserService } from '../../../../services/current-user.service';
+import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+
+const CURRENT_USER_ID = 'current-user-id';
+
+describe('ApplicationTabMembersComponent', () => {
+  let fixture: ComponentFixture<ApplicationTabMembersComponent>;
+  let httpTestingController: HttpTestingController;
+  const applicationId = 'app-1';
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApplicationTabMembersComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+        { provide: CurrentUserService, useValue: { user: () => ({ id: CURRENT_USER_ID }) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationTabMembersComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.componentRef.setInput('applicationId', applicationId);
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+  });
+
+  afterEach(() => httpTestingController.verify());
+
+  async function getHarness(): Promise<ApplicationTabMembersComponentHarness> {
+    return TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationTabMembersComponentHarness);
+  }
+
+  async function flush(response: MembersResponse): Promise<ApplicationTabMembersComponentHarness> {
+    fixture.detectChanges();
+    const request = httpTestingController.expectOne(req => req.url.includes('members/_search'));
+    expect(request.request.method).toBe('POST');
+    request.flush(response);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return getHarness();
+  }
+
+  it('should display members table', async () => {
+    const harness = await flush(fakeMembersResponse([fakeMember()]));
+    expect(await harness.getPaginatedTable()).not.toBeNull();
+  });
+
+  it('should show loader until the first search response', async () => {
+    // In-flight rxResource requests block fixture.whenStable(), which the harness API awaits;
+    // fall back to a synchronous DOM check for the loading state (the rule's documented escape
+    // hatch for rxResource streams that haven't completed yet).
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('app-loader')).not.toBeNull();
+    const harness = await flush(fakeMembersResponse([fakeMember()]));
+    expect(await harness.getLoader()).toBeNull();
+  });
+
+  it('should show an accessible error message when search fails', async () => {
+    fixture.detectChanges();
+    const request = httpTestingController.expectOne(req => req.url.includes('members/_search'));
+    request.flush({ error: 'Server error' }, { status: 500, statusText: 'Internal Server Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const harness = await getHarness();
+    const alert = await harness.getErrorMessage();
+    expect(alert).not.toBeNull();
+    expect(await alert!.getAttribute('role')).toBe('alert');
+  });
+
+  it('should show empty state when no members are returned', async () => {
+    const harness = await flush(fakeMembersResponse([]));
+    expect(await harness.getEmptyState()).not.toBeNull();
+  });
+
+  it('should not render the paginated table when there are no members', async () => {
+    const harness = await flush(fakeMembersResponse([], 0));
+    expect(await harness.getPaginatedTable()).toBeNull();
+  });
+
+  it('should render no action buttons in phase 01', async () => {
+    const harness = await flush(fakeMembersResponse([fakeMember(), fakeMember({ id: 'member-2', role: 'PRIMARY_OWNER' })]));
+    const table = await harness.getPaginatedTable();
+    const actions = await table!.getActionButtons();
+    expect(actions.length).toBe(0);
+  });
+
+  it('should hide the table and not call service when user lacks MEMBER[R] permission', async () => {
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: [] }));
+    fixture.detectChanges();
+    httpTestingController.expectNone(req => req.url.includes('members/_search'));
+    const harness = await getHarness();
+    expect(await harness.getPaginatedTable()).toBeNull();
+  });
+
+  it('should POST with page=2 when page changes', async () => {
+    await flush(fakeMembersResponse([fakeMember()], 25));
+    fixture.componentInstance.onPageChange(2);
+    fixture.detectChanges();
+    const request = httpTestingController.expectOne(req => req.url.includes('members/_search') && req.params.get('page') === '2');
+    expect(request.request.method).toBe('POST');
+    request.flush(fakeMembersResponse([fakeMember({ id: 'member-p2' })]));
+    await fixture.whenStable();
+  });
+
+  describe('name cell', () => {
+    it('should use display_name as primary label', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ user: { id: 'u1', display_name: 'Alice Smith', _links: {} } })]));
+      const userCell = await harness.getFirstUserCell();
+      expect(await userCell.getPrimaryText()).toBe('Alice Smith');
+    });
+
+    it('should fall back to first_name + last_name when display_name absent', async () => {
+      const harness = await flush(
+        fakeMembersResponse([fakeMember({ user: { id: 'u1', first_name: 'Bob', last_name: 'Jones', _links: {} } })]),
+      );
+      const userCell = await harness.getFirstUserCell();
+      expect(await userCell.getPrimaryText()).toBe('Bob Jones');
+    });
+
+    it('should fall back to user id when no name fields available', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ user: { id: 'user-xyz', _links: {} } })]));
+      const userCell = await harness.getFirstUserCell();
+      expect(await userCell.getPrimaryText()).toBe('user-xyz');
+    });
+
+    it('should render email as secondary text', async () => {
+      const harness = await flush(
+        fakeMembersResponse([fakeMember({ user: { id: 'u1', display_name: 'Alice', email: 'alice@example.com', _links: {} } })]),
+      );
+      const userCell = await harness.getFirstUserCell();
+      expect(await userCell.getSecondaryText()).toBe('alice@example.com');
+    });
+
+    it('should compute initials from display_name split by space', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ user: { id: 'u1', display_name: 'Alice Smith', _links: {} } })]));
+      const userCell = await harness.getFirstUserCell();
+      expect(await userCell.getInitialsText()).toBe('AS');
+    });
+
+    it('should normalize multiple spaces when computing initials from display_name', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ user: { id: 'u1', display_name: 'Alice    Smith', _links: {} } })]));
+      const userCell = await harness.getFirstUserCell();
+      expect(await userCell.getInitialsText()).toBe('AS');
+    });
+
+    it('should compute initials from first_name and last_name', async () => {
+      const harness = await flush(
+        fakeMembersResponse([fakeMember({ user: { id: 'u1', first_name: 'Bob', last_name: 'Jones', _links: {} } })]),
+      );
+      const userCell = await harness.getFirstUserCell();
+      expect(await userCell.getInitialsText()).toBe('BJ');
+    });
+
+    it('should show (you) label for the current user', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ user: { id: CURRENT_USER_ID, display_name: 'Me', _links: {} } })]));
+      const userCell = await harness.getFirstUserCell();
+      expect(await userCell.hasYouBadge()).toBe(true);
+    });
+
+    it('should not show (you) label for other users', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ user: { id: 'other-user', display_name: 'Other', _links: {} } })]));
+      const userCell = await harness.getFirstUserCell();
+      expect(await userCell.hasYouBadge()).toBe(false);
+    });
+  });
+
+  describe('role cell', () => {
+    it('should mark PRIMARY_OWNER via data-testid', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ role: 'PRIMARY_OWNER' })]));
+      expect(await harness.isPrimaryOwnerRoleVisible()).toBe(true);
+    });
+
+    it('should not mark other roles as PRIMARY_OWNER', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ role: 'USER' })]));
+      expect(await harness.isPrimaryOwnerRoleVisible()).toBe(false);
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject, input, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { of } from 'rxjs';
+
+import { LoaderComponent } from '../../../../components/loader/loader.component';
+import { PaginatedTableComponent, TableAction, TableColumn } from '../../../../components/paginated-table/paginated-table.component';
+import { TableCellDirective } from '../../../../components/paginated-table/table-cell.directive';
+import { UserCellComponent, UserCellVM } from '../../../../components/user-cell/user-cell.component';
+import { Member, MembersResponse } from '../../../../entities/member/member';
+import { UserApplicationPermissions } from '../../../../entities/permission/permission';
+import { CurrentUserService } from '../../../../services/current-user.service';
+import { MembershipService } from '../../../../services/membership.service';
+
+interface MemberTableRow {
+  id: string;
+  user: UserCellVM;
+  isCurrentUser: boolean;
+  role: string;
+  isPrimaryOwner: boolean;
+}
+
+interface MembersRequestParams {
+  applicationId: string;
+  page: number;
+  size: number;
+}
+
+@Component({
+  selector: 'app-application-tab-members',
+  standalone: true,
+  imports: [LoaderComponent, PaginatedTableComponent, TableCellDirective, UserCellComponent],
+  templateUrl: './application-tab-members.component.html',
+  styleUrl: './application-tab-members.component.scss',
+})
+export class ApplicationTabMembersComponent {
+  private readonly membershipService = inject(MembershipService);
+  private readonly currentUserService = inject(CurrentUserService);
+
+  readonly applicationId = input.required<string>();
+  readonly userApplicationPermissions = input.required<UserApplicationPermissions>();
+
+  readonly currentPage = signal(1);
+  readonly pageSize = signal(10);
+
+  readonly tableColumns: TableColumn[] = [
+    { id: 'name', label: $localize`:@@memberColumnName:Name` },
+    { id: 'role', label: $localize`:@@memberColumnRole:Role` },
+  ];
+
+  // Empty in phase 01; update/delete will be added in phase 02 (APIM-12770).
+  readonly actions: TableAction<MemberTableRow>[] = [];
+
+  readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
+
+  protected readonly membersResource = rxResource<MembersResponse | undefined, MembersRequestParams | null>({
+    params: () => (this.canRead() ? { applicationId: this.applicationId(), page: this.currentPage(), size: this.pageSize() } : null),
+    stream: ({ params }) =>
+      params ? this.membershipService.searchApplicationMembers(params.applicationId, params.page, params.size) : of(undefined),
+  });
+
+  readonly rows = computed<MemberTableRow[]>(() => (this.membersResource.value()?.data ?? []).map(member => this.toRow(member)));
+
+  readonly totalElements = computed(() => this.membersResource.value()?.metadata?.pagination?.total ?? 0);
+
+  onPageChange(page: number): void {
+    this.currentPage.set(page);
+  }
+
+  onPageSizeChange(size: number): void {
+    this.pageSize.set(size);
+    this.currentPage.set(1);
+  }
+
+  private toRow(member: Member): MemberTableRow {
+    const user = member.user;
+    const displayName =
+      user?.display_name ??
+      (user?.first_name || user?.last_name ? `${user?.first_name ?? ''} ${user?.last_name ?? ''}`.trim() : (user?.id ?? ''));
+    return {
+      id: member.id ?? '',
+      user: {
+        displayName,
+        email: user?.email,
+        avatarUrl: user?._links?.avatar,
+        initials: this.getInitialsFromDisplayName(displayName),
+      },
+      isCurrentUser: !!user?.id && user.id === this.currentUserService.user()?.id,
+      role: member.role ?? '',
+      isPrimaryOwner: member.role === 'PRIMARY_OWNER',
+    };
+  }
+
+  private getInitialsFromDisplayName(displayName: string): string {
+    const parts = displayName
+      .trim()
+      .split(/\s+/)
+      .filter(part => part.length > 0);
+    if (parts.length === 0) {
+      return '';
+    }
+    return parts
+      .slice(0, 2)
+      .map(part => part[0])
+      .join('')
+      .toUpperCase();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.html
@@ -26,6 +26,17 @@
         [active]="settingsActive.isActive"
         ><span class="next-gen-small-bold" i18n="@@appSettings">Settings & Security</span></a
       >
+      @if (canViewMembersTab()) {
+        <a
+          mat-tab-link
+          [routerLink]="['.', 'members']"
+          routerLinkActive
+          #membersActive="routerLinkActive"
+          [active]="membersActive.isActive"
+          data-testid="application-members-tab"
+          ><span class="next-gen-small-bold" i18n="@@appMembers">Members</span></a
+        >
+      }
       <a mat-tab-link [routerLink]="['.', 'logs']" routerLinkActive #logsActive="routerLinkActive" [active]="logsActive.isActive"
         ><span class="next-gen-small-bold" i18n="@@appAnalyticsAndLogs">Logs</span></a
       >

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.spec.ts
@@ -13,31 +13,68 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ComponentHarness, HarnessLoader, HarnessPredicate } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
 import ApplicationComponent from './application.component';
 import { fakeApplication } from '../../../entities/application/application.fixture';
+import { fakeUserApplicationPermissions } from '../../../entities/permission/permission.fixtures';
 import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { applicationListBreadcrumb } from '../applications/application-breadcrumbs';
+
+class TestIdHarness extends ComponentHarness {
+  static hostSelector = '[data-testid]';
+
+  static for(testId: string): HarnessPredicate<TestIdHarness> {
+    return new HarnessPredicate(TestIdHarness, { selector: `[data-testid="${testId}"]` });
+  }
+}
 
 describe('ApplicationComponent', () => {
   let fixture: ComponentFixture<ApplicationComponent>;
   let breadcrumbService: BreadcrumbService;
+  let loader: HarnessLoader;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ApplicationComponent],
-      providers: [provideRouter([])],
+      providers: [provideRouter([]), provideNoopAnimations()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ApplicationComponent);
     breadcrumbService = TestBed.inject(BreadcrumbService);
+    breadcrumbService.clear();
+    loader = TestbedHarnessEnvironment.loader(fixture);
     fixture.componentRef.setInput('application', fakeApplication({ id: 'app-1', name: 'My App' }));
-    fixture.detectChanges();
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+  });
+
+  afterEach(() => {
+    fixture.destroy();
   });
 
   it('should set breadcrumbs for application details', () => {
+    fixture.detectChanges();
     expect(breadcrumbService.breadcrumbs()).toEqual([applicationListBreadcrumb(true), { id: 'application-app-1', label: 'My App' }]);
+  });
+
+  it('should render Members tab when user has MEMBER read permission', async () => {
+    fixture.detectChanges();
+    expect(await loader.getHarnessOrNull(TestIdHarness.for('application-members-tab'))).not.toBeNull();
+  });
+
+  it('should not render Members tab when user lacks MEMBER read permission', async () => {
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: [] }));
+    fixture.detectChanges();
+    expect(await loader.getHarnessOrNull(TestIdHarness.for('application-members-tab'))).toBeNull();
+  });
+
+  it('should not render Members tab when MEMBER has no R flag', async () => {
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['U'] }));
+    fixture.detectChanges();
+    expect(await loader.getHarnessOrNull(TestIdHarness.for('application-members-tab'))).toBeNull();
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, effect, inject, input } from '@angular/core';
+import { Component, computed, effect, inject, input } from '@angular/core';
 import { MatTabLink, MatTabNav, MatTabNavPanel } from '@angular/material/tabs';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 import { Application } from '../../../entities/application/application';
+import { UserApplicationPermissions } from '../../../entities/permission/permission';
 import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { applicationListBreadcrumb } from '../applications/application-breadcrumbs';
 
@@ -29,7 +30,11 @@ import { applicationListBreadcrumb } from '../applications/application-breadcrum
 })
 export default class ApplicationComponent {
   private readonly breadcrumbService = inject(BreadcrumbService);
+
   readonly application = input.required<Application>();
+  readonly userApplicationPermissions = input.required<UserApplicationPermissions>();
+
+  readonly canViewMembersTab = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
 
   constructor() {
     effect(() => {

--- a/gravitee-apim-portal-webui-next/src/components/loader/loader.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/loader/loader.harness.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class LoaderHarness extends ComponentHarness {
+  static hostSelector = 'app-loader';
+}

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.html
@@ -21,12 +21,16 @@
       <ng-container [matColumnDef]="column.id">
         <th mat-header-cell *matHeaderCellDef class="next-gen-small-bold">{{ column.label }}</th>
         <td mat-cell *matCellDef="let element">
-          @switch (column.type) {
-            @case ('date') {
-              {{ element[column.id] | date: 'yyyy-MM-dd' }}
-            }
-            @default {
-              {{ element[column.id] }}
+          @if (cellTemplates().get(column.id); as cellTemplate) {
+            <ng-container *ngTemplateOutlet="cellTemplate; context: { $implicit: element, row: element }" />
+          } @else {
+            @switch (column.type) {
+              @case ('date') {
+                {{ element[column.id] | date: 'yyyy-MM-dd' }}
+              }
+              @default {
+                {{ element[column.id] }}
+              }
             }
           }
         </td>

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.scss
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 @use '../../scss/theme/index' as app-theme;
+@use '../../scss/typography';
 
 .paginated-table {
   width: 100%;
@@ -22,7 +23,8 @@
     border-bottom: 1px solid app-theme.$table-border-color;
     background-color: app-theme.$table-header-background-color;
     color: app-theme.$table-header-headline-color;
-    font-weight: 600;
+
+    @extend .next-gen-small-bold;
   }
 
   td {

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.spec.ts
@@ -21,6 +21,7 @@ import { provideRouter } from '@angular/router';
 
 import { PaginatedTableComponent, TableAction, TableColumn } from './paginated-table.component';
 import { PaginatedTableHarness } from './paginated-table.harness';
+import { TableCellDirective } from './table-cell.directive';
 
 type TestRow = {
   id: string;
@@ -30,7 +31,7 @@ type TestRow = {
 
 @Component({
   standalone: true,
-  imports: [PaginatedTableComponent],
+  imports: [PaginatedTableComponent, TableCellDirective],
   template: `
     <app-paginated-table
       [columns]="columns"
@@ -41,7 +42,13 @@ type TestRow = {
       [navigable]="navigable"
       [actions]="actions"
       (actionClick)="onActionClick($event)"
-    />
+    >
+      @if (withCustomNameCell) {
+        <ng-template appTableCell="name" let-row>
+          <span class="custom-name-cell">custom:{{ row.name }}</span>
+        </ng-template>
+      }
+    </app-paginated-table>
   `,
 })
 class TestHostComponent {
@@ -55,6 +62,7 @@ class TestHostComponent {
   pageSize = 10;
   navigable = true;
   actions: TableAction<TestRow>[] = [];
+  withCustomNameCell = false;
   receivedAction: { actionId: string; row: TestRow } | null = null;
 
   onActionClick(event: { actionId: string; row: TestRow }): void {
@@ -112,5 +120,26 @@ describe('PaginatedTableComponent', () => {
       actionId: 'delete',
       row: host.rows[0],
     });
+  });
+
+  it('should render default text for a column without a custom template', async () => {
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, PaginatedTableHarness);
+
+    const cell = await harness.getCellElement(0, 'name');
+    expect((await cell?.text())?.trim()).toBe('First row');
+  });
+
+  it('should project a custom cell template by column id', async () => {
+    host.withCustomNameCell = true;
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, PaginatedTableHarness);
+
+    const cell = await harness.getCellElement(0, 'name');
+    expect((await cell?.text())?.trim()).toBe('custom:First row');
+
+    // Other columns still use the default rendering.
+    const dateCell = await harness.getCellElement(0, 'createdAt');
+    expect((await dateCell?.text())?.trim()).toBe('2026-01-01');
   });
 });

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.component.ts
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DatePipe } from '@angular/common';
-import { Component, computed, input, output } from '@angular/core';
+import { DatePipe, NgTemplateOutlet } from '@angular/common';
+import { Component, computed, contentChildren, input, output, TemplateRef } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { RouterLink } from '@angular/router';
 
+import { TableCellContext, TableCellDirective } from './table-cell.directive';
 import { DEFAULT_PAGE_SIZE_OPTIONS, PaginationComponent } from '../pagination/pagination.component';
 
 export interface TableColumn {
@@ -40,7 +41,7 @@ export interface TableAction<T> {
 @Component({
   selector: 'app-paginated-table',
   standalone: true,
-  imports: [DatePipe, MatTableModule, MatIcon, RouterLink, PaginationComponent, MatButtonModule],
+  imports: [DatePipe, MatTableModule, MatIcon, RouterLink, PaginationComponent, MatButtonModule, NgTemplateOutlet],
   templateUrl: './paginated-table.component.html',
   styleUrl: './paginated-table.component.scss',
 })
@@ -58,8 +59,18 @@ export class PaginatedTableComponent<T> {
   pageSizeChange = output<number>();
   actionClick = output<{ actionId: string; row: T }>();
 
+  private readonly cellDefs = contentChildren(TableCellDirective);
+
+  readonly cellTemplates = computed(() => {
+    const map = new Map<string, TemplateRef<TableCellContext<T>>>();
+    for (const def of this.cellDefs()) {
+      map.set(def.appTableCell(), def.templateRef as TemplateRef<TableCellContext<T>>);
+    }
+    return map;
+  });
+
   displayedColumns = computed(() => [
-    ...this.columns().map(c => c.id as string),
+    ...this.columns().map(column => column.id),
     ...(this.actions().length > 0 ? ['actions'] : []),
     ...(this.navigable() ? ['expand'] : []),
   ]);

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/paginated-table.harness.ts
@@ -15,6 +15,7 @@
  */
 import { ComponentHarness, TestElement } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing';
 
 export class PaginatedTableHarness extends ComponentHarness {
   public static readonly hostSelector = 'app-paginated-table';
@@ -22,6 +23,7 @@ export class PaginatedTableHarness extends ComponentHarness {
   protected locateNavigableRows = this.locatorForAll('.paginated-table__row--navigable');
   protected locateExpandColumns = this.locatorForAll('.paginated-table__column-expand');
   protected locateActionButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[data-testid^="paginated-table-action-"]' }));
+  protected locateTable = this.locatorFor(MatTableHarness);
 
   async getNavigableRows(): Promise<TestElement[]> {
     return this.locateNavigableRows();
@@ -37,5 +39,22 @@ export class PaginatedTableHarness extends ComponentHarness {
 
   async getActionButton(actionId: string): Promise<MatButtonHarness | null> {
     return this.locatorForOptional(MatButtonHarness.with({ selector: `[data-testid="paginated-table-action-${actionId}"]` }))();
+  }
+
+  /**
+   * Returns the host `TestElement` of the cell at `rowIndex` in the column identified by `columnId`.
+   * Useful for asserting on custom-template cells projected via `[appTableCell]`.
+   */
+  async getCellElement(rowIndex: number, columnId: string): Promise<TestElement | null> {
+    const rows = await this.getDataRows();
+    const row = rows[rowIndex];
+    if (!row) return null;
+    const cells = await row.getCells({ columnName: columnId });
+    return cells[0] ? cells[0].host() : null;
+  }
+
+  private async getDataRows(): Promise<MatRowHarness[]> {
+    const table = await this.locateTable();
+    return table.getRows();
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/paginated-table/table-cell.directive.ts
+++ b/gravitee-apim-portal-webui-next/src/components/paginated-table/table-cell.directive.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Directive, inject, input, TemplateRef } from '@angular/core';
+
+/**
+ * Projects a custom cell template into `PaginatedTableComponent`, matched against a column id.
+ *
+ * Usage:
+ * ```html
+ * <app-paginated-table [columns]="columns" [rows]="rows" ...>
+ *   <ng-template appTableCell="name" let-row>
+ *     <app-user-cell [user]="row.user" />
+ *   </ng-template>
+ * </app-paginated-table>
+ * ```
+ *
+ * The context exposes the row as `$implicit` (so `let-row` works) and as `row`.
+ */
+@Directive({
+  selector: '[appTableCell]',
+  standalone: true,
+})
+export class TableCellDirective<T = unknown> {
+  /** Column id to bind this template to (must match `TableColumn.id`). */
+  appTableCell = input.required<string>();
+
+  readonly templateRef = inject(TemplateRef<TableCellContext<T>>);
+}
+
+export interface TableCellContext<T> {
+  $implicit: T;
+  row: T;
+}

--- a/gravitee-apim-portal-webui-next/src/components/user-cell/user-cell.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/user-cell/user-cell.component.html
@@ -1,0 +1,35 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="user-cell">
+  @if (showAvatar()) {
+    <img class="user-cell__avatar" [src]="user().avatarUrl" [alt]="user().displayName" (error)="onAvatarError()" />
+  } @else {
+    <span class="user-cell__initials next-gen-caption" aria-hidden="true">{{ user().initials }}</span>
+  }
+  <div class="user-cell__text">
+    <span class="user-cell__primary next-gen-body">
+      {{ user().displayName }}
+      @if (isCurrentUser()) {
+        <span class="user-cell__you next-gen-caption" i18n="@@userCellYouLabel">(you)</span>
+      }
+    </span>
+    @if (user().email) {
+      <span class="user-cell__secondary next-gen-caption">{{ user().email }}</span>
+    }
+  </div>
+</div>

--- a/gravitee-apim-portal-webui-next/src/components/user-cell/user-cell.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/user-cell/user-cell.component.scss
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/theme/index' as app-theme;
+
+.user-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  &__avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  &__initials {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    color: app-theme.$default-text-contrast-color;
+    background-color: app-theme.$user-avatar-text-color;
+    flex-shrink: 0;
+  }
+
+  &__text {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__secondary {
+    color: app-theme.$secondary-main-color;
+  }
+
+  &__you {
+    margin-left: 4px;
+    color: app-theme.$secondary-main-color;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/user-cell/user-cell.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/user-cell/user-cell.component.spec.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserCellComponent, UserCellVM } from './user-cell.component';
+import { UserCellHarness } from './user-cell.harness';
+
+describe('UserCellComponent', () => {
+  let fixture: ComponentFixture<UserCellComponent>;
+  let component: UserCellComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UserCellComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserCellComponent);
+    component = fixture.componentInstance;
+  });
+
+  function render(user: UserCellVM, isCurrentUser = false): void {
+    fixture.componentRef.setInput('user', user);
+    fixture.componentRef.setInput('isCurrentUser', isCurrentUser);
+    fixture.detectChanges();
+  }
+
+  async function getHarness(): Promise<UserCellHarness> {
+    return await TestbedHarnessEnvironment.harnessForFixture(fixture, UserCellHarness);
+  }
+
+  it('should render displayName as primary label', async () => {
+    render({ displayName: 'Alice Smith', initials: 'AS' });
+    const harness = await getHarness();
+    expect(await harness.getPrimaryText()).toBe('Alice Smith');
+  });
+
+  it('should render email as secondary text when present', async () => {
+    render({ displayName: 'Alice', email: 'alice@example.com', initials: 'A' });
+    const harness = await getHarness();
+    expect(await harness.getSecondaryText()).toBe('alice@example.com');
+  });
+
+  it('should not render secondary text when email is missing', async () => {
+    render({ displayName: 'Alice', initials: 'A' });
+    const harness = await getHarness();
+    expect(await harness.hasSecondary()).toBe(false);
+  });
+
+  it('should show initials when avatarUrl is missing', async () => {
+    render({ displayName: 'Alice Smith', initials: 'AS' });
+    const harness = await getHarness();
+    expect(await harness.getInitialsText()).toBe('AS');
+    expect(await harness.getAvatar()).toBeNull();
+  });
+
+  it('should show avatar image when avatarUrl is present', async () => {
+    render({ displayName: 'Alice', initials: 'A', avatarUrl: '/api/avatar/alice' });
+    const harness = await getHarness();
+    const src = await harness.getAvatarSrc();
+    expect(src).toContain('/api/avatar/alice');
+    expect(await harness.getInitialsText()).toBeNull();
+  });
+
+  it('should fall back to initials on image load error', async () => {
+    render({ displayName: 'Alice', initials: 'A', avatarUrl: '/api/avatar/broken' });
+    const harness = await getHarness();
+    await harness.triggerAvatarError();
+    fixture.detectChanges();
+
+    expect(await harness.getAvatar()).toBeNull();
+    expect(await harness.getInitialsText()).toBe('A');
+  });
+
+  it('should reset fallback state when avatar URL changes', async () => {
+    render({ displayName: 'Alice', initials: 'A', avatarUrl: '/api/avatar/broken' });
+    let harness = await getHarness();
+    await harness.triggerAvatarError();
+    fixture.detectChanges();
+    harness = await getHarness();
+    expect(await harness.getAvatar()).toBeNull();
+
+    render({ displayName: 'Alice', initials: 'A', avatarUrl: '/api/avatar/fresh' });
+    harness = await getHarness();
+    expect(await harness.getAvatar()).not.toBeNull();
+  });
+
+  it('should render (you) label when isCurrentUser is true', async () => {
+    render({ displayName: 'Me', initials: 'M' }, true);
+    const harness = await getHarness();
+    expect(await harness.hasYouBadge()).toBe(true);
+  });
+
+  it('should not render (you) label when isCurrentUser is false', async () => {
+    render({ displayName: 'Other', initials: 'O' }, false);
+    const harness = await getHarness();
+    expect(await harness.hasYouBadge()).toBe(false);
+  });
+
+  it('should expose component for direct use', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/user-cell/user-cell.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/user-cell/user-cell.component.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, input, linkedSignal } from '@angular/core';
+
+export interface UserCellVM {
+  displayName: string;
+  email?: string;
+  avatarUrl?: string;
+  initials: string;
+}
+
+@Component({
+  selector: 'app-user-cell',
+  standalone: true,
+  templateUrl: './user-cell.component.html',
+  styleUrl: './user-cell.component.scss',
+})
+export class UserCellComponent {
+  user = input.required<UserCellVM>();
+  isCurrentUser = input(false);
+
+  /** Resets automatically whenever the avatar URL changes (linkedSignal re-initializes from source). */
+  protected avatarLoadFailed = linkedSignal<string | undefined, boolean>({
+    source: () => this.user().avatarUrl,
+    computation: () => false,
+  });
+
+  protected showAvatar = computed(() => !!this.user().avatarUrl && !this.avatarLoadFailed());
+
+  protected onAvatarError(): void {
+    this.avatarLoadFailed.set(true);
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/user-cell/user-cell.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/user-cell/user-cell.harness.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+export class UserCellHarness extends ComponentHarness {
+  static hostSelector = 'app-user-cell';
+
+  private readonly locatePrimary = this.locatorForOptional('.user-cell__primary');
+  private readonly locateSecondary = this.locatorForOptional('.user-cell__secondary');
+  private readonly locateInitials = this.locatorForOptional('.user-cell__initials');
+  private readonly locateAvatar = this.locatorForOptional('img.user-cell__avatar');
+  private readonly locateYou = this.locatorForOptional('.user-cell__you');
+
+  async getPrimaryText(): Promise<string | null> {
+    const el = await this.locatePrimary();
+    return el ? (await el.text()).trim() : null;
+  }
+
+  async getSecondaryText(): Promise<string | null> {
+    const el = await this.locateSecondary();
+    return el ? (await el.text()).trim() : null;
+  }
+
+  async hasSecondary(): Promise<boolean> {
+    return !!(await this.locateSecondary());
+  }
+
+  async getInitialsText(): Promise<string | null> {
+    const el = await this.locateInitials();
+    return el ? (await el.text()).trim() : null;
+  }
+
+  async getAvatar(): Promise<TestElement | null> {
+    return this.locateAvatar();
+  }
+
+  async getAvatarSrc(): Promise<string | null> {
+    const img = await this.locateAvatar();
+    return img ? img.getAttribute('src') : null;
+  }
+
+  async hasYouBadge(): Promise<boolean> {
+    return !!(await this.locateYou());
+  }
+
+  /** Fires the image `error` event (broken URL / failed load). */
+  async triggerAvatarError(): Promise<void> {
+    const img = await this.locateAvatar();
+    if (!img) {
+      throw new Error('Expected avatar image to be present');
+    }
+    await img.dispatchEvent('error');
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/entities/member/member.fixtures.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/member/member.fixtures.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isFunction } from 'lodash';
+
+import { Member, MembersResponse } from './member';
+
+export function fakeMember(modifier?: Partial<Member> | ((base: Member) => Member)): Member {
+  const base: Member = {
+    id: 'member-1',
+    role: 'USER',
+    user: {
+      id: 'user-1',
+      display_name: 'Alice Smith',
+      email: 'alice@example.com',
+      _links: {},
+    },
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+
+export function fakeMembersResponse(members: Member[], total = members.length): MembersResponse {
+  return {
+    data: members,
+    metadata: { pagination: { current_page: 1, total, size: 10 } },
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/entities/member/member.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/member/member.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { User } from '../user/user';
+
+export interface Member {
+  id?: string;
+  user?: User;
+  created_at?: string;
+  updated_at?: string;
+  role?: string;
+}
+
+export interface MembersResponse {
+  data?: Member[];
+  metadata?: {
+    pagination?: {
+      current_page?: number;
+      total?: number;
+      size?: number;
+    };
+  };
+  links?: unknown;
+}
+
+/** Filters supported by member search APIs (e.g. application members `_search`). */
+export interface MemberSearchFilters {
+  displayName?: string;
+}

--- a/gravitee-apim-portal-webui-next/src/services/membership.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/membership.service.spec.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { MembershipService } from './membership.service';
+import { Member, MembersResponse } from '../entities/member/member';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
+
+describe('MembershipService', () => {
+  let service: MembershipService;
+  let httpTestingController: HttpTestingController;
+  const applicationId = 'app-1';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    service = TestBed.inject(MembershipService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should search application members with default pagination', done => {
+    const members: Member[] = [{ id: 'm1', role: 'USER' }];
+    const response: MembersResponse = {
+      data: members,
+      metadata: { pagination: { current_page: 1, total: 1, size: 10 } },
+    };
+
+    service.searchApplicationMembers(applicationId).subscribe(res => {
+      expect(res).toEqual(response);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(
+      r =>
+        r.url === `${TESTING_BASE_URL}/applications/${applicationId}/members/_search` &&
+        r.method === 'POST' &&
+        r.params.get('page') === '1' &&
+        r.params.get('size') === '10',
+    );
+    expect(req.request.body).toEqual({ filters: {} });
+    req.flush(response);
+  });
+
+  it('should search application members with page, size and filters', done => {
+    const response: MembersResponse = { data: [], metadata: { pagination: { current_page: 2, total: 0, size: 5 } } };
+
+    service.searchApplicationMembers(applicationId, 2, 5, { displayName: 'Ada' }).subscribe(res => {
+      expect(res).toEqual(response);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(
+      r =>
+        r.url === `${TESTING_BASE_URL}/applications/${applicationId}/members/_search` &&
+        r.method === 'POST' &&
+        r.params.get('page') === '2' &&
+        r.params.get('size') === '5',
+    );
+    expect(req.request.body).toEqual({ filters: { displayName: 'Ada' } });
+    req.flush(response);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/membership.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/membership.service.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ConfigService } from './config.service';
+import { MemberSearchFilters, MembersResponse } from '../entities/member/member';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MembershipService {
+  private readonly http = inject(HttpClient);
+  private readonly configService = inject(ConfigService);
+
+  searchApplicationMembers(applicationId: string, page = 1, size = 10, filters: MemberSearchFilters = {}): Observable<MembersResponse> {
+    return this.http.post<MembersResponse>(
+      `${this.configService.baseURL}/applications/${applicationId}/members/_search`,
+      { filters },
+      { params: { page, size } },
+    );
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13466

## Description

- Extended `PaginatedTable` with optional **per-column cell templates** (`TableCellDirective` + `NgTemplateOutlet`), so complex cells stay out of the generic column model.
- Added `UserCell` for member rows: avatar with initials fallback, display name, optional email, and **(you)** for the signed-in user.
- Introduced the **Application → Members** tab: paginated table backed by `POST …/applications/{id}/members/_search`, with **PRIMARY_OWNER** role highlighted in the Role column.


⚠️: **Search bar, member management, and action buttons column are not in this PR and will be added in follow-up PRs.**
⚠️ **This PR should be merged once the [search endpoint backend changes](https://github.com/gravitee-io/gravitee-api-management/pull/16316) are on master.**


## Additional context


https://github.com/user-attachments/assets/edb74350-995c-437c-a092-c4cae658e1c0



