### PR TITLE
chore(deps): bump gravitee-policy-data-logging-masking to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <gravitee-policy-custom-query-parameters.version>2.0.0</gravitee-policy-custom-query-parameters.version>
         <gravitee-policy-cloud-events.version>1.1.0</gravitee-policy-cloud-events.version>
         <gravitee-policy-data-cache.version>1.0.6</gravitee-policy-data-cache.version>
-        <gravitee-policy-data-logging-masking.version>3.1.1</gravitee-policy-data-logging-masking.version>
+        <gravitee-policy-data-logging-masking.version>3.1.2</gravitee-policy-data-logging-masking.version>
         <gravitee-policy-dynamic-routing.version>1.13.0</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.3.0</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.8.0</gravitee-policy-generate-jwt.version>


### PR DESCRIPTION
## Summary
- Bump `gravitee-policy-data-logging-masking` from `3.1.1` to `3.1.2`
https://gravitee.atlassian.net/browse/APIM-13405
## Test plan
- [ ] CI passes with updated dependency version