### PR TITLE
feat(gamma): dynamic environment selection in gamma-console

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/jest.config.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/jest.config.ts
@@ -21,6 +21,7 @@ export default {
     moduleNameMapper: {
         '^@gravitee/graphene-core$': '<rootDir>/../../node_modules/@gravitee/graphene-core/dist/index.js',
         '^@gravitee/gamma-modules-sdk$': '<rootDir>/src/shared/gamma-modules-sdk.ts',
+        '^@gravitee/gamma-modules-sdk/routing$': '<rootDir>/../../packages/gamma-modules-sdk/src/routing.ts',
     },
     transform: {
         '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/app/AppRoutes.tsx
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 
 import { LoginPage, ProtectedRoute, PublicOnlyRoute } from '../features/auth';
+import { EnvironmentGuard, RootRedirect } from '../features/environment';
 import { type GammaModule, RemoteModuleRoute, useGammaModules } from '../features/modules';
 import { AboutPage } from '../pages/AboutPage';
 import { HomePage } from '../pages/HomePage';
@@ -31,15 +32,20 @@ export function AppRoutes() {
                 <Route path="/login" element={<LoginPage />} />
             </Route>
             <Route element={<ProtectedRoute />}>
-                <Route element={<ShellLayout modules={modules} />}>
-                    <Route element={<RouteLayout />}>
-                        <Route path="/" element={<HomePage modules={modules} loading={loading} error={error} />} />
-                        <Route path="/about" element={<AboutPage />} />
+                <Route path="/environments/:envHrid" element={<ShellLayout modules={modules} />}>
+                    <Route element={<EnvironmentGuard />}>
+                        <Route element={<RouteLayout />}>
+                            <Route path="home" element={<HomePage modules={modules} loading={loading} error={error} />} />
+                            <Route path="about" element={<AboutPage />} />
+                        </Route>
+                        {modules.map((m: GammaModule) => (
+                            <Route key={m.id} path={`${m.id}/*`} element={<RemoteModuleRoute module={m} />} />
+                        ))}
+                        <Route index element={<Navigate to="home" replace />} />
                     </Route>
-                    {modules.map((m: GammaModule) => (
-                        <Route key={m.id} path={`/${m.id}/*`} element={<RemoteModuleRoute module={m} />} />
-                    ))}
                 </Route>
+                <Route path="/" element={<RootRedirect />} />
+                <Route path="*" element={<RootRedirect />} />
             </Route>
         </Routes>
     );

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap-initialize.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap-initialize.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { runApplicationBootstrap } from './bootstrap-initialize';
+import { useAuthStore } from './features/auth/auth.store';
+import { useEnvironmentStore } from './features/environment/environment.store';
+import * as permissionSync from './features/permissions/permission-sync';
+import { TEST_ENVIRONMENTS, TEST_MANAGEMENT_BASE } from './testing/factories';
+import { trackHandler, respondWithError } from './testing/helpers';
+
+describe('runApplicationBootstrap', () => {
+    let startSyncSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        startSyncSpy = jest.spyOn(permissionSync, 'startPermissionSync').mockReturnValue(jest.fn());
+    });
+
+    afterEach(() => {
+        startSyncSpy.mockRestore();
+    });
+
+    it('should not request environments when the user is not authenticated', async () => {
+        respondWithError('get', `${TEST_MANAGEMENT_BASE}/user`, 401);
+        const envListTracker = trackHandler('get', `${TEST_MANAGEMENT_BASE}/environments`, TEST_ENVIRONMENTS);
+
+        await runApplicationBootstrap();
+
+        expect(useAuthStore.getState().user).toBeNull();
+        expect(envListTracker.callCount).toBe(0);
+        expect(useEnvironmentStore.getState().initialized).toBe(false);
+    });
+
+    it('should load environments when a session is already present', async () => {
+        const envListTracker = trackHandler('get', `${TEST_MANAGEMENT_BASE}/environments`, TEST_ENVIRONMENTS);
+
+        await runApplicationBootstrap();
+
+        expect(useAuthStore.getState().user).toBeTruthy();
+        expect(envListTracker.callCount).toBe(1);
+        expect(useEnvironmentStore.getState().environments).toEqual(TEST_ENVIRONMENTS);
+        expect(useEnvironmentStore.getState().initialized).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap-initialize.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap-initialize.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useAuthStore } from './features/auth';
+import { useEnvironmentStore } from './features/environment';
+import { startPermissionSync } from './features/permissions/permission-sync';
+import { useBootstrapStore } from './shared/config/bootstrap.store';
+
+/**
+ * Loads config, session, and (when the user is authenticated) the environment list
+ * before the React app mounts.
+ */
+export async function runApplicationBootstrap(): Promise<void> {
+    await useBootstrapStore.getState().initialize();
+
+    startPermissionSync();
+
+    const config = useBootstrapStore.getState().config!;
+
+    await useAuthStore.getState().initialize();
+    if (useAuthStore.getState().user) {
+        await useEnvironmentStore.getState().initialize(config.organizationId);
+    }
+
+    // If we just completed an OAuth callback, redirect to the intended URL
+    const oauthRedirectUrl = useAuthStore.getState().oauthRedirectUrl;
+    if (oauthRedirectUrl) {
+        window.history.replaceState({}, '', oauthRedirectUrl);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/bootstrap.tsx
@@ -19,30 +19,10 @@ import * as ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
 import { AppRoutes } from './app/AppRoutes';
-import { useAuthStore } from './features/auth';
-import { useEnvironmentStore } from './features/environment';
-import { startPermissionSync } from './features/permissions/permission-sync';
+import { runApplicationBootstrap } from './bootstrap-initialize';
 import { ErrorBoundary } from './shared/components/ErrorBoundary';
-import { useBootstrapStore } from './shared/config/bootstrap.store';
 
-async function initialize() {
-    await useBootstrapStore.getState().initialize();
-
-    startPermissionSync();
-
-    const config = useBootstrapStore.getState().config!;
-
-    await useAuthStore.getState().initialize();
-    await useEnvironmentStore.getState().initialize(config.organizationId);
-
-    // If we just completed an OAuth callback, redirect to the intended URL
-    const oauthRedirectUrl = useAuthStore.getState().oauthRedirectUrl;
-    if (oauthRedirectUrl) {
-        window.history.replaceState({}, '', oauthRedirectUrl);
-    }
-}
-
-initialize().then(() => {
+runApplicationBootstrap().then(() => {
     const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
     root.render(
         <StrictMode>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/auth.store.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/auth.store.spec.ts
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { waitFor } from '@testing-library/react';
+
 import { useAuthStore } from './auth.store';
-import { TEST_MANAGEMENT_BASE, buildUser } from '../../testing/factories';
+import { TEST_ENVIRONMENTS, TEST_MANAGEMENT_BASE, buildUser } from '../../testing/factories';
 import { respondWithError, trackHandler } from '../../testing/helpers';
+import { useEnvironmentStore } from '../environment/environment.store';
 
 describe('authStore', () => {
     it('should initialize with existing session', async () => {
@@ -52,13 +55,41 @@ describe('authStore', () => {
         expect(loginTracker.callCount).toBe(1);
         expect(userTracker.callCount).toBe(1);
         expect(useAuthStore.getState().user?.displayName).toBe('Bob');
+        await waitFor(() => {
+            expect(useEnvironmentStore.getState().initialized).toBe(true);
+        });
     });
 
-    it('should clear user on logout', async () => {
+    it('should load environments after login', async () => {
+        useEnvironmentStore.getState().reset();
+        const envTracker = trackHandler('get', `${TEST_MANAGEMENT_BASE}/environments`, TEST_ENVIRONMENTS);
+        trackHandler('post', `${TEST_MANAGEMENT_BASE}/user/login`, null, 200);
+        trackHandler('get', `${TEST_MANAGEMENT_BASE}/user`, buildUser({ displayName: 'Bob' }));
+
+        await useAuthStore.getState().login('bob', 'password');
+
+        await waitFor(() => {
+            expect(envTracker.callCount).toBe(1);
+        });
+        expect(useEnvironmentStore.getState().environments).toEqual(TEST_ENVIRONMENTS);
+    });
+
+    it('should clear user and reset environment state on logout', async () => {
         useAuthStore.setState({ user: buildUser() });
+        useEnvironmentStore.setState({
+            organizationId: 'test-org',
+            environmentId: 'e1',
+            environments: TEST_ENVIRONMENTS,
+            currentEnvironment: TEST_ENVIRONMENTS[0]!,
+            loading: false,
+            error: null,
+            initialized: true,
+        });
 
         await useAuthStore.getState().logout();
 
         expect(useAuthStore.getState().user).toBeNull();
+        expect(useEnvironmentStore.getState().environments).toEqual([]);
+        expect(useEnvironmentStore.getState().initialized).toBe(false);
     });
 });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/auth.store.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/auth/auth.store.ts
@@ -20,6 +20,7 @@ import { devtools } from 'zustand/middleware';
 import type { CurrentUser, SocialIdentityProvider } from './auth.types';
 import { managementApi } from '../../shared/api/api-client';
 import { useBootstrapStore } from '../../shared/config/bootstrap.store';
+import { useEnvironmentStore } from '../environment/environment.store';
 
 const USER_PROVIDER_ID_SELECTED = 'user-provider-id-selected';
 
@@ -113,6 +114,8 @@ export const useAuthStore = create<AuthState>()(
                 });
                 const user = await managementApi.get<CurrentUser>('/user');
                 set({ user });
+                const config = useBootstrapStore.getState().config!;
+                void useEnvironmentStore.getState().initialize(config.organizationId);
             },
 
             loginWithProvider: async (providerId: string, redirectUrl: string) => {
@@ -139,6 +142,7 @@ export const useAuthStore = create<AuthState>()(
                 localStorage.removeItem(USER_PROVIDER_ID_SELECTED);
                 localStorage.removeItem('XSRF-TOKEN');
                 set({ user: null });
+                useEnvironmentStore.getState().reset();
             },
         }),
         { name: 'auth' },

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/EnvironmentGuard.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/EnvironmentGuard.spec.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { useEnvironmentStore } from './environment.store';
+import { EnvironmentGuard } from './EnvironmentGuard';
+import { TEST_ENVIRONMENTS } from '../../testing/factories';
+import { resetAllStores, seedBootstrap, seedEnvironments } from '../../testing/helpers';
+import { PathnameProbe } from '../../testing/PathnameProbe';
+
+describe('EnvironmentGuard', () => {
+    let lastPath = '';
+
+    beforeEach(() => {
+        resetAllStores();
+        seedBootstrap();
+        lastPath = '';
+    });
+
+    function renderGuard(initialPath: string) {
+        return render(
+            <MemoryRouter initialEntries={[initialPath]}>
+                <PathnameProbe onPath={p => (lastPath = p)} />
+                <Routes>
+                    <Route path="/environments/:envHrid" element={<EnvironmentGuard />}>
+                        <Route path="home" element={<div>Child</div>} />
+                    </Route>
+                </Routes>
+            </MemoryRouter>,
+        );
+    }
+
+    it('should render children when env segment matches a known hrid', async () => {
+        seedEnvironments();
+        renderGuard('/environments/env-1/home');
+
+        await waitFor(() => expect(screen.getByText('Child')).toBeTruthy());
+    });
+
+    it('should set current environment in the store on match', async () => {
+        seedEnvironments();
+        renderGuard('/environments/env-2/home');
+
+        await waitFor(() => {
+            expect(useEnvironmentStore.getState().currentEnvironment?.id).toBe('env-2-id');
+        });
+    });
+
+    it('should replace id in URL with primary hrid', async () => {
+        useEnvironmentStore.setState({
+            organizationId: 'test-org',
+            environments: TEST_ENVIRONMENTS,
+            currentEnvironment: null,
+            environmentId: '',
+            loading: false,
+            error: null,
+            initialized: true,
+        });
+
+        render(
+            <MemoryRouter initialEntries={['/environments/env-1-id/home']}>
+                <PathnameProbe onPath={p => (lastPath = p)} />
+                <Routes>
+                    <Route path="/environments/:envHrid" element={<EnvironmentGuard />}>
+                        <Route path="home" element={<div>Child</div>} />
+                    </Route>
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => {
+            expect(lastPath).toBe('/environments/env-1/home');
+        });
+    });
+
+    it('should redirect to first environment when segment is unknown', async () => {
+        seedEnvironments();
+        render(
+            <MemoryRouter initialEntries={['/environments/unknown-segment/home']}>
+                <PathnameProbe onPath={p => (lastPath = p)} />
+                <Routes>
+                    <Route path="/environments/:envHrid" element={<EnvironmentGuard />}>
+                        <Route path="home" element={<div>Child</div>} />
+                    </Route>
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => {
+            expect(lastPath).toBe('/environments/env-1/home');
+        });
+    });
+
+    it('should render nothing when environments list is empty', () => {
+        useEnvironmentStore.setState({
+            organizationId: 'x',
+            environments: [],
+            currentEnvironment: null,
+            environmentId: '',
+            loading: false,
+            error: null,
+            initialized: true,
+        });
+
+        const { container } = renderGuard('/environments/x/home');
+        expect(container.textContent).not.toContain('Child');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/EnvironmentGuard.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/EnvironmentGuard.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useRef } from 'react';
+import { type NavigateFunction, Outlet, useLocation, useNavigate } from 'react-router-dom';
+
+import { useEnvironmentStore } from './environment.store';
+import type { Environment } from './environment.types';
+import { getPrimaryHrid, resolveEnvironmentFromSegment, shouldRewriteIdToHrid, useEnvHrid } from './environment.utils';
+
+function redirectToFirst(env: Environment, navigate: NavigateFunction, search: string, hash: string) {
+    navigate({ pathname: `/environments/${getPrimaryHrid(env)}/home`, search, hash }, { replace: true });
+}
+
+function rewriteToHrid(env: Environment, pathname: string, navigate: NavigateFunction, search: string, hash: string) {
+    const rest = pathname.split('/').filter(Boolean).slice(2);
+    const base = `/environments/${getPrimaryHrid(env)}`;
+    navigate({ pathname: rest.length > 0 ? `${base}/${rest.join('/')}` : base, search, hash }, { replace: true });
+}
+
+/**
+ * Synchronizes URL :envHrid with the environment store, canonicalizes id to primary hrid in the URL,
+ * and redirects invalid segments to the first available environment.
+ */
+export function EnvironmentGuard() {
+    const envHrid = useEnvHrid();
+    const navigate = useNavigate();
+    const location = useLocation();
+    const locationRef = useRef(location);
+    locationRef.current = location;
+
+    const environments = useEnvironmentStore(s => s.environments);
+    const setCurrentEnvironment = useEnvironmentStore(s => s.setCurrentEnvironment);
+    const lastSyncedId = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (!environments.length) return;
+
+        const { search, hash, pathname } = locationRef.current;
+        const first = environments[0]!;
+        const resolved = resolveEnvironmentFromSegment(environments, envHrid);
+
+        if (!resolved) {
+            lastSyncedId.current = null;
+            redirectToFirst(first, navigate, search, hash);
+            return;
+        }
+
+        if (shouldRewriteIdToHrid(resolved, envHrid)) {
+            lastSyncedId.current = null;
+            rewriteToHrid(resolved, pathname, navigate, search, hash);
+            return;
+        }
+
+        if (lastSyncedId.current !== resolved.id) {
+            lastSyncedId.current = resolved.id;
+            setCurrentEnvironment(resolved);
+        }
+    }, [envHrid, environments, navigate, setCurrentEnvironment]);
+
+    if (!environments.length) {
+        return null;
+    }
+
+    return <Outlet />;
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/RootRedirect.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/RootRedirect.spec.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { useEnvironmentStore } from './environment.store';
+import { RootRedirect } from './RootRedirect';
+import { resetAllStores, seedBootstrap, seedEnvironments } from '../../testing/helpers';
+import { PathnameProbe } from '../../testing/PathnameProbe';
+
+describe('RootRedirect', () => {
+    let lastPath = '';
+
+    beforeEach(() => {
+        resetAllStores();
+        seedBootstrap();
+        lastPath = '';
+    });
+
+    it('should redirect / to /environments/:firstHrid/home', async () => {
+        seedEnvironments();
+        render(
+            <MemoryRouter initialEntries={['/']}>
+                <PathnameProbe onPath={p => (lastPath = p)} />
+                <Routes>
+                    <Route path="/" element={<RootRedirect />} />
+                    <Route path="/environments/:envHrid/home" element={<div data-testid="landed">ok</div>} />
+                </Routes>
+            </MemoryRouter>,
+        );
+
+        await waitFor(() => {
+            expect(lastPath).toBe('/environments/env-1/home');
+        });
+        expect(await screen.findByTestId('landed')).toBeTruthy();
+    });
+
+    it('should show error when store has an error and no environments', () => {
+        useEnvironmentStore.setState({
+            organizationId: '',
+            environments: [],
+            currentEnvironment: null,
+            environmentId: '',
+            loading: false,
+            error: new Error('boom'),
+            initialized: true,
+        });
+        render(
+            <MemoryRouter>
+                <RootRedirect />
+            </MemoryRouter>,
+        );
+        expect(screen.getByRole('alert').textContent).toContain('boom');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/RootRedirect.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/RootRedirect.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Navigate } from 'react-router-dom';
+
+import { useEnvironmentStore } from './environment.store';
+import { getPrimaryHrid } from './environment.utils';
+
+/**
+ * Sends users to the first environment "home" when the URL has no environment segment
+ * (e.g. legacy `/` or unknown paths under the protected area).
+ */
+export function RootRedirect() {
+    const environments = useEnvironmentStore(s => s.environments);
+    const loading = useEnvironmentStore(s => s.loading);
+    const error = useEnvironmentStore(s => s.error);
+
+    if (error) {
+        return (
+            <p role="alert" className="text-destructive p-4">
+                {error.message}
+            </p>
+        );
+    }
+
+    if (!environments.length) {
+        if (loading) return <p>Loading environments…</p>;
+        return (
+            <p role="alert" className="text-destructive p-4">
+                No environments available.
+            </p>
+        );
+    }
+
+    const hrid = getPrimaryHrid(environments[0]!);
+    return <Navigate to={`/environments/${hrid}/home`} replace />;
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.store.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.store.spec.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { http, HttpResponse } from 'msw';
+
+import { useEnvironmentStore } from './environment.store';
+import { TEST_ENVIRONMENTS, TEST_MANAGEMENT_BASE } from '../../testing/factories';
+import { resetAllStores, trackHandler, respondWithError, seedBootstrap } from '../../testing/helpers';
+import { server } from '../../testing/server';
+
+describe('environmentStore', () => {
+    beforeEach(() => {
+        resetAllStores();
+        seedBootstrap();
+    });
+
+    it('should fetch environments on initialize and set first as current', async () => {
+        await useEnvironmentStore.getState().initialize('test-org');
+
+        expect(useEnvironmentStore.getState().environments).toEqual(TEST_ENVIRONMENTS);
+        expect(useEnvironmentStore.getState().currentEnvironment).toEqual(TEST_ENVIRONMENTS[0]);
+        expect(useEnvironmentStore.getState().environmentId).toBe('env-1-id');
+    });
+
+    it('should not refetch if already initialized', async () => {
+        const tracker = trackHandler('get', `${TEST_MANAGEMENT_BASE}/environments`, TEST_ENVIRONMENTS);
+
+        await useEnvironmentStore.getState().initialize('test-org');
+        await useEnvironmentStore.getState().initialize('test-org');
+
+        expect(tracker.callCount).toBe(1);
+    });
+
+    it('should set error on API failure during initialize', async () => {
+        respondWithError('get', `${TEST_MANAGEMENT_BASE}/environments`, 500);
+
+        await useEnvironmentStore.getState().initialize('test-org');
+
+        expect(useEnvironmentStore.getState().error).toBeTruthy();
+        expect(useEnvironmentStore.getState().environments).toEqual([]);
+    });
+
+    it('should set error when environment list is empty', async () => {
+        server.use(http.get(`${TEST_MANAGEMENT_BASE}/environments`, () => HttpResponse.json([])));
+
+        await useEnvironmentStore.getState().initialize('test-org');
+
+        expect(useEnvironmentStore.getState().error?.message).toBe('No environment found!');
+        expect(useEnvironmentStore.getState().environments).toEqual([]);
+    });
+
+    it('resolveEnvironment should find by hrid', async () => {
+        await useEnvironmentStore.getState().initialize('test-org');
+
+        expect(useEnvironmentStore.getState().resolveEnvironment('env-2')?.id).toBe('env-2-id');
+    });
+
+    it('resolveEnvironment should find by id (case insensitive)', async () => {
+        await useEnvironmentStore.getState().initialize('test-org');
+
+        expect(useEnvironmentStore.getState().resolveEnvironment('ENV-1-ID')?.id).toBe('env-1-id');
+    });
+
+    it('resolveEnvironment should return null for unknown value', async () => {
+        await useEnvironmentStore.getState().initialize('test-org');
+
+        expect(useEnvironmentStore.getState().resolveEnvironment('nope')).toBeNull();
+    });
+
+    it('setCurrentEnvironment should update currentEnvironment and environmentId', async () => {
+        await useEnvironmentStore.getState().initialize('test-org');
+        const second = TEST_ENVIRONMENTS[1]!;
+
+        useEnvironmentStore.getState().setCurrentEnvironment(second);
+
+        expect(useEnvironmentStore.getState().currentEnvironment).toEqual(second);
+        expect(useEnvironmentStore.getState().environmentId).toBe('env-2-id');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.store.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.store.ts
@@ -16,32 +16,82 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
+import type { Environment } from './environment.types';
+import { resolveEnvironmentFromSegment } from './environment.utils';
+import { managementApi } from '../../shared/api/api-client';
+
 interface EnvironmentState {
     organizationId: string;
     environmentId: string;
+    environments: Environment[];
+    currentEnvironment: Environment | null;
     loading: boolean;
+    error: Error | null;
     initialized: boolean;
     initialize: (organizationId: string) => Promise<void>;
-    setEnvironment: (org: string, env: string) => void;
+    setCurrentEnvironment: (env: Environment) => void;
+    resolveEnvironment: (envHridOrId: string) => Environment | null;
+    reset: () => void;
 }
+
+const initialState = {
+    organizationId: '',
+    environmentId: '',
+    environments: [] as Environment[],
+    currentEnvironment: null as Environment | null,
+    loading: false,
+    error: null as Error | null,
+    initialized: false,
+};
 
 export const useEnvironmentStore = create<EnvironmentState>()(
     devtools(
         (set, get) => ({
-            organizationId: '',
-            environmentId: '',
-            loading: false,
-            initialized: false,
+            ...initialState,
+
+            reset: () => set({ ...initialState }),
+
+            resolveEnvironment: (envHridOrId: string) => resolveEnvironmentFromSegment(get().environments, envHridOrId),
 
             initialize: async (organizationId: string) => {
                 if (get().initialized) return;
-                set({ loading: true });
+                set({ loading: true, error: null });
 
-                set({ initialized: true, loading: false, organizationId, environmentId: 'DEFAULT' });
+                try {
+                    const environments = await managementApi.get<Environment[]>('/environments');
+                    if (!environments?.length) {
+                        set({
+                            ...initialState,
+                            organizationId,
+                            initialized: true,
+                            loading: false,
+                            error: new Error('No environment found!'),
+                        });
+                        return;
+                    }
+                    const first = environments[0]!;
+                    set({
+                        organizationId,
+                        environments,
+                        currentEnvironment: first,
+                        environmentId: first.id,
+                        loading: false,
+                        error: null,
+                        initialized: true,
+                    });
+                } catch (e) {
+                    set({
+                        ...initialState,
+                        organizationId,
+                        loading: false,
+                        error: e instanceof Error ? e : new Error(String(e)),
+                        initialized: true,
+                    });
+                }
             },
 
-            setEnvironment: (organizationId: string, environmentId: string) => {
-                set({ organizationId, environmentId });
+            setCurrentEnvironment: (env: Environment) => {
+                set({ currentEnvironment: env, environmentId: env.id, organizationId: env.organizationId || get().organizationId });
             },
         }),
         { name: 'environment' },

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.types.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.types.ts
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { EnvironmentGuard } from './EnvironmentGuard';
-export { RootRedirect } from './RootRedirect';
-export { useEnvironmentStore } from './environment.store';
-export type { Environment } from './environment.types';
-export { getPrimaryHrid, resolveEnvironmentFromSegment, shouldRewriteIdToHrid, useEnvHrid } from './environment.utils';
+/** APIM environment as returned by `GET /organizations/{orgId}/environments`. */
+export interface Environment {
+    id: string;
+    hrids?: string[];
+    name?: string;
+    description?: string;
+    organizationId: string;
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.utils.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.utils.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getPrimaryHrid, resolveEnvironmentFromSegment, shouldRewriteIdToHrid } from './environment.utils';
+import { buildEnvironment, TEST_ENVIRONMENTS } from '../../testing/factories';
+
+describe('environment.utils', () => {
+    describe('getPrimaryHrid', () => {
+        it('should return first hrid when present', () => {
+            expect(getPrimaryHrid(buildEnvironment({ hrids: ['a', 'b'] }))).toBe('a');
+        });
+
+        it('should fall back to id when no hrids', () => {
+            expect(getPrimaryHrid(buildEnvironment({ id: 'only-id', hrids: [] }))).toBe('only-id');
+        });
+    });
+
+    describe('resolveEnvironmentFromSegment', () => {
+        it('should match hrid case-insensitively', () => {
+            const env = resolveEnvironmentFromSegment(TEST_ENVIRONMENTS, 'ENV-1');
+            expect(env?.id).toBe('env-1-id');
+        });
+
+        it('should return null for empty segment', () => {
+            expect(resolveEnvironmentFromSegment(TEST_ENVIRONMENTS, '')).toBeNull();
+        });
+    });
+
+    describe('shouldRewriteIdToHrid', () => {
+        it('should be true when segment is id and hrids exist', () => {
+            const env = buildEnvironment({ id: 'abc', hrids: ['x'] });
+            expect(shouldRewriteIdToHrid(env, 'abc')).toBe(true);
+        });
+
+        it('should be false when URL already uses primary hrid', () => {
+            const env = buildEnvironment({ id: 'abc', hrids: ['x'] });
+            expect(shouldRewriteIdToHrid(env, 'x')).toBe(false);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.utils.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/environment/environment.utils.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useParams } from 'react-router-dom';
+
+import type { Environment } from './environment.types';
+
+export function useEnvHrid(): string {
+    const { envHrid = '' } = useParams();
+    return envHrid;
+}
+
+/**
+ * First human-readable id for URLs, or technical id when no hrids exist.
+ */
+export function getPrimaryHrid(environment: Environment): string {
+    const h = environment.hrids?.[0];
+    return h ?? environment.id;
+}
+
+/**
+ * Resolves an environment from the URL segment (may be id or hrid).
+ * Tries id first, then hrids -- both case-insensitively.
+ */
+export function resolveEnvironmentFromSegment(environments: readonly Environment[], segment: string): Environment | null {
+    if (!segment) return null;
+    const lower = segment.toLowerCase();
+    return (
+        environments.find(e => e.id.toLowerCase() === lower) ??
+        environments.find(e => e.hrids?.some(h => h.toLowerCase() === lower)) ??
+        null
+    );
+}
+
+/**
+ * True when the segment in the URL is the environment's technical id (not a primary hrid), and the env has hrids
+ * to canonicalize to.
+ */
+export function shouldRewriteIdToHrid(environment: Environment, segment: string): boolean {
+    if (!segment || !environment.hrids?.length) return false;
+    return environment.id.toLowerCase() === segment.toLowerCase();
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/permissions/permission-sync.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/permissions/permission-sync.spec.ts
@@ -18,7 +18,7 @@ import { waitFor } from '@testing-library/react';
 import { permissionService } from '@gravitee/gamma-modules-sdk';
 
 import { startPermissionSync } from './permission-sync';
-import { buildUser, TEST_MANAGEMENT_BASE } from '../../testing/factories';
+import { buildEnvironment, buildUser, TEST_MANAGEMENT_BASE } from '../../testing/factories';
 import { respondWithError, trackHandler } from '../../testing/helpers';
 import { useAuthStore } from '../auth/auth.store';
 import { useEnvironmentStore } from '../environment/environment.store';
@@ -63,7 +63,7 @@ describe('permission-sync', () => {
             API: ['R'],
         });
 
-        useEnvironmentStore.getState().setEnvironment('test-org', 'staging');
+        useEnvironmentStore.getState().setCurrentEnvironment(buildEnvironment({ id: 'staging' }));
 
         await waitFor(() => expect(tracker.callCount).toBe(1));
         expect(permissionService.hasAnyOf(['environment-api-r'])).toBe(true);
@@ -74,7 +74,7 @@ describe('permission-sync', () => {
             API: ['R'],
         });
 
-        useEnvironmentStore.getState().setEnvironment('test-org', 'staging');
+        useEnvironmentStore.getState().setCurrentEnvironment(buildEnvironment({ id: 'staging' }));
 
         expect(tracker.callCount).toBe(0);
     });
@@ -96,8 +96,8 @@ describe('permission-sync', () => {
     });
 
     it('should reload environment permissions on login when environmentId does not change', async () => {
-        useEnvironmentStore.getState().setEnvironment('test-org', 'DEFAULT');
-        const envPermTracker = trackHandler('get', `${TEST_MANAGEMENT_BASE}/environments/DEFAULT/permissions`, {
+        useEnvironmentStore.getState().setCurrentEnvironment(buildEnvironment({ id: 'env-1-id' }));
+        const envPermTracker = trackHandler('get', `${TEST_MANAGEMENT_BASE}/environments/env-1-id/permissions`, {
             API: ['R'],
         });
 

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/AboutPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/AboutPage.tsx
@@ -22,7 +22,7 @@ export function AboutPage() {
             <h1>About</h1>
             <p>
                 <Button variant="link" asChild>
-                    <Link to="/">Home</Link>
+                    <Link to="../home">Home</Link>
                 </Button>
             </p>
         </div>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/HomePage.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/HomePage.tsx
@@ -34,7 +34,7 @@ export function HomePage({
             <ul>
                 <li>
                     <Button variant="link" asChild>
-                        <Link to="/about">About</Link>
+                        <Link to="../about">About</Link>
                     </Button>
                 </li>
             </ul>
@@ -47,7 +47,7 @@ export function HomePage({
                     {modules.map(m => (
                         <li key={m.id}>
                             <Button variant="link" asChild>
-                                <Link to={`/${m.id}`}>
+                                <Link to={`../${m.id}`}>
                                     <strong>{m.name}</strong>
                                 </Link>
                             </Button>{' '}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/RouteLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/RouteLayout.tsx
@@ -17,22 +17,24 @@ import { buildLinearBreadcrumbs, SidebarNavigation, useLayoutConfig } from '@gra
 import { useCallback, useMemo } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
+import { useEnvHrid } from '../../features/environment/environment.utils';
 import { NAV_GROUPS } from '../config/navigation';
-import { HOST_NAV_PATHS, isHostNavKey, resolveHostRoute } from '../config/routes';
+import { hostNavPath, isHostNavKey, resolveHostRoute } from '../config/routes';
 
 export function RouteLayout() {
     const navigate = useNavigate();
+    const envHrid = useEnvHrid();
     const { pathname } = useLocation();
 
-    const { activeNavKey, breadcrumbSegments } = useMemo(() => resolveHostRoute(pathname), [pathname]);
+    const { activeNavKey, breadcrumbSegments } = useMemo(() => resolveHostRoute(pathname, envHrid), [pathname, envHrid]);
 
     const handleNavSelect = useCallback(
         (key: string) => {
             if (isHostNavKey(key)) {
-                navigate(HOST_NAV_PATHS[key]);
+                navigate(hostNavPath(key, envHrid));
             }
         },
-        [navigate],
+        [navigate, envHrid],
     );
 
     const breadcrumbs = useMemo(() => buildLinearBreadcrumbs(navigate, [...breadcrumbSegments]), [breadcrumbSegments, navigate]);

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/ShellLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/ShellLayout.tsx
@@ -19,7 +19,10 @@ import { useCallback, useMemo } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { useLogout, useUser } from '../../features/auth';
+import { useEnvironmentStore } from '../../features/environment/environment.store';
+import { useEnvHrid, getPrimaryHrid } from '../../features/environment/environment.utils';
 import type { GammaModule } from '../../features/modules';
+import { buildPathnameAfterEnvironmentChange, pathSegmentsAfterEnvironment } from '../config/routes';
 
 const GAMMA_APP_KEY = 'gamma-console';
 
@@ -42,9 +45,16 @@ function buildAppDefinitions(modules: readonly GammaModule[]) {
     ];
 }
 
-function resolveActiveAppKey(pathname: string, modules: readonly GammaModule[]): string {
+function resolveActiveAppKey(pathname: string, envHrid: string, modules: readonly GammaModule[]): string {
+    const rest = pathSegmentsAfterEnvironment(pathname, envHrid);
+    if (rest.length === 0) {
+        return GAMMA_APP_KEY;
+    }
+    if (rest[0] === 'home' || rest[0] === 'about') {
+        return GAMMA_APP_KEY;
+    }
     for (const m of modules) {
-        if (pathname === `/${m.id}` || pathname.startsWith(`/${m.id}/`)) {
+        if (rest[0] === m.id) {
             return m.id;
         }
     }
@@ -55,22 +65,38 @@ function ShellLayoutInner({ modules }: { readonly modules: readonly GammaModule[
     const user = useUser();
     const logout = useLogout();
     const navigate = useNavigate();
+    const envHrid = useEnvHrid();
     const location = useLocation();
     const pathname = location.pathname;
     const { slots } = useLayoutSlots();
 
+    const environments = useEnvironmentStore(s => s.environments);
+
     const apps = useMemo(() => buildAppDefinitions(modules), [modules]);
-    const activeAppKey = useMemo(() => resolveActiveAppKey(pathname, modules), [pathname, modules]);
+    const activeAppKey = useMemo(() => resolveActiveAppKey(pathname, envHrid, modules), [pathname, envHrid, modules]);
+
+    const envItems = useMemo(
+        () => environments.map(env => ({ key: getPrimaryHrid(env), label: env.name ?? getPrimaryHrid(env) })),
+        [environments],
+    );
 
     const handleAppChange = useCallback(
         (key: string) => {
             if (key === GAMMA_APP_KEY) {
-                navigate('/');
+                navigate(`/environments/${envHrid}/home`);
                 return;
             }
-            navigate(`/${key}`);
+            navigate(`/environments/${envHrid}/${key}`);
         },
-        [navigate],
+        [envHrid, navigate],
+    );
+
+    const handleEnvironmentChange = useCallback(
+        (newEnvHrid: string) => {
+            const newPathname = buildPathnameAfterEnvironmentChange(pathname, envHrid, newEnvHrid);
+            navigate({ pathname: newPathname, search: location.search, hash: location.hash });
+        },
+        [envHrid, location.hash, location.search, navigate, pathname],
     );
 
     const handleSignOut = useCallback(() => {
@@ -88,6 +114,9 @@ function ShellLayoutInner({ modules }: { readonly modules: readonly GammaModule[
                     activeAppKey={activeAppKey}
                     onAppChange={handleAppChange}
                     renderNavigation={() => slots.navigation}
+                    environments={envItems}
+                    activeEnvironmentKey={envHrid}
+                    onEnvironmentChange={handleEnvironmentChange}
                 />
             }
             subheader={

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/routes.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/routes.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { buildPathnameAfterEnvironmentChange, hostNavPath, pathSegmentsAfterEnvironment, resolveHostRoute } from './routes';
+
+describe('hostNavPath', () => {
+    it('should build home and about paths under environment', () => {
+        expect(hostNavPath('home', 'default')).toBe('/environments/default/home');
+        expect(hostNavPath('about', 'default')).toBe('/environments/default/about');
+    });
+});
+
+describe('resolveHostRoute', () => {
+    it('should resolve about for /environments/:envHrid/about', () => {
+        const { activeNavKey, breadcrumbSegments } = resolveHostRoute('/environments/my-env/about', 'my-env');
+        expect(activeNavKey).toBe('about');
+        expect(breadcrumbSegments[0]?.to).toBe('/environments/my-env/home');
+        expect(breadcrumbSegments[1]?.label).toBe('About');
+    });
+
+    it('should resolve home for /environments/:envHrid/home', () => {
+        const { activeNavKey, breadcrumbSegments } = resolveHostRoute('/environments/my-env/home', 'my-env');
+        expect(activeNavKey).toBe('home');
+        expect(breadcrumbSegments[0]?.label).toBe('Home');
+    });
+
+    it('should use default when pathname env does not match param', () => {
+        const { activeNavKey } = resolveHostRoute('/environments/other/home', 'my-env');
+        expect(activeNavKey).toBe('home');
+    });
+});
+
+describe('pathSegmentsAfterEnvironment', () => {
+    it('should return segments under the given environment', () => {
+        expect(pathSegmentsAfterEnvironment('/environments/a/apim/nested', 'a')).toEqual(['apim', 'nested']);
+        expect(pathSegmentsAfterEnvironment('/environments/a/home', 'a')).toEqual(['home']);
+    });
+
+    it('should return empty when pathname does not start with the environment prefix', () => {
+        expect(pathSegmentsAfterEnvironment('/environments/b/apim', 'a')).toEqual([]);
+    });
+});
+
+describe('buildPathnameAfterEnvironmentChange', () => {
+    it('should keep path after the environment when switching to another', () => {
+        expect(buildPathnameAfterEnvironmentChange('/environments/env-1/some-module/apis/list', 'env-1', 'env-2')).toBe(
+            '/environments/env-2/some-module/apis/list',
+        );
+    });
+
+    it('should use home when the URL is only the environment base', () => {
+        expect(buildPathnameAfterEnvironmentChange('/environments/env-1', 'env-1', 'env-2')).toBe('/environments/env-2/home');
+    });
+
+    it('should keep host home and about when switching', () => {
+        expect(buildPathnameAfterEnvironmentChange('/environments/a/about', 'a', 'b')).toBe('/environments/b/about');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/config/routes.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /** Sidebar / route keys for the host shell area (home, about, …). */
 export type HostNavKey = 'home' | 'about';
 
-export const DEFAULT_HOST_NAV_KEY: HostNavKey = 'home';
+export const HOME_NAV_KEY: HostNavKey = 'home';
+export const ABOUT_NAV_KEY: HostNavKey = 'about';
 
 /** Labels for sidebar titles and breadcrumbs (single source of truth). */
 export const HOST_NAV_LABELS: Record<HostNavKey, string> = {
@@ -25,11 +25,13 @@ export const HOST_NAV_LABELS: Record<HostNavKey, string> = {
     about: 'About',
 };
 
-/** React Router paths for each nav key. */
-export const HOST_NAV_PATHS: Record<HostNavKey, string> = {
-    home: '/',
-    about: '/about',
-};
+/**
+ * Path for a host nav key under a given environment segment (hrid or id in URL).
+ * @example hostNavPath('home', 'default') -> '/environments/default/home'
+ */
+export function hostNavPath(navKey: HostNavKey, envHrid: string): string {
+    return `/environments/${envHrid}/${navKey}`;
+}
 
 export interface HostBreadcrumbSegment {
     readonly label: string;
@@ -38,42 +40,82 @@ export interface HostBreadcrumbSegment {
 
 interface HostNavArea {
     readonly navKey: HostNavKey;
-    readonly matches: (pathname: string) => boolean;
-    readonly breadcrumbSegments: readonly HostBreadcrumbSegment[];
+    readonly matches: (subPath: string) => boolean;
+    readonly breadcrumbSegments: (envHrid: string) => readonly HostBreadcrumbSegment[];
 }
 
-/**
- * Most specific matchers first. Extend this list as host routes grow; keep
- * `matches` disjoint or ordered so the first win is intentional.
- */
 const HOST_NAV_AREAS: readonly HostNavArea[] = [
     {
-        navKey: 'about',
-        matches: p => p === '/about' || p.startsWith('/about/'),
-        breadcrumbSegments: [{ label: HOST_NAV_LABELS.home, to: HOST_NAV_PATHS.home }, { label: HOST_NAV_LABELS.about }],
+        navKey: ABOUT_NAV_KEY,
+        matches: sub => sub === ABOUT_NAV_KEY || sub.startsWith(`${ABOUT_NAV_KEY}/`),
+        breadcrumbSegments: envHrid => [
+            { label: HOST_NAV_LABELS.home, to: hostNavPath(HOME_NAV_KEY, envHrid) },
+            { label: HOST_NAV_LABELS.about },
+        ],
     },
     {
-        navKey: 'home',
-        matches: p => p === '/' || p === '',
-        breadcrumbSegments: [{ label: HOST_NAV_LABELS.home }],
+        navKey: HOME_NAV_KEY,
+        matches: sub => sub === HOME_NAV_KEY || sub === '' || sub.startsWith(`${HOME_NAV_KEY}/`),
+        breadcrumbSegments: () => [{ label: HOST_NAV_LABELS.home }],
     },
 ];
 
-export function resolveHostRoute(pathname: string): {
+/**
+ * Path segments after /environments/:envHrid (e.g. ['apim', 'x'] for .../environments/e/apim/x).
+ * Empty when the pathname is not under that environment prefix.
+ */
+export function pathSegmentsAfterEnvironment(pathname: string, envHrid: string): string[] {
+    const prefix = `/environments/${envHrid}`;
+    if (!pathname.startsWith(prefix)) {
+        return [];
+    }
+    const tail = pathname.slice(prefix.length);
+    return tail.split('/').filter(Boolean);
+}
+
+/**
+ * New pathname when changing the environment segment while keeping the same page
+ * (host area, module path, or nested route). If there is no path under the current
+ * environment, returns /environments/{new}/home.
+ */
+export function buildPathnameAfterEnvironmentChange(pathname: string, currentEnvHrid: string, newEnvHrid: string): string {
+    const rest = pathSegmentsAfterEnvironment(pathname, currentEnvHrid);
+    const base = `/environments/${newEnvHrid}`;
+    return rest.length > 0 ? `${base}/${rest.join('/')}` : `${base}/home`;
+}
+
+function extractSubPath(pathname: string, envHrid: string): string | null {
+    const prefix = `/environments/${envHrid}`;
+    if (!pathname.startsWith(prefix)) return null;
+    const tail = pathname.slice(prefix.length);
+    if (tail === '' || tail === '/') return '';
+    if (tail.startsWith('/')) return tail.slice(1);
+    return null;
+}
+
+export function resolveHostRoute(
+    pathname: string,
+    envHrid: string,
+): {
     activeNavKey: HostNavKey;
     breadcrumbSegments: readonly HostBreadcrumbSegment[];
 } {
+    const defaultResult = {
+        activeNavKey: HOME_NAV_KEY,
+        breadcrumbSegments: [{ label: HOST_NAV_LABELS.home, to: hostNavPath(HOME_NAV_KEY, envHrid) }] as readonly HostBreadcrumbSegment[],
+    };
+
+    const subPath = extractSubPath(pathname, envHrid);
+    if (subPath === null) return defaultResult;
+
     for (const area of HOST_NAV_AREAS) {
-        if (area.matches(pathname)) {
-            return { activeNavKey: area.navKey, breadcrumbSegments: area.breadcrumbSegments };
+        if (area.matches(subPath)) {
+            return { activeNavKey: area.navKey, breadcrumbSegments: area.breadcrumbSegments(envHrid) };
         }
     }
-    return {
-        activeNavKey: DEFAULT_HOST_NAV_KEY,
-        breadcrumbSegments: [{ label: HOST_NAV_LABELS.home }],
-    };
+    return defaultResult;
 }
 
 export function isHostNavKey(key: string): key is HostNavKey {
-    return key === 'home' || key === 'about';
+    return key === HOME_NAV_KEY || key === ABOUT_NAV_KEY;
 }

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/gamma-modules-sdk.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/gamma-modules-sdk.ts
@@ -14,5 +14,12 @@
  * limitations under the License.
  */
 
-/** Top-level barrel for `@gravitee/gamma-modules-sdk`; add new domains with `export * from './<domain>/index'`. */
+/**
+ * Host barrel for `@gravitee/gamma-modules-sdk` — replaces the package stubs
+ * with the real implementation via rspack alias + MF singleton.
+ *
+ * Only domains that need host override belong here (e.g. permissions).
+ * Standalone domains like routing live on their own subpath
+ * (`@gravitee/gamma-modules-sdk/routing`) and are NOT re-exported here.
+ */
 export * from './permissions/index';

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/PathnameProbe.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/PathnameProbe.tsx
@@ -13,16 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { http, HttpResponse } from 'msw';
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
-import { TEST_MANAGEMENT_BASE } from '../factories';
-
-/** Default env permissions for tests (feature key -> CRUD letters). */
-export const permissionsHandlers = [
-    http.get(`${TEST_MANAGEMENT_BASE}/environments/DEFAULT/permissions`, () =>
-        HttpResponse.json({
-            API: ['R', 'C', 'U', 'D'],
-            APPLICATION: ['R', 'C', 'U', 'D'],
-        }),
-    ),
-];
+export function PathnameProbe({ onPath }: { readonly onPath: (p: string) => void }) {
+    const { pathname } = useLocation();
+    useEffect(() => {
+        onPath(pathname);
+    }, [pathname, onPath]);
+    return null;
+}

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/factories.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/factories.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import type { CurrentUser } from '../features/auth/auth.types';
+import type { Environment } from '../features/environment/environment.types';
 import type { BootstrapConfig } from '../shared/config/bootstrap.store';
 
 export const TEST_CONFIG: BootstrapConfig = {
@@ -40,3 +41,20 @@ export function buildUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
 export function buildBootstrapConfig(overrides: Partial<BootstrapConfig> = {}): BootstrapConfig {
     return { ...TEST_CONFIG, ...overrides };
 }
+
+export function buildEnvironment(overrides: Partial<Environment> = {}): Environment {
+    return {
+        id: 'env-1-id',
+        hrids: ['env-1'],
+        name: 'Environment 1',
+        description: 'First environment',
+        organizationId: TEST_CONFIG.organizationId,
+        ...overrides,
+    };
+}
+
+/** Two environments for MSW and integration-style tests. */
+export const TEST_ENVIRONMENTS: Environment[] = [
+    buildEnvironment(),
+    buildEnvironment({ id: 'env-2-id', hrids: ['env-2'], name: 'Environment 2' }),
+];

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/handlers/environments.handlers.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/handlers/environments.handlers.ts
@@ -13,9 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { authHandlers } from './auth.handlers';
-import { bootstrapHandlers } from './bootstrap.handlers';
-import { environmentsHandlers } from './environments.handlers';
-import { modulesHandlers } from './modules.handlers';
+import { http, HttpResponse } from 'msw';
 
-export const defaultHandlers = [...bootstrapHandlers, ...authHandlers, ...modulesHandlers, ...environmentsHandlers];
+import { TEST_ENVIRONMENTS, TEST_MANAGEMENT_BASE } from '../factories';
+
+/** List environments and per-env permissions (any env id). */
+export const environmentsHandlers = [
+    http.get(`${TEST_MANAGEMENT_BASE}/environments`, () => HttpResponse.json(TEST_ENVIRONMENTS)),
+    http.get(`${TEST_MANAGEMENT_BASE}/environments/:envId/permissions`, () =>
+        HttpResponse.json({
+            API: ['R', 'C', 'U', 'D'],
+            APPLICATION: ['R', 'C', 'U', 'D'],
+        }),
+    ),
+];

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/helpers.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/testing/helpers.ts
@@ -17,7 +17,7 @@ import { http, HttpResponse, type JsonBodyType } from 'msw';
 
 import { permissionService } from '@gravitee/gamma-modules-sdk';
 
-import { buildBootstrapConfig, TEST_MANAGEMENT_BASE } from './factories';
+import { buildBootstrapConfig, TEST_ENVIRONMENTS, TEST_MANAGEMENT_BASE } from './factories';
 import { server } from './server';
 import { useAuthStore } from '../features/auth/auth.store';
 import { useEnvironmentStore } from '../features/environment/environment.store';
@@ -86,7 +86,7 @@ export function respondWithError(method: 'get' | 'post' | 'put' | 'delete', url:
 export function resetAllStores() {
     useBootstrapStore.setState({ config: null, loading: false, error: null });
     useAuthStore.setState({ user: null, loading: false, initialized: false, oauthRedirectUrl: null });
-    useEnvironmentStore.setState({ organizationId: '', environmentId: 'DEFAULT' });
+    useEnvironmentStore.getState().reset();
     permissionService.reset();
     localStorage.clear();
 }
@@ -103,6 +103,20 @@ export function seedBootstrap(overrides: Partial<BootstrapConfig> = {}) {
  * Overrides the default environment permissions MSW handler for a single test.
  * Reset automatically by `server.resetHandlers()` in afterEach.
  */
-export function fakePermissions(permissions: Record<string, string[]>) {
-    server.use(http.get(`${TEST_MANAGEMENT_BASE}/environments/DEFAULT/permissions`, () => HttpResponse.json(permissions)));
+export function fakePermissions(permissions: Record<string, string[]>, envId = 'env-1-id') {
+    server.use(http.get(`${TEST_MANAGEMENT_BASE}/environments/${envId}/permissions`, () => HttpResponse.json(permissions)));
+}
+
+/** Pre-populates the environment store as if `initialize` succeeded with {@link TEST_ENVIRONMENTS}. */
+export function seedEnvironments() {
+    const first = TEST_ENVIRONMENTS[0]!;
+    useEnvironmentStore.setState({
+        organizationId: 'test-org',
+        environments: TEST_ENVIRONMENTS,
+        currentEnvironment: first,
+        environmentId: first.id,
+        loading: false,
+        error: null,
+        initialized: true,
+    });
 }

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/tsconfig.app.json
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/tsconfig.app.json
@@ -5,7 +5,8 @@
         "outDir": "../../dist/out-tsc",
         "types": ["node", "@nx/react/typings/cssmodule.d.ts", "@nx/react/typings/image.d.ts"],
         "paths": {
-            "@gravitee/gamma-modules-sdk": ["./src/shared/gamma-modules-sdk.ts"]
+            "@gravitee/gamma-modules-sdk": ["./src/shared/gamma-modules-sdk.ts"],
+            "@gravitee/gamma-modules-sdk/routing": ["../packages/gamma-modules-sdk/src/routing.ts"]
         }
     },
     "exclude": [

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -13,42 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
 import { buildLinearBreadcrumbs, SidebarNavigation, useLayoutConfig } from '@gravitee/graphene-core';
-import { useCallback, useMemo } from 'react';
-import { Outlet, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { useMemo } from 'react';
+import { Outlet, Route, Routes, useNavigate } from 'react-router-dom';
 
 import { NAV_GROUPS } from '../config/navigation';
-import { navigateToNavKey, ROUTES, resolveModulePath } from '../config/routes';
+import { APIM_ROUTE_CONFIG } from '../config/routes';
 import { AnalyticsPage } from '../pages/AnalyticsPage';
 import { ApisPage } from '../pages/ApisPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { SettingsPage } from '../pages/SettingsPage';
 
 function ModuleLayout() {
-    const location = useLocation();
     const navigate = useNavigate();
+    const { activeNavKey, navigateToKey, rootPath } = useModuleRouting(APIM_ROUTE_CONFIG);
 
-    const { modulePrefix, activeNavKey } = useMemo(() => resolveModulePath(location.pathname), [location.pathname]);
-
-    const handleNavSelect = useCallback(
-        (key: string) => {
-            navigateToNavKey(navigate, modulePrefix, key);
-        },
-        [navigate, modulePrefix],
+    const breadcrumbs = useMemo(
+        () => buildLinearBreadcrumbs(navigate, [{ label: 'APIM', to: rootPath }, { label: APIM_ROUTE_CONFIG.routes[activeNavKey].label }]),
+        [activeNavKey, navigate, rootPath],
     );
-
-    const breadcrumbs = useMemo(() => {
-        const pageLabel = ROUTES[activeNavKey].label;
-        const rootPath = modulePrefix ? `/${modulePrefix}/apis` : '/';
-        return buildLinearBreadcrumbs(navigate, [{ label: 'APIM', to: rootPath }, { label: pageLabel }]);
-    }, [activeNavKey, navigate, modulePrefix]);
 
     useLayoutConfig(
         {
-            navigation: <SidebarNavigation groups={NAV_GROUPS} activeItemKey={activeNavKey} onItemSelect={handleNavSelect} />,
+            navigation: <SidebarNavigation groups={NAV_GROUPS} activeItemKey={activeNavKey} onItemSelect={navigateToKey} />,
             breadcrumbs,
         },
-        [activeNavKey, breadcrumbs, handleNavSelect],
+        [activeNavKey, breadcrumbs, navigateToKey],
     );
 
     return <Outlet />;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/routes.ts
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { NavigateFunction } from 'react-router-dom';
+import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 
 export const ROUTE_KEYS = ['apis', 'applications', 'analytics', 'settings'] as const;
 export type RouteKey = (typeof ROUTE_KEYS)[number];
-
-const ROUTE_KEY_SET = new Set<string>(ROUTE_KEYS);
-const DEFAULT_ROUTE_KEY = 'apis';
 
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
     apis: { path: 'apis', label: 'APIs' },
@@ -28,36 +25,8 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     settings: { path: 'settings', label: 'Settings' },
 };
 
-export function isRouteKey(segment: string): segment is RouteKey {
-    return ROUTE_KEY_SET.has(segment);
-}
-
-/**
- * Resolves the active sidebar key and optional host module prefix from the URL.
- */
-export function resolveModulePath(pathname: string): { modulePrefix: string; activeNavKey: RouteKey } {
-    const segments = pathname.split('/').filter(Boolean);
-    if (segments.length === 0) {
-        return { modulePrefix: '', activeNavKey: DEFAULT_ROUTE_KEY };
-    }
-    if (isRouteKey(segments[0])) {
-        return { modulePrefix: '', activeNavKey: segments[0] };
-    }
-    const moduleId = segments[0];
-    const sub = segments[1] ?? DEFAULT_ROUTE_KEY;
-    const activeNavKey = isRouteKey(sub) ? sub : DEFAULT_ROUTE_KEY;
-    return { modulePrefix: moduleId, activeNavKey };
-}
-
-/**
- * Navigates to the URL for a sidebar item key.
- * With a host `modulePrefix` (federated), paths are `/{modulePrefix}/{key}`.
- * In standalone mode, the default key `apis` maps to `/`.
- */
-export function navigateToNavKey(navigate: NavigateFunction, modulePrefix: string, key: string): void {
-    if (modulePrefix) {
-        navigate(`/${modulePrefix}/${key}`);
-        return;
-    }
-    navigate(key === 'apis' ? '/' : `/${key}`);
-}
+export const APIM_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {
+    routeKeys: ROUTE_KEYS,
+    routes: ROUTES,
+    defaultRouteKey: 'apis',
+};

--- a/gravitee-gamma/gravitee-gamma-module-apim/tsconfig.app.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/tsconfig.app.json
@@ -5,7 +5,8 @@
         "outDir": "../../dist/out-tsc",
         "types": ["node", "@nx/react/typings/cssmodule.d.ts", "@nx/react/typings/image.d.ts"],
         "paths": {
-            "@gravitee/gamma-modules-sdk": ["../packages/gamma-modules-sdk/src/index.ts"]
+            "@gravitee/gamma-modules-sdk": ["../packages/gamma-modules-sdk/src/index.ts"],
+            "@gravitee/gamma-modules-sdk/routing": ["../packages/gamma-modules-sdk/src/routing.ts"]
         }
     },
     "exclude": [

--- a/gravitee-gamma/packages/gamma-modules-sdk/jest.config.ts
+++ b/gravitee-gamma/packages/gamma-modules-sdk/jest.config.ts
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Root barrel — contains domains that the host overrides via Module Federation
- * singleton (e.g. permissions). Standalone domains like routing have their own
- * subpath: `@gravitee/gamma-modules-sdk/routing`.
- */
-export * from './permissions';
+export default {
+    displayName: 'gamma-modules-sdk',
+    testEnvironment: 'node',
+    transform: {
+        '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
+    },
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+    coverageDirectory: __dirname + '/coverage',
+};

--- a/gravitee-gamma/packages/gamma-modules-sdk/package.json
+++ b/gravitee-gamma/packages/gamma-modules-sdk/package.json
@@ -5,8 +5,13 @@
     "license": "Apache-2.0",
     "main": "src/index.ts",
     "types": "src/index.ts",
+    "exports": {
+        ".": "./src/index.ts",
+        "./routing": "./src/routing.ts"
+    },
     "peerDependencies": {
         "react": ">=19",
-        "react-dom": ">=19"
+        "react-dom": ">=19",
+        "react-router-dom": ">=6"
     }
 }

--- a/gravitee-gamma/packages/gamma-modules-sdk/project.json
+++ b/gravitee-gamma/packages/gamma-modules-sdk/project.json
@@ -3,5 +3,14 @@
     "$schema": "../../../node_modules/nx/schemas/project-schema.json",
     "sourceRoot": "gravitee-gamma/packages/gamma-modules-sdk/src",
     "projectType": "library",
-    "tags": []
+    "tags": [],
+    "targets": {
+        "test": {
+            "executor": "@nx/jest:jest",
+            "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+            "options": {
+                "jestConfig": "gravitee-gamma/packages/gamma-modules-sdk/jest.config.ts"
+            }
+        }
+    }
 }

--- a/gravitee-gamma/packages/gamma-modules-sdk/src/routing.spec.ts
+++ b/gravitee-gamma/packages/gamma-modules-sdk/src/routing.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { type ModuleRouteConfig, buildModuleNavPath, buildModuleRootPath, isRouteKey, resolveModulePath } from './routing';
+
+const SAMPLE_CONFIG: ModuleRouteConfig<'apis' | 'settings'> = {
+    routeKeys: ['apis', 'settings'],
+    routes: {
+        apis: { path: 'apis', label: 'APIs' },
+        settings: { path: 'settings', label: 'Settings' },
+    },
+    defaultRouteKey: 'apis',
+};
+
+describe('isRouteKey', () => {
+    it('should return true for a known key', () => {
+        expect(isRouteKey('apis', SAMPLE_CONFIG.routeKeys)).toBe(true);
+        expect(isRouteKey('settings', SAMPLE_CONFIG.routeKeys)).toBe(true);
+    });
+
+    it('should return false for an unknown key', () => {
+        expect(isRouteKey('unknown', SAMPLE_CONFIG.routeKeys)).toBe(false);
+        expect(isRouteKey('', SAMPLE_CONFIG.routeKeys)).toBe(false);
+    });
+});
+
+describe('resolveModulePath', () => {
+    it('should return defaults for an empty pathname', () => {
+        expect(resolveModulePath('/', SAMPLE_CONFIG)).toEqual({ modulePrefix: '', activeNavKey: 'apis' });
+    });
+
+    it('should resolve federated path /environments/:envHrid/:moduleId/<key>', () => {
+        expect(resolveModulePath('/environments/my-env/apim/settings', SAMPLE_CONFIG)).toEqual({
+            modulePrefix: 'apim',
+            activeNavKey: 'settings',
+        });
+    });
+
+    it('should default activeNavKey when the sub-segment is not a known key', () => {
+        expect(resolveModulePath('/environments/my-env/apim/unknown-page', SAMPLE_CONFIG)).toEqual({
+            modulePrefix: 'apim',
+            activeNavKey: 'apis',
+        });
+    });
+
+    it('should default activeNavKey when no sub-segment exists under /environments/:env/:module', () => {
+        expect(resolveModulePath('/environments/my-env/apim', SAMPLE_CONFIG)).toEqual({
+            modulePrefix: 'apim',
+            activeNavKey: 'apis',
+        });
+    });
+
+    it('should handle legacy standalone path where first segment is a route key', () => {
+        expect(resolveModulePath('/settings', SAMPLE_CONFIG)).toEqual({
+            modulePrefix: '',
+            activeNavKey: 'settings',
+        });
+    });
+
+    it('should handle standalone with module prefix', () => {
+        expect(resolveModulePath('/apim/settings', SAMPLE_CONFIG)).toEqual({
+            modulePrefix: 'apim',
+            activeNavKey: 'settings',
+        });
+    });
+
+    it('should handle deep paths preserving the active key', () => {
+        expect(resolveModulePath('/environments/e1/apim/apis/some/nested', SAMPLE_CONFIG)).toEqual({
+            modulePrefix: 'apim',
+            activeNavKey: 'apis',
+        });
+    });
+});
+
+describe('buildModuleNavPath', () => {
+    it('should build federated path when environment prefix is present', () => {
+        expect(buildModuleNavPath('apim', 'settings', '/environments/my-env/apim/apis')).toBe('/environments/my-env/apim/settings');
+    });
+
+    it('should build standalone prefixed path when no environment prefix', () => {
+        expect(buildModuleNavPath('apim', 'settings', '/apim/apis')).toBe('/apim/settings');
+    });
+
+    it('should build root-level path when no module prefix', () => {
+        expect(buildModuleNavPath('', 'settings')).toBe('/settings');
+    });
+});
+
+describe('buildModuleRootPath', () => {
+    it('should build root path under federated environment', () => {
+        expect(buildModuleRootPath('/environments/my-env/apim/settings', 'apim', 'apis')).toBe('/environments/my-env/apim/apis');
+    });
+
+    it('should build root path under standalone prefix', () => {
+        expect(buildModuleRootPath('/apim/settings', 'apim', 'apis')).toBe('/apim/apis');
+    });
+
+    it('should return / when no module prefix', () => {
+        expect(buildModuleRootPath('/settings', '', 'apis')).toBe('/');
+    });
+});

--- a/gravitee-gamma/packages/gamma-modules-sdk/src/routing.ts
+++ b/gravitee-gamma/packages/gamma-modules-sdk/src/routing.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+/**
+ * Routing domain — generic helpers for federated modules mounted under the
+ * gamma host URL scheme `/environments/:envHrid/:moduleId/<routeKey>`.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ModuleRouteDefinition {
+    readonly path: string;
+    readonly label: string;
+}
+
+export interface ModuleRouteConfig<K extends string = string> {
+    readonly routeKeys: readonly K[];
+    readonly routes: Record<K, ModuleRouteDefinition>;
+    readonly defaultRouteKey: K;
+}
+
+// ── Pure helpers (no React) ──────────────────────────────────────────────────
+
+/** Type-guard: is `segment` one of the declared route keys? */
+export function isRouteKey<K extends string>(segment: string, routeKeys: readonly K[]): segment is K {
+    return (routeKeys as readonly string[]).includes(segment);
+}
+
+/**
+ * Resolves the active sidebar key and optional host module prefix from the URL.
+ *
+ * Handles three mounting modes:
+ *   1. **Federated** — `/environments/:envHrid/:moduleId/<routeKey>`
+ *   2. **Standalone with prefix** — `/:moduleId/<routeKey>`
+ *   3. **Legacy standalone** — `/<routeKey>` (first segment is itself a key)
+ */
+export function resolveModulePath<K extends string>(
+    pathname: string,
+    config: ModuleRouteConfig<K>,
+): { modulePrefix: string; activeNavKey: K } {
+    const segments = pathname.split('/').filter(Boolean);
+    const { routeKeys, defaultRouteKey } = config;
+
+    if (segments.length === 0) {
+        return { modulePrefix: '', activeNavKey: defaultRouteKey };
+    }
+
+    if (segments[0] === 'environments' && segments.length >= 3) {
+        const moduleId = segments[2]!;
+        const sub = segments[3] ?? defaultRouteKey;
+        return { modulePrefix: moduleId, activeNavKey: isRouteKey(sub, routeKeys) ? sub : defaultRouteKey };
+    }
+
+    if (isRouteKey(segments[0], routeKeys)) {
+        return { modulePrefix: '', activeNavKey: segments[0] };
+    }
+
+    const moduleId = segments[0]!;
+    const sub = segments[1] ?? defaultRouteKey;
+    return { modulePrefix: moduleId, activeNavKey: isRouteKey(sub, routeKeys) ? sub : defaultRouteKey };
+}
+
+/**
+ * Pure string builder: returns the target pathname for navigating to a route
+ * key inside a module.
+ *
+ * When federated, the environment prefix is extracted from `currentPathname`.
+ */
+export function buildModuleNavPath(modulePrefix: string, key: string, currentPathname?: string): string {
+    if (modulePrefix) {
+        const pathname = currentPathname ?? (typeof window !== 'undefined' ? window.location.pathname : '');
+        const envEnd = pathname.indexOf('/', '/environments/'.length);
+        if (pathname.startsWith('/environments/') && envEnd > 0) {
+            return `${pathname.slice(0, envEnd)}/${modulePrefix}/${key}`;
+        }
+        return `/${modulePrefix}/${key}`;
+    }
+    return `/${key}`;
+}
+
+/**
+ * Returns the "root" pathname for breadcrumbs (e.g. the module's landing page
+ * under the current environment).
+ */
+export function buildModuleRootPath(pathname: string, modulePrefix: string, defaultRouteKey: string): string {
+    if (!modulePrefix) {
+        return '/';
+    }
+    const envEnd = pathname.indexOf('/', '/environments/'.length);
+    if (pathname.startsWith('/environments/') && envEnd > 0) {
+        return `${pathname.slice(0, envEnd)}/${modulePrefix}/${defaultRouteKey}`;
+    }
+    return `/${modulePrefix}/${defaultRouteKey}`;
+}
+
+// ── React hook (react + react-router-dom only) ──────────────────────────────
+
+export interface ModuleRoutingResult<K extends string = string> {
+    modulePrefix: string;
+    activeNavKey: K;
+    navigateToKey: (key: string) => void;
+    rootPath: string;
+}
+
+/**
+ * Convenience hook that composes the pure routing helpers for a federated module.
+ *
+ * Returns raw data — no JSX, no graphene types. Modules use the returned values
+ * to wire graphene layout components in their own `ModuleLayout`.
+ */
+export function useModuleRouting<K extends string>(config: ModuleRouteConfig<K>): ModuleRoutingResult<K> {
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const { modulePrefix, activeNavKey } = useMemo(() => resolveModulePath(location.pathname, config), [location.pathname, config]);
+
+    const rootPath = useMemo(
+        () => buildModuleRootPath(location.pathname, modulePrefix, config.defaultRouteKey),
+        [location.pathname, modulePrefix, config.defaultRouteKey],
+    );
+
+    const navigateToKey = useCallback(
+        (key: string) => {
+            navigate(buildModuleNavPath(modulePrefix, key, location.pathname));
+        },
+        [navigate, modulePrefix, location.pathname],
+    );
+
+    return { modulePrefix, activeNavKey, navigateToKey, rootPath };
+}

--- a/gravitee-gamma/packages/gamma-modules-sdk/tsconfig.spec.json
+++ b/gravitee-gamma/packages/gamma-modules-sdk/tsconfig.spec.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node10",
+        "jsx": "react-jsx",
+        "types": ["jest", "node"]
+    },
+    "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.test.tsx", "src/**/*.spec.tsx", "src/**/*.d.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,8 @@
         "allowSyntheticDefaultImports": true,
         "baseUrl": ".",
         "paths": {
-            "@gravitee/gamma-modules-sdk": ["gravitee-gamma/packages/gamma-modules-sdk/src/index.ts"]
+            "@gravitee/gamma-modules-sdk": ["gravitee-gamma/packages/gamma-modules-sdk/src/index.ts"],
+            "@gravitee/gamma-modules-sdk/routing": ["gravitee-gamma/packages/gamma-modules-sdk/src/routing.ts"]
         }
     },
     "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Summary

Implements environment-scoped navigation in the **gamma-console** host (Gravitee Gamma control plane web UI), with URLs under `/environments/:envHrid/...`, management API–backed environment state, and shared **SDK routing** helpers for federated modules. Remote modules can import routing from `@gravitee/gamma-modules-sdk/routing` so it is not shadowed by the host’s permissions-only `Module Federation` entry for the root package.

## What changed

### `@gravitee/gamma-modules-sdk`

- **Routing API** in [`src/routing.ts`](gravitee-gamma/packages/gamma-modules-sdk/src/routing.ts): `resolveModulePath`, `buildModuleNavPath`, `buildModuleRootPath`, `isRouteKey`, and `useModuleRouting` (React + `react-router-dom` only; no `graphene-core`).
- **Subpath** `@gravitee/gamma-modules-sdk/routing` via `package.json` `exports`. The root entry re-exports **permissions only**; routing lives on the subpath so the host’s rspack alias to [`gamma-modules-sdk.ts`](gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/gamma-modules-sdk.ts) does not need to re-export it.
- **Tests:** Jest target and `routing.spec.ts` for the pure helpers.

### Monorepo wiring

- `tsconfig.base.json` and app `tsconfig.app.json` (control plane, APIM): paths for `@gravitee/gamma-modules-sdk/routing`.
- **gamma-console** Jest: `moduleNameMapper` for the same subpath.
- **Host barrel** [`src/shared/gamma-modules-sdk.ts`](gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/gamma-modules-sdk.ts): permissions implementation only; documents that routing is on the subpath.

### gamma-console

- **URL shape:** `/environments/:envHrid/home`, `/environments/:envHrid/about`, `/environments/:envHrid/:moduleId/*` for federated modules. Root `/` redirects to the first environment home.
- **Store:** Loads `GET /organizations/{orgId}/environments` on init; `currentEnvironment`, `environmentId`, and `resolveEnvironment` for the URL segment.
- **EnvironmentGuard:** Resolves segment by id or HRID, rewrites id to primary HRID when needed, redirects invalid segments to the first environment.
- **Shell (Graphene `AppSidebar`):** App switcher, **environment list** in the shell chrome, and user sign-out. Switching environment uses `buildPathnameAfterEnvironmentChange` to **keep the current page** (path after the environment segment) instead of always going to home.
- **Host routes / layout:** Breadcrumbs and nav for home/about; `pathSegmentsAfterEnvironment`, `buildPathnameAfterEnvironmentChange`, and related tests in `shared/config/routes`.

### gamma-module-apim (federated remote)

- `AppRoutes` + route config: imports `useModuleRouting` and `ModuleRouteConfig` from `@gravitee/gamma-modules-sdk/routing`; `APIM_ROUTE_CONFIG` in module `config/routes`.



https://github.com/user-attachments/assets/bb0a6c46-4dd4-4b05-9f25-163119e3bb3b

