### PR TITLE
feat: include query param metadata get all api

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -70,6 +70,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -104,6 +106,8 @@ public interface ApiMapper {
     Logger logger = LoggerFactory.getLogger(ApiMapper.class);
     ApiMapper INSTANCE = Mappers.getMapper(ApiMapper.class);
 
+    String EXPAND_METADATA = "metadata";
+
     // Api
     default Api map(io.gravitee.apim.core.api.model.Api api, UriInfo uriInfo, Boolean isSynchronized) {
         GenericApi.DeploymentStateEnum state = null;
@@ -120,6 +124,18 @@ public interface ApiMapper {
 
     @Nullable
     default Api map(GenericApiEntity apiEntity, UriInfo uriInfo, Boolean isSynchronized) {
+        return map(apiEntity, uriInfo, isSynchronized, null);
+    }
+
+    @Nullable
+    default Api map(GenericApiEntity apiEntity, UriInfo uriInfo, Boolean isSynchronized, Set<String> expands) {
+        Api api = mapGenericApiEntity(apiEntity, uriInfo, isSynchronized);
+        applyMetadataExpand(apiEntity, api, expands);
+        return api;
+    }
+
+    @Nullable
+    private Api mapGenericApiEntity(GenericApiEntity apiEntity, UriInfo uriInfo, Boolean isSynchronized) {
         GenericApi.DeploymentStateEnum state = null;
 
         if (isSynchronized != null) {
@@ -143,11 +159,40 @@ public interface ApiMapper {
         };
     }
 
+    default void applyMetadataExpand(GenericApiEntity source, Api apiWrapper, Set<String> expands) {
+        if (source == null || apiWrapper == null) {
+            return;
+        }
+        findGenericApiSurface(apiWrapper).ifPresent(surface -> surface.setMetadata(metadataPayloadForListExpand(source, expands)));
+    }
+
+    private static Optional<GenericApi> findGenericApiSurface(Api apiWrapper) {
+        return Optional.ofNullable(apiWrapper.getActualInstance()).filter(GenericApi.class::isInstance).map(GenericApi.class::cast);
+    }
+
+    @Nullable
+    private static Map<String, Object> metadataPayloadForListExpand(GenericApiEntity source, Set<String> expands) {
+        if (expands == null || !expands.contains(EXPAND_METADATA)) {
+            return null;
+        }
+        Map<String, Object> fromEntity = source.getMetadata();
+        return fromEntity != null ? fromEntity : Map.of();
+    }
+
     default List<Api> map(List<GenericApiEntity> apiEntities, UriInfo uriInfo, Function<GenericApiEntity, Boolean> isSynchronized) {
+        return map(apiEntities, uriInfo, isSynchronized, null);
+    }
+
+    default List<Api> map(
+        List<GenericApiEntity> apiEntities,
+        UriInfo uriInfo,
+        Function<GenericApiEntity, Boolean> isSynchronized,
+        Set<String> expands
+    ) {
         var result = new ArrayList<Api>();
         apiEntities.forEach(api -> {
             try {
-                result.add(this.map(api, uriInfo, isSynchronized.apply(api)));
+                result.add(this.map(api, uriInfo, isSynchronized.apply(api), expands));
             } catch (Exception e) {
                 // Ignore APIs throwing conversion issues in the list
                 // As v4 was out there in alpha version, we still want to build the list event if some APIs cannot be converted

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -201,12 +201,17 @@ public class ApisResource extends AbstractResource {
         Integer pageItemsCount = Math.toIntExact(apis.getPageElements());
         return new ApisResponse()
             .data(
-                ApiMapper.INSTANCE.map(apis.getContent(), uriInfo, api -> {
-                    if (expands == null || expands.isEmpty() || !expands.contains(EXPAND_DEPLOYMENT_STATE)) {
-                        return null;
-                    }
-                    return apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), api);
-                })
+                ApiMapper.INSTANCE.map(
+                    apis.getContent(),
+                    uriInfo,
+                    api -> {
+                        if (expands == null || expands.isEmpty() || !expands.contains(EXPAND_DEPLOYMENT_STATE)) {
+                            return null;
+                        }
+                        return apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), api);
+                    },
+                    expands
+                )
             )
             .pagination(PaginationInfo.computePaginationInfo(totalCount, pageItemsCount, paginationParam))
             .links(computePaginationLinks(totalCount, paginationParam));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3077,7 +3077,12 @@ components:
                           type: boolean
                           description: Disable membership notifications.
                           default: false
-                      # metadata ==> dedicated resource
+                      metadata:
+                          type: object
+                          description: API metadata as key-value pairs when the list request uses `expands=metadata`.
+                          additionalProperties: true
+                          example:
+                              email-support: "${(api.primaryOwner.email)!''}"
                       groups:
                           type: array
                           description: API's groups. Used to add team in your API.
@@ -8308,6 +8313,7 @@ components:
                     type: string
                     enum:
                         - deploymentState
+                        - metadata
         apisGetExpandsParam:
             name: expands
             in: query

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -28,6 +28,7 @@ import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.rest.api.management.v2.rest.model.Analytics;
 import io.gravitee.rest.api.management.v2.rest.model.ApiType;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.BaseOriginContext;
 import io.gravitee.rest.api.management.v2.rest.model.CreateApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.FailoverV4;
@@ -41,6 +42,7 @@ import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
@@ -279,6 +281,56 @@ public class ApiMapperTest {
                 var expectedFlow = FlowFixtures.aModelFlowHttpV4().toBuilder().tags(Set.of("tag1", "tag2")).build();
                 softly.assertThat(result.getFlows()).isNotNull().first().isEqualTo(expectedFlow);
             });
+        }
+    }
+
+    @Nested
+    class MetadataExpand {
+
+        @Test
+        void should_set_metadata_on_api_when_expand_metadata_requested() {
+            ApiEntity entity = new ApiEntity();
+            entity.setId("api-1");
+            entity.setMetadata(Map.of("region", "eu"));
+
+            ApiV4 apiV4 = new ApiV4();
+            apiV4.setId("api-1");
+            var apiWrapper = new io.gravitee.rest.api.management.v2.rest.model.Api(apiV4);
+
+            ApiMapper.INSTANCE.applyMetadataExpand(entity, apiWrapper, Set.of("metadata"));
+
+            assertThat(apiV4.getMetadata()).isEqualTo(Map.of("region", "eu"));
+        }
+
+        @Test
+        void should_use_empty_map_when_entity_metadata_null_and_expand_metadata_requested() {
+            ApiEntity entity = new ApiEntity();
+            entity.setId("api-1");
+            entity.setMetadata(null);
+
+            ApiV4 apiV4 = new ApiV4();
+            apiV4.setId("api-1");
+            var apiWrapper = new io.gravitee.rest.api.management.v2.rest.model.Api(apiV4);
+
+            ApiMapper.INSTANCE.applyMetadataExpand(entity, apiWrapper, Set.of("metadata"));
+
+            assertThat(apiV4.getMetadata()).isEqualTo(Map.of());
+        }
+
+        @Test
+        void should_clear_metadata_when_expand_metadata_not_requested() {
+            ApiEntity entity = new ApiEntity();
+            entity.setId("api-1");
+            entity.setMetadata(Map.of("region", "eu"));
+
+            ApiV4 apiV4 = new ApiV4();
+            apiV4.setId("api-1");
+            apiV4.setMetadata(Map.of("stale", "x"));
+            var apiWrapper = new io.gravitee.rest.api.management.v2.rest.model.Api(apiV4);
+
+            ApiMapper.INSTANCE.applyMetadataExpand(entity, apiWrapper, Set.of());
+
+            assertThat(apiV4.getMetadata()).isNull();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_GetApisTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_GetApisTest.java
@@ -54,6 +54,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -458,5 +459,87 @@ public class ApisResource_GetApisTest extends AbstractResourceTest {
         ApiV2 api2 = apis.get(1).getApiV2();
         Assertions.assertEquals("api-2", api2.getId());
         Assertions.assertEquals(GenericApi.DeploymentStateEnum.NEED_REDEPLOY, api2.getDeploymentState());
+    }
+
+    @Test
+    public void should_return_metadata_when_list_with_expands_metadata() {
+        ApiEntity returnedApi = new ApiEntity();
+        returnedApi.setId("api-1");
+        returnedApi.setName("api-name");
+        returnedApi.setApiVersion("v1");
+        returnedApi.setDescription("api-description");
+        returnedApi.setDefinitionVersion(DefinitionVersion.V4);
+        returnedApi.setDisableMembershipNotifications(true);
+        returnedApi.setLabels(List.of());
+        returnedApi.setGroups(Set.of());
+        returnedApi.setTags(Set.of());
+        returnedApi.setState(Lifecycle.State.STARTED);
+        returnedApi.setWorkflowState(WorkflowState.REVIEW_OK);
+        returnedApi.setVisibility(Visibility.PUBLIC);
+        returnedApi.setCreatedAt(Date.from(Instant.parse("2020-01-01T10:10:10.00Z")));
+        returnedApi.setUpdatedAt(Date.from(Instant.parse("2020-01-01T10:10:10.00Z")));
+        returnedApi.setDeployedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
+        returnedApi.setMetadata(Map.of("tier", "gold"));
+
+        when(
+            apiServiceV4.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                eq(Set.of("metadata")),
+                eq(new SortableImpl("name", true)),
+                eq(new PageableImpl(1, 10))
+            )
+        ).thenReturn(new Page<>(List.of(returnedApi), 1, 1, 1));
+
+        final Response response = rootTarget().queryParam("expands", "metadata").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        final ApisResponse apisResponse = response.readEntity(ApisResponse.class);
+        ApiV4 api = apisResponse.getData().get(0).getApiV4();
+        Assertions.assertEquals(Map.of("tier", "gold"), api.getMetadata());
+    }
+
+    @Test
+    public void should_omit_metadata_on_list_when_expands_omits_metadata_even_if_entity_has_metadata() {
+        ApiEntity returnedApi = new ApiEntity();
+        returnedApi.setId("api-1");
+        returnedApi.setName("api-name");
+        returnedApi.setApiVersion("v1");
+        returnedApi.setDescription("api-description");
+        returnedApi.setDefinitionVersion(DefinitionVersion.V4);
+        returnedApi.setDisableMembershipNotifications(true);
+        returnedApi.setLabels(List.of());
+        returnedApi.setGroups(Set.of());
+        returnedApi.setTags(Set.of());
+        returnedApi.setState(Lifecycle.State.STARTED);
+        returnedApi.setWorkflowState(WorkflowState.REVIEW_OK);
+        returnedApi.setVisibility(Visibility.PUBLIC);
+        returnedApi.setCreatedAt(Date.from(Instant.parse("2020-01-01T10:10:10.00Z")));
+        returnedApi.setUpdatedAt(Date.from(Instant.parse("2020-01-01T10:10:10.00Z")));
+        returnedApi.setDeployedAt(Date.from(Instant.parse("2020-02-02T20:22:02.00Z")));
+        returnedApi.setMetadata(Map.of("tier", "gold"));
+
+        when(
+            apiServiceV4.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                isNull(),
+                eq(new SortableImpl("name", true)),
+                eq(new PageableImpl(1, 10))
+            )
+        ).thenReturn(new Page<>(List.of(returnedApi), 1, 1, 1));
+
+        final Response response = rootTarget().request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        final ApisResponse apisResponse = response.readEntity(ApisResponse.class);
+        ApiV4 api = apisResponse.getData().get(0).getApiV4();
+        var md = api.getMetadata();
+        assertTrue(
+            md == null || md.isEmpty() || !md.containsKey("tier"),
+            "without expands=metadata, list payload must not expose entity metadata keys"
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/query_service/ApiMetadataQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/query_service/ApiMetadataQueryService.java
@@ -16,8 +16,10 @@
 package io.gravitee.apim.core.api.query_service;
 
 import io.gravitee.apim.core.api.model.ApiMetadata;
-import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public interface ApiMetadataQueryService {
     /**
@@ -27,4 +29,23 @@ public interface ApiMetadataQueryService {
      * @return A map of metadata key and metadata.
      */
     Map<String, ApiMetadata> findApiMetadata(String environmentId, String apiId);
+
+    /**
+     * Resolves metadata for several APIs. Default implementation delegates to {@link #findApiMetadata(String, String)}
+     * per id; production code overrides this to load environment-level metadata only once.
+     *
+     * @param environmentId environment id
+     * @param apiIds API ids (null ids skipped; duplicates resolved once)
+     * @return map of apiId → merged metadata (same shape as {@link #findApiMetadata(String, String)})
+     */
+    default Map<String, Map<String, ApiMetadata>> findApiMetadataForApis(String environmentId, Collection<String> apiIds) {
+        if (apiIds == null || apiIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Map<String, ApiMetadata>> result = new LinkedHashMap<>();
+        for (String apiId : apiIds.stream().filter(Objects::nonNull).distinct().toList()) {
+            result.put(apiId, findApiMetadata(environmentId, apiId));
+        }
+        return result;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImpl.java
@@ -23,10 +23,13 @@ import io.gravitee.apim.core.metadata.model.Metadata;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.MetadataRepository;
 import io.gravitee.repository.management.model.MetadataReferenceType;
-import io.gravitee.rest.api.model.MetadataFormat;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
@@ -44,42 +47,100 @@ public class ApiMetadataQueryServiceImpl implements ApiMetadataQueryService {
 
     @Override
     public Map<String, ApiMetadata> findApiMetadata(final String environmentId, final String apiId) {
+        return findApiMetadataForApis(environmentId, List.of(apiId)).getOrDefault(apiId, Map.of());
+    }
+
+    @Override
+    public Map<String, Map<String, ApiMetadata>> findApiMetadataForApis(final String environmentId, final Collection<String> apiIds) {
+        List<String> distinctApiIds = normalizeApiIds(apiIds);
+        if (distinctApiIds.isEmpty()) {
+            return Map.of();
+        }
         try {
-            Map<String, ApiMetadata> apiMetadata = metadataRepository
-                .findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, environmentId)
-                .stream()
-                .map(m ->
-                    ApiMetadata.builder()
-                        .key(m.getKey())
-                        .defaultValue(m.getValue())
-                        .name(m.getName())
-                        .format(Metadata.MetadataFormat.valueOf(m.getFormat().name()))
-                        .build()
-                )
-                .collect(toMap(ApiMetadata::getKey, Function.identity()));
-
-            metadataRepository
-                .findByReferenceTypeAndReferenceId(MetadataReferenceType.API, apiId)
-                .forEach(m ->
-                    apiMetadata.compute(m.getKey(), (key, existing) ->
-                        Optional.ofNullable(existing)
-                            .map(value -> value.toBuilder().apiId(apiId).name(m.getName()).value(m.getValue()).build())
-                            .orElse(
-                                ApiMetadata.builder()
-                                    .apiId(m.getReferenceId())
-                                    .key(m.getKey())
-                                    .value(m.getValue())
-                                    .name(m.getName())
-                                    .format(Metadata.MetadataFormat.valueOf(m.getFormat().name()))
-                                    .build()
-                            )
-                    )
-                );
-
-            return apiMetadata;
+            Map<String, ApiMetadata> environmentDefaults = loadEnvironmentMetadata(environmentId);
+            return mergeEnvironmentWithEachApi(distinctApiIds, environmentDefaults);
         } catch (TechnicalException e) {
-            log.error("An error occurs while trying to find metadata for an API [apiId={}]", apiId, e);
+            log.error("An error occurs while trying to find metadata for APIs in environment [{}]", environmentId, e);
             throw new TechnicalManagementException(e);
         }
+    }
+
+    private static List<String> normalizeApiIds(Collection<String> apiIds) {
+        if (apiIds == null || apiIds.isEmpty()) {
+            return List.of();
+        }
+        return apiIds.stream().filter(Objects::nonNull).distinct().toList();
+    }
+
+    private Map<String, Map<String, ApiMetadata>> mergeEnvironmentWithEachApi(
+        List<String> apiIds,
+        Map<String, ApiMetadata> environmentDefaults
+    ) throws TechnicalException {
+        Map<String, Map<String, ApiMetadata>> result = new LinkedHashMap<>(apiIds.size());
+        for (String apiId : apiIds) {
+            result.put(apiId, mergedMetadataForApi(environmentDefaults, apiId));
+        }
+        return result;
+    }
+
+    private Map<String, ApiMetadata> mergedMetadataForApi(Map<String, ApiMetadata> environmentDefaults, String apiId)
+        throws TechnicalException {
+        Map<String, ApiMetadata> merged = new HashMap<>(environmentDefaults);
+        applyApiScopedMetadata(merged, apiId);
+        return merged;
+    }
+
+    private Map<String, ApiMetadata> loadEnvironmentMetadata(String environmentId) throws TechnicalException {
+        return metadataRepository
+            .findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, environmentId)
+            .stream()
+            .map(ApiMetadataQueryServiceImpl::apiMetadataFromEnvironmentRow)
+            .collect(toMap(ApiMetadata::getKey, Function.identity()));
+    }
+
+    private void applyApiScopedMetadata(Map<String, ApiMetadata> target, String apiId) throws TechnicalException {
+        for (var row : loadApiMetadataRows(apiId)) {
+            mergeApiMetadataRowInto(target, apiId, row);
+        }
+    }
+
+    private Collection<io.gravitee.repository.management.model.Metadata> loadApiMetadataRows(String apiId) throws TechnicalException {
+        return metadataRepository.findByReferenceTypeAndReferenceId(MetadataReferenceType.API, apiId);
+    }
+
+    private static void mergeApiMetadataRowInto(
+        Map<String, ApiMetadata> target,
+        String apiId,
+        io.gravitee.repository.management.model.Metadata row
+    ) {
+        target.merge(row.getKey(), apiMetadataFromApiRow(row), (existing, ignoredDuplicateFromMerge) ->
+            mergeApiRowOntoExisting(existing, apiId, row)
+        );
+    }
+
+    private static ApiMetadata apiMetadataFromEnvironmentRow(io.gravitee.repository.management.model.Metadata m) {
+        return ApiMetadata.builder().key(m.getKey()).defaultValue(m.getValue()).name(m.getName()).format(toCoreFormat(m)).build();
+    }
+
+    private static ApiMetadata apiMetadataFromApiRow(io.gravitee.repository.management.model.Metadata m) {
+        return ApiMetadata.builder()
+            .apiId(m.getReferenceId())
+            .key(m.getKey())
+            .value(m.getValue())
+            .name(m.getName())
+            .format(toCoreFormat(m))
+            .build();
+    }
+
+    private static ApiMetadata mergeApiRowOntoExisting(
+        ApiMetadata existing,
+        String apiId,
+        io.gravitee.repository.management.model.Metadata row
+    ) {
+        return existing.toBuilder().apiId(apiId).name(row.getName()).value(row.getValue()).build();
+    }
+
+    private static Metadata.MetadataFormat toCoreFormat(io.gravitee.repository.management.model.Metadata m) {
+        return Metadata.MetadataFormat.valueOf(m.getFormat().name());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -25,6 +25,8 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
+import io.gravitee.apim.core.api.model.ApiMetadata;
+import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.DefinitionContext;
@@ -166,9 +168,11 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     private final GroupService groupService;
     private final ApiCategoryService apiCategoryService;
     private final ScoringReportRepository scoringReportRepository;
+    private final ApiMetadataQueryService apiMetadataQueryService;
 
     private static final String EMAIL_METADATA_VALUE = "${(api.primaryOwner.email)!''}";
     private static final String EXPAND_PRIMARY_OWNER = "primaryOwner";
+    private static final String EXPAND_METADATA = "metadata";
 
     public ApiServiceImpl(
         @Lazy final ApiRepository apiRepository,
@@ -200,6 +204,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         final TagsValidationService tagsValidationService,
         final ApiAuthorizationService apiAuthorizationService,
         final GroupService groupService,
+        final ApiMetadataQueryService apiMetadataQueryService,
         ApiCategoryService apiCategoryService
     ) {
         this.apiRepository = apiRepository;
@@ -230,6 +235,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         this.tagsValidationService = tagsValidationService;
         this.apiAuthorizationService = apiAuthorizationService;
         this.groupService = groupService;
+        this.apiMetadataQueryService = apiMetadataQueryService;
         this.apiCategoryService = apiCategoryService;
         this.scoringReportRepository = scoringReportRepository;
     }
@@ -715,7 +721,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             new ApiFieldFilter.Builder().excludePicture().build()
         );
 
-        return apis
+        List<GenericApiEntity> apiEntityList = apis
             .getContent()
             .stream()
             .map(api -> {
@@ -727,11 +733,13 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
                 return genericApiMapper.toGenericApi(api, primaryOwner);
             })
-            .collect(
-                Collectors.collectingAndThen(Collectors.toList(), apiEntityList ->
-                    new Page<>(apiEntityList, apis.getPageNumber(), (int) apis.getPageElements(), apis.getTotalElements())
-                )
-            );
+            .collect(Collectors.toList());
+
+        if (expands != null && expands.contains(EXPAND_METADATA) && !apiEntityList.isEmpty()) {
+            fetchAndSetMetadata(executionContext, apiEntityList);
+        }
+
+        return new Page<>(apiEntityList, apis.getPageNumber(), (int) apis.getPageElements(), apis.getTotalElements());
     }
 
     @Override
@@ -804,5 +812,40 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             log.error(errorMsg, apiId, ex);
             throw new TechnicalManagementException(errorMsg, ex);
         }
+    }
+
+    private void fetchAndSetMetadata(ExecutionContext executionContext, List<GenericApiEntity> apiEntityList) {
+        try {
+            String environmentId = executionContext.getEnvironmentId();
+            List<String> apiIds = apiEntityList.stream().map(GenericApiEntity::getId).filter(Objects::nonNull).distinct().toList();
+            if (apiIds.isEmpty()) {
+                return;
+            }
+            Map<String, Map<String, ApiMetadata>> metadataByApiId = apiMetadataQueryService.findApiMetadataForApis(environmentId, apiIds);
+            for (GenericApiEntity apiEntity : apiEntityList) {
+                Map<String, ApiMetadata> apiMetadataMap = metadataByApiId.get(apiEntity.getId());
+                if (apiMetadataMap != null && !apiMetadataMap.isEmpty()) {
+                    apiEntity.setMetadata(toResolvedMetadataValues(apiMetadataMap));
+                }
+            }
+        } catch (Exception e) {
+            throw new TechnicalManagementException("Failed to fetch metadata for APIs", e);
+        }
+    }
+
+    private static Map<String, Object> toResolvedMetadataValues(Map<String, ApiMetadata> apiMetadataMap) {
+        return apiMetadataMap
+            .values()
+            .stream()
+            .collect(
+                toMap(
+                    ApiMetadata::getKey,
+                    metadata -> {
+                        String value = metadata.getValue();
+                        return value != null ? value : Objects.requireNonNullElse(metadata.getDefaultValue(), "");
+                    },
+                    (existing, replacement) -> replacement
+                )
+            );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiMetadataQueryServiceImplTest.java
@@ -20,6 +20,9 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.api.model.ApiMetadata;
@@ -29,6 +32,7 @@ import io.gravitee.repository.management.model.Metadata;
 import io.gravitee.repository.management.model.MetadataReferenceType;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.List;
+import java.util.Map;
 import lombok.SneakyThrows;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +55,7 @@ public class ApiMetadataQueryServiceImplTest {
 
     @BeforeEach
     void setUp() {
+        reset(metadataRepository);
         service = new ApiMetadataQueryServiceImpl(metadataRepository);
     }
 
@@ -191,18 +196,69 @@ public class ApiMetadataQueryServiceImplTest {
         }
     }
 
+    @Nested
+    class FindApiMetadataForApis {
+
+        private static final String API_ID_2 = "api-id-2";
+
+        @Test
+        @SneakyThrows
+        void should_load_environment_metadata_only_once_for_multiple_apis() {
+            when(metadataRepository.findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.ENVIRONMENT), eq(ENV_ID))).thenReturn(
+                List.of(
+                    Metadata.builder()
+                        .key("brand")
+                        .referenceId(ENV_ID)
+                        .referenceType(MetadataReferenceType.ENVIRONMENT)
+                        .value("Gravitee")
+                        .format(io.gravitee.repository.management.model.MetadataFormat.STRING)
+                        .build()
+                )
+            );
+            when(metadataRepository.findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.API), eq(API_ID))).thenReturn(
+                List.of(
+                    Metadata.builder()
+                        .key("homepage")
+                        .referenceId(API_ID)
+                        .referenceType(MetadataReferenceType.API)
+                        .value("https://a.example")
+                        .format(io.gravitee.repository.management.model.MetadataFormat.URL)
+                        .build()
+                )
+            );
+            when(metadataRepository.findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.API), eq(API_ID_2))).thenReturn(
+                List.of(
+                    Metadata.builder()
+                        .key("homepage")
+                        .referenceId(API_ID_2)
+                        .referenceType(MetadataReferenceType.API)
+                        .value("https://b.example")
+                        .format(io.gravitee.repository.management.model.MetadataFormat.URL)
+                        .build()
+                )
+            );
+
+            Map<String, Map<String, ApiMetadata>> result = service.findApiMetadataForApis(ENV_ID, List.of(API_ID, API_ID_2));
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(API_ID).get("homepage").getValue()).isEqualTo("https://a.example");
+            assertThat(result.get(API_ID_2).get("homepage").getValue()).isEqualTo("https://b.example");
+            assertThat(result.get(API_ID).get("brand").getDefaultValue()).isEqualTo("Gravitee");
+
+            verify(metadataRepository, times(1)).findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.ENVIRONMENT), eq(ENV_ID));
+            verify(metadataRepository, times(1)).findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.API), eq(API_ID));
+            verify(metadataRepository, times(1)).findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.API), eq(API_ID_2));
+        }
+    }
+
     @SneakyThrows
     private void givenExistingEnvironmentMetadata(String envId, List<Metadata.MetadataBuilder> metadata) {
-        lenient()
-            .when(metadataRepository.findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.ENVIRONMENT), eq(envId)))
-            .thenReturn(List.of());
-
         lenient()
             .when(metadataRepository.findByReferenceTypeAndReferenceId(eq(MetadataReferenceType.ENVIRONMENT), eq(envId)))
             .thenReturn(
                 metadata
                     .stream()
-                    .map(m -> m.referenceType(MetadataReferenceType.API).build())
+                    .map(m -> m.referenceType(MetadataReferenceType.ENVIRONMENT).referenceId(envId).build())
                     .toList()
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -368,6 +368,7 @@ public class ApiServiceImplTest {
             tagsValidationService,
             apiAuthorizationService,
             groupService,
+            mock(io.gravitee.apim.core.api.query_service.ApiMetadataQueryService.class),
             apiCategoryService
         );
         var apiSearchService = new ApiSearchServiceImpl(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
@@ -16,9 +16,11 @@
 package io.gravitee.rest.api.service.v4.impl;
 
 import static io.gravitee.rest.api.service.impl.promotion.PromotionServiceTest.USER_ID;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -28,6 +30,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api.model.ApiMetadata;
+import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
@@ -66,6 +70,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
@@ -82,6 +87,7 @@ import io.gravitee.rest.api.service.v4.mapper.GenericApiMapper;
 import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -209,6 +215,9 @@ public class ApiServiceImpl_findAllTest {
     @Mock
     private CategoryMapper categoryMapper;
 
+    @Mock
+    private ApiMetadataQueryService apiMetadataQueryService;
+
     private ApiService apiService;
 
     @AfterClass
@@ -278,6 +287,7 @@ public class ApiServiceImpl_findAllTest {
             tagsValidationService,
             apiAuthorizationService,
             groupService,
+            apiMetadataQueryService,
             apiCategoryService
         );
     }
@@ -446,5 +456,123 @@ public class ApiServiceImpl_findAllTest {
             .isEqualTo(PrimaryOwnerEntity.builder().id("po-id").displayName("a PO").build());
 
         verify(primaryOwnerService).getPrimaryOwner(anyString(), eq("API_1"));
+    }
+
+    @Test
+    public void should_fetch_and_set_metadata_when_expand_metadata() {
+        var sortable = new SortableBuilder().field("name").order(Order.ASC).build();
+        var pageable = new PageableBuilder().pageNumber(0).pageSize(10).build();
+        var api1 = new Api();
+        api1.setId("API_1");
+
+        when(
+            apiRepository.search(
+                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).build()),
+                eq(sortable),
+                eq(pageable),
+                eq(new ApiFieldFilter.Builder().excludePicture().build())
+            )
+        ).thenReturn(new Page<>(List.of(api1), 1, 1, 1));
+
+        when(
+            apiMetadataQueryService.findApiMetadataForApis(
+                eq(GraviteeContext.getExecutionContext().getEnvironmentId()),
+                argThat(ids -> ids.size() == 1 && ids.contains("API_1"))
+            )
+        ).thenReturn(
+            Map.of(
+                "API_1",
+                Map.of(
+                    "m1",
+                    ApiMetadata.builder().apiId("API_1").key("m1").value("v1").build(),
+                    "m2",
+                    ApiMetadata.builder().apiId("API_1").key("m2").value(null).defaultValue("defaulted").build()
+                )
+            )
+        );
+
+        final Page<GenericApiEntity> apis = apiService.findAll(
+            GraviteeContext.getExecutionContext(),
+            "UnitTests",
+            true,
+            Set.of("metadata"),
+            new SortableImpl("name", true),
+            new PageableImpl(1, 10)
+        );
+
+        assertThat(apis.getContent().size()).isEqualTo(1);
+        assertThat(apis.getContent().get(0).getMetadata()).isEqualTo(Map.of("m1", "v1", "m2", "defaulted"));
+        verify(apiMetadataQueryService).findApiMetadataForApis(
+            eq(GraviteeContext.getExecutionContext().getEnvironmentId()),
+            argThat(ids -> ids.size() == 1 && ids.contains("API_1"))
+        );
+    }
+
+    @Test
+    public void should_not_query_metadata_service_when_expand_omits_metadata() {
+        var sortable = new SortableBuilder().field("name").order(Order.ASC).build();
+        var pageable = new PageableBuilder().pageNumber(0).pageSize(10).build();
+        var api1 = new Api();
+        api1.setId("API_1");
+
+        when(
+            apiRepository.search(
+                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).build()),
+                eq(sortable),
+                eq(pageable),
+                eq(new ApiFieldFilter.Builder().excludePicture().build())
+            )
+        ).thenReturn(new Page<>(List.of(api1), 1, 1, 1));
+
+        when(primaryOwnerService.getPrimaryOwner(anyString(), anyString())).thenReturn(
+            PrimaryOwnerEntity.builder().id("po-id").displayName("a PO").build()
+        );
+
+        apiService.findAll(
+            GraviteeContext.getExecutionContext(),
+            "UnitTests",
+            true,
+            Set.of("primaryOwner"),
+            new SortableImpl("name", true),
+            new PageableImpl(1, 10)
+        );
+
+        verify(apiMetadataQueryService, never()).findApiMetadataForApis(anyString(), any());
+        verify(apiMetadataQueryService, never()).findApiMetadata(anyString(), anyString());
+    }
+
+    @Test
+    public void should_wrap_failure_when_metadata_query_fails() {
+        var sortable = new SortableBuilder().field("name").order(Order.ASC).build();
+        var pageable = new PageableBuilder().pageNumber(0).pageSize(10).build();
+        var api1 = new Api();
+        api1.setId("API_1");
+
+        when(
+            apiRepository.search(
+                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).build()),
+                eq(sortable),
+                eq(pageable),
+                eq(new ApiFieldFilter.Builder().excludePicture().build())
+            )
+        ).thenReturn(new Page<>(List.of(api1), 1, 1, 1));
+
+        when(apiMetadataQueryService.findApiMetadataForApis(anyString(), any())).thenThrow(
+            new IllegalStateException("metadata store down")
+        );
+
+        assertThatThrownBy(() ->
+            apiService.findAll(
+                GraviteeContext.getExecutionContext(),
+                "UnitTests",
+                true,
+                Set.of("metadata"),
+                new SortableImpl("name", true),
+                new PageableImpl(1, 10)
+            )
+        )
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("Failed to fetch metadata for APIs")
+            .hasCauseInstanceOf(IllegalStateException.class);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11932

## Description

Management API v2 list APIs (GET `/environments/{envId}/apis`) can now return per-item metadata when `?expands=metadata` is used, so clients avoid extra per-API metadata calls for list views.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

Proof Video:

https://github.com/user-attachments/assets/03076344-e1cb-4a10-8ecf-48a4882feff9


