### PR TITLE
fix: api group permissions in portal.

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -1101,9 +1101,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ApiPortalMembershipDomainService apiPortalMembershipDomainService(
         MembershipQueryService membershipQueryService,
-        SubscriptionQueryService subscriptionQueryService
+        SubscriptionQueryService subscriptionQueryService,
+        ApiQueryService apiQueryService
     ) {
-        return new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        return new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService, apiQueryService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiPortalMembershipDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiPortalMembershipDomainService.java
@@ -18,11 +18,16 @@ package io.gravitee.apim.core.membership.domain_service;
 import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiFieldFilter;
+import io.gravitee.apim.core.api.model.ApiSearchCriteria;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
@@ -32,6 +37,7 @@ public class ApiPortalMembershipDomainService {
 
     private final MembershipQueryService membershipQueryService;
     private final SubscriptionQueryService subscriptionQueryService;
+    private final ApiQueryService apiQueryService;
 
     public Set<String> filterApiIdsByUserMembership(String userId, Set<String> candidateApiIds) {
         if (candidateApiIds.isEmpty()) {
@@ -50,12 +56,18 @@ public class ApiPortalMembershipDomainService {
             .map(Membership::getReferenceId)
             .collect(toSet());
 
+        // Group-based API access is stored on the API itself (Api.groups field) when a group is
+        // assigned to an API, not as a GROUP->API Membership record. Match candidate APIs whose
+        // groups intersect the user's groups.
         Set<String> groupApiIds = userGroupIds.isEmpty()
             ? Set.of()
-            : membershipQueryService
-                .findByMemberIdsAndMemberTypeAndReferenceType(userGroupIds, Membership.Type.GROUP, Membership.ReferenceType.API)
-                .stream()
-                .map(Membership::getReferenceId)
+            : apiQueryService
+                .search(
+                    ApiSearchCriteria.builder().ids(List.copyOf(candidateApiIds)).groups(List.copyOf(userGroupIds)).build(),
+                    null,
+                    ApiFieldFilter.builder().pictureExcluded(true).definitionExcluded(true).build()
+                )
+                .map(Api::getId)
                 .collect(toSet());
 
         Set<String> allowed = new HashSet<>(directApiIds);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiQueryServiceInMemory.java
@@ -66,7 +66,12 @@ public class ApiQueryServiceInMemory implements ApiQueryService, InMemoryAlterna
                     isNull(apiCriteria) ||
                     isNull(apiCriteria.getLifecycleStates()) ||
                     apiCriteria.getLifecycleStates().contains(api.getApiLifecycleState());
-                return matchesIntegrationId && matchesApiId && matchesLifecycleState && matchesEnvironmentId;
+                var matchesGroups =
+                    isNull(apiCriteria) ||
+                    isNull(apiCriteria.getGroups()) ||
+                    apiCriteria.getGroups().isEmpty() ||
+                    (api.getGroups() != null && !Collections.disjoint(api.getGroups(), apiCriteria.getGroups()));
+                return (matchesIntegrationId && matchesApiId && matchesLifecycleState && matchesEnvironmentId && matchesGroups);
             })
             .toList();
 
@@ -88,7 +93,8 @@ public class ApiQueryServiceInMemory implements ApiQueryService, InMemoryAlterna
             (apiCriteria.getIntegrationId() != null ||
                 apiCriteria.getIds() != null ||
                 apiCriteria.getDefinitionVersion() != null ||
-                apiCriteria.getEnvironmentId() != null)
+                apiCriteria.getEnvironmentId() != null ||
+                (apiCriteria.getGroups() != null && !apiCriteria.getGroups().isEmpty()))
         ) {
             return this.storage()
                 .stream()
@@ -107,8 +113,17 @@ public class ApiQueryServiceInMemory implements ApiQueryService, InMemoryAlterna
                         apiCriteria.getDefinitionVersion().contains(api.getDefinitionVersion());
                     var matchesEnvironmentId =
                         isNull(apiCriteria.getEnvironmentId()) || apiCriteria.getEnvironmentId().equals(api.getEnvironmentId());
+                    var matchesGroups =
+                        isNull(apiCriteria.getGroups()) ||
+                        apiCriteria.getGroups().isEmpty() ||
+                        (api.getGroups() != null && !Collections.disjoint(api.getGroups(), apiCriteria.getGroups()));
                     return (
-                        matchesIntegrationId && matchesApiId && matchesLifecycleState && matchesApiDefinitionVersion && matchesEnvironmentId
+                        matchesIntegrationId &&
+                        matchesApiId &&
+                        matchesLifecycleState &&
+                        matchesApiDefinitionVersion &&
+                        matchesEnvironmentId &&
+                        matchesGroups
                     );
                 });
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiForPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/GetApiForPortalUseCaseTest.java
@@ -17,9 +17,11 @@ package io.gravitee.apim.core.api.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
@@ -28,6 +30,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -46,10 +49,15 @@ class GetApiForPortalUseCaseTest {
     private PortalNavigationItemsQueryServiceInMemory navQueryService = new PortalNavigationItemsQueryServiceInMemory();
     private MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
     private SubscriptionQueryServiceInMemory subscriptionQueryService = new SubscriptionQueryServiceInMemory();
+    private ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
 
     @BeforeEach
     void setUp() {
-        var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            subscriptionQueryService,
+            apiQueryService
+        );
         useCase = new GetApiForPortalUseCase(new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService));
     }
 
@@ -84,6 +92,30 @@ class GetApiForPortalUseCaseTest {
                     .referenceId(PRIVATE_API_ID)
                     .build()
             )
+        );
+
+        var output = useCase.execute(new GetApiForPortalUseCase.Input(ENV_ID, PRIVATE_API_ID, USER_ID));
+
+        assertThat(output.visible()).isTrue();
+    }
+
+    @Test
+    void should_return_visible_when_api_is_private_and_user_has_access_via_group() {
+        var groupId = "group-1";
+        navQueryService.initWith(List.of(publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE)));
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("membership-" + USER_ID + "-" + groupId)
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.GROUP)
+                    .referenceId(groupId)
+                    .build()
+            )
+        );
+        apiQueryService.initWith(
+            List.of(Api.builder().id(PRIVATE_API_ID).environmentId(ENV_ID).name(PRIVATE_API_ID).groups(Set.of(groupId)).build())
         );
 
         var output = useCase.execute(new GetApiForPortalUseCase.Input(ENV_ID, PRIVATE_API_ID, USER_ID));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/SearchApisForPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/SearchApisForPortalUseCaseTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.api.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import inmemory.ApiPortalSearchQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
@@ -57,7 +58,12 @@ class SearchApisForPortalUseCaseTest {
         membershipQueryService = new MembershipQueryServiceInMemory();
         var subscriptionQueryService = new SubscriptionQueryServiceInMemory();
         apiSearchQueryService = new ApiPortalSearchQueryServiceInMemory();
-        var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        var apiQueryService = new ApiQueryServiceInMemory();
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            subscriptionQueryService,
+            apiQueryService
+        );
         var visibilityDomainService = new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService);
         useCase = new SearchApisForPortalUseCase(visibilityDomainService, apiSearchQueryService);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainServiceTest.java
@@ -17,9 +17,11 @@ package io.gravitee.apim.core.portal_page.domain_service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
@@ -28,6 +30,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -48,13 +51,19 @@ class PortalNavigationApiVisibilityDomainServiceTest {
     private PortalNavigationItemsQueryServiceInMemory navQueryService;
     private MembershipQueryServiceInMemory membershipQueryService;
     private SubscriptionQueryServiceInMemory subscriptionQueryService;
+    private ApiQueryServiceInMemory apiQueryService;
 
     @BeforeEach
     void setUp() {
         navQueryService = new PortalNavigationItemsQueryServiceInMemory();
         membershipQueryService = new MembershipQueryServiceInMemory();
         subscriptionQueryService = new SubscriptionQueryServiceInMemory();
-        var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        apiQueryService = new ApiQueryServiceInMemory();
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            subscriptionQueryService,
+            apiQueryService
+        );
         domainService = new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService);
     }
 
@@ -121,7 +130,8 @@ class PortalNavigationApiVisibilityDomainServiceTest {
                 publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE)
             )
         );
-        membershipQueryService.initWith(List.of(userGroupMembership(USER_ID, groupId), groupApiMembership(groupId, PRIVATE_API_ID)));
+        membershipQueryService.initWith(List.of(userGroupMembership(USER_ID, groupId)));
+        apiQueryService.initWith(List.of(apiWithGroups(PRIVATE_API_ID, Set.of(groupId))));
 
         var result = domainService.resolveVisibleItems(ENV_ID, USER_ID);
 
@@ -129,7 +139,7 @@ class PortalNavigationApiVisibilityDomainServiceTest {
     }
 
     @Test
-    void authenticated_user_whose_group_has_no_api_membership_cannot_see_private_api() {
+    void authenticated_user_whose_group_has_no_api_access_cannot_see_private_api() {
         var groupId = "group-1";
         navQueryService.initWith(
             List.of(
@@ -138,6 +148,7 @@ class PortalNavigationApiVisibilityDomainServiceTest {
             )
         );
         membershipQueryService.initWith(List.of(userGroupMembership(USER_ID, groupId)));
+        apiQueryService.initWith(List.of(apiWithGroups(PRIVATE_API_ID, Set.of("other-group"))));
 
         var result = domainService.resolveVisibleItems(ENV_ID, USER_ID);
 
@@ -220,6 +231,15 @@ class PortalNavigationApiVisibilityDomainServiceTest {
     }
 
     @Test
+    void private_item_is_visible_to_user_via_group() {
+        var groupId = "group-1";
+        membershipQueryService.initWith(List.of(userGroupMembership(USER_ID, groupId)));
+        apiQueryService.initWith(List.of(apiWithGroups(PRIVATE_API_ID, Set.of(groupId))));
+        var item = publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE);
+        assertThat(domainService.isVisibleToUser(item, USER_ID)).isTrue();
+    }
+
+    @Test
     void private_item_is_visible_to_subscriber_user() {
         var appId = "app-1";
         membershipQueryService.initWith(List.of(applicationMembership(USER_ID, appId)));
@@ -253,6 +273,15 @@ class PortalNavigationApiVisibilityDomainServiceTest {
         void private_api_is_visible_to_member_by_id() {
             navQueryService.initWith(List.of(publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE)));
             membershipQueryService.initWith(List.of(apiMembership(USER_ID, PRIVATE_API_ID)));
+            assertThat(domainService.isApiVisibleToUser(ENV_ID, PRIVATE_API_ID, USER_ID)).isTrue();
+        }
+
+        @Test
+        void private_api_is_visible_to_user_via_group_by_id() {
+            var groupId = "group-1";
+            navQueryService.initWith(List.of(publishedApiNavItem(PRIVATE_API_ID, PortalVisibility.PRIVATE)));
+            membershipQueryService.initWith(List.of(userGroupMembership(USER_ID, groupId)));
+            apiQueryService.initWith(List.of(apiWithGroups(PRIVATE_API_ID, Set.of(groupId))));
             assertThat(domainService.isApiVisibleToUser(ENV_ID, PRIVATE_API_ID, USER_ID)).isTrue();
         }
 
@@ -314,14 +343,8 @@ class PortalNavigationApiVisibilityDomainServiceTest {
             .build();
     }
 
-    private Membership groupApiMembership(String groupId, String apiId) {
-        return Membership.builder()
-            .id("membership-" + groupId + "-" + apiId)
-            .memberId(groupId)
-            .memberType(Membership.Type.GROUP)
-            .referenceType(Membership.ReferenceType.API)
-            .referenceId(apiId)
-            .build();
+    private Api apiWithGroups(String apiId, Set<String> groups) {
+        return Api.builder().id(apiId).environmentId(ENV_ID).name(apiId).groups(groups).build();
     }
 
     private Membership applicationMembership(String userId, String appId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.portal_page.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import inmemory.ApiPortalSearchQueryServiceInMemory;
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
@@ -59,7 +60,12 @@ class GetVisiblePortalNavigationApisUseCaseTest {
         membershipQueryService = new MembershipQueryServiceInMemory();
         apiSearchQueryService = new ApiPortalSearchQueryServiceInMemory();
         var subscriptionQueryService = new SubscriptionQueryServiceInMemory();
-        var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        var apiQueryService = new ApiQueryServiceInMemory();
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            subscriptionQueryService,
+            apiQueryService
+        );
         var visibilityDomainService = new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService);
         useCase = new GetVisiblePortalNavigationApisUseCase(visibilityDomainService, apiSearchQueryService);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/GetSubscriptionFormForApiPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription_form/use_case/GetSubscriptionFormForApiPortalUseCaseTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.core.model.SubscriptionFormFixtures;
+import inmemory.ApiQueryServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.SubscriptionFormElResolverInMemory;
@@ -53,6 +54,7 @@ class GetSubscriptionFormForApiPortalUseCaseTest {
     private final PortalNavigationItemsQueryServiceInMemory navQueryService = new PortalNavigationItemsQueryServiceInMemory();
     private final MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
     private final SubscriptionQueryServiceInMemory subscriptionQueryService = new SubscriptionQueryServiceInMemory();
+    private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory();
     private final SubscriptionFormQueryServiceInMemory queryService = new SubscriptionFormQueryServiceInMemory();
     private final SubscriptionFormElResolverInMemory elResolver = new SubscriptionFormElResolverInMemory();
     private final SubscriptionFormSchemaGeneratorImpl schemaGenerator = new SubscriptionFormSchemaGeneratorImpl();
@@ -63,10 +65,15 @@ class GetSubscriptionFormForApiPortalUseCaseTest {
         navQueryService.reset();
         membershipQueryService.reset();
         subscriptionQueryService.reset();
+        apiQueryService.reset();
         queryService.reset();
         elResolver.reset();
 
-        var apiMembershipDomainService = new ApiPortalMembershipDomainService(membershipQueryService, subscriptionQueryService);
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            subscriptionQueryService,
+            apiQueryService
+        );
         var visibility = new PortalNavigationApiVisibilityDomainService(navQueryService, apiMembershipDomainService);
         useCase = new GetSubscriptionFormForApiPortalUseCase(visibility, queryService, schemaGenerator, elResolver);
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13728

## Description

Private APIs in the portal catalog now take into account **group-based access** via the API **`groups`** field: a user can see an API when their groups **intersect** the API’s groups (alongside direct `USER → API` membership and unchanged subscription behavior).

## Implementation

**`ApiPortalMembershipDomainService`**: loads group access through `ApiQueryService.search` using **`ApiSearchCriteria`** with both **`ids`** (candidates) and **`groups`** (the user’s group ids), so storage applies the intersection in the query.


https://github.com/user-attachments/assets/e6c242ec-1a8c-449f-b04a-233347d642d4


