### PR TITLE
Revert "[4.9.x] chore(gravitee-policy-jwt): Align versions with CI release version"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <gravitee-policy-json-validation.version>2.1.1</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>2.0.0</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>7.0.2</gravitee-policy-jwt.version>
+        <gravitee-policy-jwt.version>7.0.1</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>4.0.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>2.0.1</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.1</gravitee-policy-metrics-reporter.version>


### PR DESCRIPTION
Reverts gravitee-io/gravitee-api-management#16335

The approach for this fix needs to be reviewed. Hence this PR needs to be closed. 