### PR TITLE
fix(console): clarify Analytics V2-only scope and rename HTTP Proxy template [GKO-2816]

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -241,7 +241,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       permissions: ['environment-platform-r'],
       routerBasePath: `/${this.currentEnv.hrids}/analytics`,
       iconRight$: of('gio:info'),
-      iconRightTooltip: 'This feature is deprecated, please use Observability > Dashboards instead.',
+      iconRightTooltip: 'This interface supports API V2 only. For API V4, switch to the new Observability interface.',
       items: [
         {
           displayName: 'Dashboard',

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/dashboards-list/ui/template-selector-dialog/template-selector-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/dashboards-list/ui/template-selector-dialog/template-selector-dialog.component.html
@@ -47,6 +47,12 @@
               <div class="preview-panel__title-row">
                 <h2 class="preview-panel__title">{{ selected.name }}</h2>
               </div>
+              @if (selected.info) {
+                <p class="preview-panel__info">
+                  <span class="gio-badge preview-panel__info-badge"> <mat-icon svgIcon="gio:info" class="gio-left"></mat-icon>Info </span>
+                  {{ selected.info }}
+                </p>
+              }
               <p class="preview-panel__description">{{ selected.description }}</p>
               @if (selected.initialConfig?.labels) {
                 <p class="preview-panel__labels">

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/dashboards-list/ui/template-selector-dialog/template-selector-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/dashboards-list/ui/template-selector-dialog/template-selector-dialog.component.scss
@@ -142,6 +142,18 @@ $primary: mat.m2-get-color-from-palette(gio.$mat-primary-palette, default);
     color: rgba(0, 0, 0, 0.87);
   }
 
+  &__info {
+    margin: 8px 0 0;
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.6);
+    line-height: 1.5;
+  }
+
+  &__info-badge {
+    background-color: mat.m2-get-color-from-palette(gio.$mat-cyan-palette, lighter80);
+    color: mat.m2-get-color-from-palette(gio.$mat-cyan-palette, default);
+  }
+
   &__description {
     margin: 15px 0;
     font-size: 14px;

--- a/gravitee-apim-console-webui/src/management/observability/data-access/templates/dashboard-template.model.ts
+++ b/gravitee-apim-console-webui/src/management/observability/data-access/templates/dashboard-template.model.ts
@@ -20,6 +20,7 @@ export interface DashboardTemplate {
   name: string;
   shortDescription: string;
   description: string;
+  info?: string;
   previewImage: string;
   initialConfig: Partial<Dashboard>;
 }

--- a/gravitee-apim-console-webui/src/management/observability/data-access/templates/http-proxy.template.ts
+++ b/gravitee-apim-console-webui/src/management/observability/data-access/templates/http-proxy.template.ts
@@ -16,11 +16,12 @@
 import { DashboardTemplate } from './dashboard-template.model';
 
 export const HTTP_PROXY_TEMPLATE: DashboardTemplate = {
-  id: 'proxy-performance',
-  name: 'Proxy Generic Protocol',
+  id: 'http-proxy',
+  name: 'HTTP Proxy',
   shortDescription: 'Monitor real-time API health, traffic trends, and service reliability.',
   description:
     'This dashboard provides a centralized view of global API performance, error distribution, and latency across your infrastructure. It enables teams to quickly identify service bottlenecks and ensure consistent reliability for all API consumers.',
+  info: 'For V4 proxy APIs only. V2 APIs are not supported.',
   previewImage: 'assets/images/templates/proxy-preview.png',
   initialConfig: {
     labels: { Focus: 'HTTP / TCP', Theme: 'proxy' },


### PR DESCRIPTION
## Summary

Two small UX fixes around the Observability / Analytics experience in the Console:

1. **Analytics sidenav tooltip** — Clarify that the legacy Analytics section only covers V2 APIs and direct users to the new Observability interface for V4.
2. **HTTP Proxy dashboard template** — Rename the previously named _Proxy Generic Protocol_ template to _HTTP Proxy_ and surface an info pill in the template preview panel warning users that it is only applicable to V4 proxy APIs (V2 is not supported).

Jira: [GKO-2816](https://gravitee.atlassian.net/browse/GKO-2816)

## Changes

### 1. Analytics sidenav tooltip

<img width="279" height="226" alt="Screenshot 2026-04-20 at 12 51 25" src="https://github.com/user-attachments/assets/736a0c4d-00db-411f-b4e7-44573ebb46ea" />

Updated the tooltip shown on hover of the _Analytics_ entry in the main sidenav.

- **Before:** _This feature is deprecated, please use Observability > Dashboards instead._
- **After:** _This interface supports API V2 only. For API V4, please switch to the new Observability interface 🚀_

Touched: `gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts`

### 2. HTTP Proxy template + generic info pill

<img width="1293" height="716" alt="Screenshot 2026-04-20 at 12 51 10" src="https://github.com/user-attachments/assets/f627c484-5b5d-4ef7-a60c-26d678d1a05f" />

- Renamed the dashboard template to **HTTP Proxy** and aligned its id to `http-proxy` (was `proxy-performance`).
- Added an **optional, generic** `info?: string` field to the `DashboardTemplate` model so any template (not just HTTP Proxy) can surface a short contextual note in the preview panel.
- Rendered the info as a small pill beneath the title in the template selector dialog, implemented using the existing `gio-badge` component from `@gravitee/ui-particles-angular` — only the color is overridden via the `cyan` palette tokens (info-blue). No custom padding, radius or typography is introduced.
- For HTTP Proxy, the info is set to: _For V4 proxy APIs only. V2 APIs are not supported._

## Test plan

- [ ] Hover the **Analytics** item in the sidenav and verify the new tooltip text is displayed.
- [ ] Open **Observability > Dashboards > Create from template** and verify:
  - [ ] The first template is named **HTTP Proxy**.
  - [ ] The preview panel shows a cyan/blue pill "(i) Info" followed by "For V4 proxy APIs only. V2 APIs are not supported." under the title.
  - [ ] The ``shortDescription`` and ``description`` are unchanged.
  - [ ] Other templates (LLM, MCP, …) do not display an info pill.
- [ ] Confirm that the template id is now ``http-proxy`` (used when instantiating the dashboard).

[GKO-2816]: https://gravitee.atlassian.net/browse/GKO-2816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ