### PR TITLE
chore(4.10.x): bump gravitee-endpoint-kafka from 5.1.3 to 5.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <gravitee-entrypoint-agent-to-agent.version>1.0.1</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp.version>1.1.0</gravitee-entrypoint-mcp.version>
         <gravitee-endpoint-jms.version>1.0.1</gravitee-endpoint-jms.version>
-        <gravitee-endpoint-kafka.version>5.1.3</gravitee-endpoint-kafka.version>
+        <gravitee-endpoint-kafka.version>5.1.4</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>4.0.1</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>3.0.2</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>3.0.2</gravitee-endpoint-solace.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-endpoint-kafka](https://github.com/gravitee-io/gravitee-endpoint-kafka)** from `5.1.3` to `5.1.4` on branch `4.10.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-endpoint-kafka/releases) page for details.

## Jira

[APIM-13697](https://gravitee.atlassian.net/browse/APIM-13697)

[APIM-13697]: https://gravitee.atlassian.net/browse/APIM-13697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ