### PR TITLE
feat(APIM-13690): display apiProductId in log details view

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.ts
@@ -31,9 +31,13 @@ import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { EnvLog } from '../../models/env-log.model';
 import { EnvLogsDetailsRowComponent } from '../env-logs-details-row/env-logs-details-row.component';
 import { GioHeaderComponent } from '../../../../../shared/components/gio-header/gio-header.component';
-import { EnvironmentLogsService } from '../../../../../services-ngx/environment-logs.service';
+import { EnvironmentLogsService, EnvironmentApiLog } from '../../../../../services-ngx/environment-logs.service';
 import { ApiLogsV2Service } from '../../../../../services-ngx/api-logs-v2.service';
 import { ApiAnalyticsV2Service } from '../../../../../services-ngx/api-analytics-v2.service';
+import { ConnectionLogDetail } from '../../../../../entities/management-api-v2';
+import { ApiMetricsDetailResponse } from '../../../../../entities/management-api-v2/analytics/apiMetricsDetailResponse';
+
+const UNKNOWN_VALUE = '—';
 
 @Component({
   selector: 'env-logs-details',
@@ -133,18 +137,18 @@ export class EnvLogsDetailsComponent {
     );
   }
 
-  private mapToEnvLog(overview: any, detail: any, metrics: any): EnvLog {
+  private mapToEnvLog(overview: EnvironmentApiLog, detail: ConnectionLogDetail | null, metrics: ApiMetricsDetailResponse | null): EnvLog {
     return {
       id: overview.id,
       apiId: overview.apiId,
       timestamp: this.formatTimestamp(overview.timestamp),
       api: overview.apiName ?? overview.apiId,
       apiProductName: overview.apiProductName,
-      application: overview.application?.name ?? overview.application?.id ?? '—',
-      method: overview.method ?? '—',
-      path: overview.uri ?? '—',
+      application: overview.application?.name ?? overview.application?.id ?? UNKNOWN_VALUE,
+      method: overview.method ?? UNKNOWN_VALUE,
+      path: overview.uri ?? UNKNOWN_VALUE,
       status: overview.status,
-      responseTime: overview.gatewayResponseTime != null ? `${overview.gatewayResponseTime} ms` : '—',
+      responseTime: overview.gatewayResponseTime != null ? `${overview.gatewayResponseTime} ms` : UNKNOWN_VALUE,
       gateway: overview.gateway,
       plan: this.resolvePlanName(overview.plan?.name, metrics?.plan?.name),
       requestEnded: overview.requestEnded,
@@ -152,7 +156,7 @@ export class EnvLogsDetailsComponent {
       transactionId: overview.transactionId,
       requestId: detail?.requestId,
       clientIdentifier: detail?.clientIdentifier,
-      warnings: overview.warnings?.map((w: any) => ({ key: w.key ?? '' })),
+      warnings: overview.warnings?.map(w => ({ key: w.key ?? '' })),
       entrypointRequest: detail?.entrypointRequest,
       endpointRequest: detail?.endpointRequest,
       entrypointResponse: detail?.entrypointResponse,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13690
## Description

Adds API Product ID to details component and also updates CSS for API Product Name on logs list table. 

<img width="1270" height="483" alt="Screenshot 2026-04-21 at 10 05 01 AM" src="https://github.com/user-attachments/assets/d4ddeddf-c995-454e-a601-9113800d33fd" />
<img width="1269" height="567" alt="Screenshot 2026-04-21 at 10 05 08 AM" src="https://github.com/user-attachments/assets/68ff0de1-ebac-47d3-b4b0-d81a360eb8e3" />

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

