### PR TITLE
fix(console): update Toast UI editor import paths and types for better compatibility

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/page/page-editormarkdown.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/page/page-editormarkdown.component.ts
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { EditorOptions, Editor } from '@toast-ui/editor';
-import { ToolbarItemOptions } from '@toast-ui/editor/types/ui';
+import ToastUiEditor from '@toast-ui/editor';
 import codeSyntaxHighlightPlugin from '@toast-ui/editor-plugin-code-syntax-highlight';
 import Prism from 'prismjs';
 import { ActivatedRoute } from '@angular/router';
+
+import type { ToolbarItemOptions } from '@toast-ui/editor/types/ui';
+import type { Editor, EditorOptions } from '@toast-ui/editor';
 
 import NotificationService from '../../../services/notification.service';
 // Step 2. Import language files of prismjs that you need
@@ -115,7 +117,7 @@ class ComponentCtrl implements ng.IComponentController {
       },
       plugins: [[codeSyntaxHighlightPlugin, { highlighter: Prism }]],
     };
-    this.tuiEditor = new Editor(defaultOptions);
+    this.tuiEditor = new ToastUiEditor(defaultOptions);
     this.tuiEditor.addCommand('markdown', 'addLinkToPage', () => {
       this.$mdDialog
         .show({

--- a/gravitee-apim-console-webui/tsconfig.json
+++ b/gravitee-apim-console-webui/tsconfig.json
@@ -9,8 +9,7 @@
       "@gravitee/gravitee-dashboard": ["../gravitee-apim-webui-libs/gravitee-dashboard/src/public-api.ts"],
       "@gravitee/gravitee-kafka-explorer": ["../gravitee-apim-webui-libs/gravitee-kafka-explorer/src/public-api.ts"],
       "@gravitee/gravitee-kafka-explorer/testing": ["../gravitee-apim-webui-libs/gravitee-kafka-explorer/src/testing-public-api.ts"],
-      /* Used in v2 API markdown editor */
-      "@toast-ui/editor": ["../node_modules/@toast-ui/editor/types/index.d.ts"],
+      /* Toolbar types only — package "exports" does not expose ./types/ui */
       "@toast-ui/editor/types/ui": ["../node_modules/@toast-ui/editor/types/ui.d.ts"],
 
       "path": ["../node_modules/path-browserify"],


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13687

## Description

The fix aligns imports/types with Toast UI package export behavior, reducing type-resolution/import compatibility issues in the console markdown editor.


## Additional context

### Pre fix behaviour: 

https://github.com/user-attachments/assets/6641b5dd-d048-4417-8ff3-f6d8481c1f38

### Post fix behaviour: 

https://github.com/user-attachments/assets/c5051fde-d80e-43f2-884d-f5810e661805

