### PR TITLE
fix: refactor breadcrumbs in portal dashboard.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+
+import ApplicationComponent from './application.component';
+import { fakeApplication } from '../../../entities/application/application.fixture';
+import { BreadcrumbService } from '../../../services/breadcrumb.service';
+import { applicationListBreadcrumb } from '../applications/application-breadcrumbs';
+
+describe('ApplicationComponent', () => {
+  let fixture: ComponentFixture<ApplicationComponent>;
+  let breadcrumbService: BreadcrumbService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApplicationComponent],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationComponent);
+    breadcrumbService = TestBed.inject(BreadcrumbService);
+    fixture.componentRef.setInput('application', fakeApplication({ id: 'app-1', name: 'My App' }));
+    fixture.detectChanges();
+  });
+
+  it('should set breadcrumbs for application details', () => {
+    expect(breadcrumbService.breadcrumbs()).toEqual([applicationListBreadcrumb(true), { id: 'application-app-1', label: 'My App' }]);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.ts
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, input } from '@angular/core';
+import { Component, effect, inject, input } from '@angular/core';
 import { MatTabLink, MatTabNav, MatTabNavPanel } from '@angular/material/tabs';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 import { Application } from '../../../entities/application/application';
+import { BreadcrumbService } from '../../../services/breadcrumb.service';
+import { applicationListBreadcrumb } from '../applications/application-breadcrumbs';
 
 @Component({
   selector: 'app-application',
@@ -26,5 +28,13 @@ import { Application } from '../../../entities/application/application';
   styleUrl: './application.component.scss',
 })
 export default class ApplicationComponent {
-  application = input.required<Application>();
+  private readonly breadcrumbService = inject(BreadcrumbService);
+  readonly application = input.required<Application>();
+
+  constructor() {
+    effect(() => {
+      const application = this.application();
+      this.breadcrumbService.set([applicationListBreadcrumb(true), { id: `application-${application.id}`, label: application.name }]);
+    });
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/applications/application-breadcrumbs.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/applications/application-breadcrumbs.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Breadcrumb } from '../../../components/breadcrumbs/breadcrumbs.component';
+
+export const applicationListBreadcrumb = (includeLink?: boolean): Breadcrumb => {
+  return {
+    id: 'applications',
+    label: $localize`:@@applicationsBreadcrumb:Applications`,
+    url: includeLink ? '/dashboard/applications' : undefined,
+  };
+};

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/applications/applications.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/applications/applications.component.spec.ts
@@ -20,12 +20,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { RouterModule } from '@angular/router';
 
+import { applicationListBreadcrumb } from './application-breadcrumbs';
 import ApplicationsComponent from './applications.component';
 import { ApplicationCardHarness } from './applications.harness';
 import { PaginationHarness } from '../../../components/pagination/pagination.harness';
 import { ApplicationsResponse } from '../../../entities/application/application';
 import { fakeApplication, fakeApplicationsResponse } from '../../../entities/application/application.fixture';
 import { fakeUser } from '../../../entities/user/user.fixtures';
+import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { CurrentUserService } from '../../../services/current-user.service';
 import { AppTestingModule, TESTING_BASE_URL } from '../../../testing/app-testing.module';
 
@@ -50,6 +52,12 @@ describe('ApplicationsComponent', () => {
 
   afterEach(() => {
     httpTestingController.verify();
+  });
+
+  it('should set breadcrumbs for the applications list', () => {
+    const breadcrumbService = TestBed.inject(BreadcrumbService);
+    expect(breadcrumbService.breadcrumbs()).toEqual([applicationListBreadcrumb()]);
+    expectApplicationList();
   });
 
   describe('populated application list', () => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/applications/applications.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/applications/applications.component.ts
@@ -21,11 +21,13 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { BehaviorSubject, catchError, distinctUntilChanged, map, switchMap, tap } from 'rxjs';
 import { of } from 'rxjs/internal/observable/of';
 
+import { applicationListBreadcrumb } from './application-breadcrumbs';
 import { ApplicationCardComponent } from '../../../components/application-card/application-card.component';
 import { CardsGridComponent } from '../../../components/cards-grid/cards-grid.component';
 import { LoaderComponent } from '../../../components/loader/loader.component';
 import { PaginationComponent } from '../../../components/pagination/pagination.component';
 import { ApplicationService } from '../../../services/application.service';
+import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { CurrentUserService } from '../../../services/current-user.service';
 
 export interface ApplicationPaginatorVM {
@@ -56,11 +58,16 @@ export default class ApplicationsComponent {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly applicationService = inject(ApplicationService);
   private readonly router = inject(Router);
+  private readonly breadcrumbService = inject(BreadcrumbService);
   private readonly page$ = new BehaviorSubject<number>(1);
 
   protected readonly applicationPaginator: Signal<ApplicationPaginatorVM> = toSignal(this.loadApplications$(), {
     initialValue: { data: [], page: 1, totalResults: 0 },
   });
+
+  constructor() {
+    this.breadcrumbService.set([applicationListBreadcrumb()]);
+  }
 
   onPageChange(page: number) {
     this.page$.next(page);

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/applications/create-application/create-application.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/applications/create-application/create-application.component.spec.ts
@@ -34,8 +34,10 @@ import {
   fakeBackendToBackendApplicationType,
   fakeBrowserApplicationType,
 } from '../../../../entities/application/application.fixture';
+import { BreadcrumbService } from '../../../../services/breadcrumb.service';
 import { ObservabilityBreakpointService } from '../../../../services/observability-breakpoint.service';
 import { AppTestingModule, TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+import { applicationListBreadcrumb } from '../application-breadcrumbs';
 
 describe('CreateApplicationComponent', () => {
   let fixture: ComponentFixture<CreateApplicationComponent>;
@@ -52,6 +54,10 @@ describe('CreateApplicationComponent', () => {
     fakeBackendToBackendApplicationType(),
     fakeBrowserApplicationType(),
   ];
+
+  function flushInitialApplicationTypes(): void {
+    httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+  }
 
   beforeEach(async () => {
     isMobileSignal = signal(false);
@@ -87,46 +93,54 @@ describe('CreateApplicationComponent', () => {
   });
 
   describe('Component initialization', () => {
-    it('should show loader while loading application types', () => {
-      const loader = fixture.nativeElement.querySelector('app-loader');
-      expect(loader).toBeTruthy();
+    describe('while application types are loading', () => {
+      it('should show loader while loading application types', () => {
+        const loader = fixture.nativeElement.querySelector('app-loader');
+        expect(loader).toBeTruthy();
 
-      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+        flushInitialApplicationTypes();
+      });
+
+      it('should load application types from API', () => {
+        const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`);
+        expect(req.request.method).toBe('GET');
+        req.flush({ data: mockApplicationTypes });
+      });
     });
 
-    it('should load application types from API', () => {
-      const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`);
-      expect(req.request.method).toBe('GET');
-      req.flush({ data: mockApplicationTypes });
-    });
+    describe('after application types are loaded', () => {
+      beforeEach(async () => {
+        flushInitialApplicationTypes();
+        await fixture.whenStable();
+        fixture.detectChanges();
+      });
 
-    it('should automatically select first type (simple) as default when types are loaded', async () => {
-      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+      it('should set breadcrumbs for create application', () => {
+        const breadcrumbService = TestBed.inject(BreadcrumbService);
+        expect(breadcrumbService.breadcrumbs()).toEqual([
+          applicationListBreadcrumb(true),
+          { id: 'create', label: $localize`:@@createApplicationBreadcrumb:Create` },
+        ]);
+      });
 
-      await fixture.whenStable();
-      fixture.detectChanges();
+      it('should automatically select first type (simple) as default when types are loaded', () => {
+        expect(component.typeIdControl.value).toBe('simple');
+        expect(component.selectedType()?.id).toBe('simple');
+      });
 
-      expect(component.typeIdControl.value).toBe('simple');
-      expect(component.selectedType()?.id).toBe('simple');
-    });
+      it('should display form after types are loaded', () => {
+        const loader = fixture.nativeElement.querySelector('app-loader');
+        expect(loader).toBeFalsy();
 
-    it('should display form after types are loaded', async () => {
-      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
-
-      await fixture.whenStable();
-      fixture.detectChanges();
-
-      const loader = fixture.nativeElement.querySelector('app-loader');
-      expect(loader).toBeFalsy();
-
-      const form = fixture.nativeElement.querySelector('form');
-      expect(form).toBeTruthy();
+        const form = fixture.nativeElement.querySelector('form');
+        expect(form).toBeTruthy();
+      });
     });
   });
 
   describe('Application type selection', () => {
     beforeEach(async () => {
-      httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/types`).flush({ data: mockApplicationTypes });
+      flushInitialApplicationTypes();
       await fixture.whenStable();
       fixture.detectChanges();
     });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/applications/create-application/create-application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/applications/create-application/create-application.component.ts
@@ -36,6 +36,8 @@ import { NarrowClassDirective } from '../../../../directives/narrow-class.direct
 import { ApplicationInput, ApplicationSettings, ApplicationType } from '../../../../entities/application/application';
 import { ApplicationTypeTranslatePipe } from '../../../../pipe/application-type-translate.pipe';
 import { ApplicationService } from '../../../../services/application.service';
+import { BreadcrumbService } from '../../../../services/breadcrumb.service';
+import { applicationListBreadcrumb } from '../application-breadcrumbs';
 
 type BaseControls = {
   name: FormControl<string>;
@@ -83,6 +85,7 @@ export class CreateApplicationComponent {
   readonly applicationService = inject(ApplicationService);
   readonly router = inject(Router);
   readonly destroyRef = inject(DestroyRef);
+  readonly breadcrumbService = inject(BreadcrumbService);
 
   readonly typeIdControl = new FormControl<string | null>(null, { nonNullable: false });
 
@@ -130,6 +133,10 @@ export class CreateApplicationComponent {
   hasApplicationError: boolean = false;
 
   constructor() {
+    this.breadcrumbService.set([
+      applicationListBreadcrumb(true),
+      { id: 'create', label: $localize`:@@createApplicationBreadcrumb:Create` },
+    ]);
     this.setupDynamicFormFields();
     this.setupDefaultApplicationType();
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<app-sidenav-layout [breadcrumbs]="breadcrumbs()!">
+<app-sidenav-layout [breadcrumbs]="breadcrumbService.breadcrumbs()">
   <div sidenavContent class="dashboard__sidenav__content">
     @for (menuItem of menuItems(); track menuItem.path) {
       <button class="nav-button next-gen-small" mat-stroked-button [routerLink]="menuItem.path" routerLinkActive="selected">

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.spec.ts
@@ -19,10 +19,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute, provideRouter, Router, Routes } from '@angular/router';
 
-import { routes } from '../app.routes';
 import { DashboardComponent } from './dashboard.component';
 import { DashboardComponentHarness } from './dashboard.component.harness';
+import { BreadcrumbService } from '../../services/breadcrumb.service';
 import { AppTestingModule } from '../../testing/app-testing.module';
+import { routes } from '../app.routes';
 
 describe('DashboardComponent', () => {
   let fixture: ComponentFixture<DashboardComponent>;
@@ -69,6 +70,16 @@ describe('DashboardComponent', () => {
 
   it('should create', async () => {
     expect(await harness.host()).toBeTruthy();
+  });
+
+  it('should clear breadcrumbs when the component is destroyed', () => {
+    const breadcrumbService = TestBed.inject(BreadcrumbService);
+    breadcrumbService.set([{ id: 'stale', label: 'Stale' }]);
+    expect(breadcrumbService.breadcrumbs().length).toBe(1);
+
+    fixture.destroy();
+
+    expect(breadcrumbService.breadcrumbs()).toEqual([]);
   });
 
   it('should display Subscriptions sidenav and breadcrumb', async () => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.ts
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, inject, signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { MatButton } from '@angular/material/button';
-import { NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
-import { filter, map } from 'rxjs';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
-import { Breadcrumb } from '../../components/breadcrumbs/breadcrumbs.component';
 import { SidenavLayoutComponent } from '../../components/sidenav-layout/sidenav-layout.component';
+import { BreadcrumbService } from '../../services/breadcrumb.service';
 
 interface MenuItem {
   path: string;
@@ -39,43 +37,11 @@ const MENU_ITEMS: MenuItem[] = [
   styleUrl: './dashboard.component.scss',
 })
 export class DashboardComponent {
-  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+  readonly breadcrumbService = inject(BreadcrumbService);
   menuItems = signal<MenuItem[]>(MENU_ITEMS);
 
-  breadcrumbs = toSignal<Breadcrumb[]>(
-    // TODO generalize and extract this logic to a shared service or smth similar
-    this.router.events.pipe(
-      filter(event => event instanceof NavigationEnd),
-      map(() => {
-        const segments = this.router.url.split('/').filter(Boolean);
-
-        const relevantSegments = segments
-          .filter(s => s !== 'dashboard')
-          .map(segment => {
-            const startOfQueryParam = segment.indexOf('?');
-            return startOfQueryParam >= 0 ? segment.substring(0, startOfQueryParam) : segment;
-          });
-        const breadcrumbs: Breadcrumb[] = [];
-        relevantSegments.forEach((segment, index) => {
-          const isLast = index === relevantSegments.length - 1;
-          const menuItem = MENU_ITEMS.find(mi => mi.path === segment);
-          let label = '';
-          let url;
-          if (menuItem) {
-            label = menuItem.title;
-            if (!isLast) {
-              url = `/dashboard/${menuItem.path}`;
-            }
-          } else if (index > 0 && relevantSegments[index - 1] === 'subscriptions') {
-            const subscriptionId = segment;
-            label = $localize`:@@subscriptionTitle:Subscription ` + subscriptionId;
-          } else {
-            label = segment; // Fallback
-          }
-          breadcrumbs.push({ id: segment, label, url });
-        });
-        return breadcrumbs;
-      }),
-    ),
-  );
+  constructor() {
+    this.destroyRef.onDestroy(() => this.breadcrumbService.clear());
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.spec.ts
@@ -22,8 +22,10 @@ import { of } from 'rxjs';
 import SubscriptionDetailsComponent from './subscription-details.component';
 import { SubscriptionDetailsHarness } from './subscription-details.harness';
 import { Subscription } from '../../../entities/subscription/subscription';
+import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { SubscriptionService } from '../../../services/subscription.service';
 import { SubscriptionsDetailsComponent } from '../../api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component';
+import { subscriptionListBreadcrumb } from '../subscriptions/subscription-breadcrumbs';
 
 @Component({
   selector: 'app-subscriptions-details',
@@ -62,5 +64,17 @@ describe('SubscriptionDetailsComponent', () => {
   it('should show subscriptions details when apiId is retrieved', async () => {
     const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SubscriptionDetailsHarness);
     expect(await harness.hasSubscriptionsDetails()).toBeTruthy();
+  });
+
+  it('should set breadcrumbs for subscription details', () => {
+    const breadcrumbService = TestBed.inject(BreadcrumbService);
+    fixture.detectChanges();
+    expect(breadcrumbService.breadcrumbs()).toEqual([
+      subscriptionListBreadcrumb(true),
+      {
+        id: 'subscription-subscription-id',
+        label: $localize`:@@subscriptionTitle:Subscription ` + 'subscription-id',
+      },
+    ]);
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscription-details/subscription-details.component.ts
@@ -13,12 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, inject, input } from '@angular/core';
+import { Component, effect, inject, input } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs';
 
+import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { SubscriptionService } from '../../../services/subscription.service';
 import { SubscriptionsDetailsComponent } from '../../api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component';
+import { subscriptionListBreadcrumb } from '../subscriptions/subscription-breadcrumbs';
 
 @Component({
   selector: 'app-subscription-details',
@@ -28,9 +30,20 @@ import { SubscriptionsDetailsComponent } from '../../api/api-details/api-tab-sub
 })
 export default class SubscriptionDetailsComponent {
   private readonly subscriptionService = inject(SubscriptionService);
+  private readonly breadcrumbService = inject(BreadcrumbService);
   subscriptionId = input.required<string>();
   apiId = rxResource({
     params: this.subscriptionId,
     stream: ({ params }) => this.subscriptionService.get(params).pipe(map(subscription => subscription.api)),
   });
+
+  constructor() {
+    effect(() => {
+      const id = this.subscriptionId();
+      this.breadcrumbService.set([
+        subscriptionListBreadcrumb(true),
+        { id: `subscription-${id}`, label: $localize`:@@subscriptionTitle:Subscription ` + id },
+      ]);
+    });
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscription-breadcrumbs.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscription-breadcrumbs.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Breadcrumb } from '../../../components/breadcrumbs/breadcrumbs.component';
+
+export const subscriptionListBreadcrumb = (includeLink?: boolean): Breadcrumb => {
+  return {
+    id: 'subscriptions',
+    label: $localize`:@@subscriptionsBreadcrumb:Subscriptions`,
+    url: includeLink ? '/dashboard/subscriptions' : undefined,
+  };
+};

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.spec.ts
@@ -21,6 +21,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, provideRouter, Router } from '@angular/router';
 import { of } from 'rxjs';
 
+import { subscriptionListBreadcrumb } from './subscription-breadcrumbs';
 import SubscriptionsComponent from './subscriptions.component';
 import { SubscriptionsComponentHarness } from './subscriptions.component.harness';
 import { ApplicationsResponse } from '../../../entities/application/application';
@@ -29,6 +30,7 @@ import { SubscriptionConsumerStatusEnum, SubscriptionStatusEnum } from '../../..
 import { fakeSubscriptionResponse } from '../../../entities/subscription/subscription.fixture';
 import { SubscriptionsResponse } from '../../../entities/subscription/subscriptions-response';
 import { ApiService } from '../../../services/api.service';
+import { BreadcrumbService } from '../../../services/breadcrumb.service';
 
 const emptySubscriptions = { data: [], links: { self: '' }, metadata: {} };
 
@@ -82,6 +84,12 @@ describe('SubscriptionsComponent', () => {
     await getHarness();
     expect(fixture.componentInstance).toBeTruthy();
     expect(await harness.host()).toBeTruthy();
+  });
+
+  it('should set breadcrumbs for the subscriptions list', async () => {
+    await setup();
+    const breadcrumbService = TestBed.inject(BreadcrumbService);
+    expect(breadcrumbService.breadcrumbs()).toEqual([subscriptionListBreadcrumb()]);
   });
 
   it('should show empty state when no subscriptions', async () => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/subscriptions/subscriptions.component.ts
@@ -21,6 +21,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { merge } from 'rxjs';
 import { debounceTime, map } from 'rxjs/operators';
 
+import { subscriptionListBreadcrumb } from './subscription-breadcrumbs';
 import {
   DropdownSearchComponent,
   ResultsLoaderInput,
@@ -31,6 +32,7 @@ import { PaginatedTableComponent, TableColumn } from '../../../components/pagina
 import { SubscriptionMetadata, SubscriptionStatusEnum } from '../../../entities/subscription';
 import { ApiService } from '../../../services/api.service';
 import { ApplicationService } from '../../../services/application.service';
+import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { SubscriptionService } from '../../../services/subscription.service';
 import { areFiltersEqual, parseArrayParam, parsePageParam, parseSizeParam, toTitleCase } from '../../../utils/common.utils';
 
@@ -60,6 +62,7 @@ export default class SubscriptionsComponent {
   private router = inject(Router);
   private activatedRoute = inject(ActivatedRoute);
   private destroyRef = inject(DestroyRef);
+  private readonly breadcrumbService = inject(BreadcrumbService);
 
   subscriptionStatusesList = Object.values(SubscriptionStatusEnum);
   statusOptions = this.subscriptionStatusesList.map(status => ({
@@ -142,6 +145,7 @@ export default class SubscriptionsComponent {
   });
 
   constructor() {
+    this.breadcrumbService.set([subscriptionListBreadcrumb()]);
     this.setupUrlSync();
   }
 

--- a/gravitee-apim-portal-webui-next/src/services/breadcrumb.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/breadcrumb.service.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+
+import { BreadcrumbService } from './breadcrumb.service';
+import { Breadcrumb } from '../components/breadcrumbs/breadcrumbs.component';
+
+describe('BreadcrumbService', () => {
+  let service: BreadcrumbService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(BreadcrumbService);
+  });
+
+  it('should start with empty breadcrumbs', () => {
+    expect(service.breadcrumbs()).toEqual([]);
+  });
+
+  it('should set breadcrumbs', () => {
+    const crumbs: Breadcrumb[] = [
+      { id: 'home', label: 'Home', url: '/' },
+      { id: 'apps', label: 'Applications' },
+    ];
+
+    service.set(crumbs);
+
+    expect(service.breadcrumbs()).toEqual(crumbs);
+  });
+
+  it('should replace breadcrumbs when set again', () => {
+    service.set([{ id: 'a', label: 'A' }]);
+    const next: Breadcrumb[] = [{ id: 'b', label: 'B', url: '/b' }];
+
+    service.set(next);
+
+    expect(service.breadcrumbs()).toEqual(next);
+  });
+
+  it('should clear breadcrumbs', () => {
+    service.set([{ id: 'x', label: 'X' }]);
+
+    service.clear();
+
+    expect(service.breadcrumbs()).toEqual([]);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/breadcrumb.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/breadcrumb.service.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable, signal } from '@angular/core';
+
+import { Breadcrumb } from '../components/breadcrumbs/breadcrumbs.component';
+
+@Injectable({ providedIn: 'root' })
+export class BreadcrumbService {
+  private readonly _breadcrumbs = signal<Breadcrumb[]>([]);
+  readonly breadcrumbs = this._breadcrumbs.asReadonly();
+
+  set(breadcrumbs: Breadcrumb[]) {
+    this._breadcrumbs.set(breadcrumbs);
+  }
+
+  clear(): void {
+    this._breadcrumbs.set([]);
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13521

## Summary

Refactor dashboard breadcrumbs in **gravitee-apim-portal-webui-next** so they are managed by a shared `BreadcrumbService` and set explicitly from feature components, instead of being inferred from the router URL in `DashboardComponent`.

## Motivation

The previous implementation derived breadcrumb labels and links from URL segments after each `NavigationEnd`. That was brittle (special cases like subscription IDs, fallbacks to raw segments) and duplicated routing knowledge in the shell. Child routes can now declare accurate, localized breadcrumbs where the data lives.

## What changed

- **New `BreadcrumbService`** (`providedIn: 'root'`): holds breadcrumbs in a `signal`, with `setBreadcrumbs()` and `clear()`.
- **`DashboardComponent`**: binds `[breadcrumbs]="breadcrumbService.breadcrumbs()"` and clears the service on destroy; removes router-event / URL-parsing breadcrumb logic.
- **Shared builders**: `application-breadcrumbs.ts` and `subscription-breadcrumbs.ts` centralize list-level crumbs and optional `url` when a segment should be clickable (e.g. on detail pages).
- **Components set their own trail**:
  - Applications list, create application (Applications → Create), application details (Applications → app name).
  - Subscriptions list, subscription details (Subscriptions → “Subscription &lt;id&gt;”).


https://github.com/user-attachments/assets/cbb5e2f3-0c6f-40cb-9c32-9203c4afd202


