### PR TITLE
feat: add observability endpoint for filter values

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/api/AnalyticsRepository.java
@@ -30,6 +30,8 @@ import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQu
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
 import io.gravitee.repository.log.v4.model.analytics.CountAggregate;
 import io.gravitee.repository.log.v4.model.analytics.CountByAggregate;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesQuery;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesResult;
 import io.gravitee.repository.log.v4.model.analytics.GroupByAggregate;
 import io.gravitee.repository.log.v4.model.analytics.GroupByQuery;
 import io.gravitee.repository.log.v4.model.analytics.HistogramAggregate;
@@ -96,4 +98,6 @@ public interface AnalyticsRepository {
     TimeSeriesResult searchHTTPTimeSeries(QueryContext queryContext, TimeSeriesQuery query);
 
     MeasuresResult searchMessageMeasures(QueryContext queryContext, MeasuresQuery query);
+
+    FilterValuesResult searchFilterValues(QueryContext queryContext, FilterValuesQuery query);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/FilterValuesQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/FilterValuesQuery.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.log.v4.model.analytics;
+
+import java.util.Map;
+import java.util.Set;
+import lombok.Builder;
+
+@Builder
+public record FilterValuesQuery(
+    String esFieldName,
+    Long from,
+    Long to,
+    int size,
+    Map<String, Object> afterKey,
+    String searchPattern,
+    Set<String> apiIds
+) {}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/FilterValuesResult.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/analytics/FilterValuesResult.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.log.v4.model.analytics;
+
+import java.util.List;
+import java.util.Map;
+
+public record FilterValuesResult(List<String> values, Map<String, Object> afterKey, long totalCount) {}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/AnalyticsElasticsearchRepository.java
@@ -49,6 +49,8 @@ import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchResponseS
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.SearchTopFailedApisAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.adapter.StatsQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FacetsResponseAdapter;
+import io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterValuesQueryAdapter;
+import io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterValuesResponseAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.HTTPFacetsQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.HTTPMeasuresQueryAdapter;
 import io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.HTTPTimeSeriesQueryAdapter;
@@ -64,6 +66,8 @@ import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQu
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
 import io.gravitee.repository.log.v4.model.analytics.CountAggregate;
 import io.gravitee.repository.log.v4.model.analytics.CountByAggregate;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesQuery;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesResult;
 import io.gravitee.repository.log.v4.model.analytics.GroupByAggregate;
 import io.gravitee.repository.log.v4.model.analytics.GroupByQuery;
 import io.gravitee.repository.log.v4.model.analytics.HistogramAggregate;
@@ -113,6 +117,8 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
     private final FacetsResponseAdapter facetsResponseAdapter = new FacetsResponseAdapter();
     private final TimeSeriesResponseAdapter timeSeriesResponseAdapter = new TimeSeriesResponseAdapter();
     private final MessageMeasuresQueryAdapter messageMeasuresQueryAdapter = new MessageMeasuresQueryAdapter();
+    private final FilterValuesQueryAdapter filterValuesQueryAdapter = new FilterValuesQueryAdapter();
+    private final FilterValuesResponseAdapter filterValuesResponseAdapter = new FilterValuesResponseAdapter();
 
     public AnalyticsElasticsearchRepository(RepositoryConfiguration configuration) {
         clusters = ClusterUtils.extractClusterIndexPrefixes(configuration);
@@ -406,6 +412,16 @@ public class AnalyticsElasticsearchRepository extends AbstractElasticsearchRepos
         }
 
         return searchMessageConnectionRequestIDs(query, httpIndex, nextAfterKey, accumulatedRequestIDs, iteration + 1);
+    }
+
+    @Override
+    public FilterValuesResult searchFilterValues(QueryContext queryContext, FilterValuesQuery query) {
+        var index = this.indexNameGenerator.getWildcardIndexName(queryContext.placeholder(), Type.V4_METRICS, clusters);
+        var esQuery = filterValuesQueryAdapter.adapt(query);
+
+        log.debug("Filter values query: {}", esQuery);
+
+        return client.search(index, null, esQuery).map(filterValuesResponseAdapter::adapt).blockingGet();
     }
 
     private String getIndices(QueryContext queryContext, Collection<DefinitionVersion> definitionVersions) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterValuesQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterValuesQueryAdapter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesQuery;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+
+public class FilterValuesQueryAdapter {
+
+    private static final String API_ID_FIELD = "api-id";
+
+    public String adapt(FilterValuesQuery query) {
+        var root = new JsonObject();
+        root.put("size", 0);
+
+        var boolFilter = new JsonArray();
+        if (query.from() != null && query.to() != null) {
+            boolFilter.add(JsonObject.of("range", JsonObject.of("@timestamp", JsonObject.of("gte", query.from(), "lte", query.to()))));
+        }
+
+        if (query.searchPattern() != null && !query.searchPattern().isBlank()) {
+            // Exact match on the keyword field (case-insensitive); avoids costly leading/trailing wildcards.
+            var termValue = JsonObject.of("value", query.searchPattern(), "case_insensitive", true);
+            boolFilter.add(JsonObject.of("term", JsonObject.of(query.esFieldName(), termValue)));
+        }
+
+        if (query.apiIds() != null) {
+            if (query.apiIds().isEmpty()) {
+                boolFilter.add(JsonObject.of("match_none", JsonObject.of()));
+            } else {
+                boolFilter.add(JsonObject.of("terms", JsonObject.of(API_ID_FIELD, new JsonArray(new ArrayList<>(query.apiIds())))));
+            }
+        }
+
+        if (!boolFilter.isEmpty()) {
+            root.put("query", JsonObject.of("bool", JsonObject.of("filter", boolFilter)));
+        }
+
+        var termsSource = JsonObject.of("field", query.esFieldName());
+        var compositeSource = JsonObject.of("value", JsonObject.of("terms", termsSource));
+        var composite = JsonObject.of("size", query.size(), "sources", JsonArray.of(compositeSource));
+
+        if (query.afterKey() != null && !query.afterKey().isEmpty()) {
+            composite.put("after", new JsonObject(query.afterKey()));
+        }
+
+        root.put(
+            "aggs",
+            JsonObject.of(
+                "filter_values",
+                JsonObject.of("composite", composite),
+                "total_count",
+                JsonObject.of("cardinality", JsonObject.of("field", query.esFieldName()))
+            )
+        );
+
+        return root.encode();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterValuesResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterValuesResponseAdapter.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.elasticsearch.model.Aggregation;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesResult;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FilterValuesResponseAdapter {
+
+    static final String AGG_NAME = "filter_values";
+    static final String TOTAL_COUNT_AGG_NAME = "total_count";
+
+    public FilterValuesResult adapt(SearchResponse response) {
+        if (response == null || response.getAggregations() == null || response.getAggregations().isEmpty()) {
+            return new FilterValuesResult(Collections.emptyList(), null, 0);
+        }
+
+        var agg = response.getAggregations().get(AGG_NAME);
+        if (agg == null) {
+            return new FilterValuesResult(Collections.emptyList(), null, 0);
+        }
+
+        var values = extractValues(agg);
+        var afterKey = extractAfterKey(agg);
+        var totalCount = extractTotalCount(response);
+
+        return new FilterValuesResult(values, afterKey, totalCount);
+    }
+
+    private long extractTotalCount(SearchResponse response) {
+        var totalCountAgg = response.getAggregations().get(TOTAL_COUNT_AGG_NAME);
+        if (totalCountAgg == null || totalCountAgg.getValue() == null) {
+            return 0;
+        }
+        return totalCountAgg.getValue().longValue();
+    }
+
+    private List<String> extractValues(Aggregation agg) {
+        var buckets = agg.getBuckets();
+        if (buckets == null || buckets.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        var values = new ArrayList<String>(buckets.size());
+        for (var bucket : buckets) {
+            var keyNode = bucket.get("key");
+            if (keyNode != null && keyNode.has("value")) {
+                values.add(keyNode.get("value").asText());
+            }
+        }
+        return values;
+    }
+
+    private Map<String, Object> extractAfterKey(Aggregation agg) {
+        var afterKeyNode = agg.getAfterKey();
+        if (afterKeyNode == null || afterKeyNode.isNull() || !afterKeyNode.isObject()) {
+            return null;
+        }
+
+        var afterKey = new HashMap<String, Object>();
+        afterKeyNode.fields().forEachRemaining(entry -> afterKey.put(entry.getKey(), extractJsonValue(entry.getValue())));
+        return afterKey;
+    }
+
+    private Object extractJsonValue(JsonNode node) {
+        if (node.isTextual()) return node.asText();
+        if (node.isLong()) return node.asLong();
+        if (node.isInt()) return node.asInt();
+        if (node.isDouble()) return node.asDouble();
+        if (node.isBoolean()) return node.asBoolean();
+        return node.asText();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterValuesQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterValuesQueryAdapterTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesQuery;
+import io.vertx.core.json.JsonObject;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FilterValuesQueryAdapterTest {
+
+    private final FilterValuesQueryAdapter adapter = new FilterValuesQueryAdapter();
+
+    @Test
+    void should_build_composite_query_without_time_range() {
+        var query = FilterValuesQuery.builder().esFieldName("api-id").size(10).build();
+
+        var result = new JsonObject(adapter.adapt(query));
+
+        assertThat(result.getInteger("size")).isEqualTo(0);
+        assertThat(result.getJsonObject("query")).isNull();
+
+        var composite = result.getJsonObject("aggs").getJsonObject("filter_values").getJsonObject("composite");
+        assertThat(composite.getInteger("size")).isEqualTo(10);
+
+        var source = composite.getJsonArray("sources").getJsonObject(0).getJsonObject("value").getJsonObject("terms");
+        assertThat(source.getString("field")).isEqualTo("api-id");
+    }
+
+    @Test
+    void should_build_composite_query_with_time_range() {
+        var query = FilterValuesQuery.builder().esFieldName("gateway").from(1704067200000L).to(1735689599000L).size(10).build();
+
+        var result = new JsonObject(adapter.adapt(query));
+
+        var boolFilter = result.getJsonObject("query").getJsonObject("bool").getJsonArray("filter");
+        assertThat(boolFilter).hasSize(1);
+
+        var range = boolFilter.getJsonObject(0).getJsonObject("range").getJsonObject("@timestamp");
+        assertThat(range.getLong("gte")).isEqualTo(1704067200000L);
+        assertThat(range.getLong("lte")).isEqualTo(1735689599000L);
+    }
+
+    @Test
+    void should_include_after_key_for_pagination() {
+        var query = FilterValuesQuery.builder().esFieldName("api-id").size(10).afterKey(Map.of("value", "last-api-id")).build();
+
+        var result = new JsonObject(adapter.adapt(query));
+        var composite = result.getJsonObject("aggs").getJsonObject("filter_values").getJsonObject("composite");
+
+        assertThat(composite.getJsonObject("after").getString("value")).isEqualTo("last-api-id");
+    }
+
+    @Test
+    void should_omit_after_key_when_null() {
+        var query = FilterValuesQuery.builder().esFieldName("api-id").size(10).build();
+
+        var result = new JsonObject(adapter.adapt(query));
+        var composite = result.getJsonObject("aggs").getJsonObject("filter_values").getJsonObject("composite");
+
+        assertThat(composite.getJsonObject("after")).isNull();
+    }
+
+    @Test
+    void should_include_cardinality_aggregation() {
+        var query = FilterValuesQuery.builder().esFieldName("api-id").size(10).build();
+
+        var result = new JsonObject(adapter.adapt(query));
+
+        var cardinality = result.getJsonObject("aggs").getJsonObject("total_count").getJsonObject("cardinality");
+        assertThat(cardinality.getString("field")).isEqualTo("api-id");
+    }
+
+    @Test
+    void should_include_term_query_for_search_pattern() {
+        var query = FilterValuesQuery.builder().esFieldName("gateway").size(10).searchPattern("gw-1").build();
+
+        var result = new JsonObject(adapter.adapt(query));
+        var boolFilter = result.getJsonObject("query").getJsonObject("bool").getJsonArray("filter");
+        assertThat(boolFilter).hasSize(1);
+
+        var term = boolFilter.getJsonObject(0).getJsonObject("term").getJsonObject("gateway");
+        assertThat(term.getString("value")).isEqualTo("gw-1");
+        assertThat(term.getBoolean("case_insensitive")).isTrue();
+    }
+
+    @Test
+    void should_combine_time_range_and_search_pattern() {
+        var query = FilterValuesQuery.builder()
+            .esFieldName("gateway")
+            .from(1704067200000L)
+            .to(1735689599000L)
+            .size(10)
+            .searchPattern("prod")
+            .build();
+
+        var result = new JsonObject(adapter.adapt(query));
+        var boolFilter = result.getJsonObject("query").getJsonObject("bool").getJsonArray("filter");
+        assertThat(boolFilter).hasSize(2);
+
+        var range = boolFilter.getJsonObject(0).getJsonObject("range").getJsonObject("@timestamp");
+        assertThat(range.getLong("gte")).isEqualTo(1704067200000L);
+
+        var term = boolFilter.getJsonObject(1).getJsonObject("term").getJsonObject("gateway");
+        assertThat(term.getString("value")).isEqualTo("prod");
+        assertThat(term.getBoolean("case_insensitive")).isTrue();
+    }
+
+    @Test
+    void should_add_terms_filter_on_api_id_when_api_ids_provided() {
+        var query = FilterValuesQuery.builder().esFieldName("gateway").size(10).apiIds(Set.of("a1", "a2")).build();
+
+        var result = new JsonObject(adapter.adapt(query));
+        var boolFilter = result.getJsonObject("query").getJsonObject("bool").getJsonArray("filter");
+        assertThat(boolFilter).hasSize(1);
+
+        var terms = boolFilter.getJsonObject(0).getJsonObject("terms").getJsonArray("api-id");
+        assertThat(terms).containsExactlyInAnyOrder("a1", "a2");
+    }
+
+    @Test
+    void should_add_match_none_when_api_ids_empty_set() {
+        var query = FilterValuesQuery.builder().esFieldName("api-id").size(10).apiIds(Set.of()).build();
+
+        var result = new JsonObject(adapter.adapt(query));
+        var boolFilter = result.getJsonObject("query").getJsonObject("bool").getJsonArray("filter");
+        assertThat(boolFilter).hasSize(1);
+        assertThat(boolFilter.getJsonObject(0).getJsonObject("match_none")).isNotNull();
+    }
+
+    @Test
+    void should_combine_time_range_search_pattern_and_api_ids() {
+        var query = FilterValuesQuery.builder()
+            .esFieldName("gateway")
+            .from(1704067200000L)
+            .to(1735689599000L)
+            .size(10)
+            .searchPattern("prod")
+            .apiIds(Set.of("api-1"))
+            .build();
+
+        var result = new JsonObject(adapter.adapt(query));
+        var boolFilter = result.getJsonObject("query").getJsonObject("bool").getJsonArray("filter");
+        assertThat(boolFilter).hasSize(3);
+
+        assertThat(boolFilter.getJsonObject(0).getJsonObject("range")).isNotNull();
+        assertThat(boolFilter.getJsonObject(1).getJsonObject("term")).isNotNull();
+        assertThat(boolFilter.getJsonObject(2).getJsonObject("terms").getJsonArray("api-id")).containsExactly("api-1");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterValuesResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterValuesResponseAdapterTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.elasticsearch.model.Aggregation;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FilterValuesResponseAdapterTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final FilterValuesResponseAdapter adapter = new FilterValuesResponseAdapter();
+
+    @Test
+    void should_return_empty_result_for_null_response() {
+        var result = adapter.adapt(null);
+
+        assertThat(result.values()).isEmpty();
+        assertThat(result.afterKey()).isNull();
+        assertThat(result.totalCount()).isZero();
+    }
+
+    @Test
+    void should_return_empty_result_for_empty_aggregations() {
+        var response = new SearchResponse();
+        response.setAggregations(new HashMap<>());
+
+        var result = adapter.adapt(response);
+
+        assertThat(result.values()).isEmpty();
+        assertThat(result.afterKey()).isNull();
+        assertThat(result.totalCount()).isZero();
+    }
+
+    @Test
+    void should_extract_values_from_composite_buckets() {
+        var response = buildSearchResponse(new String[] { "gw-1", "gw-2", "gw-3" }, null, 0);
+
+        var result = adapter.adapt(response);
+
+        assertThat(result.values()).containsExactly("gw-1", "gw-2", "gw-3");
+        assertThat(result.afterKey()).isNull();
+    }
+
+    @Test
+    void should_extract_after_key() {
+        var afterKeyNode = MAPPER.createObjectNode().put("value", "gw-3");
+        var response = buildSearchResponse(new String[] { "gw-1", "gw-2", "gw-3" }, afterKeyNode, 0);
+
+        var result = adapter.adapt(response);
+
+        assertThat(result.values()).hasSize(3);
+        assertThat(result.afterKey()).containsEntry("value", "gw-3");
+    }
+
+    @Test
+    void should_extract_after_key_with_type_aware_values() {
+        var afterKeyNode = MAPPER.createObjectNode().put("value", "gw-3").put("timestamp", 1700000000000L).put("status", 200);
+        var response = buildSearchResponse(new String[] { "gw-1" }, afterKeyNode, 0);
+
+        var result = adapter.adapt(response);
+
+        assertThat(result.afterKey())
+            .containsEntry("value", "gw-3")
+            .containsEntry("timestamp", 1700000000000L)
+            .containsEntry("status", 200);
+    }
+
+    @Test
+    void should_return_null_after_key_when_missing() {
+        var response = buildSearchResponse(new String[] { "gw-1" }, null, 0);
+
+        var result = adapter.adapt(response);
+
+        assertThat(result.afterKey()).isNull();
+    }
+
+    @Test
+    void should_extract_total_count_from_cardinality_aggregation() {
+        var response = buildSearchResponse(new String[] { "gw-1", "gw-2" }, null, 42);
+
+        var result = adapter.adapt(response);
+
+        assertThat(result.totalCount()).isEqualTo(42);
+    }
+
+    @Test
+    void should_return_zero_total_count_when_cardinality_aggregation_missing() {
+        var response = buildSearchResponse(new String[] { "gw-1" }, null, 0);
+        response.getAggregations().remove("total_count");
+
+        var result = adapter.adapt(response);
+
+        assertThat(result.totalCount()).isZero();
+    }
+
+    private SearchResponse buildSearchResponse(String[] values, ObjectNode afterKeyNode, long totalCount) {
+        ArrayNode bucketsArray = MAPPER.createArrayNode();
+        for (String value : values) {
+            ObjectNode bucket = MAPPER.createObjectNode();
+            bucket.set("key", MAPPER.createObjectNode().put("value", value));
+            bucket.put("doc_count", 1);
+            bucketsArray.add(bucket);
+        }
+
+        var agg = new Aggregation();
+        agg.setBuckets(new java.util.ArrayList<>());
+        for (JsonNode node : bucketsArray) {
+            agg.getBuckets().add(node);
+        }
+
+        if (afterKeyNode != null) {
+            agg.setAfterKey(afterKeyNode);
+        }
+
+        var aggregations = new HashMap<String, Aggregation>();
+        aggregations.put("filter_values", agg);
+
+        if (totalCount > 0) {
+            var totalCountAgg = new Aggregation();
+            totalCountAgg.setValue((float) totalCount);
+            aggregations.put("total_count", totalCountAgg);
+        }
+
+        var response = new SearchResponse();
+        response.setAggregations(aggregations);
+        return response;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpAnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/log/v4/NoOpAnalyticsRepository.java
@@ -31,6 +31,8 @@ import io.gravitee.repository.log.v4.model.analytics.AverageConnectionDurationQu
 import io.gravitee.repository.log.v4.model.analytics.AverageMessagesPerRequestQuery;
 import io.gravitee.repository.log.v4.model.analytics.CountAggregate;
 import io.gravitee.repository.log.v4.model.analytics.CountByAggregate;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesQuery;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesResult;
 import io.gravitee.repository.log.v4.model.analytics.GroupByAggregate;
 import io.gravitee.repository.log.v4.model.analytics.GroupByQuery;
 import io.gravitee.repository.log.v4.model.analytics.HistogramAggregate;
@@ -159,5 +161,10 @@ public class NoOpAnalyticsRepository implements AnalyticsRepository {
     @Override
     public MeasuresResult searchMessageMeasures(QueryContext queryContext, MeasuresQuery query) {
         return null;
+    }
+
+    @Override
+    public FilterValuesResult searchFilterValues(QueryContext queryContext, FilterValuesQuery query) {
+        return new FilterValuesResult(Collections.emptyList(), null, 0);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -41,9 +41,11 @@ import inmemory.SubscriptionSearchQueryServiceInMemory;
 import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryContextLoader;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
+import io.gravitee.apim.core.analytics_engine.domain_service.FilterValueNameResolver;
 import io.gravitee.apim.core.analytics_engine.domain_service.QueryFilterTransformer;
 import io.gravitee.apim.core.analytics_engine.domain_service.UnitEnrichmentPostProcessor;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFacetSpecUseCase;
@@ -1071,6 +1073,16 @@ public class ResourceContextConfiguration {
     @Bean
     public AnalyticsQueryContextLoader analyticsQueryContextLoader() {
         return mock(AnalyticsQueryContextLoader.class);
+    }
+
+    @Bean
+    public FilterValuesQueryService filterValuesQueryService() {
+        return mock(FilterValuesQueryService.class);
+    }
+
+    @Bean
+    public FilterValueNameResolver filterValueNameResolver() {
+        return mock(FilterValueNameResolver.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/AnalyticsDefinitionMapper.java
@@ -15,7 +15,11 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import io.gravitee.apim.core.analytics_engine.model.FilterValue;
+import io.gravitee.apim.core.analytics_engine.model.FilterValuesPage;
 import io.gravitee.apim.core.observability.model.NumberRange;
+import io.gravitee.rest.api.management.v2.rest.model.Pagination;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiName;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiSpecsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetSpec;
@@ -23,6 +27,8 @@ import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FacetSpecs
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpecRange;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpecsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterValueItem;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterValuesResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.MetricSpecsResponse;
 import java.util.List;
@@ -62,11 +68,30 @@ public interface AnalyticsDefinitionMapper {
     @Mapping(source = "to", target = "max")
     FilterSpecRange mapRange(NumberRange range);
 
+    @Mapping(source = "apis", target = "apiTypes")
     FilterSpec mapFilterSpec(io.gravitee.apim.core.analytics_engine.model.FilterSpec filterSpec);
+
+    ApiName mapApiSpecName(io.gravitee.apim.core.analytics_engine.model.ApiSpec.Name name);
+
+    List<ApiName> mapApiSpecNames(List<io.gravitee.apim.core.analytics_engine.model.ApiSpec.Name> names);
 
     List<FilterSpec> mapFilterSpecs(List<io.gravitee.apim.core.analytics_engine.model.FilterSpec> filterSpecs);
 
     default FilterSpecsResponse toFilterSpecsResponse(List<io.gravitee.apim.core.analytics_engine.model.FilterSpec> filterSpecs) {
         return new FilterSpecsResponse().data(mapFilterSpecs(filterSpecs));
+    }
+
+    FilterValueItem mapFilterValue(FilterValue filterValue);
+
+    List<FilterValueItem> mapFilterValues(List<FilterValue> filterValues);
+
+    default FilterValuesResponse toFilterValuesResponse(FilterValuesPage page, int pageNumber, int perPage) {
+        var data = mapFilterValues(page.data());
+        var pagination = new Pagination()
+            .page(pageNumber)
+            .perPage(perPage)
+            .pageItemsCount(data.size())
+            .totalCount(page.totalFilteredCount());
+        return new FilterValuesResponse().data(data).pagination(pagination);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFilterValuesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFilterValuesResource.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.observability;
+
+import io.gravitee.apim.core.analytics_engine.use_case.GetFilterValuesUseCase;
+import io.gravitee.rest.api.management.v2.rest.mapper.AnalyticsDefinitionMapper;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterValuesResponse;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import java.time.Instant;
+
+public class ObservabilityFilterValuesResource extends AbstractResource {
+
+    @Inject
+    GetFilterValuesUseCase getFilterValuesUseCase;
+
+    @PathParam("filterName")
+    String filterName;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public FilterValuesResponse getFilterValues(
+        @QueryParam("from") Long from,
+        @QueryParam("to") Long to,
+        @QueryParam("page") @DefaultValue("1") int page,
+        @QueryParam("perPage") @DefaultValue("10") int perPage,
+        @QueryParam("query") String query
+    ) {
+        if (!canReadDashboards()) {
+            throw new ForbiddenAccessException();
+        }
+
+        var input = new GetFilterValuesUseCase.Input(
+            getAuditInfo(),
+            filterName,
+            from != null ? Instant.ofEpochMilli(from) : null,
+            to != null ? Instant.ofEpochMilli(to) : null,
+            page,
+            perPage,
+            query
+        );
+
+        var output = getFilterValuesUseCase.execute(input);
+
+        return AnalyticsDefinitionMapper.INSTANCE.toFilterValuesResponse(output.valuesPage(), page, perPage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResource.java
@@ -18,24 +18,25 @@ package io.gravitee.rest.api.management.v2.rest.resource.observability;
 import io.gravitee.apim.core.analytics_engine.use_case.GetAnalyticsFilterDefinitionsUseCase;
 import io.gravitee.rest.api.management.v2.rest.mapper.AnalyticsDefinitionMapper;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpecsResponse;
-import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.rest.annotation.Permission;
-import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-public class ObservabilityFiltersDefinitionResource {
+public class ObservabilityFiltersDefinitionResource extends AbstractResource {
 
     @Inject
     GetAnalyticsFilterDefinitionsUseCase getAnalyticsFilterDefinitions;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.API_ANALYTICS, acls = { RolePermissionAction.READ }) })
     public FilterSpecsResponse getFilterDefinitions() {
+        if (!canReadDashboards()) {
+            throw new ForbiddenAccessException();
+        }
+
         return AnalyticsDefinitionMapper.INSTANCE.toFilterSpecsResponse(getAnalyticsFilterDefinitions.execute().specs());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityResource.java
@@ -28,4 +28,9 @@ public class ObservabilityResource {
     public ObservabilityFiltersDefinitionResource getFiltersDefinitionResource() {
         return resourceContext.getResource(ObservabilityFiltersDefinitionResource.class);
     }
+
+    @Path("/filters/{filterName}/values")
+    public ObservabilityFilterValuesResource getFilterValuesResource() {
+        return resourceContext.getResource(ObservabilityFilterValuesResource.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -283,6 +283,112 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
 
+    /environments/{envId}/observability/filters/{filterName}/values:
+        get:
+            operationId: getObservabilityFilterValues
+            summary: Get values for an observability filter
+            description: |
+                Returns a paginated list of distinct values for a given filter within an optional time range.
+                - ENUM filters return their static enum values.
+                - KEYWORD filters return distinct values from the analytics data store.
+                - NUMBER and STRING filters are not supported and return 400.
+            tags:
+                - definition
+            parameters:
+                - $ref: "#/components/parameters/EnvId"
+                - name: filterName
+                  in: path
+                  required: true
+                  description: The filter name for which to retrieve values
+                  schema:
+                      $ref: "#/components/schemas/FilterName"
+                - name: from
+                  in: query
+                  required: false
+                  description: Start of the time range (epoch milliseconds). Only applies to KEYWORD filters.
+                  schema:
+                      type: integer
+                      format: int64
+                - name: to
+                  in: query
+                  required: false
+                  description: End of the time range (epoch milliseconds). Only applies to KEYWORD filters.
+                  schema:
+                      type: integer
+                      format: int64
+                - name: page
+                  in: query
+                  required: false
+                  description: Page number (starting from 1)
+                  schema:
+                      type: integer
+                      minimum: 1
+                      maximum: 10000
+                      default: 1
+                - name: perPage
+                  in: query
+                  required: false
+                  description: Number of items per page
+                  schema:
+                      type: integer
+                      minimum: 1
+                      default: 10
+                - name: query
+                  in: query
+                  required: false
+                  description: |
+                    Optional search string (case-insensitive). For ENUM filters, matches enum labels by substring.
+                    For KEYWORD filters backed by analytics data (Elasticsearch), matches the stored keyword value exactly.
+                    For ID-based filters (API, APPLICATION, PLAN), matches display names by substring.
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: A paginated list of filter values.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FilterValuesResponse"
+                            examples:
+                                keyword-values:
+                                    summary: KEYWORD filter values (direct-value)
+                                    value:
+                                        data:
+                                            - value: "gateway-1"
+                                            - value: "gateway-2"
+                                        pagination:
+                                            page: 1
+                                            perPage: 10
+                                            pageCount: 1
+                                            pageItemsCount: 2
+                                            totalCount: 2
+                                enum-values:
+                                    summary: ENUM filter values
+                                    value:
+                                        data:
+                                            - value: "GET"
+                                            - value: "POST"
+                                            - value: "PUT"
+                                        pagination:
+                                            page: 1
+                                            perPage: 10
+                                            pageCount: 1
+                                            pageItemsCount: 3
+                                            totalCount: 3
+                "400":
+                    description: |
+                        The filter type does not support value listing (NUMBER or STRING filters).
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                "500":
+                    description: Internal server error while getting filter values.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+
     /environments/{envId}/analytics/measures:
         post:
             operationId: queryMeasures
@@ -1411,11 +1517,18 @@ components:
                     example:
                         min: 100
                         max: 600
+                apiTypes:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/ApiName"
+                    description: List of API types this filter applies to, derived from the metrics that reference it.
+                    example: ["HTTP_PROXY", "LLM"]
             example:
                 name: "API"
                 label: "API"
                 type: "KEYWORD"
                 operators: ["EQ", "IN"]
+                apiTypes: ["HTTP_PROXY", "MESSAGE", "LLM", "MCP"]
 
         MetricSpec:
             type: object
@@ -1533,6 +1646,44 @@ components:
                       range:
                           min: 100
                           max: 600
+
+        FilterValueItem:
+            type: object
+            required:
+                - value
+            description: A single filter value, optionally with an associated ID for ID-based filters (e.g. API, APPLICATION, PLAN).
+            properties:
+                value:
+                    type: string
+                    description: The display value of the filter option.
+                    example: "gateway-1"
+                id:
+                    type: string
+                    description: The unique identifier associated with the value, present for ID-based filters.
+                    example: "67e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+
+        FilterValuesResponse:
+            type: object
+            description: A paginated list of filter values.
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FilterValueItem"
+                    description: List of filter values for the current page
+                pagination:
+                    $ref: "#/components/schemas/Pagination"
+            example:
+                data:
+                    - value: "gateway-1"
+                    - value: "gateway-2"
+                    - value: "gateway-3"
+                pagination:
+                    page: 1
+                    perPage: 10
+                    pageCount: 1
+                    pageItemsCount: 3
+                    totalCount: 3
 
         MetricSpecsResponse:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFilterValuesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFilterValuesResourceTest.java
@@ -1,0 +1,583 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.observability;
+
+import static assertions.MAPIAssertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryContextLoader;
+import io.gravitee.apim.core.analytics_engine.domain_service.FilterValueNameResolver;
+import io.gravitee.apim.core.analytics_engine.model.AnalyticsQueryContext;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.FilterValue;
+import io.gravitee.apim.core.analytics_engine.model.FilterValuesPage;
+import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterValueItem;
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterValuesResponse;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ObservabilityFilterValuesResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "my-env";
+
+    @Inject
+    FilterValuesQueryService filterValuesQueryService;
+
+    @Inject
+    FilterValueNameResolver filterValueNameResolver;
+
+    @Inject
+    AnalyticsQueryContextLoader analyticsQueryContextLoader;
+
+    @Inject
+    PlanQueryServiceInMemory planQueryServiceInMemory;
+
+    @BeforeEach
+    void setup() {
+        var environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENVIRONMENT);
+        environmentEntity.setOrganizationId(ORGANIZATION);
+
+        when(environmentService.findById(ENVIRONMENT)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(environmentEntity);
+
+        when(analyticsQueryContextLoader.load(any())).thenReturn(
+            new AnalyticsQueryContext(null, new ExecutionContext(ORGANIZATION, ENVIRONMENT), Set.of(), Map.of(), Map.of(), Map.of())
+        );
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+    }
+
+    @Override
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        GraviteeContext.cleanContext();
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/observability/filters";
+    }
+
+    @Test
+    void should_return_enum_values_for_http_method() {
+        var response = rootTarget("HTTP_METHOD/values").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .extracting(FilterValuesResponse::getData)
+            .satisfies(data -> {
+                assertThat(data).isNotEmpty();
+                assertThat(data).extracting(FilterValueItem::getValue).contains("GET", "POST", "PUT");
+            });
+    }
+
+    @Test
+    void should_return_400_for_number_filter() {
+        var response = rootTarget("HTTP_STATUS/values").request().get();
+
+        assertThat(response).hasStatus(400);
+    }
+
+    @Test
+    void should_return_400_for_string_filter() {
+        var response = rootTarget("HTTP_PATH/values").request().get();
+
+        assertThat(response).hasStatus(400);
+    }
+
+    @Test
+    void should_return_keyword_filter_values() {
+        when(
+            filterValuesQueryService.searchFilterValues(
+                any(),
+                any(),
+                eq(FilterSpec.Name.GATEWAY),
+                any(),
+                any(),
+                anyInt(),
+                eq(10),
+                any(),
+                any(),
+                any()
+            )
+        ).thenReturn(new FilterValuesPage(List.of(new FilterValue("gw-1"), new FilterValue("gw-2")), null));
+
+        var response = rootTarget("GATEWAY/values").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .extracting(FilterValuesResponse::getData)
+            .satisfies(data -> {
+                assertThat(data).hasSize(2);
+                assertThat(data).extracting(FilterValueItem::getValue).containsExactly("gw-1", "gw-2");
+            });
+    }
+
+    @Test
+    void should_pass_authorized_api_ids_from_analytics_context_to_keyword_filter_query() {
+        when(analyticsQueryContextLoader.load(any())).thenReturn(
+            new AnalyticsQueryContext(
+                null,
+                new ExecutionContext(ORGANIZATION, ENVIRONMENT),
+                Set.of("auth-api-1", "auth-api-2"),
+                Map.of(),
+                Map.of(),
+                Map.of()
+            )
+        );
+        when(
+            filterValuesQueryService.searchFilterValues(
+                any(),
+                any(),
+                eq(FilterSpec.Name.GATEWAY),
+                any(),
+                any(),
+                anyInt(),
+                eq(10),
+                any(),
+                any(),
+                eq(Set.of("auth-api-1", "auth-api-2"))
+            )
+        ).thenReturn(new FilterValuesPage(List.of(new FilterValue("gw-1")), null));
+
+        var response = rootTarget("GATEWAY/values").request().get();
+
+        assertThat(response).hasStatus(200);
+        verify(filterValuesQueryService).searchFilterValues(
+            eq(ORGANIZATION),
+            eq(ENVIRONMENT),
+            eq(FilterSpec.Name.GATEWAY),
+            any(),
+            any(),
+            eq(1),
+            eq(10),
+            any(),
+            any(),
+            eq(Set.of("auth-api-1", "auth-api-2"))
+        );
+    }
+
+    @Test
+    void should_pass_time_range_to_keyword_filter() {
+        when(
+            filterValuesQueryService.searchFilterValues(any(), any(), any(), any(), any(), anyInt(), eq(10), any(), any(), any())
+        ).thenReturn(new FilterValuesPage(Collections.emptyList(), null));
+
+        var response = rootTarget("API/values").queryParam("from", 1704067200000L).queryParam("to", 1735689599000L).request().get();
+
+        assertThat(response).hasStatus(200);
+    }
+
+    @Test
+    void should_return_400_for_invalid_filter_name() {
+        var response = rootTarget("INVALID_FILTER/values").request().get();
+
+        assertThat(response).hasStatus(400);
+    }
+
+    @Test
+    void should_pass_query_param_for_keyword_filter() {
+        when(
+            filterValuesQueryService.searchFilterValues(
+                any(),
+                any(),
+                eq(FilterSpec.Name.GATEWAY),
+                any(),
+                any(),
+                anyInt(),
+                eq(10),
+                any(),
+                eq("gw-prod-1"),
+                any()
+            )
+        ).thenReturn(new FilterValuesPage(List.of(new FilterValue("gw-prod-1")), null));
+
+        var response = rootTarget("GATEWAY/values").queryParam("query", "gw-prod-1").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .extracting(FilterValuesResponse::getData)
+            .satisfies(data -> {
+                assertThat(data).hasSize(1);
+                assertThat(data.get(0).getValue()).isEqualTo("gw-prod-1");
+            });
+    }
+
+    @Test
+    void should_search_by_name_for_id_based_filter_with_query() {
+        when(analyticsQueryContextLoader.load(any())).thenReturn(
+            new AnalyticsQueryContext(
+                null,
+                new ExecutionContext(ORGANIZATION, ENVIRONMENT),
+                Set.of(),
+                Map.of("api-id-1", "My API 1", "api-id-2", "Other API"),
+                Map.of(),
+                Map.of()
+            )
+        );
+
+        var response = rootTarget("API/values").queryParam("query", "My").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .extracting(FilterValuesResponse::getData)
+            .satisfies(data -> {
+                assertThat(data).hasSize(1);
+                assertThat(data.get(0).getValue()).isEqualTo("My API 1");
+                assertThat(data.get(0).getId()).isEqualTo("api-id-1");
+            });
+    }
+
+    @Test
+    void should_filter_enum_values_with_query() {
+        var response = rootTarget("HTTP_METHOD/values").queryParam("query", "PO").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .extracting(FilterValuesResponse::getData)
+            .satisfies(data -> {
+                assertThat(data).hasSize(1);
+                assertThat(data.get(0).getValue()).isEqualTo("POST");
+            });
+    }
+
+    @Test
+    void should_resolve_id_based_filter_names_without_query() {
+        when(analyticsQueryContextLoader.load(any())).thenReturn(
+            new AnalyticsQueryContext(
+                null,
+                new ExecutionContext(ORGANIZATION, ENVIRONMENT),
+                Set.of(),
+                Map.of("api-id-1", "My API 1", "api-id-2", "My API 2"),
+                Map.of(),
+                Map.of()
+            )
+        );
+        when(
+            filterValuesQueryService.searchFilterValues(
+                any(),
+                any(),
+                eq(FilterSpec.Name.API),
+                any(),
+                any(),
+                anyInt(),
+                eq(10),
+                any(),
+                any(),
+                any()
+            )
+        ).thenReturn(new FilterValuesPage(List.of(new FilterValue("api-id-1"), new FilterValue("api-id-2")), null));
+
+        var response = rootTarget("API/values").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .extracting(FilterValuesResponse::getData)
+            .satisfies(data -> {
+                assertThat(data).hasSize(2);
+                assertThat(data).extracting(FilterValueItem::getValue).containsExactly("My API 1", "My API 2");
+                assertThat(data).extracting(FilterValueItem::getId).containsExactly("api-id-1", "api-id-2");
+            });
+    }
+
+    @Test
+    void should_paginate_enum_values_with_query() {
+        var response = rootTarget("HTTP_METHOD/values")
+            .queryParam("query", "PO")
+            .queryParam("page", 1)
+            .queryParam("perPage", 1)
+            .request()
+            .get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .extracting(FilterValuesResponse::getData)
+            .satisfies(data -> {
+                assertThat(data).hasSize(1);
+                assertThat(data.get(0).getValue()).isEqualTo("POST");
+            });
+    }
+
+    @Test
+    void should_pass_query_and_time_range_for_direct_value_keyword() {
+        when(
+            filterValuesQueryService.searchFilterValues(
+                any(),
+                any(),
+                eq(FilterSpec.Name.GATEWAY),
+                any(),
+                any(),
+                anyInt(),
+                eq(10),
+                any(),
+                eq("gw-prod"),
+                any()
+            )
+        ).thenReturn(new FilterValuesPage(List.of(new FilterValue("gw-prod")), null));
+
+        var response = rootTarget("GATEWAY/values")
+            .queryParam("query", "gw-prod")
+            .queryParam("from", 1704067200000L)
+            .queryParam("to", 1735689599000L)
+            .request()
+            .get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .extracting(FilterValuesResponse::getData)
+            .satisfies(data -> {
+                assertThat(data).hasSize(1);
+                assertThat(data.get(0).getValue()).isEqualTo("gw-prod");
+                assertThat(data.get(0).getId()).isNull();
+            });
+    }
+
+    @Test
+    void should_resolve_application_names_for_id_based_filter() {
+        when(
+            filterValuesQueryService.searchFilterValues(
+                any(),
+                any(),
+                eq(FilterSpec.Name.APPLICATION),
+                any(),
+                any(),
+                anyInt(),
+                eq(10),
+                any(),
+                any(),
+                any()
+            )
+        ).thenReturn(new FilterValuesPage(List.of(new FilterValue("app-id-1")), null));
+        when(filterValueNameResolver.resolveNames(any(), eq(FilterSpec.Name.APPLICATION), any())).thenReturn(
+            java.util.Map.of("app-id-1", "My Application")
+        );
+
+        var response = rootTarget("APPLICATION/values").request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .extracting(FilterValuesResponse::getData)
+            .satisfies(data -> {
+                assertThat(data).hasSize(1);
+                assertThat(data.get(0).getValue()).isEqualTo("My Application");
+                assertThat(data.get(0).getId()).isEqualTo("app-id-1");
+            });
+    }
+
+    @Test
+    void should_search_plan_by_name_with_query() {
+        planQueryServiceInMemory.reset();
+        when(analyticsQueryContextLoader.load(any())).thenReturn(
+            new AnalyticsQueryContext(null, new ExecutionContext(ORGANIZATION, ENVIRONMENT), Set.of("api-1"), Map.of(), Map.of(), Map.of())
+        );
+        // initWith uses Plan#copy(); definitionVersion must be set or copy() fails on switch (null).
+        planQueryServiceInMemory.initWith(
+            List.of(
+                Plan.builder()
+                    .id("plan-id-1")
+                    .name("Gold Plan")
+                    .definitionVersion(DefinitionVersion.V4)
+                    .referenceId("api-1")
+                    .referenceType(GenericPlanEntity.ReferenceType.API)
+                    .environmentId(ENVIRONMENT)
+                    .build()
+            )
+        );
+
+        try {
+            var response = rootTarget("PLAN/values").queryParam("query", "Gold").request().get();
+
+            assertThat(response)
+                .hasStatus(200)
+                .asEntity(FilterValuesResponse.class)
+                .extracting(FilterValuesResponse::getData)
+                .satisfies(data -> {
+                    assertThat(data).hasSize(1);
+                    assertThat(data.get(0).getValue()).isEqualTo("Gold Plan");
+                    assertThat(data.get(0).getId()).isEqualTo("plan-id-1");
+                });
+        } finally {
+            planQueryServiceInMemory.reset();
+        }
+    }
+
+    @Test
+    void should_return_pagination_for_keyword_filter_page_2() {
+        when(
+            filterValuesQueryService.searchFilterValues(
+                any(),
+                any(),
+                eq(FilterSpec.Name.GATEWAY),
+                any(),
+                any(),
+                eq(2),
+                eq(5),
+                any(),
+                any(),
+                any()
+            )
+        ).thenReturn(new FilterValuesPage(List.of(new FilterValue("gw-6"), new FilterValue("gw-7")), null, 12L));
+
+        var response = rootTarget("GATEWAY/values").queryParam("page", 2).queryParam("perPage", 5).request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .satisfies(body -> {
+                assertThat(body.getData()).hasSize(2);
+                assertThat(body.getData()).extracting(FilterValueItem::getValue).containsExactly("gw-6", "gw-7");
+                assertThat(body.getPagination().getPage()).isEqualTo(2);
+                assertThat(body.getPagination().getPerPage()).isEqualTo(5);
+                assertThat(body.getPagination().getPageItemsCount()).isEqualTo(2);
+                assertThat(body.getPagination().getTotalCount()).isEqualTo(12L);
+            });
+    }
+
+    @Test
+    void should_return_pagination_for_enum_values() {
+        var response = rootTarget("HTTP_METHOD/values").queryParam("page", 1).queryParam("perPage", 3).request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .satisfies(body -> {
+                assertThat(body.getData()).hasSize(3);
+                assertThat(body.getPagination().getPage()).isEqualTo(1);
+                assertThat(body.getPagination().getPerPage()).isEqualTo(3);
+                assertThat(body.getPagination().getPageItemsCount()).isEqualTo(3);
+                assertThat(body.getPagination().getTotalCount()).isEqualTo(10L);
+            });
+    }
+
+    @Test
+    void should_return_400_for_per_page_out_of_range() {
+        var response = rootTarget("HTTP_METHOD/values").queryParam("perPage", 101).request().get();
+
+        assertThat(response).hasStatus(400);
+    }
+
+    @Test
+    void should_return_400_for_per_page_zero() {
+        var response = rootTarget("HTTP_METHOD/values").queryParam("perPage", 0).request().get();
+
+        assertThat(response).hasStatus(400);
+    }
+
+    @Test
+    void should_return_empty_page_for_keyword_filter_beyond_data() {
+        when(
+            filterValuesQueryService.searchFilterValues(
+                any(),
+                any(),
+                eq(FilterSpec.Name.GATEWAY),
+                any(),
+                any(),
+                eq(5),
+                eq(10),
+                any(),
+                any(),
+                any()
+            )
+        ).thenReturn(new FilterValuesPage(Collections.emptyList(), null, 3L));
+
+        var response = rootTarget("GATEWAY/values").queryParam("page", 5).request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .satisfies(body -> {
+                assertThat(body.getData()).isEmpty();
+                assertThat(body.getPagination().getPage()).isEqualTo(5);
+                assertThat(body.getPagination().getPageItemsCount()).isEqualTo(0);
+                assertThat(body.getPagination().getTotalCount()).isEqualTo(3L);
+            });
+    }
+
+    @Test
+    void should_return_id_based_filter_values_on_page_2() {
+        when(analyticsQueryContextLoader.load(any())).thenReturn(
+            new AnalyticsQueryContext(
+                null,
+                new ExecutionContext(ORGANIZATION, ENVIRONMENT),
+                Set.of(),
+                Map.of("api-id-6", "My API 6"),
+                Map.of(),
+                Map.of()
+            )
+        );
+        when(
+            filterValuesQueryService.searchFilterValues(
+                any(),
+                any(),
+                eq(FilterSpec.Name.API),
+                any(),
+                any(),
+                eq(2),
+                eq(5),
+                any(),
+                any(),
+                any()
+            )
+        ).thenReturn(new FilterValuesPage(List.of(new FilterValue("api-id-6")), null, 11L));
+
+        var response = rootTarget("API/values").queryParam("page", 2).queryParam("perPage", 5).request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterValuesResponse.class)
+            .satisfies(body -> {
+                assertThat(body.getData()).hasSize(1);
+                assertThat(body.getData().get(0).getValue()).isEqualTo("My API 6");
+                assertThat(body.getData().get(0).getId()).isEqualTo("api-id-6");
+                assertThat(body.getPagination().getPage()).isEqualTo(2);
+                assertThat(body.getPagination().getPerPage()).isEqualTo(5);
+            });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.observability;
 import static assertions.MAPIAssertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.ApiName;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpec;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.FilterSpecsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.analytics.engine.Operator;
@@ -110,6 +111,25 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
                 assertThat(apiTypeFilter.getType()).isEqualTo(FilterSpec.TypeEnum.ENUM);
                 assertThat(apiTypeFilter.getOperators()).containsExactlyInAnyOrder(Operator.EQ, Operator.IN);
                 assertThat(apiTypeFilter.getEnumValues()).containsExactlyInAnyOrder("HTTP_PROXY", "LLM", "MESSAGE", "MCP");
+            });
+    }
+
+    @Test
+    void should_return_filter_definitions_with_api_types() {
+        var response = rootTarget().request().get();
+
+        assertThat(response)
+            .hasStatus(200)
+            .asEntity(FilterSpecsResponse.class)
+            .extracting(FilterSpecsResponse::getData)
+            .satisfies(filters -> {
+                var apiFilter = filters
+                    .stream()
+                    .filter(f -> f.getName().getValue().equals("API"))
+                    .findFirst()
+                    .orElseThrow();
+                assertThat(apiFilter.getApiTypes()).isNotNull();
+                assertThat(apiFilter.getApiTypes()).isNotEmpty();
             });
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -42,12 +42,15 @@ import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryContextLoader;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryValidator;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
+import io.gravitee.apim.core.analytics_engine.domain_service.FilterValueNameResolver;
 import io.gravitee.apim.core.analytics_engine.domain_service.QueryFilterTransformer;
 import io.gravitee.apim.core.analytics_engine.domain_service.UnitEnrichmentPostProcessor;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetAnalyticsFilterDefinitionsUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.GetFilterValuesUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFacetSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFilterSpecUseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
@@ -89,6 +92,7 @@ import io.gravitee.apim.core.api_product.use_case.members.UpdateApiProductMember
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
+import io.gravitee.apim.core.application.query_service.ApplicationQueryService;
 import io.gravitee.apim.core.application.use_case.ValidateApplicationCRDUseCase;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateDomainService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
@@ -140,6 +144,7 @@ import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
 import io.gravitee.apim.core.plan.domain_service.PlanValidatorDomainService;
 import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.ValidatePlanDomainService;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.apim.core.plan.use_case.CreateApiProductPlanUseCase;
 import io.gravitee.apim.core.plan.use_case.CreatePlanUseCase;
 import io.gravitee.apim.core.plan.use_case.GetPlansUseCase;
@@ -1232,6 +1237,35 @@ public class ResourceContextConfiguration {
         AnalyticsDefinitionQueryService analyticsDefinitionQueryService
     ) {
         return new GetAnalyticsFilterDefinitionsUseCase(analyticsDefinitionQueryService);
+    }
+
+    @Bean
+    public FilterValuesQueryService filterValuesQueryService() {
+        return mock(FilterValuesQueryService.class);
+    }
+
+    @Bean
+    public FilterValueNameResolver filterValueNameResolver() {
+        return mock(FilterValueNameResolver.class);
+    }
+
+    @Bean
+    public GetFilterValuesUseCase getFilterValuesUseCase(
+        AnalyticsDefinitionQueryService analyticsDefinitionQueryService,
+        FilterValuesQueryService filterValuesQueryService,
+        FilterValueNameResolver filterValueNameResolver,
+        AnalyticsQueryContextLoader analyticsQueryContextLoader,
+        io.gravitee.apim.core.application.query_service.ApplicationQueryService applicationQueryService,
+        io.gravitee.apim.core.plan.query_service.PlanQueryService planQueryService
+    ) {
+        return new GetFilterValuesUseCase(
+            analyticsDefinitionQueryService,
+            filterValuesQueryService,
+            filterValueNameResolver,
+            analyticsQueryContextLoader,
+            applicationQueryService,
+            planQueryService
+        );
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -36,9 +36,11 @@ import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryContextLoader;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
+import io.gravitee.apim.core.analytics_engine.domain_service.FilterValueNameResolver;
 import io.gravitee.apim.core.analytics_engine.domain_service.QueryFilterTransformer;
 import io.gravitee.apim.core.analytics_engine.domain_service.UnitEnrichmentPostProcessor;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFacetSpecUseCase;
@@ -1268,6 +1270,16 @@ public class ResourceContextConfiguration {
     @Bean
     public AnalyticsQueryContextLoader analyticsQueryContextLoader() {
         return mock(AnalyticsQueryContextLoader.class);
+    }
+
+    @Bean
+    public FilterValuesQueryService filterValuesQueryService() {
+        return mock(FilterValuesQueryService.class);
+    }
+
+    @Bean
+    public FilterValueNameResolver filterValueNameResolver() {
+        return mock(FilterValueNameResolver.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -36,9 +36,11 @@ import inmemory.spring.InMemoryConfiguration;
 import io.gravitee.apim.core.access_point.query_service.AccessPointQueryService;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryContextLoader;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
+import io.gravitee.apim.core.analytics_engine.domain_service.FilterValueNameResolver;
 import io.gravitee.apim.core.analytics_engine.domain_service.QueryFilterTransformer;
 import io.gravitee.apim.core.analytics_engine.domain_service.UnitEnrichmentPostProcessor;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFacetSpecUseCase;
@@ -1227,6 +1229,16 @@ public class ResourceContextConfiguration {
     @Bean
     public AnalyticsQueryContextLoader analyticsQueryContextLoader() {
         return mock(AnalyticsQueryContextLoader.class);
+    }
+
+    @Bean
+    public FilterValuesQueryService filterValuesQueryService() {
+        return mock(FilterValuesQueryService.class);
+    }
+
+    @Bean
+    public FilterValueNameResolver filterValueNameResolver() {
+        return mock(FilterValueNameResolver.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/FilterValueNameResolver.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/domain_service/FilterValueNameResolver.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.domain_service;
+
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.FilterValue;
+import java.util.List;
+import java.util.Map;
+
+public interface FilterValueNameResolver {
+    /**
+     * Resolve IDs to human-readable names for ID-based filters (API, APPLICATION, PLAN).
+     *
+     * @return a map from ID to display name
+     */
+    Map<String, String> resolveNames(String environmentId, FilterSpec.Name filterName, List<String> ids);
+
+    /**
+     * Search the management database for entities matching the query by name (case-insensitive contains).
+     *
+     * @return filter values with both id and display name
+     */
+    List<FilterValue> searchByName(String environmentId, FilterSpec.Name filterName, String query, int page, int perPage);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -26,7 +26,8 @@ public record FilterSpec(
     FilterType type,
     List<String> enumValues,
     NumberRange range,
-    List<FilterOperator> operators
+    List<FilterOperator> operators,
+    List<ApiSpec.Name> apis
 ) {
     public enum Name {
         API,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterValue.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterValue.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.model;
+
+/**
+ * Represents a single value for a filter.
+ *
+ * @param value The display value
+ * @param id    Optional unique identifier for ID-based filters (API, APPLICATION, PLAN). Null for direct-value filters.
+ */
+public record FilterValue(String value, String id) {
+    public FilterValue(String value) {
+        this(value, null);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterValuesPage.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterValuesPage.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.model;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A page of filter values, with an opaque cursor for the next page.
+ *
+ * @param data               The filter values in this page
+ * @param afterKey            Opaque cursor for requesting the next page. Null when there are no more pages.
+ * @param totalFilteredCount  Total number of matching values across all pages. Null when the total is unknowable
+ *                            (e.g. ES composite aggregations for KEYWORD filters).
+ */
+public record FilterValuesPage(List<FilterValue> data, Map<String, Object> afterKey, Long totalFilteredCount) {
+    /** Convenience constructor for cursor-based pages where the total is unknown. */
+    public FilterValuesPage(List<FilterValue> data, Map<String, Object> afterKey) {
+        this(data, afterKey, null);
+    }
+
+    public boolean hasNextPage() {
+        return afterKey != null && !afterKey.isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/query_service/FilterValuesQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/query_service/FilterValuesQueryService.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.query_service;
+
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.FilterValuesPage;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+public interface FilterValuesQueryService {
+    FilterValuesPage searchFilterValues(
+        String organizationId,
+        String environmentId,
+        FilterSpec.Name filterName,
+        Instant from,
+        Instant to,
+        int page,
+        int size,
+        Map<String, Object> afterKey,
+        String searchPattern,
+        Set<String> authorizedApiIds
+    );
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCase.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryContextLoader;
+import io.gravitee.apim.core.analytics_engine.domain_service.FilterValueNameResolver;
+import io.gravitee.apim.core.analytics_engine.model.AnalyticsQueryContext;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.FilterValue;
+import io.gravitee.apim.core.analytics_engine.model.FilterValuesPage;
+import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
+import io.gravitee.apim.core.application.query_service.ApplicationQueryService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetFilterValuesUseCase {
+
+    /** Upper bound aligned with OpenAPI `page` parameter for observability filter values. */
+    private static final int MAX_PAGE = 10_000;
+
+    private static final Set<FilterSpec.Name> ID_BASED_FILTERS = Set.of(
+        FilterSpec.Name.API,
+        FilterSpec.Name.APPLICATION,
+        FilterSpec.Name.PLAN
+    );
+
+    private final AnalyticsDefinitionQueryService definitionQueryService;
+    private final FilterValuesQueryService filterValuesQueryService;
+    private final FilterValueNameResolver filterValueNameResolver;
+    private final AnalyticsQueryContextLoader contextLoader;
+    private final ApplicationQueryService applicationQueryService;
+    private final PlanQueryService planQueryService;
+
+    public record Input(AuditInfo auditInfo, String filterName, Instant from, Instant to, int page, int perPage, String query) {}
+
+    public record Output(FilterValuesPage valuesPage) {}
+
+    public Output execute(Input input) {
+        if (input.page() < 1 || input.page() > MAX_PAGE) {
+            throw new ValidationDomainException("page must be between 1 and " + MAX_PAGE, Map.of("page", String.valueOf(input.page())));
+        }
+        if (input.perPage() < 1 || input.perPage() > 100) {
+            throw new ValidationDomainException("perPage must be between 1 and 100", Map.of("perPage", String.valueOf(input.perPage())));
+        }
+
+        var filterSpecName = validateFilterName(input.filterName());
+        var filterSpec = findFilterSpec(filterSpecName);
+
+        var analyticsContext = contextLoader.load(input.auditInfo());
+
+        return switch (filterSpec.type()) {
+            case ENUM -> handleEnum(filterSpec, input);
+            case KEYWORD -> handleKeyword(input, filterSpecName, analyticsContext);
+            case NUMBER, STRING -> throw new ValidationDomainException(
+                "Filter type " + filterSpec.type() + " does not support value listing",
+                Map.of("filterName", input.filterName(), "filterType", filterSpec.type().name())
+            );
+        };
+    }
+
+    private Output handleEnum(FilterSpec filterSpec, Input input) {
+        var enumValues = filterSpec.enumValues();
+        if (enumValues == null || enumValues.isEmpty()) {
+            return new Output(new FilterValuesPage(Collections.emptyList(), null, 0L));
+        }
+
+        var stream = enumValues.stream();
+
+        if (input.query() != null && !input.query().isBlank()) {
+            var lowerQuery = input.query().toLowerCase();
+            stream = stream.filter(v -> v.toLowerCase().contains(lowerQuery));
+        }
+
+        var allValues = stream.map(FilterValue::new).toList();
+
+        var fromIndex = Math.min((input.page() - 1) * input.perPage(), allValues.size());
+        var toIndex = Math.min(fromIndex + input.perPage(), allValues.size());
+        var pageValues = allValues.subList(fromIndex, toIndex);
+
+        return new Output(new FilterValuesPage(pageValues, null, (long) allValues.size()));
+    }
+
+    private Output handleKeyword(Input input, FilterSpec.Name filterSpecName, AnalyticsQueryContext analyticsContext) {
+        Objects.requireNonNull(analyticsContext);
+
+        boolean isIdBased = ID_BASED_FILTERS.contains(filterSpecName);
+        boolean hasQuery = input.query() != null && !input.query().isBlank();
+
+        if (isIdBased && hasQuery) {
+            return handleIdBasedSearch(input, filterSpecName, analyticsContext);
+        }
+
+        if (isIdBased) {
+            return handleIdBasedNoSearch(input, filterSpecName, analyticsContext);
+        }
+
+        return handleDirectValueKeyword(input, filterSpecName, analyticsContext);
+    }
+
+    private Output handleIdBasedSearch(Input input, FilterSpec.Name filterSpecName, AnalyticsQueryContext analyticsContext) {
+        if (filterSpecName == FilterSpec.Name.API) {
+            return searchApisByNameFromContext(input, analyticsContext);
+        }
+        if (filterSpecName == FilterSpec.Name.APPLICATION) {
+            return searchApplicationsByNameFromEnvironment(input);
+        }
+        if (filterSpecName == FilterSpec.Name.PLAN) {
+            return searchPlansByNameFromAuthorizedApis(input, analyticsContext);
+        }
+        return new Output(new FilterValuesPage(Collections.emptyList(), null, 0L));
+    }
+
+    private Output searchApisByNameFromContext(Input input, AnalyticsQueryContext analyticsContext) {
+        var lowerQuery = input.query().toLowerCase();
+        var matching = analyticsContext
+            .apiNamesById()
+            .entrySet()
+            .stream()
+            .filter(e -> {
+                var name = e.getValue();
+                return name != null && name.toLowerCase().contains(lowerQuery);
+            })
+            .sorted(
+                Comparator.comparing(Map.Entry<String, String>::getValue, String.CASE_INSENSITIVE_ORDER).thenComparing(Map.Entry::getKey)
+            )
+            .toList();
+
+        var totalFiltered = (long) matching.size();
+        var fromIndex = Math.min((input.page() - 1) * input.perPage(), matching.size());
+        var toIndex = Math.min(fromIndex + input.perPage(), matching.size());
+        var pageEntries = matching.subList(fromIndex, toIndex);
+        var values = pageEntries
+            .stream()
+            .map(e -> new FilterValue(e.getValue(), e.getKey()))
+            .toList();
+
+        return new Output(new FilterValuesPage(values, null, totalFiltered));
+    }
+
+    private Output searchApplicationsByNameFromEnvironment(Input input) {
+        var environmentId = input.auditInfo().environmentId();
+        var lowerQuery = input.query().toLowerCase();
+        var matching = applicationQueryService
+            .findByEnvironment(environmentId)
+            .stream()
+            .filter(app -> app.getName() != null && app.getName().toLowerCase().contains(lowerQuery))
+            .sorted(
+                Comparator.comparing(BaseApplicationEntity::getName, String.CASE_INSENSITIVE_ORDER).thenComparing(
+                    BaseApplicationEntity::getId
+                )
+            )
+            .toList();
+
+        var totalFiltered = (long) matching.size();
+        var fromIndex = Math.min((input.page() - 1) * input.perPage(), matching.size());
+        var toIndex = Math.min(fromIndex + input.perPage(), matching.size());
+        var pageApps = matching.subList(fromIndex, toIndex);
+        var values = pageApps
+            .stream()
+            .map(app -> new FilterValue(app.getName(), app.getId()))
+            .toList();
+
+        return new Output(new FilterValuesPage(values, null, totalFiltered));
+    }
+
+    private Output searchPlansByNameFromAuthorizedApis(Input input, AnalyticsQueryContext analyticsContext) {
+        Objects.requireNonNull(analyticsContext);
+        var environmentId = input.auditInfo().environmentId();
+        var apiIds = analyticsContext.authorizedApiIds();
+        if (apiIds == null || apiIds.isEmpty()) {
+            return new Output(new FilterValuesPage(Collections.emptyList(), null, 0L));
+        }
+
+        var lowerQuery = input.query().toLowerCase();
+        var plans = planQueryService.findAllByApiIds(apiIds, Set.of(environmentId));
+        var matching = plans
+            .stream()
+            .filter(plan -> plan.getName() != null && plan.getName().toLowerCase().contains(lowerQuery))
+            .collect(Collectors.toMap(Plan::getId, p -> p, (a, b) -> a, LinkedHashMap::new))
+            .values()
+            .stream()
+            .sorted(Comparator.comparing(Plan::getName, String.CASE_INSENSITIVE_ORDER).thenComparing(Plan::getId))
+            .toList();
+
+        var totalFiltered = (long) matching.size();
+        var fromIndex = Math.min((input.page() - 1) * input.perPage(), matching.size());
+        var toIndex = Math.min(fromIndex + input.perPage(), matching.size());
+        var pagePlans = matching.subList(fromIndex, toIndex);
+        var values = pagePlans
+            .stream()
+            .map(plan -> new FilterValue(plan.getName(), plan.getId()))
+            .toList();
+
+        return new Output(new FilterValuesPage(values, null, totalFiltered));
+    }
+
+    private Output handleIdBasedNoSearch(Input input, FilterSpec.Name filterSpecName, AnalyticsQueryContext analyticsContext) {
+        var organizationId = input.auditInfo().organizationId();
+        var environmentId = input.auditInfo().environmentId();
+
+        var esPage = filterValuesQueryService.searchFilterValues(
+            organizationId,
+            environmentId,
+            filterSpecName,
+            input.from(),
+            input.to(),
+            input.page(),
+            input.perPage(),
+            null,
+            null,
+            analyticsContext.authorizedApiIds()
+        );
+
+        if (filterSpecName == FilterSpec.Name.API) {
+            var resolvedValues = esPage
+                .data()
+                .stream()
+                .map(fv -> new FilterValue(analyticsContext.apiNamesById().getOrDefault(fv.value(), fv.value()), fv.value()))
+                .toList();
+            return new Output(new FilterValuesPage(resolvedValues, esPage.afterKey()));
+        }
+
+        var ids = esPage.data().stream().map(FilterValue::value).toList();
+        var namesByIds = filterValueNameResolver.resolveNames(environmentId, filterSpecName, ids);
+
+        var resolvedValues = esPage
+            .data()
+            .stream()
+            .map(fv -> new FilterValue(namesByIds.getOrDefault(fv.value(), fv.value()), fv.value()))
+            .toList();
+
+        return new Output(new FilterValuesPage(resolvedValues, esPage.afterKey()));
+    }
+
+    private Output handleDirectValueKeyword(Input input, FilterSpec.Name filterSpecName, AnalyticsQueryContext analyticsContext) {
+        var organizationId = input.auditInfo().organizationId();
+        var environmentId = input.auditInfo().environmentId();
+
+        var page = filterValuesQueryService.searchFilterValues(
+            organizationId,
+            environmentId,
+            filterSpecName,
+            input.from(),
+            input.to(),
+            input.page(),
+            input.perPage(),
+            null,
+            input.query(),
+            analyticsContext.authorizedApiIds()
+        );
+        return new Output(page);
+    }
+
+    private FilterSpec.Name validateFilterName(String filterName) {
+        try {
+            return FilterSpec.Name.valueOf(filterName);
+        } catch (IllegalArgumentException e) {
+            throw new ValidationDomainException(
+                "Invalid filter name",
+                Map.of("invalidName", filterName, "validNames", Arrays.toString(FilterSpec.Name.values()))
+            );
+        }
+    }
+
+    private FilterSpec findFilterSpec(FilterSpec.Name name) {
+        return definitionQueryService
+            .getAllFilters()
+            .stream()
+            .filter(f -> f.name() == name)
+            .findFirst()
+            .orElseThrow(() -> new ValidationDomainException("Filter not found", Map.of("filterName", name.name())));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/FilterValueNameResolverImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/FilterValueNameResolverImpl.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine;
+
+import io.gravitee.apim.core.analytics_engine.domain_service.FilterValueNameResolver;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.FilterValue;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FilterValueNameResolverImpl implements FilterValueNameResolver {
+
+    private static final String UNKNOWN_APPLICATION_ID = "1";
+    private static final String UNKNOWN_APPLICATION_NAME = "Unknown";
+
+    private final ApiCrudService apiCrudService;
+    private final ApiQueryService apiQueryService;
+    private final ApplicationCrudService applicationCrudService;
+    private final PlanCrudService planCrudService;
+
+    @Override
+    public Map<String, String> resolveNames(String environmentId, FilterSpec.Name filterName, List<String> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return switch (filterName) {
+            case API -> apiCrudService.findByIds(ids).stream().collect(Collectors.toMap(api -> api.getId(), api -> api.getName()));
+            case APPLICATION -> {
+                var names = new HashMap<>(
+                    applicationCrudService
+                        .findByIds(ids, environmentId)
+                        .stream()
+                        .collect(Collectors.toMap(app -> app.getId(), app -> app.getName()))
+                );
+                names.put(UNKNOWN_APPLICATION_ID, UNKNOWN_APPLICATION_NAME);
+                yield names;
+            }
+            case PLAN -> planCrudService.findByIds(ids).stream().collect(Collectors.toMap(plan -> plan.getId(), plan -> plan.getName()));
+            default -> Collections.emptyMap();
+        };
+    }
+
+    @Override
+    public List<FilterValue> searchByName(String environmentId, FilterSpec.Name filterName, String query, int page, int perPage) {
+        if (query == null || query.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        return switch (filterName) {
+            case API -> searchApisByName(environmentId, query, page, perPage);
+            default -> Collections.emptyList();
+        };
+    }
+
+    private List<FilterValue> searchApisByName(String environmentId, String query, int page, int perPage) {
+        var criteria = ApiSearchCriteria.builder().name(query).environmentId(environmentId).build();
+
+        var fieldFilter = ApiFieldFilter.builder().pictureExcluded(true).definitionExcluded(true).build();
+
+        var skip = (long) (page - 1) * perPage;
+        return apiQueryService
+            .search(criteria, null, fieldFilter)
+            .skip(skip)
+            .limit(perPage)
+            .map(api -> new FilterValue(api.getName(), api.getId()))
+            .toList();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/ManagementContextLoader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/ManagementContextLoader.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -70,6 +71,18 @@ public class ManagementContextLoader implements AnalyticsQueryContextLoader {
 
         if (!isAdmin()) {
             Set<String> userApiIds = apiAuthorizationService.findApiIdsByUserId(executionContext, userId, null, true);
+            if (userApiIds.isEmpty()) {
+                // Align with ApiServiceImpl.findAll: empty scope must not widen to "all APIs in environment"
+                // (ApiCriteria with empty ids does not apply an id filter in the repository).
+                return new AnalyticsQueryContext(
+                    auditInfo,
+                    executionContext,
+                    Collections.emptySet(),
+                    Collections.emptyMap(),
+                    Collections.emptyMap(),
+                    Collections.emptyMap()
+                );
+            }
             apiCriteriaBuilder.ids(userApiIds);
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/definition/AnalyticsDefinitionYAMLQueryService.java
@@ -23,8 +23,12 @@ import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.infra.domain_service.observability.YAMLDefinitionLoader;
+import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -35,7 +39,35 @@ public class AnalyticsDefinitionYAMLQueryService implements AnalyticsDefinitionQ
     private final AnalyticsDefinitionSpec spec;
 
     public AnalyticsDefinitionYAMLQueryService() {
-        spec = YAMLDefinitionLoader.load(ANALYTICS_DEFINITION_FILE, AnalyticsDefinition.class).spec();
+        var rawSpec = YAMLDefinitionLoader.load(ANALYTICS_DEFINITION_FILE, AnalyticsDefinition.class).spec();
+        spec = enrichFiltersWithApiTypes(rawSpec);
+    }
+
+    private static AnalyticsDefinitionSpec enrichFiltersWithApiTypes(AnalyticsDefinitionSpec rawSpec) {
+        Map<FilterSpec.Name, Set<ApiSpec.Name>> apisByFilter = new EnumMap<>(FilterSpec.Name.class);
+        for (var metric : rawSpec.metrics()) {
+            for (var filterName : metric.filters()) {
+                apisByFilter.computeIfAbsent(filterName, k -> EnumSet.noneOf(ApiSpec.Name.class)).addAll(metric.apis());
+            }
+        }
+
+        var enrichedFilters = rawSpec
+            .filters()
+            .stream()
+            .map(f ->
+                new FilterSpec(
+                    f.name(),
+                    f.label(),
+                    f.type(),
+                    f.enumValues(),
+                    f.range(),
+                    f.operators(),
+                    List.copyOf(apisByFilter.getOrDefault(f.name(), Set.of()))
+                )
+            )
+            .toList();
+
+        return new AnalyticsDefinitionSpec(rawSpec.apis(), rawSpec.metrics(), enrichedFilters, rawSpec.facets());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/UserContextLoaderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/UserContextLoaderImpl.java
@@ -27,6 +27,7 @@ import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -68,7 +69,9 @@ public class UserContextLoaderImpl implements UserContextLoader {
 
         if (!isAdmin()) {
             Set<String> userApiIds = apiAuthorizationService.findApiIdsByUserId(executionContext, userId, null, true);
-
+            if (userApiIds.isEmpty()) {
+                return context.withApis(Collections.emptyList()).withApiNamesById(Collections.emptyMap());
+            }
             apiCriteriaBuilder.ids(userApiIds);
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImpl.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.analytics_engine;
+
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.FilterValue;
+import io.gravitee.apim.core.analytics_engine.model.FilterValuesPage;
+import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.log.v4.api.AnalyticsRepository;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesQuery;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesResult;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FilterValuesQueryServiceImpl implements FilterValuesQueryService {
+
+    private final AnalyticsRepository analyticsRepository;
+
+    public FilterValuesQueryServiceImpl(@Lazy AnalyticsRepository analyticsRepository) {
+        this.analyticsRepository = analyticsRepository;
+    }
+
+    @Override
+    public FilterValuesPage searchFilterValues(
+        String organizationId,
+        String environmentId,
+        FilterSpec.Name filterName,
+        Instant from,
+        Instant to,
+        int page,
+        int size,
+        Map<String, Object> afterKey,
+        String searchPattern,
+        Set<String> authorizedApiIds
+    ) {
+        var esFieldName = resolveEsFieldName(filterName);
+        var queryContext = new QueryContext(organizationId, environmentId);
+
+        Map<String, Object> currentAfterKey = null;
+        FilterValuesResult result = null;
+
+        for (int i = 1; i <= page; i++) {
+            var query = FilterValuesQuery.builder()
+                .esFieldName(esFieldName)
+                .from(from != null ? from.toEpochMilli() : null)
+                .to(to != null ? to.toEpochMilli() : null)
+                .size(size)
+                .afterKey(currentAfterKey)
+                .searchPattern(searchPattern)
+                .apiIds(authorizedApiIds)
+                .build();
+
+            result = analyticsRepository.searchFilterValues(queryContext, query);
+
+            if (i < page && (result.afterKey() == null || result.afterKey().isEmpty())) {
+                return new FilterValuesPage(Collections.emptyList(), null, result.totalCount());
+            }
+            currentAfterKey = result.afterKey();
+        }
+
+        var values = result.values().stream().map(FilterValue::new).toList();
+        return new FilterValuesPage(values, result.afterKey(), result.totalCount());
+    }
+
+    /**
+     * Maps domain filter names to Elasticsearch field names.
+     * Mirrors the mapping in HTTPFieldResolver (ES module) to keep the repository API simple (String field name).
+     */
+    private static String resolveEsFieldName(FilterSpec.Name filterName) {
+        return switch (filterName) {
+            case API -> "api-id";
+            case APPLICATION -> "application-id";
+            case PLAN -> "plan-id";
+            case GATEWAY -> "gateway";
+            case HOST -> "host";
+            case TENANT -> "tenant";
+            case ZONE -> "zone";
+            case HTTP_METHOD -> "http-method";
+            case HTTP_STATUS_CODE_GROUP, HTTP_STATUS -> "status";
+            case HTTP_PATH -> "path";
+            case HTTP_PATH_MAPPING -> "mapped-path";
+            case GEO_IP_COUNTRY -> "geoip.country_iso_code";
+            case GEO_IP_REGION -> "geoip.region_name";
+            case GEO_IP_CITY -> "geoip.city_name";
+            case GEO_IP_CONTINENT -> "geoip.continent_name";
+            case CONSUMER_IP -> "remote-address";
+            case HTTP_USER_AGENT_OS_NAME -> "user_agent.os_name";
+            case HTTP_USER_AGENT_DEVICE -> "user_agent.device.name";
+            case LLM_PROXY_MODEL -> "additional-metrics.keyword_llm-proxy_model";
+            case LLM_PROXY_PROVIDER -> "additional-metrics.keyword_llm-proxy_provider";
+            case MCP_PROXY_METHOD -> "additional-metrics.keyword_mcp-proxy_method";
+            case MCP_PROXY_TOOL -> "additional-metrics.keyword_mcp-proxy_tools/call";
+            case MCP_PROXY_RESOURCE -> "additional-metrics.keyword_mcp-proxy_resources/read";
+            case MCP_PROXY_PROMPT -> "additional-metrics.keyword_mcp-proxy_prompts/get";
+            default -> throw new UnsupportedOperationException("No ES field mapping for filter: " + filterName);
+        };
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCaseTest.java
@@ -1,0 +1,1156 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.analytics_engine.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryContextLoader;
+import io.gravitee.apim.core.analytics_engine.domain_service.FilterValueNameResolver;
+import io.gravitee.apim.core.analytics_engine.model.AnalyticsQueryContext;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.FilterValue;
+import io.gravitee.apim.core.analytics_engine.model.FilterValuesPage;
+import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
+import io.gravitee.apim.core.application.query_service.ApplicationQueryService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.observability.model.FilterOperator;
+import io.gravitee.apim.core.observability.model.FilterType;
+import io.gravitee.apim.core.observability.model.NumberRange;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetFilterValuesUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder().organizationId("org-id").environmentId("env-id").build();
+
+    private static final AnalyticsQueryContext ANALYTICS_CONTEXT = new AnalyticsQueryContext(
+        AUDIT_INFO,
+        new ExecutionContext("org-id", "env-id"),
+        Set.of(),
+        Map.of(),
+        Map.of(),
+        Map.of()
+    );
+
+    @Mock
+    private AnalyticsDefinitionQueryService definitionQueryService;
+
+    @Mock
+    private FilterValuesQueryService filterValuesQueryService;
+
+    @Mock
+    private FilterValueNameResolver filterValueNameResolver;
+
+    @Mock
+    private AnalyticsQueryContextLoader contextLoader;
+
+    @Mock
+    private ApplicationQueryService applicationQueryService;
+
+    @Mock
+    private PlanQueryService planQueryService;
+
+    private GetFilterValuesUseCase useCase;
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+        when(contextLoader.load(any())).thenReturn(ANALYTICS_CONTEXT);
+        useCase = new GetFilterValuesUseCase(
+            definitionQueryService,
+            filterValuesQueryService,
+            filterValueNameResolver,
+            contextLoader,
+            applicationQueryService,
+            planQueryService
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    void should_reject_invalid_filter_name() {
+        assertThatThrownBy(() -> useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "INVALID_FILTER", null, null, 1, 10, null)))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("Invalid filter name");
+        verifyNoInteractions(contextLoader);
+    }
+
+    @Test
+    void should_reject_page_below_1() {
+        assertThatThrownBy(() -> useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 0, 10, null)))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("page must be between 1 and 10000");
+        verifyNoInteractions(contextLoader);
+    }
+
+    @Test
+    void should_reject_page_above_10000() {
+        assertThatThrownBy(() -> useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 10001, 10, null)))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("page must be between 1 and 10000");
+        verifyNoInteractions(contextLoader);
+    }
+
+    @Test
+    void should_reject_per_page_below_1() {
+        assertThatThrownBy(() -> useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 1, 0, null)))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("perPage must be between 1 and 100");
+        verifyNoInteractions(contextLoader);
+    }
+
+    @Test
+    void should_reject_per_page_above_100() {
+        assertThatThrownBy(() -> useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 1, 101, null)))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("perPage must be between 1 and 100");
+        verifyNoInteractions(contextLoader);
+    }
+
+    @Test
+    void should_reject_negative_per_page() {
+        assertThatThrownBy(() -> useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 1, -5, null)))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("perPage must be between 1 and 100");
+        verifyNoInteractions(contextLoader);
+    }
+
+    @Nested
+    class EnumFilters {
+
+        @BeforeEach
+        void setUp() {
+            when(definitionQueryService.getAllFilters()).thenReturn(
+                List.of(
+                    new FilterSpec(
+                        FilterSpec.Name.HTTP_METHOD,
+                        "HTTP Method",
+                        FilterType.ENUM,
+                        List.of("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"),
+                        null,
+                        List.of(FilterOperator.EQ, FilterOperator.IN),
+                        null
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_return_static_enum_values() {
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 1, 10, null));
+
+            assertThat(output.valuesPage().data())
+                .extracting(FilterValue::value)
+                .containsExactly("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS");
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(7L);
+            verifyNoInteractions(filterValuesQueryService);
+        }
+
+        @Test
+        void should_paginate_enum_values() {
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 1, 3, null));
+
+            assertThat(output.valuesPage().data()).extracting(FilterValue::value).containsExactly("GET", "POST", "PUT");
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(7L);
+        }
+
+        @Test
+        void should_paginate_enum_values_second_page() {
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 2, 3, null));
+
+            assertThat(output.valuesPage().data()).extracting(FilterValue::value).containsExactly("DELETE", "PATCH", "HEAD");
+        }
+
+        @Test
+        void should_return_empty_page_when_page_exceeds_total() {
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 5, 10, null));
+
+            assertThat(output.valuesPage().data()).isEmpty();
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(7L);
+        }
+
+        @Test
+        void should_filter_enum_values_by_query() {
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 1, 10, "et"));
+
+            assertThat(output.valuesPage().data()).extracting(FilterValue::value).containsExactly("GET", "DELETE");
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(2L);
+        }
+
+        @Test
+        void should_filter_enum_values_by_query_case_insensitive() {
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 1, 10, "PO"));
+
+            assertThat(output.valuesPage().data()).extracting(FilterValue::value).containsExactly("POST");
+        }
+
+        @Test
+        void should_return_all_enum_values_when_query_is_blank() {
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 1, 10, "   "));
+
+            assertThat(output.valuesPage().data())
+                .extracting(FilterValue::value)
+                .containsExactly("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS");
+        }
+
+        @Test
+        void should_paginate_enum_values_after_query_filtering() {
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 1, 1, "et"));
+
+            assertThat(output.valuesPage().data()).extracting(FilterValue::value).containsExactly("GET");
+
+            var output2 = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 2, 1, "et"));
+
+            assertThat(output2.valuesPage().data()).extracting(FilterValue::value).containsExactly("DELETE");
+        }
+
+        @Test
+        void should_return_no_id_for_enum_values() {
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_METHOD", null, null, 1, 10, null));
+
+            assertThat(output.valuesPage().data()).allSatisfy(v -> assertThat(v.id()).isNull());
+        }
+    }
+
+    @Nested
+    class DirectValueKeywordFilters {
+
+        @BeforeEach
+        void setUp() {
+            when(definitionQueryService.getAllFilters()).thenReturn(
+                List.of(
+                    new FilterSpec(
+                        FilterSpec.Name.GATEWAY,
+                        "Gateway",
+                        FilterType.KEYWORD,
+                        null,
+                        null,
+                        List.of(FilterOperator.EQ, FilterOperator.IN),
+                        null
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_delegate_to_filter_values_query_service() {
+            var expectedPage = new FilterValuesPage(List.of(new FilterValue("gw-1"), new FilterValue("gw-2")), null);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.GATEWAY),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(10),
+                    any(),
+                    any(),
+                    any()
+                )
+            ).thenReturn(expectedPage);
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "GATEWAY", null, null, 1, 10, null));
+
+            assertThat(output.valuesPage().data()).hasSize(2);
+            assertThat(output.valuesPage().totalFilteredCount()).isNull();
+            verify(filterValuesQueryService).searchFilterValues(
+                eq("org-id"),
+                eq("env-id"),
+                eq(FilterSpec.Name.GATEWAY),
+                eq(null),
+                eq(null),
+                eq(1),
+                eq(10),
+                eq(null),
+                eq(null),
+                eq(Set.of())
+            );
+        }
+
+        @Test
+        void should_pass_search_pattern_to_query_service_for_direct_value() {
+            when(
+                filterValuesQueryService.searchFilterValues(any(), any(), any(), any(), any(), anyInt(), eq(10), any(), any(), any())
+            ).thenReturn(new FilterValuesPage(Collections.emptyList(), null));
+
+            useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "GATEWAY", null, null, 1, 10, "gw-"));
+
+            verify(filterValuesQueryService).searchFilterValues(
+                eq("org-id"),
+                eq("env-id"),
+                eq(FilterSpec.Name.GATEWAY),
+                eq(null),
+                eq(null),
+                eq(1),
+                eq(10),
+                eq(null),
+                eq("gw-"),
+                eq(Set.of())
+            );
+        }
+
+        @Test
+        void should_pass_both_time_range_and_search_pattern() {
+            var from = Instant.parse("2025-01-01T00:00:00Z");
+            var to = Instant.parse("2025-12-31T23:59:59Z");
+
+            when(
+                filterValuesQueryService.searchFilterValues(any(), any(), any(), any(), any(), anyInt(), eq(10), any(), any(), any())
+            ).thenReturn(new FilterValuesPage(List.of(new FilterValue("gw-prod-1")), null));
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "GATEWAY", from, to, 1, 10, "prod"));
+
+            verify(filterValuesQueryService).searchFilterValues(
+                eq("org-id"),
+                eq("env-id"),
+                eq(FilterSpec.Name.GATEWAY),
+                eq(from),
+                eq(to),
+                eq(1),
+                eq(10),
+                eq(null),
+                eq("prod"),
+                eq(Set.of())
+            );
+            assertThat(output.valuesPage().data()).extracting(FilterValue::value).containsExactly("gw-prod-1");
+        }
+
+        @Test
+        void should_not_resolve_names_for_direct_value_keyword() {
+            when(
+                filterValuesQueryService.searchFilterValues(any(), any(), any(), any(), any(), anyInt(), eq(10), any(), any(), any())
+            ).thenReturn(new FilterValuesPage(List.of(new FilterValue("gw-1")), null));
+
+            useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "GATEWAY", null, null, 1, 10, null));
+
+            verifyNoInteractions(filterValueNameResolver);
+        }
+
+        @Test
+        void should_pass_page_number_to_query_service() {
+            when(
+                filterValuesQueryService.searchFilterValues(any(), any(), any(), any(), any(), anyInt(), eq(5), any(), any(), any())
+            ).thenReturn(new FilterValuesPage(List.of(new FilterValue("gw-6")), null));
+
+            useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "GATEWAY", null, null, 2, 5, null));
+
+            verify(filterValuesQueryService).searchFilterValues(
+                eq("org-id"),
+                eq("env-id"),
+                eq(FilterSpec.Name.GATEWAY),
+                eq(null),
+                eq(null),
+                eq(2),
+                eq(5),
+                eq(null),
+                eq(null),
+                eq(Set.of())
+            );
+        }
+
+        @Test
+        void should_pass_page_number_with_search_pattern() {
+            when(
+                filterValuesQueryService.searchFilterValues(any(), any(), any(), any(), any(), anyInt(), eq(5), any(), any(), any())
+            ).thenReturn(new FilterValuesPage(List.of(new FilterValue("gw-prod-6")), null));
+
+            useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "GATEWAY", null, null, 3, 5, "prod"));
+
+            verify(filterValuesQueryService).searchFilterValues(
+                eq("org-id"),
+                eq("env-id"),
+                eq(FilterSpec.Name.GATEWAY),
+                eq(null),
+                eq(null),
+                eq(3),
+                eq(5),
+                eq(null),
+                eq("prod"),
+                eq(Set.of())
+            );
+        }
+
+        @Test
+        void should_pass_authorized_api_ids_from_analytics_context_to_query_service() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of("allowed-api-1", "allowed-api-2"),
+                    Map.of(),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+            when(
+                filterValuesQueryService.searchFilterValues(any(), any(), any(), any(), any(), anyInt(), eq(10), any(), any(), any())
+            ).thenReturn(new FilterValuesPage(List.of(new FilterValue("gw-1")), null));
+
+            useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "GATEWAY", null, null, 1, 10, null));
+
+            verify(filterValuesQueryService).searchFilterValues(
+                eq("org-id"),
+                eq("env-id"),
+                eq(FilterSpec.Name.GATEWAY),
+                eq(null),
+                eq(null),
+                eq(1),
+                eq(10),
+                eq(null),
+                eq(null),
+                eq(Set.of("allowed-api-1", "allowed-api-2"))
+            );
+        }
+
+        @Test
+        void should_load_analytics_context_once_per_request_for_keyword_filter() {
+            when(
+                filterValuesQueryService.searchFilterValues(any(), any(), any(), any(), any(), anyInt(), eq(10), any(), any(), any())
+            ).thenReturn(new FilterValuesPage(Collections.emptyList(), null));
+
+            useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "GATEWAY", null, null, 1, 10, null));
+
+            verify(contextLoader).load(eq(AUDIT_INFO));
+            verifyNoMoreInteractions(contextLoader);
+        }
+    }
+
+    @Nested
+    class IdBasedKeywordFilters {
+
+        @BeforeEach
+        void setUp() {
+            when(definitionQueryService.getAllFilters()).thenReturn(
+                List.of(
+                    new FilterSpec(
+                        FilterSpec.Name.API,
+                        "API",
+                        FilterType.KEYWORD,
+                        null,
+                        null,
+                        List.of(FilterOperator.EQ, FilterOperator.IN),
+                        null
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_resolve_names_for_id_based_filter() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of(),
+                    Map.of("api-id-1", "My API 1", "api-id-2", "My API 2"),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+            var esPage = new FilterValuesPage(List.of(new FilterValue("api-id-1"), new FilterValue("api-id-2")), null);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.API),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(10),
+                    any(),
+                    any(),
+                    any()
+                )
+            ).thenReturn(esPage);
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", null, null, 1, 10, null));
+
+            assertThat(output.valuesPage().data()).satisfiesExactly(
+                v -> {
+                    assertThat(v.value()).isEqualTo("My API 1");
+                    assertThat(v.id()).isEqualTo("api-id-1");
+                },
+                v -> {
+                    assertThat(v.value()).isEqualTo("My API 2");
+                    assertThat(v.id()).isEqualTo("api-id-2");
+                }
+            );
+            verifyNoInteractions(filterValueNameResolver);
+        }
+
+        @Test
+        void should_search_by_name_when_query_provided() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of(),
+                    Map.of("api-id-1", "My API 1", "other-id", "Other"),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", null, null, 1, 10, "My"));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("My API 1");
+                    assertThat(v.id()).isEqualTo("api-id-1");
+                });
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(1L);
+            verifyNoInteractions(filterValuesQueryService);
+            verifyNoInteractions(filterValueNameResolver);
+        }
+
+        @Test
+        void should_pass_time_range_for_id_based_without_query() {
+            var from = Instant.parse("2025-01-01T00:00:00Z");
+            var to = Instant.parse("2025-12-31T23:59:59Z");
+
+            when(
+                filterValuesQueryService.searchFilterValues(any(), any(), any(), any(), any(), anyInt(), eq(10), any(), any(), any())
+            ).thenReturn(new FilterValuesPage(Collections.emptyList(), null));
+
+            useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", from, to, 1, 10, null));
+
+            verify(filterValuesQueryService).searchFilterValues(
+                eq("org-id"),
+                eq("env-id"),
+                eq(FilterSpec.Name.API),
+                eq(from),
+                eq(to),
+                eq(1),
+                eq(10),
+                eq(null),
+                eq(null),
+                eq(Set.of())
+            );
+            verifyNoInteractions(filterValueNameResolver);
+        }
+
+        @Test
+        void should_fallback_to_raw_id_when_name_not_resolved() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of(),
+                    Map.of("api-id-1", "My API 1"),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+            var esPage = new FilterValuesPage(List.of(new FilterValue("api-id-1"), new FilterValue("api-id-unknown")), null);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.API),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(10),
+                    any(),
+                    any(),
+                    any()
+                )
+            ).thenReturn(esPage);
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", null, null, 1, 10, null));
+
+            assertThat(output.valuesPage().data()).satisfiesExactly(
+                v -> {
+                    assertThat(v.value()).isEqualTo("My API 1");
+                    assertThat(v.id()).isEqualTo("api-id-1");
+                },
+                v -> {
+                    assertThat(v.value()).isEqualTo("api-id-unknown");
+                    assertThat(v.id()).isEqualTo("api-id-unknown");
+                }
+            );
+            verifyNoInteractions(filterValueNameResolver);
+        }
+
+        @Test
+        void should_preserve_after_key_from_es_for_id_based_without_query() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of(),
+                    Map.of("api-id-1", "My API 1", "api-id-2", "My API 2"),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+            var afterKey = Map.<String, Object>of("value", "api-id-2");
+            var esPage = new FilterValuesPage(List.of(new FilterValue("api-id-1"), new FilterValue("api-id-2")), afterKey);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.API),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(10),
+                    any(),
+                    any(),
+                    any()
+                )
+            ).thenReturn(esPage);
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", null, null, 1, 10, null));
+
+            assertThat(output.valuesPage().afterKey()).containsEntry("value", "api-id-2");
+            verifyNoInteractions(filterValueNameResolver);
+        }
+
+        @Test
+        void should_treat_blank_query_as_no_query_for_id_based() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of(),
+                    Map.of("api-id-1", "My API 1"),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+            var esPage = new FilterValuesPage(List.of(new FilterValue("api-id-1")), null);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.API),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(10),
+                    any(),
+                    any(),
+                    any()
+                )
+            ).thenReturn(esPage);
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", null, null, 1, 10, "   "));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("My API 1");
+                    assertThat(v.id()).isEqualTo("api-id-1");
+                });
+            verify(filterValuesQueryService).searchFilterValues(any(), any(), any(), any(), any(), anyInt(), eq(10), any(), any(), any());
+            verifyNoInteractions(filterValueNameResolver);
+        }
+
+        @Test
+        void should_not_call_es_when_query_provided_for_id_based() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of(),
+                    Map.of("match-id", "Matching API"),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", null, null, 1, 10, "Match"));
+
+            assertThat(output.valuesPage().data()).extracting(FilterValue::id).containsExactly("match-id");
+            verifyNoInteractions(filterValuesQueryService);
+            verifyNoInteractions(filterValueNameResolver);
+        }
+
+        @Test
+        void should_pass_page_number_for_id_based_without_query() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of(),
+                    Map.of("api-id-3", "My API 3"),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+            var esPage = new FilterValuesPage(List.of(new FilterValue("api-id-3")), null);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.API),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(5),
+                    any(),
+                    any(),
+                    any()
+                )
+            ).thenReturn(esPage);
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", null, null, 2, 5, null));
+
+            verify(filterValuesQueryService).searchFilterValues(
+                eq("org-id"),
+                eq("env-id"),
+                eq(FilterSpec.Name.API),
+                eq(null),
+                eq(null),
+                eq(2),
+                eq(5),
+                eq(null),
+                eq(null),
+                eq(Set.of())
+            );
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("My API 3");
+                    assertThat(v.id()).isEqualTo("api-id-3");
+                });
+            verifyNoInteractions(filterValueNameResolver);
+        }
+
+        @Test
+        void should_pass_page_number_for_id_based_search_by_name() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of(),
+                    Map.of("id-a", "My API A", "id-b", "My API B", "id-c", "My API C", "id-d", "My API D", "id-e", "My API E"),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API", null, null, 2, 2, "My"));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(2)
+                .satisfiesExactly(
+                    v -> {
+                        assertThat(v.value()).isEqualTo("My API C");
+                        assertThat(v.id()).isEqualTo("id-c");
+                    },
+                    v -> {
+                        assertThat(v.value()).isEqualTo("My API D");
+                        assertThat(v.id()).isEqualTo("id-d");
+                    }
+                );
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(5L);
+            verifyNoInteractions(filterValuesQueryService);
+            verifyNoInteractions(filterValueNameResolver);
+        }
+    }
+
+    @Nested
+    class ApplicationIdBasedFilters {
+
+        @BeforeEach
+        void setUp() {
+            when(definitionQueryService.getAllFilters()).thenReturn(
+                List.of(
+                    new FilterSpec(
+                        FilterSpec.Name.APPLICATION,
+                        "Application",
+                        FilterType.KEYWORD,
+                        null,
+                        null,
+                        List.of(FilterOperator.EQ, FilterOperator.IN),
+                        null
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_resolve_names_for_application_filter() {
+            var esPage = new FilterValuesPage(List.of(new FilterValue("app-id-1")), null);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.APPLICATION),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(10),
+                    any(),
+                    any(),
+                    any()
+                )
+            ).thenReturn(esPage);
+            when(filterValueNameResolver.resolveNames(any(), eq(FilterSpec.Name.APPLICATION), any())).thenReturn(
+                Map.of("app-id-1", "My Application")
+            );
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "APPLICATION", null, null, 1, 10, null));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("My Application");
+                    assertThat(v.id()).isEqualTo("app-id-1");
+                });
+        }
+
+        @Test
+        void should_search_application_by_name_when_query_provided() {
+            var app = new BaseApplicationEntity();
+            app.setId("app-id-1");
+            app.setName("My App 1");
+            when(applicationQueryService.findByEnvironment("env-id")).thenReturn(Set.of(app));
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "APPLICATION", null, null, 1, 10, "My App"));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("My App 1");
+                    assertThat(v.id()).isEqualTo("app-id-1");
+                });
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(1L);
+            verifyNoInteractions(filterValuesQueryService);
+            verifyNoInteractions(filterValueNameResolver);
+            verify(applicationQueryService).findByEnvironment("env-id");
+        }
+
+        @Test
+        void should_paginate_application_search_by_name() {
+            var app1 = new BaseApplicationEntity();
+            app1.setId("a-1");
+            app1.setName("My App A");
+            var app2 = new BaseApplicationEntity();
+            app2.setId("a-2");
+            app2.setName("My App B");
+            var app3 = new BaseApplicationEntity();
+            app3.setId("a-3");
+            app3.setName("My App C");
+            when(applicationQueryService.findByEnvironment("env-id")).thenReturn(Set.of(app1, app2, app3));
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "APPLICATION", null, null, 2, 2, "My App"));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("My App C");
+                    assertThat(v.id()).isEqualTo("a-3");
+                });
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(3L);
+        }
+
+        @Test
+        void should_pass_authorized_api_ids_for_application_id_based_without_query() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of("scoped-api-1", "scoped-api-2"),
+                    Map.of(),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+            var esPage = new FilterValuesPage(List.of(new FilterValue("app-id-1")), null);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.APPLICATION),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(10),
+                    any(),
+                    any(),
+                    eq(Set.of("scoped-api-1", "scoped-api-2"))
+                )
+            ).thenReturn(esPage);
+            when(filterValueNameResolver.resolveNames(any(), eq(FilterSpec.Name.APPLICATION), any())).thenReturn(
+                Map.of("app-id-1", "My Application")
+            );
+
+            useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "APPLICATION", null, null, 1, 10, null));
+
+            verify(filterValuesQueryService).searchFilterValues(
+                eq("org-id"),
+                eq("env-id"),
+                eq(FilterSpec.Name.APPLICATION),
+                eq(null),
+                eq(null),
+                eq(1),
+                eq(10),
+                eq(null),
+                eq(null),
+                eq(Set.of("scoped-api-1", "scoped-api-2"))
+            );
+        }
+    }
+
+    @Nested
+    class PlanIdBasedFilters {
+
+        @BeforeEach
+        void setUp() {
+            when(definitionQueryService.getAllFilters()).thenReturn(
+                List.of(
+                    new FilterSpec(
+                        FilterSpec.Name.PLAN,
+                        "Plan",
+                        FilterType.KEYWORD,
+                        null,
+                        null,
+                        List.of(FilterOperator.EQ, FilterOperator.IN),
+                        null
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_resolve_names_for_plan_filter() {
+            var esPage = new FilterValuesPage(List.of(new FilterValue("plan-id-1")), null);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.PLAN),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(10),
+                    any(),
+                    any(),
+                    any()
+                )
+            ).thenReturn(esPage);
+            when(filterValueNameResolver.resolveNames(any(), eq(FilterSpec.Name.PLAN), any())).thenReturn(Map.of("plan-id-1", "Gold Plan"));
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "PLAN", null, null, 1, 10, null));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("Gold Plan");
+                    assertThat(v.id()).isEqualTo("plan-id-1");
+                });
+        }
+
+        @Test
+        void should_search_plan_by_name_when_query_provided() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of("api-1"),
+                    Map.of(),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+            when(planQueryService.findAllByApiIds(eq(Set.of("api-1")), eq(Set.of("env-id")))).thenReturn(
+                List.of(Plan.builder().id("plan-id-1").name("Gold Plan").build())
+            );
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "PLAN", null, null, 1, 10, "Gold"));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("Gold Plan");
+                    assertThat(v.id()).isEqualTo("plan-id-1");
+                });
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(1L);
+            verifyNoInteractions(filterValuesQueryService);
+            verifyNoInteractions(filterValueNameResolver);
+            verify(planQueryService).findAllByApiIds(eq(Set.of("api-1")), eq(Set.of("env-id")));
+        }
+
+        @Test
+        void should_paginate_plan_search_by_name() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of("api-1"),
+                    Map.of(),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+            when(planQueryService.findAllByApiIds(eq(Set.of("api-1")), eq(Set.of("env-id")))).thenReturn(
+                List.of(
+                    Plan.builder().id("p-1").name("Gold A").build(),
+                    Plan.builder().id("p-2").name("Gold B").build(),
+                    Plan.builder().id("p-3").name("Gold C").build()
+                )
+            );
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "PLAN", null, null, 2, 2, "Gold"));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("Gold C");
+                    assertThat(v.id()).isEqualTo("p-3");
+                });
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(3L);
+        }
+
+        @Test
+        void should_return_empty_when_plan_search_by_name_and_no_authorized_apis() {
+            when(contextLoader.load(any())).thenReturn(ANALYTICS_CONTEXT);
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "PLAN", null, null, 1, 10, "Gold"));
+
+            assertThat(output.valuesPage().data()).isEmpty();
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(0L);
+            verifyNoInteractions(filterValuesQueryService);
+            verifyNoInteractions(planQueryService);
+        }
+
+        @Test
+        void should_pass_authorized_api_ids_for_plan_id_based_without_query() {
+            when(contextLoader.load(any())).thenReturn(
+                new AnalyticsQueryContext(
+                    AUDIT_INFO,
+                    new ExecutionContext("org-id", "env-id"),
+                    Set.of("plan-scope-a", "plan-scope-b"),
+                    Map.of(),
+                    Map.of(),
+                    Map.of()
+                )
+            );
+            var esPage = new FilterValuesPage(List.of(new FilterValue("plan-id-1")), null);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.PLAN),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(10),
+                    any(),
+                    any(),
+                    eq(Set.of("plan-scope-a", "plan-scope-b"))
+                )
+            ).thenReturn(esPage);
+            when(filterValueNameResolver.resolveNames(any(), eq(FilterSpec.Name.PLAN), any())).thenReturn(Map.of("plan-id-1", "Gold Plan"));
+
+            useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "PLAN", null, null, 1, 10, null));
+
+            verify(filterValuesQueryService).searchFilterValues(
+                eq("org-id"),
+                eq("env-id"),
+                eq(FilterSpec.Name.PLAN),
+                eq(null),
+                eq(null),
+                eq(1),
+                eq(10),
+                eq(null),
+                eq(null),
+                eq(Set.of("plan-scope-a", "plan-scope-b"))
+            );
+        }
+    }
+
+    @Nested
+    class UnsupportedFilterTypes {
+
+        @BeforeEach
+        void setUp() {
+            when(definitionQueryService.getAllFilters()).thenReturn(
+                List.of(
+                    new FilterSpec(
+                        FilterSpec.Name.HTTP_STATUS,
+                        "Status Code",
+                        FilterType.NUMBER,
+                        null,
+                        new NumberRange(100, 599),
+                        List.of(FilterOperator.EQ, FilterOperator.LTE, FilterOperator.GTE),
+                        null
+                    ),
+                    new FilterSpec(FilterSpec.Name.HTTP_PATH, "Path", FilterType.STRING, null, null, List.of(FilterOperator.EQ), null)
+                )
+            );
+        }
+
+        @Test
+        void should_reject_number_filter() {
+            assertThatThrownBy(() -> useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_STATUS", null, null, 1, 10, null)))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("does not support value listing");
+        }
+
+        @Test
+        void should_reject_string_filter() {
+            assertThatThrownBy(() -> useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "HTTP_PATH", null, null, 1, 10, null)))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("does not support value listing");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/FilterValueNameResolverImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/FilterValueNameResolverImplTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.FilterValue;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FilterValueNameResolverImplTest {
+
+    private static final String ENVIRONMENT_ID = "env-id";
+
+    @Mock
+    private ApiCrudService apiCrudService;
+
+    @Mock
+    private ApiQueryService apiQueryService;
+
+    @Mock
+    private ApplicationCrudService applicationCrudService;
+
+    @Mock
+    private PlanCrudService planCrudService;
+
+    private FilterValueNameResolverImpl resolver;
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+        resolver = new FilterValueNameResolverImpl(apiCrudService, apiQueryService, applicationCrudService, planCrudService);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Nested
+    class ResolveNames {
+
+        @Test
+        void should_return_empty_map_for_null_ids() {
+            var result = resolver.resolveNames(ENVIRONMENT_ID, FilterSpec.Name.API, null);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_map_for_empty_ids() {
+            var result = resolver.resolveNames(ENVIRONMENT_ID, FilterSpec.Name.API, Collections.emptyList());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_resolve_api_names() {
+            var ids = List.of("api-1", "api-2");
+            when(apiCrudService.findByIds(ids)).thenReturn(
+                List.of(Api.builder().id("api-1").name("My API 1").build(), Api.builder().id("api-2").name("My API 2").build())
+            );
+
+            var result = resolver.resolveNames(ENVIRONMENT_ID, FilterSpec.Name.API, ids);
+
+            assertThat(result).containsEntry("api-1", "My API 1").containsEntry("api-2", "My API 2").hasSize(2);
+        }
+
+        @Test
+        void should_resolve_application_names_and_include_unknown() {
+            var ids = List.of("app-1", "app-2");
+            var app1 = new BaseApplicationEntity();
+            app1.setId("app-1");
+            app1.setName("My App 1");
+            var app2 = new BaseApplicationEntity();
+            app2.setId("app-2");
+            app2.setName("My App 2");
+
+            when(applicationCrudService.findByIds(ids, "env-id")).thenReturn(List.of(app1, app2));
+
+            var result = resolver.resolveNames(ENVIRONMENT_ID, FilterSpec.Name.APPLICATION, ids);
+
+            assertThat(result)
+                .containsEntry("app-1", "My App 1")
+                .containsEntry("app-2", "My App 2")
+                .containsEntry("1", "Unknown")
+                .hasSize(3);
+        }
+
+        @Test
+        void should_resolve_plan_names() {
+            var ids = List.of("plan-1", "plan-2");
+            when(planCrudService.findByIds(ids)).thenReturn(
+                List.of(Plan.builder().id("plan-1").name("Gold Plan").build(), Plan.builder().id("plan-2").name("Silver Plan").build())
+            );
+
+            var result = resolver.resolveNames(ENVIRONMENT_ID, FilterSpec.Name.PLAN, ids);
+
+            assertThat(result).containsEntry("plan-1", "Gold Plan").containsEntry("plan-2", "Silver Plan").hasSize(2);
+        }
+
+        @Test
+        void should_return_empty_map_for_unsupported_filter() {
+            var result = resolver.resolveNames(ENVIRONMENT_ID, FilterSpec.Name.GATEWAY, List.of("gw-1"));
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    class SearchByName {
+
+        @Test
+        void should_return_empty_list_for_null_query() {
+            var result = resolver.searchByName(ENVIRONMENT_ID, FilterSpec.Name.API, null, 1, 10);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_list_for_blank_query() {
+            var result = resolver.searchByName(ENVIRONMENT_ID, FilterSpec.Name.API, "   ", 1, 10);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_search_apis_by_name() {
+            var api1 = Api.builder().id("api-1").name("My API Alpha").build();
+            var api2 = Api.builder().id("api-2").name("My API Beta").build();
+
+            when(apiQueryService.search(any(ApiSearchCriteria.class), eq(null), any(ApiFieldFilter.class))).thenReturn(
+                Stream.of(api1, api2)
+            );
+
+            var result = resolver.searchByName(ENVIRONMENT_ID, FilterSpec.Name.API, "My API", 1, 10);
+
+            assertThat(result)
+                .hasSize(2)
+                .satisfiesExactly(
+                    v -> {
+                        assertThat(v.value()).isEqualTo("My API Alpha");
+                        assertThat(v.id()).isEqualTo("api-1");
+                    },
+                    v -> {
+                        assertThat(v.value()).isEqualTo("My API Beta");
+                        assertThat(v.id()).isEqualTo("api-2");
+                    }
+                );
+        }
+
+        @Test
+        void should_limit_api_search_results_to_per_page() {
+            var apis = Stream.of(
+                Api.builder().id("api-1").name("API 1").build(),
+                Api.builder().id("api-2").name("API 2").build(),
+                Api.builder().id("api-3").name("API 3").build()
+            );
+            when(apiQueryService.search(any(ApiSearchCriteria.class), eq(null), any(ApiFieldFilter.class))).thenReturn(apis);
+
+            var result = resolver.searchByName(ENVIRONMENT_ID, FilterSpec.Name.API, "API", 1, 2);
+
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        void should_skip_results_for_second_page_of_api_search() {
+            var apis = Stream.of(
+                Api.builder().id("api-1").name("API 1").build(),
+                Api.builder().id("api-2").name("API 2").build(),
+                Api.builder().id("api-3").name("API 3").build()
+            );
+            when(apiQueryService.search(any(ApiSearchCriteria.class), eq(null), any(ApiFieldFilter.class))).thenReturn(apis);
+
+            var result = resolver.searchByName(ENVIRONMENT_ID, FilterSpec.Name.API, "API", 2, 2);
+
+            assertThat(result)
+                .hasSize(1)
+                .satisfiesExactly(v -> {
+                    assertThat(v.value()).isEqualTo("API 3");
+                    assertThat(v.id()).isEqualTo("api-3");
+                });
+        }
+
+        @Test
+        void should_return_empty_list_for_unsupported_filter_search() {
+            var result = resolver.searchByName(ENVIRONMENT_ID, FilterSpec.Name.APPLICATION, "My App", 1, 10);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_list_when_no_apis_match() {
+            when(apiQueryService.search(any(ApiSearchCriteria.class), eq(null), any(ApiFieldFilter.class))).thenReturn(Stream.empty());
+
+            var result = resolver.searchByName(ENVIRONMENT_ID, FilterSpec.Name.API, "nonexistent", 1, 10);
+
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/ManagementContextLoaderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/ManagementContextLoaderTest.java
@@ -199,7 +199,6 @@ class ManagementContextLoaderTest {
         @Test
         void should_return_empty_when_no_apis_are_authorized() {
             when(apiAuthorizationService.findApiIdsByUserId(any(), any(), any(), anyBoolean())).thenReturn(Collections.emptySet());
-            when(apiRepository.search(any(), any())).thenReturn(Collections.emptyList());
 
             var context = contextLoader.load(auditInfo);
 
@@ -210,6 +209,7 @@ class ManagementContextLoaderTest {
             assertThat(context.authorizedApiIds()).isEmpty();
             assertThat(context.apiNamesById()).isEmpty();
             assertThat(context.apiIdsByType()).isEmpty();
+            verify(apiRepository, never()).search(any(), any());
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/UserContextLoaderImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/UserContextLoaderImplTest.java
@@ -183,7 +183,6 @@ class UserContextLoaderImplTest {
         void should_return_empty_list_when_no_apis_are_authorized() {
             // Given
             when(apiAuthorizationService.findApiIdsByUserId(any(), any(), any(), anyBoolean())).thenReturn(Collections.emptySet());
-            when(apiRepository.search(any(), any())).thenReturn(Collections.emptyList());
 
             // When
             var context = userContextLoader.loadApis(new UserContext(auditInfo));
@@ -195,6 +194,7 @@ class UserContextLoaderImplTest {
 
             assertThat(context.apis()).hasValue(Collections.emptyList());
             assertThat(context.apiNameById()).hasValue(Collections.emptyMap());
+            verify(apiRepository, never()).search(any(), any());
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImplTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.analytics_engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.repository.log.v4.api.AnalyticsRepository;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesQuery;
+import io.gravitee.repository.log.v4.model.analytics.FilterValuesResult;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class FilterValuesQueryServiceImplTest {
+
+    private static final String ORG_ID = "org-id";
+    private static final String ENV_ID = "env-id";
+
+    @Mock
+    private AnalyticsRepository analyticsRepository;
+
+    @InjectMocks
+    private FilterValuesQueryServiceImpl service;
+
+    @Captor
+    private ArgumentCaptor<FilterValuesQuery> queryCaptor;
+
+    @Test
+    void should_make_single_es_call_for_page_one() {
+        when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(
+            new FilterValuesResult(List.of("gw-1", "gw-2"), Map.of("value", "gw-2"), 42)
+        );
+
+        var result = service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.GATEWAY, null, null, 1, 10, null, null, null);
+
+        verify(analyticsRepository, times(1)).searchFilterValues(any(), queryCaptor.capture());
+        var capturedQuery = queryCaptor.getValue();
+        assertThat(capturedQuery.afterKey()).isNull();
+        assertThat(capturedQuery.esFieldName()).isEqualTo("gateway");
+        assertThat(capturedQuery.size()).isEqualTo(10);
+
+        assertThat(result.data())
+            .extracting(fv -> fv.value())
+            .containsExactly("gw-1", "gw-2");
+        assertThat(result.afterKey()).containsEntry("value", "gw-2");
+        assertThat(result.totalFilteredCount()).isEqualTo(42L);
+    }
+
+    @Test
+    void should_iterate_composite_pages_to_reach_requested_page() {
+        var page1AfterKey = Map.<String, Object>of("value", "gw-10");
+        when(analyticsRepository.searchFilterValues(any(), argThat(q -> q != null && q.afterKey() == null))).thenReturn(
+            new FilterValuesResult(List.of("gw-1", "gw-2"), page1AfterKey, 25)
+        );
+        when(
+            analyticsRepository.searchFilterValues(
+                any(),
+                argThat(q -> q != null && q.afterKey() != null && q.afterKey().equals(page1AfterKey))
+            )
+        ).thenReturn(new FilterValuesResult(List.of("gw-11", "gw-12"), Map.of("value", "gw-20"), 25));
+
+        var result = service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.GATEWAY, null, null, 2, 10, null, null, null);
+
+        verify(analyticsRepository, times(2)).searchFilterValues(any(), queryCaptor.capture());
+        var queries = queryCaptor.getAllValues();
+        assertThat(queries.get(0).afterKey()).isNull();
+        assertThat(queries.get(1).afterKey()).isEqualTo(page1AfterKey);
+
+        assertThat(result.data())
+            .extracting(fv -> fv.value())
+            .containsExactly("gw-11", "gw-12");
+        assertThat(result.totalFilteredCount()).isEqualTo(25L);
+    }
+
+    @Test
+    void should_return_empty_page_when_data_exhausted_before_target_page() {
+        when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(new FilterValuesResult(List.of("gw-1"), null, 1));
+
+        var result = service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.GATEWAY, null, null, 3, 10, null, null, null);
+
+        verify(analyticsRepository, times(1)).searchFilterValues(any(), any());
+        assertThat(result.data()).isEmpty();
+        assertThat(result.totalFilteredCount()).isEqualTo(1L);
+    }
+
+    @Test
+    void should_return_empty_page_when_after_key_is_empty_map_before_target_page() {
+        when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(new FilterValuesResult(List.of("gw-1"), Map.of(), 5));
+
+        var result = service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.GATEWAY, null, null, 2, 10, null, null, null);
+
+        verify(analyticsRepository, times(1)).searchFilterValues(any(), any());
+        assertThat(result.data()).isEmpty();
+        assertThat(result.totalFilteredCount()).isEqualTo(5L);
+    }
+
+    @Test
+    void should_propagate_total_count_from_first_es_response() {
+        var page1AfterKey = Map.<String, Object>of("value", "gw-5");
+        when(analyticsRepository.searchFilterValues(any(), argThat(q -> q != null && q.afterKey() == null))).thenReturn(
+            new FilterValuesResult(List.of("gw-1"), page1AfterKey, 100)
+        );
+        when(analyticsRepository.searchFilterValues(any(), argThat(q -> q != null && q.afterKey() != null))).thenReturn(
+            new FilterValuesResult(List.of("gw-6"), null, 100)
+        );
+
+        var result = service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.GATEWAY, null, null, 2, 5, null, null, null);
+
+        assertThat(result.totalFilteredCount()).isEqualTo(100L);
+    }
+
+    @Test
+    void should_pass_time_range_to_es_query() {
+        var from = Instant.parse("2025-01-01T00:00:00Z");
+        var to = Instant.parse("2025-12-31T23:59:59Z");
+
+        when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(new FilterValuesResult(List.of("gw-1"), null, 1));
+
+        service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.GATEWAY, from, to, 1, 10, null, null, null);
+
+        verify(analyticsRepository).searchFilterValues(any(), queryCaptor.capture());
+        var capturedQuery = queryCaptor.getValue();
+        assertThat(capturedQuery.from()).isEqualTo(from.toEpochMilli());
+        assertThat(capturedQuery.to()).isEqualTo(to.toEpochMilli());
+    }
+
+    @Test
+    void should_pass_search_pattern_to_es_query() {
+        when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(new FilterValuesResult(List.of("gw-prod"), null, 1));
+
+        service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.GATEWAY, null, null, 1, 10, null, "prod", null);
+
+        verify(analyticsRepository).searchFilterValues(any(), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().searchPattern()).isEqualTo("prod");
+    }
+
+    @Test
+    void should_resolve_es_field_name_for_api_filter() {
+        when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(new FilterValuesResult(List.of("api-1"), null, 1));
+
+        service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.API, null, null, 1, 10, null, null, null);
+
+        verify(analyticsRepository).searchFilterValues(any(), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().esFieldName()).isEqualTo("api-id");
+    }
+
+    @Test
+    void should_pass_authorized_api_ids_to_es_query() {
+        when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(new FilterValuesResult(List.of("gw-1"), null, 1));
+
+        var apiIds = Set.of("api-1", "api-2");
+        service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.GATEWAY, null, null, 1, 10, null, null, apiIds);
+
+        verify(analyticsRepository).searchFilterValues(any(), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().apiIds()).containsExactlyInAnyOrder("api-1", "api-2");
+    }
+
+    @Test
+    void should_leave_api_ids_null_on_query_when_authorized_api_ids_not_provided() {
+        when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(new FilterValuesResult(List.of("gw-1"), null, 1));
+
+        service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.GATEWAY, null, null, 1, 10, null, null, null);
+
+        verify(analyticsRepository).searchFilterValues(any(), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().apiIds()).isNull();
+    }
+}


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-12090

# feat: add observability endpoint for filter values

**Jira:** [APIM-12118](https://gravitee.atlassian.net/browse/APIM-12118) / [APIM-12090](https://gravitee.atlassian.net/browse/APIM-12090)

## Summary

Adds a new observability endpoint that returns the available values for a given analytics filter, so the UI can populate filter dropdowns dynamically instead of relying on free-text input.

- New REST resource `ObservabilityFilterValuesResource` exposing `GET .../observability/filters/{filterName}/values` (paginated, searchable).
- New use case `GetFilterValuesUseCase` + `FilterValuesQueryService` / `FilterValueNameResolver` domain services to resolve raw values (e.g. API IDs, application IDs, plan IDs) into human-readable labels.
- Repository layer: `AnalyticsRepository#searchFilterValues` with an Elasticsearch implementation (`FilterValuesQueryAdapter` / `FilterValuesResponseAdapter`) and a no-op fallback.
- OpenAPI spec updated (`openapi-analytics.yaml`) and `AnalyticsDefinitionMapper` extended to expose filter metadata.

## Test plan

- [ ] Unit tests pass (`GetFilterValuesUseCaseTest`, `FilterValuesQueryServiceImplTest`, `FilterValueNameResolverImplTest`, adapter tests)
- [ ] Integration test `ObservabilityFilterValuesResourceTest` passes
- [ ] Manual check: call the endpoint against an env with ES analytics and verify values + pagination + search


[APIM-12118]: https://gravitee.atlassian.net/browse/APIM-12118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-12090]: https://gravitee.atlassian.net/browse/APIM-12090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ