### PR TITLE
feat(portal): analytics enabled guard and conditional navigation

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -39,6 +39,7 @@ import { DashboardComponent } from './dashboard/dashboard.component';
 import { RegistrationConfirmationComponent } from './registration/registration-confirmation/registration-confirmation.component';
 import { ServiceUnavailableComponent } from './service-unavailable/service-unavailable.component';
 import { NavigationPageFullWidthComponent } from '../components/navigation-page-full-width/navigation-page-full-width.component';
+import { analyticsEnabledGuard } from '../guards/analytics-enabled.guard';
 import { redirectGuard } from '../guards/redirect.guard';
 import { apiResolver } from '../resolvers/api.resolver';
 import { applicationPermissionResolver, applicationResolver, applicationTypeResolver } from '../resolvers/application.resolver';
@@ -205,6 +206,7 @@ export const routes: Routes = [
       },
       {
         path: 'analytics',
+        canActivate: [analyticsEnabledGuard],
         children: [
           {
             path: '',

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.spec.ts
@@ -22,7 +22,8 @@ import { ActivatedRoute, provideRouter, Router, Routes } from '@angular/router';
 import { DashboardComponent } from './dashboard.component';
 import { DashboardComponentHarness } from './dashboard.component.harness';
 import { BreadcrumbService } from '../../services/breadcrumb.service';
-import { AppTestingModule } from '../../testing/app-testing.module';
+import { ConfigService } from '../../services/config.service';
+import { AppTestingModule, ConfigServiceStub } from '../../testing/app-testing.module';
 import { routes } from '../app.routes';
 
 describe('DashboardComponent', () => {
@@ -31,7 +32,11 @@ describe('DashboardComponent', () => {
   let router: Router;
   let httpTestingController: HttpTestingController;
 
-  const init = async () => {
+  const init = async (
+    params: Partial<{ enablePortalNextAnalytics: boolean }> = {
+      enablePortalNextAnalytics: false,
+    },
+  ) => {
     const dashboardRoute = (routes as Routes).find(route => route.path === 'dashboard');
 
     await TestBed.configureTestingModule({
@@ -53,6 +58,22 @@ describe('DashboardComponent', () => {
             snapshot: {
               url: [],
             },
+          },
+        },
+        {
+          provide: ConfigService,
+          useFactory: () => {
+            const stub = new ConfigServiceStub();
+            if (params.enablePortalNextAnalytics) {
+              stub.configuration = {
+                ...stub.configuration,
+                portalNext: {
+                  ...stub.configuration.portalNext,
+                  analytics: { enabled: true },
+                },
+              };
+            }
+            return stub;
           },
         },
       ],
@@ -105,14 +126,28 @@ describe('DashboardComponent', () => {
     expect(await breadcrumbs?.getText()).toContain('Subscriptions');
   });
 
-  it('should include Analytics in menu items', async () => {
+  it('should omit Analytics from menu items when portal next analytics is not enabled', async () => {
     await init();
+
+    expect(fixture.componentInstance.menuItems().map(item => item.path)).toEqual(['applications', 'subscriptions']);
+  });
+
+  it('should not show Analytics in the sidenav when portal next analytics is not enabled', async () => {
+    await init();
+
+    fixture.detectChanges();
+    const sidenav = await harness.getSidenav();
+    expect(await sidenav?.getText()).not.toContain('Analytics');
+  });
+
+  it('should include Analytics in menu items when portal next analytics is enabled', async () => {
+    await init({ enablePortalNextAnalytics: true });
 
     expect(fixture.componentInstance.menuItems().map(item => item.path)).toEqual(['analytics', 'applications', 'subscriptions']);
   });
 
-  it('should show Analytics in the sidenav', async () => {
-    await init();
+  it('should show Analytics in the sidenav when portal next analytics is enabled', async () => {
+    await init({ enablePortalNextAnalytics: true });
 
     await router.navigate(['subscriptions']);
     fixture.detectChanges();

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/dashboard.component.ts
@@ -19,6 +19,7 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 import { SidenavLayoutComponent } from '../../components/sidenav-layout/sidenav-layout.component';
 import { BreadcrumbService } from '../../services/breadcrumb.service';
+import { ConfigService } from '../../services/config.service';
 
 interface MenuItem {
   path: string;
@@ -39,9 +40,13 @@ const MENU_ITEMS: MenuItem[] = [
 })
 export class DashboardComponent {
   private readonly destroyRef = inject(DestroyRef);
+  private readonly configService = inject(ConfigService);
   readonly breadcrumbService = inject(BreadcrumbService);
 
-  readonly menuItems = computed(() => MENU_ITEMS);
+  readonly menuItems = computed(() => {
+    const analyticsEnabled = this.configService.configuration.portalNext?.analytics?.enabled ?? false;
+    return analyticsEnabled ? MENU_ITEMS : MENU_ITEMS.filter(item => item.path !== 'analytics');
+  });
 
   constructor() {
     this.destroyRef.onDestroy(() => this.breadcrumbService.clear());

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/desktop-nav-bar/desktop-nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/desktop-nav-bar/desktop-nav-bar.component.html
@@ -39,7 +39,7 @@
 
 @if (isLoggedIn()) {
   <div class="actions">
-    <app-user-avatar [user]="currentUser()" />
+    <app-user-avatar [user]="currentUser()" [analyticsEnabled]="analyticsEnabled()" />
   </div>
 } @else {
   <div class="actions">

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/desktop-nav-bar/desktop-nav-bar.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/desktop-nav-bar/desktop-nav-bar.component.ts
@@ -33,6 +33,7 @@ import { NavBarButtonComponent } from '../nav-bar-button/nav-bar-button.componen
 export class DesktopNavBarComponent {
   currentUser: InputSignal<User> = input({});
   topBarNavigationItems: InputSignal<PortalNavigationItem[]> = input<PortalNavigationItem[]>([]);
+  analyticsEnabled: InputSignal<boolean> = input(false);
   protected isLoggedIn = computed(() => {
     return !isEmpty(this.currentUser());
   });

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/mobile-nav-bar/mobile-nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/mobile-nav-bar/mobile-nav-bar.component.html
@@ -56,14 +56,16 @@
     <div class="mobile-menu__hr"></div>
 
     @if (isLoggedIn()) {
-      <a
-        class="mobile-menu__link"
-        i18n="@@analyticsTitle"
-        [routerLink]="['/dashboard', 'analytics']"
-        routerLinkActive="active"
-        (click)="closeMenu()"
-        >Analytics</a
-      >
+      @if (analyticsEnabled()) {
+        <a
+          class="mobile-menu__link"
+          i18n="@@analyticsTitle"
+          [routerLink]="['/dashboard', 'analytics']"
+          routerLinkActive="active"
+          (click)="closeMenu()"
+          >Analytics</a
+        >
+      }
       <a
         class="mobile-menu__link"
         i18n="@@applications"

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/mobile-nav-bar/mobile-nav-bar.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/mobile-nav-bar/mobile-nav-bar.component.ts
@@ -35,6 +35,7 @@ import { PortalService } from '../../../services/portal.service';
 export class MobileNavBarComponent {
   currentUser: InputSignal<User> = input({});
   topBarNavigationItems: InputSignal<PortalNavigationItem[]> = input<PortalNavigationItem[]>([]);
+  analyticsEnabled: InputSignal<boolean> = input(false);
   hasHomepage = toSignal(
     inject(PortalService)
       .getPortalHomepages()

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.html
@@ -19,9 +19,17 @@
   <app-company-title [logo]="logo()" />
   @if (!forceLogin() || isLoggedIn()) {
     @if (isMobile()) {
-      <app-mobile-nav-bar [currentUser]="currentUser()" [topBarNavigationItems]="topBarNavigationItems()" />
+      <app-mobile-nav-bar
+        [currentUser]="currentUser()"
+        [topBarNavigationItems]="topBarNavigationItems()"
+        [analyticsEnabled]="analyticsEnabled()"
+      />
     } @else {
-      <app-desktop-nav-bar [currentUser]="currentUser()" [topBarNavigationItems]="topBarNavigationItems()" />
+      <app-desktop-nav-bar
+        [currentUser]="currentUser()"
+        [topBarNavigationItems]="topBarNavigationItems()"
+        [analyticsEnabled]="analyticsEnabled()"
+      />
     }
   }
 </div>

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.spec.ts
@@ -27,8 +27,9 @@ import { NavBarComponent } from './nav-bar.component';
 import { PortalPage } from '../../entities/portal/portal-page';
 import { PortalNavigationItem, PortalNavigationLink } from '../../entities/portal-navigation/portal-navigation-item';
 import { fakeUser } from '../../entities/user/user.fixtures';
+import { ConfigService } from '../../services/config.service';
 import { PortalNavigationItemsService } from '../../services/portal-navigation-items.service';
-import { AppTestingModule, TESTING_BASE_URL } from '../../testing/app-testing.module';
+import { AppTestingModule, ConfigServiceStub, TESTING_BASE_URL } from '../../testing/app-testing.module';
 import { DivHarness } from '../../testing/div.harness';
 
 describe('NavBarComponent', () => {
@@ -59,7 +60,7 @@ describe('NavBarComponent', () => {
     } as PortalNavigationLink,
   ];
 
-  const init = async (isMobile: boolean = false) => {
+  const init = async (isMobile: boolean = false, portalNextAnalyticsEnabled = false) => {
     const mockBreakpointObserver = {
       observe: () => of({ matches: isMobile, breakpoints: { [Breakpoints.XSmall]: isMobile } }),
     };
@@ -83,6 +84,18 @@ describe('NavBarComponent', () => {
     componentRef = fixture.componentRef;
     harnessLoader = TestbedHarnessEnvironment.loader(fixture);
     httpTestingController = TestBed.inject(HttpTestingController);
+
+    if (portalNextAnalyticsEnabled) {
+      const config = TestBed.inject(ConfigService) as unknown as ConfigServiceStub;
+      config.configuration = {
+        ...config.configuration,
+        portalNext: {
+          ...config.configuration.portalNext,
+          analytics: { enabled: true },
+        },
+      };
+    }
+
     fixture.detectChanges();
   };
 
@@ -162,7 +175,7 @@ describe('NavBarComponent', () => {
 
       const links: NodeList = fixture.debugElement.nativeElement.querySelectorAll('.mobile-menu__link');
       const linkTexts = Array.from(links).map((el: Node) => el.textContent?.trim());
-      expect(linkTexts).toEqual(['Homepage', 'Catalog', 'Analytics', 'Applications', 'Subscriptions', 'Log out']);
+      expect(linkTexts).toEqual(['Homepage', 'Catalog', 'Applications', 'Subscriptions', 'Log out']);
     });
 
     it('should not show menu if user is not connected and login is forced', async () => {
@@ -192,7 +205,6 @@ describe('NavBarComponent', () => {
         'Catalog',
         'link-name-1 open_in_new(opens in new tab)',
         'link-name-2 open_in_new(opens in new tab)',
-        'Analytics',
         'Applications',
         'Subscriptions',
         'Log out',
@@ -257,6 +269,29 @@ describe('NavBarComponent', () => {
       const links: NodeList = fixture.debugElement.nativeElement.querySelectorAll('.mobile-menu__link');
       const linkTexts = Array.from(links).map((el: Node) => el.textContent?.trim());
       expect(linkTexts).toEqual(['Catalog', 'Sign in']);
+    });
+  });
+
+  describe('using mobile view with portal next analytics enabled', () => {
+    beforeEach(async () => {
+      await init(true, true);
+    });
+
+    afterEach(() => {
+      httpTestingController.verify();
+    });
+
+    it('should show Analytics link when portal next analytics is enabled', async () => {
+      expectHomePage();
+      componentRef.setInput('currentUser', fakeUser());
+      fixture.detectChanges();
+
+      const menuButton = await harnessLoader.getHarness(MatButtonHarness.with({ selector: '.mobile-menu__button' }));
+      await menuButton.click();
+
+      const links: NodeList = fixture.debugElement.nativeElement.querySelectorAll('.mobile-menu__link');
+      const linkTexts = Array.from(links).map((el: Node) => el.textContent?.trim());
+      expect(linkTexts).toEqual(['Homepage', 'Catalog', 'Analytics', 'Applications', 'Subscriptions', 'Log out']);
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/nav-bar/nav-bar.component.ts
@@ -21,6 +21,7 @@ import { DesktopNavBarComponent } from './desktop-nav-bar/desktop-nav-bar.compon
 import { MobileNavBarComponent } from './mobile-nav-bar/mobile-nav-bar.component';
 import { PortalNavigationItem } from '../../entities/portal-navigation/portal-navigation-item';
 import { User } from '../../entities/user/user';
+import { ConfigService } from '../../services/config.service';
 import { ObservabilityBreakpointService } from '../../services/observability-breakpoint.service';
 import { CompanyTitleComponent } from '../company-title/company-title.component';
 
@@ -31,11 +32,14 @@ import { CompanyTitleComponent } from '../company-title/company-title.component'
   styleUrls: ['./nav-bar.component.scss'],
 })
 export class NavBarComponent {
+  protected readonly configService = inject(ConfigService);
+
   topBarNavigationItems: InputSignal<PortalNavigationItem[]> = input<PortalNavigationItem[]>([]);
   currentUser: InputSignal<User> = input({});
   forceLogin: InputSignal<boolean> = input(false);
   logo: InputSignal<string> = input('');
   protected readonly isMobile = inject(ObservabilityBreakpointService).isMobile;
+  protected readonly analyticsEnabled = computed(() => this.configService.configuration.portalNext?.analytics?.enabled ?? false);
 
   protected isLoggedIn = computed(() => {
     return !isEmpty(this.currentUser());

--- a/gravitee-apim-portal-webui-next/src/components/user-avatar/user-avatar.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/user-avatar/user-avatar.component.html
@@ -19,7 +19,9 @@
   {{ initials }}
 </button>
 <mat-menu #user="matMenu">
-  <button i18n="@@analyticsTitle" mat-menu-item [routerLink]="['/dashboard', 'analytics']">Analytics</button>
+  @if (analyticsEnabled()) {
+    <button i18n="@@analyticsTitle" mat-menu-item [routerLink]="['/dashboard', 'analytics']">Analytics</button>
+  }
   <button i18n="@@applications" mat-menu-item [routerLink]="['/dashboard', 'applications']">Applications</button>
   <button i18n="@@subscriptions" mat-menu-item [routerLink]="['/dashboard', 'subscriptions']">Subscriptions</button>
   <button i18n="@@userAvatarMenuLogOut" mat-menu-item [routerLink]="['/log-out']">Log out</button>

--- a/gravitee-apim-portal-webui-next/src/components/user-avatar/user-avatar.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/user-avatar/user-avatar.component.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+
+import { UserAvatarComponent } from './user-avatar.component';
+import { fakeUser } from '../../entities/user/user.fixtures';
+
+describe('UserAvatarComponent', () => {
+  let fixture: ComponentFixture<UserAvatarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UserAvatarComponent, NoopAnimationsModule],
+      providers: [provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserAvatarComponent);
+    fixture.componentRef.setInput('user', fakeUser());
+    fixture.detectChanges();
+  });
+
+  it('should not show Analytics menu item when analyticsEnabled is false', async () => {
+    fixture.componentRef.setInput('analyticsEnabled', false);
+    fixture.detectChanges();
+
+    (fixture.nativeElement as HTMLElement).querySelector('.user-avatar')?.dispatchEvent(new MouseEvent('click'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const panel = document.querySelector('.mat-mdc-menu-panel');
+    const labels = Array.from(panel?.querySelectorAll('.mat-mdc-menu-item') ?? []).map(el => el.textContent?.trim());
+    expect(labels.some(t => t === 'Analytics')).toBe(false);
+  });
+
+  it('should show Analytics menu item when analyticsEnabled is true', async () => {
+    fixture.componentRef.setInput('analyticsEnabled', true);
+    fixture.detectChanges();
+
+    (fixture.nativeElement as HTMLElement).querySelector('.user-avatar')?.dispatchEvent(new MouseEvent('click'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const panel = document.querySelector('.mat-mdc-menu-panel');
+    const labels = Array.from(panel?.querySelectorAll('.mat-mdc-menu-item') ?? []).map(el => el.textContent?.trim());
+    expect(labels).toContain('Analytics');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/user-avatar/user-avatar.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/user-avatar/user-avatar.component.ts
@@ -28,6 +28,7 @@ import { User } from '../../entities/user/user';
 })
 export class UserAvatarComponent {
   user: InputSignal<User> = input({});
+  analyticsEnabled: InputSignal<boolean> = input(false);
   initials: string = '';
 
   constructor() {

--- a/gravitee-apim-portal-webui-next/src/guards/analytics-enabled.guard.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/analytics-enabled.guard.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+
+import { analyticsEnabledGuard } from './analytics-enabled.guard';
+import { ConfigService } from '../services/config.service';
+
+describe('analyticsEnabledGuard', () => {
+  const dummyRoute = {} as ActivatedRouteSnapshot;
+  const dummyState = {} as RouterStateSnapshot;
+
+  it('should allow navigation when portal next analytics is enabled', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ConfigService, useValue: { configuration: { portalNext: { analytics: { enabled: true } } } } },
+        { provide: Router, useValue: { parseUrl: jest.fn() } },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => analyticsEnabledGuard(dummyRoute, dummyState));
+
+    expect(result).toBe(true);
+  });
+
+  it('should redirect to home when portal next analytics is disabled', () => {
+    const parseUrl = jest.fn().mockReturnValue('PARSED');
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ConfigService, useValue: { configuration: { portalNext: { analytics: { enabled: false } } } } },
+        { provide: Router, useValue: { parseUrl } },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => analyticsEnabledGuard(dummyRoute, dummyState));
+
+    expect(parseUrl).toHaveBeenCalledWith('/');
+    expect(result).toBe('PARSED');
+  });
+
+  it('should redirect to home when portal next analytics is missing', () => {
+    const parseUrl = jest.fn().mockReturnValue('PARSED');
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ConfigService, useValue: { configuration: {} } },
+        { provide: Router, useValue: { parseUrl } },
+      ],
+    });
+
+    TestBed.runInInjectionContext(() => analyticsEnabledGuard(dummyRoute, dummyState));
+
+    expect(parseUrl).toHaveBeenCalledWith('/');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/guards/analytics-enabled.guard.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/analytics-enabled.guard.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+import { ConfigService } from '../services/config.service';
+
+export const analyticsEnabledGuard: CanActivateFn = () => {
+  const enabled = inject(ConfigService).configuration.portalNext?.analytics?.enabled === true;
+  if (enabled) {
+    return true;
+  }
+  return inject(Router).parseUrl('/');
+};


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12889

### Stacked PRs
- **master**
  - https://github.com/gravitee-io/gravitee-api-management/pull/16466 
    - https://github.com/gravitee-io/gravitee-api-management/pull/16470 👈

## Description

Added a guard **`analyticsEnabledGuard`** on dashboard analytics routes and **conditional Analytics** entries in the sidenav, mobile menu, desktop top bar (via avatar), and user avatar menu. When analytics is off or unset, deep links to `/dashboard/analytics` are redirected to **`/`** (home), and Analytics disappears from navigation surfaces.

## What changed

### Route guard

- New **`analyticsEnabledGuard`** (`CanActivateFn`): allows navigation only when `portalNext.analytics.enabled` is strictly `true`; otherwise returns `Router.parseUrl('/')`.
- Wired with **`canActivate: [analyticsEnabledGuard]`** on the dashboard `analytics` route segment (list and `:dashboardId` children inherit activation).

### Dashboard sidenav

- **`DashboardComponent`** injects **`ConfigService`** and builds **`menuItems`** with a `computed`: includes **Analytics** only when the flag is enabled; otherwise filters out the analytics `MenuItem`.
- **`dashboard.component.spec.ts`** uses a parameterized **`init({ enablePortalNextAnalytics })`** + **`ConfigServiceStub`** to cover enabled vs disabled menu and sidenav visibility.

### Top navigation and user menu

- **`NavBarComponent`** reads the same flag from **`ConfigService`** and passes **`analyticsEnabled`** into mobile and desktop nav children.
- **`MobileNavBarComponent`** / **`DesktopNavBarComponent`**: accept **`analyticsEnabled`** input; mobile wraps the Analytics link in **`@if`**; desktop passes the flag into **`UserAvatarComponent`**.
- **`UserAvatarComponent`**: new **`analyticsEnabled`** input (default `false`); Analytics **`mat-menu-item`** is shown only when enabled.


https://github.com/user-attachments/assets/37369785-0a94-41b5-9706-34bec4d3ceb3

