### PR TITLE
feat(console): enable API Product manage groups like API members

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
@@ -40,6 +40,10 @@ export interface ApiProduct {
    */
   apiIds?: string[];
   /**
+   * Groups attached to this API Product (membership access through the console).
+   */
+  groups?: string[];
+  /**
    * The date (as timestamp) when the API Product was created.
    */
   createdAt?: Date;

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/updateApiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/updateApiProduct.ts
@@ -31,4 +31,8 @@ export interface UpdateApiProduct {
    * List of API IDs included in the product.
    */
   apiIds?: string[];
+  /**
+   * Groups attached to this API Product.
+   */
+  groups?: string[];
 }

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-group-members/api-product-group-members.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-group-members/api-product-group-members.component.harness.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
+
+import { GioTableWrapperHarness } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
+
+/** Inherited group members card under the direct members table. */
+export class ApiProductGroupMembersComponentHarness extends ComponentHarness {
+  static readonly hostSelector = 'api-product-group-members';
+
+  /** Primary heading in the card (inherited members title or permission-denied title). */
+  async getCardHeading(): Promise<string> {
+    const el = await this.locatorFor('mat-card-content h3')();
+    return (await el.text()).trim();
+  }
+
+  async getPermissionDeniedMessage(): Promise<string | null> {
+    const el = await this.locatorForOptional('#cannot-view-members')();
+    return el ? (await el.text()).trim() : null;
+  }
+
+  async getInheritedMembersTableWrapper(): Promise<GioTableWrapperHarness | null> {
+    return this.locatorForOptional(GioTableWrapperHarness)();
+  }
+
+  async getInheritedMembersTable(): Promise<MatTableHarness | null> {
+    return this.locatorForOptional(MatTableHarness)();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-group-members/api-product-group-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-group-members/api-product-group-members.component.html
@@ -1,0 +1,79 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card class="card">
+  @if (dataSourceGroupVM(); as vm) {
+    @if (!vm.canViewGroupMembers) {
+      <mat-card-content>
+        <h3 class="title">Group {{ groupData().name }}</h3>
+        <p id="cannot-view-members">You do not have the appropriate permissions to view members of this group.</p>
+      </mat-card-content>
+    }
+    @if (vm.canViewGroupMembers) {
+      <mat-card-content>
+        <div>
+          <h3>Group {{ groupData().name }} inherited members ({{ vm.memberTotalCount }})</h3>
+        </div>
+      </mat-card-content>
+      <gio-table-wrapper
+        [disableSearchInput]="true"
+        [length]="vm.memberTotalCount"
+        [filters]="filters()"
+        (filtersChange)="onFiltersChanged($event)"
+        [paginationPageSizeOptions]="[5, 10, 25, 50]"
+      >
+        <table
+          mat-table
+          [dataSource]="vm.membersPageResult"
+          class="card__table"
+          [attr.aria-label]="'Group ' + groupData().name + ' members table'"
+        >
+          <ng-container matColumnDef="picture">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let member">
+              <gio-avatar [src]="member.picture" [name]="member.displayName" [size]="24" [roundedBorder]="true"></gio-avatar>
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="displayName">
+            <th mat-header-cell *matHeaderCellDef>Name</th>
+            <td mat-cell *matCellDef="let member" [class.primary-owner-name]="member.role === 'PRIMARY_OWNER'">
+              {{ member.displayName }}
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="role">
+            <th mat-header-cell *matHeaderCellDef>Role</th>
+            <td mat-cell *matCellDef="let member">
+              {{ member.role }}
+            </td>
+          </ng-container>
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+          <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+            <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
+              @if (vm.isLoading) {
+                <gio-loader></gio-loader>
+              } @else {
+                <span data-testid="api_product_group_members_table_empty">No member</span>
+              }
+            </td>
+          </tr>
+        </table>
+      </gio-table-wrapper>
+    }
+  }
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-group-members/api-product-group-members.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-group-members/api-product-group-members.component.scss
@@ -1,0 +1,17 @@
+.card {
+  margin-top: 16px;
+
+  &__table {
+    width: 100%;
+
+    .mat-column-picture {
+      text-align: center;
+      width: 24px;
+      padding-right: 8px;
+    }
+
+    .primary-owner-name {
+      font-weight: bold;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-group-members/api-product-group-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-group-members/api-product-group-members.component.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, input, output } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatTableModule } from '@angular/material/table';
+import { GioAvatarModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import { isEqual } from 'lodash';
+
+import { GioTableWrapperFilters } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+
+export interface ApiProductGroupCardData {
+  id: string;
+  name?: string;
+}
+
+export interface ApiProductGroupMemberRow {
+  id: string;
+  role: string;
+  displayName: string;
+  picture: string;
+}
+
+export interface ApiProductGroupMembersViewModel {
+  memberTotalCount: number;
+  membersPageResult: ApiProductGroupMemberRow[];
+  isLoading: boolean;
+  canViewGroupMembers: boolean;
+}
+
+@Component({
+  selector: 'api-product-group-members',
+  standalone: true,
+  imports: [MatCardModule, MatTableModule, GioAvatarModule, GioLoaderModule, GioTableWrapperModule],
+  templateUrl: './api-product-group-members.component.html',
+  styleUrls: ['./api-product-group-members.component.scss'],
+})
+export class ApiProductGroupMembersComponent {
+  readonly groupData = input.required<ApiProductGroupCardData>();
+  readonly filters = input.required<GioTableWrapperFilters>();
+  readonly dataSourceGroupVM = input<ApiProductGroupMembersViewModel | null>();
+  readonly filtersChange = output<GioTableWrapperFilters>();
+
+  protected readonly displayedColumns = ['picture', 'displayName', 'role'];
+
+  protected onFiltersChanged(filters: GioTableWrapperFilters): void {
+    if (isEqual(this.filters(), filters)) {
+      return;
+    }
+    this.filtersChange.emit(filters);
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-groups/api-product-groups.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-groups/api-product-groups.component.harness.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+/** Host for the “Manage groups” dialog body (`MatDialog.open` → `ApiProductGroupsComponent`). */
+export class ApiProductGroupsDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'api-product-groups';
+
+  async getHeadingTitle(): Promise<string> {
+    const el = await this.locatorFor('[data-testid="api_product_groups_dialog_title"]')();
+    return (await el.text()).trim();
+  }
+
+  async getGroupsSelect(): Promise<MatSelectHarness | null> {
+    return this.locatorForOptional(MatSelectHarness.with({ selector: '[formControlName="selectedGroups"]' }))();
+  }
+
+  async getSaveButton(): Promise<MatButtonHarness | null> {
+    return this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="api_product_groups_dialog_save"]' }))();
+  }
+
+  /** No-op when read-only (Save is hidden); throws if editable but button is missing. */
+  async clickSave(): Promise<void> {
+    const btn = await this.getSaveButton();
+    if (!btn) {
+      throw new Error('Save API Product groups button not found (dialog may be read-only).');
+    }
+    await btn.click();
+  }
+
+  async selectGroupsByOptionTexts(texts: string[]): Promise<void> {
+    const select = await this.getGroupsSelect();
+    if (!select) {
+      throw new Error('Groups mat-select not found (read-only mode?).');
+    }
+    await select.open();
+    for (const text of texts) {
+      await select.clickOptions({ text });
+    }
+    await select.close();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-groups/api-product-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-groups/api-product-groups.component.html
@@ -1,0 +1,59 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="api-product-groups">
+  <h2 mat-dialog-title class="api-product-groups__title" data-testid="api_product_groups_dialog_title">Manage groups</h2>
+  <p class="api-product-groups__subtitle">Give groups access to your API Product through the API Management console</p>
+
+  <form [formGroup]="form" (ngSubmit)="save()">
+    <mat-dialog-content class="api-product-groups__body">
+      @if (!isReadOnly) {
+        <mat-form-field appearance="outline" class="api-product-groups__field" subscriptSizing="dynamic">
+          <mat-label>Groups</mat-label>
+          <mat-select formControlName="selectedGroups" multiple>
+            @for (availableGroup of groupsWithId; track availableGroup.id) {
+              <mat-option [value]="availableGroup.id">{{ availableGroup.name }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      } @else {
+        <section class="api-product-groups__read-only" aria-labelledby="api-product-groups-readonly-heading">
+          <h3 id="api-product-groups-readonly-heading" class="api-product-groups__readonly-heading">Groups</h3>
+          <div class="api-product-groups__read-only-groups">
+            <span class="mat-subtitle-2 api-product-groups__read-only-label">Associated groups</span>
+            <span>{{ readOnlyGroupList }}</span>
+          </div>
+        </section>
+      }
+    </mat-dialog-content>
+
+    @if (!isReadOnly) {
+      <mat-dialog-actions align="end">
+        <button
+          type="submit"
+          color="primary"
+          aria-label="Save API Product groups"
+          mat-raised-button
+          [disabled]="form.invalid"
+          data-testid="api_product_groups_dialog_save"
+        >
+          Save
+        </button>
+      </mat-dialog-actions>
+    }
+  </form>
+</div>

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-groups/api-product-groups.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-groups/api-product-groups.component.scss
@@ -1,0 +1,47 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+$typography: map.get(gio.$mat-theme, typography);
+
+.api-product-groups {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
+  margin: 1rem;
+
+  &__title {
+    margin: 0;
+  }
+
+  &__subtitle {
+    margin: 0 0 1rem;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    @include mat.m2-typography-level($typography, body-2);
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    padding-top: 0;
+  }
+
+  &__field {
+    width: 100%;
+  }
+
+  &__readonly-heading {
+    margin: 0 0 0.5rem;
+    @include mat.m2-typography-level($typography, headline-6);
+  }
+
+  &__read-only-groups {
+    display: flex;
+    gap: 1rem;
+    align-items: baseline;
+
+    .api-product-groups__read-only-label {
+      white-space: nowrap;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-groups/api-product-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-groups/api-product-groups.component.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, inject } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+
+import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { Group } from '../../../../entities/management-api-v2';
+import { ApiProduct } from '../../../../entities/management-api-v2/api-product';
+
+export interface ApiProductGroupsDialogData {
+  apiProduct: ApiProduct;
+  groups: Group[];
+}
+
+export interface ApiProductGroupsDialogResult {
+  groups: string[];
+}
+
+interface ApiProductGroupsForm {
+  selectedGroups: FormControl<string[]>;
+}
+
+@Component({
+  selector: 'api-product-groups',
+  standalone: true,
+  imports: [ReactiveFormsModule, MatButtonModule, MatDialogModule, MatFormFieldModule, MatSelectModule],
+  templateUrl: './api-product-groups.component.html',
+  styleUrls: ['./api-product-groups.component.scss'],
+})
+export class ApiProductGroupsComponent {
+  private readonly permissionService = inject(GioPermissionService);
+  private readonly formBuilder = inject(FormBuilder);
+  public readonly dialogRef = inject<MatDialogRef<ApiProductGroupsComponent, ApiProductGroupsDialogResult>>(MatDialogRef);
+
+  private readonly dialogData = inject<ApiProductGroupsDialogData>(MAT_DIALOG_DATA);
+
+  public readonly apiProduct: ApiProduct = this.dialogData.apiProduct;
+  public readonly groups: Group[] = this.dialogData.groups;
+  public readonly groupsWithId: Group[] = this.groups.filter((g): g is Group & { id: string } => !!g.id);
+  public readonly isReadOnly: boolean = !this.permissionService.hasAnyMatching(['api_product-member-u']);
+
+  private readonly userGroupList: Group[] = this.groupsWithId.filter(group => this.apiProduct.groups?.includes(group.id));
+  public readonly readOnlyGroupList: string =
+    this.userGroupList.length === 0 ? 'No groups associated' : this.userGroupList.map(g => g.name ?? '').join(', ');
+
+  public readonly form: FormGroup<ApiProductGroupsForm> = this.formBuilder.group<ApiProductGroupsForm>({
+    selectedGroups: new FormControl<string[]>(
+      { value: this.userGroupList.map(({ id }) => id), disabled: this.isReadOnly },
+      { nonNullable: true },
+    ),
+  });
+
+  save(): void {
+    if (this.form.invalid) {
+      return;
+    }
+    this.dialogRef.close({
+      groups: this.form.getRawValue().selectedGroups,
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.harness.ts
@@ -13,11 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentHarness } from '@angular/cdk/testing';
+import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
+import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
+
+import { ApiProductGroupMembersComponentHarness } from './api-product-group-members/api-product-group-members.component.harness';
 
 import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
+
+export const API_PRODUCT_MANAGE_GROUPS_DIALOG_ID = 'apiProductManageGroupsDialog';
+
+export const API_PRODUCT_ADD_MEMBER_DIALOG_ID = 'addApiProductMemberDialog';
+
+export const API_PRODUCT_CONFIRM_REMOVE_MEMBER_DIALOG_ID = 'confirmApiProductMemberDeleteDialog';
+
+/** Root harness predicate for the Manage groups overlay (use with `documentRootLoader().getHarness(...)`). */
+export function getApiProductManageGroupsDialogPredicate(): HarnessPredicate<MatDialogHarness> {
+  return MatDialogHarness.with({ selector: `#${API_PRODUCT_MANAGE_GROUPS_DIALOG_ID}` });
+}
 
 export class ApiProductMembersComponentHarness extends ComponentHarness {
   static hostSelector = 'api-product-members';
@@ -37,6 +52,26 @@ export class ApiProductMembersComponentHarness extends ComponentHarness {
     return (await el.text()).trim();
   }
 
+  async getEmptyMessageOrNull(): Promise<string | null> {
+    const el = await this.locatorForOptional('[data-testid="api_product_members_table_empty"]')();
+    return el ? (await el.text()).trim() : null;
+  }
+
+  async getLoadErrorMessage(): Promise<string | null> {
+    const el = await this.locatorForOptional('[data-testid="api_product_members_table_error"]')();
+    return el ? (await el.text()).trim() : null;
+  }
+
+  async clickRetryMembersLoad(): Promise<void> {
+    const btn = await this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="api_product_members_retry_button"]' }))();
+    await btn.click();
+  }
+
+  async getLoadingMembersMessage(): Promise<string | null> {
+    const el = await this.locatorForOptional('[data-testid="api_product_members_table_loading"]')();
+    return el ? (await el.text()).trim() : null;
+  }
+
   async getMembersTable(): Promise<MatTableHarness> {
     return this.locatorFor(MatTableHarness)();
   }
@@ -45,11 +80,53 @@ export class ApiProductMembersComponentHarness extends ComponentHarness {
     return this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="api_product_members_add_button"]' }))();
   }
 
+  async getManageGroupsButton(): Promise<MatButtonHarness | null> {
+    return this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="api_product_members_manage_groups_button"]' }))();
+  }
+
+  /** Clicks **Manage groups** (throws if the control is absent, e.g. missing permission). */
+  async clickManageGroups(): Promise<void> {
+    const btn = await this.getManageGroupsButton();
+    if (!btn) {
+      throw new Error('Manage groups button not found (check gioPermission and that the environment exposes at least one group).');
+    }
+    await btn.click();
+  }
+
+  async getTransferOwnershipButton(): Promise<MatButtonHarness | null> {
+    return this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="api_product_members_transfer_ownership_button"]' }))();
+  }
+
   async getDeleteMemberButton(): Promise<MatButtonHarness> {
     return this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="api_product_members_delete_button"]' }))();
   }
 
   async getTableWrapper(): Promise<GioTableWrapperHarness> {
     return this.locatorFor(GioTableWrapperHarness)();
+  }
+
+  async getSaveBar(): Promise<GioSaveBarHarness | null> {
+    return this.locatorForOptional(GioSaveBarHarness)();
+  }
+
+  async clickSave(): Promise<void> {
+    const bar = await this.getSaveBar();
+    if (!bar) {
+      throw new Error('gio-save-bar not found');
+    }
+    await bar.clickSubmit();
+  }
+
+  async clickReset(): Promise<void> {
+    const bar = await this.getSaveBar();
+    if (!bar) {
+      throw new Error('gio-save-bar not found');
+    }
+    await bar.clickReset();
+  }
+
+  /** One entry per visible linked group with inherited members UI. */
+  async getInheritedGroupMemberCards(): Promise<ApiProductGroupMembersComponentHarness[]> {
+    return this.locatorForAll(ApiProductGroupMembersComponentHarness)();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.html
@@ -27,8 +27,25 @@
             </p>
           </div>
           <div class="card__header__actions">
-            <button class="card__header__actions__button" mat-raised-button type="button" disabled>Transfer ownership</button>
-            <button class="card__header__actions__button" mat-raised-button type="button" disabled aria-label="Manage groups">
+            <button
+              class="card__header__actions__button"
+              mat-raised-button
+              type="button"
+              disabled
+              data-testid="api_product_members_transfer_ownership_button"
+            >
+              Transfer ownership
+            </button>
+            <button
+              *gioPermission="{ anyOf: ['api_product-member-u'] }"
+              class="card__header__actions__button"
+              mat-raised-button
+              type="button"
+              aria-label="Manage groups"
+              data-testid="api_product_members_manage_groups_button"
+              [disabled]="(state.groups?.length ?? 0) === 0"
+              (click)="openManageGroups()"
+            >
               Manage groups
             </button>
             <button
@@ -120,6 +137,19 @@
             <td [attr.colspan]="displayedColumns.length">
               @if (state.isLoading) {
                 <span data-testid="api_product_members_table_loading">Loading members…</span>
+              } @else if (state.loadError) {
+                <div class="card__table__no-data-error">
+                  <span data-testid="api_product_members_table_error">{{ state.loadError }}</span>
+                  <button
+                    mat-stroked-button
+                    type="button"
+                    color="primary"
+                    data-testid="api_product_members_retry_button"
+                    (click)="retryMembersLoad()"
+                  >
+                    Retry
+                  </button>
+                </div>
               } @else {
                 <span data-testid="api_product_members_table_empty">No members found</span>
               }
@@ -128,6 +158,21 @@
         </table>
       </gio-table-wrapper>
     </mat-card>
+
+    @if (visibleInheritedGroupCards().length) {
+      <div>
+        @for (group of visibleInheritedGroupCards(); track group.id) {
+          @if (groupInheritedVm()[group.id]) {
+            <api-product-group-members
+              [groupData]="group"
+              [filters]="groupInheritedFilters()[group.id] ?? groupInheritedFiltersDefault"
+              [dataSourceGroupVM]="groupInheritedVm()[group.id]"
+              (filtersChange)="onGroupInheritedFiltersChanged(group.id, $event)"
+            ></api-product-group-members>
+          }
+        }
+      </div>
+    }
 
     <gio-save-bar [form]="form" (resetClicked)="onReset()" (submitted)="onSave()"></gio-save-bar>
   }

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.scss
@@ -49,6 +49,13 @@
   &__table {
     width: 100%;
 
+    &__no-data-error {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
     .mat-column-picture {
       text-align: center;
       width: 1.5rem;

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.spec.ts
@@ -15,6 +15,7 @@
  */
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
@@ -23,17 +24,21 @@ import { InteractivityChecker } from '@angular/cdk/a11y';
 import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 
-import { ApiProductMembersComponent } from './api-product-members.component';
+import { ApiProductMembersComponent, GROUP_LIST_PAGE_SIZE } from './api-product-members.component';
+import { ApiProductGroupsDialogHarness } from './api-product-groups/api-product-groups.component.harness';
 import { ApiProductMembersComponentHarness } from './api-product-members.component.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { Member } from '../../../entities/management-api-v2/member/member';
 import { fakeMember } from '../../../entities/management-api-v2/member/member.fixture';
+import { fakeGroup } from '../../../entities/management-api-v2/group/group.fixture';
 
 describe('ApiProductMembersComponent', () => {
   const API_PRODUCT_ID = 'test-api-product-id';
   const MEMBERS_URL = `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}/members`;
+  const GROUPS_LIST_URL = `${CONSTANTS_TESTING.env.v2BaseURL}/groups`;
   const ROLES_URL = `${CONSTANTS_TESTING.org.baseURL}/configuration/rolescopes/API_PRODUCT/roles`;
 
   let fixture: ComponentFixture<ApiProductMembersComponent>;
@@ -48,13 +53,13 @@ describe('ApiProductMembersComponent', () => {
     initialQueryParams: Record<string, string> = {},
   ) {
     await TestBed.configureTestingModule({
-      imports: [ApiProductMembersComponent, NoopAnimationsModule, GioTestingModule, MatIconTestingModule],
+      imports: [ApiProductMembersComponent, NoopAnimationsModule, GioTestingModule, MatIconTestingModule, MatDialogModule],
       providers: [
         { provide: GioTestingPermissionProvider, useValue: permissions },
         { provide: SnackBarService, useValue: snackBarService },
         {
           provide: InteractivityChecker,
-          useValue: { isFocusable: () => true },
+          useValue: { isFocusable: () => true, isTabbable: () => true },
         },
         {
           provide: ActivatedRoute,
@@ -82,11 +87,72 @@ describe('ApiProductMembersComponent', () => {
     queryParams$.next({});
   });
 
-  function expectMembersRequest(members = [fakeMember()], totalCount = members.length, page = 1, perPage = 10) {
-    const req = httpTestingController.expectOne(r => r.url === MEMBERS_URL);
-    expect(req.request.params.get('page')).toEqual(page.toString());
-    expect(req.request.params.get('perPage')).toEqual(perPage.toString());
-    req.flush({ data: members, pagination: { totalCount, page, perPage } });
+  function expectMembersPageRequests(
+    members = [fakeMember()],
+    totalCount = members.length,
+    page = 1,
+    perPage = 10,
+    apiProductExtras: Record<string, unknown> = {},
+    groups = [fakeGroup({ id: 'group-1', name: 'Group One' })],
+  ) {
+    const pending = httpTestingController.match(
+      req => req.method === 'GET' && !req.url.includes('/configuration/rolescopes/API_PRODUCT/roles'),
+    );
+    expect(pending.length).toBe(3);
+    for (const req of pending) {
+      const url = req.request.url;
+      if (url.includes(`/api-products/${API_PRODUCT_ID}/members`)) {
+        expect(req.request.params.get('page')).toEqual(page.toString());
+        expect(req.request.params.get('perPage')).toEqual(perPage.toString());
+        req.flush({ data: members, pagination: { totalCount, page, perPage } });
+      } else if (url.includes(`/api-products/${API_PRODUCT_ID}`) && !url.includes('/members')) {
+        req.flush({
+          id: API_PRODUCT_ID,
+          name: 'Test API Product',
+          version: '1.0',
+          apiIds: [],
+          groups: [],
+          ...apiProductExtras,
+        });
+      } else if (url.includes(GROUPS_LIST_URL)) {
+        req.flush({
+          data: groups,
+          pagination: { totalCount: groups.length, page: 1, perPage: GROUP_LIST_PAGE_SIZE },
+        });
+      } else {
+        fail(`Unexpected GET ${url}`);
+      }
+    }
+  }
+
+  function expectMembersPageLoadFailure(errorMessage = 'Could not load members list', page = 1, perPage = 10) {
+    const pending = httpTestingController.match(
+      req => req.method === 'GET' && !req.url.includes('/configuration/rolescopes/API_PRODUCT/roles'),
+    );
+    expect(pending.length).toBe(3);
+    const membersReq = pending.find(r => r.request.url.includes(`/api-products/${API_PRODUCT_ID}/members`));
+    const apiProductReq = pending.find(
+      r => r.request.url.includes(`/api-products/${API_PRODUCT_ID}`) && !r.request.url.includes('/members'),
+    );
+    const groupsReq = pending.find(r => r.request.url.includes(GROUPS_LIST_URL));
+    expect(membersReq).toBeTruthy();
+    expect(apiProductReq).toBeTruthy();
+    expect(groupsReq).toBeTruthy();
+    expect(membersReq!.request.params.get('page')).toEqual(page.toString());
+    expect(membersReq!.request.params.get('perPage')).toEqual(perPage.toString());
+
+    apiProductReq!.flush({
+      id: API_PRODUCT_ID,
+      name: 'Test API Product',
+      version: '1.0',
+      apiIds: [],
+      groups: [],
+    });
+    groupsReq!.flush({
+      data: [],
+      pagination: { totalCount: 0, page: 1, perPage: GROUP_LIST_PAGE_SIZE },
+    });
+    membersReq!.flush({ message: errorMessage }, { status: 500, statusText: 'Internal Server Error' });
   }
 
   function expectRolesRequest() {
@@ -98,9 +164,43 @@ describe('ApiProductMembersComponent', () => {
     ]);
   }
 
+  /** Inherited group member tables load GET /groups/{id}/members after the main members page resolves. */
+  /** `gio-table-wrapper` may emit `filtersChange` after init and trigger a duplicate load for the same group. */
+  function flushGroupInheritedMemberRequests(groupIds: string[]) {
+    for (const groupId of groupIds) {
+      const requests = httpTestingController.match(r => r.method === 'GET' && r.url.includes(`/groups/${groupId}/members`));
+      expect(requests.length).toBeGreaterThan(0);
+      for (const req of requests) {
+        req.flush({ data: [], metadata: { groupName: groupId }, pagination: { totalCount: 0 } });
+      }
+    }
+  }
+
+  function flushGroupInheritedMemberForbidden(groupIds: string[]) {
+    for (const groupId of groupIds) {
+      const requests = httpTestingController.match(r => r.method === 'GET' && r.url.includes(`/groups/${groupId}/members`));
+      expect(requests.length).toBeGreaterThan(0);
+      for (const req of requests) {
+        req.flush(
+          { httpStatus: 403, message: 'You do not have the permissions to access this resource' },
+          { status: 403, statusText: 'Forbidden' },
+        );
+      }
+    }
+  }
+
+  function flushGroupInheritedMemberRequestsWithMembers(groupId: string, members: Member[]) {
+    const requests = httpTestingController.match(r => r.method === 'GET' && r.url.includes(`/groups/${groupId}/members`));
+    expect(requests.length).toBeGreaterThan(0);
+    const totalCount = members.length;
+    for (const req of requests) {
+      req.flush({ data: members, metadata: { groupName: groupId }, pagination: { totalCount, page: 1, perPage: 10 } });
+    }
+  }
+
   it('should render the Members section with title and description', fakeAsync(async () => {
     await init();
-    expectMembersRequest([]);
+    expectMembersPageRequests([]);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -111,7 +211,7 @@ describe('ApiProductMembersComponent', () => {
 
   it('should render picture, Name and Role column headers', fakeAsync(async () => {
     await init();
-    expectMembersRequest([]);
+    expectMembersPageRequests([]);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -125,7 +225,7 @@ describe('ApiProductMembersComponent', () => {
 
   it('should render delete column when user has delete permission', fakeAsync(async () => {
     await init(['api_product-member-r', 'api_product-member-c', 'api_product-member-d', 'api_product-member-u']);
-    expectMembersRequest([]);
+    expectMembersPageRequests([]);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -140,7 +240,7 @@ describe('ApiProductMembersComponent', () => {
   it('should display existing members in the table', fakeAsync(async () => {
     await init();
     const member = fakeMember({ id: 'user-1', displayName: 'Alice', roles: [{ name: 'USER' }] });
-    expectMembersRequest([member]);
+    expectMembersPageRequests([member]);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -157,7 +257,7 @@ describe('ApiProductMembersComponent', () => {
   it('should show Primary Owner role in the Role column', fakeAsync(async () => {
     await init();
     const owner = fakeMember({ id: 'owner-1', displayName: 'Admin', roles: [{ name: 'PRIMARY_OWNER' }] });
-    expectMembersRequest([owner]);
+    expectMembersPageRequests([owner]);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -170,7 +270,7 @@ describe('ApiProductMembersComponent', () => {
 
   it('should show "No members found" when there are no members', fakeAsync(async () => {
     await init();
-    expectMembersRequest([]);
+    expectMembersPageRequests([]);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -178,9 +278,32 @@ describe('ApiProductMembersComponent', () => {
     expect(await harness.getEmptyMessage()).toBe('No members found');
   }));
 
+  it('should surface load failure with message and retry (not empty state)', fakeAsync(async () => {
+    await init();
+    expectMembersPageLoadFailure('Members endpoint unavailable');
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    expect(snackBarService.error).not.toHaveBeenCalled();
+    expect(await harness.getLoadErrorMessage()).toBe('Members endpoint unavailable');
+    expect(await harness.getEmptyMessageOrNull()).toBeNull();
+
+    await harness.clickRetryMembersLoad();
+    tick();
+    fixture.detectChanges();
+
+    expectMembersPageRequests([]);
+    tick();
+    fixture.detectChanges();
+
+    expect(await harness.getLoadErrorMessage()).toBeNull();
+    expect(await harness.getEmptyMessage()).toBe('No members found');
+  }));
+
   it('should show "Add members" button when user has create permission', fakeAsync(async () => {
     await init(['api_product-member-r', 'api_product-member-c']);
-    expectMembersRequest([]);
+    expectMembersPageRequests([]);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -188,9 +311,132 @@ describe('ApiProductMembersComponent', () => {
     expect(await harness.getAddMemberButton()).not.toBeNull();
   }));
 
+  it('should expose Manage groups when permitted and groups exist', fakeAsync(async () => {
+    await init(['api_product-member-r', 'api_product-member-u']);
+    expectMembersPageRequests([], 0, 1, 10, { groups: ['group-1'] }, [fakeGroup({ id: 'group-1', name: 'Group One' })]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+    flushGroupInheritedMemberRequests(['group-1']);
+    tick();
+    fixture.detectChanges();
+
+    expect(await harness.getManageGroupsButton()).not.toBeNull();
+  }));
+
+  it('should open Manage groups dialog with editable groups select and save when user has api_product-member-u', fakeAsync(async () => {
+    await init(['api_product-member-r', 'api_product-member-u']);
+    expectMembersPageRequests([], 0, 1, 10, { groups: ['group-1'] }, [fakeGroup({ id: 'group-1', name: 'Group One' })]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+    flushGroupInheritedMemberRequests(['group-1']);
+    tick();
+    fixture.detectChanges();
+
+    await harness.clickManageGroups();
+    tick();
+    fixture.detectChanges();
+
+    const rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    const dialogBody = await rootLoader.getHarness(ApiProductGroupsDialogHarness);
+    expect(await dialogBody.getHeadingTitle()).toBe('Manage groups');
+    expect(await dialogBody.getGroupsSelect()).not.toBeNull();
+    expect(await dialogBody.getSaveButton()).not.toBeNull();
+  }));
+
+  it('should PUT API Product with selected groups when Manage groups save is confirmed', fakeAsync(async () => {
+    await init(['api_product-member-r', 'api_product-member-u']);
+    const g1 = fakeGroup({ id: 'group-1', name: 'Group One' });
+    const g2 = fakeGroup({ id: 'group-2', name: 'Group Two' });
+    expectMembersPageRequests([], 0, 1, 10, { groups: ['group-1'] }, [g1, g2]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+    flushGroupInheritedMemberRequestsWithMembers('group-1', [
+      fakeMember({ id: 'gm-1', displayName: 'Inherited User', roles: [{ name: 'USER', scope: 'API_PRODUCT' }] }),
+    ]);
+    tick();
+    fixture.detectChanges();
+
+    await harness.clickManageGroups();
+    tick();
+    fixture.detectChanges();
+
+    const rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+    const dialogBody = await rootLoader.getHarness(ApiProductGroupsDialogHarness);
+    expect(await dialogBody.getHeadingTitle()).toBe('Manage groups');
+    expect(await dialogBody.getGroupsSelect()).not.toBeNull();
+    expect(await dialogBody.getSaveButton()).not.toBeNull();
+
+    await dialogBody.clickSave();
+    tick();
+    fixture.detectChanges();
+
+    const putReq = httpTestingController.expectOne(
+      req => req.method === 'PUT' && req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`,
+    );
+    expect(putReq.request.body.groups).toEqual(['group-1']);
+    putReq.flush({
+      id: API_PRODUCT_ID,
+      name: 'Test API Product',
+      version: '1.0',
+      apiIds: [],
+      groups: ['group-1'],
+    });
+    tick();
+    fixture.detectChanges();
+
+    expectMembersPageRequests([], 0, 1, 10, { groups: ['group-1'] }, [g1, g2]);
+    tick();
+    fixture.detectChanges();
+  }));
+
+  it('should show permission message on inherited group card when group members API returns 403', fakeAsync(async () => {
+    await init(['api_product-member-r', 'api_product-member-u']);
+    expectMembersPageRequests([], 0, 1, 10, { groups: ['group-1'] }, [fakeGroup({ id: 'group-1', name: 'Group One' })]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+    flushGroupInheritedMemberForbidden(['group-1']);
+    tick();
+    fixture.detectChanges();
+
+    const cards = await harness.getInheritedGroupMemberCards();
+    expect(cards.length).toBe(1);
+    expect(await cards[0].getPermissionDeniedMessage()).toContain('appropriate permissions');
+    expect(await cards[0].getInheritedMembersTable()).toBeNull();
+  }));
+
+  it('should render inherited group member rows on group card when API returns members', fakeAsync(async () => {
+    await init(['api_product-member-r', 'api_product-member-u']);
+    expectMembersPageRequests([], 0, 1, 10, { groups: ['group-1'] }, [fakeGroup({ id: 'group-1', name: 'Group One' })]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+    flushGroupInheritedMemberRequestsWithMembers('group-1', [
+      fakeMember({ id: 'gm-1', displayName: 'Inherited User', roles: [{ name: 'USER', scope: 'API_PRODUCT' }] }),
+    ]);
+    tick();
+    fixture.detectChanges();
+
+    const cards = await harness.getInheritedGroupMemberCards();
+    expect(cards.length).toBe(1);
+    expect(await cards[0].getCardHeading()).toContain('Group One');
+    expect(await cards[0].getCardHeading()).toContain('inherited members');
+    const table = await cards[0].getInheritedMembersTable();
+    expect(table).not.toBeNull();
+    const rows = await table!.getRows();
+    expect(rows.length).toBe(1);
+    const cells = await rows[0].getCells();
+    const cellTexts = await Promise.all(cells.map(c => c.getText()));
+    expect(cellTexts[1]).toContain('Inherited User');
+    expect(cellTexts[2]).toContain('USER');
+  }));
+
   it('should hide "Add members" button when user lacks create permission', fakeAsync(async () => {
     await init(['api_product-member-r']);
-    expectMembersRequest([]);
+    expectMembersPageRequests([]);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -203,7 +449,7 @@ describe('ApiProductMembersComponent', () => {
     const router = TestBed.inject(Router);
     const navigateSpy = jest.spyOn(router, 'navigate');
 
-    expectMembersRequest([fakeMember({ id: 'm1', roles: [{ name: 'USER' }] })], 50, 1, 10);
+    expectMembersPageRequests([fakeMember({ id: 'm1', roles: [{ name: 'USER' }] })], 50, 1, 10);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -225,7 +471,7 @@ describe('ApiProductMembersComponent', () => {
     await init(['api_product-member-r', 'api_product-member-c', 'api_product-member-d']);
 
     const onlyMember = fakeMember({ id: 'last-member', displayName: 'Last Member', roles: [{ name: 'USER' }] });
-    expectMembersRequest([onlyMember], 11, 1, 10);
+    expectMembersPageRequests([onlyMember], 11, 1, 10);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -239,11 +485,11 @@ describe('ApiProductMembersComponent', () => {
     tick();
     fixture.detectChanges();
 
-    httpTestingController.expectOne(r => r.url === `${MEMBERS_URL}/last-member` && r.method === 'DELETE').flush({});
+    httpTestingController.expectOne(req => req.url === `${MEMBERS_URL}/last-member` && req.method === 'DELETE').flush({});
     tick();
     fixture.detectChanges();
 
-    expectMembersRequest([], 10, 1, 10);
+    expectMembersPageRequests([], 10, 1, 10);
     tick();
     fixture.detectChanges();
 
@@ -258,7 +504,7 @@ describe('ApiProductMembersComponent', () => {
     const navigateSpy = jest.spyOn(router, 'navigate');
 
     const onlyMember = fakeMember({ id: 'page3-member', displayName: 'Page 3 Member', roles: [{ name: 'USER' }] });
-    expectMembersRequest([onlyMember], 21, 3, 10);
+    expectMembersPageRequests([onlyMember], 21, 3, 10);
     expectRolesRequest();
     tick();
     fixture.detectChanges();
@@ -272,11 +518,11 @@ describe('ApiProductMembersComponent', () => {
     tick();
     fixture.detectChanges();
 
-    httpTestingController.expectOne(r => r.url === `${MEMBERS_URL}/page3-member` && r.method === 'DELETE').flush({});
+    httpTestingController.expectOne(req => req.url === `${MEMBERS_URL}/page3-member` && req.method === 'DELETE').flush({});
     tick();
     fixture.detectChanges();
 
-    httpTestingController.expectNone(r => r.url === MEMBERS_URL && r.method === 'GET');
+    httpTestingController.expectNone(req => req.url === MEMBERS_URL && req.method === 'GET');
     expect(navigateSpy).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { page: 2 }, queryParamsHandling: 'merge' }));
   }));
 });

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.ts
@@ -27,6 +27,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatTableModule } from '@angular/material/table';
 import { ActivatedRoute, Router } from '@angular/router';
 import {
+  GIO_DIALOG_WIDTH,
   GioAvatarModule,
   GioConfirmDialogComponent,
   GioConfirmDialogData,
@@ -38,6 +39,18 @@ import { combineLatest, EMPTY, forkJoin, merge, Observable, of, Subject } from '
 import { catchError, distinctUntilChanged, filter, map, shareReplay, startWith, switchMap, take, tap } from 'rxjs/operators';
 import { isEqual, uniqueId } from 'lodash';
 
+import {
+  ApiProductGroupsComponent,
+  ApiProductGroupsDialogData,
+  ApiProductGroupsDialogResult,
+} from './api-product-groups/api-product-groups.component';
+import {
+  ApiProductGroupCardData,
+  ApiProductGroupMemberRow,
+  ApiProductGroupMembersComponent,
+  ApiProductGroupMembersViewModel,
+} from './api-product-group-members/api-product-group-members.component';
+
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
@@ -48,10 +61,12 @@ import {
   GioUsersSelectorData,
 } from '../../../shared/components/gio-users-selector/gio-users-selector.component';
 import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { GroupV2Service } from '../../../services-ngx/group-v2.service';
 import { RoleService } from '../../../services-ngx/role.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { UsersService } from '../../../services-ngx/users.service';
-import { Member } from '../../../entities/management-api-v2';
+import { Group, Member } from '../../../entities/management-api-v2';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
 import { SearchableUser } from '../../../entities/user/searchableUser';
 
 export interface MemberRow {
@@ -65,11 +80,32 @@ export interface MemberRow {
 
 interface MembersState {
   isLoading: boolean;
+  loadError: string | null;
   rows: MemberRow[];
   totalCount: number;
+  apiProduct: ApiProduct | null;
+  groups: Group[];
+  groupCards: ApiProductGroupCardData[];
 }
 
-const LOADING_STATE: MembersState = { isLoading: true, rows: [], totalCount: 0 };
+const LOADING_STATE: MembersState = {
+  isLoading: true,
+  loadError: null,
+  rows: [],
+  totalCount: 0,
+  apiProduct: null,
+  groups: [],
+  groupCards: [],
+};
+
+const MEMBERS_PAGE_LOAD_FAILED = 'Could not load API Product members.';
+
+export const GROUP_LIST_PAGE_SIZE = 9999;
+
+export const GROUP_INHERITED_FILTERS_DEFAULT: Readonly<GioTableWrapperFilters> = {
+  pagination: { index: 1, size: 10 },
+  searchTerm: '',
+};
 
 function effectiveRoleName(member: Member): string {
   const roles = member.roles ?? [];
@@ -97,12 +133,15 @@ function effectiveRoleName(member: Member): string {
     GioSaveBarModule,
     GioTableWrapperModule,
     GioUsersSelectorModule,
+    ApiProductGroupMembersComponent,
+    ApiProductGroupsComponent,
   ],
 })
 export class ApiProductMembersComponent {
   private readonly router = inject(Router);
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly apiProductV2Service = inject(ApiProductV2Service);
+  private readonly groupV2Service = inject(GroupV2Service);
   private readonly roleService = inject(RoleService);
   private readonly usersService = inject(UsersService);
   private readonly permissionService = inject(GioPermissionService);
@@ -112,6 +151,9 @@ export class ApiProductMembersComponent {
 
   private readonly reloadMembers$ = new Subject<void>();
   private readonly pendingUsers = signal<Array<SearchableUser & { viewId: string; userPicture: string }>>([]);
+  protected readonly groupInheritedFilters = signal<Record<string, GioTableWrapperFilters>>({});
+  protected readonly groupInheritedVm = signal<Record<string, ApiProductGroupMembersViewModel>>({});
+  protected readonly groupInheritedFiltersDefault = GROUP_INHERITED_FILTERS_DEFAULT;
   protected readonly isReadOnly = !this.permissionService.hasAnyMatching(['api_product-member-u']);
   protected readonly displayedColumns = this.permissionService.hasAnyMatching(['api_product-member-d'])
     ? ['picture', 'displayName', 'role', 'delete']
@@ -128,7 +170,16 @@ export class ApiProductMembersComponent {
     shareReplay({ bufferSize: 1, refCount: true }),
   );
 
-  private readonly roles = toSignal(this.roleService.list('API_PRODUCT').pipe(take(1)));
+  /** `apiProductId` from the route (same stream as `membersLoadState` / pagination; no snapshot). */
+  private readonly apiProductIdFromRoute$ = this.activatedRoute.paramMap.pipe(
+    map(p => p.get('apiProductId') ?? ''),
+    distinctUntilChanged(),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+
+  private readonly apiProductId = toSignal(this.apiProductIdFromRoute$, { initialValue: '' });
+
+  private readonly roles = toSignal(this.roleService.list('API_PRODUCT'));
 
   protected readonly roleNames = computed(() => (this.roles() ?? []).map(r => r.name));
 
@@ -139,25 +190,46 @@ export class ApiProductMembersComponent {
 
   protected readonly membersLoadState = toSignal(
     combineLatest([
-      this.activatedRoute.paramMap.pipe(
-        map(p => p.get('apiProductId') ?? ''),
-        filter(id => id !== ''),
-        distinctUntilChanged(),
-      ),
+      this.apiProductIdFromRoute$.pipe(filter(id => id !== '')),
       this.paginationFromRoute$,
       merge(of(null), this.reloadMembers$),
     ]).pipe(
       switchMap(([apiProductId, { page, size }]) =>
-        this.apiProductV2Service.getPagedMembers(apiProductId, page, size).pipe(
-          map(res => ({
-            isLoading: false,
-            rows: (res.data ?? []).map(m => this.mapMemberToRow(m)),
-            totalCount: res.pagination?.totalCount ?? 0,
-          })),
-          catchError(() => of({ ...LOADING_STATE, isLoading: false })),
+        forkJoin({
+          membersRes: this.apiProductV2Service.getPagedMembers(apiProductId, page, size),
+          apiProduct: this.apiProductV2Service.get(apiProductId),
+          groupsRes: this.groupV2Service.list(1, GROUP_LIST_PAGE_SIZE),
+        }).pipe(
+          map(({ membersRes, apiProduct, groupsRes }) => {
+            const groups = groupsRes.data ?? [];
+            const groupCards: ApiProductGroupCardData[] =
+              apiProduct.groups?.map(id => ({
+                id,
+                name: groups.find(g => g.id === id)?.name,
+              })) ?? [];
+            return {
+              isLoading: false,
+              loadError: null,
+              rows: (membersRes.data ?? []).map(m => this.mapMemberToRow(m)),
+              totalCount: membersRes.pagination?.totalCount ?? 0,
+              apiProduct,
+              groups,
+              groupCards,
+            };
+          }),
+          catchError((err: unknown) => {
+            const message =
+              err instanceof HttpErrorResponse
+                ? ((err.error?.message as string | undefined) ?? MEMBERS_PAGE_LOAD_FAILED)
+                : MEMBERS_PAGE_LOAD_FAILED;
+            return of({ ...LOADING_STATE, isLoading: false, loadError: message });
+          }),
         ),
       ),
-      tap(state => this.syncMembersFormGroup(state.rows)),
+      tap(state => {
+        this.syncMembersFormGroup(state.rows);
+        this.syncGroupInheritedMembersState(state);
+      }),
     ),
     { initialValue: LOADING_STATE },
   );
@@ -166,7 +238,9 @@ export class ApiProductMembersComponent {
     this.paginationFromRoute$.pipe(
       map(({ page, size }) => ({ pagination: { index: page, size }, searchTerm: '' }) satisfies GioTableWrapperFilters),
     ),
-    { initialValue: { pagination: { index: 1, size: 10 }, searchTerm: '' } satisfies GioTableWrapperFilters },
+    {
+      initialValue: { ...GROUP_INHERITED_FILTERS_DEFAULT } satisfies GioTableWrapperFilters,
+    },
   );
 
   private readonly pendingRows = computed<MemberRow[]>(() =>
@@ -182,9 +256,59 @@ export class ApiProductMembersComponent {
 
   protected readonly allRows = computed<MemberRow[]>(() => [...this.pendingRows(), ...this.membersLoadState().rows]);
 
+  protected readonly visibleInheritedGroupCards = computed<ApiProductGroupCardData[]>(() =>
+    (this.membersLoadState().groupCards ?? []).filter(g => !!g.id),
+  );
+
+  protected onGroupInheritedFiltersChanged(groupId: string, filters: GioTableWrapperFilters): void {
+    const previous = this.groupInheritedFilters()[groupId];
+    if (previous && isEqual(previous, filters)) {
+      return;
+    }
+    this.groupInheritedFilters.update(m => ({ ...m, [groupId]: filters }));
+    this.loadGroupInheritedMembers(groupId, filters.pagination.index, filters.pagination.size);
+  }
+
   private readonly roleValidationSubscription = merge(this.membersForm.statusChanges, this.membersForm.valueChanges)
     .pipe(startWith(null), takeUntilDestroyed())
     .subscribe(() => this.refreshRoleFieldRequiredErrors());
+
+  protected openManageGroups(): void {
+    const state = this.membersLoadState();
+    const apiProduct = state.apiProduct;
+    const groups = state.groups;
+    if (!apiProduct || groups.length === 0) {
+      return;
+    }
+
+    this.matDialog
+      .open<ApiProductGroupsComponent, ApiProductGroupsDialogData, ApiProductGroupsDialogResult>(ApiProductGroupsComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        role: 'alertdialog',
+        id: 'apiProductManageGroupsDialog',
+        data: {
+          apiProduct,
+          groups: groups.filter(group => !group.apiPrimaryOwner),
+        },
+      })
+      .afterClosed()
+      .pipe(
+        filter((result): result is ApiProductGroupsDialogResult => !!result),
+        switchMap(result =>
+          this.apiProductV2Service.update(this.apiProductId(), {
+            name: apiProduct.name,
+            version: apiProduct.version,
+            description: apiProduct.description,
+            apiIds: apiProduct.apiIds ?? [],
+            groups: result.groups,
+          }),
+        ),
+        tap(() => this.reloadMembers$.next()),
+        catchError(this.memberHttpErrorHandler('Could not update API Product groups.')),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
 
   protected onFiltersChanged(filters: GioTableWrapperFilters): void {
     this.router.navigate([], {
@@ -194,8 +318,12 @@ export class ApiProductMembersComponent {
     });
   }
 
+  protected retryMembersLoad(): void {
+    this.reloadMembers$.next();
+  }
+
   protected openAddMemberDialog(): void {
-    const apiProductId = this.apiProductId;
+    const apiProductId = this.apiProductId();
     const { totalCount, rows } = this.membersLoadState();
     const pendingIds = this.pendingUsers()
       .map(u => u.id ?? '')
@@ -216,7 +344,7 @@ export class ApiProductMembersComponent {
           const existingIds = new Set([...memberIds, ...pendingIds]);
           return this.matDialog
             .open<GioUsersSelectorComponent, GioUsersSelectorData, SearchableUser[]>(GioUsersSelectorComponent, {
-              width: '500px',
+              width: GIO_DIALOG_WIDTH.MEDIUM,
               data: {
                 userFilterPredicate: user => !existingIds.has(user.id ?? ''),
               },
@@ -236,7 +364,7 @@ export class ApiProductMembersComponent {
     if (!member.id || member.isPending || member.isPrimaryOwner) {
       return;
     }
-    const apiProductId = this.apiProductId;
+    const apiProductId = this.apiProductId();
     const confirm = this.matDialog.open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
       data: {
         title: 'Remove API Product member',
@@ -275,7 +403,7 @@ export class ApiProductMembersComponent {
   }
 
   protected onSave(): void {
-    const apiProductId = this.apiProductId;
+    const apiProductId = this.apiProductId();
     const controls = this.membersForm.controls as Record<string, AbstractControl>;
     const dirtyEntries = Object.entries(controls).filter(([, c]) => c.dirty) as [string, FormControl<string>][];
 
@@ -322,10 +450,6 @@ export class ApiProductMembersComponent {
     return this.form.get('members') as FormGroup;
   }
 
-  private get apiProductId(): string {
-    return this.activatedRoute.snapshot.paramMap.get('apiProductId') ?? '';
-  }
-
   private memberHttpErrorHandler(fallbackMessage: string) {
     return (err: HttpErrorResponse) => {
       this.snackBarService.error(err.error?.message ?? fallbackMessage);
@@ -339,6 +463,134 @@ export class ApiProductMembersComponent {
       next[id] = this.membersForm.controls[id].hasError('required');
     }
     this.roleFieldShowsRequiredError.set(next);
+  }
+
+  private syncGroupInheritedMembersState(state: MembersState): void {
+    const visibleCards = (state.groupCards ?? []).filter(g => !!g.id);
+    const visibleIds = new Set(visibleCards.map(g => g.id));
+
+    this.groupInheritedFilters.update(m => {
+      const next = { ...m };
+      for (const id of Object.keys(next)) {
+        if (!visibleIds.has(id)) {
+          delete next[id];
+        }
+      }
+      return next;
+    });
+
+    this.groupInheritedVm.update(m => {
+      const next = { ...m };
+      for (const id of Object.keys(next)) {
+        if (!visibleIds.has(id)) {
+          delete next[id];
+        }
+      }
+      return next;
+    });
+
+    for (const card of visibleCards) {
+      const id = card.id;
+      if (this.groupInheritedVm()[id] !== undefined) {
+        continue;
+      }
+      this.groupInheritedFilters.update(m => ({
+        ...m,
+        [id]: m[id] ?? { ...GROUP_INHERITED_FILTERS_DEFAULT },
+      }));
+      this.groupInheritedVm.update(m => ({
+        ...m,
+        [id]: {
+          isLoading: true,
+          canViewGroupMembers: true,
+          memberTotalCount: 0,
+          membersPageResult: [],
+        },
+      }));
+      this.loadGroupInheritedMembers(id, 1, 10);
+    }
+  }
+
+  private loadGroupInheritedMembers(groupId: string, page: number, perPage: number): void {
+    const previousVm = this.groupInheritedVm()[groupId];
+    this.groupInheritedVm.update(m => ({
+      ...m,
+      [groupId]: {
+        isLoading: true,
+        canViewGroupMembers: previousVm?.canViewGroupMembers ?? true,
+        memberTotalCount: previousVm?.memberTotalCount ?? 0,
+        membersPageResult: [],
+      },
+    }));
+
+    this.groupV2Service
+      .getMembers(groupId, page, perPage)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        take(1),
+        catchError((err: HttpErrorResponse) => {
+          const forbidden = err.error?.httpStatus === 403 || err.status === 403;
+          if (forbidden) {
+            this.groupInheritedVm.update(m => ({
+              ...m,
+              [groupId]: {
+                isLoading: false,
+                canViewGroupMembers: false,
+                memberTotalCount: 0,
+                membersPageResult: [],
+              },
+            }));
+            return EMPTY;
+          }
+          this.snackBarService.error(err.error?.message ?? 'Could not load inherited group members.');
+          this.groupInheritedVm.update(m => ({
+            ...m,
+            [groupId]: {
+              isLoading: false,
+              canViewGroupMembers: previousVm?.canViewGroupMembers ?? true,
+              memberTotalCount: 0,
+              membersPageResult: [],
+            },
+          }));
+          return EMPTY;
+        }),
+      )
+      .subscribe(res => {
+        const totalCount = res.pagination?.totalCount ?? 0;
+        if (totalCount === 0) {
+          this.groupInheritedFilters.update(m => {
+            const next = { ...m };
+            delete next[groupId];
+            return next;
+          });
+          this.groupInheritedVm.update(m => {
+            const next = { ...m };
+            delete next[groupId];
+            return next;
+          });
+          return;
+        }
+        this.groupInheritedVm.update(m => ({
+          ...m,
+          [groupId]: {
+            isLoading: false,
+            canViewGroupMembers: true,
+            memberTotalCount: totalCount,
+            membersPageResult: (res.data ?? []).map(member => this.mapGroupMemberToRow(member)),
+          },
+        }));
+      });
+  }
+
+  private mapGroupMemberToRow(member: Member): ApiProductGroupMemberRow {
+    const roles = member.roles ?? [];
+    const roleName = roles.find(r => r.scope === 'API_PRODUCT')?.name ?? '';
+    return {
+      id: member.id ?? '',
+      role: roleName,
+      displayName: member.displayName ?? '',
+      picture: this.usersService.getUserAvatar(member.id),
+    };
   }
 
   private mapMemberToRow(member: Member): MemberRow {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13379

## Description

Extends the API Product → Configuration → User permissions → Members experience so it matches the API → User & group access → Members pattern: users with the right permissions can attach environment groups to the product, and the UI shows inherited members for each linked group with pagination and error handling.

## Additional context

https://github.com/user-attachments/assets/8192981f-7033-4fcb-b172-2f43b5a05a3a


https://github.com/user-attachments/assets/f1f8dddc-b63f-43a2-8c71-3726eaaf3335




