### PR TITLE
build: expose es-index-mappings on download website

### DIFF
--- a/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/pom.xml
+++ b/gravitee-apim-distribution/gravitee-apim-distribution-es-index-mappings/pom.xml
@@ -30,6 +30,11 @@
 
     <name>Gravitee.io APIM - Distribution - Elasticsearch Index Mappings</name>
 
+    <properties>
+        <!-- Property used by the publication job in CI-->
+        <publish-folder-path>graviteeio-apim/es-index-mappings</publish-folder-path>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.reflections</groupId>


### PR DESCRIPTION
## Description

expose es-index-mappings on download website here:
<img width="536" height="390" alt="image" src="https://github.com/user-attachments/assets/74e53af7-d41f-4529-8b83-7c25daa0fec3" />
