### PR TITLE
chore(deps): bump gravitee-node to 9.0.0-alpha.4 and gravitee-plugin-common-configurations to 1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-alpha.2</gravitee-node.version>
+        <gravitee-node.version>9.0.0-alpha.4</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.0.0</gravitee-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.0.0</gravitee-plugin.version>
-        <gravitee-plugin-common-configurations.version>1.1.0</gravitee-plugin-common-configurations.version>
+        <gravitee-plugin-common-configurations.version>1.2.1</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>2.2.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>


### PR DESCRIPTION
## Summary
Two dependency bumps required by the cache-redis refactor (gravitee-io/gravitee-resource-cache-redis#76):

- `gravitee-node.version`: `9.0.0-alpha.2` → `9.0.0-alpha.4`. Ships `VertxRedisClientFactory`, which the cache-redis plugin now consumes to replace `SharedRedisClientRegistry` and get proper client dedup + ref counting.
- `gravitee-plugin-common-configurations.version`: `1.1.0` → `1.2.1`. `1.2.0` introduced `RedisClientOptions` / `RedisSentinelOptions` (the schema the cache-redis plugin now uses); `1.2.1` fixes a silent sentinel-mode regression where `RedisSentinelOptions.enabled` defaulted to `false`, causing callers that previously activated sentinel via `nodes + masterId` alone to be silently downgraded to standalone.

Once both are pinned here, the cache-redis plugin PR can drop its local `<gravitee-node.version>` / `<gravitee-plugin-common-configurations.version>` overrides and rely on the APIM BOM.

Commits between `gravitee-node` `alpha.2` and `alpha.4`:
- `feat(redis): add VertxRedisClientFactory for shared Redis clients`
- `fix: http2 keep alive timeout needs is in seconds`

## Test plan
- [ ] CI green on this PR