### PR TITLE
feat(portal): add analytics dashboards endpoints

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalAnalyticsDashboardMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalAnalyticsDashboardMapper.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.dashboard.model.Dashboard;
+import io.gravitee.apim.core.dashboard.model.DashboardWidget;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsDashboard;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFilter;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMetricRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeRange;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsWidget;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsWidgetLayout;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsWidgetRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsWidgetType;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Mapper(uses = DateMapper.class)
+public interface PortalAnalyticsDashboardMapper {
+    PortalAnalyticsDashboardMapper INSTANCE = Mappers.getMapper(PortalAnalyticsDashboardMapper.class);
+
+    @BeanMapping(ignoreUnmappedSourceProperties = "environmentId")
+    AnalyticsDashboard toDto(Dashboard dashboard);
+
+    List<AnalyticsDashboard> toDto(List<Dashboard> dashboards);
+
+    default OffsetDateTime map(java.time.ZonedDateTime value) {
+        return value == null ? null : value.toOffsetDateTime();
+    }
+
+    default AnalyticsWidgetType mapWidgetType(String type) {
+        return type == null ? null : AnalyticsWidgetType.fromValue(type);
+    }
+
+    AnalyticsWidget map(DashboardWidget widget);
+
+    AnalyticsWidgetLayout map(DashboardWidget.Layout layout);
+
+    AnalyticsWidgetRequest map(DashboardWidget.Request request);
+
+    AnalyticsTimeRange map(DashboardWidget.TimeRange timeRange);
+
+    AnalyticsMetricRequest map(DashboardWidget.MetricRequest metric);
+
+    AnalyticsFilter map(DashboardWidget.Filter filter);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/EnvironmentsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/EnvironmentsResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.rest.api.portal.rest.resource.analytics.PortalAnalyticsResource;
 import io.gravitee.rest.api.portal.rest.resource.v4.endpoint.EndpointsResource;
 import io.gravitee.rest.api.portal.rest.resource.v4.entrypoint.EntrypointsResource;
 import jakarta.ws.rs.Path;
@@ -54,6 +55,11 @@ public class EnvironmentsResource extends AbstractResource {
     @Path("configuration")
     public ConfigurationResource getConfigurationResource() {
         return resourceContext.getResource(ConfigurationResource.class);
+    }
+
+    @Path("analytics")
+    public PortalAnalyticsResource getPortalAnalyticsResource() {
+        return resourceContext.getResource(PortalAnalyticsResource.class);
     }
 
     @Path("dashboards")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsDashboardResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsDashboardResource.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource.analytics;
+
+import io.gravitee.apim.core.dashboard.exception.DashboardNotFoundException;
+import io.gravitee.apim.core.dashboard.use_case.GetDashboardUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.portal.rest.mapper.PortalAnalyticsDashboardMapper;
+import io.gravitee.rest.api.portal.rest.resource.AbstractResource;
+import io.gravitee.rest.api.service.ParameterService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import java.util.Objects;
+
+/**
+ * Story 2 (APIM-12689): {@code GET /portal/environments/{envId}/analytics/dashboards/{dashboardId}} using {@link GetDashboardUseCase},
+ * gated by {@link io.gravitee.rest.api.model.parameters.Key#PORTAL_NEXT_ANALYTICS_ENABLED}.
+ *
+ * @author GraviteeSource Team
+ */
+public class PortalAnalyticsDashboardResource extends AbstractResource<Object, Object> {
+
+    @PathParam("dashboardId")
+    private String dashboardId;
+
+    @Inject
+    private GetDashboardUseCase getDashboardUseCase;
+
+    @Inject
+    private ParameterService parameterService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getDashboard() {
+        PortalAnalyticsGate.requireAnalyticsEnabled(parameterService);
+
+        var executionContext = GraviteeContext.getExecutionContext();
+        var dashboard = getDashboardUseCase.execute(new GetDashboardUseCase.Input(dashboardId)).dashboard();
+
+        if (!Objects.equals(dashboard.getEnvironmentId(), executionContext.getEnvironmentId())) {
+            throw new DashboardNotFoundException(dashboardId);
+        }
+
+        return Response.ok(PortalAnalyticsDashboardMapper.INSTANCE.toDto(dashboard)).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsDashboardsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsDashboardsResource.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource.analytics;
+
+import io.gravitee.apim.core.dashboard.model.Dashboard;
+import io.gravitee.apim.core.dashboard.use_case.ListDashboardsUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.portal.rest.mapper.PortalAnalyticsDashboardMapper;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsDashboard;
+import io.gravitee.rest.api.portal.rest.resource.AbstractResource;
+import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
+import io.gravitee.rest.api.service.ParameterService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Story 2 (APIM-12689): {@code GET /portal/environments/{envId}/analytics/dashboards} — paginated list using {@link ListDashboardsUseCase},
+ * gated by {@link io.gravitee.rest.api.model.parameters.Key#PORTAL_NEXT_ANALYTICS_ENABLED}.
+ *
+ * @author GraviteeSource Team
+ */
+public class PortalAnalyticsDashboardsResource extends AbstractResource<AnalyticsDashboard, Dashboard> {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private ListDashboardsUseCase listDashboardsUseCase;
+
+    @Inject
+    private ParameterService parameterService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listDashboards(@BeanParam PaginationParam paginationParam) {
+        PortalAnalyticsGate.requireAnalyticsEnabled(parameterService);
+
+        var executionContext = GraviteeContext.getExecutionContext();
+        var dashboards = listDashboardsUseCase.execute(new ListDashboardsUseCase.Input(executionContext.getEnvironmentId())).dashboards();
+
+        if (!paginationParam.hasPagination()) {
+            return createListResponse(executionContext, dashboards, PaginationParam.builder().page(1).size(dashboards.size()).build());
+        }
+
+        return createListResponse(executionContext, dashboards, paginationParam);
+    }
+
+    @Override
+    protected List<AnalyticsDashboard> transformPageContent(ExecutionContext executionContext, List<Dashboard> pageContent) {
+        if (pageContent.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return PortalAnalyticsDashboardMapper.INSTANCE.toDto(pageContent);
+    }
+
+    @Path("{dashboardId}")
+    public PortalAnalyticsDashboardResource getDashboardResource() {
+        return resourceContext.getResource(PortalAnalyticsDashboardResource.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsGate.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsGate.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource.analytics;
+
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.ParameterService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
+
+/**
+ * Ensures portal analytics REST endpoints honor {@link Key#PORTAL_NEXT_ANALYTICS_ENABLED}.
+ */
+final class PortalAnalyticsGate {
+
+    private PortalAnalyticsGate() {}
+
+    static void requireAnalyticsEnabled(ParameterService parameterService) {
+        if (
+            !parameterService.findAsBoolean(
+                GraviteeContext.getExecutionContext(),
+                Key.PORTAL_NEXT_ANALYTICS_ENABLED,
+                ParameterReferenceType.ENVIRONMENT
+            )
+        ) {
+            throw new ForbiddenAccessException();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsResource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource.analytics;
+
+import io.gravitee.rest.api.portal.rest.resource.AbstractResource;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalAnalyticsResource extends AbstractResource<Object, Object> {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Path("dashboards")
+    public PortalAnalyticsDashboardsResource getDashboardsResource() {
+        return resourceContext.getResource(PortalAnalyticsDashboardsResource.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3184,6 +3184,64 @@ paths:
                 500:
                     $ref: "#/components/responses/InternalServerError"
 
+    /analytics/dashboards:
+        get:
+            tags:
+                - Analytics
+            summary: Get analytics dashboards
+            description: |
+                Get the list of analytics dashboards available in the current environment.
+            operationId: getAnalyticsDashboards
+            security:
+                - BasicAuth: []
+                - CookieAuth: []
+            parameters:
+                - $ref: "#/components/parameters/pageNumberParam"
+                - $ref: "#/components/parameters/pageSizeParam"
+            responses:
+                200:
+                    description: List of analytics dashboards
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AnalyticsDashboardsResponse"
+                403:
+                    $ref: "#/components/responses/UnauthorizedError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+
+    /analytics/dashboards/{dashboardId}:
+        get:
+            tags:
+                - Analytics
+            summary: Get an analytics dashboard
+            description: |
+                Get the full definition of a single analytics dashboard.
+            operationId: getAnalyticsDashboard
+            security:
+                - BasicAuth: []
+                - CookieAuth: []
+            parameters:
+                - name: dashboardId
+                  in: path
+                  required: true
+                  description: The analytics dashboard identifier.
+                  schema:
+                      type: string
+            responses:
+                200:
+                    description: Analytics dashboard
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AnalyticsDashboard"
+                403:
+                    $ref: "#/components/responses/UnauthorizedError"
+                404:
+                    $ref: "#/components/responses/NotFoundError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+
     /auth/login:
         post:
             tags:
@@ -5485,6 +5543,146 @@ components:
                     type: string
                 definition:
                     type: string
+        AnalyticsDashboardsResponse:
+            properties:
+                data:
+                    description: List of analytics dashboards.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsDashboard"
+                metadata:
+                    $ref: "#/components/schemas/MetadataMap"
+                links:
+                    $ref: "#/components/schemas/Links"
+        AnalyticsDashboard:
+            properties:
+                id:
+                    description: Unique identifier of an analytics dashboard.
+                    type: string
+                name:
+                    description: Display name of the dashboard.
+                    type: string
+                createdBy:
+                    description: Identifier of the user who created the dashboard.
+                    type: string
+                createdAt:
+                    description: Creation timestamp of the dashboard.
+                    type: string
+                    format: date-time
+                lastModified:
+                    description: Last modification timestamp of the dashboard.
+                    type: string
+                    format: date-time
+                labels:
+                    description: Key-value labels attached to the dashboard.
+                    type: object
+                    additionalProperties:
+                        type: string
+                widgets:
+                    description: Widgets displayed on the dashboard.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsWidget"
+        AnalyticsWidget:
+            properties:
+                id:
+                    type: string
+                title:
+                    type: string
+                description:
+                    type: string
+                type:
+                    $ref: "#/components/schemas/AnalyticsWidgetType"
+                layout:
+                    $ref: "#/components/schemas/AnalyticsWidgetLayout"
+                request:
+                    $ref: "#/components/schemas/AnalyticsWidgetRequest"
+        AnalyticsWidgetLayout:
+            properties:
+                cols:
+                    type: integer
+                    format: int32
+                rows:
+                    type: integer
+                    format: int32
+                x:
+                    type: integer
+                    format: int32
+                y:
+                    type: integer
+                    format: int32
+        AnalyticsWidgetRequest:
+            properties:
+                type:
+                    description: Request type used by the widget.
+                    type: string
+                timeRange:
+                    $ref: "#/components/schemas/AnalyticsTimeRange"
+                metrics:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsMetricRequest"
+                interval:
+                    description: Interval in milliseconds for time-series widgets.
+                    type: integer
+                    format: int64
+                by:
+                    description: Facets used to group analytics data.
+                    type: array
+                    items:
+                        type: string
+                limit:
+                    description: Maximum number of buckets to return.
+                    type: integer
+                    format: int32
+                filters:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFilter"
+        AnalyticsTimeRange:
+            properties:
+                from:
+                    type: string
+                    format: date-time
+                to:
+                    type: string
+                    format: date-time
+        AnalyticsMetricRequest:
+            properties:
+                name:
+                    description: Analytics metric identifier.
+                    type: string
+                measures:
+                    description: Measures requested for the metric.
+                    type: array
+                    items:
+                        type: string
+                filters:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFilter"
+        AnalyticsFilter:
+            properties:
+                name:
+                    description: Analytics filter identifier.
+                    type: string
+                operator:
+                    description: Operator applied to the filter.
+                    type: string
+                value:
+                    description: Value applied to the filter.
+                    type: object
+        AnalyticsWidgetType:
+            type: string
+            enum:
+                - stats
+                - doughnut
+                - pie
+                - polarArea
+                - time-series-line
+                - time-series-bar
+                - vertical-bar
+                - horizontal-bar
         Info:
             properties:
                 name:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalAnalyticsDashboardsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalAnalyticsDashboardsResourceTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.dashboard.exception.DashboardNotFoundException;
+import io.gravitee.apim.core.dashboard.model.Dashboard;
+import io.gravitee.apim.core.dashboard.model.DashboardWidget;
+import io.gravitee.apim.core.dashboard.use_case.GetDashboardUseCase;
+import io.gravitee.apim.core.dashboard.use_case.ListDashboardsUseCase;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsDashboard;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsDashboardsResponse;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Story 2 — Portal backend: dashboard list and detail endpoints (see APIM-12689 implementation plan).
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayName("Story 2 — Portal analytics dashboards")
+public class PortalAnalyticsDashboardsResourceTest extends AbstractResourceTest {
+
+    @Autowired
+    private ListDashboardsUseCase listDashboardsUseCase;
+
+    @Autowired
+    private GetDashboardUseCase getDashboardUseCase;
+
+    @Override
+    protected String contextPath() {
+        return "analytics/dashboards";
+    }
+
+    @BeforeEach
+    void setUp() {
+        resetAllMocks();
+        reset(listDashboardsUseCase, getDashboardUseCase);
+        when(
+            parameterService.findAsBoolean(any(), eq(Key.PORTAL_NEXT_ANALYTICS_ENABLED), eq(ParameterReferenceType.ENVIRONMENT))
+        ).thenReturn(true);
+    }
+
+    @Nested
+    @DisplayName("Acceptance: GET /portal/environments/{envId}/analytics/dashboards returns paginated dashboard list")
+    class PaginatedDashboardList {
+
+        @Test
+        @DisplayName("returns data, pagination metadata, and links; delegates to ListDashboardsUseCase")
+        void returnsPaginatedList() {
+            when(listDashboardsUseCase.execute(any())).thenReturn(
+                new ListDashboardsUseCase.Output(
+                    List.of(aDashboard("dashboard-1", "Dashboard 1"), aDashboard("dashboard-2", "Dashboard 2"))
+                )
+            );
+
+            final var response = target().queryParam("page", 1).queryParam("size", 10).request().get();
+
+            assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+            final var dashboardsResponse = response.readEntity(AnalyticsDashboardsResponse.class);
+            assertEquals(2, dashboardsResponse.getData().size());
+            assertEquals("dashboard-1", dashboardsResponse.getData().get(0).getId());
+            assertEquals("Dashboard 2", dashboardsResponse.getData().get(1).getName());
+            assertNotNull(dashboardsResponse.getMetadata());
+            assertNotNull(dashboardsResponse.getLinks());
+
+            verify(listDashboardsUseCase).execute(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Acceptance: GET /portal/environments/{envId}/analytics/dashboards/{dashboardId} returns single dashboard")
+    class SingleDashboard {
+
+        @Test
+        @DisplayName("returns dashboard body; delegates to GetDashboardUseCase")
+        void returnsOneDashboard() {
+            when(getDashboardUseCase.execute(any())).thenReturn(new GetDashboardUseCase.Output(aDashboard("dashboard-1", "Dashboard 1")));
+
+            final var response = target().path("dashboard-1").request().get();
+
+            assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+            final var dashboard = response.readEntity(AnalyticsDashboard.class);
+            assertEquals("dashboard-1", dashboard.getId());
+            assertEquals("Dashboard 1", dashboard.getName());
+            assertEquals("stats", dashboard.getWidgets().get(0).getType().getValue());
+
+            verify(getDashboardUseCase).execute(any());
+        }
+
+        @Test
+        @DisplayName("404 when dashboard does not exist")
+        void notFoundWhenMissing() {
+            when(getDashboardUseCase.execute(any())).thenThrow(new DashboardNotFoundException("missing-dashboard"));
+
+            final var response = target().path("missing-dashboard").request().get();
+
+            assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+        }
+
+        @Test
+        @DisplayName("404 when dashboard belongs to another environment")
+        void notFoundWhenWrongEnvironment() {
+            when(getDashboardUseCase.execute(any())).thenReturn(
+                new GetDashboardUseCase.Output(aDashboard("dashboard-1", "Dashboard 1").toBuilder().environmentId("OTHER").build())
+            );
+
+            final var response = target().path("dashboard-1").request().get();
+
+            assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+        }
+    }
+
+    @Nested
+    @DisplayName("Acceptance: endpoints gated by analytics-enabled setting")
+    class GatedByAnalyticsSetting {
+
+        @BeforeEach
+        void analyticsDisabled() {
+            when(
+                parameterService.findAsBoolean(any(), eq(Key.PORTAL_NEXT_ANALYTICS_ENABLED), eq(ParameterReferenceType.ENVIRONMENT))
+            ).thenReturn(false);
+        }
+
+        @Test
+        @DisplayName("403 on dashboard list when PORTAL_NEXT_ANALYTICS_ENABLED is false")
+        void forbiddenOnList() {
+            final var response = target().request().get();
+
+            assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+            verify(listDashboardsUseCase, never()).execute(any());
+        }
+
+        @Test
+        @DisplayName("403 on dashboard by id when PORTAL_NEXT_ANALYTICS_ENABLED is false")
+        void forbiddenOnGetById() {
+            final var response = target().path("dashboard-1").request().get();
+
+            assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+            verify(getDashboardUseCase, never()).execute(any());
+        }
+    }
+
+    private static Dashboard aDashboard(String id, String name) {
+        return Dashboard.builder()
+            .id(id)
+            .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+            .name(name)
+            .createdBy("user-1")
+            .createdAt(ZonedDateTime.parse("2025-10-07T06:50:30Z"))
+            .lastModified(ZonedDateTime.parse("2025-12-07T11:35:30Z"))
+            .labels(Map.of("team", "apim"))
+            .widgets(
+                List.of(
+                    DashboardWidget.builder()
+                        .id("widget-1")
+                        .title("Requests")
+                        .type("stats")
+                        .layout(DashboardWidget.Layout.builder().cols(1).rows(1).x(0).y(0).build())
+                        .request(
+                            DashboardWidget.Request.builder()
+                                .type("measures")
+                                .timeRange(
+                                    DashboardWidget.TimeRange.builder()
+                                        .from(Instant.parse("2025-10-07T06:50:30Z"))
+                                        .to(Instant.parse("2025-12-07T11:35:30Z"))
+                                        .build()
+                                )
+                                .metrics(
+                                    List.of(
+                                        DashboardWidget.MetricRequest.builder().name("HTTP_REQUESTS").measures(List.of("COUNT")).build()
+                                    )
+                                )
+                                .build()
+                        )
+                        .build()
+                )
+            )
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -93,6 +93,8 @@ import io.gravitee.apim.core.cluster.use_case.members.GetClusterMembersUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.GetClusterPermissionsUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.TransferClusterOwnershipUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.UpdateClusterMemberUseCase;
+import io.gravitee.apim.core.dashboard.use_case.GetDashboardUseCase;
+import io.gravitee.apim.core.dashboard.use_case.ListDashboardsUseCase;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDomainService;
 import io.gravitee.apim.core.group.crud_service.GroupCrudService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
@@ -1262,6 +1264,16 @@ public class ResourceContextConfiguration {
     @Bean
     public FilterValueNameResolver filterValueNameResolver() {
         return mock(FilterValueNameResolver.class);
+    }
+
+    @Bean
+    public ListDashboardsUseCase listDashboardsUseCase() {
+        return mock(ListDashboardsUseCase.class);
+    }
+
+    @Bean
+    public GetDashboardUseCase getDashboardUseCase() {
+        return mock(GetDashboardUseCase.class);
     }
 
     @Bean


### PR DESCRIPTION
Introduce new REST endpoints for managing analytics dashboards, including paginated list retrieval (`GET /portal/environments/{envId}/analytics/dashboards`) and single dashboard retrieval (`GET /portal/environments/{envId}/analytics/dashboards/{dashboardId}`). Add authorization gating based on `PORTAL_NEXT_ANALYTICS_ENABLED` setting and update OpenAPI spec. Includes implementation, mapper, and comprehensive tests.

## Issue

https://gravitee.atlassian.net/browse/APIM-13614

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

