### PR TITLE
fix: resolve NPE and add metadata support for Dashboard audits

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditReferenceType.java
@@ -27,4 +27,5 @@ public enum AuditReferenceType {
     APPLICATION,
     API,
     API_PRODUCT,
+    DASHBOARD,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -30,6 +30,7 @@ import io.gravitee.repository.management.api.*;
 import io.gravitee.repository.management.api.search.AuditCriteria.Builder;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.*;
+import io.gravitee.repository.management.model.Dashboard;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.audit.AuditEntity;
@@ -66,7 +67,8 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
         entry(Audit.AuditReferenceType.ENVIRONMENT, AuditReferenceType.ENVIRONMENT),
         entry(Audit.AuditReferenceType.APPLICATION, AuditReferenceType.APPLICATION),
         entry(Audit.AuditReferenceType.API, AuditReferenceType.API),
-        entry(Audit.AuditReferenceType.API_PRODUCT, AuditReferenceType.API_PRODUCT)
+        entry(Audit.AuditReferenceType.API_PRODUCT, AuditReferenceType.API_PRODUCT),
+        entry(Audit.AuditReferenceType.DASHBOARD, AuditReferenceType.DASHBOARD)
     );
 
     @Lazy
@@ -96,6 +98,10 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
     @Lazy
     @Autowired
     private ApiProductsRepository apiProductsRepository;
+
+    @Lazy
+    @Autowired
+    private DashboardRepository dashboardRepository;
 
     @Lazy
     @Autowired
@@ -191,6 +197,11 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
                 metadata.put(metadataKey, auditEntity.getUser());
             }
 
+            if (auditEntity.getReferenceType() == null) {
+                log.warn("Audit entry {} has null referenceType, skipping metadata resolution", auditEntity.getId());
+                continue;
+            }
+
             if (Audit.AuditReferenceType.ORGANIZATION.name().equals(auditEntity.getReferenceType().name())) {
                 metadataKey = "ORGANIZATION:" + auditEntity.getReferenceId() + ":name";
                 if (!metadata.containsKey(metadataKey)) {
@@ -261,6 +272,22 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
                         if (optApiProduct.isPresent()) {
                             metadata.put(metadataKey, optApiProduct.get().getName());
                         }
+                    } catch (TechnicalException e) {
+                        log.error("Error finding metadata {}", metadataKey);
+                        metadata.put(metadataKey, auditEntity.getReferenceId());
+                    }
+                }
+            } else if (auditEntity.getReferenceId() != null && auditEntity.getReferenceType() == AuditReferenceType.DASHBOARD) {
+                metadataKey = "DASHBOARD:" + auditEntity.getReferenceId() + ":name";
+                if (!metadata.containsKey(metadataKey)) {
+                    try {
+                        metadata.put(
+                            metadataKey,
+                            dashboardRepository
+                                .findById(auditEntity.getReferenceId())
+                                .map(Dashboard::getName)
+                                .orElse(auditEntity.getReferenceId())
+                        );
                     } catch (TechnicalException e) {
                         log.error("Error finding metadata {}", metadataKey);
                         metadata.put(metadataKey, auditEntity.getReferenceId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AuditServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AuditServiceImplTest.java
@@ -16,17 +16,51 @@
 package io.gravitee.rest.api.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.AuditRepository;
+import io.gravitee.repository.management.api.DashboardRepository;
+import io.gravitee.repository.management.model.Audit;
+import io.gravitee.repository.management.model.Dashboard;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.audit.AuditQuery;
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class AuditServiceImplTest {
 
-    private AuditServiceImpl auditService = new AuditServiceImpl();
+    @Mock
+    private AuditRepository auditRepository;
+
+    @Mock
+    private DashboardRepository dashboardRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private PermissionService permissionService;
+
+    @InjectMocks
+    private AuditServiceImpl auditService;
 
     @Nested
     class AnonymizeData {
@@ -148,6 +182,72 @@ class AuditServiceImplTest {
             auditService.anonymizeData(diff, List.of("/clientId"));
 
             assertThat(diff).isEqualTo(mapper.readTree(data));
+        }
+    }
+
+    @Nested
+    class Search {
+
+        private static final String ORG_ID = "org-id";
+        private static final String ENV_ID = "env-id";
+        private static final String DASHBOARD_ID = "dash-id";
+        private static final String DASHBOARD_NAME = "My Dashboard";
+        private static final String USER_ID = "user-id";
+
+        private final ExecutionContext executionContext = new ExecutionContext(ORG_ID, ENV_ID);
+
+        @BeforeEach
+        void setUp() throws UserNotFoundException {
+            when(userService.findById(any(), any())).thenThrow(new UserNotFoundException(USER_ID));
+        }
+
+        private Audit dashboardAudit() {
+            Audit audit = new Audit();
+            audit.setId("audit-id");
+            audit.setReferenceType(Audit.AuditReferenceType.DASHBOARD);
+            audit.setReferenceId(DASHBOARD_ID);
+            audit.setUser(USER_ID);
+            audit.setEvent("DASHBOARD_CREATED");
+            audit.setPatch("[]");
+            return audit;
+        }
+
+        @Test
+        void should_resolve_dashboard_name_in_metadata() throws TechnicalException {
+            Dashboard dashboard = Dashboard.builder().id(DASHBOARD_ID).name(DASHBOARD_NAME).build();
+            when(auditRepository.search(any(), any())).thenReturn(new Page<>(List.of(dashboardAudit()), 0, 1, 1));
+            when(dashboardRepository.findById(DASHBOARD_ID)).thenReturn(Optional.of(dashboard));
+
+            var result = auditSearch();
+
+            assertThat(result.getMetadata()).containsEntry("DASHBOARD:" + DASHBOARD_ID + ":name", DASHBOARD_NAME);
+        }
+
+        @Test
+        void should_fallback_to_reference_id_when_dashboard_not_found() throws TechnicalException {
+            when(auditRepository.search(any(), any())).thenReturn(new Page<>(List.of(dashboardAudit()), 0, 1, 1));
+            when(dashboardRepository.findById(DASHBOARD_ID)).thenReturn(Optional.empty());
+
+            var result = auditSearch();
+
+            assertThat(result.getMetadata()).containsEntry("DASHBOARD:" + DASHBOARD_ID + ":name", DASHBOARD_ID);
+        }
+
+        @Test
+        void should_fallback_to_reference_id_on_technical_exception() throws TechnicalException {
+            when(auditRepository.search(any(), any())).thenReturn(new Page<>(List.of(dashboardAudit()), 0, 1, 1));
+            when(dashboardRepository.findById(DASHBOARD_ID)).thenThrow(new TechnicalException("db error"));
+
+            var result = auditSearch();
+
+            assertThat(result.getMetadata()).containsEntry("DASHBOARD:" + DASHBOARD_ID + ":name", DASHBOARD_ID);
+        }
+
+        private io.gravitee.common.data.domain.MetadataPage<io.gravitee.rest.api.model.audit.AuditEntity> auditSearch() {
+            AuditQuery query = new AuditQuery();
+            query.setPage(1);
+            query.setSize(10);
+            return auditService.search(executionContext, query);
         }
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13608

## Description

This PR fixes  **_NullPointerException_** that crashed the Audit Log page when a dashboard was created from a template. The failure occurred because the **_DASHBOARD_** reference type was not mapped between the repository and service layers.

## Additional context

**_Fix_**: Added DASHBOARD to AuditReferenceType and updated the AuditServiceImpl conversion map to prevent null returns.

**_Metadata_**: Injected DashboardRepository to resolve dashboard names for a better UI experience.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

