### PR TITLE
fix(portal): add worker-src blob: directive to CSP for Redoc worker support

### DIFF
--- a/gravitee-apim-portal-webui/docker/config/default-next.conf
+++ b/gravitee-apim-portal-webui/docker/config/default-next.conf
@@ -3,7 +3,7 @@ server {
     listen [::]:$HTTPS_PORT ipv6only=off;
     server_name $SERVER_NAME;
 
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; worker-src 'self' blob:; object-src 'none'; frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;

--- a/gravitee-apim-portal-webui/docker/config/default.conf
+++ b/gravitee-apim-portal-webui/docker/config/default.conf
@@ -3,7 +3,7 @@ server {
     listen [::]:$HTTPS_PORT ipv6only=off;
     server_name $SERVER_NAME;
 
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'none'; frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; worker-src 'self' blob:; object-src 'none'; frame-ancestors $ALLOWED_FRAME_ANCESTOR_URLS; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13798

## Description

Add `worker-src 'self' blob:` to default CSP in portal nginx configs so Redoc's blob workers aren't blocked.
