### PR TITLE
fix(gateway): set template variable providers on v2 DeploymentContext

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
@@ -216,6 +216,9 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
                 customComponentProvider.add(Api.class, api);
                 customComponentProvider.add(ReactableApi.class, api);
 
+                final DefaultReferenceRegister referenceRegister = referenceRegister();
+                deploymentContext.templateVariableProviders(v3TemplateVariableProviders(api, referenceRegister));
+
                 final ResourceLifecycleManager resourceLifecycleManager = resourceLifecycleManager(
                     api,
                     applicationContext.getBean(ResourceClassLoaderFactory.class),
@@ -225,8 +228,6 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
                 );
 
                 customComponentProvider.add(ResourceManager.class, resourceLifecycleManager);
-
-                final DefaultReferenceRegister referenceRegister = referenceRegister();
                 final GroupLifecycleManager groupLifecycleManager = groupLifecyleManager(
                     api,
                     referenceRegister,


### PR DESCRIPTION
## Summary

Fixes [APIM-13685](https://gravitee.atlassian.net/browse/APIM-13685)

Dictionary EL expressions in v2 API resource configurations fail because the `DeploymentContext` has no template variable providers set.

## Changes

Move `referenceRegister` creation before `resourceLifecycleManager` and set `templateVariableProviders` on the `DeploymentContext` in `ApiReactorHandlerFactory`. This matches the v4 `AbstractReactorFactory` pattern which already does `deploymentContext.templateVariableProviders(commonTemplateVariableProviders(reactableApi))`.

1 file, 3 lines added, 2 removed.

## Test plan

- [x] v2 API with `{#dictionaries['redis-config']['host']}` in Redis cache resource config: HTTP 200, cache working
- [x] v4 API with same dictionary config: HTTP 200 (not affected, already worked)
- [x] v2 API without dictionaries: HTTP 200 (no regression)

[APIM-13685]: https://gravitee.atlassian.net/browse/APIM-13685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ