### PR TITLE
Next-gen application member search

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/catalog/catalog.component.scss
@@ -43,6 +43,17 @@ $empty-state-height: 400px;
     justify-content: space-between;
     gap: 16px;
 
+    &__controls {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 16px;
+
+      app-search-bar {
+        width: 300px;
+      }
+    }
+
     &--mobile {
       display: grid;
       grid-template-columns: 1fr auto;
@@ -68,13 +79,6 @@ $empty-state-height: 400px;
         grid-row: 2 / 3;
         width: 100%;
       }
-    }
-
-    &__controls {
-      display: flex;
-      align-items: center;
-      justify-content: flex-end;
-      gap: 16px;
     }
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.harness.ts
@@ -23,6 +23,7 @@ export class ApplicationTabMembersComponentHarness extends ComponentHarness {
   public static readonly hostSelector = 'app-application-tab-members';
 
   private readonly locateLoader = this.locatorForOptional(LoaderHarness);
+  private readonly locateSectionTitle = this.locatorForOptional('[data-testid="members-section-title"]');
   private readonly locateErrorMessage = this.locatorForOptional('[data-testid="members-list-error"]');
   private readonly locateEmptyState = this.locatorForOptional('[data-testid="members-empty-state"]');
   private readonly locatePaginatedTable = this.locatorForOptional(PaginatedTableHarness);
@@ -31,6 +32,10 @@ export class ApplicationTabMembersComponentHarness extends ComponentHarness {
 
   public async getLoader(): Promise<LoaderHarness | null> {
     return this.locateLoader();
+  }
+
+  public async getSectionTitle(): Promise<TestElement | null> {
+    return this.locateSectionTitle();
   }
 
   public async getErrorMessage(): Promise<TestElement | null> {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.html
@@ -16,6 +16,10 @@
 
 -->
 @if (canRead()) {
+  <app-search-bar (searchTerm)="onSearchTermChange($event)" />
+  <h4 class="next-gen-h4 members__title" data-testid="members-section-title" i18n="@@applicationMembersTitle">
+    Members ({{ totalElements() }})
+  </h4>
   @if (membersResource.isLoading()) {
     <app-loader />
   } @else if (membersResource.error()) {
@@ -23,9 +27,15 @@
       An error occurred while loading members. Try again later or contact your Portal administrator.
     </div>
   } @else if (totalElements() === 0) {
-    <div class="members__empty-state" data-testid="members-empty-state">
-      <p class="next-gen-body" i18n="@@membersEmptyState">No members found.</p>
-    </div>
+    @if (searchTerm() !== '') {
+      <div class="members__empty-state" data-testid="members-search-no-match">
+        <p i18n="@@membersSearchNoMatch">No members match your search.</p>
+      </div>
+    } @else {
+      <div class="members__empty-state" data-testid="members-empty-state">
+        <p class="next-gen-body" i18n="@@membersEmptyState">No members found.</p>
+      </div>
+    }
   } @else {
     <app-paginated-table
       [columns]="tableColumns"

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.scss
@@ -15,7 +15,17 @@
  */
 @use '../../../../scss/theme/index' as app-theme;
 
+app-search-bar {
+  display: block;
+  margin-bottom: 24px;
+  max-width: 400px;
+}
+
 .members {
+  &__title {
+    margin: 0 0 16px;
+  }
+
   &__empty-state {
     padding: 24px 0;
     text-align: center;

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
@@ -76,6 +76,35 @@ describe('ApplicationTabMembersComponent', () => {
     expect(await harness.getPaginatedTable()).not.toBeNull();
   });
 
+  it('should show section title with total member count from pagination', async () => {
+    await flush(fakeMembersResponse([fakeMember()], 42));
+    const harness = await getHarness();
+    const title = await harness.getSectionTitle();
+    expect(title).not.toBeNull();
+    expect((await title!.text())?.replace(/\s+/g, ' ').trim()).toBe('Members (42)');
+  });
+
+  it('should show Members (0) in section title when the list is empty', async () => {
+    await flush(fakeMembersResponse([]));
+    const harness = await getHarness();
+    const title = await harness.getSectionTitle();
+    expect(title).not.toBeNull();
+    expect((await title!.text())?.replace(/\s+/g, ' ').trim()).toBe('Members (0)');
+  });
+
+  it('should show section title and error when search fails', async () => {
+    fixture.detectChanges();
+    const req = httpTestingController.expectOne(r => r.url.includes('members/_search'));
+    req.flush({ error: 'Server error' }, { status: 500, statusText: 'Internal Server Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const harness = await getHarness();
+    const title = await harness.getSectionTitle();
+    expect(title).not.toBeNull();
+    expect((await title!.text())?.replace(/\s+/g, ' ').trim()).toBe('Members (0)');
+    expect(await harness.getErrorMessage()).not.toBeNull();
+  });
+
   it('should show loader until the first search response', async () => {
     // In-flight rxResource requests block fixture.whenStable(), which the harness API awaits;
     // fall back to a synchronous DOM check for the loading state (the rule's documented escape
@@ -192,6 +221,81 @@ describe('ApplicationTabMembersComponent', () => {
       const harness = await flush(fakeMembersResponse([fakeMember({ user: { id: 'other-user', display_name: 'Other', _links: {} } })]));
       const userCell = await harness.getFirstUserCell();
       expect(await userCell.hasYouBadge()).toBe(false);
+    });
+  });
+
+  describe('search behavior', () => {
+    it('should render search bar when canRead', () => {
+      fixture.detectChanges();
+      httpTestingController.expectOne(r => r.url.includes('members/_search')).flush(fakeMembersResponse([fakeMember()]));
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('app-search-bar')).toBeTruthy();
+    });
+
+    it('should not render search bar when canRead is false', () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: [] }));
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('app-search-bar')).toBeNull();
+    });
+
+    it('should send displayName in filters on initial load', () => {
+      fixture.detectChanges();
+      const req = httpTestingController.expectOne(r => r.url.includes('members/_search'));
+      expect(req.request.body).toEqual({ filters: { displayName: '' } });
+      req.flush(fakeMembersResponse([fakeMember()]));
+    });
+
+    it('should send displayName filter when search term is set', () => {
+      flush(fakeMembersResponse([fakeMember()]));
+      fixture.componentInstance.onSearchTermChange('alice');
+      fixture.detectChanges();
+      const req = httpTestingController.expectOne(r => r.url.includes('members/_search') && r.params.get('page') === '1');
+      expect(req.request.body).toEqual({ filters: { displayName: 'alice' } });
+      req.flush(fakeMembersResponse([fakeMember()]));
+    });
+
+    it('should reset page to 1 when search term changes', () => {
+      flush(fakeMembersResponse([fakeMember()], 25));
+      fixture.componentInstance.onPageChange(2);
+      fixture.detectChanges();
+      httpTestingController.expectOne(r => r.params.get('page') === '2').flush(fakeMembersResponse([fakeMember()]));
+
+      fixture.componentInstance.onSearchTermChange('alice');
+      fixture.detectChanges();
+      const req = httpTestingController.expectOne(r => r.url.includes('members/_search'));
+      expect(req.request.params.get('page')).toBe('1');
+      req.flush(fakeMembersResponse([fakeMember()]));
+    });
+
+    it('should show no-match empty state when search is active and returns 0 results', async () => {
+      await flush(fakeMembersResponse([fakeMember()]));
+      fixture.componentInstance.onSearchTermChange('zzz');
+      fixture.detectChanges();
+      const searchReq = httpTestingController.expectOne(r => r.url.includes('members/_search'));
+      searchReq.flush(fakeMembersResponse([]));
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-testid="members-search-no-match"]')).toBeTruthy();
+      expect(fixture.nativeElement.querySelector('.members__empty-state p')?.textContent?.trim()).toBe('No members match your search.');
+    });
+
+    it('should show generic empty state when no search is active and returns 0 results', async () => {
+      await flush(fakeMembersResponse([]));
+      expect(fixture.nativeElement.querySelector('[data-testid="members-search-no-match"]')).toBeNull();
+      expect(fixture.nativeElement.querySelector('.members__empty-state p')?.textContent?.trim()).toBe('No members found.');
+    });
+
+    it('should clear displayName in filters after clearing the search term', async () => {
+      await flush(fakeMembersResponse([fakeMember()]));
+      fixture.componentInstance.onSearchTermChange('alice');
+      fixture.detectChanges();
+      httpTestingController.expectOne(r => r.url.includes('members/_search')).flush(fakeMembersResponse([fakeMember()]));
+
+      fixture.componentInstance.onSearchTermChange('');
+      fixture.detectChanges();
+      const req = httpTestingController.expectOne(r => r.url.includes('members/_search'));
+      expect(req.request.body).toEqual({ filters: { displayName: '' } });
+      req.flush(fakeMembersResponse([fakeMember()]));
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
@@ -20,8 +20,9 @@ import { of } from 'rxjs';
 import { LoaderComponent } from '../../../../components/loader/loader.component';
 import { PaginatedTableComponent, TableAction, TableColumn } from '../../../../components/paginated-table/paginated-table.component';
 import { TableCellDirective } from '../../../../components/paginated-table/table-cell.directive';
+import { SearchBarComponent } from '../../../../components/search-bar/search-bar.component';
 import { UserCellComponent, UserCellVM } from '../../../../components/user-cell/user-cell.component';
-import { Member, MembersResponse } from '../../../../entities/member/member';
+import { Member, MemberSearchFilters, MembersResponse } from '../../../../entities/member/member';
 import { UserApplicationPermissions } from '../../../../entities/permission/permission';
 import { CurrentUserService } from '../../../../services/current-user.service';
 import { MembershipService } from '../../../../services/membership.service';
@@ -38,12 +39,13 @@ interface MembersRequestParams {
   applicationId: string;
   page: number;
   size: number;
+  filters: MemberSearchFilters;
 }
 
 @Component({
   selector: 'app-application-tab-members',
   standalone: true,
-  imports: [LoaderComponent, PaginatedTableComponent, TableCellDirective, UserCellComponent],
+  imports: [LoaderComponent, PaginatedTableComponent, SearchBarComponent, TableCellDirective, UserCellComponent],
   templateUrl: './application-tab-members.component.html',
   styleUrl: './application-tab-members.component.scss',
 })
@@ -56,6 +58,7 @@ export class ApplicationTabMembersComponent {
 
   readonly currentPage = signal(1);
   readonly pageSize = signal(10);
+  readonly searchTerm = signal('');
 
   readonly tableColumns: TableColumn[] = [
     { id: 'name', label: $localize`:@@memberColumnName:Name` },
@@ -68,14 +71,34 @@ export class ApplicationTabMembersComponent {
   readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
 
   protected readonly membersResource = rxResource<MembersResponse | undefined, MembersRequestParams | null>({
-    params: () => (this.canRead() ? { applicationId: this.applicationId(), page: this.currentPage(), size: this.pageSize() } : null),
+    params: () =>
+      this.canRead()
+        ? {
+            applicationId: this.applicationId(),
+            page: this.currentPage(),
+            size: this.pageSize(),
+            filters: { displayName: this.searchTerm() },
+          }
+        : null,
     stream: ({ params }) =>
-      params ? this.membershipService.searchApplicationMembers(params.applicationId, params.page, params.size) : of(undefined),
+      params
+        ? this.membershipService.searchApplicationMembers(params.applicationId, params.page, params.size, params.filters)
+        : of(undefined),
   });
 
-  readonly rows = computed<MemberTableRow[]>(() => (this.membersResource.value()?.data ?? []).map(member => this.toRow(member)));
+  readonly rows = computed<MemberTableRow[]>(() => {
+    if (this.membersResource.error()) {
+      return [];
+    }
+    return (this.membersResource.value()?.data ?? []).map(member => this.toRow(member));
+  });
 
-  readonly totalElements = computed(() => this.membersResource.value()?.metadata?.pagination?.total ?? 0);
+  readonly totalElements = computed(() => {
+    if (this.membersResource.error()) {
+      return 0;
+    }
+    return this.membersResource.value()?.metadata?.pagination?.total ?? 0;
+  });
 
   onPageChange(page: number): void {
     this.currentPage.set(page);
@@ -83,6 +106,11 @@ export class ApplicationTabMembersComponent {
 
   onPageSizeChange(size: number): void {
     this.pageSize.set(size);
+    this.currentPage.set(1);
+  }
+
+  onSearchTermChange(term: string): void {
+    this.searchTerm.set(term);
     this.currentPage.set(1);
   }
 

--- a/gravitee-apim-portal-webui-next/src/components/search-bar/search-bar.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/search-bar/search-bar.component.scss
@@ -18,8 +18,6 @@
 @use '@angular/material' as mat;
 
 .search-input {
-  width: 240px;
-
   &--mobile {
     width: 100%;
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13551

## Description

Add a search bar that filters members via POST .../members/_search with
filters.displayName, reset page to 1 on term change, and separate empty
states for "no matches" vs "no members". Show an h3 heading "Members (N)"
using pagination total from the same response, except on load errors.
Cover behavior with unit tests.

**ℹ️ This PR follows changes introduced in [this PR](https://github.com/gravitee-io/gravitee-api-management/pull/16413)
⚠️ This PR should be merged once the [search endpoint backend changes](https://github.com/gravitee-io/gravitee-api-management/pull/16316) are on master.**

## Additional context

https://github.com/user-attachments/assets/a851925d-5c80-4013-b785-dd01844e1713


