### PR TITLE
fix: take into account api permissions for nav items visibility.

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -146,6 +146,7 @@ import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudSe
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiPortalPageContentValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
@@ -1140,9 +1141,10 @@ public class ResourceContextConfiguration {
 
     @Bean
     public ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase(
-        PortalNavigationItemsQueryService portalNavigationItemsQueryService
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService
     ) {
-        return new ListPortalNavigationItemsUseCase(portalNavigationItemsQueryService);
+        return new ListPortalNavigationItemsUseCase(portalNavigationItemsQueryService, portalNavigationApiVisibilityDomainService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
@@ -50,7 +50,7 @@ public class PortalNavigationItemResource extends AbstractResource {
             new GetPortalNavigationItemUseCase.Input(
                 PortalNavigationItemId.of(portalNavigationItemId),
                 executionContext.getEnvironmentId(),
-                PortalNavigationItemViewerContext.forPortal(isAuthenticated())
+                PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull())
             )
         );
 
@@ -67,7 +67,7 @@ public class PortalNavigationItemResource extends AbstractResource {
             new GetPortalPageContentByNavigationIdUseCase.Input(
                 portalNavigationItemId,
                 executionContext.getEnvironmentId(),
-                PortalNavigationItemViewerContext.forPortal(isAuthenticated())
+                PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull())
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemsResource.java
@@ -79,7 +79,7 @@ public class PortalNavigationItemsResource extends AbstractResource {
             portalNavigationItemMapper.map(area),
             Optional.ofNullable(parentId).map(PortalNavigationItemId::of),
             loadChildren,
-            PortalNavigationItemViewerContext.forPortal(isAuthenticated())
+            PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull())
         );
         var output = listPortalNavigationItemsUseCase.execute(input);
         return Response.ok(portalNavigationItemMapper.map(output.items())).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -1078,9 +1078,10 @@ public class ResourceContextConfiguration {
 
     @Bean
     public ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase(
-        PortalNavigationItemsQueryService portalNavigationItemsQueryService
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService,
+        PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService
     ) {
-        return new ListPortalNavigationItemsUseCase(portalNavigationItemsQueryService);
+        return new ListPortalNavigationItemsUseCase(portalNavigationItemsQueryService, portalNavigationApiVisibilityDomainService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationApiVisibilityDomainService.java
@@ -18,8 +18,10 @@ package io.gravitee.apim.core.portal_page.domain_service;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import jakarta.annotation.Nullable;
@@ -121,5 +123,46 @@ public class PortalNavigationApiVisibilityDomainService {
             !apiMembershipDomainService.filterApiIdsByUserMembership(userId, candidate).isEmpty() ||
             !apiMembershipDomainService.filterAllowedApiIdsBySubscription(userId, candidate).isEmpty()
         );
+    }
+
+    /**
+     * Returns {@code true} when the given API navigation item must be hidden from the viewer,
+     * applying portal visibility (PUBLIC / PRIVATE) and, for authenticated users, API
+     * membership and subscription-based access rules. Mirrors the logic used by the catalog
+     * endpoint so navigation and catalog expose the same set of APIs.
+     */
+    public boolean isApiItemHidden(PortalNavigationApi item, PortalNavigationItemViewerContext viewerContext) {
+        if (!viewerContext.isPortalMode()) {
+            return false;
+        }
+        if (PortalVisibility.PUBLIC.equals(item.getVisibility())) {
+            return false;
+        }
+        if (!viewerContext.isAuthenticated()) {
+            return true;
+        }
+        return viewerContext
+            .userId()
+            .map(uid -> !isVisibleToUser(item, uid))
+            .orElse(true);
+    }
+
+    /**
+     * Walks the parent chain of the given item and returns {@code true} if any ancestor is a
+     * {@link PortalNavigationApi} hidden from the viewer. Used to prevent direct access (by id)
+     * to descendants of an API navigation item the viewer cannot see.
+     */
+    public boolean hasHiddenApiAncestor(String environmentId, PortalNavigationItem item, PortalNavigationItemViewerContext viewerContext) {
+        if (!viewerContext.isPortalMode()) {
+            return false;
+        }
+        PortalNavigationItem current = item;
+        while (current != null && current.getParentId() != null) {
+            current = queryService.findByIdAndEnvironmentId(environmentId, current.getParentId());
+            if (current instanceof PortalNavigationApi apiAncestor && isApiItemHidden(apiAncestor, viewerContext)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemViewerContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalNavigationItemViewerContext.java
@@ -16,23 +16,33 @@
 package io.gravitee.apim.core.portal_page.model;
 
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import jakarta.annotation.Nullable;
+import java.util.Optional;
 
 public class PortalNavigationItemViewerContext {
 
     private final boolean isPortalMode;
     private final boolean isAuthenticated;
 
-    private PortalNavigationItemViewerContext(boolean isAuthenticated, boolean isPortalView) {
+    @Nullable
+    private final String userId;
+
+    private PortalNavigationItemViewerContext(boolean isAuthenticated, boolean isPortalView, @Nullable String userId) {
         this.isAuthenticated = isAuthenticated;
         this.isPortalMode = isPortalView;
+        this.userId = userId;
     }
 
     public static PortalNavigationItemViewerContext forPortal(boolean isAuthenticated) {
-        return new PortalNavigationItemViewerContext(isAuthenticated, true);
+        return new PortalNavigationItemViewerContext(isAuthenticated, true, null);
+    }
+
+    public static PortalNavigationItemViewerContext forPortal(@Nullable String userId) {
+        return new PortalNavigationItemViewerContext(userId != null, true, userId);
     }
 
     public static PortalNavigationItemViewerContext forConsole() {
-        return new PortalNavigationItemViewerContext(true, false);
+        return new PortalNavigationItemViewerContext(true, false, null);
     }
 
     public boolean isPortalMode() {
@@ -41,6 +51,10 @@ public class PortalNavigationItemViewerContext {
 
     public boolean isAuthenticated() {
         return this.isAuthenticated;
+    }
+
+    public Optional<String> userId() {
+        return Optional.ofNullable(this.userId);
     }
 
     public boolean shouldNotShow(PortalNavigationItem item) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCase.java
@@ -16,7 +16,9 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
@@ -29,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class GetPortalNavigationItemUseCase {
 
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
 
     public Output execute(Input input) {
         final PortalNavigationItem foundItem = Optional.ofNullable(
@@ -36,6 +39,14 @@ public class GetPortalNavigationItemUseCase {
         ).orElseThrow(() -> new PortalNavigationItemNotFoundException(input.portalNavigationItemId().id().toString()));
 
         input.viewerContext().validateAccess(foundItem);
+
+        if (foundItem instanceof PortalNavigationApi api && apiVisibilityDomainService.isApiItemHidden(api, input.viewerContext())) {
+            throw new PortalNavigationItemNotFoundException(foundItem.getId().json());
+        }
+
+        if (apiVisibilityDomainService.hasHiddenApiAncestor(input.environmentId(), foundItem, input.viewerContext())) {
+            throw new PortalNavigationItemNotFoundException(foundItem.getId().json());
+        }
 
         return new Output(foundItem);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
@@ -16,9 +16,11 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
@@ -36,6 +38,7 @@ public class GetPortalPageContentByNavigationIdUseCase {
 
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
     private final PortalPageContentQueryService portalPageContentQueryService;
+    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
 
     public Output execute(Input input) {
         // Get the portal navigation item by id and env id
@@ -47,6 +50,17 @@ public class GetPortalPageContentByNavigationIdUseCase {
         ).orElseThrow(() -> new PortalNavigationItemNotFoundException(input.portalNavigationItemId()));
 
         input.viewerContext().validateAccess(portalNavigationItem);
+
+        if (
+            portalNavigationItem instanceof PortalNavigationApi api &&
+            apiVisibilityDomainService.isApiItemHidden(api, input.viewerContext())
+        ) {
+            throw new PortalNavigationItemNotFoundException(portalNavigationItem.getId().json());
+        }
+
+        if (apiVisibilityDomainService.hasHiddenApiAncestor(input.environmentId(), portalNavigationItem, input.viewerContext())) {
+            throw new PortalNavigationItemNotFoundException(portalNavigationItem.getId().json());
+        }
 
         // If the nav item is not a page, throw exception
         if (!(portalNavigationItem instanceof PortalNavigationPage page)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCase.java
@@ -16,7 +16,9 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemComparator;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
@@ -37,6 +39,7 @@ import lombok.RequiredArgsConstructor;
 public class ListPortalNavigationItemsUseCase {
 
     private final PortalNavigationItemsQueryService queryService;
+    private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
     private static final Predicate<PortalNavigationItem> IS_CONTAINER_PREDICATE = i -> i instanceof PortalNavigationItemContainer;
 
     public Output execute(Input input) {
@@ -68,6 +71,19 @@ public class ListPortalNavigationItemsUseCase {
         }
 
         if (input.viewerContext().shouldNotShow(parent)) {
+            return null;
+        }
+
+        // The parent itself may be an API navigation item the viewer cannot see (private API,
+        // user is not a member/subscriber). In that case none of its descendants must be exposed.
+        if (parent instanceof PortalNavigationApi api && apiVisibilityDomainService.isApiItemHidden(api, input.viewerContext())) {
+            return null;
+        }
+
+        // The parent may also be a descendant of a hidden API navigation item. Walk up to make sure
+        // no ancestor API is hidden; otherwise descendants of an API the viewer cannot access would
+        // still be reachable by navigating to them directly.
+        if (apiVisibilityDomainService.hasHiddenApiAncestor(input.environmentId(), parent, input.viewerContext())) {
             return null;
         }
 
@@ -113,7 +129,23 @@ public class ListPortalNavigationItemsUseCase {
             }
         }
 
-        return queryService.search(builder.build());
+        List<PortalNavigationItem> items = queryService.search(builder.build());
+        return filterHiddenApis(items, input.viewerContext());
+    }
+
+    /**
+     * Drops {@link PortalNavigationApi} items the viewer must not see. When an API navigation
+     * item is dropped here it is also not enqueued by the BFS in {@link #loadDescendants},
+     * so its descendants are naturally excluded from the result.
+     */
+    private List<PortalNavigationItem> filterHiddenApis(List<PortalNavigationItem> items, PortalNavigationItemViewerContext viewerContext) {
+        if (!viewerContext.isPortalMode()) {
+            return items;
+        }
+        return items
+            .stream()
+            .filter(i -> !(i instanceof PortalNavigationApi api) || !apiVisibilityDomainService.isApiItemHidden(api, viewerContext))
+            .toList();
     }
 
     private List<PortalNavigationItem> sortItems(List<PortalNavigationItem> items) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalNavigationItemUseCaseTest.java
@@ -23,7 +23,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
@@ -42,7 +47,15 @@ class GetPortalNavigationItemUseCaseTest {
     @BeforeEach
     void setUp() {
         PortalNavigationItemsQueryServiceInMemory queryService = new PortalNavigationItemsQueryServiceInMemory();
-        useCase = new GetPortalNavigationItemUseCase(queryService);
+        var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(
+            queryService,
+            new ApiPortalMembershipDomainService(
+                new MembershipQueryServiceInMemory(),
+                new SubscriptionQueryServiceInMemory(),
+                new ApiQueryServiceInMemory()
+            )
+        );
+        useCase = new GetPortalNavigationItemUseCase(queryService, apiVisibilityDomainService);
 
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
@@ -22,8 +22,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import fixtures.core.model.PortalPageContentFixtures;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
@@ -51,7 +56,19 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
     void setUp() {
         PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
         pageContentQueryService = new PortalPageContentQueryServiceInMemory();
-        useCase = new GetPortalPageContentByNavigationIdUseCase(navigationItemsQueryService, pageContentQueryService);
+        var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(
+            navigationItemsQueryService,
+            new ApiPortalMembershipDomainService(
+                new MembershipQueryServiceInMemory(),
+                new SubscriptionQueryServiceInMemory(),
+                new ApiQueryServiceInMemory()
+            )
+        );
+        useCase = new GetPortalPageContentByNavigationIdUseCase(
+            navigationItemsQueryService,
+            pageContentQueryService,
+            apiVisibilityDomainService
+        );
 
         // Create page contents first with known IDs
         var supportContentId = PortalPageContentId.of(PortalNavigationItemFixtures.SUPPORT_CONTENT_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ListPortalNavigationItemsUseCaseTest.java
@@ -20,7 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiQueryServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -39,11 +44,23 @@ class ListPortalNavigationItemsUseCaseTest {
 
     private ListPortalNavigationItemsUseCase useCase;
     private PortalNavigationItemsQueryServiceInMemory queryService;
+    private MembershipQueryServiceInMemory membershipQueryService;
+    private SubscriptionQueryServiceInMemory subscriptionQueryService;
+    private ApiQueryServiceInMemory apiQueryService;
 
     @BeforeEach
     void setUp() {
         queryService = new PortalNavigationItemsQueryServiceInMemory();
-        useCase = new ListPortalNavigationItemsUseCase(queryService);
+        membershipQueryService = new MembershipQueryServiceInMemory();
+        subscriptionQueryService = new SubscriptionQueryServiceInMemory();
+        apiQueryService = new ApiQueryServiceInMemory();
+        var apiMembershipDomainService = new ApiPortalMembershipDomainService(
+            membershipQueryService,
+            subscriptionQueryService,
+            apiQueryService
+        );
+        var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(queryService, apiMembershipDomainService);
+        useCase = new ListPortalNavigationItemsUseCase(queryService, apiVisibilityDomainService);
 
         queryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
     }
@@ -368,6 +385,186 @@ class ListPortalNavigationItemsUseCaseTest {
 
         // Then
         assertThat(result.items()).hasSize(1).extracting(PortalNavigationItem::getTitle).containsExactly("Public Page");
+    }
+
+    @Test
+    void should_hide_private_api_nav_item_from_authenticated_non_member() {
+        // Given a private API nav item and an authenticated user that is neither a member nor a subscriber.
+        var apiNavItem = PortalNavigationItemFixtures.anApi(
+            PortalNavigationItemId.random().toString(),
+            "Restricted API",
+            null,
+            "private-api-id"
+        );
+        apiNavItem.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        apiNavItem.setPublished(true);
+
+        queryService.initWith(List.of(apiNavItem));
+
+        // When
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forPortal("user-without-access")
+            )
+        );
+
+        // Then the API nav item is not exposed through the documentation endpoint either,
+        // keeping it consistent with the catalog visibility rules.
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    void should_show_private_api_nav_item_to_authenticated_member() {
+        // Given a private API and a user that is a member of it.
+        var apiNavItem = PortalNavigationItemFixtures.anApi(
+            PortalNavigationItemId.random().toString(),
+            "Restricted API",
+            null,
+            "private-api-id"
+        );
+        apiNavItem.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        apiNavItem.setPublished(true);
+
+        queryService.initWith(List.of(apiNavItem));
+        membershipQueryService.initWith(
+            List.of(
+                io.gravitee.apim.core.membership.model.Membership.builder()
+                    .id("m-1")
+                    .memberId("user-member")
+                    .memberType(io.gravitee.apim.core.membership.model.Membership.Type.USER)
+                    .referenceType(io.gravitee.apim.core.membership.model.Membership.ReferenceType.API)
+                    .referenceId("private-api-id")
+                    .build()
+            )
+        );
+
+        // When
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forPortal("user-member")
+            )
+        );
+
+        // Then
+        assertThat(result.items()).extracting(PortalNavigationItem::getTitle).containsExactly("Restricted API");
+    }
+
+    @Test
+    void should_hide_children_of_private_api_nav_item_for_non_member() {
+        // Given a private API nav item with a public child folder containing a public page.
+        var apiNavItem = PortalNavigationItemFixtures.anApi(
+            PortalNavigationItemId.random().toString(),
+            "Restricted API",
+            null,
+            "private-api-id"
+        );
+        apiNavItem.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        apiNavItem.setPublished(true);
+
+        var childFolder = PortalNavigationItemFixtures.aFolder(
+            PortalNavigationItemId.random().toString(),
+            "API Resources",
+            apiNavItem.getId()
+        );
+        childFolder.updateParent(apiNavItem);
+
+        var childPage = PortalNavigationItemFixtures.aPage(PortalNavigationItemId.random().toString(), "API Overview", childFolder.getId());
+        childPage.updateParent(childFolder);
+
+        queryService.initWith(List.of(apiNavItem, childFolder, childPage));
+
+        // When — non-member tries to load the whole tree
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.empty(),
+                true,
+                PortalNavigationItemViewerContext.forPortal("user-without-access")
+            )
+        );
+
+        // Then none of the restricted API subtree is returned.
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_when_parent_is_private_api_and_user_is_not_member() {
+        // Given a private API nav item with a public child.
+        var apiNavItem = PortalNavigationItemFixtures.anApi(
+            PortalNavigationItemId.random().toString(),
+            "Restricted API",
+            null,
+            "private-api-id"
+        );
+        apiNavItem.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        apiNavItem.setPublished(true);
+
+        var childPage = PortalNavigationItemFixtures.aPage(PortalNavigationItemId.random().toString(), "API Overview", apiNavItem.getId());
+        childPage.updateParent(apiNavItem);
+
+        queryService.initWith(List.of(apiNavItem, childPage));
+
+        // When — user queries with the API nav item as parent directly (bypass attempt)
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.of(apiNavItem.getId()),
+                true,
+                PortalNavigationItemViewerContext.forPortal("user-without-access")
+            )
+        );
+
+        // Then the parent is rejected and no children are exposed.
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_when_parent_is_descendant_of_private_api_and_user_is_not_member() {
+        // Given a private API nav item with a folder child containing a page.
+        var apiNavItem = PortalNavigationItemFixtures.anApi(
+            PortalNavigationItemId.random().toString(),
+            "Restricted API",
+            null,
+            "private-api-id"
+        );
+        apiNavItem.setVisibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PRIVATE);
+        apiNavItem.setPublished(true);
+
+        var childFolder = PortalNavigationItemFixtures.aFolder(
+            PortalNavigationItemId.random().toString(),
+            "API Resources",
+            apiNavItem.getId()
+        );
+        childFolder.updateParent(apiNavItem);
+
+        var childPage = PortalNavigationItemFixtures.aPage(PortalNavigationItemId.random().toString(), "API Overview", childFolder.getId());
+        childPage.updateParent(childFolder);
+
+        queryService.initWith(List.of(apiNavItem, childFolder, childPage));
+
+        // When — user queries with the folder as parent (descendant of hidden API)
+        var result = useCase.execute(
+            new ListPortalNavigationItemsUseCase.Input(
+                ENV_ID,
+                PortalArea.TOP_NAVBAR,
+                Optional.of(childFolder.getId()),
+                true,
+                PortalNavigationItemViewerContext.forPortal("user-without-access")
+            )
+        );
+
+        // Then the ancestor check still prevents exposure.
+        assertThat(result.items()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13730

## Description

Fixes portal navigation so **API-linked navigation items** respect the same visibility rules as the API catalog: **PUBLIC** APIs stay visible to anonymous users; **PRIVATE** APIs are shown only when the viewer is allowed (membership / subscription), and **descendants of hidden API items** are not exposed via direct access by id.

## Changes

- Extend `PortalNavigationItemViewerContext` with optional **user id** for portal requests (authenticated = non-null user).
- Portal REST resources pass `getAuthenticatedUserOrNull()` instead of a boolean.
- Add `PortalNavigationApiVisibilityDomainService` helpers: `isApiItemHidden`, `hasHiddenApiAncestor`.
- Wire filtering into `ListPortalNavigationItemsUseCase`, `GetPortalNavigationItemUseCase`, and `GetPortalPageContentByNavigationIdUseCase`; expand tests and test `ResourceContextConfiguration` beans.


https://github.com/user-attachments/assets/1a7d4215-411c-4a17-8ef6-4c6ef9e9b232


