### PR TITLE
feat(dashboard): add DynamicFilterBarComponent for observability filters

### DIFF
--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.html
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.html
@@ -1,0 +1,48 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="gd-dynamic-filter-bar">
+  <div class="gd-dynamic-filter-bar__controls">
+    <span class="gd-dynamic-filter-bar__label">Filters</span>
+
+    @if (editable()) {
+      <mat-chip class="gd-dynamic-filter-bar__add-btn" (click)="addRequested.emit()">
+        <span class="gd-dynamic-filter-bar__add-btn-icon" aria-hidden="true">+</span>
+        Add filter
+      </mat-chip>
+    }
+  </div>
+
+  @if (hasConditions()) {
+    <div class="gd-dynamic-filter-bar__chips">
+      @for (condition of conditions(); track condition.field; let i = $index) {
+        <gd-filter-chip
+          [filter]="condition"
+          [editable]="editable()"
+          (clicked)="editRequested.emit({ index: i, condition: condition })"
+          (removed)="removeRequested.emit(i)"
+        />
+      }
+    </div>
+
+    @if (editable()) {
+      <button mat-icon-button class="gd-dynamic-filter-bar__clear-btn" matTooltip="Clear all filters" (click)="clearRequested.emit()">
+        <mat-icon>filter_list_off</mat-icon>
+      </button>
+    }
+  }
+</div>

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.scss
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+gd-dynamic-filter-bar {
+  display: block;
+}
+
+.gd-dynamic-filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  line-height: 1;
+}
+
+.gd-dynamic-filter-bar__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.gd-dynamic-filter-bar__label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gd-filter-bar-label-color, rgba(0, 0, 0, 0.6));
+  white-space: nowrap;
+  user-select: none;
+}
+
+.gd-dynamic-filter-bar__add-btn {
+  --mat-chip-container-shape-radius: var(--gd-filter-chip-radius, 6px);
+  --mat-chip-container-height: var(--gd-filter-chip-height, 24px);
+  --mat-chip-elevated-container-color: transparent;
+  --mat-chip-label-text-color: var(--gd-filter-chip-color, var(--mat-sys-on-primary-container, #f15115));
+  --mat-chip-label-text-size: var(--gd-filter-chip-font-size, 12px);
+  --mat-chip-label-text-weight: var(--gd-filter-chip-font-weight, 600);
+  --mat-chip-outline-width: 0;
+  --mat-chip-hover-state-layer-opacity: 0;
+  --mat-chip-focus-state-layer-opacity: 0;
+  cursor: pointer;
+
+  &:hover,
+  &:focus-within {
+    --mat-chip-elevated-container-color: var(--gd-filter-chip-background, var(--mat-sys-primary-container, #fff3eb));
+  }
+}
+
+.gd-dynamic-filter-bar__add-btn .mdc-evolution-chip__action--primary {
+  padding-left: var(--gd-filter-chip-padding-h, 8px);
+  padding-right: var(--gd-filter-chip-padding-h, 8px);
+  cursor: pointer;
+}
+
+.gd-dynamic-filter-bar__add-btn .mdc-evolution-chip__text-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-family: var(--gd-filter-chip-font-family, inherit);
+}
+
+.gd-dynamic-filter-bar__add-btn-icon {
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.gd-dynamic-filter-bar__chips {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.gd-dynamic-filter-bar .mat-mdc-standard-chip {
+  margin: 0;
+}
+
+.gd-dynamic-filter-bar__chips > gd-filter-chip {
+  display: flex;
+}
+
+.gd-dynamic-filter-bar__clear-btn.mat-mdc-icon-button {
+  --mdc-icon-button-state-layer-size: 24px;
+  --mdc-icon-button-icon-size: 16px;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  flex-shrink: 0;
+
+  .mat-mdc-button-touch-target {
+    width: 24px;
+    height: 24px;
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.spec.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { FilterCondition } from '../filter.model';
+import { DynamicFilterBarComponent } from './dynamic-filter-bar.component';
+
+const STATUS_EQ_200: FilterCondition = { field: 'HTTP_STATUS', label: 'Status Code', operator: 'EQ', values: ['200'] };
+const API_IN_TWO: FilterCondition = { field: 'API', label: 'API', operator: 'IN', values: ['uuid-1', 'uuid-2'] };
+const UNKNOWN_FILTER: FilterCondition = { field: 'UNKNOWN_NEW_FILTER', label: 'Unknown', operator: 'EQ', values: ['val'] };
+
+@Component({
+  standalone: true,
+  imports: [DynamicFilterBarComponent],
+  template: `
+    <gd-dynamic-filter-bar
+      [conditions]="conditions()"
+      [editable]="editable()"
+      (addRequested)="addCount.set(addCount() + 1)"
+      (editRequested)="lastEdit.set($event)"
+      (removeRequested)="lastRemoveIndex.set($event)"
+      (clearRequested)="clearCount.set(clearCount() + 1)"
+    />
+  `,
+})
+class TestHostComponent {
+  conditions = signal<FilterCondition[]>([]);
+  editable = signal(true);
+  addCount = signal(0);
+  lastEdit = signal<{ index: number; condition: FilterCondition } | null>(null);
+  lastRemoveIndex = signal<number | null>(null);
+  clearCount = signal(0);
+}
+
+describe('DynamicFilterBarComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  describe('empty state', () => {
+    it('should render no chips when conditions is empty', () => {
+      const chips = fixture.debugElement.queryAll(By.css('gd-filter-chip'));
+      expect(chips.length).toBe(0);
+    });
+
+    it('should render the add button', () => {
+      const addBtn = fixture.debugElement.query(By.css('.gd-dynamic-filter-bar__add-btn'));
+      expect(addBtn).toBeTruthy();
+    });
+
+    it('should not render the clear button when no conditions', () => {
+      const clearBtn = fixture.debugElement.query(By.css('.gd-dynamic-filter-bar__clear-btn'));
+      expect(clearBtn).toBeNull();
+    });
+  });
+
+  describe('with conditions', () => {
+    beforeEach(() => {
+      host.conditions.set([STATUS_EQ_200, API_IN_TWO]);
+      fixture.detectChanges();
+    });
+
+    it('should render one chip per condition', () => {
+      const chips = fixture.debugElement.queryAll(By.css('gd-filter-chip'));
+      expect(chips.length).toBe(2);
+    });
+
+    it('should render the clear button when conditions exist', () => {
+      const clearBtn = fixture.debugElement.query(By.css('.gd-dynamic-filter-bar__clear-btn'));
+      expect(clearBtn).toBeTruthy();
+    });
+
+    it('should emit removeRequested with index when chip remove is triggered', () => {
+      const chips = fixture.debugElement.queryAll(By.css('gd-filter-chip'));
+      chips[1].componentInstance.removed.emit();
+      fixture.detectChanges();
+      expect(host.lastRemoveIndex()).toBe(1);
+    });
+
+    it('should emit editRequested with index and condition when chip is clicked', () => {
+      const chips = fixture.debugElement.queryAll(By.css('gd-filter-chip'));
+      chips[0].componentInstance.clicked.emit();
+      fixture.detectChanges();
+      expect(host.lastEdit()).toEqual({ index: 0, condition: STATUS_EQ_200 });
+    });
+  });
+
+  describe('add button', () => {
+    it('should emit addRequested when add button is clicked', () => {
+      const addBtn = fixture.debugElement.query(By.css('.gd-dynamic-filter-bar__add-btn'));
+      addBtn.nativeElement.click();
+      fixture.detectChanges();
+      expect(host.addCount()).toBe(1);
+    });
+  });
+
+  describe('clear button', () => {
+    it('should emit clearRequested when clear button is clicked', () => {
+      host.conditions.set([STATUS_EQ_200]);
+      fixture.detectChanges();
+      const clearBtn = fixture.debugElement.query(By.css('.gd-dynamic-filter-bar__clear-btn'));
+      clearBtn.nativeElement.click();
+      fixture.detectChanges();
+      expect(host.clearCount()).toBe(1);
+    });
+  });
+
+  describe('editable=false', () => {
+    beforeEach(() => {
+      host.conditions.set([STATUS_EQ_200]);
+      host.editable.set(false);
+      fixture.detectChanges();
+    });
+
+    it('should hide add and clear buttons', () => {
+      expect(fixture.debugElement.query(By.css('.gd-dynamic-filter-bar__add-btn'))).toBeNull();
+      expect(fixture.debugElement.query(By.css('.gd-dynamic-filter-bar__clear-btn'))).toBeNull();
+    });
+
+    it('should pass editable=false to chips', () => {
+      const chip = fixture.debugElement.query(By.css('gd-filter-chip'));
+      expect(chip.componentInstance.editable()).toBe(false);
+    });
+  });
+
+  describe('resilience to unknown filter names', () => {
+    it('should render chips for unknown filter names without crashing', () => {
+      host.conditions.set([UNKNOWN_FILTER]);
+      fixture.detectChanges();
+      const chips = fixture.debugElement.queryAll(By.css('gd-filter-chip'));
+      expect(chips.length).toBe(1);
+    });
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.stories.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, signal } from '@angular/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+
+import { FilterCondition } from '../filter.model';
+import { DynamicFilterBarComponent } from './dynamic-filter-bar.component';
+
+const SAMPLE_CONDITIONS: FilterCondition[] = [
+  { field: 'API', label: 'API', operator: 'IN', values: ['my-api-uuid-1', 'my-api-uuid-2'] },
+  { field: 'HTTP_STATUS', label: 'Status Code', operator: 'GTE', values: ['400'] },
+  { field: 'API_TYPE', label: 'API Type', operator: 'EQ', values: ['HTTP_PROXY'] },
+];
+
+@Component({
+  standalone: true,
+  selector: 'gd-dynamic-filter-bar-story-wrapper',
+  imports: [DynamicFilterBarComponent],
+  changeDetection: ChangeDetectionStrategy.Default,
+  template: `
+    <div class="story-layout">
+      <gd-dynamic-filter-bar
+        [conditions]="conditions()"
+        [editable]="editable"
+        (addRequested)="onAdd()"
+        (editRequested)="onEdit($event)"
+        (removeRequested)="onRemove($event)"
+        (clearRequested)="onClear()"
+      />
+
+      <div class="story-events">
+        <span class="story-events__label">Events log</span>
+        @for (event of events(); track $index) {
+          <span class="story-events__row">{{ event }}</span>
+        }
+        @if (events().length === 0) {
+          <span class="story-events__row story-events__row--empty">No events yet — interact with the bar above.</span>
+        }
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .story-layout {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+        font-family: 'Kanit', 'Roboto', sans-serif;
+      }
+      .story-events {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 12px;
+        color: #555;
+        max-height: 200px;
+        overflow-y: auto;
+      }
+      .story-events__label {
+        font-weight: 600;
+        color: #333;
+      }
+      .story-events__row {
+        font-family: monospace;
+        font-size: 11px;
+      }
+      .story-events__row--empty {
+        color: #999;
+        font-style: italic;
+      }
+    `,
+  ],
+})
+class DynamicFilterBarWrapperComponent implements OnInit, OnChanges {
+  @Input() initialConditions: FilterCondition[] = [];
+  @Input() editable = true;
+
+  conditions = signal<FilterCondition[]>([]);
+  events = signal<string[]>([]);
+
+  ngOnInit(): void {
+    this.conditions.set([...this.initialConditions]);
+  }
+
+  ngOnChanges(): void {
+    this.conditions.set([...this.initialConditions]);
+  }
+
+  onAdd(): void {
+    this.events.update(e => [`addRequested()`, ...e]);
+  }
+
+  onEdit(event: { index: number; condition: FilterCondition }): void {
+    this.events.update(e => [`editRequested(index=${event.index}, field=${event.condition.field})`, ...e]);
+  }
+
+  onRemove(index: number): void {
+    this.conditions.update(c => c.filter((_, i) => i !== index));
+    this.events.update(e => [`removeRequested(index=${index}) → chip removed`, ...e]);
+  }
+
+  onClear(): void {
+    this.conditions.set([]);
+    this.events.update(e => [`clearRequested() → all chips removed`, ...e]);
+  }
+}
+
+interface StoryArgs {
+  initialConditions: FilterCondition[];
+  editable: boolean;
+}
+
+export default {
+  title: 'Gravitee Dashboard/Components/Filter/Dynamic Filter Bar',
+  component: DynamicFilterBarWrapperComponent,
+  tags: ['autodocs'],
+  decorators: [
+    moduleMetadata({ imports: [DynamicFilterBarWrapperComponent] }),
+    applicationConfig({ providers: [provideNoopAnimations()] }),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+\`gd-dynamic-filter-bar\` renders a horizontal bar of filter chips with **Add filter** and **Clear all** controls.
+
+It is a **stateless, presentational component** — it displays the provided \`FilterCondition[]\` and delegates all
+mutations (add, edit, remove, clear) to the parent via outputs.
+
+### Usage
+
+\`\`\`html
+<gd-dynamic-filter-bar
+  [conditions]="store.conditions()"
+  [editable]="canEdit()"
+  (addRequested)="openAddFilterDialog()"
+  (editRequested)="openEditDialog($event.index, $event.condition)"
+  (removeRequested)="store.remove($event)"
+  (clearRequested)="store.clear()"
+/>
+\`\`\`
+
+### Inputs
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| \`conditions\` | \`FilterCondition[]\` | \`[]\` | Active filter conditions to display as chips |
+| \`editable\` | \`boolean\` | \`true\` | When \`false\`, hides Add/Clear buttons and sets chips to read-only |
+
+### Outputs
+
+| Output | Payload | Description |
+|---|---|---|
+| \`addRequested\` | \`void\` | User clicked "Add filter" |
+| \`editRequested\` | \`{ index, condition }\` | User clicked a chip to edit it |
+| \`removeRequested\` | \`number\` | User removed a chip (by index) |
+| \`clearRequested\` | \`void\` | User clicked "Clear all" |
+        `,
+      },
+    },
+  },
+  argTypes: {
+    editable: {
+      control: { type: 'boolean' },
+      description: 'When `false`, Add/Clear buttons are hidden and chips are read-only.',
+      table: { defaultValue: { summary: 'true' } },
+    },
+    initialConditions: {
+      control: { type: 'object' },
+      description: 'Array of FilterCondition objects to display.',
+    },
+  },
+} satisfies Meta<StoryArgs>;
+
+export const Empty: StoryObj<StoryArgs> = {
+  args: { initialConditions: [], editable: true },
+  render: (args: StoryArgs) => ({
+    template: `<gd-dynamic-filter-bar-story-wrapper [initialConditions]="initialConditions" [editable]="editable" />`,
+    props: args,
+  }),
+};
+
+export const WithFilters: StoryObj<StoryArgs> = {
+  args: { initialConditions: SAMPLE_CONDITIONS, editable: true },
+  render: (args: StoryArgs) => ({
+    template: `<gd-dynamic-filter-bar-story-wrapper [initialConditions]="initialConditions" [editable]="editable" />`,
+    props: args,
+  }),
+};
+
+export const ReadOnly: StoryObj<StoryArgs> = {
+  args: { initialConditions: SAMPLE_CONDITIONS, editable: false },
+  render: (args: StoryArgs) => ({
+    template: `<gd-dynamic-filter-bar-story-wrapper [initialConditions]="initialConditions" [editable]="editable" />`,
+    props: args,
+  }),
+};

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, computed, input, output, ViewEncapsulation } from '@angular/core';
+import { MatIconButton } from '@angular/material/button';
+import { MatChip } from '@angular/material/chips';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import { FilterChipComponent } from '../filter-chip/filter-chip.component';
+import { FilterCondition } from '../filter.model';
+
+@Component({
+  selector: 'gd-dynamic-filter-bar',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  imports: [FilterChipComponent, MatChip, MatIconButton, MatIcon, MatTooltipModule],
+  templateUrl: './dynamic-filter-bar.component.html',
+  styleUrl: './dynamic-filter-bar.component.scss',
+})
+export class DynamicFilterBarComponent {
+  conditions = input<FilterCondition[]>([]);
+  editable = input<boolean>(true);
+
+  addRequested = output<void>();
+  editRequested = output<{ index: number; condition: FilterCondition }>();
+  removeRequested = output<number>();
+  clearRequested = output<void>();
+
+  protected hasConditions = computed(() => this.conditions().length > 0);
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.ts
@@ -22,13 +22,16 @@ export type FilterOperator = 'EQ' | 'NEQ' | 'IN' | 'NOT_IN' | 'LTE' | 'GTE';
 // FilterDefinition — mirrors the backend /filter-definitions endpoint response item.
 // All discriminant fields are widened to handle unknown values from future backend evolutions.
 export interface FilterDefinition {
-  name: FilterName | string; // wider: backend may send unknown field names
+  name: FilterName | string;
   label: string;
-  type: FilterType | string; // wider: backend may send unknown types (Phase 2 concern)
-  operators: (FilterOperator | string)[]; // wider: backend may send unknown operators
-  range?: { min: number; max: number }; // NUMBER only
-  values?: string[]; // ENUM only
+  type: FilterType | string;
+  operators: (FilterOperator | string)[];
+  range?: { min: number; max: number };
+  values?: string[];
+  apiTypes?: string[];
 }
+
+export const ID_BASED_FILTER_NAMES: ReadonlyArray<string> = ['API', 'APPLICATION', 'PLAN'];
 
 // FilterCondition — represents a single active filter applied by the user.
 // One condition per field at a time (enforced by filter-bar, Phase 2).

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/public-api.ts
@@ -33,3 +33,4 @@ export * from './lib/components/filter/dropdown-search/dropdown-search.component
 export * from './lib/components/filter/generic-filter-bar/generic-filter-bar.component';
 export * from './lib/components/filter/filter.model';
 export * from './lib/components/filter/filter-chip/filter-chip.component';
+export * from './lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component';


### PR DESCRIPTION
## Summary
- Introduce `gd-dynamic-filter-bar`, a stateless presentational component that renders active `FilterCondition[]` as chips with **Add filter** / **Clear all** controls
- All mutations (add, edit, remove, clear) are delegated to the parent via typed outputs
- Add `apiTypes` and `ID_BASED_FILTER_NAMES` to `FilterDefinition` model for forward-compatible dynamic filter support
- Includes unit tests (8 specs) and Storybook stories (Empty, WithFilters, ReadOnly)

## Jira
[APIM-13188](https://gravitee.atlassian.net/browse/APIM-13188)

## Test plan
- [x] `npx nx run dashboard:test` — all 211 tests pass
- [x] `npx nx run dashboard:lint` — 0 errors (1 pre-existing warning in filter-chip stories)
- [x] `npx prettier --check` — all files formatted
- [x] Manual: run `npx nx run dashboard:storybook` and verify "Dynamic Filter Bar" stories render correctly

<img width="1037" height="47" alt="Screenshot 2026-04-22 at 19 52 42" src="https://github.com/user-attachments/assets/5b31c37d-765f-49e7-b088-dceb520bcc64" />
<img width="1040" height="47" alt="Screenshot 2026-04-22 at 19 52 49" src="https://github.com/user-attachments/assets/45fee95b-95b6-4a23-b4b1-dd306a571d4e" />
<img width="1038" height="48" alt="Screenshot 2026-04-22 at 19 52 33" src="https://github.com/user-attachments/assets/03e001b9-49c6-4b9c-9721-5e45401d22cd" />
<img width="1038" height="48" alt="Screenshot 2026-04-22 at 19 52 56" src="https://github.com/user-attachments/assets/9a7f7005-9d87-46b5-b66e-3fecea278790" />



[APIM-13188]: https://gravitee.atlassian.net/browse/APIM-13188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ