### PR TITLE
fix: apim v4.11.x failing changeset because of orphan plans

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/03_add_environment_id_and_definition_version_on_plans.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/03_add_environment_id_and_definition_version_on_plans.yml
@@ -15,6 +15,9 @@ databaseChangeLog:
         - sql:
             dbms: 'postgresql,mssql'
             sql: UPDATE ${gravitee_prefix}plans SET environment_id = a.environment_id, definition_version = a.definition_version FROM ${gravitee_prefix}apis a WHERE api = a.id;
+        - sql:
+            comment: Remove plans referencing APIs that no longer exist; they would have a NULL environment_id and fail the NOT NULL constraint below.
+            sql: DELETE FROM ${gravitee_prefix}plans WHERE environment_id IS NULL;
         - addNotNullConstraint:
             columnName: environment_id
             columnDataType: VARCHAR(64)


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13753

To test it:
- run APIM 4.10 with PSQL
- create an API with a Keyless plan => so in DB you have 1 line in the `apis` table and 1 line in the `plans` table
- remove the api from the DB with an SQL request not from the UI
- upgrade to 4.11
- you should see an error in the APIM logs before the change / no error after