### PR TITLE
feat: expose apiProductId part two

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapter.java
@@ -53,6 +53,8 @@ public class SearchMetricsQueryAdapter {
 
         addApisFilter(filter, mustFilterList);
 
+        addApiProductIdsFilter(filter, mustFilterList);
+
         addFromAndToFilters(filter, mustFilterList);
 
         addApplicationsFilter(filter, mustFilterList);
@@ -87,6 +89,13 @@ public class SearchMetricsQueryAdapter {
     private static void addApisFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getApiIds())) {
             mustFilterList.add(buildV2AndV4Terms(RequestV2MetricsV4Fields.API_ID, filter.getApiIds()));
+        }
+    }
+
+    private static void addApiProductIdsFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getApiProductIds())) {
+            // API product ID exists only in the v4 metrics index — use buildV4Terms, not buildV2AndV4Terms
+            mustFilterList.add(buildV4Terms(RequestV2MetricsV4Fields.API_PRODUCT_ID, filter.getApiProductIds()));
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapterTest.java
@@ -710,4 +710,78 @@ class SearchMetricsQueryAdapterTest {
             assertThat(hasErrorKeysFilter).isFalse();
         }
     }
+
+    @Nested
+    class ApiProductIdsFilter {
+
+        @Test
+        void should_add_api_product_ids_terms_filter_when_provided() {
+            var query = MetricsQuery.builder()
+                .filter(
+                    MetricsQuery.Filter.builder()
+                        .apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9"))
+                        .apiProductIds(Set.of("f5e6a5a0-1234-4b3a-9c1e-000000000001", "f5e6a5a0-1234-4b3a-9c1e-000000000002"))
+                        .build()
+                )
+                .build();
+
+            var result = new JsonObject(SearchMetricsQueryAdapter.adapt(query));
+            var mustClauses = result.getJsonObject("query").getJsonObject("bool").getJsonArray("must");
+
+            var hasApiProductFilter = mustClauses
+                .stream()
+                .map(o -> (JsonObject) o)
+                .anyMatch(
+                    clause ->
+                        clause.containsKey("terms") &&
+                        clause.getJsonObject("terms").containsKey(RequestV2MetricsV4Fields.API_PRODUCT_ID.v4Metrics())
+                );
+
+            assertThat(hasApiProductFilter).isTrue();
+        }
+
+        @Test
+        void should_not_add_api_product_ids_filter_when_null() {
+            var query = MetricsQuery.builder()
+                .filter(MetricsQuery.Filter.builder().apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9")).apiProductIds(null).build())
+                .build();
+
+            var result = new JsonObject(SearchMetricsQueryAdapter.adapt(query));
+            var mustClauses = result.getJsonObject("query").getJsonObject("bool").getJsonArray("must");
+
+            var hasApiProductFilter = mustClauses
+                .stream()
+                .map(o -> (JsonObject) o)
+                .anyMatch(
+                    clause ->
+                        clause.containsKey("terms") &&
+                        clause.getJsonObject("terms").containsKey(RequestV2MetricsV4Fields.API_PRODUCT_ID.v4Metrics())
+                );
+
+            assertThat(hasApiProductFilter).isFalse();
+        }
+
+        @Test
+        void should_not_add_api_product_ids_filter_when_empty() {
+            var query = MetricsQuery.builder()
+                .filter(
+                    MetricsQuery.Filter.builder().apiIds(Set.of("f1608475-dd77-4603-a084-75dd775603e9")).apiProductIds(Set.of()).build()
+                )
+                .build();
+
+            var result = new JsonObject(SearchMetricsQueryAdapter.adapt(query));
+            var mustClauses = result.getJsonObject("query").getJsonObject("bool").getJsonArray("must");
+
+            var hasApiProductFilter = mustClauses
+                .stream()
+                .map(o -> (JsonObject) o)
+                .anyMatch(
+                    clause ->
+                        clause.containsKey("terms") &&
+                        clause.getJsonObject("terms").containsKey(RequestV2MetricsV4Fields.API_PRODUCT_ID.v4Metrics())
+                );
+
+            assertThat(hasApiProductFilter).isFalse();
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsResponseAdapterTest.java
@@ -71,7 +71,7 @@ class SearchMetricsResponseAdapterTest extends AbstractAdapterTest {
 
             assertThat(result.data()).hasSize(1);
             Metrics metrics = result.data().getFirst();
-            assertThat(metrics.getApiProductId()).isEqualTo("product-abc-123");
+            assertThat(metrics.getApiProductId()).isEqualTo("f5e6a5a0-1234-4b3a-9c1e-aabbccddeeff");
         }
 
         @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/hits/api-proxy-v4-metrics-with-api-product.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/hits/api-proxy-v4-metrics-with-api-product.json
@@ -21,5 +21,5 @@
   "application-id": "1",
   "gateway-response-time-ms": 19,
   "status": 202,
-  "api-product-id": "product-abc-123"
+  "api-product-id": "f5e6a5a0-1234-4b3a-9c1e-aabbccddeeff"
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/log/param/SearchLogsParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/log/param/SearchLogsParam.java
@@ -30,6 +30,7 @@ public class SearchLogsParam implements TimeInterval {
     public static final String FROM_QUERY_PARAM_NAME = "from";
     public static final String TO_QUERY_PARAM_NAME = "to";
     public static final String APPLICATION_IDS_QUERY_PARAM_NAME = "applicationIds";
+    public static final String API_PRODUCT_IDS_QUERY_PARAM_NAME = "apiProductIds";
     public static final String PLAN_IDS_QUERY_PARAM_NAME = "planIds";
     public static final String METHODS_QUERY_PARAM_NAME = "methods";
     public static final String MCP_METHODS_QUERY_PARAM_NAME = "mcpMethods";
@@ -47,6 +48,9 @@ public class SearchLogsParam implements TimeInterval {
 
     @QueryParam(APPLICATION_IDS_QUERY_PARAM_NAME)
     Set<String> applicationIds;
+
+    @QueryParam(API_PRODUCT_IDS_QUERY_PARAM_NAME)
+    Set<String> apiProductIds;
 
     @QueryParam(PLAN_IDS_QUERY_PARAM_NAME)
     Set<String> planIds;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -2434,6 +2434,16 @@ paths:
                 - $ref: "#/components/parameters/applicationIds"
                 - $ref: "#/components/parameters/planIds"
                 - $ref: "#/components/parameters/methods"
+                - name: apiProductIds
+                  in: query
+                  description: Filter by API Product IDs. Only supported for v4 APIs.
+                  explode: false
+                  schema:
+                      type: array
+                      items:
+                          type: string
+                      example:
+                          - f5e6a5a0-1234-4b3a-9c1e-aabbccddeeff
             tags:
                 - API Analytics
             summary: Get API logs
@@ -7024,6 +7034,14 @@ components:
                   type: object
                   additionalProperties: true
                   description: A map of string keys to values
+                apiProductId:
+                  type: string
+                  description: The ID of the API Product associated with this log entry. Absent when the request is not associated with any API Product.
+                  example: f5e6a5a0-1234-4b3a-9c1e-aabbccddeeff
+                apiProductName:
+                  type: string
+                  description: The human-readable name of the API Product. Absent when no API Product is associated or the product cannot be resolved.
+                  example: My Partner API Product
 
         ApiLogDiagnostic:
           type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
@@ -501,6 +501,33 @@ class ApiLogsResourceTest extends ApiResourceTest {
                         .links(new Links().self(connectionLogsTarget.getUri().toString()))
                 );
         }
+
+        @Test
+        void should_return_connection_logs_filtered_by_api_product_ids() {
+            connectionLogStorageService.initWith(
+                List.of(
+                    connectionLogFixtures.aConnectionLog("req1").toBuilder().apiProductId("f5e6a5a0-1234-4b3a-9c1e-000000000001").build(),
+                    connectionLogFixtures.aConnectionLog("req2").toBuilder().apiProductId("f5e6a5a0-1234-4b3a-9c1e-000000000001").build(),
+                    connectionLogFixtures.aConnectionLog("req3").toBuilder().apiProductId("f5e6a5a0-1234-4b3a-9c1e-000000000002").build()
+                )
+            );
+
+            connectionLogsTarget = connectionLogsTarget.queryParam(
+                SearchLogsParam.API_PRODUCT_IDS_QUERY_PARAM_NAME,
+                "f5e6a5a0-1234-4b3a-9c1e-000000000001"
+            );
+            final Response response = connectionLogsTarget.request().get();
+
+            assertThat(response).hasStatus(OK_200);
+
+            var apiLogsResponse = assertThat(response).asEntity(ApiLogsResponse.class).actual();
+            assertThat(apiLogsResponse.getPagination()).isEqualTo(
+                new Pagination().page(1).perPage(10).pageCount(1).pageItemsCount(2).totalCount(2L)
+            );
+            assertThat(apiLogsResponse.getData())
+                .extracting(io.gravitee.rest.api.management.v2.rest.model.ApiLog::getRequestId)
+                .containsExactlyInAnyOrder("req1", "req2");
+        }
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/model/BaseConnectionLog.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/model/BaseConnectionLog.java
@@ -50,12 +50,7 @@ public class BaseConnectionLog {
     private String errorComponentName;
     private String errorComponentType;
     private List<ConnectionDiagnosticModel> warnings;
-    /** The ID of the API Product associated with this connection log entry. Null when no product is associated. */
     private String apiProductId;
 
-    /**
-     * Resolved from {@code apiProductId} by {@code SearchApiV4ConnectionLogsUseCase} via {@code ApiProductQueryService}.
-     * This field is intentionally null in the data foundation layer and will be populated in APIM-13545 ST-3.
-     */
     private String apiProductName;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/use_case/SearchApiV4ConnectionLogsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/log/use_case/SearchApiV4ConnectionLogsUseCase.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.core.log.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
@@ -35,7 +37,10 @@ import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @UseCase
 public class SearchApiV4ConnectionLogsUseCase {
@@ -44,15 +49,18 @@ public class SearchApiV4ConnectionLogsUseCase {
     private final ConnectionLogsCrudService connectionLogsCrudService;
     private final PlanCrudService planCrudService;
     private final ApplicationCrudService applicationCrudService;
+    private final ApiProductQueryService apiProductQueryService;
 
     public SearchApiV4ConnectionLogsUseCase(
         ConnectionLogsCrudService connectionLogsCrudService,
         PlanCrudService planCrudService,
-        ApplicationCrudService applicationCrudService
+        ApplicationCrudService applicationCrudService,
+        ApiProductQueryService apiProductQueryService
     ) {
         this.connectionLogsCrudService = connectionLogsCrudService;
         this.planCrudService = planCrudService;
         this.applicationCrudService = applicationCrudService;
+        this.apiProductQueryService = apiProductQueryService;
     }
 
     public Output execute(ExecutionContext executionContext, Input input) {
@@ -70,16 +78,34 @@ public class SearchApiV4ConnectionLogsUseCase {
 
     private Output mapToResponse(ExecutionContext executionContext, SearchLogsResponse<BaseConnectionLog> logs) {
         var total = logs.total();
-        var data = logs
-            .logs()
+        var logList = logs.logs();
+
+        var apiProductNames = prefetchApiProductNames(executionContext, logList);
+
+        var data = logList
             .stream()
-            .map(log -> mapToModel(executionContext, log))
+            .map(log -> mapToModel(executionContext, log, apiProductNames))
             .toList();
 
         return new Output(total, data);
     }
 
-    private ConnectionLogModel mapToModel(ExecutionContext executionContext, BaseConnectionLog connectionLog) {
+    private Map<String, String> prefetchApiProductNames(ExecutionContext executionContext, List<BaseConnectionLog> logs) {
+        var ids = logs.stream().map(BaseConnectionLog::getApiProductId).filter(Objects::nonNull).collect(Collectors.toSet());
+        if (ids.isEmpty()) {
+            return Map.of();
+        }
+        return apiProductQueryService
+            .findByEnvironmentIdAndIdIn(executionContext.getEnvironmentId(), ids)
+            .stream()
+            .collect(Collectors.toMap(ApiProduct::getId, ApiProduct::getName));
+    }
+
+    private ConnectionLogModel mapToModel(
+        ExecutionContext executionContext,
+        BaseConnectionLog connectionLog,
+        Map<String, String> apiProductNames
+    ) {
         return ConnectionLogModel.builder()
             .apiId(connectionLog.getApiId())
             .requestId(connectionLog.getRequestId())
@@ -100,6 +126,8 @@ public class SearchApiV4ConnectionLogsUseCase {
             .message(connectionLog.getMessage())
             .warnings(connectionLog.getWarnings() != null ? connectionLog.getWarnings() : List.of())
             .additionalMetrics(connectionLog.getAdditionalMetrics() != null ? connectionLog.getAdditionalMetrics() : Map.of())
+            .apiProductId(connectionLog.getApiProductId())
+            .apiProductName(connectionLog.getApiProductId() != null ? apiProductNames.get(connectionLog.getApiProductId()) : null)
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
@@ -191,6 +191,7 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
             .to(searchLogsFilters.to())
             .applicationIds(searchLogsFilters.applicationIds())
             .apiIds(searchLogsFilters.apiIds())
+            .apiProductIds(searchLogsFilters.apiProductIds())
             .planIds(searchLogsFilters.planIds())
             .methods(searchLogsFilters.methods())
             .mcpMethods(searchLogsFilters.mcpMethods())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ConnectionLogsCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ConnectionLogsCrudServiceInMemory.java
@@ -257,6 +257,10 @@ public class ConnectionLogsCrudServiceInMemory implements ConnectionLogsCrudServ
             predicate = predicate.and(connectionLog -> logsFilters.errorKeys().contains(connectionLog.getErrorKey()));
         }
 
+        if (!CollectionUtils.isEmpty(logsFilters.apiProductIds())) {
+            predicate = predicate.and(connectionLog -> logsFilters.apiProductIds().contains(connectionLog.getApiProductId()));
+        }
+
         if (!CollectionUtils.isEmpty(logsFilters.responseTimeRanges())) {
             predicate = predicate.and(connectionLog ->
                 logsFilters

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchApiV4ConnectionLogsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/log/use_case/SearchApiV4ConnectionLogsUseCaseTest.java
@@ -21,10 +21,12 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import fixtures.core.model.PlanFixtures;
 import fixtures.repository.ConnectionLogFixtures;
+import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.ConnectionLogsCrudServiceInMemory;
 import inmemory.InMemoryAlternative;
 import inmemory.PlanCrudServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.log.use_case.SearchApiV4ConnectionLogsUseCase.Input;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.common.http.HttpMethod;
@@ -68,12 +70,18 @@ class SearchApiV4ConnectionLogsUseCaseTest {
     ConnectionLogsCrudServiceInMemory logStorageService = new ConnectionLogsCrudServiceInMemory();
     PlanCrudServiceInMemory planStorageService = new PlanCrudServiceInMemory();
     ApplicationCrudServiceInMemory applicationStorageService = new ApplicationCrudServiceInMemory();
+    ApiProductQueryServiceInMemory apiProductStorageService = new ApiProductQueryServiceInMemory();
 
     SearchApiV4ConnectionLogsUseCase usecase;
 
     @BeforeEach
     void setUp() {
-        usecase = new SearchApiV4ConnectionLogsUseCase(logStorageService, planStorageService, applicationStorageService);
+        usecase = new SearchApiV4ConnectionLogsUseCase(
+            logStorageService,
+            planStorageService,
+            applicationStorageService,
+            apiProductStorageService
+        );
 
         planStorageService.initWith(List.of(PLAN_1, PLAN_2));
         applicationStorageService.initWith(List.of(APPLICATION_1, APPLICATION_2));
@@ -81,7 +89,9 @@ class SearchApiV4ConnectionLogsUseCaseTest {
 
     @AfterEach
     void tearDown() {
-        Stream.of(logStorageService, planStorageService, applicationStorageService).forEach(InMemoryAlternative::reset);
+        Stream.of(logStorageService, planStorageService, applicationStorageService, apiProductStorageService).forEach(
+            InMemoryAlternative::reset
+        );
 
         GraviteeContext.cleanContext();
     }
@@ -381,5 +391,68 @@ class SearchApiV4ConnectionLogsUseCaseTest {
             soft.assertThat(result.total()).isEqualTo(1);
             soft.assertThat(result.data()).extracting(ConnectionLogModel::getRequestId).containsExactly("req1");
         });
+    }
+
+    @Test
+    void should_map_api_product_id_onto_connection_log_model() {
+        logStorageService.initWithConnectionLogs(
+            List.of(connectionLogFixtures.aConnectionLog("req1").toBuilder().apiProductId("f5e6a5a0-1234-4b3a-9c1e-000000000001").build())
+        );
+
+        var result = usecase.execute(
+            GraviteeContext.getExecutionContext(),
+            new Input(API_ID, SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(SECOND_FEBRUARY_2020).build())
+        );
+
+        assertThat(result.data()).extracting(ConnectionLogModel::getApiProductId).containsExactly("f5e6a5a0-1234-4b3a-9c1e-000000000001");
+    }
+
+    @Test
+    void should_resolve_api_product_name_when_product_exists() {
+        var product = ApiProduct.builder()
+            .id("f5e6a5a0-1234-4b3a-9c1e-000000000001")
+            .name("My Partner API Product")
+            .version("1.0")
+            .environmentId("DEFAULT")
+            .build();
+        apiProductStorageService.initWith(List.of(product));
+        logStorageService.initWithConnectionLogs(
+            List.of(connectionLogFixtures.aConnectionLog("req1").toBuilder().apiProductId("f5e6a5a0-1234-4b3a-9c1e-000000000001").build())
+        );
+
+        var result = usecase.execute(
+            GraviteeContext.getExecutionContext(),
+            new Input(API_ID, SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(SECOND_FEBRUARY_2020).build())
+        );
+
+        assertThat(result.data()).extracting(ConnectionLogModel::getApiProductName).containsExactly("My Partner API Product");
+    }
+
+    @Test
+    void should_return_null_api_product_name_when_no_product_is_associated() {
+        logStorageService.initWithConnectionLogs(
+            List.of(connectionLogFixtures.aConnectionLog("req1").toBuilder().apiProductId(null).build())
+        );
+
+        var result = usecase.execute(
+            GraviteeContext.getExecutionContext(),
+            new Input(API_ID, SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(SECOND_FEBRUARY_2020).build())
+        );
+
+        assertThat(result.data()).extracting(ConnectionLogModel::getApiProductName).containsOnlyNulls();
+    }
+
+    @Test
+    void should_return_null_api_product_name_when_product_is_not_found() {
+        logStorageService.initWithConnectionLogs(
+            List.of(connectionLogFixtures.aConnectionLog("req1").toBuilder().apiProductId("f5e6a5a0-1234-4b3a-9c1e-000000000099").build())
+        );
+
+        var result = usecase.execute(
+            GraviteeContext.getExecutionContext(),
+            new Input(API_ID, SearchLogsFilters.builder().from(FIRST_FEBRUARY_2020).to(SECOND_FEBRUARY_2020).build())
+        );
+
+        assertThat(result.data()).extracting(ConnectionLogModel::getApiProductName).containsOnlyNulls();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13545
## Description

Exposes `apiProductId` and `apiProductName` in the v4 connection logs REST API and adds the ability to filter logs by API Product.

Changes
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

