### PR TITLE
feat: add port-based routing fields to NativePlan [APIM-12493]

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativePlan.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativePlan.java
@@ -22,7 +22,6 @@ import io.gravitee.definition.model.v4.plan.AbstractPlan;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,7 +34,6 @@ import lombok.experimental.SuperBuilder;
  * @author GraviteeSource Team
  */
 @NoArgsConstructor
-@AllArgsConstructor
 @SuperBuilder(toBuilder = true)
 @Getter
 @Setter
@@ -54,6 +52,10 @@ public class NativePlan extends AbstractPlan {
 
     private Integer brokerRangeStart;
     private Integer brokerRangeEnd;
+
+    public NativePlan(List<NativeFlow> flows) {
+        this.flows = flows;
+    }
 
     @JsonIgnore
     @Override

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativePlan.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativePlan.java
@@ -46,6 +46,15 @@ public class NativePlan extends AbstractPlan {
 
     private List<NativeFlow> flows;
 
+    /**
+     * Port-based routing fields — only used when {@code kafka.routingMode=port}.
+     * Null in host (SNI) routing mode.
+     */
+    private Integer bootstrapPort;
+
+    private Integer brokerRangeStart;
+    private Integer brokerRangeEnd;
+
     @JsonIgnore
     @Override
     public List<Plugin> getPlugins() {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
@@ -160,6 +160,15 @@ public class Plan {
      */
     private ApiType apiType;
 
+    /**
+     * Port-based routing fields — only used when {@code kafka.routingMode=port} and {@code apiType=NATIVE}.
+     * Null in host (SNI) routing mode.
+     */
+    private Integer bootstrapPort;
+
+    private Integer brokerRangeStart;
+    private Integer brokerRangeEnd;
+
     public Plan(Plan cloned) {
         this.id = cloned.id;
         this.definitionVersion = cloned.definitionVersion;
@@ -192,6 +201,9 @@ public class Plan {
         this.apiType = cloned.apiType;
         this.referenceId = cloned.referenceId;
         this.referenceType = cloned.referenceType;
+        this.bootstrapPort = cloned.bootstrapPort;
+        this.brokerRangeStart = cloned.brokerRangeStart;
+        this.brokerRangeEnd = cloned.brokerRangeEnd;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PlanMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PlanMongo.java
@@ -115,4 +115,12 @@ public class PlanMongo extends Auditable {
     private String referenceId;
 
     private String referenceType;
+
+    /**
+     * Port-based routing fields — only used for native (Kafka) plans with port routing mode.
+     */
+    private Integer bootstrapPort;
+
+    private Integer brokerRangeStart;
+    private Integer brokerRangeEnd;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
@@ -98,6 +98,18 @@ public interface PlanMapper {
     @Mapping(target = "mode", source = "planDefinitionV4.mode")
     @Mapping(target = "flows", expression = "java(computeFlows(source))")
     @Mapping(target = "definitionVersion", constant = "V4")
+    @Mapping(
+        target = "bootstrapPort",
+        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBootstrapPort() : null)"
+    )
+    @Mapping(
+        target = "brokerRangeStart",
+        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBrokerRangeStart() : null)"
+    )
+    @Mapping(
+        target = "brokerRangeEnd",
+        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBrokerRangeEnd() : null)"
+    )
     PlanV4 map(PlanWithFlows source);
 
     default <T extends PlanDescriptor> PlanV4 map(T source) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
@@ -98,18 +98,9 @@ public interface PlanMapper {
     @Mapping(target = "mode", source = "planDefinitionV4.mode")
     @Mapping(target = "flows", expression = "java(computeFlows(source))")
     @Mapping(target = "definitionVersion", constant = "V4")
-    @Mapping(
-        target = "bootstrapPort",
-        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBootstrapPort() : null)"
-    )
-    @Mapping(
-        target = "brokerRangeStart",
-        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBrokerRangeStart() : null)"
-    )
-    @Mapping(
-        target = "brokerRangeEnd",
-        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBrokerRangeEnd() : null)"
-    )
+    @Mapping(target = "bootstrapPort", source = "planDefinitionNativeV4.bootstrapPort")
+    @Mapping(target = "brokerRangeStart", source = "planDefinitionNativeV4.brokerRangeStart")
+    @Mapping(target = "brokerRangeEnd", source = "planDefinitionNativeV4.brokerRangeEnd")
     PlanV4 map(PlanWithFlows source);
 
     default <T extends PlanDescriptor> PlanV4 map(T source) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -5063,6 +5063,18 @@ components:
                           type: array
                           items:
                               $ref: "#/components/schemas/FlowV4"
+                      bootstrapPort:
+                          type: integer
+                          description: Bootstrap port for port-based routing (native Kafka APIs only). Null in host/SNI routing mode.
+                          example: 9092
+                      brokerRangeStart:
+                          type: integer
+                          description: Start of broker port range for port-based routing (native Kafka APIs only).
+                          example: 9100
+                      brokerRangeEnd:
+                          type: integer
+                          description: End of broker port range for port-based routing (native Kafka APIs only).
+                          example: 9102
         PlanFederated:
             type: object
             title: "PlanFederated"
@@ -5312,6 +5324,18 @@ components:
                               $ref: "#/components/schemas/FlowV4"
                       mode:
                           $ref: "#/components/schemas/PlanMode"
+                      bootstrapPort:
+                          type: integer
+                          description: Bootstrap port for port-based routing (native Kafka APIs only). Null in host/SNI routing mode.
+                          example: 9092
+                      brokerRangeStart:
+                          type: integer
+                          description: Start of broker port range for port-based routing (native Kafka APIs only).
+                          example: 9100
+                      brokerRangeEnd:
+                          type: integer
+                          description: End of broker port range for port-based routing (native Kafka APIs only).
+                          example: 9102
         PlanMode:
             type: string
             description: The behavioural mode of the Plan (Standard for classical plan, Push for subscription plan).
@@ -5433,6 +5457,18 @@ components:
                           type: array
                           items:
                               $ref: "#/components/schemas/FlowV4"
+                      bootstrapPort:
+                          type: integer
+                          description: Bootstrap port for port-based routing (native Kafka APIs only). Null in host/SNI routing mode.
+                          example: 9092
+                      brokerRangeStart:
+                          type: integer
+                          description: Start of broker port range for port-based routing (native Kafka APIs only).
+                          example: 9100
+                      brokerRangeEnd:
+                          type: integer
+                          description: End of broker port range for port-based routing (native Kafka APIs only).
+                          example: 9102
 
         UpdatePlanFederated:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapperTest.java
@@ -386,6 +386,68 @@ public class PlanMapperTest {
         assertEquals(planWithFlows.getFlows().size(), plan.getFlows().size());
     }
 
+    @Test
+    void should_map_native_PlanWithFlows_with_port_routing_to_PlanV4() {
+        final var basePlan = PlanFixtures.aPlanWithNativeFlows();
+        basePlan.getPlanDefinitionNativeV4().setBootstrapPort(9092);
+        basePlan.getPlanDefinitionNativeV4().setBrokerRangeStart(9100);
+        basePlan.getPlanDefinitionNativeV4().setBrokerRangeEnd(9102);
+
+        final var plan = planMapper.map(basePlan);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(plan.getBootstrapPort()).isEqualTo(9092);
+            soft.assertThat(plan.getBrokerRangeStart()).isEqualTo(9100);
+            soft.assertThat(plan.getBrokerRangeEnd()).isEqualTo(9102);
+        });
+    }
+
+    @Test
+    void should_leave_port_routing_fields_null_when_mapping_http_PlanWithFlows() {
+        // HTTP plans have no planDefinitionNativeV4, so port fields stay null
+        final var planWithFlows = PlanFixtures.aPlanWithHttpFlows();
+
+        final var plan = planMapper.map(planWithFlows);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(plan.getBootstrapPort()).isNull();
+            soft.assertThat(plan.getBrokerRangeStart()).isNull();
+            soft.assertThat(plan.getBrokerRangeEnd()).isNull();
+        });
+    }
+
+    @Test
+    void should_map_CreatePlanV4_port_routing_fields_to_native_plan_definition() {
+        final var createPlanV4 = PlanFixtures.aCreatePlanNativeV4();
+        createPlanV4.setBootstrapPort(9092);
+        createPlanV4.setBrokerRangeStart(9100);
+        createPlanV4.setBrokerRangeEnd(9102);
+
+        final var plan = planMapper.map(createPlanV4, Api.builder().type(ApiType.NATIVE).build());
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(plan.getPlanDefinitionNativeV4().getBootstrapPort()).isEqualTo(9092);
+            soft.assertThat(plan.getPlanDefinitionNativeV4().getBrokerRangeStart()).isEqualTo(9100);
+            soft.assertThat(plan.getPlanDefinitionNativeV4().getBrokerRangeEnd()).isEqualTo(9102);
+        });
+    }
+
+    @Test
+    void should_map_UpdatePlanV4_port_routing_fields_to_PlanUpdates() {
+        final var updatePlanV4 = PlanFixtures.anUpdatePlanNativeV4();
+        updatePlanV4.setBootstrapPort(9092);
+        updatePlanV4.setBrokerRangeStart(9100);
+        updatePlanV4.setBrokerRangeEnd(9102);
+
+        final var planUpdates = planMapper.mapToPlanUpdates(updatePlanV4);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(planUpdates.getBootstrapPort()).isEqualTo(9092);
+            soft.assertThat(planUpdates.getBrokerRangeStart()).isEqualTo(9100);
+            soft.assertThat(planUpdates.getBrokerRangeEnd()).isEqualTo(9102);
+        });
+    }
+
     private void assertSecurityV4Equals(
         PlanSecurity planEntitySecurity,
         io.gravitee.rest.api.management.v2.rest.model.PlanSecurity planSecurity

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/nativeapi/NativePlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/nativeapi/NativePlanEntity.java
@@ -29,7 +29,6 @@ import lombok.experimental.SuperBuilder;
  * @author GraviteeSource Team
  */
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @Setter
 @ToString(callSuper = true)
@@ -41,4 +40,16 @@ public class NativePlanEntity extends BasePlanEntity {
     @DeploymentRequired
     @Builder.Default
     private List<NativeFlow> flows = new ArrayList<>();
+
+    /**
+     * Port-based routing fields — only used for native (Kafka) plans with port routing mode.
+     */
+    private Integer bootstrapPort;
+
+    private Integer brokerRangeStart;
+    private Integer brokerRangeEnd;
+
+    public NativePlanEntity(List<NativeFlow> flows) {
+        this.flows = flows;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/PlanDescriptor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/PlanDescriptor.java
@@ -248,7 +248,11 @@ public sealed interface PlanDescriptor {
         String commentMessage,
         String generalConditions,
 
-        Collection<NativeFlow> flows
+        Collection<NativeFlow> flows,
+
+        Integer bootstrapPort,
+        Integer brokerRangeStart,
+        Integer brokerRangeEnd
     ) implements PlanDescriptor {
         @JsonProperty("tags")
         public Set<String> tags() {
@@ -281,7 +285,10 @@ public sealed interface PlanDescriptor {
                 commentRequired,
                 commentMessage,
                 generalConditions,
-                newFlow
+                newFlow,
+                bootstrapPort,
+                brokerRangeStart,
+                brokerRangeEnd
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanUpdates.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanUpdates.java
@@ -47,6 +47,10 @@ public class PlanUpdates {
     private String referenceId;
     private GenericPlanEntity.ReferenceType referenceType;
 
+    private Integer bootstrapPort;
+    private Integer brokerRangeStart;
+    private Integer brokerRangeEnd;
+
     public Plan applyTo(Plan oldPlan) {
         Plan result = oldPlan
             .toBuilder()
@@ -70,6 +74,12 @@ public class PlanUpdates {
         definition.setSelectionRule(selectionRule);
         if (definition.getSecurity() != null) {
             definition.getSecurity().setConfiguration(securityConfiguration);
+        }
+        if (result.getPlanDefinitionNativeV4() != null) {
+            var nativePlan = result.getPlanDefinitionNativeV4();
+            nativePlan.setBootstrapPort(bootstrapPort);
+            nativePlan.setBrokerRangeStart(brokerRangeStart);
+            nativePlan.setBrokerRangeEnd(brokerRangeEnd);
         }
         return result;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
@@ -68,6 +68,9 @@ public interface GraviteeDefinitionAdapter {
     @Mapping(target = "security", expression = "java(mapPlanSecurity(source.getPlanDefinitionNativeV4().getSecurity()))")
     @Mapping(target = "mode", source = "source.planDefinitionNativeV4.mode")
     @Mapping(target = "status", source = "source.planDefinitionNativeV4.status")
+    @Mapping(target = "bootstrapPort", source = "source.planDefinitionNativeV4.bootstrapPort")
+    @Mapping(target = "brokerRangeStart", source = "source.planDefinitionNativeV4.brokerRangeStart")
+    @Mapping(target = "brokerRangeEnd", source = "source.planDefinitionNativeV4.brokerRangeEnd")
     PlanDescriptor.Native mapPlanNative(Plan source, boolean ignoreId);
 
     @Mapping(target = "security", expression = "java(mapPlanSecurity(source.getFederatedPlanDefinition().getSecurity()))")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PlanAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PlanAdapter.java
@@ -65,6 +65,18 @@ public interface PlanAdapter {
     @Mapping(target = "selectionRule", expression = "java(serializeSelectionRule(source))")
     @Mapping(target = "status", source = "planStatus")
     @Mapping(target = "tags", expression = "java(serializeTags(source))")
+    @Mapping(
+        target = "bootstrapPort",
+        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBootstrapPort() : null)"
+    )
+    @Mapping(
+        target = "brokerRangeStart",
+        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBrokerRangeStart() : null)"
+    )
+    @Mapping(
+        target = "brokerRangeEnd",
+        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBrokerRangeEnd() : null)"
+    )
     io.gravitee.repository.management.model.Plan toRepository(Plan source);
 
     @Mapping(target = "status", source = "planStatus")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PlanAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PlanAdapter.java
@@ -65,18 +65,9 @@ public interface PlanAdapter {
     @Mapping(target = "selectionRule", expression = "java(serializeSelectionRule(source))")
     @Mapping(target = "status", source = "planStatus")
     @Mapping(target = "tags", expression = "java(serializeTags(source))")
-    @Mapping(
-        target = "bootstrapPort",
-        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBootstrapPort() : null)"
-    )
-    @Mapping(
-        target = "brokerRangeStart",
-        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBrokerRangeStart() : null)"
-    )
-    @Mapping(
-        target = "brokerRangeEnd",
-        expression = "java(source.getPlanDefinitionNativeV4() != null ? source.getPlanDefinitionNativeV4().getBrokerRangeEnd() : null)"
-    )
+    @Mapping(target = "bootstrapPort", source = "planDefinitionNativeV4.bootstrapPort")
+    @Mapping(target = "brokerRangeStart", source = "planDefinitionNativeV4.brokerRangeStart")
+    @Mapping(target = "brokerRangeEnd", source = "planDefinitionNativeV4.brokerRangeEnd")
     io.gravitee.repository.management.model.Plan toRepository(Plan source);
 
     @Mapping(target = "status", source = "planStatus")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/PlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/PlanMapper.java
@@ -54,7 +54,11 @@ public class PlanMapper {
     }
 
     public NativePlanEntity toNativeEntity(Plan plan, List<NativeFlow> flows) {
-        return toEntity(plan, new NativePlanEntity(flows));
+        NativePlanEntity entity = toEntity(plan, new NativePlanEntity(flows));
+        entity.setBootstrapPort(plan.getBootstrapPort());
+        entity.setBrokerRangeStart(plan.getBrokerRangeStart());
+        entity.setBrokerRangeEnd(plan.getBrokerRangeEnd());
+        return entity;
     }
 
     private <T extends BasePlanEntity> T toEntity(Plan plan, T entity) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/model/PlanUpdatesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/model/PlanUpdatesTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.model;
+
+import fixtures.core.model.PlanFixtures;
+import io.gravitee.definition.model.v4.nativeapi.NativePlan;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlanUpdatesTest {
+
+    @Test
+    void applyTo_should_update_port_routing_fields_on_native_plan() {
+        var oldPlan = PlanFixtures.NativeV4.aKeyless()
+            .toBuilder()
+            .planDefinitionNativeV4(
+                NativePlan.builder()
+                    .security(PlanSecurity.builder().type("key-less").build())
+                    .mode(PlanMode.STANDARD)
+                    .status(PlanStatus.PUBLISHED)
+                    .bootstrapPort(9092)
+                    .brokerRangeStart(9100)
+                    .brokerRangeEnd(9102)
+                    .build()
+            )
+            .build();
+
+        var updates = PlanUpdates.builder()
+            .name("new-name")
+            .description("new-description")
+            .order(1)
+            .validation(Plan.PlanValidationType.MANUAL)
+            .bootstrapPort(19092)
+            .brokerRangeStart(19100)
+            .brokerRangeEnd(19102)
+            .build();
+
+        var result = updates.applyTo(oldPlan);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.getPlanDefinitionNativeV4().getBootstrapPort()).isEqualTo(19092);
+            soft.assertThat(result.getPlanDefinitionNativeV4().getBrokerRangeStart()).isEqualTo(19100);
+            soft.assertThat(result.getPlanDefinitionNativeV4().getBrokerRangeEnd()).isEqualTo(19102);
+        });
+    }
+
+    @Test
+    void applyTo_should_clear_port_routing_fields_when_updates_are_null() {
+        // Switching from port-based routing to host/SNI routing mode
+        var oldPlan = PlanFixtures.NativeV4.aKeyless()
+            .toBuilder()
+            .planDefinitionNativeV4(
+                NativePlan.builder()
+                    .security(PlanSecurity.builder().type("key-less").build())
+                    .mode(PlanMode.STANDARD)
+                    .status(PlanStatus.PUBLISHED)
+                    .bootstrapPort(9092)
+                    .brokerRangeStart(9100)
+                    .brokerRangeEnd(9102)
+                    .build()
+            )
+            .build();
+
+        var updates = PlanUpdates.builder()
+            .name("new-name")
+            .description("new-description")
+            .order(1)
+            .validation(Plan.PlanValidationType.MANUAL)
+            .build();
+
+        var result = updates.applyTo(oldPlan);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.getPlanDefinitionNativeV4().getBootstrapPort()).isNull();
+            soft.assertThat(result.getPlanDefinitionNativeV4().getBrokerRangeStart()).isNull();
+            soft.assertThat(result.getPlanDefinitionNativeV4().getBrokerRangeEnd()).isNull();
+        });
+    }
+
+    @Test
+    void applyTo_should_not_touch_port_routing_fields_on_http_plan() {
+        // HTTP plans have no planDefinitionNativeV4 — port fields must be a no-op
+        var oldPlan = PlanFixtures.HttpV4.anApiKey();
+
+        var updates = PlanUpdates.builder()
+            .name("new-name")
+            .description("new-description")
+            .order(1)
+            .validation(Plan.PlanValidationType.MANUAL)
+            .bootstrapPort(9092)
+            .brokerRangeStart(9100)
+            .brokerRangeEnd(9102)
+            .build();
+
+        var result = updates.applyTo(oldPlan);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.getPlanDefinitionNativeV4()).isNull();
+            soft.assertThat(result.getPlanDefinitionHttpV4()).isNotNull();
+        });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
@@ -20,13 +20,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.NewApiMetadata;
 import io.gravitee.apim.core.api.model.import_definition.ApiDescriptor;
+import io.gravitee.apim.core.api.model.import_definition.PlanDescriptor;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.nativeapi.NativePlan;
+import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.WorkflowState;
 import java.util.List;
 import java.util.Set;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -113,5 +118,64 @@ class GraviteeDefinitionAdapterTest {
         );
 
         assertThat(descriptor.allowedInApiProducts()).isNull();
+    }
+
+    @Test
+    void mapPlanNative_should_propagate_port_routing_fields_from_definition() {
+        // Given a core Plan with port-based routing configured on the native definition
+        var nativePlanDefinition = NativePlan.builder()
+            .security(io.gravitee.definition.model.v4.plan.PlanSecurity.builder().type("key-less").build())
+            .mode(PlanMode.STANDARD)
+            .status(PlanStatus.PUBLISHED)
+            .bootstrapPort(9092)
+            .brokerRangeStart(9100)
+            .brokerRangeEnd(9102)
+            .build();
+
+        var corePlan = io.gravitee.apim.core.plan.model.Plan.builder()
+            .id("plan-id")
+            .name("plan-name")
+            .definitionVersion(DefinitionVersion.V4)
+            .apiType(ApiType.NATIVE)
+            .validation(io.gravitee.apim.core.plan.model.Plan.PlanValidationType.MANUAL)
+            .planDefinitionNativeV4(nativePlanDefinition)
+            .build();
+
+        // When exported via GraviteeDefinitionAdapter
+        PlanDescriptor.Native descriptor = GraviteeDefinitionAdapter.INSTANCE.mapPlanNative(corePlan, false);
+
+        // Then port fields are present in the exported descriptor
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(descriptor.bootstrapPort()).isEqualTo(9092);
+            soft.assertThat(descriptor.brokerRangeStart()).isEqualTo(9100);
+            soft.assertThat(descriptor.brokerRangeEnd()).isEqualTo(9102);
+        });
+    }
+
+    @Test
+    void mapPlanNative_should_leave_port_routing_fields_null_when_not_set() {
+        // Given a native plan in host/SNI routing mode (no port fields)
+        var nativePlanDefinition = NativePlan.builder()
+            .security(io.gravitee.definition.model.v4.plan.PlanSecurity.builder().type("key-less").build())
+            .mode(PlanMode.STANDARD)
+            .status(PlanStatus.PUBLISHED)
+            .build();
+
+        var corePlan = io.gravitee.apim.core.plan.model.Plan.builder()
+            .id("plan-id")
+            .name("plan-name")
+            .definitionVersion(DefinitionVersion.V4)
+            .apiType(ApiType.NATIVE)
+            .validation(io.gravitee.apim.core.plan.model.Plan.PlanValidationType.MANUAL)
+            .planDefinitionNativeV4(nativePlanDefinition)
+            .build();
+
+        PlanDescriptor.Native descriptor = GraviteeDefinitionAdapter.INSTANCE.mapPlanNative(corePlan, false);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(descriptor.bootstrapPort()).isNull();
+            soft.assertThat(descriptor.brokerRangeStart()).isNull();
+            soft.assertThat(descriptor.brokerRangeEnd()).isNull();
+        });
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PlanAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PlanAdapterTest.java
@@ -304,6 +304,87 @@ class PlanAdapterTest {
         }
 
         @Test
+        void should_convert_from_native_repository_with_port_routing_to_core_model() {
+            var repository = planNativeV4().bootstrapPort(9092).brokerRangeStart(9100).brokerRangeEnd(9102).build();
+
+            var plan = PlanAdapter.INSTANCE.fromRepository(repository);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(plan.getPlanDefinitionNativeV4().getBootstrapPort()).isEqualTo(9092);
+                soft.assertThat(plan.getPlanDefinitionNativeV4().getBrokerRangeStart()).isEqualTo(9100);
+                soft.assertThat(plan.getPlanDefinitionNativeV4().getBrokerRangeEnd()).isEqualTo(9102);
+            });
+        }
+
+        @Test
+        void should_convert_native_plan_with_port_routing_to_repository() {
+            var model = PlanFixtures.NativeV4.aKeyless()
+                .toBuilder()
+                .planDefinitionNativeV4(
+                    io.gravitee.definition.model.v4.nativeapi.NativePlan.builder()
+                        .security(PlanSecurity.builder().type("key-less").build())
+                        .mode(PlanMode.STANDARD)
+                        .status(PlanStatus.PUBLISHED)
+                        .bootstrapPort(9092)
+                        .brokerRangeStart(9100)
+                        .brokerRangeEnd(9102)
+                        .build()
+                )
+                .build();
+
+            var plan = PlanAdapter.INSTANCE.toRepository(model);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(plan.getBootstrapPort()).isEqualTo(9092);
+                soft.assertThat(plan.getBrokerRangeStart()).isEqualTo(9100);
+                soft.assertThat(plan.getBrokerRangeEnd()).isEqualTo(9102);
+            });
+        }
+
+        @Test
+        void should_convert_native_plan_without_port_routing_to_repository_with_null_ports() {
+            // Host/SNI routing mode: no port fields set on the definition
+            var model = PlanFixtures.NativeV4.aKeyless();
+
+            var plan = PlanAdapter.INSTANCE.toRepository(model);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(plan.getBootstrapPort()).isNull();
+                soft.assertThat(plan.getBrokerRangeStart()).isNull();
+                soft.assertThat(plan.getBrokerRangeEnd()).isNull();
+            });
+        }
+
+        @Test
+        void should_roundtrip_native_plan_with_port_routing_through_repository_mapping() {
+            // Simulates the full DEPLOY event chain: core Plan → repo Plan → core Plan
+            var originalModel = PlanFixtures.NativeV4.aKeyless()
+                .toBuilder()
+                .planDefinitionNativeV4(
+                    io.gravitee.definition.model.v4.nativeapi.NativePlan.builder()
+                        .security(PlanSecurity.builder().type("key-less").build())
+                        .mode(PlanMode.STANDARD)
+                        .status(PlanStatus.PUBLISHED)
+                        .bootstrapPort(9092)
+                        .brokerRangeStart(9100)
+                        .brokerRangeEnd(9102)
+                        .build()
+                )
+                .build();
+
+            var repo = PlanAdapter.INSTANCE.toRepository(originalModel);
+            repo.setApiType(ApiType.NATIVE);
+            repo.setDefinitionVersion(DefinitionVersion.V4);
+            var roundTripped = PlanAdapter.INSTANCE.fromRepository(repo);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(roundTripped.getPlanDefinitionNativeV4().getBootstrapPort()).isEqualTo(9092);
+                soft.assertThat(roundTripped.getPlanDefinitionNativeV4().getBrokerRangeStart()).isEqualTo(9100);
+                soft.assertThat(roundTripped.getPlanDefinitionNativeV4().getBrokerRangeEnd()).isEqualTo(9102);
+            });
+        }
+
+        @Test
         void should_convert_federated_plan_to_repository() {
             var model = PlanFixtures.aFederatedPlan()
                 .toBuilder()


### PR DESCRIPTION
## Summary

- Add `bootstrapPort`, `brokerRangeStart`, and `brokerRangeEnd` fields to `NativePlan.java` for the upcoming Kafka port-based routing mode (`kafka.routingMode=port`).
- Fields are `Integer` (nullable) — `null` in host/SNI routing mode, populated only when publishers configure port-based plans.
- Scoped to `NativePlan` only — `Plan.java`, `HttpPlan.java`, and other plan types are not modified.

**Jira:** [APIM-12493](https://gravitee.atlassian.net/browse/APIM-12493)

This is the first PR in the port-based routing implementation series. The reactor (`gravitee-reactor-native-kafka`) will consume these fields in a follow-up PR.

## Test plan

- [x] `gravitee-apim-definition-model` compiles
- [x] All existing tests pass (no behavioral change — fields are additive and nullable)
- [x] Prettier formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APIM-12493]: https://gravitee.atlassian.net/browse/APIM-12493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ