### PR TITLE
feat(dashboard): observability dynamic filter bar and add-filter dialog

### DIFF
--- a/gravitee-apim-webui-libs/gravitee-dashboard/.storybook/index.scss
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/.storybook/index.scss
@@ -36,12 +36,24 @@
 html {
   font-family: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
 
-  // Override M3 body typography tokens so overlays (tooltip, menu, dialog)
-  // that live outside the component tree also use Kanit.
-  // azure-blue.css sets these to Roboto on :root.
-  --mat-sys-body-small-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  // Override M3 typography tokens so overlays (tooltip, menu, dialog) and
+  // form fields (mat-form-field, mat-input) that pick the font from M3 tokens
+  // also use Kanit. azure-blue.css sets these to Roboto on :root.
+  --mat-sys-body-large-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
   --mat-sys-body-medium-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-body-small-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
   --mat-sys-label-large-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-label-medium-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-label-small-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-title-large-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-title-medium-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-title-small-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-headline-large-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-headline-medium-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-headline-small-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-display-large-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-display-medium-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
+  --mat-sys-display-small-font: 'Kanit', 'Roboto', 'Helvetica Neue', sans-serif;
 
   --mat-sys-primary: #fe733f;
   --mat-sys-on-primary: #ffffff;
@@ -52,4 +64,14 @@ html {
   --mat-sys-on-primary-fixed: #9c3900;
   --mat-sys-on-primary-fixed-variant: #c45200;
   --mat-sys-inverse-primary: #ffb990;
+
+  // M3 azure-blue maps overlay surfaces to tinted gray containers.
+  // Console UI (particles / M2-based) uses white surfaces — override to match.
+  --mat-sys-surface: #ffffff;
+  --mat-sys-surface-container: #ffffff;
+  --mat-sys-surface-container-low: #ffffff;
+  --mat-sys-surface-container-high: #ffffff;
+  --mat-autocomplete-background-color: #ffffff;
+  --mat-menu-container-color: #ffffff;
+  --mat-dialog-container-color: #ffffff;
 }

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.html
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.html
@@ -1,0 +1,123 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title>{{ isEditMode() ? 'Edit filter' : 'Add a filter' }}</h2>
+
+<mat-dialog-content class="gd-add-filter__content">
+  <!-- Row 1 — Filter by -->
+  <div class="gd-add-filter__row-block">
+    <mat-form-field appearance="outline" subscriptSizing="dynamic" class="gd-add-filter__field">
+      <mat-label>Filter by</mat-label>
+      <input
+        #fieldTrigger="matAutocompleteTrigger"
+        id="gd-add-filter-field"
+        matInput
+        type="text"
+        matAutocompletePosition="below"
+        [formControl]="fieldControl"
+        [matAutocomplete]="fieldAuto"
+        (click)="onFieldInputClick()"
+      />
+      <mat-autocomplete
+        #fieldAuto="matAutocomplete"
+        [displayWith]="displayDefinition"
+        [hideSingleSelectionIndicator]="true"
+        (closed)="onFieldAutocompletePanelClosed()"
+        (opened)="onFieldAutocompletePanelOpened()"
+        (optionSelected)="onFieldSelected($event)"
+        class="gd-add-filter__autocomplete-panel"
+      >
+        @for (def of filteredDefinitions$ | async; track def.name) {
+          <mat-option [value]="def" class="gd-add-filter__field-item gd-add-filter__field-option">
+            <div class="gd-add-filter__row">
+              <span class="gd-add-filter__row-label">{{ def.label }}</span>
+              @if (def.apiTypes?.length) {
+                <span class="gd-add-filter__row-meta">
+                  @for (apiType of def.apiTypes; track apiType) {
+                    <span class="gd-add-filter__api-badge">{{ apiType }}</span>
+                  }
+                </span>
+              }
+            </div>
+          </mat-option>
+        }
+      </mat-autocomplete>
+    </mat-form-field>
+  </div>
+
+  <!-- Row 2 — Choose operator -->
+  <div class="gd-add-filter__row-block" [class.gd-add-filter__row-block--disabled]="!selectedDefinition()">
+    <mat-form-field appearance="outline" subscriptSizing="dynamic" class="gd-add-filter__operator">
+      <mat-label>Choose operator</mat-label>
+      <mat-select id="gd-add-filter-operator" [formControl]="operatorControl" panelClass="gd-add-filter__select-panel">
+        @for (op of availableOperators(); track op) {
+          <mat-option [value]="op">{{ operatorLabel(op) }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <!-- Row 3 — Filter value -->
+  <div class="gd-add-filter__row-block" [class.gd-add-filter__row-block--disabled]="!selectedDefinition() || !selectedOperator()">
+    @if (selectedDefinition(); as def) {
+      @if (selectedOperator()) {
+        @switch (resolvedFilterType()) {
+          @case ('ENUM') {
+            <gd-enum-value-input
+              [definition]="def"
+              [selectedOperator]="selectedOperator()!"
+              [selectedValues]="selectedValues()"
+              (valuesChange)="onValuesChange($event)"
+            />
+          }
+          @case ('KEYWORD') {
+            <gd-keyword-value-input
+              [filterName]="def.name"
+              [timeFrom]="data.timeFrom"
+              [timeTo]="data.timeTo"
+              [selectedValues]="selectedValues()"
+              (valuesChange)="onValuesChange($event)"
+            />
+          }
+          @case ('NUMBER') {
+            <gd-number-value-input [definition]="def" [selectedValues]="selectedValues()" (valuesChange)="onValuesChange($event)" />
+          }
+          @case ('STRING') {
+            <gd-string-value-input [selectedValues]="selectedValues()" (valuesChange)="onValuesChange($event)" />
+          }
+        }
+      } @else {
+        <mat-form-field appearance="outline" subscriptSizing="dynamic" class="gd-add-filter__value-placeholder">
+          <mat-label>Filter value</mat-label>
+          <input matInput type="text" disabled />
+        </mat-form-field>
+      }
+    } @else {
+      <mat-form-field appearance="outline" subscriptSizing="dynamic" class="gd-add-filter__value-placeholder">
+        <mat-label>Filter value</mat-label>
+        <input matInput type="text" disabled />
+      </mat-form-field>
+    }
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="gd-add-filter__actions">
+  <button mat-button type="button" class="gd-add-filter__cancel-btn" [mat-dialog-close]="undefined">Cancel</button>
+  <button mat-flat-button type="button" color="primary" class="gd-add-filter__submit-btn" [disabled]="!canConfirm()" (click)="confirm()">
+    {{ isEditMode() ? 'Update' : 'Apply' }}
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.scss
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+:host {
+  display: block;
+  font-family: inherit;
+}
+
+.gd-add-filter__content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 560px;
+  font-family: inherit;
+  // mat-dialog-content defaults to overflow:auto which clips outline floating labels.
+  overflow: visible;
+  padding-top: 8px;
+}
+
+.gd-add-filter__row-block {
+  &--disabled {
+    opacity: 0.55;
+    pointer-events: none;
+  }
+}
+
+// ─── Dialog actions — Gravitee-styled buttons ───────────────────────────────
+// Defaults reproduce the Gravitee orange→red gradient used in Console UI so the
+// dialog feels native when dropped into the console (ui-particles theme) while
+// still being fully customizable for Portal Next or any other host app.
+// Consumers override behavior by setting the tokens below on any ancestor (e.g.
+// :root, body, or the dialog container) — no template changes required.
+//
+// Public tokens:
+//   --gd-filter-dialog-primary-button-background      : gradient OR flat color
+//   --gd-filter-dialog-primary-button-hover-background: flat color used on hover
+//   --gd-filter-dialog-primary-button-color           : primary label text color
+//   --gd-filter-dialog-primary-button-radius          : primary border-radius
+//   --gd-filter-dialog-primary-button-weight          : primary label weight
+//   --gd-filter-dialog-cancel-button-color            : cancel label text color
+//   --gd-filter-dialog-cancel-button-weight           : cancel label weight
+.gd-add-filter__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 8px;
+
+  // Cancel — text button with a neutral dark label, matching Console UI.
+  .gd-add-filter__cancel-btn {
+    --mdc-text-button-label-text-color: var(--gd-filter-dialog-cancel-button-color, #1e1b1b);
+    --mdc-text-button-label-text-weight: var(--gd-filter-dialog-cancel-button-weight, 700);
+
+    font-weight: var(--gd-filter-dialog-cancel-button-weight, 700);
+  }
+
+  // Primary — mat-flat-button (filled) matching Console UI style.
+  // Gravitee orange→red gradient, white bold label, rectangular (4px radius).
+  // We only apply the background-image when the button is idle (not hovered
+  // and not disabled) so Material's disabled + hover states keep working.
+  .gd-add-filter__submit-btn {
+    --mdc-filled-button-label-text-color: var(--gd-filter-dialog-primary-button-color, #fff);
+    --mdc-filled-button-container-shape: var(--gd-filter-dialog-primary-button-radius, 4px);
+
+    border-radius: var(--gd-filter-dialog-primary-button-radius, 4px);
+    font-weight: var(--gd-filter-dialog-primary-button-weight, 700);
+
+    &:not(:disabled, :hover) {
+      background-image: var(--gd-filter-dialog-primary-button-background, linear-gradient(222.67deg, #ff7200 7.45%, #f01114 94.83%));
+    }
+
+    &:hover:not(:disabled) {
+      background-color: var(--gd-filter-dialog-primary-button-hover-background, #da3b00);
+    }
+  }
+}
+
+.gd-add-filter__field,
+.gd-add-filter__operator,
+.gd-add-filter__value-placeholder {
+  width: 100%;
+}
+
+// Avoid clipping the outline notch / floating label at the top of focused fields.
+:host ::ng-deep .gd-add-filter__field .mat-mdc-text-field-wrapper,
+:host ::ng-deep .gd-add-filter__operator .mat-mdc-text-field-wrapper,
+:host ::ng-deep .gd-add-filter__value-placeholder .mat-mdc-text-field-wrapper {
+  overflow: visible;
+}
+
+.gd-add-filter__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  // `width: 100%` alone stays shrink-wrapped inside Material’s `mdc-list-item__primary-text`.
+  // Panel sets `--gd-add-filter-field-panel-inner-px` on open so the row matches the real panel width.
+  width: var(--gd-add-filter-field-panel-inner-px, 100%);
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.gd-add-filter__row-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gd-add-filter__row-meta {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 4px;
+  flex: 0 0 auto;
+  margin-inline-start: auto;
+  text-align: right;
+}
+
+.gd-add-filter__api-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  background-color: rgba(103, 80, 164, 0.12);
+  color: #4a4458;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+// Autocomplete panel is portaled under `.cdk-overlay-container`. Anchor on
+// `.mat-mdc-autocomplete-panel.gd-add-filter__autocomplete-panel` (class from the template, moved
+// onto the panel div by Material) so overrides always match — no dependency on CDK `panelClass`.
+// Outranks `.mat-mdc-option .mdc-list-item__primary-text { margin-right: auto }`: flex-grow on the
+// primary-text flex item so `.gd-add-filter__row` spans the full option width.
+@at-root {
+  .cdk-overlay-container div.mat-mdc-autocomplete-panel.gd-add-filter__autocomplete-panel,
+  .cdk-overlay-container div.gd-add-filter__autocomplete-panel.mat-mdc-autocomplete-panel {
+    min-width: min(100vw - 32px, 600px);
+
+    mat-option.mat-mdc-option.mdc-list-item.gd-add-filter__field-item.gd-add-filter__field-option {
+      width: 100%;
+      min-width: 0;
+      box-sizing: border-box;
+    }
+
+    mat-option.mat-mdc-option.mdc-list-item.gd-add-filter__field-item.gd-add-filter__field-option span.mdc-list-item__primary-text {
+      display: flex;
+      align-items: center;
+      flex-grow: 1;
+      flex-shrink: 1;
+      flex-basis: 0%;
+      width: 100%;
+      min-width: 0;
+      max-width: none;
+      // Beat Material’s `margin-right: auto` / RTL mirror when stylesheet order loses.
+      margin-inline-start: 0 !important;
+      margin-inline-end: 0 !important;
+      box-sizing: border-box;
+    }
+
+    mat-option.mat-mdc-option.mdc-list-item.gd-add-filter__field-item.gd-add-filter__field-option .gd-add-filter__row {
+      display: flex;
+      flex: 1 1 auto;
+      width: 100%;
+      min-width: 0;
+      justify-content: space-between;
+      align-items: center;
+      box-sizing: border-box;
+    }
+  }
+
+  .cdk-overlay-container .mat-mdc-select-panel.gd-add-filter__select-panel {
+    min-width: min(100vw - 32px, 600px);
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.spec.ts
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { firstValueFrom, of } from 'rxjs';
+
+import { FILTER_DEFINITION_PROVIDER, FILTER_VALUES_PROVIDER, FilterDefinitionProvider, FilterValuesProvider } from '../filter-providers';
+import { FilterDefinition } from '../filter.model';
+import { AddFilterDialogComponent, AddFilterDialogData } from './add-filter-dialog.component';
+
+const ENUM_DEF: FilterDefinition = {
+  name: 'HTTP_METHOD',
+  label: 'HTTP Method',
+  type: 'ENUM',
+  operators: ['EQ', 'IN'],
+  values: ['GET', 'POST', 'PUT', 'DELETE'],
+  apiTypes: ['HTTP_PROXY', 'LLM'],
+};
+
+const NUMBER_DEF: FilterDefinition = {
+  name: 'HTTP_STATUS',
+  label: 'Status Code',
+  type: 'NUMBER',
+  operators: ['EQ', 'LTE', 'GTE'],
+  range: { min: 100, max: 599 },
+  apiTypes: ['HTTP_PROXY'],
+};
+
+const KEYWORD_DEF: FilterDefinition = {
+  name: 'API',
+  label: 'API',
+  type: 'KEYWORD',
+  operators: ['EQ', 'IN'],
+  apiTypes: ['HTTP_PROXY', 'LLM', 'MESSAGE', 'MCP'],
+};
+
+const STRING_DEF: FilterDefinition = {
+  name: 'HTTP_PATH',
+  label: 'HTTP Path',
+  type: 'STRING',
+  operators: ['EQ'],
+};
+
+const UNKNOWN_TYPE_DEF: FilterDefinition = {
+  name: 'FUTURE_FILTER',
+  label: 'Future Filter',
+  type: 'BOOLEAN',
+  operators: ['EQ', 'BETWEEN'],
+};
+
+const ALL_DEFINITIONS = [ENUM_DEF, NUMBER_DEF, KEYWORD_DEF, STRING_DEF, UNKNOWN_TYPE_DEF];
+
+class MockDefinitionProvider implements FilterDefinitionProvider {
+  getDefinitions() {
+    return of(ALL_DEFINITIONS);
+  }
+}
+
+class MockValuesProvider implements FilterValuesProvider {
+  getValues() {
+    return of({ data: [], hasNextPage: false });
+  }
+}
+
+describe('AddFilterDialogComponent', () => {
+  let fixture: ComponentFixture<AddFilterDialogComponent>;
+  let component: AddFilterDialogComponent;
+  let dialogRefSpy: { close: jest.Mock };
+
+  async function setup(data: AddFilterDialogData = {}) {
+    dialogRefSpy = { close: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [AddFilterDialogComponent],
+      providers: [
+        provideNoopAnimations(),
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRefSpy },
+        { provide: FILTER_DEFINITION_PROVIDER, useClass: MockDefinitionProvider },
+        { provide: FILTER_VALUES_PROVIDER, useClass: MockValuesProvider },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddFilterDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  describe('field selection (Filter by autocomplete)', () => {
+    beforeEach(() => setup());
+
+    it('should expose all filter definitions on init', async () => {
+      const filtered = await firstValueFrom(component['filteredDefinitions$']);
+      expect(filtered.length).toBe(ALL_DEFINITIONS.length);
+    });
+
+    it('should filter definitions by label search term', async () => {
+      component['fieldControl'].setValue('Method');
+      const filtered = await firstValueFrom(component['filteredDefinitions$']);
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].name).toBe('HTTP_METHOD');
+    });
+
+    it('should filter definitions by apiType search term', async () => {
+      component['fieldControl'].setValue('LLM');
+      const filtered = await firstValueFrom(component['filteredDefinitions$']);
+      expect(filtered.length).toBe(2);
+      const names = filtered.map(d => d.name);
+      expect(names).toContain('HTTP_METHOD');
+      expect(names).toContain('API');
+    });
+
+    it('should filter definitions by name (case insensitive)', async () => {
+      component['fieldControl'].setValue('http_status');
+      const filtered = await firstValueFrom(component['filteredDefinitions$']);
+      expect(filtered.length).toBe(1);
+      expect(filtered[0].name).toBe('HTTP_STATUS');
+    });
+
+    it('should clear field value on click when a definition is already selected', () => {
+      component['selectDefinition'](ENUM_DEF);
+      component['fieldControl'].setValue(ENUM_DEF, { emitEvent: false });
+
+      component['onFieldInputClick']();
+
+      expect(component['fieldControl'].value).toBe('');
+    });
+  });
+
+  describe('operator selection', () => {
+    beforeEach(async () => {
+      await setup();
+      component['selectDefinition'](ENUM_DEF);
+      fixture.detectChanges();
+    });
+
+    it('should expose available operators', () => {
+      expect(component['availableOperators']()).toEqual(['EQ', 'IN']);
+    });
+
+    it('should auto-select operator when only one is available', () => {
+      component['selectDefinition'](STRING_DEF);
+      expect(component['selectedOperator']()).toBe('EQ');
+      expect(component['operatorControl'].value).toBe('EQ');
+    });
+
+    it('should not auto-select when multiple operators are available', () => {
+      component['selectDefinition'](ENUM_DEF);
+      expect(component['selectedOperator']()).toBeNull();
+    });
+
+    it('should reset operator when a new definition is selected', () => {
+      component['selectedOperator'].set('EQ');
+      component['selectDefinition'](NUMBER_DEF);
+      expect(component['selectedOperator']()).toBeNull();
+    });
+  });
+
+  describe('unknown type fallback', () => {
+    beforeEach(async () => {
+      await setup();
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      component['selectDefinition'](UNKNOWN_TYPE_DEF);
+      fixture.detectChanges();
+      consoleSpy.mockRestore();
+    });
+
+    it('should fall back to STRING type for unknown filter types', () => {
+      expect(component['resolvedFilterType']()).toBe('STRING');
+    });
+
+    it('should filter out unknown operators', () => {
+      const operators = component['availableOperators']();
+      expect(operators).toEqual(['EQ']);
+      expect(operators).not.toContain('BETWEEN');
+    });
+  });
+
+  describe('edit mode', () => {
+    it('should restore existing condition in edit mode', async () => {
+      await setup({
+        existingCondition: {
+          field: 'HTTP_METHOD',
+          label: 'HTTP Method',
+          operator: 'IN',
+          values: ['GET', 'POST'],
+        },
+      });
+
+      expect(component['selectedDefinition']()?.name).toBe('HTTP_METHOD');
+      expect(component['selectedOperator']()).toBe('IN');
+      expect(component['selectedValues']()).toEqual(['GET', 'POST']);
+      expect(component['fieldControl'].value).toEqual(expect.objectContaining({ name: 'HTTP_METHOD' }));
+      expect(component['operatorControl'].value).toBe('IN');
+    });
+
+    it('should normalize IN to EQ when restoring a single value', async () => {
+      await setup({
+        existingCondition: {
+          field: 'HTTP_METHOD',
+          label: 'HTTP Method',
+          operator: 'IN',
+          values: ['GET'],
+        },
+      });
+
+      expect(component['selectedOperator']()).toBe('EQ');
+      expect(component['operatorControl'].value).toBe('EQ');
+    });
+
+    it('should switch the title to "Edit filter" in edit mode', async () => {
+      await setup({
+        existingCondition: { field: 'HTTP_METHOD', label: 'HTTP Method', operator: 'EQ', values: ['GET'] },
+      });
+      expect(component['isEditMode']()).toBe(true);
+    });
+  });
+
+  describe('confirm', () => {
+    it('should close dialog with FilterCondition on confirm', async () => {
+      await setup();
+      component['selectDefinition'](ENUM_DEF);
+      component['selectedOperator'].set('EQ');
+      component['selectedValues'].set(['GET']);
+      fixture.detectChanges();
+
+      component['confirm']();
+
+      expect(dialogRefSpy.close).toHaveBeenCalledWith({
+        field: 'HTTP_METHOD',
+        label: 'HTTP Method',
+        operator: 'EQ',
+        values: ['GET'],
+      });
+    });
+
+    it('should emit IN when confirming with EQ and multiple values', async () => {
+      await setup();
+      component['selectDefinition'](ENUM_DEF);
+      component['selectedOperator'].set('EQ');
+      component['selectedValues'].set(['GET', 'POST']);
+      fixture.detectChanges();
+
+      component['confirm']();
+
+      expect(dialogRefSpy.close).toHaveBeenCalledWith({
+        field: 'HTTP_METHOD',
+        label: 'HTTP Method',
+        operator: 'IN',
+        values: ['GET', 'POST'],
+      });
+    });
+
+    it('should not close the dialog when selection is incomplete', async () => {
+      await setup();
+      component['selectDefinition'](ENUM_DEF);
+      // operator + values missing
+      component['confirm']();
+
+      expect(dialogRefSpy.close).not.toHaveBeenCalled();
+    });
+
+    it('canConfirm should be false until a definition, operator, and values are all provided', async () => {
+      await setup();
+      expect(component['canConfirm']()).toBe(false);
+
+      component['selectDefinition'](ENUM_DEF);
+      expect(component['canConfirm']()).toBe(false);
+
+      component['selectedOperator'].set('EQ');
+      expect(component['canConfirm']()).toBe(false);
+
+      component['selectedValues'].set(['GET']);
+      expect(component['canConfirm']()).toBe(true);
+    });
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.stories.ts
@@ -1,0 +1,515 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { JsonPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { of } from 'rxjs';
+
+import { DynamicFilterBarComponent } from '../dynamic-filter-bar/dynamic-filter-bar.component';
+import {
+  FILTER_DEFINITION_PROVIDER,
+  FILTER_VALUES_PROVIDER,
+  FilterDefinitionProvider,
+  FilterValuesProvider,
+  FilterValuesQuery,
+  FilterValuesResult,
+} from '../filter-providers';
+import { FilterCondition, FilterDefinition } from '../filter.model';
+import { AddFilterDialogComponent, AddFilterDialogData } from './add-filter-dialog.component';
+
+// ─── Sample data ──────────────────────────────────────────────────────────────
+
+const SAMPLE_DEFINITIONS: FilterDefinition[] = [
+  {
+    name: 'HTTP_METHOD',
+    label: 'HTTP Method',
+    type: 'ENUM',
+    operators: ['EQ', 'NEQ'],
+    values: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'],
+    // Shown when the dashboard context is limited to HTTP proxy analytics.
+    apiTypes: ['HTTP_PROXY'],
+  },
+  {
+    name: 'HTTP_STATUS',
+    label: 'Status Code',
+    type: 'NUMBER',
+    operators: ['GTE', 'LTE'],
+    range: { min: 100, max: 599 },
+    apiTypes: ['HTTP_PROXY'],
+  },
+  {
+    name: 'API',
+    label: 'API',
+    type: 'KEYWORD',
+    operators: ['IN', 'NOT_IN'],
+    // Keyword pickers apply across API kinds in observability.
+    apiTypes: ['HTTP_PROXY', 'MESSAGE', 'NATIVE'],
+  },
+  {
+    name: 'APPLICATION',
+    label: 'Application',
+    type: 'KEYWORD',
+    operators: ['IN', 'NOT_IN'],
+    // No badge: applies to any API type in the story dataset.
+  },
+  {
+    name: 'PLAN',
+    label: 'Plan',
+    type: 'KEYWORD',
+    operators: ['IN'],
+    apiTypes: ['HTTP_PROXY', 'MESSAGE'],
+  },
+  {
+    name: 'API_TYPE',
+    label: 'API Type',
+    type: 'ENUM',
+    operators: ['EQ'],
+    values: ['HTTP_PROXY', 'MESSAGE', 'NATIVE'],
+  },
+  {
+    name: 'RESPONSE_TIME',
+    label: 'Response Time (ms)',
+    type: 'NUMBER',
+    operators: ['GTE', 'LTE'],
+    range: { min: 0, max: 60000 },
+  },
+  {
+    name: 'HTTP_PATH',
+    label: 'HTTP Path',
+    type: 'STRING',
+    operators: ['EQ'],
+    apiTypes: ['HTTP_PROXY'],
+  },
+];
+
+const MOCK_VALUES_BY_FILTER: Record<string, { value: string; label: string; id: string }[]> = {
+  API: [
+    { value: 'api-uuid-1', label: 'My First API', id: 'api-uuid-1' },
+    { value: 'api-uuid-2', label: 'Payments API', id: 'api-uuid-2' },
+    { value: 'api-uuid-3', label: 'Auth Service', id: 'api-uuid-3' },
+    { value: 'api-uuid-4', label: 'Notification Hub', id: 'api-uuid-4' },
+    { value: 'api-uuid-5', label: 'Data Pipeline', id: 'api-uuid-5' },
+  ],
+  APPLICATION: [
+    { value: 'app-uuid-1', label: 'Customer Portal', id: 'app-uuid-1' },
+    { value: 'app-uuid-2', label: 'Partner B2B App', id: 'app-uuid-2' },
+    { value: 'app-uuid-3', label: 'Mobile Client', id: 'app-uuid-3' },
+  ],
+  PLAN: [
+    { value: 'plan-uuid-1', label: 'Gold', id: 'plan-uuid-1' },
+    { value: 'plan-uuid-2', label: 'Silver', id: 'plan-uuid-2' },
+    { value: 'plan-uuid-3', label: 'Free tier', id: 'plan-uuid-3' },
+  ],
+};
+
+class MockFilterDefinitionProvider implements FilterDefinitionProvider {
+  getDefinitions() {
+    return of(SAMPLE_DEFINITIONS);
+  }
+}
+
+class MockFilterValuesProvider implements FilterValuesProvider {
+  getValues(query: FilterValuesQuery) {
+    const pool = MOCK_VALUES_BY_FILTER[query.filterName] ?? [];
+    const q = (query.query ?? '').trim().toLowerCase();
+    const data = pool.filter(item => !q || item.label.toLowerCase().includes(q));
+    const all: FilterValuesResult = {
+      data,
+      hasNextPage: false,
+    };
+    return of(all);
+  }
+}
+
+/** 42 items → 5 pages at perPage 10, for manual scroll-pagination QA on the API keyword field. */
+const LARGE_API_VALUE_POOL: FilterValuesResult['data'] = Array.from({ length: 42 }, (_, i) => ({
+  id: `api-scroll-${i}`,
+  value: `api-scroll-${i}`,
+  label: `Scroll demo API ${String(i + 1).padStart(2, '0')}`,
+}));
+
+class MockFilterValuesProviderPaginatedApi implements FilterValuesProvider {
+  getValues(query: FilterValuesQuery) {
+    const perPage = query.perPage;
+    if (query.filterName === 'API') {
+      const q = (query.query ?? '').trim().toLowerCase();
+      const pool = LARGE_API_VALUE_POOL.filter(item => !q || item.label.toLowerCase().includes(q));
+      const start = (query.page - 1) * perPage;
+      const slice = pool.slice(start, start + perPage);
+      const hasNextPage = start + perPage < pool.length;
+      return of({ data: slice, hasNextPage });
+    }
+    const pool = MOCK_VALUES_BY_FILTER[query.filterName] ?? [];
+    const q = (query.query ?? '').trim().toLowerCase();
+    const data = pool.filter(item => !q || item.label.toLowerCase().includes(q));
+    return of({ data, hasNextPage: false });
+  }
+}
+
+const mockDefinitionProvider = new MockFilterDefinitionProvider();
+const mockValuesProvider = new MockFilterValuesProvider();
+const mockValuesProviderPaginatedApi = new MockFilterValuesProviderPaginatedApi();
+
+// ─── Shared providers for direct-render stories ───────────────────────────────
+
+function makeDirectRenderProviders(data: AddFilterDialogData = {}, valuesProvider: FilterValuesProvider = mockValuesProvider) {
+  return [
+    { provide: MAT_DIALOG_DATA, useValue: data },
+    {
+      provide: MatDialogRef,
+      useValue: {
+        close: (result?: FilterCondition) => {
+          // eslint-disable-next-line no-console
+          console.log('[story] dialog closed with', result);
+        },
+      },
+    },
+    { provide: FILTER_DEFINITION_PROVIDER, useValue: mockDefinitionProvider },
+    { provide: FILTER_VALUES_PROVIDER, useValue: valuesProvider },
+  ];
+}
+
+// ─── Story: dialog content rendered directly (no overlay) ─────────────────────
+
+@Component({
+  standalone: true,
+  selector: 'gd-add-filter-dialog-direct-story',
+  imports: [AddFilterDialogComponent],
+  changeDetection: ChangeDetectionStrategy.Default,
+  template: `
+    <div class="story-dialog-frame">
+      <gd-add-filter-dialog />
+    </div>
+  `,
+  styles: [
+    `
+      .story-dialog-frame {
+        display: inline-block;
+        background: #fff;
+        border-radius: 8px;
+        box-shadow:
+          0 11px 15px -7px rgba(0, 0, 0, 0.2),
+          0 24px 38px 3px rgba(0, 0, 0, 0.14),
+          0 9px 46px 8px rgba(0, 0, 0, 0.12);
+        min-width: 520px;
+        padding: 24px;
+        font-family: 'Kanit', 'Roboto', sans-serif;
+      }
+    `,
+  ],
+})
+class AddFilterDialogDirectStoryComponent {}
+
+// ─── Story: dynamic filter bar + dialog (integration) ─────────────────────────
+
+@Component({
+  standalone: true,
+  selector: 'gd-add-filter-dialog-trigger-story',
+  imports: [DynamicFilterBarComponent, MatDialogModule, JsonPipe],
+  changeDetection: ChangeDetectionStrategy.Default,
+  template: `
+    <div class="story-layout">
+      <div class="story-description">
+        Uses <code>gd-dynamic-filter-bar</code> like the console: <strong>Add filter</strong> opens an empty dialog. Click a chip to edit
+        that filter with its current settings. Applying again replaces a chip with the same field + operator, or appends a new chip.
+      </div>
+
+      <gd-dynamic-filter-bar
+        [conditions]="conditions()"
+        [editable]="true"
+        (addRequested)="onAddRequested()"
+        (editRequested)="onEditRequested($event)"
+        (removeRequested)="onRemoveRequested($event)"
+        (clearRequested)="onClearRequested()"
+      />
+
+      @if (lastCondition()) {
+        <div class="story-result">
+          <span class="story-result__label">Last applied condition</span>
+          <code class="story-result__code">{{ lastCondition() | json }}</code>
+        </div>
+      }
+    </div>
+  `,
+  styles: [
+    `
+      .story-layout {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 24px;
+        font-family: 'Kanit', 'Roboto', sans-serif;
+        padding: 32px;
+      }
+
+      .story-description {
+        font-size: 13px;
+        color: #555;
+        max-width: 480px;
+        line-height: 1.5;
+      }
+
+      .story-result {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        padding: 12px 16px;
+        background: #f5f5f5;
+        border-radius: 6px;
+        border-left: 4px solid #6750a4;
+      }
+
+      .story-result__label {
+        font-size: 11px;
+        font-weight: 600;
+        color: #6750a4;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .story-result__code {
+        font-family: monospace;
+        font-size: 12px;
+        color: #333;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+    `,
+  ],
+})
+class AddFilterDialogTriggerStoryComponent {
+  private readonly dialog = inject(MatDialog);
+
+  protected readonly conditions = signal<FilterCondition[]>([]);
+  protected readonly lastCondition = signal<FilterCondition | null>(null);
+  private editIndex: number | null = null;
+
+  onAddRequested(): void {
+    this.editIndex = null;
+    this.openDialog({});
+  }
+
+  onEditRequested(event: { index: number; condition: FilterCondition }): void {
+    this.editIndex = event.index;
+    this.openDialog({ existingCondition: event.condition });
+  }
+
+  onRemoveRequested(index: number): void {
+    this.conditions.update(c => c.filter((_, i) => i !== index));
+  }
+
+  onClearRequested(): void {
+    this.conditions.set([]);
+    this.lastCondition.set(null);
+  }
+
+  private openDialog(data: AddFilterDialogData): void {
+    const ref = this.dialog.open<AddFilterDialogComponent, AddFilterDialogData, FilterCondition>(AddFilterDialogComponent, {
+      data,
+      autoFocus: 'dialog',
+    });
+
+    ref.afterClosed().subscribe(result => {
+      if (!result) {
+        this.editIndex = null;
+        return;
+      }
+      this.lastCondition.set(result);
+      const idx = this.editIndex;
+      if (idx != null) {
+        this.conditions.update(arr => {
+          const next = [...arr];
+          next[idx] = result;
+          return next;
+        });
+        this.editIndex = null;
+        return;
+      }
+      this.conditions.update(list => {
+        const at = list.findIndex(c => c.field === result.field && c.operator === result.operator);
+        if (at >= 0) {
+          const next = [...list];
+          next[at] = result;
+          return next;
+        }
+        return [...list, result];
+      });
+    });
+  }
+}
+
+// ─── Meta ─────────────────────────────────────────────────────────────────────
+
+export default {
+  title: 'Gravitee Dashboard/Components/Filter/Add Filter Dialog',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+\`gd-add-filter-dialog\` is an Angular Material dialog that lets the user build a single \`FilterCondition\`.
+
+The dialog displays three always-visible rows — **Filter by**, **Choose operator** and **Filter value** — and uses
+\`MatAutocomplete\` on the field and operator inputs so the user can type to filter and click to pick. Re-clicking
+the field input clears it and re-triggers the dropdown, so there is no dedicated "Change" button.
+
+Required DI tokens:
+
+| Token | Purpose |
+|---|---|
+| \`FILTER_DEFINITION_PROVIDER\` | Returns the list of filterable fields (\`FilterDefinition[]\`) |
+| \`FILTER_VALUES_PROVIDER\` | Provides autocomplete values for \`KEYWORD\` fields |
+
+### Opening the dialog
+
+\`\`\`typescript
+// Add — empty form
+this.dialog.open(AddFilterDialogComponent, { data: {} });
+
+// Edit — pre-fill from the chip
+this.dialog.open(AddFilterDialogComponent, {
+  data: { existingCondition } satisfies AddFilterDialogData,
+});
+\`\`\`
+
+The dialog emits a \`FilterCondition\` via \`dialogRef.close(result)\` when the user clicks **Apply**/**Update**, or \`undefined\` when they cancel.
+        `,
+      },
+    },
+  },
+} satisfies Meta;
+
+// ─── Story 1: Add mode (empty) ───────────────────────────────────────────────
+
+export const AddMode: StoryObj = {
+  name: 'Add mode (empty)',
+  decorators: [
+    moduleMetadata({ imports: [AddFilterDialogDirectStoryComponent] }),
+    applicationConfig({ providers: makeDirectRenderProviders() }),
+  ],
+  render: () => ({ template: `<gd-add-filter-dialog-direct-story />` }),
+};
+
+// ─── Story 2: Edit mode — enum filter (HTTP Method) ──────────────────────────
+
+export const EditEnumFilter: StoryObj = {
+  name: 'Edit mode — Enum filter',
+  decorators: [
+    moduleMetadata({ imports: [AddFilterDialogDirectStoryComponent] }),
+    applicationConfig({
+      providers: makeDirectRenderProviders({
+        existingCondition: { field: 'HTTP_METHOD', label: 'HTTP Method', operator: 'EQ', values: ['GET'] },
+      }),
+    }),
+  ],
+  render: () => ({ template: `<gd-add-filter-dialog-direct-story />` }),
+};
+
+// ─── Story 3: Edit mode — number filter (Status Code ≥ 400) ──────────────────
+
+export const EditNumberFilter: StoryObj = {
+  name: 'Edit mode — Number filter',
+  decorators: [
+    moduleMetadata({ imports: [AddFilterDialogDirectStoryComponent] }),
+    applicationConfig({
+      providers: makeDirectRenderProviders({
+        existingCondition: { field: 'HTTP_STATUS', label: 'Status Code', operator: 'GTE', values: ['400'] },
+      }),
+    }),
+  ],
+  render: () => ({ template: `<gd-add-filter-dialog-direct-story />` }),
+};
+
+// ─── Story 4: Edit mode — keyword filter (API IN [...]) ──────────────────────
+
+export const EditKeywordFilter: StoryObj = {
+  name: 'Edit mode — Keyword filter',
+  decorators: [
+    moduleMetadata({ imports: [AddFilterDialogDirectStoryComponent] }),
+    applicationConfig({
+      providers: makeDirectRenderProviders({
+        existingCondition: {
+          field: 'API',
+          label: 'API',
+          operator: 'IN',
+          values: ['api-uuid-1', 'api-uuid-2'],
+        },
+      }),
+    }),
+  ],
+  render: () => ({ template: `<gd-add-filter-dialog-direct-story />` }),
+};
+
+// ─── Story 5: Edit mode — string filter (HTTP Path) ──────────────────────────
+
+export const EditStringFilter: StoryObj = {
+  name: 'Edit mode — String filter',
+  decorators: [
+    moduleMetadata({ imports: [AddFilterDialogDirectStoryComponent] }),
+    applicationConfig({
+      providers: makeDirectRenderProviders({
+        existingCondition: { field: 'HTTP_PATH', label: 'HTTP Path', operator: 'EQ', values: ['/api/v1/users'] },
+      }),
+    }),
+  ],
+  render: () => ({ template: `<gd-add-filter-dialog-direct-story />` }),
+};
+
+// ─── Story 6: Badge trigger (opens real dialog overlay) ──────────────────────
+
+export const WithDialogTrigger: StoryObj = {
+  name: 'With dynamic filter bar + dialog',
+  decorators: [
+    moduleMetadata({ imports: [AddFilterDialogTriggerStoryComponent] }),
+    applicationConfig({
+      providers: [
+        { provide: FILTER_DEFINITION_PROVIDER, useValue: mockDefinitionProvider },
+        { provide: FILTER_VALUES_PROVIDER, useValue: mockValuesProvider },
+      ],
+    }),
+  ],
+  render: () => ({ template: `<gd-add-filter-dialog-trigger-story />` }),
+};
+
+// ─── Story 7: KEYWORD scroll pagination (API field) ──────────────────────────
+
+export const AddModeKeywordScrollPagination: StoryObj = {
+  name: 'Add mode — KEYWORD scroll pagination (API)',
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Uses a **paginated** \`FILTER_VALUES_PROVIDER\` mock for the **API** field only (\`hasNextPage\` + 10 items per page, 42 values total).
+Other KEYWORD fields (**Application**, **Plan**) still behave like a **fixed single-page** list (\`hasNextPage: false\`).
+
+**How to try scroll loading**
+1. Choose **Filter by → API**, operator **IN** (or **NOT IN**).
+2. Focus **Filter value** and open the autocomplete.
+3. Scroll the panel to the bottom: the next page should load automatically (no "Load more" button).
+
+**Fixed lists**
+Pick **Application** or **Plan** instead: every value is returned in one response; scrolling must not trigger extra network calls in the real app (here the mock simply returns \`hasNextPage: false\`).
+        `,
+      },
+    },
+  },
+  decorators: [
+    moduleMetadata({ imports: [AddFilterDialogDirectStoryComponent] }),
+    applicationConfig({ providers: makeDirectRenderProviders({}, mockValuesProviderPaginatedApi) }),
+  ],
+  render: () => ({ template: `<gd-add-filter-dialog-direct-story />` }),
+};

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.ts
@@ -1,0 +1,363 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AsyncPipe } from '@angular/common';
+import {
+  afterNextRender,
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  inject,
+  Injector,
+  OnInit,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger, MatOption } from '@angular/material/autocomplete';
+import { MatButton } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+import { MatSelect } from '@angular/material/select';
+import { defer, Observable, of } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
+
+import { FILTER_DEFINITION_PROVIDER } from '../filter-providers';
+import { FilterCondition, FilterDefinition, FilterOperator, normalizeMembershipOperatorForValues, OPERATOR_SYMBOLS } from '../filter.model';
+import { EnumValueInputComponent } from './value-inputs/enum-value-input.component';
+import { KeywordValueInputComponent } from './value-inputs/keyword-value-input.component';
+import { NumberValueInputComponent } from './value-inputs/number-value-input.component';
+import { StringValueInputComponent } from './value-inputs/string-value-input.component';
+
+export interface AddFilterDialogData {
+  existingCondition?: FilterCondition;
+  timeFrom?: number;
+  timeTo?: number;
+}
+
+const KNOWN_OPERATORS: ReadonlySet<string> = new Set<FilterOperator>(['EQ', 'NEQ', 'IN', 'NOT_IN', 'LTE', 'GTE']);
+
+@Component({
+  selector: 'gd-add-filter-dialog',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    AsyncPipe,
+    ReactiveFormsModule,
+    MatAutocomplete,
+    MatAutocompleteTrigger,
+    MatOption,
+    MatSelect,
+    MatButton,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    EnumValueInputComponent,
+    KeywordValueInputComponent,
+    NumberValueInputComponent,
+    StringValueInputComponent,
+  ],
+  templateUrl: './add-filter-dialog.component.html',
+  styleUrl: './add-filter-dialog.component.scss',
+})
+export class AddFilterDialogComponent implements OnInit, AfterViewInit {
+  private readonly dialogRef = inject(MatDialogRef<AddFilterDialogComponent, FilterCondition>);
+  protected readonly data = inject<AddFilterDialogData>(MAT_DIALOG_DATA);
+  private readonly definitionProvider = inject(FILTER_DEFINITION_PROVIDER);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly injector = inject(Injector);
+
+  private readonly fieldTrigger = viewChild<MatAutocompleteTrigger>('fieldTrigger');
+  private readonly fieldAutocomplete = viewChild<MatAutocomplete>('fieldAuto');
+
+  protected readonly fieldControl = new FormControl<FilterDefinition | string | null>(null);
+  protected readonly operatorControl = new FormControl<string | null>(null);
+
+  protected definitions = signal<FilterDefinition[]>([]);
+  protected selectedDefinition = signal<FilterDefinition | null>(null);
+  protected selectedOperator = signal<string | null>(null);
+  protected selectedValues = signal<string[]>([]);
+
+  protected filteredDefinitions$: Observable<FilterDefinition[]> = of([]);
+
+  protected isEditMode = computed(() => this.data.existingCondition != null);
+
+  protected availableOperators = computed(() => {
+    const def = this.selectedDefinition();
+    if (!def) return [];
+    return def.operators.filter(op => {
+      if (!KNOWN_OPERATORS.has(op)) {
+        console.warn(`[gd-add-filter-dialog] Ignoring unknown operator '${op}' for filter '${def.name}'`);
+        return false;
+      }
+      return true;
+    });
+  });
+
+  protected resolvedFilterType = computed(() => {
+    const def = this.selectedDefinition();
+    if (!def) return null;
+    const type = def.type;
+    switch (type) {
+      case 'ENUM':
+      case 'KEYWORD':
+      case 'NUMBER':
+      case 'STRING':
+        return type;
+      default:
+        console.warn(`[gd-add-filter-dialog] Unsupported filter type '${type}' for filter '${def.name}', falling back to STRING`);
+        return 'STRING';
+    }
+  });
+
+  protected canConfirm = computed(() => {
+    return this.selectedDefinition() != null && this.selectedOperator() != null && this.selectedValues().length > 0;
+  });
+
+  ngOnInit(): void {
+    this.definitionProvider.getDefinitions().subscribe(defs => {
+      this.definitions.set(defs);
+      this.setupFieldAutocomplete();
+      this.setupOperatorSelect();
+      this.restoreExistingCondition(defs);
+    });
+  }
+
+  ngAfterViewInit(): void {
+    // The dialog's default autoFocus behavior targets the first tabbable element,
+    // which is the "Filter by" input. That would auto-open the autocomplete on mount.
+    // We explicitly close any panel that opened during dialog focus so the user
+    // has to click the input to reveal options (matches the target UX).
+    Promise.resolve().then(() => {
+      this.fieldTrigger()?.closePanel();
+    });
+  }
+
+  protected selectDefinition(def: FilterDefinition): void {
+    this.selectedDefinition.set(def);
+    this.selectedValues.set([]);
+    // Reset operator control so mat-select reflects the new definition's operators.
+    this.operatorControl.setValue(null);
+    this.selectedOperator.set(null);
+
+    const operators = def.operators.filter(op => KNOWN_OPERATORS.has(op));
+    if (operators.length === 1) {
+      this.operatorControl.setValue(operators[0]);
+      this.selectedOperator.set(operators[0]);
+    }
+  }
+
+  protected onFieldSelected(event: MatAutocompleteSelectedEvent): void {
+    const value = event.option.value;
+    if (this.isFilterDefinition(value)) {
+      this.selectDefinition(value);
+    }
+  }
+
+  protected onValuesChange(values: string[]): void {
+    this.selectedValues.set(values);
+    this.syncOperatorToValueCount();
+  }
+
+  protected displayDefinition = (value: FilterDefinition | string | null): string => {
+    if (!value) return '';
+    if (this.isFilterDefinition(value)) return value.label;
+    return String(value);
+  };
+
+  /** Human-readable operator text only (no raw token suffix like "in IN"). */
+  protected operatorLabel(op: string): string {
+    switch (op) {
+      case 'EQ':
+        return '=';
+      case 'NEQ':
+        return '≠';
+      case 'IN':
+        return 'In';
+      case 'NOT_IN':
+        return 'Not in';
+      case 'GTE':
+        return '≥';
+      case 'LTE':
+        return '≤';
+      default:
+        return OPERATOR_SYMBOLS[op] ?? op;
+    }
+  }
+
+  protected onFieldInputClick(): void {
+    // Clicking a field that already has a selection clears the value so the user
+    // can type to search again. We keep this on `click` (not `focus`) because the
+    // autocomplete returns focus to the input after a selection, which would
+    // otherwise wipe the value we just selected.
+    if (this.isFilterDefinition(this.fieldControl.value)) {
+      this.fieldControl.setValue('');
+    }
+  }
+
+  protected confirm(): void {
+    const def = this.selectedDefinition();
+    const op = this.selectedOperator();
+    const vals = this.selectedValues();
+    if (!def || !op || vals.length === 0) return;
+
+    const operator = normalizeMembershipOperatorForValues(def, op, vals.length);
+    const condition: FilterCondition = {
+      field: def.name,
+      label: def.label,
+      operator,
+      values: vals,
+    };
+    this.dialogRef.close(condition);
+  }
+
+  /** Material shrink-wraps option rows; set a concrete inner width like a manual fixed `width` in DevTools. */
+  protected onFieldAutocompletePanelOpened(): void {
+    afterNextRender(
+      () => {
+        this.syncFieldAutocompletePanelInnerWidth();
+        // Scrollbar appears after layout; measure again so width matches the visible track (no clipped badges).
+        requestAnimationFrame(() => this.syncFieldAutocompletePanelInnerWidth());
+      },
+      { injector: this.injector },
+    );
+  }
+
+  protected onFieldAutocompletePanelClosed(): void {
+    this.fieldAutocomplete()?.panel?.nativeElement?.style.removeProperty('--gd-add-filter-field-panel-inner-px');
+  }
+
+  private syncFieldAutocompletePanelInnerWidth(): void {
+    if (!this.fieldTrigger()?.panelOpen) return;
+    const panel = this.fieldAutocomplete()?.panel?.nativeElement;
+    if (!panel) return;
+    const w = this.measureFieldAutocompleteOptionContentWidth(panel);
+    panel.style.setProperty('--gd-add-filter-field-panel-inner-px', `${w}px`);
+  }
+
+  /**
+   * Row must fit inside `mat-option`’s **content** box (padding excluded), not the full panel width,
+   * or badges sit under the scrollbar / past the clip edge.
+   */
+  private measureFieldAutocompleteOptionContentWidth(panel: HTMLElement): number {
+    const opt = panel.querySelector<HTMLElement>('mat-option.gd-add-filter__field-option');
+    if (!opt) {
+      return Math.max(0, Math.round(panel.clientWidth));
+    }
+    const cs = getComputedStyle(opt);
+    const padX = (parseFloat(cs.paddingLeft) || 0) + (parseFloat(cs.paddingRight) || 0);
+    const fromOption = Math.max(0, Math.round(opt.clientWidth - padX));
+    // Options can span the full scroll width (under the vertical scrollbar); cap to the visible track.
+    const fromPanel = Math.max(0, Math.round(panel.clientWidth));
+    return Math.min(fromOption, fromPanel);
+  }
+
+  /** Client-side filter list for `mat-autocomplete` (Material v20 Autocomplete pattern). */
+  private setupFieldAutocomplete(): void {
+    this.filteredDefinitions$ = defer(() =>
+      this.fieldControl.valueChanges.pipe(
+        startWith(this.fieldControl.value),
+        map(value => this.filterDefinitions(value)),
+      ),
+    );
+
+    this.fieldControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(value => {
+      // User cleared or is typing — reset selection if the current selected def no longer matches
+      if (value == null || typeof value === 'string') {
+        const current = this.selectedDefinition();
+        if (current && current.label !== value) {
+          this.selectedDefinition.set(null);
+          this.selectedOperator.set(null);
+          this.selectedValues.set([]);
+          this.operatorControl.setValue(null);
+        }
+      }
+      if (this.fieldTrigger()?.panelOpen) {
+        afterNextRender(() => this.syncFieldAutocompletePanelInnerWidth(), { injector: this.injector });
+      }
+    });
+  }
+
+  private setupOperatorSelect(): void {
+    this.operatorControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(value => {
+      if (value == null || value === '') {
+        this.selectedOperator.set(null);
+      } else {
+        this.selectedOperator.set(value);
+        this.syncOperatorToValueCount();
+      }
+    });
+  }
+
+  private filterDefinitions(value: FilterDefinition | string | null): FilterDefinition[] {
+    const all = this.definitions();
+    if (!value || this.isFilterDefinition(value)) return all;
+    const term = value.toLowerCase();
+    if (!term) return all;
+    return all.filter(
+      d =>
+        d.label.toLowerCase().includes(term) ||
+        d.name.toLowerCase().includes(term) ||
+        (d.apiTypes ?? []).some(t => t.toLowerCase().includes(term)),
+    );
+  }
+
+  private isFilterDefinition(value: unknown): value is FilterDefinition {
+    return value != null && typeof value === 'object' && 'name' in value && 'label' in value && 'type' in value && 'operators' in value;
+  }
+
+  private restoreExistingCondition(defs: FilterDefinition[]): void {
+    const existing = this.data.existingCondition;
+    if (!existing) return;
+
+    const match = defs.find(d => d.name === existing.field);
+    if (match) {
+      this.selectedDefinition.set(match);
+      this.fieldControl.setValue(match, { emitEvent: false });
+      this.selectedOperator.set(existing.operator);
+      this.operatorControl.setValue(existing.operator, { emitEvent: false });
+      this.selectedValues.set([...existing.values]);
+      this.syncOperatorToValueCount();
+    }
+  }
+
+  private syncOperatorToValueCount(): void {
+    const def = this.selectedDefinition();
+    const op = this.selectedOperator();
+    if (!def || !op) return;
+    const n = this.selectedValues().length;
+    if (n === 0) return;
+    const next = normalizeMembershipOperatorForValues(def, op, n);
+    if (next !== op) {
+      this.selectedOperator.set(next);
+      this.operatorControl.setValue(next, { emitEvent: false });
+    }
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/enum-value-input.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/enum-value-input.component.scss
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+:host {
+  display: block;
+}
+
+.gd-value-input {
+  width: 100%;
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/enum-value-input.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/enum-value-input.component.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatOption, MatSelect, MatSelectChange } from '@angular/material/select';
+
+import { FilterDefinition } from '../../filter.model';
+
+@Component({
+  selector: 'gd-enum-value-input',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styleUrl: './enum-value-input.component.scss',
+  imports: [MatFormField, MatLabel, MatSelect, MatOption],
+  template: `
+    <mat-form-field appearance="outline" subscriptSizing="dynamic" class="gd-value-input">
+      <mat-label>Filter value</mat-label>
+      <mat-select
+        panelClass="gd-value-input-select-panel"
+        [multiple]="isMultiSelect()"
+        [value]="selectValue()"
+        (selectionChange)="onSelectionChange($event)"
+      >
+        @for (opt of definition().values ?? []; track opt) {
+          <mat-option [value]="opt">{{ opt }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  `,
+})
+export class EnumValueInputComponent {
+  definition = input.required<FilterDefinition>();
+  /** Current operator token (e.g. IN / EQ) from the parent dialog. */
+  selectedOperator = input.required<string>();
+  selectedValues = input<string[]>([]);
+  valuesChange = output<string[]>();
+
+  protected readonly isMultiSelect = computed(() => {
+    const op = this.selectedOperator();
+    return op === 'IN' || op === 'NOT_IN';
+  });
+
+  /** Value binding for `mat-select`: array when multi, first value when single. */
+  protected selectValue(): string | string[] | null {
+    const vals = this.selectedValues();
+    if (this.isMultiSelect()) {
+      return [...vals];
+    }
+    return vals.length > 0 ? vals[0] : null;
+  }
+
+  protected onSelectionChange(event: MatSelectChange): void {
+    if (this.isMultiSelect()) {
+      const next = (event.value as string[] | undefined) ?? [];
+      this.valuesChange.emit([...next]);
+    } else {
+      const v = event.value as string | null | undefined;
+      this.valuesChange.emit(v != null && v !== '' ? [v] : []);
+    }
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/keyword-value-input.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/keyword-value-input.component.scss
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@use './value-input-autocomplete-overlay';
+
+:host {
+  display: block;
+}
+
+.gd-value-input {
+  width: 100%;
+}
+
+.gd-keyword-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+}
+
+.gd-keyword-option__label {
+  flex: 1;
+  min-width: 0;
+}
+
+.gd-keyword-option__check {
+  flex-shrink: 0;
+  font-size: 18px;
+  width: 20px;
+  height: 20px;
+  color: var(--mat-sys-primary);
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/keyword-value-input.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/keyword-value-input.component.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { OverlayContainer, OverlayModule } from '@angular/cdk/overlay';
+import { ComponentFixture, fakeAsync, flushMicrotasks, TestBed, tick } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+
+import { KeywordValueInputComponent } from './keyword-value-input.component';
+import { FILTER_VALUES_PROVIDER, FilterValueItem, FilterValuesProvider, FilterValuesQuery } from '../../filter-providers';
+
+function makeItems(prefix: string, count: number): FilterValueItem[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i}`,
+    value: `${prefix}-${i}`,
+    label: `${prefix} ${i}`,
+  }));
+}
+
+function appendFakeAutocompletePanel(overlay: OverlayContainer): HTMLElement {
+  const host = overlay.getContainerElement();
+  const panel = document.createElement('div');
+  panel.className = 'mat-mdc-autocomplete-panel gd-value-input-autocomplete-panel';
+  panel.style.height = '80px';
+  panel.style.overflow = 'auto';
+  const inner = document.createElement('div');
+  inner.style.height = '400px';
+  inner.appendChild(document.createTextNode('\u00a0'));
+  panel.appendChild(inner);
+  host.appendChild(panel);
+  // jsdom often reports scrollHeight === clientHeight without explicit layout; the scroll logic
+  // depends on these metrics.
+  Object.defineProperty(panel, 'scrollHeight', { configurable: true, value: 480 });
+  Object.defineProperty(panel, 'clientHeight', { configurable: true, value: 80 });
+  return panel;
+}
+
+function scrollPanelToBottom(panel: HTMLElement): void {
+  panel.scrollTop = panel.scrollHeight - panel.clientHeight;
+  panel.dispatchEvent(new Event('scroll', { bubbles: false }));
+}
+
+describe('KeywordValueInputComponent', () => {
+  let fixture: ComponentFixture<KeywordValueInputComponent>;
+  let getValuesSpy: jest.MockedFunction<FilterValuesProvider['getValues']>;
+
+  function asTestable(c: KeywordValueInputComponent): { onAutocompletePanelOpened(): void } {
+    return c as unknown as { onAutocompletePanelOpened(): void };
+  }
+
+  afterEach(() => {
+    const host = TestBed.inject(OverlayContainer).getContainerElement();
+    host.querySelectorAll('.mat-mdc-autocomplete-panel.gd-value-input-autocomplete-panel').forEach(el => el.remove());
+  });
+
+  function configureBed(getValuesImpl: FilterValuesProvider['getValues']): void {
+    getValuesSpy = jest.fn(getValuesImpl);
+    TestBed.configureTestingModule({
+      imports: [KeywordValueInputComponent, OverlayModule],
+      providers: [
+        provideNoopAnimations(),
+        { provide: FILTER_VALUES_PROVIDER, useValue: { getValues: getValuesSpy } as FilterValuesProvider },
+      ],
+    });
+    fixture = TestBed.createComponent(KeywordValueInputComponent);
+    fixture.componentRef.setInput('filterName', 'API');
+    fixture.detectChanges();
+  }
+
+  it('should request only page 1 for a fixed list (hasNextPage false) and ignore scroll', fakeAsync(() => {
+    TestBed.resetTestingModule();
+    const data = makeItems('fixed', 3);
+    configureBed(() => of({ data, hasNextPage: false }));
+
+    tick(200);
+    expect(getValuesSpy).toHaveBeenCalledTimes(1);
+    expect(getValuesSpy).toHaveBeenLastCalledWith(expect.objectContaining({ page: 1, perPage: 10, filterName: 'API' }));
+
+    const panel = appendFakeAutocompletePanel(TestBed.inject(OverlayContainer));
+    asTestable(fixture.componentInstance).onAutocompletePanelOpened();
+    flushMicrotasks();
+    // requestAnimationFrame in onAutocompletePanelOpened is a macrotask in Zone.js fakeAsync
+    tick(16);
+
+    scrollPanelToBottom(panel);
+    tick(120);
+
+    expect(getValuesSpy).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should load the next page when the user scrolls near the bottom and hasNextPage is true', fakeAsync(() => {
+    TestBed.resetTestingModule();
+    const page1 = makeItems('p1', 10);
+    const page2 = makeItems('p2', 5);
+    configureBed((q: FilterValuesQuery) => {
+      if (q.page === 1) {
+        return of({ data: page1, hasNextPage: true });
+      }
+      if (q.page === 2) {
+        return of({ data: page2, hasNextPage: false });
+      }
+      return of({ data: [], hasNextPage: false });
+    });
+
+    tick(200);
+    expect(getValuesSpy).toHaveBeenCalledTimes(1);
+    expect(getValuesSpy).toHaveBeenLastCalledWith(expect.objectContaining({ page: 1 }));
+
+    const panel = appendFakeAutocompletePanel(TestBed.inject(OverlayContainer));
+    asTestable(fixture.componentInstance).onAutocompletePanelOpened();
+    flushMicrotasks();
+    // requestAnimationFrame in onAutocompletePanelOpened is a macrotask in Zone.js fakeAsync
+    tick(16);
+
+    scrollPanelToBottom(panel);
+    tick(120);
+
+    expect(getValuesSpy).toHaveBeenCalledTimes(2);
+    expect(getValuesSpy).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
+  }));
+});

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/keyword-value-input.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/keyword-value-input.component.ts
@@ -1,0 +1,369 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { AsyncPipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  ElementRef,
+  inject,
+  input,
+  output,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger, MatOption } from '@angular/material/autocomplete';
+import { MatChipGrid, MatChipInput, MatChipRemove, MatChipRow } from '@angular/material/chips';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
+import { MatInput } from '@angular/material/input';
+import { BehaviorSubject, combineLatest, fromEvent, Observable, of, Subscription } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, filter, finalize, map, startWith, switchMap, tap } from 'rxjs/operators';
+
+import { FILTER_VALUES_PROVIDER, FilterValueItem } from '../../filter-providers';
+import { ID_BASED_FILTER_NAMES } from '../../filter.model';
+
+interface KeywordOption {
+  value: string;
+  label: string;
+}
+
+@Component({
+  selector: 'gd-keyword-value-input',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    AsyncPipe,
+    ReactiveFormsModule,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatAutocomplete,
+    MatAutocompleteTrigger,
+    MatOption,
+    MatChipGrid,
+    MatChipRow,
+    MatChipInput,
+    MatChipRemove,
+    MatIcon,
+  ],
+  styleUrl: './keyword-value-input.component.scss',
+  template: `
+    <mat-form-field appearance="outline" subscriptSizing="dynamic" class="gd-value-input">
+      <mat-label>Filter value</mat-label>
+      <mat-chip-grid #chipGrid aria-label="Selected values">
+        @for (chip of selectedChips(); track chip.value) {
+          <mat-chip-row (removed)="removeValue(chip.value)">
+            {{ chip.label }}
+            <button matChipRemove [attr.aria-label]="'Remove ' + chip.label">
+              <mat-icon>cancel</mat-icon>
+            </button>
+          </mat-chip-row>
+        }
+        <input
+          #valueInput
+          [placeholder]="chipInputPlaceholder()"
+          matAutocompletePosition="below"
+          [formControl]="searchControl"
+          [matAutocomplete]="auto"
+          [matChipInputFor]="chipGrid"
+          [matChipInputAddOnBlur]="false"
+        />
+      </mat-chip-grid>
+      <mat-autocomplete
+        #auto="matAutocomplete"
+        class="gd-value-input-autocomplete-panel"
+        [hideSingleSelectionIndicator]="true"
+        (opened)="onAutocompletePanelOpened()"
+        (closed)="onAutocompletePanelClosed()"
+        (optionSelected)="onAutocompleteOptionSelected($event)"
+      >
+        @if (panelState$ | async; as panel) {
+          @if (panel.loading) {
+            <mat-option disabled>Loading…</mat-option>
+          } @else {
+            @for (option of panel.options; track option.value) {
+              <mat-option [value]="option.value" [disabled]="isOptionSelected(option)">
+                <span class="gd-keyword-option">
+                  <span class="gd-keyword-option__label">{{ option.label }}</span>
+                  @if (isOptionSelected(option)) {
+                    <mat-icon class="gd-keyword-option__check">check</mat-icon>
+                  }
+                </span>
+              </mat-option>
+            }
+            @if (panel.options.length === 0) {
+              <mat-option disabled>No matching values</mat-option>
+            }
+          }
+        }
+      </mat-autocomplete>
+    </mat-form-field>
+  `,
+})
+export class KeywordValueInputComponent {
+  /** Distance from bottom (px) that still counts as "near end" (small panels). */
+  private static readonly scrollLoadThresholdPx = 100;
+  /** Start loading the next page after this fraction of the scroll range (≈ 7/8). */
+  private static readonly scrollPrefetchRatio = 7 / 8;
+
+  private readonly valuesProvider = inject(FILTER_VALUES_PROVIDER);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly overlayContainer = inject(OverlayContainer);
+  /** Material exposes `#panel` on the real scroll container; `querySelector` is unreliable because
+   * `panelClass` is not a MatAutocomplete @Input in MDC — only `class` applies to the inner panel. */
+  private readonly keywordAutocomplete = viewChild(MatAutocomplete);
+
+  filterName = input.required<string>();
+  timeFrom = input<number | undefined>(undefined);
+  timeTo = input<number | undefined>(undefined);
+  selectedValues = input<string[]>([]);
+  valuesChange = output<string[]>();
+
+  protected readonly searchControl = new FormControl<string>('', { nonNullable: true });
+  protected readonly valueInput = viewChild<ElementRef<HTMLInputElement>>('valueInput');
+
+  protected readonly chipInputPlaceholder = computed(() => (this.selectedChips().length > 0 ? '' : this.searchLabel()));
+
+  private readonly loading$ = new BehaviorSubject<boolean>(false);
+  private readonly hasNextPage$ = new BehaviorSubject<boolean>(false);
+
+  private readonly page$ = new BehaviorSubject<number>(1);
+  private readonly accumulatedOptions$ = new BehaviorSubject<KeywordOption[]>([]);
+  private readonly labelByValue = signal<Map<string, string>>(new Map());
+  private panelScrollSub?: Subscription;
+
+  protected readonly panelState$ = combineLatest({
+    loading: this.loading$,
+    options: this.accumulatedOptions$.asObservable(),
+    hasNextPage: this.hasNextPage$,
+  });
+
+  protected isIdBased = computed(() => ID_BASED_FILTER_NAMES.includes(this.filterName()));
+  protected searchLabel = computed(() => (this.isIdBased() ? 'Search by name' : 'Search (exact match)'));
+
+  protected selectedChips = computed(() => {
+    const labels = this.labelByValue();
+    return this.selectedValues().map(value => ({
+      value,
+      label: labels.get(value) ?? value,
+    }));
+  });
+
+  constructor() {
+    const searchTerm$ = this.searchControl.valueChanges.pipe(
+      startWith(''),
+      debounceTime(200),
+      distinctUntilChanged(),
+      tap(() => {
+        this.accumulatedOptions$.next([]);
+        if (this.page$.getValue() !== 1) {
+          this.page$.next(1);
+        }
+      }),
+    );
+
+    searchTerm$
+      .pipe(
+        switchMap(term => this.page$.pipe(switchMap(page => this.fetchKeywordPage(term, page)))),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+
+    this.destroyRef.onDestroy(() => this.detachPanelScrollListener());
+  }
+
+  protected onAutocompletePanelOpened(): void {
+    this.detachPanelScrollListener();
+    queueMicrotask(() => {
+      requestAnimationFrame(() => {
+        const panelRoot = this.getAutocompletePanelElement();
+        if (!panelRoot) {
+          return;
+        }
+        const scrollSurface = this.getAutocompleteScrollSurface(panelRoot);
+        this.panelScrollSub = fromEvent(scrollSurface, 'scroll', { passive: true })
+          .pipe(
+            debounceTime(80),
+            filter(() => !this.loading$.getValue() && this.hasNextPage$.getValue()),
+            filter(() => this.shouldPrefetchNextPage(scrollSurface)),
+          )
+          .subscribe(() => this.requestNextKeywordPage());
+      });
+    });
+  }
+
+  protected onAutocompletePanelClosed(): void {
+    this.detachPanelScrollListener();
+  }
+
+  protected isOptionSelected(option: KeywordOption): boolean {
+    return this.selectedValues().includes(option.value);
+  }
+
+  protected onAutocompleteOptionSelected(event: MatAutocompleteSelectedEvent): void {
+    const value = event.option.value as string;
+    if (value == null || value === '') {
+      return;
+    }
+    const current = this.selectedValues();
+    if (current.includes(value)) {
+      return;
+    }
+    const label = this.accumulatedOptions$.getValue().find(o => o.value === value)?.label ?? this.labelByValue().get(value) ?? value;
+    this.updateLabels([{ value, label }]);
+    this.valuesChange.emit([...current, value]);
+    this.clearSearchInputAfterPick();
+  }
+
+  protected removeValue(value: string): void {
+    const next = this.selectedValues().filter(v => v !== value);
+    this.valuesChange.emit(next);
+  }
+
+  private fetchKeywordPage(term: string, page: number): Observable<void> {
+    this.loading$.next(true);
+    return this.valuesProvider
+      .getValues({
+        filterName: this.filterName(),
+        query: term || undefined,
+        from: this.timeFrom(),
+        to: this.timeTo(),
+        page,
+        perPage: 10,
+      })
+      .pipe(
+        catchError(() => of({ data: [] as FilterValueItem[], hasNextPage: false })),
+        map(result => ({
+          options: result.data.map(
+            (item): KeywordOption => ({
+              value: item.id ?? item.value,
+              label: item.label,
+            }),
+          ),
+          hasNextPage: result.hasNextPage,
+        })),
+        tap(({ options, hasNextPage }) => {
+          this.updateLabels(options);
+          const current = this.accumulatedOptions$.getValue();
+          const merged = page === 1 ? options : this.mergeUnique(current, options);
+          this.accumulatedOptions$.next(merged);
+          this.hasNextPage$.next(hasNextPage);
+        }),
+        map(() => undefined),
+        finalize(() => {
+          this.loading$.next(false);
+          queueMicrotask(() => this.tryLoadNextPageIfPanelStillAtBottom());
+        }),
+      );
+  }
+
+  private clearSearchInputAfterPick(): void {
+    if (this.searchControl.value) {
+      this.searchControl.setValue('');
+    } else {
+      this.searchControl.setValue('', { emitEvent: false });
+    }
+    const input = this.valueInput()?.nativeElement;
+    if (input) input.value = '';
+  }
+
+  private mergeUnique(current: KeywordOption[], incoming: KeywordOption[]): KeywordOption[] {
+    const seen = new Set(current.map(o => o.value));
+    const additions = incoming.filter(o => !seen.has(o.value));
+    return [...current, ...additions];
+  }
+
+  private updateLabels(options: KeywordOption[]): void {
+    const next = new Map(this.labelByValue());
+    options.forEach(o => next.set(o.value, o.label));
+    this.labelByValue.set(next);
+  }
+
+  private getAutocompletePanelElement(): HTMLElement | null {
+    const overlayHost = this.overlayContainer.getContainerElement();
+    const fromAutocomplete = this.keywordAutocomplete()?.panel?.nativeElement;
+    if (fromAutocomplete instanceof HTMLElement && overlayHost.contains(fromAutocomplete)) {
+      return fromAutocomplete;
+    }
+    return overlayHost.querySelector<HTMLElement>('.mat-mdc-autocomplete-panel.gd-value-input-autocomplete-panel');
+  }
+
+  private getAutocompleteScrollSurface(panelRoot: HTMLElement): HTMLElement {
+    const overflowScrollable = (el: HTMLElement): boolean => {
+      const y = getComputedStyle(el).overflowY;
+      const allowsScroll = y === 'auto' || y === 'scroll' || y === 'overlay';
+      return allowsScroll && el.scrollHeight > el.clientHeight + 1;
+    };
+
+    if (overflowScrollable(panelRoot)) {
+      return panelRoot;
+    }
+    for (const el of Array.from(panelRoot.querySelectorAll<HTMLElement>('*'))) {
+      if (overflowScrollable(el)) {
+        return el;
+      }
+    }
+    return panelRoot;
+  }
+
+  private shouldPrefetchNextPage(scrollEl: HTMLElement): boolean {
+    const scrollTop = scrollEl.scrollTop;
+    const visible = scrollEl.clientHeight;
+    const total = scrollEl.scrollHeight;
+    const maxScroll = total - visible;
+    if (maxScroll <= 1) {
+      return false;
+    }
+    const distanceFromBottom = total - scrollTop - visible;
+    const scrolledRatio = scrollTop / maxScroll;
+    return (
+      scrolledRatio >= KeywordValueInputComponent.scrollPrefetchRatio ||
+      distanceFromBottom <= KeywordValueInputComponent.scrollLoadThresholdPx
+    );
+  }
+
+  private requestNextKeywordPage(): void {
+    if (this.loading$.getValue() || !this.hasNextPage$.getValue()) {
+      return;
+    }
+    this.page$.next(this.page$.getValue() + 1);
+  }
+
+  private tryLoadNextPageIfPanelStillAtBottom(): void {
+    const panelRoot = this.getAutocompletePanelElement();
+    if (!panelRoot) {
+      return;
+    }
+    if (!this.hasNextPage$.getValue() || this.loading$.getValue()) {
+      return;
+    }
+    const surface = this.getAutocompleteScrollSurface(panelRoot);
+    if (!this.shouldPrefetchNextPage(surface)) {
+      return;
+    }
+    this.requestNextKeywordPage();
+  }
+
+  private detachPanelScrollListener(): void {
+    this.panelScrollSub?.unsubscribe();
+    this.panelScrollSub = undefined;
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/number-value-input.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/number-value-input.component.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, computed, input, OnInit, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatFormField, MatHint, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+
+import { FilterDefinition } from '../../filter.model';
+
+@Component({
+  selector: 'gd-number-value-input',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, MatFormField, MatLabel, MatHint, MatInput],
+  template: `
+    <mat-form-field appearance="outline" subscriptSizing="dynamic" class="gd-value-input">
+      <mat-label>Filter value</mat-label>
+      <input
+        matInput
+        type="number"
+        placeholder="Enter a number"
+        [min]="rangeMin()"
+        [max]="rangeMax()"
+        [ngModel]="numberValue()"
+        (ngModelChange)="onInput($event)"
+      />
+      @if (hasRange()) {
+        <mat-hint>{{ rangeMin() }} – {{ rangeMax() }}</mat-hint>
+      }
+    </mat-form-field>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .gd-value-input {
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class NumberValueInputComponent implements OnInit {
+  definition = input.required<FilterDefinition>();
+  selectedValues = input<string[]>([]);
+  valuesChange = output<string[]>();
+
+  protected hasRange = computed(() => this.definition().range != null);
+  protected rangeMin = computed(() => this.definition().range?.min ?? undefined);
+  protected rangeMax = computed(() => this.definition().range?.max ?? undefined);
+
+  protected numberValue = signal<number | null>(null);
+
+  ngOnInit(): void {
+    const initial = this.selectedValues();
+    if (initial.length > 0) {
+      const parsed = Number(initial[0]);
+      if (!isNaN(parsed)) this.numberValue.set(parsed);
+    }
+  }
+
+  protected onInput(value: number | null): void {
+    this.numberValue.set(value);
+    if (value != null && !isNaN(value)) {
+      this.valuesChange.emit([String(value)]);
+    } else {
+      this.valuesChange.emit([]);
+    }
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/string-value-input.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/string-value-input.component.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeDetectionStrategy, Component, input, OnInit, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
+import { MatInput } from '@angular/material/input';
+
+@Component({
+  selector: 'gd-string-value-input',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [FormsModule, MatFormField, MatLabel, MatInput],
+  template: `
+    <mat-form-field appearance="outline" subscriptSizing="dynamic" class="gd-value-input">
+      <mat-label>Filter value</mat-label>
+      <input matInput placeholder="Enter a value" [ngModel]="textValue()" (ngModelChange)="onInput($event)" />
+    </mat-form-field>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+      .gd-value-input {
+        width: 100%;
+      }
+    `,
+  ],
+})
+export class StringValueInputComponent implements OnInit {
+  selectedValues = input<string[]>([]);
+  valuesChange = output<string[]>();
+
+  protected textValue = signal('');
+
+  ngOnInit(): void {
+    const initial = this.selectedValues();
+    if (initial.length > 0) this.textValue.set(initial[0]);
+  }
+
+  protected onInput(value: string): void {
+    this.textValue.set(value);
+    if (value.trim()) {
+      this.valuesChange.emit([value.trim()]);
+    } else {
+      this.valuesChange.emit([]);
+    }
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/value-input-autocomplete-overlay.scss
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/value-input-autocomplete-overlay.scss
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// CDK overlay: must be unscoped — imported from component styleUrl (not inline styles).
+// Selection UX is driven by custom row + check icon (see value-input components), not MatOption
+// background states, to avoid fighting M3 hover/active layers and autocomplete close/reopen.
+@at-root {
+  .mat-mdc-autocomplete-panel.gd-value-input-autocomplete-panel {
+    .mat-mdc-option.gd-value-option--custom-row:hover:not(.mdc-list-item--disabled) {
+      background-color: color-mix(in srgb, var(--mat-sys-on-surface) 6%, var(--mat-sys-surface));
+    }
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component.scss
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
+// Full width of the parent so inner flex (chips `flex: 1`) can push Clear to the trailing edge.
+// Without this, a column parent with `align-items: flex-start` (e.g. add-filter-dialog trigger story)
+// shrink-wraps the host and Clear sits immediately after chips instead of at the viewport edge.
 gd-dynamic-filter-bar {
   display: block;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .gd-dynamic-filter-bar {

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter-chip/filter-chip.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter-chip/filter-chip.component.stories.ts
@@ -464,7 +464,6 @@ update in real time. Copy the values you like into your application's stylesheet
 `;
 
 export const CustomTokens: StoryObj<StoryArgs> = {
-  name: 'Custom Tokens',
   parameters: {
     docs: {
       description: { story: CUSTOM_TOKENS_DESCRIPTION },

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter-providers.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter-providers.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InjectionToken, Provider, Type } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { FilterDefinition } from './filter.model';
+
+export interface FilterValueItem {
+  value: string;
+  label: string;
+  id?: string;
+}
+
+export interface FilterValuesResult {
+  data: FilterValueItem[];
+  hasNextPage: boolean;
+  totalCount?: number;
+}
+
+export interface FilterValuesQuery {
+  filterName: string;
+  query?: string;
+  from?: number;
+  to?: number;
+  page: number;
+  perPage: number;
+}
+
+export interface FilterDefinitionProvider {
+  getDefinitions(): Observable<FilterDefinition[]>;
+}
+
+export interface FilterValuesProvider {
+  getValues(query: FilterValuesQuery): Observable<FilterValuesResult>;
+}
+
+export const FILTER_DEFINITION_PROVIDER = new InjectionToken<FilterDefinitionProvider>('FILTER_DEFINITION_PROVIDER');
+
+export const FILTER_VALUES_PROVIDER = new InjectionToken<FilterValuesProvider>('FILTER_VALUES_PROVIDER');
+
+export function provideFilterDefinitions(impl: Type<FilterDefinitionProvider>): Provider {
+  return { provide: FILTER_DEFINITION_PROVIDER, useExisting: impl };
+}
+
+export function provideFilterValues(impl: Type<FilterValuesProvider>): Provider {
+  return { provide: FILTER_VALUES_PROVIDER, useExisting: impl };
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FilterDefinition, normalizeMembershipOperatorForValues } from './filter.model';
+
+describe('normalizeMembershipOperatorForValues', () => {
+  const eqIn: Pick<FilterDefinition, 'operators'> = { operators: ['EQ', 'IN'] };
+  const neqNotIn: Pick<FilterDefinition, 'operators'> = { operators: ['NEQ', 'NOT_IN'] };
+  const eqOnly: Pick<FilterDefinition, 'operators'> = { operators: ['EQ'] };
+
+  it('should_upgrade_EQ_to_IN_when_two_or_more_values_and_IN_is_allowed', () => {
+    expect(normalizeMembershipOperatorForValues(eqIn, 'EQ', 2)).toBe('IN');
+    expect(normalizeMembershipOperatorForValues(eqIn, 'EQ', 3)).toBe('IN');
+  });
+
+  it('should_keep_EQ_when_multiple_values_but_IN_is_not_available', () => {
+    expect(normalizeMembershipOperatorForValues(eqOnly, 'EQ', 2)).toBe('EQ');
+  });
+
+  it('should_downgrade_IN_to_EQ_for_a_single_value_when_EQ_is_allowed', () => {
+    expect(normalizeMembershipOperatorForValues(eqIn, 'IN', 1)).toBe('EQ');
+  });
+
+  it('should_keep_IN_for_a_single_value_when_EQ_is_not_available', () => {
+    expect(normalizeMembershipOperatorForValues({ operators: ['IN'] }, 'IN', 1)).toBe('IN');
+  });
+
+  it('should_upgrade_NEQ_to_NOT_IN_when_two_or_more_values', () => {
+    expect(normalizeMembershipOperatorForValues(neqNotIn, 'NEQ', 2)).toBe('NOT_IN');
+  });
+
+  it('should_downgrade_NOT_IN_to_NEQ_for_a_single_value', () => {
+    expect(normalizeMembershipOperatorForValues(neqNotIn, 'NOT_IN', 1)).toBe('NEQ');
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.ts
@@ -57,8 +57,30 @@ function getOperatorSymbol(op: string): string {
   return OPERATOR_SYMBOLS[op] ?? op;
 }
 
+const hasOperator = (definition: Pick<FilterDefinition, 'operators'>, op: string): boolean => definition.operators.some(o => o === op);
+
+/**
+ * Aligns membership operators with how many values are selected when the definition allows both forms:
+ * multi-value → IN / NOT_IN, single-value → EQ / NEQ. No-op when the target operator is not available.
+ */
+export function normalizeMembershipOperatorForValues(
+  definition: Pick<FilterDefinition, 'operators'>,
+  operator: string,
+  valueCount: number,
+): string {
+  if (valueCount >= 2) {
+    if (operator === 'EQ' && hasOperator(definition, 'IN')) return 'IN';
+    if (operator === 'NEQ' && hasOperator(definition, 'NOT_IN')) return 'NOT_IN';
+  }
+  if (valueCount === 1) {
+    if (operator === 'IN' && hasOperator(definition, 'EQ')) return 'EQ';
+    if (operator === 'NOT_IN' && hasOperator(definition, 'NEQ')) return 'NEQ';
+  }
+  return operator;
+}
+
 // Visual-only normalization: IN with a single value displays as = for readability.
-// The stored FilterCondition keeps operator: 'IN' — consistent with what the edit form will re-present.
+// New filters emit EQ in that case; this still handles legacy IN + one value from storage/API.
 function displayOperator(condition: FilterCondition): string {
   if (condition.values.length === 1 && condition.operator === 'IN') return 'EQ';
   return condition.operator;

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/public-api.ts
@@ -34,3 +34,5 @@ export * from './lib/components/filter/generic-filter-bar/generic-filter-bar.com
 export * from './lib/components/filter/filter.model';
 export * from './lib/components/filter/filter-chip/filter-chip.component';
 export * from './lib/components/filter/dynamic-filter-bar/dynamic-filter-bar.component';
+export * from './lib/components/filter/add-filter-dialog/add-filter-dialog.component';
+export * from './lib/components/filter/filter-providers';


### PR DESCRIPTION
## Jira

[APIM-13187](https://gravitee.atlassian.net/browse/APIM-13187)

## Summary

- **`gd-dynamic-filter-bar`**: observability filter bar (chips + **Filters** label, **Add filter** as `mat-chip`, chips area + **Clear** depending on state). Host uses **`width: 100%`** so the chips region (`flex: 1`) consumes free horizontal space and **Clear** stays on the trailing edge when the parent has a defined width (e.g. Storybook layouts with `align-items: flex-start`).
- **`gd-add-filter-dialog`**: Material dialog with three rows — field (**Filter by** autocomplete with domain badges and panel alignment), operator, value — including **edit mode**; typed inputs `EnumValueInput`, `KeywordValueInput` (autocomplete + scroll pagination), `NumberValueInput`, `StringValueInput` (fallback for unknown types).
- **DI tokens** `FILTER_DEFINITION_PROVIDER` / `FILTER_VALUES_PROVIDER` plus `provideFilterDefinitions()` / `provideFilterValues()` helpers for host app wiring.
- **Stories / tests**: Storybook for add-filter and dynamic bar, `filter.model.spec.ts`, value-input specs; unknown types/operators fall back with `console.warn` as documented.

<img width="572" height="332" alt="Screenshot 2026-04-23 at 22 47 39" src="https://github.com/user-attachments/assets/8c0f2b27-9985-4328-9800-663bc23a19dd" />

<img width="615" height="590" alt="Screenshot 2026-04-23 at 22 43 12" src="https://github.com/user-attachments/assets/85ac7c6e-ef0e-4f35-8d69-d610c0f51a7f" />
<img width="628" height="584" alt="Screenshot 2026-04-23 at 22 42 55" src="https://github.com/user-attachments/assets/b759e525-d76a-45b1-be59-1ac0698a9fa6" />
<img width="658" height="457" alt="Screenshot 2026-04-23 at 22 42 43" src="https://github.com/user-attachments/assets/847fa59b-7786-46f5-b951-1abea8df09db" />
<img width="333" height="225" alt="Screenshot 2026-04-23 at 22 43 37" src="https://github.com/user-attachments/assets/e0d57617-a4f1-4418-b1ac-f657072f24ba" />


## Test plan

- [ ] `npx nx run dashboard:test` — covers `add-filter-dialog`, `dynamic-filter-bar`, `filter.model`, value-inputs
- [ ] `npx nx run dashboard:lint-eslint` (if touching linted paths)
- [ ] Storybook: **Add filter dialog** stories (including trigger + dialog) and **Dynamic filter bar** — confirm **Clear** right alignment and add / edit / clear flow


[APIM-13187]: https://gravitee.atlassian.net/browse/APIM-13187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ