### PR TITLE
fix(helm): render upgrader additional plugins

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.11.3
+- Fix API upgrader job rendering when additional plugins are configured.
+
 ### 4.11.2
 - Improve JDBC driver delivery options in the Helm chart:
   - `auto` uses bundled PostgreSQL, MariaDB, and SQL Server drivers, and uses startup download for MySQL and other custom JDBC families

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,4 +29,6 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: 'Fix API upgrader job rendering when additional plugins are configured.'

--- a/helm/templates/api/api-upgrader-job.yaml
+++ b/helm/templates/api/api-upgrader-job.yaml
@@ -88,7 +88,7 @@ spec:
       {{- if .Values.api.additionalPlugins -}}
         {{- $plugins = concat $plugins .Values.api.additionalPlugins -}}
       {{- end -}}
-      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers -}}
+      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers "context" . -}}
       {{- $shouldDownloadJdbcDriver := eq (include "apim.shouldDownloadJdbcDriver" .) "true" -}}
       {{- $shouldCopyJdbcDriverFromImage := eq (include "apim.shouldCopyJdbcDriverFromImage" .) "true" -}}
       {{- $shouldProvisionJdbcDriver := eq (include "apim.shouldProvisionJdbcDriver" .) "true" -}}

--- a/helm/tests/api/job_upgrader_test.yaml
+++ b/helm/tests/api/job_upgrader_test.yaml
@@ -45,6 +45,82 @@ tests:
             name: GRAVITEE_SERVICES_SYNC_ENABLED
             value: "false"
 
+  - it: Should render additional plugins init container
+    template: api/api-upgrader-job.yaml
+    set:
+      api:
+        upgrader: true
+        additionalPlugins:
+          - https://d.g.io/toto.zip
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: get-plugins
+            env: []
+            image: alpine:latest
+            imagePullPolicy: Always
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            command: ['sh', '-c', "mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  toto.zip  2>/dev/null || true ) && wget https://d.g.io/toto.zip"]
+            volumeMounts:
+              - name: graviteeio-apim-plugins
+                mountPath: /tmp/plugins
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: graviteeio-apim-plugins
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: graviteeio-apim-plugins
+
+  - it: Should adapt additional plugins init container security context for OpenShift
+    template: api/api-upgrader-job.yaml
+    set:
+      openshift:
+        enabled: true
+      api:
+        upgrader: true
+        additionalPlugins:
+          - https://d.g.io/toto.zip
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: Should not adapt additional plugins init container security context when disabled
+    template: api/api-upgrader-job.yaml
+    set:
+      openshift:
+        enabled: true
+        adaptSecurityContext: disabled
+      api:
+        upgrader: true
+        additionalPlugins:
+          - https://d.g.io/toto.zip
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1001
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
   - it: Check that alerts have been disabled
     template: api/api-upgrader-job.yaml
     set:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13721

## Description

Fixes Helm rendering for the API upgrader job when `api.upgrader=true` and `api.additionalPlugins` are configured.

The upgrader job now passes the Helm context to the shared plugin init container helper, matching the regular API deployment behavior. This prevents the OpenShift security context helper from failing with a nil `.context.Values` reference.

Added regression tests for:
- rendering additional plugin init containers in the upgrader job
- OpenShift security context adaptation
- disabling OpenShift security context adaptation

## Additional context

Reproduction before the fix:

```sh
helm template test helm \
  --set api.upgrader=true \
  --set api.additionalPlugins[0]=https://example.com/foo.jar \
  --set openshift.enabled=false \
  --set openshift.adaptSecurityContext=disabled \
  --include-crds