### PR TITLE
feat(portal): add analytics toggle to portal settings form

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -222,6 +222,9 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
       mtls: {
         enabled: false,
       },
+      analytics: {
+        enabled: false,
+      },
       banner: {
         enabled: true,
         title: 'testTitle',

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -250,6 +250,9 @@ export interface PortalSettingsPortalNext {
   mtls?: {
     enabled?: boolean;
   };
+  analytics?: {
+    enabled?: boolean;
+  };
   banner?: {
     title?: string;
     subtitle?: string;

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -465,6 +465,15 @@
                 aria-label="mTLS Certificate Management Enabled"
               ></mat-slide-toggle>
             </gio-form-slide-toggle>
+            <gio-form-slide-toggle formGroupName="analytics" class="portal__form__card__form-field">
+              <gio-form-label>Enable Analytics</gio-form-label>
+              <mat-slide-toggle
+                id="enable-portal-next-analytics"
+                formControlName="enabled"
+                gioFormSlideToggle
+                aria-label="Analytics Enabled"
+              ></mat-slide-toggle>
+            </gio-form-slide-toggle>
             @if (!!settings.portalNext?.access?.enabled) {
               <div class="new-developer-portal-actions">
                 @if (portalUrl) {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -201,6 +201,9 @@ describe('PortalSettingsComponent', () => {
           mtls: {
             enabled: false,
           },
+          analytics: {
+            enabled: false,
+          },
           banner: {
             ...portalSettingsMock.portalNext.banner,
             enabled: true,
@@ -209,6 +212,22 @@ describe('PortalSettingsComponent', () => {
           },
         },
       });
+    });
+
+    it('display settings form and edit Portal Next analytics toggle', async () => {
+      portalSettingsMock = fakePortalSettings();
+      expectPortalSettingsGetRequest(portalSettingsMock);
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isVisible()).toBe(false);
+
+      const analyticsToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-analytics' }));
+      await analyticsToggle.toggle();
+      expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body.portalNext.analytics.enabled).toEqual(true);
     });
 
     it('display settings form and edit CORS fields', async () => {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -111,6 +111,7 @@ interface PortalForm {
   portalNext: FormGroup<{
     access: FormGroup<{ enabled: FormControl<boolean> }>;
     mtls: FormGroup<{ enabled: FormControl<boolean> }>;
+    analytics: FormGroup<{ enabled: FormControl<boolean> }>;
   }>;
   scheduler: FormGroup<{
     tasks: FormControl<number>;
@@ -417,6 +418,12 @@ export class PortalSettingsComponent implements OnInit {
             disabled: this.isReadonly('portalNext.mtls.enabled'),
           }),
         }),
+        analytics: new FormGroup({
+          enabled: new FormControl({
+            value: !!this.settings.portalNext?.analytics?.enabled,
+            disabled: this.isReadonly('portalNext.analytics.enabled'),
+          }),
+        }),
       }),
       scheduler: new FormGroup({
         tasks: new FormControl({
@@ -671,6 +678,7 @@ export class PortalSettingsComponent implements OnInit {
           ...this.portalForm.get('portalNext.access').value,
         },
         mtls: this.portalForm.get('portalNext.mtls').value,
+        analytics: this.portalForm.get('portalNext.analytics').value,
       },
     };
 


### PR DESCRIPTION
Introduce a new toggle to enable or disable analytics in the Portal Settings form. Update related forms, configuration, and tests to support the new feature.

## Issue

https://gravitee.atlassian.net/browse/APIM-13638

## Description


https://github.com/user-attachments/assets/375d4252-7475-4c87-8447-8648e5f80a52



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

