### PR TITLE
feat(management-api): add PATCH endpoint for v4 HTTP Proxy APIs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+@../AGENTS.md

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/pom.xml
@@ -189,6 +189,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.github.java-json-tools</groupId>
+			<artifactId>json-patch</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.openapitools</groupId>
 			<artifactId>jackson-databind-nullable</artifactId>
 			<version>${jackson-databind-nullable-version}</version>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.management.v2.rest.exceptionMapper.ConstraintValidat
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.JsonMappingExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.ManagementExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.NotFoundExceptionMapper;
+import io.gravitee.rest.api.management.v2.rest.exceptionMapper.NotSupportedExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.ParamExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.PreconditionFailedExceptionMapper;
 import io.gravitee.rest.api.management.v2.rest.exceptionMapper.ThrowableMapper;
@@ -103,6 +104,7 @@ public class GraviteeManagementV2Application extends ResourceConfig {
         register(UnrecognizedPropertyExceptionMapper.class);
         register(ThrowableMapper.class);
         register(NotFoundExceptionMapper.class);
+        register(NotSupportedExceptionMapper.class);
         register(io.gravitee.rest.api.management.v2.rest.exceptionMapper.NotAllowedExceptionMapper.class);
         register(BadRequestExceptionMapper.class);
         register(PreconditionFailedExceptionMapper.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/NotSupportedExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/NotSupportedExceptionMapper.java
@@ -13,20 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.api.domain_service;
+package io.gravitee.rest.api.management.v2.rest.exceptionMapper;
 
-import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
-import io.gravitee.apim.core.audit.model.AuditInfo;
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
 
-/**
- * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
- * @author GraviteeSource Team
- */
-public interface UpdateApiDomainService {
-    Api update(String apiId, ApiCRDSpec crd, AuditInfo auditInfo);
+@Provider
+public class NotSupportedExceptionMapper extends AbstractExceptionMapper<NotSupportedException> {
 
-    Api updateV4(Api api, AuditInfo auditInfo);
-
-    Api validateV4(Api api, AuditInfo auditInfo);
+    @Override
+    public Response toResponse(NotSupportedException e) {
+        final Response.Status status = Response.Status.UNSUPPORTED_MEDIA_TYPE;
+        return Response.status(status).type(MediaType.APPLICATION_JSON_TYPE).entity(convert(e, status.getStatusCode())).build();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.api.model.UpdateNativeApi;
 import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
 import io.gravitee.apim.core.documentation.model.Page;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.AbstractEndpoint;
@@ -50,7 +51,9 @@ import io.gravitee.rest.api.management.v2.rest.model.IngestedApi;
 import io.gravitee.rest.api.management.v2.rest.model.IntegrationOriginContext;
 import io.gravitee.rest.api.management.v2.rest.model.KubernetesOriginContext;
 import io.gravitee.rest.api.management.v2.rest.model.ManagementOriginContext;
+import io.gravitee.rest.api.management.v2.rest.model.MembershipMemberType;
 import io.gravitee.rest.api.management.v2.rest.model.PageCRD;
+import io.gravitee.rest.api.management.v2.rest.model.PrimaryOwner;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiFederated;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV2;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV4;
@@ -197,6 +200,17 @@ public interface ApiMapper {
         return mapToHttpV4(source, uriInfo, deploymentState);
     }
 
+    default PrimaryOwner map(PrimaryOwnerEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new PrimaryOwner()
+            .id(entity.id())
+            .email(entity.email())
+            .displayName(entity.displayName())
+            .type(entity.type() != null ? MembershipMemberType.valueOf(entity.type().name()) : null);
+    }
+
     default ApiV4 mapToV4(GenericApiEntity genericApiEntity) {
         if (genericApiEntity instanceof ApiEntity asApiEntity) {
             return mapToV4(asApiEntity);
@@ -209,13 +223,20 @@ public interface ApiMapper {
     @Mapping(target = "definitionContext", source = "source.originContext")
     @Mapping(target = "apiVersion", source = "source.version")
     @Mapping(target = "analytics", source = "source.apiDefinitionHttpV4.analytics")
+    @Mapping(target = "allowedInApiProducts", source = "source.apiDefinitionHttpV4.allowedInApiProducts", defaultValue = "false")
     @Mapping(target = "deploymentState", source = "deploymentState")
     @Mapping(target = "endpointGroups", source = "source.apiDefinitionHttpV4.endpointGroups")
+    @Mapping(target = "failover", source = "source.apiDefinitionHttpV4.failover")
     @Mapping(target = "flowExecution", source = "source.apiDefinitionHttpV4.flowExecution")
     @Mapping(target = "flows", source = "source.apiDefinitionHttpV4.flows")
     @Mapping(target = "lifecycleState", source = "source.apiLifecycleState")
     @Mapping(target = "links", expression = "java(computeCoreApiLinks(source, uriInfo))")
     @Mapping(target = "listeners", source = "source.apiDefinitionHttpV4.listeners", qualifiedByName = "fromHttpListeners")
+    @Mapping(
+        target = "responseTemplates",
+        expression = "java(source != null && source.getApiDefinitionHttpV4() != null ? responseTemplateMapper.mapResponseTemplateToApiModel(source.getApiDefinitionHttpV4().getResponseTemplates()) : null)"
+    )
+    @Mapping(target = "services", source = "source.apiDefinitionHttpV4.services")
     @Mapping(target = "state", source = "source.lifecycleState")
     ApiV4 mapToHttpV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -32,6 +32,7 @@ import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.MigrateApiUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
@@ -41,6 +42,7 @@ import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.Excludable;
 import io.gravitee.apim.core.promotion.use_case.CreatePromotionUseCase;
+import io.gravitee.apim.core.workflow.model.Workflow;
 import io.gravitee.apim.infra.adapter.ApiAdapter;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.common.data.domain.Page;
@@ -61,6 +63,7 @@ import io.gravitee.rest.api.management.v2.rest.model.ApiCRD;
 import io.gravitee.rest.api.management.v2.rest.model.ApiReview;
 import io.gravitee.rest.api.management.v2.rest.model.ApiRollback;
 import io.gravitee.rest.api.management.v2.rest.model.ApiTransferOwnership;
+import io.gravitee.rest.api.management.v2.rest.model.ApiWorkflowState;
 import io.gravitee.rest.api.management.v2.rest.model.DuplicateApiOptions;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
@@ -142,7 +145,9 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -225,6 +230,9 @@ public class ApiResource extends AbstractResource {
 
     @Inject
     private ApiDuplicateService duplicateApiService;
+
+    @Inject
+    private PatchApiUseCase patchApiUseCase;
 
     @Inject
     UpdateFederatedApiUseCase updateFederatedApiUseCase;
@@ -527,6 +535,50 @@ public class ApiResource extends AbstractResource {
         );
         setPicturesUrl(updatedApi);
         return updatedApi;
+    }
+
+    @PATCH
+    @Consumes({ MediaType.APPLICATION_JSON, "application/merge-patch+json", "application/json-patch+json" })
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions(
+        {
+            @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE),
+            @Permission(value = RolePermission.API_GATEWAY_DEFINITION, acls = RolePermissionAction.UPDATE),
+        }
+    )
+    public Response patchApi(
+        @PathParam("apiId") String apiId,
+        @QueryParam("dryRun") @DefaultValue("false") boolean dryRun,
+        @Context HttpHeaders headers,
+        String body
+    ) {
+        var contentType = headers.getMediaType();
+        var patchType = contentType != null &&
+            "application".equals(contentType.getType()) &&
+            "json-patch+json".equals(contentType.getSubtype())
+            ? PatchApiUseCase.PatchType.JSON_PATCH
+            : PatchApiUseCase.PatchType.MERGE_PATCH;
+
+        var input = PatchApiUseCase.Input.builder()
+            .apiId(apiId)
+            .patchType(patchType)
+            .patchBody(body)
+            .dryRun(dryRun)
+            .auditInfo(getAuditInfo())
+            .build();
+
+        var output = patchApiUseCase.execute(input);
+
+        var apiV4 = ApiMapper.INSTANCE.mapToV4(output.api(), uriInfo, null);
+        apiV4.primaryOwner(ApiMapper.INSTANCE.map(output.primaryOwner()));
+        apiV4.workflowState(output.workflowState() != null ? ApiWorkflowState.valueOf(output.workflowState().name()) : null);
+        var rawUpdatedAt = output.api().getUpdatedAt();
+        var updatedAt = rawUpdatedAt != null ? rawUpdatedAt.toInstant() : null;
+        var builder = Response.ok(apiV4);
+        if (updatedAt != null) {
+            builder.tag(Long.toString(updatedAt.toEpochMilli())).lastModified(java.util.Date.from(updatedAt));
+        }
+        return builder.build();
     }
 
     @DELETE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -290,6 +290,50 @@ paths:
                                 $ref: "#/components/schemas/Api"
                 default:
                     $ref: "#/components/responses/Error"
+        patch:
+            tags:
+                - APIs
+            summary: Patch a V4 HTTP Proxy API
+            description: |-
+                Partially update a V4 HTTP Proxy API using JSON Patch (RFC 6902) or JSON Merge Patch (RFC 7396).
+
+                Only the following fields are patchable: name, description, apiVersion, visibility, labels, tags,
+                lifecycleState, categories, analytics, failover, flowExecution, services, allowedInApiProducts,
+                allowMultiJwtOauth2Subscriptions, disableMembershipNotifications, groups, properties,
+                responseTemplates.
+
+                Use dryRun=true to preview the result without persisting.
+
+                User must have API_DEFINITION[UPDATE] or API_GATEWAY_DEFINITION[UPDATE] permissions.
+            operationId: patchApi
+            parameters:
+                - name: dryRun
+                  in: query
+                  required: false
+                  schema:
+                      type: boolean
+                      default: false
+            requestBody:
+                required: true
+                content:
+                    application/merge-patch+json:
+                        schema:
+                            $ref: "#/components/schemas/ApiMergePatch"
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ApiMergePatch"
+                    application/json-patch+json:
+                        schema:
+                            $ref: "#/components/schemas/ApiJsonPatch"
+            responses:
+                "200":
+                    description: API successfully patched
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiV4"
+                default:
+                    $ref: "#/components/responses/Error"
         delete:
             parameters:
                 - name: closePlans
@@ -3179,6 +3223,20 @@ paths:
 
 components:
     schemas:
+        ApiMergePatch:
+            type: object
+            description: |-
+                A JSON Merge Patch document (RFC 7396) for partially updating a V4 HTTP Proxy API.
+                Only patchable fields are accepted.
+            additionalProperties: true
+        ApiJsonPatch:
+            type: array
+            description: |-
+                A JSON Patch document (RFC 6902) for partially updating a V4 HTTP Proxy API.
+                Only operations targeting patchable fields are accepted.
+            items:
+                type: object
+                additionalProperties: true
         Analytics:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -26,6 +26,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.rest.api.management.v2.rest.model.Analytics;
 import io.gravitee.rest.api.management.v2.rest.model.ApiType;
 import io.gravitee.rest.api.management.v2.rest.model.BaseOriginContext;
@@ -39,11 +40,15 @@ import io.gravitee.rest.api.management.v2.rest.model.Visibility;
 import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,14 +56,16 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mapstruct.factory.Mappers;
+import org.mockito.Mockito;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class ApiMapperTest {
 
     private final ApiMapper apiMapper = Mappers.getMapper(ApiMapper.class);
     private static final String API_ID = "api-id";
 
     @Test
-    void shouldMapToUpdateApiEntityV4() {
+    void should_map_to_update_api_entity_v4() {
         var updateApi = ApiFixtures.anUpdateApiV4();
         updateApi.failover(
             new FailoverV4().enabled(true).perSubscription(false).maxFailures(3).openStateDuration(11000L).slowCallDuration(500L)
@@ -97,7 +104,7 @@ public class ApiMapperTest {
     }
 
     @Test
-    void shouldMapToUpdateApiEntityV2() {
+    void should_map_to_update_api_entity_v2() {
         var updateApi = ApiFixtures.anUpdateApiV2();
 
         var updateApiEntity = apiMapper.map(updateApi);
@@ -128,7 +135,7 @@ public class ApiMapperTest {
 
     @ParameterizedTest
     @EnumSource(Visibility.class)
-    void shouldMapCreateApiV4Visibility(Visibility visibility) {
+    void should_map_create_api_v4_visibility(Visibility visibility) {
         CreateApiV4 newApi = new CreateApiV4();
         newApi.setName("Test API");
         newApi.setApiVersion("1.0.0");
@@ -143,7 +150,7 @@ public class ApiMapperTest {
 
     @ParameterizedTest
     @EnumSource(Visibility.class)
-    void shouldMapCreateNativeApiV4Visibility(Visibility visibility) {
+    void should_map_create_native_api_v4_visibility(Visibility visibility) {
         CreateApiV4 newApi = new CreateApiV4();
         newApi.setName("Test API");
         newApi.setApiVersion("1.0.0");
@@ -155,6 +162,121 @@ public class ApiMapperTest {
         var mapped = apiMapper.mapToNewNativeApi(newApi);
         assertThat(mapped).isNotNull();
         assertThat(mapped.getVisibility()).isEqualTo(Api.Visibility.valueOf(visibility.name()));
+    }
+
+    @Test
+    void map_to_http_v4_preserves_nested_definition_fields() {
+        var uriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
+
+        var baseApi = fixtures.core.model.ApiFixtures.aProxyApiV4();
+        var api = baseApi
+            .toBuilder()
+            .apiDefinitionValue(
+                baseApi
+                    .getApiDefinitionHttpV4()
+                    .toBuilder()
+                    .failover(Failover.builder().enabled(true).maxFailures(3).build())
+                    .services(new ApiServices())
+                    .allowedInApiProducts(true)
+                    .build()
+            )
+            .build();
+
+        var apiV4 = apiMapper.mapToHttpV4(api, uriInfo, null);
+
+        assertThat(apiV4.getFailover()).isNotNull();
+        assertThat(apiV4.getFailover().getEnabled()).isTrue();
+        assertThat(apiV4.getServices()).isNotNull();
+        assertThat(apiV4.getAllowedInApiProducts()).isTrue();
+    }
+
+    @Test
+    void map_to_http_v4_propagates_null_response_templates() {
+        var uriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
+
+        var baseApi = fixtures.core.model.ApiFixtures.aProxyApiV4();
+        var api = baseApi
+            .toBuilder()
+            .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().responseTemplates(null).build())
+            .build();
+
+        var apiV4 = apiMapper.mapToHttpV4(api, uriInfo, null);
+
+        assertThat(apiV4.getResponseTemplates()).isNull();
+    }
+
+    @Test
+    void map_to_http_v4_propagates_non_null_response_templates() {
+        var uriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
+
+        var template = new io.gravitee.definition.model.ResponseTemplate();
+        template.setStatusCode(400);
+        var templates = java.util.Map.of("FOO", java.util.Map.of("application/json", template));
+
+        var baseApi = fixtures.core.model.ApiFixtures.aProxyApiV4();
+        var api = baseApi
+            .toBuilder()
+            .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().responseTemplates(templates).build())
+            .build();
+
+        var apiV4 = apiMapper.mapToHttpV4(api, uriInfo, null);
+
+        assertThat(apiV4.getResponseTemplates()).isNotNull();
+        assertThat(apiV4.getResponseTemplates().containsKey("FOO")).isTrue();
+    }
+
+    @Nested
+    class MapToV4AllowedInApiProducts {
+
+        private UriInfo uriInfo;
+
+        @org.junit.jupiter.api.BeforeEach
+        void setUp() {
+            uriInfo = Mockito.mock(UriInfo.class);
+            Mockito.when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
+        }
+
+        @Test
+        void coalesces_null_to_false() {
+            var base = fixtures.core.model.ApiFixtures.aProxyApiV4();
+            var api = base
+                .toBuilder()
+                .apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().allowedInApiProducts(null).build())
+                .build();
+
+            var result = apiMapper.mapToV4(api, uriInfo, null);
+
+            assertThat(result.getAllowedInApiProducts()).isFalse();
+        }
+
+        @Test
+        void preserves_true() {
+            var base = fixtures.core.model.ApiFixtures.aProxyApiV4();
+            var api = base
+                .toBuilder()
+                .apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().allowedInApiProducts(true).build())
+                .build();
+
+            var result = apiMapper.mapToV4(api, uriInfo, null);
+
+            assertThat(result.getAllowedInApiProducts()).isTrue();
+        }
+
+        @Test
+        void preserves_false() {
+            var base = fixtures.core.model.ApiFixtures.aProxyApiV4();
+            var api = base
+                .toBuilder()
+                .apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().allowedInApiProducts(false).build())
+                .build();
+
+            var result = apiMapper.mapToV4(api, uriInfo, null);
+
+            assertThat(result.getAllowedInApiProducts()).isFalse();
+        }
     }
 
     @Nested
@@ -200,8 +322,8 @@ public class ApiMapperTest {
         }
 
         @ParameterizedTest
-        @MethodSource
-        void computeOriginContext(OriginContext input, BaseOriginContext expected) {
+        @MethodSource("computeOriginContext")
+        void compute_origin_context(OriginContext input, BaseOriginContext expected) {
             // Given
             GenericApiEntity api = new ApiEntity().withOriginContext(input);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
@@ -1,0 +1,716 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static assertions.MAPIAssertions.assertThat;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static io.gravitee.common.http.HttpStatusCode.UNSUPPORTED_MEDIA_TYPE_415;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.management.v2.rest.model.ApiServices;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.FlowMode;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ApiResource_PatchApiTest extends ApiResourceTest {
+
+    private static final String MERGE_PATCH_TYPE = "application/merge-patch+json";
+    private static final String JSON_PATCH_TYPE = "application/json-patch+json";
+
+    @Inject
+    UpdateApiDomainService updateApiDomainService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis";
+    }
+
+    @BeforeEach
+    void setUpApiAndPrimaryOwner() {
+        var existingApi = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existingApi));
+
+        roleQueryService.resetSystemRoles(ORGANIZATION);
+        primaryOwnerDomainService.initWith(
+            List.of(Map.entry(API, PrimaryOwnerEntity.builder().id(USER_NAME).type(PrimaryOwnerEntity.Type.USER).build()))
+        );
+        membershipQueryServiceInMemory.initWith(
+            List.of(
+                Membership.builder()
+                    .memberId(USER_NAME)
+                    .referenceId(API)
+                    .roleId("api-po-id-" + ORGANIZATION)
+                    .referenceType(Membership.ReferenceType.API)
+                    .memberType(Membership.Type.USER)
+                    .build()
+            )
+        );
+
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .validateV4(any(), any());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Stream.of(apiCrudService, membershipQueryServiceInMemory, primaryOwnerDomainService).forEach(InMemoryAlternative::reset);
+        reset(updateApiDomainService);
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_name() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"patched-via-merge\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("patched-via-merge");
+    }
+
+    @Test
+    void should_return_etag_and_last_modified_headers_on_successful_patch() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"hdr\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        org.assertj.core.api.Assertions.assertThat(response.getHeaderString("ETag")).isNotBlank();
+        org.assertj.core.api.Assertions.assertThat(response.getHeaderString("Last-Modified")).isNotBlank();
+    }
+
+    @Test
+    void should_return_415_when_content_type_is_unsupported() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("name=plain", MediaType.TEXT_PLAIN_TYPE));
+
+        assertThat(response).hasStatus(UNSUPPORTED_MEDIA_TYPE_415);
+    }
+
+    @Test
+    void should_return_200_when_json_patch_updates_name() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"json-patched\"}]", JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("json-patched");
+    }
+
+    @Test
+    void should_return_200_with_projected_result_when_dry_run() {
+        var response = rootTarget(API)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity("{\"name\":\"dry-run-result\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("dry-run-result");
+        org.mockito.Mockito.verify(updateApiDomainService).validateV4(any(), any());
+        org.mockito.Mockito.verify(updateApiDomainService, org.mockito.Mockito.never()).updateV4(any(), any());
+    }
+
+    @Test
+    void should_return_200_with_sanitized_tags_when_dry_run() {
+        doAnswer(inv -> {
+            io.gravitee.apim.core.api.model.Api api = inv.getArgument(0);
+            var sanitizedDef = api.getApiDefinitionHttpV4().toBuilder().tags(java.util.Set.of("allowed")).build();
+            return api.toBuilder().apiDefinitionValue(sanitizedDef).build();
+        })
+            .when(updateApiDomainService)
+            .validateV4(any(), any());
+
+        var response = rootTarget(API)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity("{\"tags\":[\"requested\",\"forbidden\"]}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getTags).asList().containsExactly("allowed");
+    }
+
+    @Test
+    void should_return_200_when_dry_run_with_json_patch() {
+        var response = rootTarget(API)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity("[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"dry\"}]", JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getDescription).isEqualTo("dry");
+        org.mockito.Mockito.verify(updateApiDomainService).validateV4(any(), any());
+        org.mockito.Mockito.verify(updateApiDomainService, org.mockito.Mockito.never()).updateV4(any(), any());
+    }
+
+    @Test
+    void should_return_400_when_dry_run_fails_domain_validation() {
+        doThrow(new ValidationDomainException("tag 'forbidden' not allowed")).when(updateApiDomainService).validateV4(any(), any());
+
+        var response = rootTarget(API)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity("{\"tags\":[\"forbidden\"]}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining("forbidden");
+        org.mockito.Mockito.verify(updateApiDomainService, org.mockito.Mockito.never()).updateV4(any(), any());
+    }
+
+    @Test
+    void should_return_400_when_dry_run_rejects_allow_list_field() {
+        var response = rootTarget(API)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity("{\"state\":\"STARTED\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining("state");
+        org.mockito.Mockito.verify(updateApiDomainService, org.mockito.Mockito.never()).validateV4(any(), any());
+        org.mockito.Mockito.verify(updateApiDomainService, org.mockito.Mockito.never()).updateV4(any(), any());
+    }
+
+    @Test
+    void should_return_400_when_patching_state_field() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"state\":\"STARTED\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining("state");
+    }
+
+    @Test
+    void should_return_400_when_patching_listeners_field() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"listeners\":[]}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining("listeners");
+    }
+
+    @Test
+    void should_return_400_when_json_patch_body_is_malformed() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("this is not json", JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_400_when_patched_api_fails_validation() {
+        doThrow(new ValidationDomainException("name must not be blank", Map.of("name", "must not be blank")))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_403_when_missing_update_permission() {
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_DEFINITION),
+                eq(API),
+                eq(RolePermissionAction.UPDATE)
+            )
+        ).thenReturn(false);
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_GATEWAY_DEFINITION),
+                eq(API),
+                eq(RolePermissionAction.UPDATE)
+            )
+        ).thenReturn(false);
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"new\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(FORBIDDEN_403)
+            .asError()
+            .hasHttpStatus(FORBIDDEN_403)
+            .hasMessage("You do not have sufficient rights to access this resource");
+    }
+
+    @Test
+    void should_return_404_when_api_not_found() {
+        apiCrudService.reset();
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"new\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(NOT_FOUND_404);
+    }
+
+    @Test
+    void should_return_400_when_patching_v2_api() {
+        apiCrudService.initWith(List.of(ApiFixtures.aProxyApiV2()));
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"new\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_400_when_patching_v4_message_api() {
+        apiCrudService.initWith(List.of(ApiFixtures.aMessageApiV4()));
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"new\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_treat_application_json_as_merge_patch() {
+        var response = rootTarget(API).request().method("PATCH", Entity.json("{\"name\":\"patched-via-json\"}"));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("patched-via-json");
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_disable_membership_notifications() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("{\"disableMembershipNotifications\":true}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getDisableMembershipNotifications).isEqualTo(true);
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_groups() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"groups\":[\"g-1\",\"g-2\"]}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getGroups)
+            .asList()
+            .containsExactlyInAnyOrder("g-1", "g-2");
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_properties() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("{\"properties\":[{\"key\":\"k1\",\"value\":\"v1\"}]}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_response_templates() {
+        var body = "{\"responseTemplates\":{\"FOO_KEY\":{\"application/json\":{\"status\":400,\"body\":\"{}\"}}}}";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_description() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"description\":\"new-description\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getDescription).isEqualTo("new-description");
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_api_version() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"apiVersion\":\"2.0.0\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getApiVersion).isEqualTo("2.0.0");
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_visibility() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"visibility\":\"PRIVATE\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(a -> a.getVisibility().name())
+            .isEqualTo("PRIVATE");
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_labels() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"labels\":[\"infra\",\"prod\"]}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getLabels)
+            .asList()
+            .containsExactlyInAnyOrder("infra", "prod");
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_tags() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"tags\":[\"tag-a\",\"tag-b\"]}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getTags)
+            .asList()
+            .containsExactlyInAnyOrder("tag-a", "tag-b");
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_lifecycle_state() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"lifecycleState\":\"DEPRECATED\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(a -> a.getLifecycleState().name())
+            .isEqualTo("DEPRECATED");
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_categories() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"categories\":[\"cat-a\",\"cat-b\"]}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getCategories)
+            .asList()
+            .containsExactlyInAnyOrder("cat-a", "cat-b");
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_analytics() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"analytics\":{\"enabled\":true}}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(a -> a.getAnalytics().getEnabled())
+            .isEqualTo(true);
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_failover() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"failover\":{\"enabled\":true}}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(a -> a.getFailover().getEnabled())
+            .isEqualTo(true);
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_flow_execution() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("{\"flowExecution\":{\"mode\":\"best-match\",\"matchRequired\":true}}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getFlowExecution)
+            .isEqualTo(new io.gravitee.rest.api.management.v2.rest.model.FlowExecution().mode(FlowMode.BEST_MATCH).matchRequired(true));
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_services() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"services\":{}}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getServices).isEqualTo(new ApiServices());
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_allowed_in_api_products() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"allowedInApiProducts\":true}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getAllowedInApiProducts).isEqualTo(true);
+    }
+
+    @Test
+    void should_return_200_when_merge_patch_updates_allow_multi_jwt_oauth2_subscriptions() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("{\"allowMultiJwtOauth2Subscriptions\":true}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getAllowMultiJwtOauth2Subscriptions).isEqualTo(true);
+    }
+
+    @Test
+    void should_include_primary_owner_in_response() {
+        primaryOwnerDomainService.initWith(
+            List.of(
+                Map.entry(
+                    API,
+                    PrimaryOwnerEntity.builder()
+                        .id(USER_NAME)
+                        .email("jane.doe@gravitee.io")
+                        .displayName("Jane Doe")
+                        .type(PrimaryOwnerEntity.Type.USER)
+                        .build()
+                )
+            )
+        );
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"with-owner\"}", MERGE_PATCH_TYPE));
+
+        var primaryOwner = assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getPrimaryOwner)
+            .isNotNull()
+            .actual();
+        org.assertj.core.api.Assertions.assertThat(primaryOwner.getId()).isEqualTo(USER_NAME);
+        org.assertj.core.api.Assertions.assertThat(primaryOwner.getEmail()).isEqualTo("jane.doe@gravitee.io");
+        org.assertj.core.api.Assertions.assertThat(primaryOwner.getDisplayName()).isEqualTo("Jane Doe");
+        org.assertj.core.api.Assertions.assertThat(primaryOwner.getType()).isEqualTo(
+            io.gravitee.rest.api.management.v2.rest.model.MembershipMemberType.USER
+        );
+    }
+
+    @Test
+    void should_return_200_when_json_patch_replaces_a_complex_field() {
+        var body = "[{\"op\":\"replace\",\"path\":\"/analytics\",\"value\":{\"enabled\":true}}]";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, JSON_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(a -> a.getAnalytics().getEnabled())
+            .isEqualTo(true);
+    }
+
+    @Test
+    void should_return_400_when_merge_patch_visibility_is_invalid() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"visibility\":\"NOT_A_VISIBILITY\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_400_when_merge_patch_lifecycle_state_is_invalid() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("{\"lifecycleState\":\"NOT_A_LIFECYCLE_STATE\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void patch_merge_null_on_name_returns_400() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":null}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("name").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_json_null_on_name_returns_400() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":null}]", JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("name").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_merge_null_on_description_returns_400() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"description\":null}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("description").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_json_null_on_description_returns_400() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("[{\"op\":\"replace\",\"path\":\"/description\",\"value\":null}]", JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("description").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_merge_null_on_apiVersion_returns_400() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"apiVersion\":null}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("apiVersion").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_json_null_on_apiVersion_returns_400() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("[{\"op\":\"replace\",\"path\":\"/apiVersion\",\"value\":null}]", JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("apiVersion").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_merge_null_on_visibility_returns_400() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"visibility\":null}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("visibility").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_json_null_on_visibility_returns_400() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("[{\"op\":\"replace\",\"path\":\"/visibility\",\"value\":null}]", JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("visibility").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_merge_null_on_lifecycleState_returns_400() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"lifecycleState\":null}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("lifecycleState").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_json_null_on_lifecycleState_returns_400() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("[{\"op\":\"replace\",\"path\":\"/lifecycleState\",\"value\":null}]", JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("lifecycleState").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_merge_null_on_allowedInApiProducts_returns_400() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"allowedInApiProducts\":null}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("allowedInApiProducts").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_json_null_on_allowedInApiProducts_returns_400() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("[{\"op\":\"add\",\"path\":\"/allowedInApiProducts\",\"value\":null}]", JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("allowedInApiProducts").hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_merge_null_on_allowMultiJwtOauth2Subscriptions_returns_400() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("{\"allowMultiJwtOauth2Subscriptions\":null}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(BAD_REQUEST_400)
+            .asError()
+            .hasMessageContaining("allowMultiJwtOauth2Subscriptions")
+            .hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_json_null_on_allowMultiJwtOauth2Subscriptions_returns_400() {
+        var response = rootTarget(API)
+            .request()
+            .method(
+                "PATCH",
+                Entity.entity("[{\"op\":\"replace\",\"path\":\"/allowMultiJwtOauth2Subscriptions\",\"value\":null}]", JSON_PATCH_TYPE)
+            );
+
+        assertThat(response)
+            .hasStatus(BAD_REQUEST_400)
+            .asError()
+            .hasMessageContaining("allowMultiJwtOauth2Subscriptions")
+            .hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_merge_null_on_disableMembershipNotifications_returns_400() {
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("{\"disableMembershipNotifications\":null}", MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(BAD_REQUEST_400)
+            .asError()
+            .hasMessageContaining("disableMembershipNotifications")
+            .hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_json_null_on_disableMembershipNotifications_returns_400() {
+        var response = rootTarget(API)
+            .request()
+            .method(
+                "PATCH",
+                Entity.entity("[{\"op\":\"replace\",\"path\":\"/disableMembershipNotifications\",\"value\":null}]", JSON_PATCH_TYPE)
+            );
+
+        assertThat(response)
+            .hasStatus(BAD_REQUEST_400)
+            .asError()
+            .hasMessageContaining("disableMembershipNotifications")
+            .hasMessageContaining("null");
+    }
+
+    @Test
+    void patch_merge_omitting_name_returns_200_with_name_unchanged() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"description\":\"changed\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("My Api");
+    }
+
+    @Test
+    void patch_merge_valid_name_returns_200_with_updated_name() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"updated-name\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("updated-name");
+    }
+
+    @Test
+    void should_render_null_allowed_in_api_products_as_false_in_patch_response() {
+        var storedApi = ApiFixtures.aProxyApiV4();
+        org.assertj.core.api.Assertions.assertThat(storedApi.getApiDefinitionHttpV4().getAllowedInApiProducts())
+            .as("precondition: fixture has null allowedInApiProducts")
+            .isNull();
+        apiCrudService.initWith(List.of(storedApi));
+
+        var capturedApi = new io.gravitee.apim.core.api.model.Api[] { null };
+        doAnswer(inv -> {
+            capturedApi[0] = inv.getArgument(0);
+            return capturedApi[0];
+        })
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"description\":\"changed\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getAllowedInApiProducts).isEqualTo(false);
+        org.assertj.core.api.Assertions.assertThat(capturedApi[0].getApiDefinitionHttpV4().getAllowedInApiProducts())
+            .as("stored value must not be coalesced before persistence")
+            .isNull();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -60,6 +60,7 @@ import io.gravitee.apim.core.api.domain_service.ApiExportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiImportDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDecoderDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiPatchDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
@@ -541,6 +542,11 @@ public class ResourceContextConfiguration {
     @Bean
     public UpdateApiDomainService updateApiDomainService() {
         return mock(UpdateApiDomainService.class);
+    }
+
+    @Bean
+    public ApiPatchDomainService apiPatchDomainService() {
+        return new ApiPatchDomainService();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiPatchDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ApiPatchDomainService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jsonpatch.JsonPatch;
+import com.github.fge.jsonpatch.JsonPatchException;
+import com.github.fge.jsonpatch.mergepatch.JsonMergePatch;
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DomainService
+public class ApiPatchDomainService {
+
+    public JsonNode applyJsonPatch(JsonNode patch, JsonNode target) throws ValidationDomainException {
+        try {
+            return JsonPatch.fromJson(patch).apply(target);
+        } catch (JsonPatchException e) {
+            throw new ValidationDomainException("Failed to apply patch: " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new ValidationDomainException("Invalid patch: " + e.getMessage(), e);
+        }
+    }
+
+    public JsonNode applyMergePatch(JsonNode patch, JsonNode target) throws ValidationDomainException {
+        if (!patch.isObject()) {
+            throw new ValidationDomainException("Invalid patch: a merge patch must be a JSON object");
+        }
+        try {
+            return JsonMergePatch.fromJson(patch).apply(target);
+        } catch (JsonPatchException e) {
+            throw new ValidationDomainException("Failed to apply patch: " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new ValidationDomainException("Invalid patch: " + e.getMessage(), e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/exception/ApiPatchNotAllowedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/exception/ApiPatchNotAllowedException.java
@@ -13,20 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.api.domain_service;
+package io.gravitee.apim.core.api.exception;
 
-import io.gravitee.apim.core.api.model.Api;
-import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
-import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import java.util.Map;
 
 /**
- * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface UpdateApiDomainService {
-    Api update(String apiId, ApiCRDSpec crd, AuditInfo auditInfo);
+public class ApiPatchNotAllowedException extends ValidationDomainException {
 
-    Api updateV4(Api api, AuditInfo auditInfo);
-
-    Api validateV4(Api api, AuditInfo auditInfo);
+    public ApiPatchNotAllowedException(String fieldName, String reason) {
+        super("Field '" + fieldName + "' cannot be patched: " + reason, Map.of("field", fieldName));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.api.domain_service.ApiPatchDomainService;
+import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.exception.ApiInvalidDefinitionVersionException;
+import io.gravitee.apim.core.api.exception.ApiInvalidTypeException;
+import io.gravitee.apim.core.api.exception.ApiPatchNotAllowedException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.workflow.model.Workflow;
+import io.gravitee.apim.core.workflow.query_service.WorkflowQueryService;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.ResponseTemplate;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.failover.Failover;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.property.Property;
+import io.gravitee.definition.model.v4.service.ApiServices;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@UseCase
+@RequiredArgsConstructor
+public class PatchApiUseCase {
+
+    private static final Set<String> ALLOWED_FIELDS = Set.of(
+        "name",
+        "description",
+        "apiVersion",
+        "visibility",
+        "labels",
+        "tags",
+        "lifecycleState",
+        "categories",
+        "analytics",
+        "failover",
+        "flowExecution",
+        "services",
+        "allowedInApiProducts",
+        "allowMultiJwtOauth2Subscriptions",
+        "disableMembershipNotifications",
+        "groups",
+        "properties",
+        "responseTemplates"
+    );
+
+    private static final Set<String> BLOCKED_WITH_HINT = Set.of("state");
+    private static final Set<String> BLOCKED_WITHOUT_HINT = Set.of("flows", "endpointGroups", "listeners", "resources");
+
+    private final ApiCrudService apiCrudService;
+    private final ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService;
+    private final UpdateApiDomainService updateApiDomainService;
+    private final ApiPatchDomainService apiPatchDomainService;
+    private final WorkflowQueryService workflowQueryService;
+    private final ObjectMapper objectMapper;
+
+    public Output execute(Input input) {
+        var existingApi = apiCrudService.get(input.apiId());
+
+        if (!DefinitionVersion.V4.equals(existingApi.getDefinitionVersion())) {
+            throw new ApiInvalidDefinitionVersionException(input.apiId());
+        }
+        if (!ApiType.PROXY.equals(existingApi.getType())) {
+            throw new ApiInvalidTypeException(input.apiId(), ApiType.PROXY);
+        }
+
+        var currentNode = toJsonNode(existingApi);
+        var patchNode = parseBody(input.patchBody());
+
+        enforceAllowList(input.patchType(), patchNode);
+
+        var patchedNode = applyPatch(input.patchType(), patchNode, currentNode);
+
+        var primaryOwner = apiPrimaryOwnerDomainService.getApiPrimaryOwner(input.auditInfo().organizationId(), input.apiId());
+
+        var workflows = workflowQueryService.findAllByApiIdAndType(input.apiId(), Workflow.Type.REVIEW);
+        var workflowState = workflows.isEmpty() ? null : workflows.get(0).getState();
+
+        var updatedApi = applyPatchedValues(existingApi, patchedNode, input.patchType(), patchNode);
+
+        if (input.dryRun()) {
+            var validated = updateApiDomainService.validateV4(updatedApi, input.auditInfo());
+            return new Output(validated, primaryOwner, workflowState);
+        }
+
+        var persisted = updateApiDomainService.updateV4(updatedApi, input.auditInfo());
+        return new Output(persisted, primaryOwner, workflowState);
+    }
+
+    private JsonNode toJsonNode(Api api) {
+        var view = buildPatchableView(api);
+        return objectMapper.valueToTree(view);
+    }
+
+    private PatchableView buildPatchableView(Api api) {
+        if (!(api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api httpV4)) {
+            throw new IllegalStateException("API definition is not an HTTP v4 definition");
+        }
+        return new PatchableView(
+            api.getName(),
+            api.getDescription(),
+            api.getVersion(),
+            api.getVisibility() != null ? api.getVisibility().name() : null,
+            api.getLabels(),
+            httpV4.getTags(),
+            api.getApiLifecycleState() != null ? api.getApiLifecycleState().name() : null,
+            api.getCategories(),
+            httpV4.getAnalytics(),
+            httpV4.getFailover(),
+            httpV4.getFlowExecution(),
+            httpV4.getServices(),
+            httpV4.getAllowedInApiProducts(),
+            api.isAllowMultiJwtOauth2Subscriptions(),
+            api.isDisableMembershipNotifications(),
+            api.getGroups() != null ? new ArrayList<>(api.getGroups()) : null,
+            httpV4.getProperties(),
+            httpV4.getResponseTemplates()
+        );
+    }
+
+    private JsonNode parseBody(String body) {
+        if (body == null || body.isBlank()) {
+            throw new ValidationDomainException("Patch body is required");
+        }
+        try {
+            return objectMapper.readTree(body);
+        } catch (Exception e) {
+            throw new ValidationDomainException("Invalid patch body: " + e.getMessage(), e);
+        }
+    }
+
+    private void enforceAllowList(PatchType patchType, JsonNode patchNode) {
+        if (patchType == PatchType.JSON_PATCH) {
+            enforceAllowListJsonPatch(patchNode);
+        } else {
+            enforceAllowListMergePatch(patchNode);
+        }
+    }
+
+    private void enforceAllowListJsonPatch(JsonNode patchArray) {
+        if (!patchArray.isArray()) {
+            throw new ValidationDomainException("JSON Patch body must be a JSON array");
+        }
+        var index = 0;
+        for (JsonNode op : patchArray) {
+            var pathNode = op.path("path");
+            if (pathNode.isMissingNode() || !pathNode.isTextual()) {
+                throw new ValidationDomainException("JSON Patch operation at index " + index + " is missing required 'path' field");
+            }
+            var field = extractTopLevelField(pathNode.asText());
+            validateField(field);
+            index++;
+        }
+    }
+
+    private void enforceAllowListMergePatch(JsonNode mergePatchNode) {
+        if (!mergePatchNode.isObject()) {
+            throw new ValidationDomainException("JSON Merge Patch body must be a JSON object");
+        }
+        var fieldNames = mergePatchNode.fieldNames();
+        while (fieldNames.hasNext()) {
+            validateField(fieldNames.next());
+        }
+    }
+
+    private String extractTopLevelField(String jsonPointer) {
+        if (jsonPointer == null || jsonPointer.isEmpty()) {
+            return "";
+        }
+        var withoutLeadingSlash = jsonPointer.startsWith("/") ? jsonPointer.substring(1) : jsonPointer;
+        var slashIndex = withoutLeadingSlash.indexOf('/');
+        return slashIndex < 0 ? withoutLeadingSlash : withoutLeadingSlash.substring(0, slashIndex);
+    }
+
+    private void validateField(String field) {
+        if (BLOCKED_WITH_HINT.contains(field)) {
+            throw new ApiPatchNotAllowedException(field, "use /_start or /_stop endpoints to change runtime state");
+        }
+        if (BLOCKED_WITHOUT_HINT.contains(field)) {
+            throw new ApiPatchNotAllowedException(field, "use PUT to update structural fields");
+        }
+        if (!ALLOWED_FIELDS.contains(field)) {
+            throw new ApiPatchNotAllowedException(field, "field is not patchable");
+        }
+    }
+
+    private JsonNode applyPatch(PatchType patchType, JsonNode patchNode, JsonNode currentNode) {
+        if (patchType == PatchType.JSON_PATCH) {
+            return apiPatchDomainService.applyJsonPatch(patchNode, currentNode);
+        }
+        return apiPatchDomainService.applyMergePatch(patchNode, currentNode);
+    }
+
+    private Api applyPatchedValues(Api existingApi, JsonNode patchedNode, PatchType patchType, JsonNode rawPatchNode) {
+        if (!(existingApi.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api httpV4)) {
+            throw new IllegalStateException("API definition is not an HTTP v4 definition");
+        }
+
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, "name");
+        var name = textOrDefault(patchedNode, "name", existingApi.getName());
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, "description");
+        var description = textOrDefault(patchedNode, "description", existingApi.getDescription());
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, "apiVersion");
+        var apiVersion = textOrDefault(patchedNode, "apiVersion", existingApi.getVersion());
+
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, "visibility");
+        var visibility = readVisibility(patchedNode, existingApi.getVisibility());
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, "lifecycleState");
+        var lifecycleState = readLifecycleState(patchedNode, existingApi.getApiLifecycleState());
+
+        var labels = resolveNullableList(patchType, rawPatchNode, patchedNode, "labels", existingApi.getLabels());
+        var categories = resolveNullableSet(patchType, rawPatchNode, patchedNode, "categories", existingApi.getCategories());
+        var tags = resolveNullableSet(patchType, rawPatchNode, patchedNode, "tags", httpV4.getTags());
+
+        var analytics = resolveNullableObject(patchType, rawPatchNode, patchedNode, "analytics", Analytics.class, httpV4.getAnalytics());
+        var failover = resolveNullableObject(patchType, rawPatchNode, patchedNode, "failover", Failover.class, httpV4.getFailover());
+        var flowExecution = resolveNullableObject(
+            patchType,
+            rawPatchNode,
+            patchedNode,
+            "flowExecution",
+            FlowExecution.class,
+            httpV4.getFlowExecution()
+        );
+        var services = resolveNullableObject(patchType, rawPatchNode, patchedNode, "services", ApiServices.class, httpV4.getServices());
+
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, "allowedInApiProducts");
+        var allowedInApiProducts = readBooleanObject(patchedNode, "allowedInApiProducts", httpV4.getAllowedInApiProducts());
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, "allowMultiJwtOauth2Subscriptions");
+        var allowMultiJwt = readBoolean(patchedNode, "allowMultiJwtOauth2Subscriptions", existingApi.isAllowMultiJwtOauth2Subscriptions());
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, "disableMembershipNotifications");
+        var disableMembershipNotifications = readBoolean(
+            patchedNode,
+            "disableMembershipNotifications",
+            existingApi.isDisableMembershipNotifications()
+        );
+
+        var groups = existingApi.getGroups();
+        if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has("groups")) {
+            if (rawPatchNode.get("groups").isNull()) {
+                groups = new HashSet<>();
+            } else {
+                var groupsList = readStringList(patchedNode, "groups", null);
+                groups = groupsList != null ? new HashSet<>(groupsList) : new HashSet<>();
+            }
+        } else if (patchType == PatchType.JSON_PATCH && patchedNode.has("groups")) {
+            var groupsList = readStringList(patchedNode, "groups", null);
+            groups = groupsList != null ? new HashSet<>(groupsList) : groups;
+        }
+
+        var properties = httpV4.getProperties();
+        if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has("properties")) {
+            if (rawPatchNode.get("properties").isNull()) {
+                properties = List.of();
+            } else {
+                properties = readList(patchedNode, "properties", Property.class, null);
+            }
+        } else if (patchType == PatchType.JSON_PATCH && patchedNode.has("properties")) {
+            properties = readList(patchedNode, "properties", Property.class, properties);
+        }
+
+        var responseTemplates = httpV4.getResponseTemplates();
+        if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has("responseTemplates")) {
+            if (rawPatchNode.get("responseTemplates").isNull()) {
+                responseTemplates = null;
+            } else {
+                try {
+                    responseTemplates = objectMapper.treeToValue(patchedNode.get("responseTemplates"), new TypeReference<>() {});
+                } catch (Exception e) {
+                    throw new ValidationDomainException("Invalid value for field 'responseTemplates': " + e.getMessage());
+                }
+            }
+        } else if (patchType == PatchType.JSON_PATCH && patchedNode.has("responseTemplates")) {
+            try {
+                responseTemplates = objectMapper.treeToValue(patchedNode.get("responseTemplates"), new TypeReference<>() {});
+            } catch (Exception e) {
+                throw new ValidationDomainException("Invalid value for field 'responseTemplates': " + e.getMessage());
+            }
+        }
+
+        var updatedDefinition = httpV4
+            .toBuilder()
+            .name(name)
+            .apiVersion(apiVersion)
+            .tags(tags)
+            .analytics(analytics)
+            .failover(failover)
+            .flowExecution(flowExecution)
+            .services(services)
+            .allowedInApiProducts(allowedInApiProducts)
+            .properties(properties)
+            .responseTemplates(responseTemplates)
+            .build();
+
+        return existingApi
+            .toBuilder()
+            .name(name)
+            .description(description)
+            .version(apiVersion)
+            .visibility(visibility)
+            .apiLifecycleState(lifecycleState)
+            .labels(labels)
+            .categories(categories)
+            .allowMultiJwtOauth2Subscriptions(allowMultiJwt)
+            .disableMembershipNotifications(disableMembershipNotifications)
+            .groups(groups)
+            .apiDefinitionValue(updatedDefinition)
+            .build();
+    }
+
+    private boolean isExplicitNull(PatchType patchType, JsonNode rawPatchNode, String field) {
+        return patchType == PatchType.MERGE_PATCH && rawPatchNode.has(field) && rawPatchNode.get(field).isNull();
+    }
+
+    private void rejectExplicitNullOnNonNullable(PatchType patchType, JsonNode rawPatchNode, String field) {
+        switch (patchType) {
+            case MERGE_PATCH -> {
+                if (isExplicitNull(patchType, rawPatchNode, field)) {
+                    throw new ValidationDomainException(
+                        "'" + field + "' cannot be null; omit the field to leave it unchanged, or send an explicit value"
+                    );
+                }
+            }
+            case JSON_PATCH -> {
+                for (JsonNode op : rawPatchNode) {
+                    String opType = op.path("op").asText();
+                    String path = op.path("path").asText();
+                    JsonNode value = op.get("value");
+                    if (
+                        ("replace".equals(opType) || "add".equals(opType)) && ("/" + field).equals(path) && value != null && value.isNull()
+                    ) {
+                        throw new ValidationDomainException(
+                            "'" + field + "' cannot be null; omit the field to leave it unchanged, or send an explicit value"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    private List<String> resolveNullableList(
+        PatchType patchType,
+        JsonNode rawPatchNode,
+        JsonNode patchedNode,
+        String field,
+        List<String> existing
+    ) {
+        if (isExplicitNull(patchType, rawPatchNode, field)) {
+            return new ArrayList<>();
+        }
+        return readStringList(patchedNode, field, existing);
+    }
+
+    private Set<String> resolveNullableSet(
+        PatchType patchType,
+        JsonNode rawPatchNode,
+        JsonNode patchedNode,
+        String field,
+        Set<String> existing
+    ) {
+        if (isExplicitNull(patchType, rawPatchNode, field)) {
+            return new HashSet<>();
+        }
+        return readStringSet(patchedNode, field, existing);
+    }
+
+    private <T> T resolveNullableObject(
+        PatchType patchType,
+        JsonNode rawPatchNode,
+        JsonNode patchedNode,
+        String field,
+        Class<T> type,
+        T existing
+    ) {
+        if (isExplicitNull(patchType, rawPatchNode, field)) {
+            return null;
+        }
+        return readObject(patchedNode, field, type, existing);
+    }
+
+    private String textOrDefault(JsonNode node, String field, String defaultValue) {
+        var fieldNode = node.get(field);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        return fieldNode.asText(defaultValue);
+    }
+
+    private Api.Visibility readVisibility(JsonNode node, Api.Visibility defaultValue) {
+        var fieldNode = node.get("visibility");
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        try {
+            return Api.Visibility.valueOf(fieldNode.asText());
+        } catch (IllegalArgumentException e) {
+            throw new ValidationDomainException("Invalid visibility value: " + fieldNode.asText());
+        }
+    }
+
+    private Api.ApiLifecycleState readLifecycleState(JsonNode node, Api.ApiLifecycleState defaultValue) {
+        var fieldNode = node.get("lifecycleState");
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        try {
+            return Api.ApiLifecycleState.valueOf(fieldNode.asText());
+        } catch (IllegalArgumentException e) {
+            throw new ValidationDomainException("Invalid lifecycleState value: " + fieldNode.asText());
+        }
+    }
+
+    private List<String> readStringList(JsonNode node, String field, List<String> defaultValue) {
+        var fieldNode = node.get(field);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        try {
+            return objectMapper.convertValue(fieldNode, objectMapper.getTypeFactory().constructCollectionType(List.class, String.class));
+        } catch (Exception e) {
+            throw new ValidationDomainException("Invalid value for field '" + field + "': " + e.getMessage());
+        }
+    }
+
+    private Set<String> readStringSet(JsonNode node, String field, Set<String> defaultValue) {
+        var fieldNode = node.get(field);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        try {
+            return objectMapper.convertValue(fieldNode, objectMapper.getTypeFactory().constructCollectionType(Set.class, String.class));
+        } catch (Exception e) {
+            throw new ValidationDomainException("Invalid value for field '" + field + "': " + e.getMessage());
+        }
+    }
+
+    private <T> T readObject(JsonNode node, String field, Class<T> type, T defaultValue) {
+        var fieldNode = node.get(field);
+        if (fieldNode == null) {
+            return defaultValue;
+        }
+        if (fieldNode.isNull()) {
+            return null;
+        }
+        try {
+            return objectMapper.treeToValue(fieldNode, type);
+        } catch (Exception e) {
+            throw new ValidationDomainException("Invalid value for field '" + field + "': " + e.getMessage());
+        }
+    }
+
+    private Boolean readBooleanObject(JsonNode node, String field, Boolean defaultValue) {
+        var fieldNode = node.get(field);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        return fieldNode.asBoolean();
+    }
+
+    private boolean readBoolean(JsonNode node, String field, boolean defaultValue) {
+        var fieldNode = node.get(field);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        return fieldNode.asBoolean();
+    }
+
+    private <T> List<T> readList(JsonNode node, String field, Class<T> elementType, List<T> defaultValue) {
+        var fieldNode = node.get(field);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        try {
+            return objectMapper.convertValue(fieldNode, objectMapper.getTypeFactory().constructCollectionType(List.class, elementType));
+        } catch (Exception e) {
+            throw new ValidationDomainException("Invalid value for field '" + field + "': " + e.getMessage());
+        }
+    }
+
+    public enum PatchType {
+        JSON_PATCH,
+        MERGE_PATCH,
+    }
+
+    @Builder
+    public record Input(String apiId, PatchType patchType, String patchBody, boolean dryRun, AuditInfo auditInfo) {}
+
+    public record Output(Api api, PrimaryOwnerEntity primaryOwner, Workflow.State workflowState) {}
+
+    record PatchableView(
+        String name,
+        String description,
+        String apiVersion,
+        String visibility,
+        List<String> labels,
+        Set<String> tags,
+        String lifecycleState,
+        Set<String> categories,
+        Analytics analytics,
+        Failover failover,
+        FlowExecution flowExecution,
+        ApiServices services,
+        Boolean allowedInApiProducts,
+        boolean allowMultiJwtOauth2Subscriptions,
+        boolean disableMembershipNotifications,
+        List<String> groups,
+        List<Property> properties,
+        Map<String, Map<String, ResponseTemplate>> responseTemplates
+    ) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
@@ -98,6 +98,7 @@ public interface ApiAdapter {
     @Mapping(target = "tags", source = "api.tags")
     @Mapping(target = "apiVersion", source = "api.version")
     @Mapping(target = "lifecycleState", source = "api.apiLifecycleState")
+    @Mapping(target = "responseTemplates", expression = "java(apiDefinitionV4 != null ? apiDefinitionV4.getResponseTemplates() : null)")
     UpdateApiEntity toUpdateApiEntity(Api api, io.gravitee.definition.model.v4.Api apiDefinitionV4);
 
     @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
@@ -58,4 +58,32 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
 
         return apiCrudService.get(api.getId());
     }
+
+    @Override
+    public Api validateV4(Api api, AuditInfo auditInfo) {
+        var executionContext = new ExecutionContext(auditInfo.organizationId(), auditInfo.environmentId());
+        var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(api, api.getApiDefinitionHttpV4());
+
+        delegate.validate(executionContext, api.getId(), updateApiEntity, auditInfo.actor().userId());
+
+        return applySanitizedValues(api, updateApiEntity);
+    }
+
+    private Api applySanitizedValues(Api original, io.gravitee.rest.api.model.v4.api.UpdateApiEntity sanitized) {
+        var originalDefinition = original.getApiDefinitionHttpV4();
+        var sanitizedLifecycle = sanitized.getLifecycleState() != null
+            ? Api.ApiLifecycleState.valueOf(sanitized.getLifecycleState().name())
+            : original.getApiLifecycleState();
+        var sanitizedDefinition = originalDefinition
+            .toBuilder()
+            .tags(sanitized.getTags() != null ? sanitized.getTags() : originalDefinition.getTags())
+            .analytics(sanitized.getAnalytics() != null ? sanitized.getAnalytics() : originalDefinition.getAnalytics())
+            .build();
+        return original
+            .toBuilder()
+            .apiLifecycleState(sanitizedLifecycle)
+            .groups(sanitized.getGroups() != null ? sanitized.getGroups() : original.getGroups())
+            .apiDefinitionValue(sanitizedDefinition)
+            .build();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiService.java
@@ -42,6 +42,8 @@ public interface ApiService {
         final String userId
     );
 
+    void validate(final ExecutionContext executionContext, final String apiId, final UpdateApiEntity api, final String userId);
+
     void delete(final ExecutionContext executionContext, final String apiId, boolean closePlans);
 
     Page<GenericApiEntity> findAll(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -395,21 +395,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         final String userId
     ) {
         try {
-            MembershipEntity primaryOwnerMembership = membershipService.getPrimaryOwner(
-                executionContext.getOrganizationId(),
-                MembershipReferenceType.API,
-                apiId
-            );
-            PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(
-                executionContext,
-                userId,
-                PrimaryOwnerEntity.builder()
-                    .type(primaryOwnerMembership.getMemberType().name())
-                    .id(primaryOwnerMembership.getMemberId())
-                    .build()
-            );
-
-            Api apiToUpdate = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
+            var primaryOwner = resolvePrimaryOwner(executionContext, apiId, userId);
+            var apiToUpdate = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
             final ApiEntity existingApiEntity = apiMapper.toEntity(executionContext, apiToUpdate, primaryOwner, false, true, true);
 
             apiValidationService.validateAndSanitizeUpdateApi(
@@ -579,9 +566,50 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             return apiEntity;
         } catch (TechnicalException ex) {
             String errorMsg = String.format("An error occurs while trying to update API '%s'", apiId);
-            log.error(errorMsg, apiId, ex);
+            log.error(errorMsg, ex);
             throw new TechnicalManagementException(errorMsg, ex);
         }
+    }
+
+    @Override
+    public void validate(
+        final ExecutionContext executionContext,
+        final String apiId,
+        final UpdateApiEntity updateApiEntity,
+        final String userId
+    ) {
+        try {
+            var primaryOwner = resolvePrimaryOwner(executionContext, apiId, userId);
+            var apiToUpdate = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
+            final var existingApiEntity = apiMapper.toEntity(executionContext, apiToUpdate, primaryOwner, false, true, true);
+
+            apiValidationService.validateAndSanitizeUpdateApi(
+                executionContext,
+                updateApiEntity,
+                existingApiEntity.getPrimaryOwner(),
+                existingApiEntity
+            );
+        } catch (TechnicalException ex) {
+            var errorMsg = String.format("An error occurs while trying to validate API '%s'", apiId);
+            log.error(errorMsg, ex);
+            throw new TechnicalManagementException(errorMsg, ex);
+        }
+    }
+
+    private PrimaryOwnerEntity resolvePrimaryOwner(ExecutionContext executionContext, String apiId, String userId) {
+        var primaryOwnerMembership = membershipService.getPrimaryOwner(
+            executionContext.getOrganizationId(),
+            MembershipReferenceType.API,
+            apiId
+        );
+        return primaryOwnerService.getPrimaryOwner(
+            executionContext,
+            userId,
+            PrimaryOwnerEntity.builder()
+                .type(primaryOwnerMembership.getMemberType().name())
+                .id(primaryOwnerMembership.getMemberId())
+                .build()
+        );
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiPatchDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ApiPatchDomainServiceTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiPatchDomainServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ApiPatchDomainService cut = new ApiPatchDomainService();
+
+    @Test
+    void applyJsonPatch_applies_replace_operation() throws Exception {
+        var target = objectMapper.readTree("{\"name\":\"old\"}");
+        var patch = objectMapper.readTree("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"new\"}]");
+
+        var result = cut.applyJsonPatch(patch, target);
+
+        assertThat(result.get("name").asText()).isEqualTo("new");
+    }
+
+    @Test
+    void applyJsonPatch_wraps_failed_operation_in_validation_exception() throws Exception {
+        var target = objectMapper.readTree("{}");
+        var patch = objectMapper.readTree("[{\"op\":\"replace\",\"path\":\"/missing\",\"value\":\"x\"}]");
+
+        assertThatThrownBy(() -> cut.applyJsonPatch(patch, target))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageStartingWith("Failed to apply patch:");
+    }
+
+    @Test
+    void applyJsonPatch_wraps_malformed_patch_in_validation_exception() throws Exception {
+        var target = objectMapper.readTree("{}");
+        var patch = objectMapper.readTree("{\"not\":\"an array\"}");
+
+        assertThatThrownBy(() -> cut.applyJsonPatch(patch, target))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageStartingWith("Invalid patch:");
+    }
+
+    @Test
+    void applyMergePatch_applies_field_override() throws Exception {
+        var target = objectMapper.readTree("{\"name\":\"old\",\"keep\":\"same\"}");
+        var patch = objectMapper.readTree("{\"name\":\"new\"}");
+
+        var result = cut.applyMergePatch(patch, target);
+
+        assertThat(result.get("name").asText()).isEqualTo("new");
+        assertThat(result.get("keep").asText()).isEqualTo("same");
+    }
+
+    @Test
+    void applyMergePatch_null_value_removes_field() throws Exception {
+        var target = objectMapper.readTree("{\"name\":\"old\"}");
+        var patch = objectMapper.readTree("{\"name\":null}");
+
+        var result = cut.applyMergePatch(patch, target);
+
+        assertThat(result.has("name")).isFalse();
+    }
+
+    @Test
+    void applyMergePatch_wraps_malformed_patch_in_validation_exception() throws Exception {
+        var target = objectMapper.readTree("{}");
+        var patch = objectMapper.readTree("[\"array\",\"not allowed\"]");
+
+        assertThatThrownBy(() -> cut.applyMergePatch(patch, target))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageStartingWith("Invalid patch:");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -1,0 +1,913 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.AuditInfoFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.WorkflowQueryServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiPatchDomainService;
+import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.exception.ApiInvalidDefinitionVersionException;
+import io.gravitee.apim.core.api.exception.ApiInvalidTypeException;
+import io.gravitee.apim.core.api.exception.ApiPatchNotAllowedException;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.ResponseTemplate;
+import io.gravitee.definition.model.v4.service.ApiServices;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PatchApiUseCaseTest {
+
+    private static final String API_ID = "my-api";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+
+    ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    WorkflowQueryServiceInMemory workflowQueryService = new WorkflowQueryServiceInMemory();
+    ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService = mock(ApiPrimaryOwnerDomainService.class);
+    UpdateApiDomainService updateApiDomainService = mock(UpdateApiDomainService.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    PatchApiUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new PatchApiUseCase(
+            apiCrudService,
+            apiPrimaryOwnerDomainService,
+            updateApiDomainService,
+            new ApiPatchDomainService(),
+            workflowQueryService,
+            objectMapper
+        );
+
+        var primaryOwner = PrimaryOwnerEntity.builder().id(USER_ID).type(PrimaryOwnerEntity.Type.USER).build();
+        when(apiPrimaryOwnerDomainService.getApiPrimaryOwner(any(), eq(API_ID))).thenReturn(primaryOwner);
+    }
+
+    @Test
+    void merge_patch_updates_allowed_field_and_persists() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"name\":\"patched-name\"}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getName()).isEqualTo("patched-name");
+        verify(updateApiDomainService).updateV4(any(), any());
+    }
+
+    @Test
+    void json_patch_replace_op_updates_allowed_field_and_persists() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
+                .patchBody("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"json-patched-name\"}]")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getName()).isEqualTo("json-patched-name");
+        verify(updateApiDomainService).updateV4(any(), any());
+    }
+
+    @Test
+    void dry_run_returns_projected_result_without_persistence() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.validateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"name\":\"dry-run-name\"}")
+                .dryRun(true)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getName()).isEqualTo("dry-run-name");
+        verify(updateApiDomainService).validateV4(any(), any());
+        verify(updateApiDomainService, never()).updateV4(any(), any());
+    }
+
+    @Test
+    void dry_run_invokes_validation_with_patched_api_and_primary_owner() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.validateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"description\":\"dry-run-desc\"}")
+                .dryRun(true)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        var apiCaptor = org.mockito.ArgumentCaptor.forClass(io.gravitee.apim.core.api.model.Api.class);
+        verify(updateApiDomainService).validateV4(apiCaptor.capture(), any());
+        assertThat(apiCaptor.getValue().getDescription()).isEqualTo("dry-run-desc");
+    }
+
+    @Test
+    void dry_run_propagates_validation_failure() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        doThrow(new ValidationDomainException("tag not allowed")).when(updateApiDomainService).validateV4(any(), any());
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"tags\":[\"forbidden\"]}")
+                    .dryRun(true)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("tag not allowed");
+        verify(updateApiDomainService, never()).updateV4(any(), any());
+    }
+
+    @Test
+    void patching_state_field_is_rejected_with_hint() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"state\":\"STARTED\"}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ApiPatchNotAllowedException.class)
+            .hasMessageContaining("state")
+            .hasMessageContaining("_start");
+    }
+
+    @Test
+    void patching_listeners_is_rejected() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"listeners\":[]}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ApiPatchNotAllowedException.class)
+            .hasMessageContaining("listeners");
+    }
+
+    @Test
+    void patching_endpointGroups_is_rejected() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"endpointGroups\":[]}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ApiPatchNotAllowedException.class)
+            .hasMessageContaining("endpointGroups");
+    }
+
+    @Test
+    void patching_flows_is_rejected() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"flows\":[]}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ApiPatchNotAllowedException.class)
+            .hasMessageContaining("flows");
+    }
+
+    @Test
+    void patching_resources_is_rejected() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"resources\":[]}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ApiPatchNotAllowedException.class)
+            .hasMessageContaining("resources");
+    }
+
+    @Test
+    void patching_unknown_field_is_rejected() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"unknownField\":\"value\"}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ApiPatchNotAllowedException.class)
+            .hasMessageContaining("unknownField");
+    }
+
+    @Test
+    void malformed_json_patch_body_produces_validation_exception() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
+                    .patchBody("not valid json")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        ).isInstanceOf(ValidationDomainException.class);
+    }
+
+    @Test
+    void non_v4_api_is_rejected_with_scope_error() {
+        var v2Api = ApiFixtures.aProxyApiV2();
+        apiCrudService.initWith(List.of(v2Api));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"name\":\"new-name\"}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        ).isInstanceOf(ApiInvalidDefinitionVersionException.class);
+    }
+
+    @Test
+    void v4_message_api_is_rejected_with_scope_error() {
+        var messageApi = ApiFixtures.aMessageApiV4();
+        apiCrudService.initWith(List.of(messageApi));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"name\":\"new-name\"}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        ).isInstanceOf(ApiInvalidTypeException.class);
+    }
+
+    @Test
+    void federated_api_is_rejected_with_scope_error() {
+        var federatedApi = ApiFixtures.aFederatedApi();
+        apiCrudService.initWith(List.of(federatedApi));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"name\":\"new-name\"}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        ).isInstanceOf(ApiInvalidDefinitionVersionException.class);
+    }
+
+    @Test
+    void validation_failure_after_patch_surfaces_as_400() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        doThrow(new ValidationDomainException("name must not be blank", Map.of("name", "must not be blank")))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"name\":\"\"}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("name");
+    }
+
+    @Test
+    void merge_patch_preserves_every_non_patched_field() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"name\":\"only-name-changed\"}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        var api = output.api();
+        var httpV4 = api.getApiDefinitionHttpV4();
+        var originalHttpV4 = existing.getApiDefinitionHttpV4();
+
+        assertThat(api.getName()).isEqualTo("only-name-changed");
+        assertThat(api.getDescription()).isEqualTo(existing.getDescription());
+        assertThat(api.getVersion()).isEqualTo(existing.getVersion());
+        assertThat(api.getVisibility()).isEqualTo(existing.getVisibility());
+        assertThat(api.getApiLifecycleState()).isEqualTo(existing.getApiLifecycleState());
+        assertThat(api.getLabels()).isEqualTo(existing.getLabels());
+        assertThat(api.getCategories()).isEqualTo(existing.getCategories());
+        assertThat(api.getGroups()).isEqualTo(existing.getGroups());
+        assertThat(api.isDisableMembershipNotifications()).isEqualTo(existing.isDisableMembershipNotifications());
+        assertThat(api.isAllowMultiJwtOauth2Subscriptions()).isEqualTo(existing.isAllowMultiJwtOauth2Subscriptions());
+        assertThat(httpV4.getTags()).isEqualTo(originalHttpV4.getTags());
+        assertThat(httpV4.getAnalytics()).isEqualTo(originalHttpV4.getAnalytics());
+        assertThat(httpV4.getFailover()).isEqualTo(originalHttpV4.getFailover());
+        assertThat(httpV4.getFlowExecution()).isEqualTo(originalHttpV4.getFlowExecution());
+        assertThat(httpV4.getServices()).isEqualTo(originalHttpV4.getServices());
+        assertThat(httpV4.getAllowedInApiProducts()).isEqualTo(originalHttpV4.getAllowedInApiProducts());
+        assertThat(httpV4.getProperties()).isEqualTo(originalHttpV4.getProperties());
+        assertThat(httpV4.getResponseTemplates()).isEqualTo(originalHttpV4.getResponseTemplates());
+    }
+
+    @Test
+    void json_patch_preserves_every_non_patched_field() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
+                .patchBody("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"json-only-name-changed\"}]")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        var api = output.api();
+        var httpV4 = api.getApiDefinitionHttpV4();
+        var originalHttpV4 = existing.getApiDefinitionHttpV4();
+
+        assertThat(api.getName()).isEqualTo("json-only-name-changed");
+        assertThat(api.getDescription()).isEqualTo(existing.getDescription());
+        assertThat(api.getVersion()).isEqualTo(existing.getVersion());
+        assertThat(api.getVisibility()).isEqualTo(existing.getVisibility());
+        assertThat(api.getApiLifecycleState()).isEqualTo(existing.getApiLifecycleState());
+        assertThat(api.getLabels()).isEqualTo(existing.getLabels());
+        assertThat(api.getCategories()).isEqualTo(existing.getCategories());
+        assertThat(api.getGroups()).isEqualTo(existing.getGroups());
+        assertThat(api.isDisableMembershipNotifications()).isEqualTo(existing.isDisableMembershipNotifications());
+        assertThat(api.isAllowMultiJwtOauth2Subscriptions()).isEqualTo(existing.isAllowMultiJwtOauth2Subscriptions());
+        assertThat(httpV4.getTags()).isEqualTo(originalHttpV4.getTags());
+        assertThat(httpV4.getAnalytics()).isEqualTo(originalHttpV4.getAnalytics());
+        assertThat(httpV4.getFailover()).isEqualTo(originalHttpV4.getFailover());
+        assertThat(httpV4.getFlowExecution()).isEqualTo(originalHttpV4.getFlowExecution());
+        assertThat(httpV4.getServices()).isEqualTo(originalHttpV4.getServices());
+        assertThat(httpV4.getAllowedInApiProducts()).isEqualTo(originalHttpV4.getAllowedInApiProducts());
+        assertThat(httpV4.getProperties()).isEqualTo(originalHttpV4.getProperties());
+        assertThat(httpV4.getResponseTemplates()).isEqualTo(originalHttpV4.getResponseTemplates());
+    }
+
+    @Test
+    void update_domain_service_is_called_when_not_dry_run() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"name\":\"new-name\"}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        verify(updateApiDomainService).updateV4(any(), any());
+    }
+
+    @Test
+    void update_domain_service_is_not_called_when_dry_run() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"name\":\"new-name\"}")
+                .dryRun(true)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        verify(updateApiDomainService, never()).updateV4(any(), any());
+    }
+
+    @Test
+    void json_patch_disallowed_field_via_path_segment_is_rejected() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
+                    .patchBody("[{\"op\":\"replace\",\"path\":\"/listeners/0/type\",\"value\":\"HTTP\"}]")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ApiPatchNotAllowedException.class)
+            .hasMessageContaining("listeners");
+    }
+
+    @Test
+    void primary_owner_is_included_in_output() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"name\":\"new-name\"}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.primaryOwner()).isNotNull();
+        assertThat(output.primaryOwner().id()).isEqualTo(USER_ID);
+    }
+
+    @Test
+    void validation_failure_during_dry_run_still_surfaces() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"responseTemplates\":42}")
+                    .dryRun(true)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        ).isInstanceOf(ValidationDomainException.class);
+    }
+
+    @Test
+    void merge_patch_null_clears_groups() {
+        var existing = ApiFixtures.aProxyApiV4().toBuilder().groups(new HashSet<>(List.of("g-1"))).build();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"groups\":null}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getGroups()).isEmpty();
+    }
+
+    @Test
+    void merge_patch_replaces_response_templates_map() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var body = "{\"responseTemplates\":{\"FOO_KEY\":{\"application/json\":{\"status\":400,\"body\":\"{}\"}}}}";
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody(body)
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        var templates = output.api().getApiDefinitionHttpV4().getResponseTemplates();
+        assertThat(templates).containsKey("FOO_KEY");
+        assertThat(templates.get("FOO_KEY")).containsKey("application/json");
+    }
+
+    @Test
+    void merge_patch_updates_visibility() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"visibility\":\"PRIVATE\"}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getVisibility()).isEqualTo(io.gravitee.apim.core.api.model.Api.Visibility.PRIVATE);
+    }
+
+    @Test
+    void merge_patch_updates_lifecycle_state() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"lifecycleState\":\"DEPRECATED\"}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiLifecycleState()).isEqualTo(io.gravitee.apim.core.api.model.Api.ApiLifecycleState.DEPRECATED);
+    }
+
+    @Test
+    void merge_patch_invalid_visibility_value_produces_400() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"visibility\":\"NOT_A_VISIBILITY\"}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("visibility")
+            .hasMessageContaining("NOT_A_VISIBILITY");
+    }
+
+    @Test
+    void merge_patch_invalid_lifecycle_state_value_produces_400() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"lifecycleState\":\"NOT_A_LIFECYCLE_STATE\"}")
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            )
+        )
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("lifecycleState")
+            .hasMessageContaining("NOT_A_LIFECYCLE_STATE");
+    }
+
+    // -------------------------------------------------------------------------
+    // Null-behaviour characterisation tests for object fields
+    //
+    // These tests document what PATCH passes to the domain service when each
+    // field is set to null.  The mock returns the argument unchanged, so the
+    // assertion captures the value produced by applyPatchedValues() before any
+    // downstream validation (e.g. AnalyticsValidationServiceImpl) runs.
+    // They serve as a baseline for aligning PATCH behaviour with PUT.
+    // -------------------------------------------------------------------------
+
+    @Test
+    void merge_patch_null_on_analytics_passes_null_to_domain_service() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"analytics\":null}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiDefinitionHttpV4().getAnalytics()).isNull();
+    }
+
+    @Test
+    void merge_patch_null_on_failover_passes_null_to_domain_service() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"failover\":null}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiDefinitionHttpV4().getFailover()).isNull();
+    }
+
+    @Test
+    void merge_patch_null_on_flowExecution_passes_null_to_domain_service() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"flowExecution\":null}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiDefinitionHttpV4().getFlowExecution()).isNull();
+    }
+
+    @Test
+    void merge_patch_null_on_services_passes_null_to_domain_service() {
+        var services = new ApiServices();
+        var existing = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .apiDefinitionValue(ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().services(services).build())
+            .build();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"services\":null}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiDefinitionHttpV4().getServices()).isNull();
+    }
+
+    @Test
+    void merge_patch_null_on_responseTemplates_passes_null_to_domain_service() {
+        var templates = Map.of("KEY", Map.of("application/json", new ResponseTemplate()));
+        var existing = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .apiDefinitionValue(ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().responseTemplates(templates).build())
+            .build();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+                .patchBody("{\"responseTemplates\":null}")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiDefinitionHttpV4().getResponseTemplates()).isNull();
+    }
+
+    @Test
+    void json_patch_replace_null_on_analytics_passes_null_to_domain_service() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
+                .patchBody("[{\"op\":\"replace\",\"path\":\"/analytics\",\"value\":null}]")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiDefinitionHttpV4().getAnalytics()).isNull();
+    }
+
+    @Test
+    void json_patch_replace_null_on_failover_passes_null_to_domain_service() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
+                .patchBody("[{\"op\":\"replace\",\"path\":\"/failover\",\"value\":null}]")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiDefinitionHttpV4().getFailover()).isNull();
+    }
+
+    @Test
+    void json_patch_replace_null_on_flowExecution_passes_null_to_domain_service() {
+        var existing = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
+                .patchBody("[{\"op\":\"replace\",\"path\":\"/flowExecution\",\"value\":null}]")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiDefinitionHttpV4().getFlowExecution()).isNull();
+    }
+
+    @Test
+    void json_patch_replace_null_on_responseTemplates_passes_null_to_domain_service() {
+        var templates = Map.of("KEY", Map.of("application/json", new ResponseTemplate()));
+        var existing = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .apiDefinitionValue(ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().responseTemplates(templates).build())
+            .build();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
+                .patchBody("[{\"op\":\"replace\",\"path\":\"/responseTemplates\",\"value\":null}]")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiDefinitionHttpV4().getResponseTemplates()).isNull();
+    }
+
+    @Test
+    void json_patch_replace_null_on_services_passes_null_to_domain_service() {
+        var services = new ApiServices();
+        var existing = ApiFixtures.aProxyApiV4()
+            .toBuilder()
+            .apiDefinitionValue(ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().services(services).build())
+            .build();
+        apiCrudService.initWith(List.of(existing));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        var output = cut.execute(
+            PatchApiUseCase.Input.builder()
+                .apiId(API_ID)
+                .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
+                .patchBody("[{\"op\":\"replace\",\"path\":\"/services\",\"value\":null}]")
+                .dryRun(false)
+                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                .build()
+        );
+
+        assertThat(output.api().getApiDefinitionHttpV4().getServices()).isNull();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
@@ -20,6 +20,7 @@ import static assertions.CoreAssertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import fixtures.core.model.ApiFixtures;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
@@ -38,6 +39,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -393,6 +395,27 @@ class ApiAdapterTest {
                     .assertThat(updateApiEntity.getListeners().getFirst())
                     .isEqualTo(model.getApiDefinitionHttpV4().getListeners().getFirst());
             });
+        }
+
+        @Test
+        void should_propagate_null_responseTemplates_to_UpdateApiEntity() {
+            var definition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().responseTemplates(null).build();
+            var model = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionValue(definition).build();
+
+            var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(model, model.getApiDefinitionHttpV4());
+
+            assertThat(updateApiEntity.getResponseTemplates()).isNull();
+        }
+
+        @Test
+        void should_propagate_non_null_responseTemplates_to_UpdateApiEntity() {
+            var templates = Map.of("KEY", Map.of("application/json", new ResponseTemplate()));
+            var definition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().responseTemplates(templates).build();
+            var model = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionValue(definition).build();
+
+            var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(model, model.getApiDefinitionHttpV4());
+
+            assertThat(updateApiEntity.getResponseTemplates()).isEqualTo(templates);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.AuditInfoFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
+import io.gravitee.rest.api.service.v4.ApiService;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UpdateApiDomainServiceImplTest {
+
+    private static final String ORGANIZATION_ID = "org-id";
+    private static final String ENVIRONMENT_ID = "env-id";
+    private static final String USER_ID = "user-id";
+
+    ApiService delegate = mock(ApiService.class);
+    ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+
+    UpdateApiDomainServiceImpl cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new UpdateApiDomainServiceImpl(delegate, apiCrudService);
+    }
+
+    @Test
+    void validateV4_returns_sanitized_tags_from_mutated_update_api_entity() {
+        var api = ApiFixtures.aProxyApiV4();
+        doAnswer(inv -> {
+            UpdateApiEntity entity = inv.getArgument(2);
+            entity.setTags(Set.of("sanitized-tag"));
+            return null;
+        })
+            .when(delegate)
+            .validate(any(), any(), any(), any());
+
+        var result = cut.validateV4(api, AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+        assertThat(result.getApiDefinitionHttpV4().getTags()).containsExactly("sanitized-tag");
+    }
+
+    @Test
+    void validateV4_returns_sanitized_groups_from_mutated_update_api_entity() {
+        var api = ApiFixtures.aProxyApiV4().toBuilder().groups(new HashSet<>(Set.of("requested-group"))).build();
+        doAnswer(inv -> {
+            UpdateApiEntity entity = inv.getArgument(2);
+            entity.setGroups(Set.of("filtered-group"));
+            return null;
+        })
+            .when(delegate)
+            .validate(any(), any(), any(), any());
+
+        var result = cut.validateV4(api, AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+        assertThat(result.getGroups()).containsExactly("filtered-group");
+    }
+
+    @Test
+    void validateV4_returns_sanitized_lifecycle_state() {
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiLifecycleState(Api.ApiLifecycleState.CREATED).build();
+        doAnswer(inv -> {
+            UpdateApiEntity entity = inv.getArgument(2);
+            entity.setLifecycleState(io.gravitee.rest.api.model.api.ApiLifecycleState.PUBLISHED);
+            return null;
+        })
+            .when(delegate)
+            .validate(any(), any(), any(), any());
+
+        var result = cut.validateV4(api, AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+        assertThat(result.getApiLifecycleState()).isEqualTo(Api.ApiLifecycleState.PUBLISHED);
+    }
+
+    @Test
+    void validateV4_returns_sanitized_analytics() {
+        var api = ApiFixtures.aProxyApiV4();
+        var sanitizedAnalytics = Analytics.builder().enabled(false).build();
+        doAnswer(inv -> {
+            UpdateApiEntity entity = inv.getArgument(2);
+            entity.setAnalytics(sanitizedAnalytics);
+            return null;
+        })
+            .when(delegate)
+            .validate(any(), any(), any(), any());
+
+        var result = cut.validateV4(api, AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+        assertThat(result.getApiDefinitionHttpV4().getAnalytics()).isEqualTo(sanitizedAnalytics);
+    }
+
+    @Test
+    void validateV4_preserves_non_mutated_fields() {
+        var api = ApiFixtures.aProxyApiV4();
+
+        var result = cut.validateV4(api, AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+        assertThat(result.getName()).isEqualTo(api.getName());
+        assertThat(result.getDescription()).isEqualTo(api.getDescription());
+        assertThat(result.getVersion()).isEqualTo(api.getVersion());
+        assertThat(result.getVisibility()).isEqualTo(api.getVisibility());
+        assertThat(result.getCategories()).isEqualTo(api.getCategories());
+    }
+
+    @Test
+    void validateV4_preserves_original_tags_when_validator_returns_null() {
+        var api = ApiFixtures.aProxyApiV4();
+        var originalTags = api.getApiDefinitionHttpV4().getTags();
+        doAnswer(inv -> {
+            UpdateApiEntity entity = inv.getArgument(2);
+            entity.setTags(null);
+            return null;
+        })
+            .when(delegate)
+            .validate(any(), any(), any(), any());
+
+        var result = cut.validateV4(api, AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+        assertThat(result.getApiDefinitionHttpV4().getTags()).isEqualTo(originalTags);
+    }
+
+    @Test
+    void validateV4_preserves_original_analytics_when_validator_returns_null() {
+        var api = ApiFixtures.aProxyApiV4();
+        var originalAnalytics = api.getApiDefinitionHttpV4().getAnalytics();
+        doAnswer(inv -> {
+            UpdateApiEntity entity = inv.getArgument(2);
+            entity.setAnalytics(null);
+            return null;
+        })
+            .when(delegate)
+            .validate(any(), any(), any(), any());
+
+        var result = cut.validateV4(api, AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+        assertThat(result.getApiDefinitionHttpV4().getAnalytics()).isEqualTo(originalAnalytics);
+    }
+
+    @Test
+    void validateV4_preserves_original_groups_when_validator_returns_null() {
+        var api = ApiFixtures.aProxyApiV4().toBuilder().groups(new HashSet<>(Set.of("group-1"))).build();
+        var originalGroups = api.getGroups();
+        doAnswer(inv -> {
+            UpdateApiEntity entity = inv.getArgument(2);
+            entity.setGroups(null);
+            return null;
+        })
+            .when(delegate)
+            .validate(any(), any(), any(), any());
+
+        var result = cut.validateV4(api, AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+        assertThat(result.getGroups()).isEqualTo(originalGroups);
+    }
+
+    @Test
+    void validateV4_preserves_lifecycle_state_when_validator_does_not_set_one() {
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiLifecycleState(Api.ApiLifecycleState.PUBLISHED).build();
+        doAnswer(inv -> {
+            UpdateApiEntity entity = inv.getArgument(2);
+            entity.setLifecycleState(null);
+            return null;
+        })
+            .when(delegate)
+            .validate(any(), any(), any(), any());
+
+        var result = cut.validateV4(api, AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID));
+
+        assertThat(result.getApiLifecycleState()).isEqualTo(Api.ApiLifecycleState.PUBLISHED);
+    }
+}


### PR DESCRIPTION
## Issue

[APIM-12243](https://gravitee.atlassian.net/browse/APIM-12243)

## Why

Automations using API management via mAPI need to update individual fields of a v4 HTTP Proxy API (name, labels, lifecycle state, analytics config, etc.) without resending the full definition on every change. The existing PUT endpoint requires a complete payload, which is brittle in automation contexts where only a subset of fields are known or managed. This change introduces a PATCH endpoint that matches the v2 behavior, supporting both JSON Patch (RFC 6902) and JSON Merge Patch (RFC 7396).

Scope is intentionally narrow: v4 HTTP Proxy APIs only. Structural sub-trees (`flows`, `endpointGroups`, `listeners`) and the runtime `state` field are explicitly rejected — callers are directed to the dedicated `_start`/`_stop` endpoints. Concurrency protection (`ETag`/`If-Match`) is deferred to a follow-up.

## What changed

- **New `PatchApiUseCase`** — owns the full patch lifecycle: scope guard (V4 + PROXY only), allow-list enforcement, patch application via `com.github.java-json-tools:json-patch:1.13`, and dispatch to either `updateApiDomainService.updateV4` (persist) or `updateApiDomainService.validateV4` (dry-run). Uses an internal `PatchableView` record for domain-centric serialization.
- **RFC 7396 null semantics** — for collection/object fields, a `null` value in a merge patch clears the field (empty collection / `null` object). Implemented by inspecting the raw patch node, since `JsonMergePatch.apply()` strips null-valued keys from the merged result.
- **New `ApiPatchNotAllowedException`** — extends `ValidationDomainException` (auto-mapped to 400); provides field-specific error messages including a redirect hint for the `state` field.
- **New `NotSupportedExceptionMapper`** — returns 415 (Unsupported Media Type) for requests with an unsupported `Content-Type`, instead of the generic 500 from the global `ThrowableMapper`.
- **`ApiResource.patchApi()`** — `@PATCH @Consumes({"application/merge-patch+json","application/json-patch+json"})` method; detects patch type from `Content-Type`, passes `?dryRun` query param through, delegates entirely to `PatchApiUseCase`. Response body includes `primaryOwner`; response also sets `ETag` and `Last-Modified` headers (timestamp-based, matches PUT).
- **`ApiMapper`** — added a `default` method mapping core domain `PrimaryOwnerEntity` → REST `PrimaryOwner` so the PATCH response body carries the primary owner. Added the missing `@Mapping` annotations for `failover`, `services`, and `allowedInApiProducts` on the `mapToHttpV4(core.Api, ...)` path — these were previously silently dropped when mapping from the core domain model (auto-mapping fails because these fields live on the nested `apiDefinitionHttpV4`, not the top-level `Api`). Also added `defaultValue = "false"` to the `allowedInApiProducts` mapping: legacy APIs whose stored definition lacks this field have `null` in the domain model; without the default MapStruct overwrites the DTO's own `false` initial value, causing the field to be omitted from the PATCH response. GET is unaffected (coalesces earlier in the service-layer mapper).
- **Dry-run validation (domain-rule enforcement)** — `dryRun=true` now runs the same domain validation chain as PUT (tags, groups, lifecycle transitions, categories, analytics, etc.) without persisting. Previously dry-run short-circuited before validation. Implementation:
  - **New `ApiService.validate(ExecutionContext, apiId, UpdateApiEntity, userId)`** on the legacy v4 interface — thin sibling of `update()` that stops at the validation step. `ApiServiceImpl.update()` and `validate()` now share a private `resolvePrimaryOwner()` helper so dry-run and real PUT are guaranteed to resolve primary-owner semantics identically.
  - **New `UpdateApiDomainService.validateV4(Api, AuditInfo)`** port method — implementation calls `delegate.validate(...)` then reverse-maps sanitized `tags`, `groups`, `lifecycleState`, `analytics` back onto the returned domain `Api` (the legacy validator mutates `UpdateApiEntity` in place — those four fields are the PATCH-reachable mutations). Dry-run response now faithfully reflects what a real PUT would persist.
- **OpenAPI spec** — added `patch` operation with `dryRun` query param and `ApiMergePatch`/`ApiJsonPatch` schemas. Description enumerates all 18 patchable fields.
- **Maven** — added `com.github.java-json-tools:json-patch` to `management-v2-rest/pom.xml` (version inherited from root BOM at 1.13).

## User-facing impact

**New endpoint**: `PATCH /management/v2/environments/{envId}/apis/{apiId}`

Accepted `Content-Type` values:
- `application/merge-patch+json` — JSON Merge Patch (RFC 7396): send only the fields to change. `null` clears a collection/object field.
- `application/json-patch+json` — JSON Patch (RFC 6902): send an array of operations.

**Patchable fields**: `name`, `description`, `apiVersion`, `visibility`, `labels`, `tags`, `lifecycleState`, `categories`, `analytics`, `failover`, `flowExecution`, `services`, `allowedInApiProducts`, `allowMultiJwtOauth2Subscriptions`, `disableMembershipNotifications`, `groups`, `properties`, `responseTemplates`.

**Rejected fields** (→ 400):
- `state` — use `POST _start` / `POST _stop` instead.
- `flows`, `endpointGroups`, `listeners`, `resources` — use PUT (deferred to APIM-12244). All four return a "use PUT" hint in the error message.
- Any other field not on the allow-list.

**`?dryRun=true`** — applies the patch, runs the full domain validation chain (same rules as PUT), and returns the projected API with sanitized values (filtered tags/groups, resolved lifecycle state, normalized analytics) without persisting. Domain-rule violations (unknown group IDs, illegal lifecycle transitions, forbidden tags, etc.) surface as 400s exactly as they would on a real PUT.

**Response body**: same shape as PUT/GET — includes `primaryOwner` and ETag/Last-Modified headers for client-side caching. `allowedInApiProducts` is now always present in the PATCH response (rendered as `false` when the stored value is absent/null).

**Permissions**: `API_DEFINITION[UPDATE]` or `API_GATEWAY_DEFINITION[UPDATE]` (same as PUT).

**Scope guard**: non-v4, v4 Message/Native, and Federated APIs return 4xx with a clear error.

## How to test

```bash
# JSON Merge Patch — rename an API
curl -X PATCH -H "Authorization: Bearer <token>" -H "Content-Type: application/merge-patch+json" -d '{"name":"Updated Name","labels":["infra","prod"]}' https://<host>/management/v2/environments/<envId>/apis/<apiId>

# JSON Merge Patch — clear groups (RFC 7396 null semantics)
curl -X PATCH -H "Content-Type: application/merge-patch+json" -d '{"groups":null}' https://<host>/management/v2/environments/<envId>/apis/<apiId>

# JSON Patch — replace description
curl -X PATCH -H "Content-Type: application/json-patch+json" -d '[{"op":"replace","path":"/description","value":"New description"}]' https://<host>/management/v2/environments/<envId>/apis/<apiId>

# Dry run — validates + returns sanitized projection without persisting
curl -X PATCH -H "Content-Type: application/merge-patch+json" -d '{"lifecycleState":"PUBLISHED"}' "https://<host>/management/v2/environments/<envId>/apis/<apiId>?dryRun=true"

# allowedInApiProducts null fix — create a legacy API, then PATCH any field and verify allowedInApiProducts appears as false in the response
curl -X PATCH -H "Content-Type: application/merge-patch+json" -d '{"description":"changed"}' https://<host>/management/v2/environments/<envId>/apis/<legacyApiId>
```

**Test coverage**:
- `PatchApiUseCaseTest` (50 scenarios) — per-field happy path, RFC 7396 null-clearing, RFC 6902 multi-op sequences, enum validation errors, scope guards, comprehensive field preservation, allow-list enforcement, dry-run delegation.
- `UpdateApiDomainServiceImplTest` (6 scenarios) — `validateV4` reverse-mapping of sanitized fields.
- `ApiResource_PatchApiTest` (40 scenarios) — merge + JSON patch per field, Content-Type dispatch, `primaryOwner` wiring, invalid-enum 400s, permissions, scope guards, dry-run, `allowedInApiProducts` null-coalescing in response.
- `ApiMapperTest` (3 new scenarios) — `mapToV4` coalesces null `allowedInApiProducts` to `false`; preserves `true`/`false` unchanged.

## Gotchas / Follow-up

- `allowedInApiProducts`, `properties`, and `responseTemplates` live on the nested `io.gravitee.definition.model.v4.Api` definition object, not the top-level domain `Api` — the updater sets them inside the definition builder.
- `JsonMergePatch.apply()` strips null-valued keys from the merged result per RFC 7396. To honor the "clear this field" intent, the use case inspects the raw merge-patch body before merging.
- Concurrency protection (`ETag`/`If-Match` enforcement) is deferred to follow-up APIM-13694. This PR sets the `ETag` response header but does not yet check `If-Match` on requests.
- Extended allow-list for `flows`, `endpointGroups`, `listeners`, `resources` is deferred to APIM-12244.
- `PATCH /apis/{apiId}/plans/{planId}` is tracked by APIM-13695.

## Known Issues

- **`ApiMapper.java:262` (minor)** — `mapToV4(ApiWithFlows, UriInfo, DeploymentStateEnum)`, used by the import-PUT endpoints (`PUT /_import/definition`, `PUT /_import/swagger`), has no `allowedInApiProducts` mapping at all. For legacy APIs this means the field is omitted from import-PUT responses. Out of scope for this PR; should be addressed when the import-PUT path is worked on.

[APIM-12243]: https://gravitee.atlassian.net/browse/APIM-12243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ