### PR TITLE
feat: add Kafka Virtual Cluster support

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -198,6 +198,11 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
           routerLink: './clusters/kafka-clusters',
           category: 'Kafka',
         },
+        {
+          displayName: 'Virtual Clusters',
+          routerLink: './clusters/kafka-virtual-clusters',
+          category: 'Kafka',
+        },
       ],
     });
 

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/Cluster.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/Cluster.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type ClusterType = 'KAFKA_CLUSTER_STANDALONE' | 'KAFKA_CLUSTER';
+export type ClusterType = 'KAFKA_CLUSTER_STANDALONE' | 'KAFKA_CLUSTER' | 'KAFKA_VIRTUAL_CLUSTER';
 export type ClusterLifecycleState = 'UNDEPLOYED' | 'DEPLOYED' | 'PENDING';
 
 export interface Cluster {
@@ -22,7 +22,7 @@ export interface Cluster {
   type: ClusterType;
   name: string;
   description?: string;
-  configuration: KafkaClusterStandaloneConfiguration | KafkaClusterConfiguration;
+  configuration: KafkaClusterStandaloneConfiguration | KafkaClusterConfiguration | KafkaVirtualClusterConfiguration;
   updatedAt: Date;
   createdAt: Date;
   groups: string[];
@@ -45,4 +45,13 @@ export interface KafkaClusterConnection {
 
 export interface KafkaClusterConfiguration {
   connections?: KafkaClusterConnection[];
+}
+
+export interface KafkaVirtualClusterBackend {
+  clusterCrossId: string;
+  connectionCrossId: string;
+}
+
+export interface KafkaVirtualClusterConfiguration {
+  backends?: KafkaVirtualClusterBackend[];
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/DeployedCluster.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/cluster/DeployedCluster.ts
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ClusterType } from './Cluster';
+
 export interface DeployedCluster {
   crossId: string;
   name: string;
   description?: string;
+  type?: ClusterType;
   deployedAt?: Date;
   version?: number;
   connections: DeployedClusterConnection[];

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.adapter.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/endpoint-groups/standard/api-endpoint-groups-standard.adapter.ts
@@ -119,6 +119,8 @@ const toGeneralColumnName = (api: ApiV4, endpointGroup: EndpointGroupV4): string
       return 'Bootstrap Servers';
     case 'NATIVE.native-kafka-cluster':
       return 'Cluster';
+    case 'NATIVE.native-kafka-virtual-cluster':
+      return 'Virtual Cluster';
     case 'MESSAGE.kafka':
       return 'Bootstrap Servers';
   }
@@ -137,6 +139,8 @@ const toGeneralInfo = (api: ApiV4, endpoint: EndpointV4): string | undefined => 
       // And display warning if cluster or connection is not found
       return connection ? `${cluster} / ${connection}` : cluster;
     }
+    case 'NATIVE.native-kafka-virtual-cluster':
+      return get(endpoint.configuration, 'virtualClusterCrossId', '');
     case 'MESSAGE.kafka':
       return get(endpoint.configuration, 'bootstrapServers', '');
   }

--- a/gravitee-apim-console-webui/src/management/clusters/cluster-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/cluster-routing.module.ts
@@ -25,6 +25,8 @@ import { ClusterConfigurationComponent } from './kafka-standalone/details/config
 import { ClusterListComponent } from './kafka-standalone/list/cluster-list.component';
 import { KafkaClusterListComponent } from './kafka-clusters/list/kafka-cluster-list.component';
 import { KafkaClusterConfigurationComponent } from './kafka-clusters/details/configuration/kafka-cluster-configuration.component';
+import { KafkaVirtualClusterListComponent } from './kafka-virtual-clusters/list/kafka-virtual-cluster-list.component';
+import { KafkaVirtualClusterConfigurationComponent } from './kafka-virtual-clusters/details/configuration/kafka-virtual-cluster-configuration.component';
 import { ClusterGuard } from './cluster.guard';
 
 import { Constants } from '../../entities/Constants';
@@ -140,6 +142,58 @@ const clusterRoutes: Routes = [
       {
         path: 'configuration',
         component: KafkaClusterConfigurationComponent,
+        data: {
+          permissions: {
+            anyOf: ['cluster-configuration-r'],
+          },
+        },
+      },
+      {
+        path: 'user-permissions',
+        component: ClusterUserPermissionsComponent,
+        data: {
+          permissions: {
+            anyOf: ['cluster-member-r'],
+          },
+        },
+      },
+    ],
+  },
+  {
+    path: 'kafka-virtual-clusters',
+    component: KafkaVirtualClusterListComponent,
+    canActivate: [PermissionGuard.checkRouteDataPermissions],
+    data: {
+      useAngularMaterial: true,
+      permissions: {
+        anyOf: ['environment-cluster-r'],
+      },
+    },
+  },
+  {
+    path: 'kafka-virtual-clusters/:clusterId',
+    component: ClusterNavigationComponent,
+    canActivate: [ClusterGuard.loadPermissions],
+    canActivateChild: [PermissionGuard.checkRouteDataPermissions],
+    canDeactivate: [ClusterGuard.clearPermissions],
+    children: [
+      {
+        path: '',
+        redirectTo: 'general',
+        pathMatch: 'full',
+      },
+      {
+        path: 'general',
+        component: ClusterGeneralComponent,
+        data: {
+          permissions: {
+            anyOf: ['cluster-definition-r'],
+          },
+        },
+      },
+      {
+        path: 'configuration',
+        component: KafkaVirtualClusterConfigurationComponent,
         data: {
           permissions: {
             anyOf: ['cluster-configuration-r'],

--- a/gravitee-apim-console-webui/src/management/clusters/general/cluster-general.component.html
+++ b/gravitee-apim-console-webui/src/management/clusters/general/cluster-general.component.html
@@ -41,7 +41,7 @@
             <dl class="gio-description-list">
               <dt>Cross ID</dt>
               <dd>{{ initialCluster.crossId }}</dd>
-              @if (initialCluster.type === 'KAFKA_CLUSTER') {
+              @if (initialCluster.type === 'KAFKA_CLUSTER' || initialCluster.type === 'KAFKA_VIRTUAL_CLUSTER') {
                 <dt>Status</dt>
                 <dd>
                   <span
@@ -72,7 +72,7 @@
       <mat-card-content>
         <h3 class="danger-card__title">Danger Zone</h3>
         <div class="danger-card__actions">
-          @if (initialCluster.type === 'KAFKA_CLUSTER') {
+          @if (initialCluster.type === 'KAFKA_CLUSTER' || initialCluster.type === 'KAFKA_VIRTUAL_CLUSTER') {
             @if (initialCluster.lifecycleState !== 'DEPLOYED') {
               <div class="danger-card__actions__action">
                 <span> Deploy this Cluster to the gateway. </span>

--- a/gravitee-apim-console-webui/src/management/clusters/general/cluster-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/general/cluster-general.component.spec.ts
@@ -164,6 +164,33 @@ describe('ClusterGeneralComponent', () => {
       expectGetClusterRequest(httpTestingController, fakeCluster({ id: CLUSTER_ID, type: 'KAFKA_CLUSTER', lifecycleState: 'DEPLOYED' }));
     });
 
+    it('should undeploy before deleting a deployed cluster', async () => {
+      // First deploy to get DEPLOYED state
+      await clusterGeneralHarness.clickDeployButton();
+      expectDeployClusterRequest(
+        httpTestingController,
+        CLUSTER_ID,
+        fakeCluster({ id: CLUSTER_ID, type: 'KAFKA_CLUSTER', lifecycleState: 'DEPLOYED' }),
+      );
+      expectGetClusterRequest(httpTestingController, fakeCluster({ id: CLUSTER_ID, type: 'KAFKA_CLUSTER', lifecycleState: 'DEPLOYED' }));
+      fixture.detectChanges();
+
+      // Now delete — should undeploy first
+      await clusterGeneralHarness.clickDeleteButton();
+
+      const confirmDialog = await rootLoader.getHarness(GioConfirmAndValidateDialogHarness);
+      await confirmDialog.confirm();
+
+      expectUndeployClusterRequest(
+        httpTestingController,
+        CLUSTER_ID,
+        fakeCluster({ id: CLUSTER_ID, type: 'KAFKA_CLUSTER', lifecycleState: 'UNDEPLOYED' }),
+      );
+      expectDeleteClusterRequest(httpTestingController, CLUSTER_ID);
+
+      expect(router.navigate).toHaveBeenCalledWith(['../../'], expect.anything());
+    });
+
     it('should undeploy the cluster when deployed', async () => {
       // First deploy to get DEPLOYED state
       await clusterGeneralHarness.clickDeployButton();

--- a/gravitee-apim-console-webui/src/management/clusters/general/cluster-general.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/general/cluster-general.component.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { Component, DestroyRef, OnInit, inject } from '@angular/core';
-import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
-import { EMPTY } from 'rxjs';
+import { catchError, filter, map, tap, concatMap } from 'rxjs/operators';
+import { EMPTY, of } from 'rxjs';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
@@ -137,13 +137,17 @@ export class ClusterGeneralComponent implements OnInit {
   }
 
   deleteCluster() {
+    const isDeployed = this.initialCluster.lifecycleState === 'DEPLOYED' || this.initialCluster.lifecycleState === 'PENDING';
+
     this.matDialog
       .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData>(GioConfirmAndValidateDialogComponent, {
         width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
-          title: `Delete Cluster`,
-          content: `Are you sure you want to delete the Cluster?`,
-          confirmButton: `Yes, delete it`,
+          title: isDeployed ? `Undeploy and Delete Cluster` : `Delete Cluster`,
+          content: isDeployed
+            ? `The Cluster is currently deployed. It will be undeployed and then deleted. Are you sure?`
+            : `Are you sure you want to delete the Cluster?`,
+          confirmButton: isDeployed ? `Yes, undeploy and delete it` : `Yes, delete it`,
           validationMessage: `Please, type in the name of the cluster <code>${this.initialCluster.name}</code> to confirm.`,
           validationValue: this.initialCluster.name,
           warning: `This operation is irreversible.`,
@@ -154,7 +158,8 @@ export class ClusterGeneralComponent implements OnInit {
       .afterClosed()
       .pipe(
         filter(confirm => confirm === true),
-        switchMap(() => this.clusterService.delete(this.activatedRoute.snapshot.params.clusterId)),
+        concatMap(() => (isDeployed ? this.clusterService.undeploy(this.activatedRoute.snapshot.params.clusterId) : of(null))),
+        concatMap(() => this.clusterService.delete(this.activatedRoute.snapshot.params.clusterId)),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);
           return EMPTY;

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/list/kafka-cluster-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-clusters/list/kafka-cluster-list.component.ts
@@ -26,9 +26,9 @@ import {
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSortModule } from '@angular/material/sort';
-import { BehaviorSubject, EMPTY, switchMap } from 'rxjs';
+import { BehaviorSubject, EMPTY, of, switchMap } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { catchError, debounceTime, filter, map, tap } from 'rxjs/operators';
+import { catchError, concatMap, debounceTime, filter, map, tap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { isEqual } from 'lodash';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -191,13 +191,17 @@ export class KafkaClusterListComponent implements OnInit {
   }
 
   protected remove(cluster: PageTableVM['items'][number]) {
+    const isDeployed = cluster.lifecycleState === 'DEPLOYED' || cluster.lifecycleState === 'PENDING';
+
     this.matDialog
       .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData>(GioConfirmAndValidateDialogComponent, {
         width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
-          title: `Delete Kafka Cluster`,
-          content: `Are you sure you want to delete the Kafka Cluster?`,
-          confirmButton: `Yes, delete it`,
+          title: isDeployed ? `Undeploy and Delete Kafka Cluster` : `Delete Kafka Cluster`,
+          content: isDeployed
+            ? `The Kafka Cluster is currently deployed. It will be undeployed and then deleted. Are you sure?`
+            : `Are you sure you want to delete the Kafka Cluster?`,
+          confirmButton: isDeployed ? `Yes, undeploy and delete it` : `Yes, delete it`,
           validationMessage: `Please, type in the name of the cluster <code>${cluster.name}</code> to confirm.`,
           validationValue: cluster.name,
           warning: `This operation is irreversible.`,
@@ -208,7 +212,8 @@ export class KafkaClusterListComponent implements OnInit {
       .afterClosed()
       .pipe(
         filter(confirm => confirm === true),
-        switchMap(() => this.clusterService.delete(cluster.id)),
+        concatMap(() => (isDeployed ? this.clusterService.undeploy(cluster.id) : of(null))),
+        concatMap(() => this.clusterService.delete(cluster.id)),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);
           return EMPTY;

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/add-dialog/kafka-virtual-clusters-add-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/add-dialog/kafka-virtual-clusters-add-dialog.component.html
@@ -1,0 +1,50 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<span mat-dialog-title>Create a new Kafka Virtual Cluster</span>
+
+<form [formGroup]="formGroup">
+  <mat-dialog-content class="mat-typography content">
+    <p>Create a new Kafka Virtual Cluster referencing existing Kafka cluster connections.</p>
+
+    <mat-form-field class="form-field">
+      <mat-label>Cluster name</mat-label>
+      <input #nameInput type="text" aria-label="Name" matInput formControlName="name" [maxLength]="512" />
+      <mat-hint align="end">{{ nameInput.value.length }}/512</mat-hint>
+      <mat-error *ngIf="formGroup.get('name').hasError('required')">Cluster name is required.</mat-error>
+    </mat-form-field>
+
+    <mat-form-field class="form-field">
+      <mat-label>Cross ID</mat-label>
+      <input #crossIdInput type="text" aria-label="Cross ID" matInput formControlName="crossId" [maxLength]="256" />
+      <mat-hint>Auto-generated from name if left empty</mat-hint>
+    </mat-form-field>
+
+    <mat-form-field class="form-field">
+      <mat-label>Description</mat-label>
+      <textarea #descriptionInput matInput formControlName="description" [maxLength]="1024"></textarea>
+      <mat-hint align="end">{{ descriptionInput.value.length }}/1024</mat-hint>
+    </mat-form-field>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button mat-flat-button [mat-dialog-close]="undefined">Cancel</button>
+    <button mat-raised-button color="primary" gioFormFocusInvalid [color]="(isValid$ | async) ? 'primary' : 'warn'" (click)="onSave()">
+      Create
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/add-dialog/kafka-virtual-clusters-add-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/add-dialog/kafka-virtual-clusters-add-dialog.component.scss
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 500px;
+}
+
+.form-field {
+  width: 100%;
+}

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/add-dialog/kafka-virtual-clusters-add-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/add-dialog/kafka-virtual-clusters-add-dialog.component.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { GioFormFocusInvalidModule } from '@gravitee/ui-particles-angular';
+import { map, startWith } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+
+export type KafkaVirtualClustersAddDialogData = undefined;
+export type KafkaVirtualClustersAddDialogResult = undefined | { name: string; crossId?: string; description?: string };
+
+@Component({
+  selector: 'kafka-virtual-clusters-add-dialog',
+  templateUrl: './kafka-virtual-clusters-add-dialog.component.html',
+  styleUrls: ['./kafka-virtual-clusters-add-dialog.component.scss'],
+  imports: [CommonModule, ReactiveFormsModule, MatDialogModule, MatButtonModule, MatFormFieldModule, MatInput, GioFormFocusInvalidModule],
+  standalone: true,
+})
+export class KafkaVirtualClustersAddDialogComponent {
+  protected formGroup: FormGroup<{
+    name: FormControl<string>;
+    crossId: FormControl<string>;
+    description: FormControl<string>;
+  }>;
+  protected isValid$: Observable<boolean>;
+
+  constructor(public dialogRef: MatDialogRef<KafkaVirtualClustersAddDialogComponent, KafkaVirtualClustersAddDialogResult>) {
+    this.formGroup = new FormGroup({
+      name: new FormControl('', Validators.required),
+      crossId: new FormControl(''),
+      description: new FormControl(''),
+    });
+
+    this.isValid$ = this.formGroup.statusChanges.pipe(
+      startWith(this.formGroup.status),
+      map(status => status === 'VALID'),
+    );
+  }
+
+  protected onSave(): void {
+    if (this.formGroup.invalid) {
+      return;
+    }
+    this.dialogRef.close({
+      name: this.formGroup.get('name').value,
+      crossId: this.formGroup.get('crossId').value || undefined,
+      description: this.formGroup.get('description').value,
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/details/configuration/kafka-virtual-cluster-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/details/configuration/kafka-virtual-cluster-configuration.component.html
@@ -1,0 +1,38 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@if (isLoadingData) {
+  <div class="loader">
+    <mat-icon svgIcon="gio:loader"></mat-icon>
+  </div>
+} @else if (configForm) {
+  <form
+    class="kafka-virtual-cluster-configuration__content"
+    [formGroup]="configForm"
+    autocomplete="off"
+    gioFormFocusInvalid
+    (ngSubmit)="onSubmit()"
+  >
+    <mat-card class="configuration-card">
+      <mat-card-content>
+        <gio-form-json-schema [jsonSchema]="configurationJsonSchema" formControlName="config"></gio-form-json-schema>
+      </mat-card-content>
+    </mat-card>
+
+    <gio-save-bar [form]="configForm" (resetClicked)="onReset()"></gio-save-bar>
+  </form>
+}

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/details/configuration/kafka-virtual-cluster-configuration.component.scss
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/details/configuration/kafka-virtual-cluster-configuration.component.scss
@@ -1,0 +1,31 @@
+@use 'sass:map';
+@use '@angular/material/index' as mat;
+@use '@gravitee/ui-particles-angular/index' as gio;
+
+@use '../../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+}
+
+.kafka-virtual-cluster-configuration {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+}
+
+.configuration-card {
+  &__field {
+    width: 100%;
+    margin-bottom: 8px;
+  }
+}
+
+.loader {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+}

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/details/configuration/kafka-virtual-cluster-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/details/configuration/kafka-virtual-cluster-configuration.component.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { forkJoin } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { GioFormFocusInvalidModule, GioSaveBarModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+
+import { GioFormJsonSchemaExtendedModule } from '../../../../../shared/components/form-json-schema-extended/form-json-schema-extended.module';
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
+import { ClusterService } from '../../../../../services-ngx/cluster.service';
+import { Cluster, UpdateCluster } from '../../../../../entities/management-api-v2';
+import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
+
+@Component({
+  selector: 'kafka-virtual-cluster-configuration',
+  templateUrl: './kafka-virtual-cluster-configuration.component.html',
+  styleUrls: ['./kafka-virtual-cluster-configuration.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatCardModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    GioSaveBarModule,
+    GioFormFocusInvalidModule,
+    MatSnackBarModule,
+    GioFormJsonSchemaExtendedModule,
+    GioIconsModule,
+  ],
+})
+export class KafkaVirtualClusterConfigurationComponent implements OnInit {
+  public initialCluster: Cluster;
+  public configForm: FormGroup<{
+    config: FormControl<unknown>;
+  }>;
+  public isLoadingData = true;
+  public isReadOnly = false;
+  public configurationJsonSchema: unknown;
+
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly clusterService = inject(ClusterService);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly permissionService = inject(GioPermissionService);
+
+  public ngOnInit() {
+    this.isLoadingData = true;
+    this.isReadOnly = !this.permissionService.hasAnyMatching(['cluster-configuration-u']);
+    forkJoin([
+      this.clusterService.get(this.activatedRoute.snapshot.params.clusterId),
+      this.clusterService.getConfigurationSchema('KAFKA_VIRTUAL_CLUSTER'),
+    ])
+      .pipe(
+        tap(([cluster, schema]) => {
+          this.initialCluster = cluster;
+          this.configurationJsonSchema = schema;
+          this.isLoadingData = false;
+
+          this.configForm = new FormGroup({
+            config: new FormControl({ value: cluster.configuration, disabled: this.isReadOnly }),
+          });
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  onSubmit() {
+    const configToUpdate: UpdateCluster = {
+      name: this.initialCluster.name,
+      description: this.initialCluster.description,
+      configuration: this.configForm.get('config').value,
+    };
+
+    this.clusterService
+      .update(this.initialCluster.id, configToUpdate)
+      .pipe(
+        tap(() => this.snackBarService.success('Kafka Virtual Cluster configuration successfully updated!')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.ngOnInit());
+  }
+
+  protected onReset() {
+    this.ngOnInit();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/list/kafka-virtual-cluster-list.component.html
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/list/kafka-virtual-cluster-list.component.html
@@ -1,0 +1,141 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<div class="title">
+  <div>
+    <h1>Kafka Virtual Clusters</h1>
+  </div>
+  <div class="title__action">
+    <button
+      *gioPermission="{ anyOf: ['environment-cluster-c'] }"
+      (click)="addKafkaVirtualCluster()"
+      mat-raised-button
+      color="primary"
+      aria-label="add-kafka-virtual-cluster"
+    >
+      <mat-icon svgIcon="gio:plus"></mat-icon>Add Kafka Virtual Cluster
+    </button>
+  </div>
+</div>
+
+@if (pageTableVM$ | async; as pageTableVM) {
+  <gio-table-wrapper
+    class="table"
+    [filters]="filters"
+    [length]="pageTableVM.totalItems"
+    [paginationPageSizeOptions]="[25, 50, 100]"
+    (filtersChange)="onFiltersChanged($event)"
+  >
+    <table mat-table matSort [dataSource]="pageTableVM.items" aria-label="Kafka Virtual Clusters">
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="name">Cluster Name</th>
+        <td mat-cell *matCellDef="let element">
+          <div class="cell">
+            <div *gioPermission="{ anyOf: ['cluster-definition-u'] }; else readOnly; roleContext: { role: 'CLUSTER', id: element.id }">
+              <a [routerLink]="[element.id]" class="cell__name">{{ element.name }}</a>
+            </div>
+
+            <ng-template #readOnly
+              ><span class="cell__name">{{ element.name }}</span></ng-template
+            >
+            <span
+              *ngIf="element.lifecycleState"
+              class="gio-badge-{{
+                element.lifecycleState === 'DEPLOYED' ? 'success' : element.lifecycleState === 'PENDING' ? 'warning' : 'neutral'
+              }}"
+            >
+              {{ element.lifecycleState }}
+            </span>
+          </div>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="description">
+        <th mat-header-cell *matHeaderCellDef>Description</th>
+        <td mat-cell *matCellDef="let element">
+          {{ element.description }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="lastUpdated">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="updatedAt">Last updated</th>
+        <td mat-cell *matCellDef="let element">
+          {{ element.updatedAt | date: 'medium' }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="lastDeployed">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="deployedAt">Last deployed</th>
+        <td mat-cell *matCellDef="let element">
+          {{ element.deployedAt ? (element.deployedAt | date: 'medium') : '-' }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let element">
+          <div class="actions_btn">
+            <button
+              *gioPermission="{ anyOf: ['cluster-definition-u'] }; else readOnly; roleContext: { role: 'CLUSTER', id: element.id }"
+              mat-button
+              aria-label="Button to edit"
+              matTooltip="Edit"
+              [routerLink]="[element.id]"
+            >
+              <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+            </button>
+
+            <ng-template #readOnly>
+              <button
+                *gioPermission="{ anyOf: ['cluster-definition-r'] }; roleContext: { role: 'CLUSTER', id: element.id }"
+                mat-button
+                aria-label="Button to view"
+                matTooltip="View"
+                [routerLink]="[element.id]"
+              >
+                <mat-icon svgIcon="gio:eye-empty"></mat-icon>
+              </button>
+            </ng-template>
+
+            <button
+              *gioPermission="{ anyOf: ['cluster-definition-d'] }; roleContext: { role: 'CLUSTER', id: element.id }"
+              type="button"
+              mat-button
+              aria-label="Button to remove Kafka Virtual Cluster"
+              matTooltip="Remove"
+              (click)="remove(element)"
+            >
+              <mat-icon svgIcon="gio:trash"></mat-icon>
+            </button>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+      <!-- Row shown when there is no data -->
+      <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+        <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
+          <div *ngIf="!pageTableVM.isLoading" class="mat-body">No Kafka Virtual Clusters</div>
+          <div *ngIf="pageTableVM.isLoading" class="mat-body">Loading...</div>
+        </td>
+      </tr>
+    </table>
+  </gio-table-wrapper>
+}

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/list/kafka-virtual-cluster-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/list/kafka-virtual-cluster-list.component.scss
@@ -1,0 +1,49 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+@use '../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+
+  h1 {
+    margin-bottom: 0;
+  }
+
+  &__action {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+}
+
+.cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  &__name {
+    margin-bottom: 4px;
+  }
+}
+
+.cdk-column-lastUpdated,
+.cdk-column-actions {
+  width: 0;
+  white-space: nowrap;
+}
+
+.actions_btn {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/list/kafka-virtual-cluster-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/list/kafka-virtual-cluster-list.component.ts
@@ -26,9 +26,9 @@ import {
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSortModule } from '@angular/material/sort';
-import { BehaviorSubject, EMPTY, switchMap } from 'rxjs';
+import { BehaviorSubject, EMPTY, of, switchMap } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { catchError, debounceTime, filter, map, tap } from 'rxjs/operators';
+import { catchError, concatMap, debounceTime, filter, map, tap } from 'rxjs/operators';
 import { MatDialog } from '@angular/material/dialog';
 import { isEqual } from 'lodash';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -194,13 +194,17 @@ export class KafkaVirtualClusterListComponent implements OnInit {
   }
 
   protected remove(cluster: PageTableVM['items'][number]) {
+    const isDeployed = cluster.lifecycleState === 'DEPLOYED' || cluster.lifecycleState === 'PENDING';
+
     this.matDialog
       .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData>(GioConfirmAndValidateDialogComponent, {
         width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
-          title: `Delete Kafka Virtual Cluster`,
-          content: `Are you sure you want to delete the Kafka Virtual Cluster?`,
-          confirmButton: `Yes, delete it`,
+          title: isDeployed ? `Undeploy and Delete Kafka Virtual Cluster` : `Delete Kafka Virtual Cluster`,
+          content: isDeployed
+            ? `The Kafka Virtual Cluster is currently deployed. It will be undeployed and then deleted. Are you sure?`
+            : `Are you sure you want to delete the Kafka Virtual Cluster?`,
+          confirmButton: isDeployed ? `Yes, undeploy and delete it` : `Yes, delete it`,
           validationMessage: `Please, type in the name of the cluster <code>${cluster.name}</code> to confirm.`,
           validationValue: cluster.name,
           warning: `This operation is irreversible.`,
@@ -211,7 +215,8 @@ export class KafkaVirtualClusterListComponent implements OnInit {
       .afterClosed()
       .pipe(
         filter(confirm => confirm === true),
-        switchMap(() => this.clusterService.delete(cluster.id)),
+        concatMap(() => (isDeployed ? this.clusterService.undeploy(cluster.id) : of(null))),
+        concatMap(() => this.clusterService.delete(cluster.id)),
         catchError(({ error }) => {
           this.snackBarService.error(error.message);
           return EMPTY;

--- a/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/list/kafka-virtual-cluster-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/clusters/kafka-virtual-clusters/list/kafka-virtual-cluster-list.component.ts
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  GIO_DIALOG_WIDTH,
+  GioConfirmAndValidateDialogComponent,
+  GioConfirmAndValidateDialogData,
+  GioIconsModule,
+} from '@gravitee/ui-particles-angular';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSortModule } from '@angular/material/sort';
+import { BehaviorSubject, EMPTY, switchMap } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { catchError, debounceTime, filter, map, tap } from 'rxjs/operators';
+import { MatDialog } from '@angular/material/dialog';
+import { isEqual } from 'lodash';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+
+import {
+  KafkaVirtualClustersAddDialogComponent,
+  KafkaVirtualClustersAddDialogData,
+  KafkaVirtualClustersAddDialogResult,
+} from '../add-dialog/kafka-virtual-clusters-add-dialog.component';
+import { GioTableWrapperFilters, Sort } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { ClusterService } from '../../../../services-ngx/cluster.service';
+import { ClusterLifecycleState, ClustersSortByParam } from '../../../../entities/management-api-v2';
+
+type PageTableVM = {
+  items: {
+    id: string;
+    name: string;
+    description: string;
+    updatedAt: Date;
+    lifecycleState?: ClusterLifecycleState;
+    deployedAt?: Date;
+  }[];
+  totalItems: number;
+  isLoading: boolean;
+};
+
+@Component({
+  selector: 'kafka-virtual-cluster-list',
+  templateUrl: './kafka-virtual-cluster-list.component.html',
+  styleUrls: ['./kafka-virtual-cluster-list.component.scss'],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatButtonModule,
+    MatTooltipModule,
+    MatTableModule,
+    MatSortModule,
+    GioIconsModule,
+    GioPermissionModule,
+    GioTableWrapperModule,
+    RouterLink,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+})
+export class KafkaVirtualClusterListComponent implements OnInit {
+  private readonly clusterService = inject(ClusterService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly matDialog = inject(MatDialog);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly permissionService = inject(GioPermissionService);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+
+  private refreshPageTableVM$ = new BehaviorSubject<void>(undefined);
+
+  protected displayedColumns: string[] = ['name', 'description', 'lastUpdated', 'lastDeployed', 'actions'];
+  protected filters: GioTableWrapperFilters = {
+    pagination: { index: 1, size: 25 },
+    searchTerm: '',
+  };
+
+  protected pageTableVM$: BehaviorSubject<PageTableVM> = new BehaviorSubject({
+    items: [],
+    totalItems: 0,
+    isLoading: true,
+  });
+
+  ngOnInit(): void {
+    this.refreshPageTableVM$
+      .pipe(
+        debounceTime(200),
+        tap(() => this.pageTableVM$.next({ items: [], totalItems: 0, isLoading: true })),
+        switchMap(() =>
+          this.clusterService
+            .list(
+              this.filters.searchTerm,
+              toKafkaVirtualClustersSortByParam(this.filters.sort),
+              this.filters.pagination.index,
+              this.filters.pagination.size,
+              'KAFKA_VIRTUAL_CLUSTER',
+            )
+            .pipe(
+              catchError(({ error }) => {
+                this.snackBarService.error(error.message);
+                this.pageTableVM$.next({ items: [], totalItems: 0, isLoading: false });
+                return EMPTY;
+              }),
+            ),
+        ),
+        map(pagedResult => {
+          const items = pagedResult.data.map(cluster => ({
+            id: cluster.id,
+            name: cluster.name,
+            description: cluster.description ?? '',
+            updatedAt: cluster.updatedAt,
+            lifecycleState: cluster.lifecycleState,
+            deployedAt: cluster.deployedAt,
+          }));
+
+          this.pageTableVM$.next({
+            items,
+            totalItems: pagedResult.pagination.totalCount ?? 0,
+            isLoading: false,
+          });
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  protected onFiltersChanged($event: GioTableWrapperFilters) {
+    if (isEqual(this.filters, $event)) {
+      return;
+    }
+    this.filters = $event;
+    this.refreshPageTableVM$.next();
+  }
+
+  protected addKafkaVirtualCluster() {
+    this.matDialog
+      .open<KafkaVirtualClustersAddDialogComponent, KafkaVirtualClustersAddDialogData, KafkaVirtualClustersAddDialogResult>(
+        KafkaVirtualClustersAddDialogComponent,
+        {
+          role: 'alertdialog',
+          id: 'addKafkaVirtualCluster',
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+        },
+      )
+      .afterClosed()
+      .pipe(
+        switchMap((result: KafkaVirtualClustersAddDialogResult) => {
+          if (!result) {
+            return EMPTY;
+          }
+
+          return this.clusterService.create({
+            type: 'KAFKA_VIRTUAL_CLUSTER',
+            crossId: result.crossId,
+            name: result.name,
+            description: result.description,
+            configuration: {
+              backends: [],
+            },
+          });
+        }),
+        tap(cluster => {
+          this.snackBarService.success('Kafka Virtual Cluster created successfully');
+          return this.router.navigate([cluster.id], {
+            relativeTo: this.activatedRoute,
+          });
+        }),
+        catchError(e => {
+          this.snackBarService.error(e.error?.message ?? 'An error occurred while creating the Kafka Virtual Cluster!');
+          return EMPTY;
+        }),
+      )
+      .subscribe();
+  }
+
+  protected remove(cluster: PageTableVM['items'][number]) {
+    this.matDialog
+      .open<GioConfirmAndValidateDialogComponent, GioConfirmAndValidateDialogData>(GioConfirmAndValidateDialogComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        data: {
+          title: `Delete Kafka Virtual Cluster`,
+          content: `Are you sure you want to delete the Kafka Virtual Cluster?`,
+          confirmButton: `Yes, delete it`,
+          validationMessage: `Please, type in the name of the cluster <code>${cluster.name}</code> to confirm.`,
+          validationValue: cluster.name,
+          warning: `This operation is irreversible.`,
+        },
+        role: 'alertdialog',
+        id: 'kafkaVirtualClusterDeleteDialog',
+      })
+      .afterClosed()
+      .pipe(
+        filter(confirm => confirm === true),
+        switchMap(() => this.clusterService.delete(cluster.id)),
+        catchError(({ error }) => {
+          this.snackBarService.error(error.message);
+          return EMPTY;
+        }),
+        map(() => this.snackBarService.success(`The Kafka Virtual Cluster has been deleted.`)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.refreshPageTableVM$.next();
+      });
+  }
+}
+
+function toKafkaVirtualClustersSortByParam(sort?: Sort): ClustersSortByParam | undefined {
+  if (!sort?.active) {
+    return undefined;
+  }
+  const prefix = sort.direction === 'asc' ? '' : '-';
+  return `${prefix}${sort.active}` as ClustersSortByParam;
+}

--- a/gravitee-apim-console-webui/src/services-ngx/cluster.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/cluster.service.spec.ts
@@ -201,8 +201,13 @@ export const expectUndeployClusterRequest = (
   req.flush(clusterUndeployed);
 };
 
-export const expectListDeployedClustersRequest = (httpTestingController: HttpTestingController, deployedClusters: any[] = []) => {
-  const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/clusters/deployed`);
+export const expectListDeployedClustersRequest = (
+  httpTestingController: HttpTestingController,
+  deployedClusters: any[] = [],
+  type?: string,
+) => {
+  const queryParams = type ? `?type=${type}` : '';
+  const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/clusters/deployed${queryParams}`);
   expect(req.request.method).toEqual('GET');
   req.flush(deployedClusters);
 };

--- a/gravitee-apim-console-webui/src/services-ngx/cluster.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/cluster.service.ts
@@ -84,8 +84,12 @@ export class ClusterService {
     return this.http.post<Cluster>(`${this.constants.env.v2BaseURL}/clusters/${id}/_undeploy`, {});
   }
 
-  listDeployed(): Observable<DeployedCluster[]> {
-    return this.http.get<DeployedCluster[]>(`${this.constants.env.v2BaseURL}/clusters/deployed`);
+  listDeployed(type?: ClusterType): Observable<DeployedCluster[]> {
+    let params = new HttpParams();
+    if (type) {
+      params = params.append('type', type);
+    }
+    return this.http.get<DeployedCluster[]>(`${this.constants.env.v2BaseURL}/clusters/deployed`, { params });
   }
 
   getConfigurationSchema(type?: ClusterType): Observable<unknown> {

--- a/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-type.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/form-json-schema-extended/cluster-type.component.ts
@@ -19,7 +19,7 @@ import { Observable, of } from 'rxjs';
 import { catchError, map, shareReplay, startWith, switchMap } from 'rxjs/operators';
 
 import { ClusterService } from '../../../services-ngx/cluster.service';
-import { DeployedCluster } from '../../../entities/management-api-v2';
+import { ClusterType, DeployedCluster } from '../../../entities/management-api-v2';
 
 @Component({
   selector: 'cluster-type',
@@ -36,7 +36,8 @@ export class ClusterTypeComponent extends FieldType<FieldTypeConfig> implements 
   }
 
   ngOnInit() {
-    const allClusters$ = this.clusterService.listDeployed().pipe(
+    const clusterType = this.props['clusterType'] as ClusterType | undefined;
+    const allClusters$ = this.clusterService.listDeployed(clusterType).pipe(
       catchError(() => of([])),
       shareReplay(1),
     );

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/cluster/ClusterType.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/cluster/ClusterType.java
@@ -18,4 +18,5 @@ package io.gravitee.definition.model.cluster;
 public enum ClusterType {
     KAFKA_CLUSTER,
     KAFKA_CLUSTER_STANDALONE,
+    KAFKA_VIRTUAL_CLUSTER,
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/cluster/KafkaVirtualClusterReactableCluster.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/cluster/KafkaVirtualClusterReactableCluster.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.cluster;
+
+import java.io.Serializable;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class KafkaVirtualClusterReactableCluster extends ReactableCluster {
+
+    {
+        setType(ClusterType.KAFKA_VIRTUAL_CLUSTER);
+    }
+
+    private List<KafkaVirtualClusterBackend> backends;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KafkaVirtualClusterBackend implements Serializable {
+
+        private String clusterCrossId;
+        private String connectionCrossId;
+    }
+}

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1551,6 +1551,19 @@
                     </exclusions>
                 </dependency>
                 <dependency>
+                    <groupId>com.graviteesource.connector</groupId>
+                    <artifactId>gravitee-endpoint-native-kafka-virtual-cluster</artifactId>
+                    <version>${gravitee-reactor-native-kafka.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
                     <groupId>com.graviteesource.endpoint</groupId>
                     <artifactId>gravitee-endpoint-agent-to-agent</artifactId>
                     <version>${gravitee-endpoint-agent-to-agent.version}</version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ClusterMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ClusterMapper.java
@@ -20,6 +20,7 @@ import static io.gravitee.repository.management.model.Event.EventProperties.CLUS
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.cluster.ClusterType;
 import io.gravitee.definition.model.cluster.KafkaClusterReactableCluster;
+import io.gravitee.definition.model.cluster.KafkaVirtualClusterReactableCluster;
 import io.gravitee.definition.model.cluster.ReactableCluster;
 import io.gravitee.definition.model.cluster.SecurityConfig;
 import io.gravitee.repository.management.model.Event;
@@ -66,6 +67,8 @@ public class ClusterMapper {
 
                 if ("KAFKA_CLUSTER".equals(type)) {
                     return buildKafkaCluster(id, crossId, name, environmentId, organizationId, deployedAt, payload);
+                } else if ("KAFKA_VIRTUAL_CLUSTER".equals(type)) {
+                    return buildKafkaVirtualCluster(id, crossId, name, environmentId, organizationId, deployedAt, payload);
                 } else {
                     log.warn("Cluster type [{}] is not deployable yet, skipping cluster [{}].", type, id);
                     return null;
@@ -115,6 +118,45 @@ public class ClusterMapper {
             .organizationId(organizationId)
             .deployedAt(deployedAt)
             .connections(connections)
+            .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private KafkaVirtualClusterReactableCluster buildKafkaVirtualCluster(
+        String id,
+        String crossId,
+        String name,
+        String environmentId,
+        String organizationId,
+        Date deployedAt,
+        Map<String, Object> payload
+    ) {
+        List<KafkaVirtualClusterReactableCluster.KafkaVirtualClusterBackend> backends = Collections.emptyList();
+        Object configuration = payload.get("configuration");
+        if (configuration instanceof Map) {
+            Map<String, Object> configMap = (Map<String, Object>) configuration;
+            Object backendsRaw = configMap.get("backends");
+            if (backendsRaw instanceof List) {
+                backends = ((List<Map<String, Object>>) backendsRaw).stream()
+                    .map(backendMap ->
+                        KafkaVirtualClusterReactableCluster.KafkaVirtualClusterBackend.builder()
+                            .clusterCrossId((String) backendMap.get("clusterCrossId"))
+                            .connectionCrossId((String) backendMap.get("connectionCrossId"))
+                            .build()
+                    )
+                    .toList();
+            }
+        }
+
+        return KafkaVirtualClusterReactableCluster.builder()
+            .id(id)
+            .crossId(crossId)
+            .name(name)
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .environmentId(environmentId)
+            .organizationId(organizationId)
+            .deployedAt(deployedAt)
+            .backends(backends)
             .build();
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ClusterMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ClusterMapperTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.cluster.KafkaClusterReactableCluster;
+import io.gravitee.definition.model.cluster.KafkaVirtualClusterReactableCluster;
 import io.gravitee.definition.model.cluster.ReactableCluster;
 import io.gravitee.repository.management.model.Event;
 import java.util.Map;
@@ -120,6 +121,51 @@ class ClusterMapperTest {
         );
 
         cut.to(event).test().assertComplete().assertNoValues();
+    }
+
+    @Test
+    void should_map_kafka_virtual_cluster_event_to_reactable() {
+        Event event = new Event();
+        event.setId("event-id");
+        event.setPayload(
+            """
+            {
+                "id": "vcluster-id",
+                "crossId": "my-virtual-cluster",
+                "name": "My Virtual Cluster",
+                "type": "KAFKA_VIRTUAL_CLUSTER",
+                "environmentId": "env-1",
+                "organizationId": "org-1",
+                "deployedAt": 1698000,
+                "configuration": {
+                    "backends": [
+                        {
+                            "clusterCrossId": "kafka-cluster-1",
+                            "connectionCrossId": "conn-1"
+                        },
+                        {
+                            "clusterCrossId": "kafka-cluster-2",
+                            "connectionCrossId": "conn-2"
+                        }
+                    ]
+                }
+            }
+            """
+        );
+
+        ReactableCluster result = cut.to(event).blockingGet();
+
+        assertThat(result).isInstanceOf(KafkaVirtualClusterReactableCluster.class);
+        assertThat(result.getCrossId()).isEqualTo("my-virtual-cluster");
+        assertThat(result.getName()).isEqualTo("My Virtual Cluster");
+        assertThat(result.getEnvironmentId()).isEqualTo("env-1");
+
+        KafkaVirtualClusterReactableCluster virtualCluster = (KafkaVirtualClusterReactableCluster) result;
+        assertThat(virtualCluster.getBackends()).hasSize(2);
+        assertThat(virtualCluster.getBackends().get(0).getClusterCrossId()).isEqualTo("kafka-cluster-1");
+        assertThat(virtualCluster.getBackends().get(0).getConnectionCrossId()).isEqualTo("conn-1");
+        assertThat(virtualCluster.getBackends().get(1).getClusterCrossId()).isEqualTo("kafka-cluster-2");
+        assertThat(virtualCluster.getBackends().get(1).getConnectionCrossId()).isEqualTo("conn-2");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/cluster/ClustersResource.java
@@ -136,9 +136,9 @@ public class ClustersResource extends AbstractResource {
     @Path("deployed")
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CLUSTER, acls = { RolePermissionAction.READ }) })
-    public Response getDeployedClusters() {
+    public Response getDeployedClusters(@QueryParam("type") ClusterType type) {
         var executionContext = GraviteeContext.getExecutionContext();
-        var output = getDeployedClustersUseCase.execute(new GetDeployedClustersUseCase.Input(executionContext.getEnvironmentId()));
+        var output = getDeployedClustersUseCase.execute(new GetDeployedClustersUseCase.Input(executionContext.getEnvironmentId(), type));
         return Response.ok(output.deployedClusters()).build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1424,7 +1424,7 @@ components:
     # Cluster
     ClusterType:
       type: string
-      enum: [ KAFKA_CLUSTER_STANDALONE, KAFKA_CLUSTER ]
+      enum: [ KAFKA_CLUSTER_STANDALONE, KAFKA_CLUSTER, KAFKA_VIRTUAL_CLUSTER ]
     CreateCluster:
       type: object
       properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ClusterConfigurationSchemaService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ClusterConfigurationSchemaService.java
@@ -32,7 +32,9 @@ public class ClusterConfigurationSchemaService {
         ClusterType.KAFKA_CLUSTER_STANDALONE,
         "/cluster/kafka-cluster-standalone-configuration-schema-form.json",
         ClusterType.KAFKA_CLUSTER,
-        "/cluster/kafka-cluster-configuration-schema-form.json"
+        "/cluster/kafka-cluster-configuration-schema-form.json",
+        ClusterType.KAFKA_VIRTUAL_CLUSTER,
+        "/cluster/kafka-virtual-cluster-configuration-schema-form.json"
     );
 
     private final Map<ClusterType, String> cachedSchemas = new ConcurrentHashMap<>();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterService.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.KafkaClusterConfiguration;
+import io.gravitee.apim.core.cluster.model.KafkaVirtualClusterBackend;
 import io.gravitee.apim.core.cluster.query_service.ClusterQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.utils.StringUtils;
@@ -60,6 +61,10 @@ public class ValidateClusterService {
             validateUniqueConnectionNames(cluster);
             validateUniqueConnectionCrossIds(cluster);
         }
+
+        if (cluster.getType() == ClusterType.KAFKA_VIRTUAL_CLUSTER) {
+            validateUniqueBackends(cluster);
+        }
     }
 
     public void validateForCreate(Cluster cluster) {
@@ -98,6 +103,26 @@ public class ValidateClusterService {
 
         if (!duplicates.isEmpty()) {
             throw new InvalidDataException("Connection names must be unique. Duplicates found: " + duplicates);
+        }
+    }
+
+    private void validateUniqueBackends(Cluster cluster) {
+        var config = cluster.getKafkaVirtualClusterConfiguration(objectMapper);
+        if (config.backends() == null || config.backends().isEmpty()) {
+            return;
+        }
+        var duplicates = config
+            .backends()
+            .stream()
+            .collect(Collectors.groupingBy(b -> b, Collectors.counting()))
+            .entrySet()
+            .stream()
+            .filter(e -> e.getValue() > 1)
+            .map(e -> e.getKey())
+            .toList();
+
+        if (!duplicates.isEmpty()) {
+            throw new InvalidDataException("Backend references must be unique within a virtual cluster. Duplicates found: " + duplicates);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/Cluster.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/Cluster.java
@@ -56,6 +56,10 @@ public class Cluster {
         return objectMapper.convertValue(this.configuration, KafkaClusterConfiguration.class);
     }
 
+    public KafkaVirtualClusterConfiguration getKafkaVirtualClusterConfiguration(ObjectMapper objectMapper) {
+        return objectMapper.convertValue(this.configuration, KafkaVirtualClusterConfiguration.class);
+    }
+
     public void update(UpdateCluster updateCluster) {
         this.updatedAt = TimeProvider.instantNow();
         if (updateCluster.getName() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/DeployedCluster.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/DeployedCluster.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.cluster.model;
 
+import io.gravitee.definition.model.cluster.ClusterType;
 import java.time.Instant;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -31,6 +32,7 @@ public class DeployedCluster {
     private String crossId;
     private String name;
     private String description;
+    private ClusterType type;
     private Instant deployedAt;
     private Integer version;
     private List<DeployedClusterConnection> connections;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaVirtualClusterBackend.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaVirtualClusterBackend.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.cluster.model;
+
+public record KafkaVirtualClusterBackend(String clusterCrossId, String connectionCrossId) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaVirtualClusterConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/model/KafkaVirtualClusterConfiguration.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.cluster.model;
+
+import java.util.List;
+
+public record KafkaVirtualClusterConfiguration(List<KafkaVirtualClusterBackend> backends) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/DeleteClusterUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/DeleteClusterUseCase.java
@@ -21,14 +21,13 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.EnvironmentAuditLogEntity;
 import io.gravitee.apim.core.cluster.crud_service.ClusterCrudService;
+import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterAuditEvent;
-import io.gravitee.apim.core.shared_policy_group.model.SharedPolicyGroup;
-import io.gravitee.apim.core.shared_policy_group.model.SharedPolicyGroupAuditEvent;
-import io.gravitee.apim.core.shared_policy_group.use_case.DeleteSharedPolicyGroupUseCase;
+import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
 import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.util.Map;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 
 @AllArgsConstructor
 @UseCase
@@ -42,6 +41,12 @@ public class DeleteClusterUseCase {
     public record Output() {}
 
     public Output execute(Input input) {
+        Cluster cluster = clusterCrudService.findByIdAndEnvironmentId(input.clusterId, input.auditInfo.environmentId());
+
+        if (cluster.getLifecycleState() == ClusterLifecycleState.DEPLOYED || cluster.getLifecycleState() == ClusterLifecycleState.PENDING) {
+            throw new InvalidDataException("Cluster must be undeployed before deletion.");
+        }
+
         clusterCrudService.delete(input.clusterId, input.auditInfo.environmentId());
 
         createAuditLog(input.clusterId, input.auditInfo());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/GetDeployedClustersUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/cluster/use_case/GetDeployedClustersUseCase.java
@@ -37,7 +37,7 @@ public class GetDeployedClustersUseCase {
     private final EventLatestQueryService eventLatestQueryService;
     private final ObjectMapper objectMapper;
 
-    public record Input(String environmentId) {}
+    public record Input(String environmentId, ClusterType type) {}
 
     public record Output(List<DeployedCluster> deployedClusters) {}
 
@@ -48,7 +48,11 @@ public class GetDeployedClustersUseCase {
             Event.EventProperties.CLUSTER_ID
         );
 
-        List<DeployedCluster> deployedClusters = events.stream().map(this::toDeployedCluster).collect(Collectors.toList());
+        var stream = events.stream().map(this::toDeployedCluster);
+        if (input.type() != null) {
+            stream = stream.filter(dc -> dc.getType() == input.type());
+        }
+        List<DeployedCluster> deployedClusters = stream.collect(Collectors.toList());
 
         return new Output(deployedClusters);
     }
@@ -73,6 +77,7 @@ public class GetDeployedClustersUseCase {
                 .crossId(cluster.getCrossId())
                 .name(cluster.getName())
                 .description(cluster.getDescription())
+                .type(cluster.getType())
                 .deployedAt(cluster.getDeployedAt())
                 .version(cluster.getVersion())
                 .connections(connections)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-virtual-cluster-configuration-schema-form.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-virtual-cluster-configuration-schema-form.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "definitions": {
+    "kafkaVirtualClusterBackend": {
+      "type": "object",
+      "properties": {
+        "clusterCrossId": {
+          "type": "string",
+          "title": "Cluster Cross ID",
+          "description": "The cross ID of the referenced Kafka cluster"
+        },
+        "connectionCrossId": {
+          "type": "string",
+          "title": "Connection Cross ID",
+          "description": "The cross ID of the connection within the referenced Kafka cluster"
+        }
+      },
+      "required": ["clusterCrossId", "connectionCrossId"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "backends": {
+      "type": "array",
+      "title": "Kafka Virtual Cluster Backends",
+      "description": "List of references to existing Kafka cluster connections",
+      "items": {
+        "$ref": "#/definitions/kafkaVirtualClusterBackend"
+      },
+      "minItems": 0
+    }
+  },
+  "required": ["backends"],
+  "additionalProperties": false
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-virtual-cluster-configuration-schema-form.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-virtual-cluster-configuration-schema-form.json
@@ -8,12 +8,21 @@
         "clusterCrossId": {
           "type": "string",
           "title": "Cluster Cross ID",
-          "description": "The cross ID of the referenced Kafka cluster"
+          "description": "The cross ID of the referenced Kafka cluster",
+          "gioConfig": {
+            "uiType": "cluster-type",
+            "uiTypeProps": {
+              "clusterType": "KAFKA_CLUSTER"
+            }
+          }
         },
         "connectionCrossId": {
           "type": "string",
           "title": "Connection Cross ID",
-          "description": "The cross ID of the connection within the referenced Kafka cluster"
+          "description": "The cross ID of the connection within the referenced Kafka cluster",
+          "gioConfig": {
+            "uiType": "cluster-connection-type"
+          }
         }
       },
       "required": ["clusterCrossId", "connectionCrossId"],

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/domain_service/ValidateClusterServiceTest.java
@@ -328,6 +328,90 @@ class ValidateClusterServiceTest {
     }
 
     @Test
+    void should_pass_with_valid_kafka_virtual_cluster_configuration() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("my-virtual-cluster")
+            .configuration(Map.of("backends", List.of(Map.of("clusterCrossId", "kafka-cluster-1", "connectionCrossId", "conn-1"))))
+            .build();
+
+        assertThatCode(() -> validateClusterService.validate(cluster)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_throw_when_kafka_virtual_cluster_has_duplicate_backends() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("my-virtual-cluster")
+            .configuration(
+                Map.of(
+                    "backends",
+                    List.of(
+                        Map.of("clusterCrossId", "kafka-cluster-1", "connectionCrossId", "conn-1"),
+                        Map.of("clusterCrossId", "kafka-cluster-1", "connectionCrossId", "conn-1")
+                    )
+                )
+            )
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validate(cluster))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessageContaining("Backend references must be unique within a virtual cluster");
+    }
+
+    @Test
+    void should_pass_when_kafka_virtual_cluster_has_different_backends() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("my-virtual-cluster")
+            .configuration(
+                Map.of(
+                    "backends",
+                    List.of(
+                        Map.of("clusterCrossId", "kafka-cluster-1", "connectionCrossId", "conn-1"),
+                        Map.of("clusterCrossId", "kafka-cluster-1", "connectionCrossId", "conn-2")
+                    )
+                )
+            )
+            .build();
+
+        assertThatCode(() -> validateClusterService.validate(cluster)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_throw_when_kafka_virtual_cluster_backend_missing_clusterCrossId() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("my-virtual-cluster")
+            .configuration(Map.of("backends", List.of(Map.of("connectionCrossId", "conn-1"))))
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validate(cluster)).isInstanceOf(InvalidDataException.class);
+    }
+
+    @Test
+    void should_throw_when_kafka_virtual_cluster_backend_missing_connectionCrossId() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("my-virtual-cluster")
+            .configuration(Map.of("backends", List.of(Map.of("clusterCrossId", "kafka-cluster-1"))))
+            .build();
+
+        assertThatThrownBy(() -> validateClusterService.validate(cluster)).isInstanceOf(InvalidDataException.class);
+    }
+
+    @Test
+    void should_pass_when_kafka_virtual_cluster_has_empty_backends() {
+        Cluster cluster = Cluster.builder()
+            .type(ClusterType.KAFKA_VIRTUAL_CLUSTER)
+            .name("my-virtual-cluster")
+            .configuration(Map.of("backends", List.of()))
+            .build();
+
+        assertThatCode(() -> validateClusterService.validate(cluster)).doesNotThrowAnyException();
+    }
+
+    @Test
     void should_throw_when_crossId_is_changed_on_update() {
         Cluster existingCluster = Cluster.builder()
             .id("cluster-id")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/CreateClusterUseCaseTest.java
@@ -286,6 +286,24 @@ class CreateClusterUseCaseTest extends AbstractUseCaseTest {
         assertThat(connections.get(0).get("crossId")).isEqualTo("primary-connection");
     }
 
+    @Test
+    void should_create_kafka_virtual_cluster() {
+        String name = "Virtual Cluster";
+        Object configuration = Map.of("backends", List.of(Map.of("clusterCrossId", "kafka-cluster-1", "connectionCrossId", "conn-1")));
+        var toCreate = CreateCluster.builder().type(ClusterType.KAFKA_VIRTUAL_CLUSTER).name(name).configuration(configuration).build();
+
+        var output = createClusterUseCase.execute(new CreateClusterUseCase.Input(toCreate, AUDIT_INFO));
+
+        assertThat(output.cluster().getType()).isEqualTo(ClusterType.KAFKA_VIRTUAL_CLUSTER);
+        assertThat(output.cluster().getName()).isEqualTo(name);
+        assertThat(output.cluster().getCrossId()).isEqualTo("virtual-cluster");
+        var config = objectMapper.convertValue(output.cluster().getConfiguration(), Map.class);
+        var backends = (List<Map<String, Object>>) config.get("backends");
+        assertThat(backends).hasSize(1);
+        assertThat(backends.get(0).get("clusterCrossId")).isEqualTo("kafka-cluster-1");
+        assertThat(backends.get(0).get("connectionCrossId")).isEqualTo("conn-1");
+    }
+
     private void initRoles() {
         List<Role> roles = List.of(
             Role.builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/DeleteClusterUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/DeleteClusterUseCaseTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.cluster.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import inmemory.AbstractUseCaseTest;
 import inmemory.ClusterCrudServiceInMemory;
@@ -24,7 +25,9 @@ import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.cluster.model.Cluster;
 import io.gravitee.apim.core.cluster.model.ClusterAuditEvent;
+import io.gravitee.apim.core.cluster.model.ClusterLifecycleState;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +52,7 @@ class DeleteClusterUseCaseTest extends AbstractUseCaseTest {
             .description("The cluster no 1")
             .environmentId(ENV_ID)
             .organizationId(ORG_ID)
+            .lifecycleState(ClusterLifecycleState.UNDEPLOYED)
             .configuration(Map.of("bootstrapServers", "localhost:9092"))
             .build();
         clusterCrudService.initWith(List.of(existingCluster));
@@ -84,5 +88,25 @@ class DeleteClusterUseCaseTest extends AbstractUseCaseTest {
         assertThat(auditCrudService.storage())
             .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
             .containsExactly(deletedAudit);
+    }
+
+    @Test
+    void should_reject_deletion_when_cluster_is_deployed() {
+        existingCluster.setLifecycleState(ClusterLifecycleState.DEPLOYED);
+        clusterCrudService.initWith(List.of(existingCluster));
+
+        assertThatThrownBy(() -> deleteClusterUseCase.execute(new DeleteClusterUseCase.Input(existingCluster.getId(), AUDIT_INFO)))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessage("Cluster must be undeployed before deletion.");
+    }
+
+    @Test
+    void should_reject_deletion_when_cluster_is_pending() {
+        existingCluster.setLifecycleState(ClusterLifecycleState.PENDING);
+        clusterCrudService.initWith(List.of(existingCluster));
+
+        assertThatThrownBy(() -> deleteClusterUseCase.execute(new DeleteClusterUseCase.Input(existingCluster.getId(), AUDIT_INFO)))
+            .isInstanceOf(InvalidDataException.class)
+            .hasMessage("Cluster must be undeployed before deletion.");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/GetDeployedClustersUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/cluster/use_case/GetDeployedClustersUseCaseTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import inmemory.EventLatestQueryServiceInMemory;
 import io.gravitee.apim.core.cluster.model.DeployedCluster;
 import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.definition.model.cluster.ClusterType;
 import io.gravitee.rest.api.model.EventType;
 import java.time.ZonedDateTime;
 import java.util.EnumMap;
@@ -48,7 +49,7 @@ class GetDeployedClustersUseCaseTest {
 
     @Test
     void should_return_empty_list_when_no_deployed_clusters() {
-        var output = useCase.execute(new GetDeployedClustersUseCase.Input(ENV_ID));
+        var output = useCase.execute(new GetDeployedClustersUseCase.Input(ENV_ID, null));
         assertThat(output.deployedClusters()).isEmpty();
     }
 
@@ -88,7 +89,7 @@ class GetDeployedClustersUseCaseTest {
             )
         );
 
-        var output = useCase.execute(new GetDeployedClustersUseCase.Input(ENV_ID));
+        var output = useCase.execute(new GetDeployedClustersUseCase.Input(ENV_ID, null));
 
         assertThat(output.deployedClusters()).hasSize(1);
         DeployedCluster cluster = output.deployedClusters().get(0);
@@ -130,7 +131,62 @@ class GetDeployedClustersUseCaseTest {
             )
         );
 
-        var output = useCase.execute(new GetDeployedClustersUseCase.Input(ENV_ID));
+        var output = useCase.execute(new GetDeployedClustersUseCase.Input(ENV_ID, null));
         assertThat(output.deployedClusters()).isEmpty();
+    }
+
+    @Test
+    void should_filter_deployed_clusters_by_type() {
+        String kafkaClusterPayload = """
+            {
+                "id": "cluster-1",
+                "crossId": "kafka-cluster",
+                "name": "Kafka Cluster",
+                "type": "KAFKA_CLUSTER",
+                "configuration": { "connections": [] }
+            }
+            """;
+
+        String virtualClusterPayload = """
+            {
+                "id": "cluster-2",
+                "crossId": "virtual-cluster",
+                "name": "Virtual Cluster",
+                "type": "KAFKA_VIRTUAL_CLUSTER",
+                "configuration": { "backends": [] }
+            }
+            """;
+
+        var props1 = new EnumMap<Event.EventProperties, String>(Event.EventProperties.class);
+        props1.put(Event.EventProperties.CLUSTER_ID, "kafka-cluster");
+        var props2 = new EnumMap<Event.EventProperties, String>(Event.EventProperties.class);
+        props2.put(Event.EventProperties.CLUSTER_ID, "virtual-cluster");
+
+        eventLatestQueryService.initWith(
+            List.of(
+                Event.builder()
+                    .id("event-1")
+                    .type(EventType.DEPLOY_CLUSTER)
+                    .payload(kafkaClusterPayload)
+                    .environments(Set.of(ENV_ID))
+                    .properties(props1)
+                    .createdAt(ZonedDateTime.now())
+                    .build(),
+                Event.builder()
+                    .id("event-2")
+                    .type(EventType.DEPLOY_CLUSTER)
+                    .payload(virtualClusterPayload)
+                    .environments(Set.of(ENV_ID))
+                    .properties(props2)
+                    .createdAt(ZonedDateTime.now())
+                    .build()
+            )
+        );
+
+        var output = useCase.execute(new GetDeployedClustersUseCase.Input(ENV_ID, ClusterType.KAFKA_VIRTUAL_CLUSTER));
+
+        assertThat(output.deployedClusters()).hasSize(1);
+        assertThat(output.deployedClusters().get(0).getCrossId()).isEqualTo("virtual-cluster");
+        assertThat(output.deployedClusters().get(0).getType()).isEqualTo(ClusterType.KAFKA_VIRTUAL_CLUSTER);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0-alpha.2</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>7.0.0-alpha.3</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>7.0.0-alpha.5</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.2</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>2.8.0</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary
- Add `KAFKA_VIRTUAL_CLUSTER` cluster type with full core models, validation, configuration schema, and OpenAPI definitions
- Add `ReactableCluster` abstraction and gateway sync support (ClusterMapper, ClusterSynchronizer, ClusterDeployer)
- Add Console UI: Kafka Virtual Cluster list, configuration, and add-dialog components
- Add native-kafka-virtual-cluster endpoint display adapter in Console
- Add type filter to deployed clusters endpoint (used by cluster-type form component)
- Require undeploy before cluster deletion (backend validation + frontend auto-undeploy in delete dialogs)
- Rename `KAFKA_CLUSTER_CONNECTION` to `KAFKA_CLUSTER_STANDALONE` for clarity
- Bump `gravitee-reactor-native-kafka` to `7.0.0-alpha.5` and add virtual-cluster endpoint to distribution

https://github.com/user-attachments/assets/0a574c50-076b-4b3a-af0c-f2c883924355