### PR TITLE
feat(rest-api): Kafka connection log level

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/ConnectionLog.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/ConnectionLog.java
@@ -30,11 +30,13 @@ import lombok.ToString;
 @Setter
 @ToString
 @EqualsAndHashCode
-public class NativeAnalytics {
+public class ConnectionLog {
+
+    public static final String ERROR_KEY = "CONNECTION_ERROR";
 
     @Builder.Default
-    protected boolean enabled = true;
+    private boolean enabled = true;
 
     @Builder.Default
-    private ConnectionLog connectionLog = new ConnectionLog();
+    private boolean debugEnabled = false;
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/v4/nativeapi/NativeAnalyticsTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/v4/nativeapi/NativeAnalyticsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.nativeapi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class NativeAnalyticsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void should_default_connection_log_when_absent_in_json() throws Exception {
+        var analytics = objectMapper.readValue("{\"enabled\":true}", NativeAnalytics.class);
+
+        assertThat(analytics.getConnectionLog())
+            .isNotNull()
+            .extracting(ConnectionLog::isEnabled, ConnectionLog::isDebugEnabled)
+            .containsExactly(true, false);
+    }
+
+    @Test
+    void should_round_trip_connection_log() throws Exception {
+        var original = NativeAnalytics.builder().connectionLog(ConnectionLog.builder().enabled(true).debugEnabled(true).build()).build();
+
+        var deserialized = objectMapper.readValue(objectMapper.writeValueAsString(original), NativeAnalytics.class);
+
+        assertThat(deserialized).isEqualTo(original);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/MetricsElasticsearchRepositoryTest.java
@@ -1005,5 +1005,20 @@ public class MetricsElasticsearchRepositoryTest extends AbstractElasticsearchRep
                 .containsEntry("keyword_native-kafka_operations", "FETCH,JOIN_GROUP")
                 .containsEntry("keyword_native-kafka_consumer-group-id", "group-beta");
         }
+
+        @Test
+        void should_return_only_error_connections_when_filtering_by_error_keys() {
+            var result = metricsV4Repository.searchMetrics(
+                queryContext,
+                MetricsQuery.builder()
+                    .filter(Filter.builder().apiIds(Set.of("kafka-api-001")).errorKeys(Set.of("CONNECTION_ERROR")).build())
+                    .size(10)
+                    .build(),
+                List.of(DefinitionVersion.V4)
+            );
+
+            assertThat(result.total()).isEqualTo(2);
+            assertThat(result.data()).extracting(Metrics::getErrorKey).containsOnly("CONNECTION_ERROR");
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -71,9 +71,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.ValueMapping;
 import org.mapstruct.factory.Mappers;
@@ -490,5 +492,14 @@ public interface ApiMapper {
             })
             .filter(Objects::nonNull)
             .collect(java.util.stream.Collectors.toList());
+    }
+
+    @AfterMapping
+    default void cascadeDisabledAnalytics(@MappingTarget io.gravitee.definition.model.v4.nativeapi.NativeAnalytics target) {
+        if (!target.isEnabled()) {
+            target.setConnectionLog(
+                io.gravitee.definition.model.v4.nativeapi.ConnectionLog.builder().enabled(false).debugEnabled(false).build()
+            );
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3188,6 +3188,30 @@ components:
                     $ref: "#/components/schemas/LoggingV4"
                 tracing:
                     $ref: "#/components/schemas/TracingV4"
+                connectionLog:
+                    $ref: "#/components/schemas/ConnectionLog"
+        NativeAnalytics:
+            type: object
+            description: Analytics configuration for Native Kafka APIs.
+            properties:
+                enabled:
+                    type: boolean
+                    description: Whether or not analytics is enabled.
+                    default: true
+                connectionLog:
+                    $ref: "#/components/schemas/ConnectionLog"
+        ConnectionLog:
+            type: object
+            description: Connection logging configuration for Native Kafka APIs.
+            properties:
+                enabled:
+                    type: boolean
+                    description: Enable connection logging.
+                    default: true
+                debugEnabled:
+                    type: boolean
+                    description: Log all connections including successful ones.
+                    default: false
         Api:
             oneOf:
                 - $ref: "#/components/schemas/ApiV2"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiLogsMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiLogsMapperTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.model.v4.nativeapi.ConnectionLog;
 import io.gravitee.rest.api.management.v2.rest.resource.api.log.param.SearchLogsParam;
 import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
 import java.util.Set;
@@ -65,7 +66,7 @@ class ApiLogsMapperTest {
             param.setMethods(Set.of(HttpMethod.GET));
             param.setStatuses(Set.of(200));
             param.setEntrypointIds(Set.of("native-kafka"));
-            param.setErrorKeys(Set.of("CONNECTION_ERROR"));
+            param.setErrorKeys(Set.of(ConnectionLog.ERROR_KEY));
             param.setNativeKafkaClientIds(Set.of("consumer-A"));
             param.setNativeKafkaConsumerGroupIds(Set.of("group-alpha"));
 
@@ -78,7 +79,7 @@ class ApiLogsMapperTest {
             assertThat(filters.methods()).containsExactly(HttpMethod.GET);
             assertThat(filters.statuses()).containsExactly(200);
             assertThat(filters.entrypointIds()).containsExactly("native-kafka");
-            assertThat(filters.errorKeys()).containsExactly("CONNECTION_ERROR");
+            assertThat(filters.errorKeys()).containsExactly(ConnectionLog.ERROR_KEY);
             assertThat(filters.nativeKafkaClientIds()).containsExactly("consumer-A");
             assertThat(filters.nativeKafkaConsumerGroupIds()).containsExactly("group-alpha");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -29,6 +29,7 @@ import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.rest.api.management.v2.rest.model.Analytics;
 import io.gravitee.rest.api.management.v2.rest.model.ApiType;
 import io.gravitee.rest.api.management.v2.rest.model.BaseOriginContext;
+import io.gravitee.rest.api.management.v2.rest.model.ConnectionLog;
 import io.gravitee.rest.api.management.v2.rest.model.CreateApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.FailoverV4;
 import io.gravitee.rest.api.management.v2.rest.model.IntegrationOriginContext;
@@ -94,6 +95,36 @@ public class ApiMapperTest {
         assertThat(updateApiEntity.getFailover()).isEqualTo(
             Failover.builder().enabled(true).perSubscription(false).maxFailures(3).openStateDuration(11000).slowCallDuration(500).build()
         );
+    }
+
+    @Test
+    void should_cascade_connection_log_off_when_native_analytics_disabled() {
+        var updateApi = ApiFixtures.anUpdateApiV4()
+            .type(ApiType.NATIVE)
+            .analytics(new Analytics().enabled(false).connectionLog(new ConnectionLog().enabled(true).debugEnabled(true)));
+
+        var updateNativeApi = apiMapper.mapToUpdateNativeApi(updateApi, API_ID);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(updateNativeApi.getAnalytics().isEnabled()).isFalse();
+            soft.assertThat(updateNativeApi.getAnalytics().getConnectionLog().isEnabled()).isFalse();
+            soft.assertThat(updateNativeApi.getAnalytics().getConnectionLog().isDebugEnabled()).isFalse();
+        });
+    }
+
+    @Test
+    void should_preserve_connection_log_when_native_analytics_enabled() {
+        var updateApi = ApiFixtures.anUpdateApiV4()
+            .type(ApiType.NATIVE)
+            .analytics(new Analytics().enabled(true).connectionLog(new ConnectionLog().enabled(true).debugEnabled(true)));
+
+        var updateNativeApi = apiMapper.mapToUpdateNativeApi(updateApi, API_ID);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(updateNativeApi.getAnalytics().isEnabled()).isTrue();
+            soft.assertThat(updateNativeApi.getAnalytics().getConnectionLog().isEnabled()).isTrue();
+            soft.assertThat(updateNativeApi.getAnalytics().getConnectionLog().isDebugEnabled()).isTrue();
+        });
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
@@ -38,12 +38,14 @@ import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.management.v2.rest.model.Analytics;
 import io.gravitee.rest.api.management.v2.rest.model.Api;
 import io.gravitee.rest.api.management.v2.rest.model.ApiFederated;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLifecycleState;
 import io.gravitee.rest.api.management.v2.rest.model.ApiType;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV2;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.ConnectionLog;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.GenericApi;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV2;
@@ -65,6 +67,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class ApiResource_UpdateApiTest extends ApiResourceTest {
 
@@ -314,6 +317,34 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
             .extracting(Api::getApiV4)
             .extracting(ApiV4::getName, ApiV4::getDescription, ApiV4::getApiVersion, ApiV4::getLifecycleState)
             .containsExactly(updatedName, updatedDescription, updatedVersion, updatedLifecycle);
+    }
+
+    @Test
+    public void should_cascade_connection_log_off_when_native_analytics_disabled_on_update() {
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+        primaryOwnerInit();
+        var existingEntity = ApiFixtures.aModelNativeApiV4().withId(API);
+        var existingApi = fixtures.core.model.ApiFixtures.aNativeApi().toBuilder().id(API).build();
+
+        apiCrudService.initWith(List.of(existingApi));
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(
+            existingEntity
+        );
+        when(validateApiDomainService.validateAndSanitizeForUpdate(eq(existingApi), any(), any(), any(), any())).thenReturn(existingApi);
+
+        var updateApiV4 = ApiFixtures.anUpdateApiV4()
+            .type(ApiType.NATIVE)
+            .analytics(new Analytics().enabled(false).connectionLog(new ConnectionLog().enabled(true).debugEnabled(true)));
+
+        rootTarget(API).request().put(Entity.json(updateApiV4));
+
+        var captor = ArgumentCaptor.forClass(io.gravitee.apim.core.api.model.Api.class);
+        verify(validateApiDomainService).validateAndSanitizeForUpdate(eq(existingApi), captor.capture(), any(), any(), any());
+        var cascaded = captor.getValue().getApiDefinitionNativeV4().getAnalytics();
+        assertEquals(false, cascaded.isEnabled());
+        assertNotNull(cascaded.getConnectionLog());
+        assertEquals(false, cascaded.getConnectionLog().isEnabled());
+        assertEquals(false, cascaded.getConnectionLog().isDebugEnabled());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
@@ -57,6 +57,8 @@ import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.definition.model.v4.nativeapi.ConnectionLog;
+import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
 import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
@@ -381,6 +383,11 @@ public class ApiResource_getApiByIdTest extends ApiResourceTest {
         assertEquals(true, dynamicPropertyConfiguration.getOverrideConfiguration());
         assertNotNull(dynamicPropertyConfiguration.getConfiguration());
         assertEquals("dynamic-property", dynamicPropertyConfiguration.getType());
+
+        var connectionLog = responseApi.getAnalytics().getConnectionLog();
+        assertTrue(responseApi.getAnalytics().getEnabled());
+        assertTrue(connectionLog.getEnabled());
+        assertEquals(false, connectionLog.getDebugEnabled());
     }
 
     @Test
@@ -705,6 +712,9 @@ public class ApiResource_getApiByIdTest extends ApiResourceTest {
         dynamicProperty.setEnabled(true);
         dynamicProperty.setOverrideConfiguration(true);
         apiEntity.setServices(new NativeApiServices(dynamicProperty));
+        apiEntity.setAnalytics(
+            NativeAnalytics.builder().enabled(true).connectionLog(ConnectionLog.builder().enabled(true).debugEnabled(false).build()).build()
+        );
 
         return apiEntity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ConnectionLogsCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ConnectionLogsCrudServiceInMemory.java
@@ -255,7 +255,9 @@ public class ConnectionLogsCrudServiceInMemory implements ConnectionLogsCrudServ
         }
 
         if (!CollectionUtils.isEmpty(logsFilters.errorKeys())) {
-            predicate = predicate.and(connectionLog -> logsFilters.errorKeys().contains(connectionLog.getErrorKey()));
+            predicate = predicate.and(
+                connectionLog -> connectionLog.getErrorKey() != null && logsFilters.errorKeys().contains(connectionLog.getErrorKey())
+            );
         }
 
         if (!CollectionUtils.isEmpty(logsFilters.responseTimeRanges())) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
@@ -247,7 +247,7 @@ class ValidateApiDomainServiceLegacyWrapperTest {
                                 .dynamicProperty(Service.builder().configuration("configuration-to-sanitize").build())
                                 .build()
                         )
-                        .analytics(new NativeAnalytics(true))
+                        .analytics(NativeAnalytics.builder().enabled(true).build())
                         .build()
                 )
                 .build();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13592

## Summary

- Add `ConnectionLog` model (`enabled`, `debugEnabled`) under `NativeAnalytics`
- `ConnectionLog.ERROR_KEY = "CONNECTION_ERROR"` constant + `errorKeys()` helper for write-side gating
- Add `NativeAnalytics`, `ConnectionLog` schemas to OpenAPI spec
- Filter behavior on reads is frontend-driven (no server-side reconciliation): UI sends `errorKeys=CONNECTION_ERROR` for default view, omits for debug view

## Co-dependent PR

APIM-13593 in `gravitee-reactor-native-kafka` (PR #304) consumes `ConnectionLog.enabled`/`debugEnabled` to gate reporter writes.