### PR TITLE
fix: only create default portal nav items on new cloud environments.

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandler.java
@@ -96,7 +96,10 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
                 accessPointsToCreate
             );
 
-            createDefaultPortalNavigationItemsUseCase.execute(environment.getOrganizationId(), environment.getId());
+            // Seed default portal navigation items only when Cockpit registers this environment for the first time
+            if (existingEnvironment == null) {
+                createDefaultPortalNavigationItemsUseCase.execute(environment.getOrganizationId(), environment.getId());
+            }
 
             log.info("Environment [{}] handled with id [{}].", environment.getName(), environment.getId());
             return Single.just(new EnvironmentReply(command.getId()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandlerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -113,8 +114,6 @@ public class EnvironmentCommandHandlerTest {
 
         obs.await();
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
-
-        verify(createDefaultPortalNavigationItemsUseCase).execute(orgId, envId);
     }
 
     @Test
@@ -186,5 +185,70 @@ public class EnvironmentCommandHandlerTest {
 
         obs.await();
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+    }
+
+    @Test
+    @SneakyThrows
+    public void environmentCreationCreatesDefaultPortalNavigationItems() {
+        String envId = "env#1";
+        String orgId = "orga#1";
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+            .id(envId)
+            .cockpitId("env#cockpit-1")
+            .hrids(Collections.singletonList("env-1"))
+            .organizationId(orgId)
+            .description("Environment description")
+            .name("Environment name")
+            .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+
+        when(environmentService.findByCockpitId(any())).thenThrow(new EnvironmentNotFoundException("Env not found"));
+        when(environmentService.createOrUpdate(eq(orgId), eq(envId), any(UpdateEnvironmentEntity.class))).thenReturn(
+            EnvironmentEntity.builder().id(envId).organizationId(orgId).build()
+        );
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.await();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verify(createDefaultPortalNavigationItemsUseCase).execute(orgId, envId);
+    }
+
+    @Test
+    public void environmentUpdateDoesNotCreateDefaultPortalNavigationItems() throws InterruptedException {
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+            .id("env#1")
+            .cockpitId("env#cockpit-1")
+            .hrids(Collections.singletonList("env-1"))
+            .organizationId("orga#1")
+            .description("Environment description")
+            .name("Environment name")
+            .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+        EnvironmentEntity existingEnvironment = mock(EnvironmentEntity.class);
+        when(existingEnvironment.getId()).thenReturn("DEFAULT");
+        when(existingEnvironment.getOrganizationId()).thenReturn("DEFAULT");
+        when(environmentService.findByCockpitId(any())).thenReturn(existingEnvironment);
+        when(
+            environmentService.createOrUpdate(
+                eq("DEFAULT"),
+                eq("DEFAULT"),
+                argThat(
+                    newEnvironment ->
+                        newEnvironment.getCockpitId().equals(environmentPayload.cockpitId()) &&
+                        newEnvironment.getHrids().equals(environmentPayload.hrids()) &&
+                        newEnvironment.getDescription().equals(environmentPayload.description()) &&
+                        newEnvironment.getName().equals(environmentPayload.name())
+                )
+            )
+        ).thenReturn(new EnvironmentEntity());
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.await();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verify(createDefaultPortalNavigationItemsUseCase, never()).execute(any(), any());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13776

## Description

`EnvironmentCommandHandler` used to run `CreateDefaultPortalNavigationItemsUseCase` on every Cockpit `ENVIRONMENT` command. It now runs it only when APIM has no environment yet for that Cockpit id (first registration), so updates and resyncs do not recreate default portal navigation items.

## Changes

- Only call `CreateDefaultPortalNavigationItemsUseCase` when `existingEnvironment == null`.

