### PR TITLE
feat(portal): APIM-13761 application invitation read and search

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/InvitationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/InvitationRepository.java
@@ -15,7 +15,10 @@
  */
 package io.gravitee.repository.management.api;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.Invitation;
 import io.gravitee.repository.management.model.InvitationReferenceType;
 import java.util.List;
@@ -26,6 +29,10 @@ import java.util.List;
  */
 public interface InvitationRepository extends CrudRepository<Invitation, String> {
     List<Invitation> findByReferenceIdAndReferenceType(String referenceId, InvitationReferenceType referenceType) throws TechnicalException;
+
+    Page<Invitation> search(InvitationCriteria criteria, Sortable sortable, Pageable pageable) throws TechnicalException;
+
+    record InvitationCriteria(String referenceId, InvitationReferenceType referenceType, String email) {}
 
     /**
      * Delete invitation by reference

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcInvitationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcInvitationRepository.java
@@ -15,17 +15,28 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.jdbc.utils.FieldUtils;
 import io.gravitee.repository.management.api.InvitationRepository;
+import io.gravitee.repository.management.api.InvitationRepository.InvitationCriteria;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.Invitation;
 import io.gravitee.repository.management.model.InvitationReferenceType;
+import java.sql.PreparedStatement;
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -34,6 +45,26 @@ import org.springframework.stereotype.Repository;
 @CustomLog
 @Repository
 public class JdbcInvitationRepository extends JdbcAbstractCrudRepository<Invitation, String> implements InvitationRepository {
+
+    private static final String DEFAULT_SORT_FIELD = "email";
+    private static final Set<String> SORTABLE_COLUMNS = Set.of(
+        "id",
+        "reference_type",
+        "reference_id",
+        "email",
+        "api_role",
+        "application_role",
+        "created_at",
+        "updated_at"
+    );
+    private static final Set<String> CASE_INSENSITIVE_SORTABLE_COLUMNS = Set.of(
+        "id",
+        "reference_type",
+        "reference_id",
+        "email",
+        "api_role",
+        "application_role"
+    );
 
     JdbcInvitationRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
         super(tablePrefix, "invitations");
@@ -76,6 +107,23 @@ public class JdbcInvitationRepository extends JdbcAbstractCrudRepository<Invitat
     }
 
     @Override
+    public Page<Invitation> search(InvitationCriteria criteria, Sortable sortable, Pageable pageable) throws TechnicalException {
+        log.debug("JdbcInvitationRepository.search({})", criteria);
+
+        try {
+            var query = new StringBuilder(getOrm().getSelectAllSql());
+            addCriteriaClauses(query, criteria);
+            applySortable(sortable, query);
+
+            var invitations = jdbcTemplate.query(query.toString(), ps -> fillPreparedStatement(criteria, ps), getOrm().getRowMapper());
+            return getResultAsPage(pageable, invitations);
+        } catch (final Exception ex) {
+            log.error("Failed to search invitations", ex);
+            throw new TechnicalException("Failed to search invitations", ex);
+        }
+    }
+
+    @Override
     public List<String> deleteByReferenceIdAndReferenceType(String referenceId, InvitationReferenceType referenceType)
         throws TechnicalException {
         log.debug("JdbcInvitationRepository.deleteByReferenceIdAndReferenceType({}/{})", referenceId, referenceType);
@@ -101,5 +149,66 @@ public class JdbcInvitationRepository extends JdbcAbstractCrudRepository<Invitat
             log.error("Failed to delete invitation for refId: {}/{}", referenceId, referenceType, ex);
             throw new TechnicalException("Failed to delete invitation by reference", ex);
         }
+    }
+
+    private void addCriteriaClauses(StringBuilder query, InvitationCriteria criteria) {
+        var clauses = new ArrayList<String>();
+
+        if (criteria != null) {
+            if (StringUtils.hasText(criteria.referenceId())) {
+                clauses.add("reference_id = ?");
+            }
+            if (criteria.referenceType() != null) {
+                clauses.add("reference_type = ?");
+            }
+            if (StringUtils.hasText(criteria.email())) {
+                clauses.add("lower(email) like ? escape '\\'");
+            }
+        }
+
+        if (!clauses.isEmpty()) {
+            query.append(" where ").append(String.join(" and ", clauses));
+        }
+    }
+
+    private void fillPreparedStatement(InvitationCriteria criteria, PreparedStatement ps) throws java.sql.SQLException {
+        if (criteria == null) {
+            return;
+        }
+
+        var index = 1;
+        if (StringUtils.hasText(criteria.referenceId())) {
+            ps.setString(index++, criteria.referenceId());
+        }
+        if (criteria.referenceType() != null) {
+            ps.setString(index++, criteria.referenceType().name());
+        }
+        if (StringUtils.hasText(criteria.email())) {
+            ps.setString(index, "%" + escapeLike(criteria.email().toLowerCase(Locale.ROOT)) + "%");
+        }
+    }
+
+    private String escapeLike(String value) {
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+    }
+
+    private void applySortable(Sortable sortable, StringBuilder query) {
+        var field = sortable != null && StringUtils.hasText(sortable.field())
+            ? FieldUtils.toSnakeCase(sortable.field())
+            : DEFAULT_SORT_FIELD;
+
+        if (!SORTABLE_COLUMNS.contains(field)) {
+            field = DEFAULT_SORT_FIELD;
+        }
+
+        query.append(" order by case when ").append(field).append(" is null then 1 else 0 end, ");
+
+        if (CASE_INSENSITIVE_SORTABLE_COLUMNS.contains(field)) {
+            query.append("lower(").append(field).append(")");
+        } else {
+            query.append(field);
+        }
+
+        query.append(sortable != null && Order.DESC.equals(sortable.order()) ? " desc " : " asc ");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoInvitationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoInvitationRepository.java
@@ -15,8 +15,12 @@
  */
 package io.gravitee.repository.mongodb.management;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.InvitationRepository;
+import io.gravitee.repository.management.api.InvitationRepository.InvitationCriteria;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.Invitation;
 import io.gravitee.repository.management.model.InvitationReferenceType;
 import io.gravitee.repository.mongodb.management.internal.api.InvitationMongoRepository;
@@ -125,6 +129,17 @@ public class MongoInvitationRepository implements InvitationRepository {
 
         log.debug("Find invitation by reference '{}' / '{}' done", referenceId, referenceType);
         return invitations.stream().map(this::map).collect(Collectors.toList());
+    }
+
+    @Override
+    public Page<Invitation> search(InvitationCriteria criteria, Sortable sortable, Pageable pageable) throws TechnicalException {
+        log.debug("Search invitations");
+
+        var invitations = internalInvitationRepo.search(criteria, sortable, pageable).map(this::map);
+
+        log.debug("Search invitations - Done");
+
+        return invitations;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/InvitationMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/InvitationMongoRepositoryCustom.java
@@ -15,20 +15,15 @@
  */
 package io.gravitee.repository.mongodb.management.internal.api;
 
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.InvitationRepository.InvitationCriteria;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.mongodb.management.internal.model.InvitationMongo;
-import java.util.List;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
-import org.springframework.stereotype.Repository;
 
 /**
- * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Repository
-public interface InvitationMongoRepository extends MongoRepository<InvitationMongo, String>, InvitationMongoRepositoryCustom {
-    List<InvitationMongo> findByReferenceIdAndReferenceType(String referenceId, String referenceType);
-
-    @Query(value = "{ 'referenceId': ?0, 'referenceType': ?1 }", fields = "{ _id : 1 }", delete = true)
-    List<InvitationMongo> deleteByReferenceIdAndReferenceType(String referenceId, String referenceType);
+public interface InvitationMongoRepositoryCustom {
+    Page<InvitationMongo> search(InvitationCriteria criteria, Sortable sortable, Pageable pageable);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/InvitationMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/InvitationMongoRepositoryImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.api;
+
+import static org.springframework.data.domain.Sort.Direction.ASC;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.InvitationRepository.InvitationCriteria;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.Sortable;
+import io.gravitee.repository.mongodb.management.internal.model.InvitationMongo;
+import io.gravitee.repository.mongodb.utils.FieldUtils;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Collation;
+import org.springframework.data.mongodb.core.query.Query;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class InvitationMongoRepositoryImpl implements InvitationMongoRepositoryCustom {
+
+    private static final String DEFAULT_SORT_FIELD = "email";
+    private static final Set<String> SORTABLE_FIELDS = Set.of(
+        "id",
+        "referenceType",
+        "referenceId",
+        "email",
+        "apiRole",
+        "applicationRole",
+        "createdAt",
+        "updatedAt"
+    );
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Override
+    public Page<InvitationMongo> search(InvitationCriteria criteria, Sortable sortable, Pageable pageable) {
+        var query = new Query();
+
+        if (criteria != null) {
+            if (StringUtils.isNotBlank(criteria.referenceId())) {
+                query.addCriteria(where("referenceId").is(criteria.referenceId()));
+            }
+
+            if (criteria.referenceType() != null) {
+                query.addCriteria(where("referenceType").is(criteria.referenceType().name()));
+            }
+
+            if (StringUtils.isNotBlank(criteria.email())) {
+                query.addCriteria(where("email").regex(Pattern.quote(criteria.email()), "i"));
+            }
+        }
+
+        query.with(buildSort(sortable));
+
+        long total = mongoTemplate.count(query, InvitationMongo.class);
+
+        if (pageable != null) {
+            query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));
+        }
+
+        query.collation(Collation.of(Locale.ENGLISH).strength(Collation.ComparisonLevel.secondary()));
+
+        List<InvitationMongo> invitations = mongoTemplate.find(query, InvitationMongo.class);
+
+        return new Page<>(invitations, pageable != null ? pageable.pageNumber() : 0, invitations.size(), total);
+    }
+
+    private Sort buildSort(Sortable sortable) {
+        var field = sortable != null && StringUtils.isNotBlank(sortable.field())
+            ? FieldUtils.toCamelCase(sortable.field())
+            : DEFAULT_SORT_FIELD;
+
+        if (!SORTABLE_FIELDS.contains(field)) {
+            field = DEFAULT_SORT_FIELD;
+        }
+
+        var direction = sortable != null && Order.DESC.equals(sortable.order()) ? Sort.Direction.DESC : ASC;
+        return Sort.by(direction, field);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/invitations/ReferenceIdReferenceTypeEmailIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/invitations/ReferenceIdReferenceTypeEmailIndexUpgrader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.invitations;
+
+import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.CollationStrength;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component("InvitationsReferenceIdReferenceTypeEmailIndexUpgrader")
+public class ReferenceIdReferenceTypeEmailIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("invitations")
+            .name("ri1rt1e1")
+            .key("referenceId", ascending())
+            .key("referenceType", ascending())
+            .key("email", ascending())
+            .collation(collation())
+            .build();
+    }
+
+    private static Collation collation() {
+        return Collation.builder()
+            .locale(Locale.ENGLISH.getLanguage())
+            .collationStrength(CollationStrength.SECONDARY)
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/InvitationFixtures.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/InvitationFixtures.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management;
+
+import io.gravitee.repository.management.model.Invitation;
+import io.gravitee.repository.management.model.InvitationReferenceType;
+import java.util.Date;
+
+final class InvitationFixtures {
+
+    private InvitationFixtures() {}
+
+    static Invitation anInvitation(String id, String referenceId, InvitationReferenceType referenceType, String email) {
+        final Invitation invitation = new Invitation();
+        invitation.setId(id);
+        invitation.setReferenceType(referenceType.name());
+        invitation.setReferenceId(referenceId);
+        invitation.setEmail(email);
+        invitation.setCreatedAt(new Date(1439022010883L));
+        invitation.setUpdatedAt(new Date(1439022010883L));
+        return invitation;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/InvitationRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/InvitationRepositoryTest.java
@@ -15,9 +15,15 @@
  */
 package io.gravitee.repository.management;
 
+import static io.gravitee.repository.management.InvitationFixtures.anInvitation;
 import static io.gravitee.repository.utils.DateUtils.compareDate;
 import static org.junit.Assert.*;
 
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.InvitationRepository.InvitationCriteria;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.Invitation;
 import io.gravitee.repository.management.model.InvitationReferenceType;
 import java.util.Date;
@@ -131,6 +137,35 @@ public class InvitationRepositoryTest extends AbstractManagementRepositoryTest {
         final List<Invitation> invitations = invitationRepository.findByReferenceIdAndReferenceType("api-id", InvitationReferenceType.API);
         assertNotNull(invitations);
         assertEquals(1, invitations.size());
+    }
+
+    @Test
+    public void shouldSearchByCriteriaWithSortableAndPageable() throws Exception {
+        invitationRepository.create(
+            anInvitation("search-1", "search-application", InvitationReferenceType.APPLICATION, "alpha@example.com")
+        );
+        invitationRepository.create(
+            anInvitation("search-2", "search-application", InvitationReferenceType.APPLICATION, "bravo@example.com")
+        );
+        invitationRepository.create(
+            anInvitation("search-3", "search-application", InvitationReferenceType.APPLICATION, "charlie@example.com")
+        );
+        invitationRepository.create(
+            anInvitation("search-4", "search-application", InvitationReferenceType.APPLICATION, "other@gravitee.io")
+        );
+        invitationRepository.create(anInvitation("search-5", "search-application", InvitationReferenceType.API, "delta@example.com"));
+
+        Page<Invitation> page = invitationRepository.search(
+            new InvitationCriteria("search-application", InvitationReferenceType.APPLICATION, "EXAMPLE.COM"),
+            new SortableBuilder().field("email").order(Order.DESC).build(),
+            new PageableBuilder().pageNumber(1).pageSize(1).build()
+        );
+
+        assertNotNull(page);
+        assertEquals(3L, page.getTotalElements());
+        assertEquals(1, page.getPageElements());
+        assertEquals(1, page.getPageNumber());
+        assertEquals("bravo@example.com", page.getContent().get(0).getEmail());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -108,6 +108,7 @@ import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.group.use_case.ValidateGroupCRDUseCase;
+import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
 import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
@@ -349,6 +350,14 @@ public class ResourceContextConfiguration {
     @Bean
     public SearchApplicationMembersDomainService searchApplicationMembersDomainService() {
         return mock(SearchApplicationMembersDomainService.class);
+    }
+
+    /**
+     * Required by SearchApplicationInvitationsUseCase.
+     */
+    @Bean
+    public InvitationQueryService invitationQueryService() {
+        return mock(InvitationQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -134,6 +134,7 @@ import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
+import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
 import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
@@ -464,6 +465,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SubscriptionSearchQueryService subscriptionSearchQueryService(SubscriptionService subscriptionService) {
         return new SubscriptionSearchQueryServiceImpl(subscriptionService);
+    }
+
+    @Bean
+    public InvitationQueryService invitationQueryService() {
+        return mock(InvitationQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -103,6 +103,7 @@ import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainService;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
 import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
@@ -317,6 +318,11 @@ public class ResourceContextConfiguration {
     @Bean
     public ApplicationService applicationService() {
         return mock(ApplicationService.class);
+    }
+
+    @Bean
+    public InvitationQueryService invitationQueryService() {
+        return mock(InvitationQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapper.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.rest.api.portal.rest.model.Invitation;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = DateMapper.class)
+public interface ApplicationInvitationMapper {
+    ApplicationInvitationMapper INSTANCE = Mappers.getMapper(ApplicationInvitationMapper.class);
+
+    @Mapping(target = "role", source = "roleName")
+    Invitation toInvitation(ApplicationInvitationItem invitation);
+
+    List<Invitation> toInvitation(List<ApplicationInvitationItem> invitations);
+
+    default String map(ApplicationInvitationId id) {
+        return id.toString();
+    }
+
+    default OffsetDateTime map(ZonedDateTime value) {
+        return value == null ? null : value.toOffsetDateTime();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsSearchCriteriaMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsSearchCriteriaMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
+import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchInput;
+import java.util.Optional;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ApplicationInvitationsSearchCriteriaMapper {
+    ApplicationInvitationsSearchCriteriaMapper INSTANCE = Mappers.getMapper(ApplicationInvitationsSearchCriteriaMapper.class);
+
+    @Mapping(target = "email", source = "filters.email")
+    SearchApplicationInvitationsCriteria toSearchCriteria(ApplicationInvitationsSearchInput input);
+
+    default Optional<String> map(String email) {
+        return Optional.ofNullable(email);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import io.gravitee.apim.core.invitation.use_case.SearchApplicationInvitationsUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationMapper;
+import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationsSearchCriteriaMapper;
+import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchInput;
+import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+@Tag(name = "Application")
+public class ApplicationInvitationsResource extends AbstractResource {
+
+    private static final ApplicationInvitationMapper INVITATION_MAPPER = ApplicationInvitationMapper.INSTANCE;
+
+    @Inject
+    private SearchApplicationInvitationsUseCase searchApplicationInvitationsUseCase;
+
+    @POST
+    @Path("/_search")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_MEMBER, acls = RolePermissionAction.READ) })
+    public Response searchInvitationsByApplicationId(
+        @PathParam("applicationId") String applicationId,
+        @Valid @BeanParam PaginationParam paginationParam,
+        @Valid @NotNull(message = "Input must not be null.") ApplicationInvitationsSearchInput input
+    ) {
+        var executionContext = GraviteeContext.getExecutionContext();
+        var output = searchApplicationInvitationsUseCase.execute(
+            new SearchApplicationInvitationsUseCase.Input(
+                executionContext,
+                applicationId,
+                ApplicationInvitationsSearchCriteriaMapper.INSTANCE.toSearchCriteria(input),
+                new PageableImpl(paginationParam.getPage(), paginationParam.getSize())
+            )
+        );
+        var invitations = INVITATION_MAPPER.toInvitation(output.invitations().getContent());
+        Map<String, Map<String, Object>> metadata = new HashMap<>(
+            Map.of("paginateMetaData", new HashMap<>(Map.of("totalElements", output.invitations().getTotalElements())))
+        );
+
+        return createListResponse(executionContext, invitations, paginationParam, metadata);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
@@ -210,6 +210,11 @@ public class ApplicationResource extends AbstractResource {
         return resourceContext.getResource(ApplicationMembersResource.class);
     }
 
+    @Path("invitations")
+    public ApplicationInvitationsResource getApplicationInvitationsResource() {
+        return resourceContext.getResource(ApplicationInvitationsResource.class);
+    }
+
     @Path("metadata")
     public ApplicationMetadataResource getApplicationMetadataResource() {
         return resourceContext.getResource(ApplicationMetadataResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -4622,11 +4622,6 @@ components:
             type: string
             enum:
                 - documentation
-        InvitationStatus:
-            type: string
-            enum:
-                - PENDING
-                - EXPIRED
         #####################
         # Responses Objects #
         #####################
@@ -5624,7 +5619,6 @@ components:
                 - id
                 - email
                 - role
-                - status
             properties:
                 id:
                     description: Unique identifier of an invitation.
@@ -5634,24 +5628,14 @@ components:
                     type: string
                     format: email
                 role:
-                    description: Role assigned to the invitation.
+                    description: Application role name assigned to the invitation.
                     type: string
-                status:
-                    $ref: "#/components/schemas/InvitationStatus"
-                registered_user:
-                    description: True when the invited person already has a platform account but has not accepted the invitation yet.
-                    type: boolean
-                    default: false
                 created_at:
                     description: Creation date and time of the invitation.
                     type: string
                     format: date-time
                 updated_at:
                     description: Last update date and time of the invitation.
-                    type: string
-                    format: date-time
-                expires_at:
-                    description: Expiration date and time of the invitation.
                     type: string
                     format: date-time
         ReferenceMetadata:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapperTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+
+class ApplicationInvitationMapperTest {
+
+    private final ApplicationInvitationMapper mapper = ApplicationInvitationMapper.INSTANCE;
+
+    @Test
+    void should_map_application_invitation_item() {
+        var invitationId = "00000000-0000-0000-0000-000000000001";
+        var invitationItem = new ApplicationInvitationItem(
+            ApplicationInvitationId.of(invitationId),
+            "alice@example.com",
+            "USER",
+            ZonedDateTime.parse("2026-04-23T09:30:00Z"),
+            ZonedDateTime.parse("2026-04-23T09:45:00Z")
+        );
+
+        var invitation = mapper.toInvitation(invitationItem);
+
+        assertThat(invitation.getId()).isEqualTo(invitationId);
+        assertThat(invitation.getEmail()).isEqualTo("alice@example.com");
+        assertThat(invitation.getRole()).isEqualTo("USER");
+        assertThat(invitation.getCreatedAt()).isEqualTo(OffsetDateTime.parse("2026-04-23T09:30:00Z"));
+        assertThat(invitation.getUpdatedAt()).isEqualTo(OffsetDateTime.parse("2026-04-23T09:45:00Z"));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsSearchCriteriaMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsSearchCriteriaMapperTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchFilters;
+import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchInput;
+import org.junit.jupiter.api.Test;
+
+class ApplicationInvitationsSearchCriteriaMapperTest {
+
+    private final ApplicationInvitationsSearchCriteriaMapper mapper = ApplicationInvitationsSearchCriteriaMapper.INSTANCE;
+
+    @Test
+    void should_map_email_filter() {
+        var input = new ApplicationInvitationsSearchInput().filters(new ApplicationInvitationsSearchFilters().email("alice"));
+
+        var criteria = mapper.toSearchCriteria(input);
+
+        assertThat(criteria.email()).contains("alice");
+    }
+
+    @Test
+    void should_map_null_filters() {
+        var input = new ApplicationInvitationsSearchInput();
+
+        var criteria = mapper.toSearchCriteria(input);
+
+        assertThat(criteria.email()).isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import inmemory.ApplicationCrudServiceInMemory;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
+import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchFilters;
+import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationsResponse;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ApplicationInvitationsResourceTest extends AbstractResourceTest {
+
+    private static final String APPLICATION = "my-application";
+    private static final String UNKNOWN_APPLICATION = "unknown-application";
+    private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
+    private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
+
+    @Autowired
+    private InvitationQueryService invitationQueryService;
+
+    @Autowired
+    private ApplicationCrudServiceInMemory applicationCrudService;
+
+    @Override
+    protected String contextPath() {
+        return "applications/";
+    }
+
+    @BeforeEach
+    void init() {
+        resetAllMocks();
+        reset(invitationQueryService);
+        applicationCrudService.reset();
+        applicationCrudService.initWith(List.of(BaseApplicationEntity.builder().id(APPLICATION).environmentId("DEFAULT").build()));
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+    }
+
+    @Test
+    void should_search_invitations() {
+        when(
+            invitationQueryService.findByApplicationId(
+                eq(APPLICATION),
+                eq(new SearchApplicationInvitationsCriteria(Optional.empty())),
+                eq(new PageableImpl(1, 10))
+            )
+        ).thenReturn(
+            new Page<>(
+                List.of(anInvitation(INVITATION_ID_1, "alice@example.com"), anInvitation(INVITATION_ID_2, "bob@example.com")),
+                1,
+                2,
+                2
+            )
+        );
+
+        var response = target(APPLICATION)
+            .path("invitations")
+            .path("_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json(new ApplicationInvitationsSearchInput()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        var invitationsResponse = response.readEntity(InvitationsResponse.class);
+        assertThat(invitationsResponse.getData()).hasSize(2);
+        assertThat(invitationsResponse.getData())
+            .extracting(io.gravitee.rest.api.portal.rest.model.Invitation::getEmail)
+            .containsExactly("alice@example.com", "bob@example.com");
+        assertThat(invitationsResponse.getMetadata().get("paginateMetaData")).containsEntry("totalElements", 2);
+        assertThat(invitationsResponse.getMetadata().get("pagination")).containsEntry("total", 2);
+        verify(invitationQueryService).findByApplicationId(
+            APPLICATION,
+            new SearchApplicationInvitationsCriteria(Optional.empty()),
+            new PageableImpl(1, 10)
+        );
+    }
+
+    @Test
+    void should_search_invitations_by_email() {
+        when(
+            invitationQueryService.findByApplicationId(
+                eq(APPLICATION),
+                eq(new SearchApplicationInvitationsCriteria(Optional.of("bob"))),
+                eq(new PageableImpl(1, 10))
+            )
+        ).thenReturn(new Page<>(List.of(anInvitation(INVITATION_ID_2, "bob@example.com")), 1, 1, 1));
+
+        var input = new ApplicationInvitationsSearchInput().filters(new ApplicationInvitationsSearchFilters().email("bob"));
+        var response = target(APPLICATION)
+            .path("invitations")
+            .path("_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json(input));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        var invitationsResponse = response.readEntity(InvitationsResponse.class);
+        assertThat(invitationsResponse.getData()).hasSize(1);
+        assertThat(invitationsResponse.getData().get(0).getEmail()).isEqualTo("bob@example.com");
+        assertThat(invitationsResponse.getMetadata().get("paginateMetaData")).containsEntry("totalElements", 1);
+    }
+
+    @Test
+    void should_return_not_found_when_application_does_not_exist() {
+        var response = target(UNKNOWN_APPLICATION)
+            .path("invitations")
+            .path("_search")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .request()
+            .post(Entity.json(new ApplicationInvitationsSearchInput()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(invitationQueryService, never()).findByApplicationId(anyString(), any(), any());
+    }
+
+    private ApplicationInvitationItem anInvitation(String id, String email) {
+        return new ApplicationInvitationItem(
+            ApplicationInvitationId.of(id),
+            email,
+            "USER",
+            ZonedDateTime.parse("2026-04-23T09:30:00Z"),
+            ZonedDateTime.parse("2026-04-23T09:45:00Z")
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -107,6 +107,7 @@ import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainService;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
 import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
@@ -456,6 +457,11 @@ public class ResourceContextConfiguration {
     @Bean
     public SearchApplicationMembersDomainService searchApplicationMembersDomainService() {
         return mock(SearchApplicationMembersDomainService.class);
+    }
+
+    @Bean
+    public InvitationQueryService invitationQueryService() {
+        return mock(InvitationQueryService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/ApplicationInvitationId.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/ApplicationInvitationId.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import jakarta.annotation.Nonnull;
+import java.util.Objects;
+import java.util.UUID;
+
+public record ApplicationInvitationId(@Nonnull UUID id) {
+    public ApplicationInvitationId {
+        Objects.requireNonNull(id, "id");
+    }
+
+    public static ApplicationInvitationId random() {
+        return new ApplicationInvitationId(UUID.randomUUID());
+    }
+
+    public static ApplicationInvitationId of(String value) {
+        return new ApplicationInvitationId(UUID.fromString(value));
+    }
+
+    @JsonValue
+    public String json() {
+        return this.toString();
+    }
+
+    @Override
+    public String toString() {
+        return id.toString();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/ApplicationInvitationItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/ApplicationInvitationItem.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.model;
+
+import io.gravitee.common.utils.TimeProvider;
+import java.time.ZonedDateTime;
+
+public record ApplicationInvitationItem(
+    ApplicationInvitationId id,
+    String email,
+    String roleName,
+    ZonedDateTime createdAt,
+    ZonedDateTime updatedAt
+) {
+    public static ApplicationInvitationItem create(String email, String roleName) {
+        var now = TimeProvider.now();
+        return new ApplicationInvitationItem(ApplicationInvitationId.random(), email, roleName, now, now);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/SearchApplicationInvitationsCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/SearchApplicationInvitationsCriteria.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.model;
+
+import jakarta.annotation.Nonnull;
+import java.util.Optional;
+
+public record SearchApplicationInvitationsCriteria(@Nonnull Optional<String> email) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/query_service/InvitationQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/query_service/InvitationQueryService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.query_service;
+
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import jakarta.annotation.Nonnull;
+
+public interface InvitationQueryService {
+    Page<ApplicationInvitationItem> findByApplicationId(
+        String applicationId,
+        @Nonnull SearchApplicationInvitationsCriteria criteria,
+        @Nonnull Pageable pageable
+    );
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/SearchApplicationInvitationsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/SearchApplicationInvitationsUseCase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
+import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+
+@UseCase
+public class SearchApplicationInvitationsUseCase {
+
+    private final ApplicationCrudService applicationCrudService;
+    private final InvitationQueryService invitationQueryService;
+
+    public SearchApplicationInvitationsUseCase(
+        ApplicationCrudService applicationCrudService,
+        InvitationQueryService invitationQueryService
+    ) {
+        this.applicationCrudService = applicationCrudService;
+        this.invitationQueryService = invitationQueryService;
+    }
+
+    public Output execute(Input input) {
+        applicationCrudService.findById(input.applicationId(), input.executionContext().getEnvironmentId());
+
+        return new Output(invitationQueryService.findByApplicationId(input.applicationId(), input.criteria(), input.pageable()));
+    }
+
+    public record Input(
+        ExecutionContext executionContext,
+        String applicationId,
+        SearchApplicationInvitationsCriteria criteria,
+        Pageable pageable
+    ) {}
+
+    public record Output(Page<ApplicationInvitationItem> invitations) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/invitation/ApplicationInvitationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/invitation/ApplicationInvitationItemMapper.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.invitation;
+
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.repository.management.model.Invitation;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ApplicationInvitationItemMapper {
+    ApplicationInvitationItemMapper INSTANCE = Mappers.getMapper(ApplicationInvitationItemMapper.class);
+
+    @Mapping(target = "roleName", source = "applicationRole")
+    ApplicationInvitationItem toApplicationInvitationItem(Invitation invitation);
+
+    default ApplicationInvitationId map(String id) {
+        return ApplicationInvitationId.of(id);
+    }
+
+    default ZonedDateTime map(Date date) {
+        return date == null ? null : date.toInstant().atZone(TimeProvider.clock().getZone());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.invitation;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
+import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.InvitationRepository;
+import io.gravitee.repository.management.api.InvitationRepository.InvitationCriteria;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
+import io.gravitee.repository.management.model.InvitationReferenceType;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import jakarta.annotation.Nonnull;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InvitationQueryServiceImpl implements InvitationQueryService {
+
+    private final InvitationRepository invitationRepository;
+
+    public InvitationQueryServiceImpl(@Lazy InvitationRepository invitationRepository) {
+        this.invitationRepository = invitationRepository;
+    }
+
+    @Override
+    public Page<ApplicationInvitationItem> findByApplicationId(
+        String applicationId,
+        @Nonnull SearchApplicationInvitationsCriteria criteria,
+        @Nonnull Pageable pageable
+    ) {
+        try {
+            var resolvedPageable = pageable == null ? new PageableImpl(1, Integer.MAX_VALUE) : pageable;
+            var repositoryPage = invitationRepository.search(
+                new InvitationCriteria(
+                    applicationId,
+                    InvitationReferenceType.APPLICATION,
+                    criteria != null ? criteria.email().orElse(null) : null
+                ),
+                new SortableBuilder().field("email").order(Order.ASC).build(),
+                new PageableBuilder().pageNumber(resolvedPageable.getPageNumber() - 1).pageSize(resolvedPageable.getPageSize()).build()
+            );
+
+            var content = repositoryPage
+                .getContent()
+                .stream()
+                .map(ApplicationInvitationItemMapper.INSTANCE::toApplicationInvitationItem)
+                .toList();
+
+            return new Page<>(content, resolvedPageable.getPageNumber(), content.size(), repositoryPage.getTotalElements());
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurs while trying to find application invitations", e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/SearchApplicationInvitationsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/SearchApplicationInvitationsUseCaseTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
+import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.PaginationInvalidException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SearchApplicationInvitationsUseCaseTest {
+
+    private static final String APPLICATION_ID = "application-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+
+    @Mock
+    private ApplicationCrudService applicationCrudService;
+
+    @Mock
+    private InvitationQueryService invitationQueryService;
+
+    private SearchApplicationInvitationsUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new SearchApplicationInvitationsUseCase(applicationCrudService, invitationQueryService);
+    }
+
+    @Test
+    void should_validate_application_existence_before_searching() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenThrow(new ApplicationNotFoundException(APPLICATION_ID));
+
+        Throwable throwable = catchThrowable(() ->
+            cut.execute(
+                new SearchApplicationInvitationsUseCase.Input(
+                    executionContext,
+                    APPLICATION_ID,
+                    new SearchApplicationInvitationsCriteria(Optional.empty()),
+                    new PageableImpl(1, 10)
+                )
+            )
+        );
+
+        assertThat(throwable).isInstanceOf(ApplicationNotFoundException.class).hasMessageContaining(APPLICATION_ID);
+        verifyNoInteractions(invitationQueryService);
+    }
+
+    @Test
+    void should_filter_sort_and_paginate_invitations() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var application = BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build();
+        var criteria = new SearchApplicationInvitationsCriteria(Optional.of("JOHN"));
+        var pageable = new PageableImpl(1, 1);
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(application);
+        when(invitationQueryService.findByApplicationId(APPLICATION_ID, criteria, pageable)).thenReturn(
+            new Page<>(List.of(anInvitation("john.alpha@example.com")), 1, 1, 1)
+        );
+
+        var result = cut.execute(new SearchApplicationInvitationsUseCase.Input(executionContext, APPLICATION_ID, criteria, pageable));
+
+        assertThat(result.invitations().getTotalElements()).isEqualTo(1);
+        assertThat(result.invitations().getPageElements()).isEqualTo(1);
+        assertThat(result.invitations().getContent())
+            .extracting(ApplicationInvitationItem::email)
+            .containsExactly("john.alpha@example.com");
+        verify(invitationQueryService).findByApplicationId(APPLICATION_ID, criteria, pageable);
+    }
+
+    @Test
+    void should_return_empty_page_when_no_invitation_matches() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var application = BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build();
+        var criteria = new SearchApplicationInvitationsCriteria(Optional.of("john"));
+        var pageable = new PageableImpl(1, 10);
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(application);
+        when(invitationQueryService.findByApplicationId(APPLICATION_ID, criteria, pageable)).thenReturn(new Page<>(List.of(), 1, 0, 0));
+
+        var result = cut.execute(new SearchApplicationInvitationsUseCase.Input(executionContext, APPLICATION_ID, criteria, pageable));
+
+        assertThat(result.invitations().getContent()).isEmpty();
+        assertThat(result.invitations().getPageElements()).isZero();
+        assertThat(result.invitations().getTotalElements()).isZero();
+    }
+
+    @Test
+    void should_throw_when_page_is_invalid() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var application = BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build();
+        var criteria = new SearchApplicationInvitationsCriteria(Optional.empty());
+        var pageable = new PageableImpl(2, 10);
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(application);
+        when(invitationQueryService.findByApplicationId(APPLICATION_ID, criteria, pageable)).thenThrow(new PaginationInvalidException());
+
+        Throwable throwable = catchThrowable(() ->
+            cut.execute(new SearchApplicationInvitationsUseCase.Input(executionContext, APPLICATION_ID, criteria, pageable))
+        );
+
+        assertThat(throwable).isInstanceOf(PaginationInvalidException.class);
+    }
+
+    private ApplicationInvitationItem anInvitation(String email) {
+        return ApplicationInvitationItem.create(email, "USER");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImplTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.query_service.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.InvitationRepository;
+import io.gravitee.repository.management.api.InvitationRepository.InvitationCriteria;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
+import io.gravitee.repository.management.model.Invitation;
+import io.gravitee.repository.management.model.InvitationReferenceType;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InvitationQueryServiceImplTest {
+
+    private static final String APPLICATION_ID = "application-id";
+    private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
+    private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
+
+    @Mock
+    private InvitationRepository invitationRepository;
+
+    private InvitationQueryServiceImpl cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new InvitationQueryServiceImpl(invitationRepository);
+    }
+
+    @Test
+    void should_search_using_repository_criteria_sortable_and_pageable() throws Exception {
+        var createdAt = OffsetDateTime.parse("2026-04-23T09:30:00Z");
+        var updatedAt = OffsetDateTime.parse("2026-04-23T09:45:00Z");
+        var alphaInvitation = anInvitation(INVITATION_ID_2, "john.alpha@example.com", null, createdAt, updatedAt);
+        var zedInvitation = anInvitation(INVITATION_ID_1, "John.Zed@example.com", "USER", createdAt, updatedAt);
+        var criteria = new SearchApplicationInvitationsCriteria(Optional.of("JOHN"));
+        var pageable = new PageableImpl(2, 10);
+        var repositoryCriteria = new InvitationCriteria(APPLICATION_ID, InvitationReferenceType.APPLICATION, "JOHN");
+        var sortable = new SortableBuilder().field("email").order(Order.ASC).build();
+        var repositoryPageable = new PageableBuilder().pageNumber(1).pageSize(10).build();
+
+        when(invitationRepository.search(repositoryCriteria, sortable, repositoryPageable)).thenReturn(
+            new Page<>(List.of(alphaInvitation, zedInvitation), 1, 2, 3)
+        );
+
+        var result = cut.findByApplicationId(APPLICATION_ID, criteria, pageable);
+        var expectedCreatedAt = createdAt.toInstant().atZone(TimeProvider.clock().getZone());
+        var expectedUpdatedAt = updatedAt.toInstant().atZone(TimeProvider.clock().getZone());
+
+        assertThat(result.getPageNumber()).isEqualTo(2);
+        assertThat(result.getPageElements()).isEqualTo(2);
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).id()).isEqualTo(ApplicationInvitationId.of(INVITATION_ID_2));
+        assertThat(result.getContent().get(0).roleName()).isNull();
+        assertThat(result.getContent().get(0).createdAt()).isEqualTo(expectedCreatedAt);
+        assertThat(result.getContent().get(0).updatedAt()).isEqualTo(expectedUpdatedAt);
+        assertThat(result.getContent().get(1).id()).isEqualTo(ApplicationInvitationId.of(INVITATION_ID_1));
+        assertThat(result.getContent().get(1).roleName()).isEqualTo("USER");
+        assertThat(result.getContent().get(1).createdAt()).isEqualTo(expectedCreatedAt);
+        assertThat(result.getContent().get(1).updatedAt()).isEqualTo(expectedUpdatedAt);
+        verify(invitationRepository).search(repositoryCriteria, sortable, repositoryPageable);
+    }
+
+    @Test
+    void should_wrap_technical_exception() throws Exception {
+        var repositoryCriteria = new InvitationCriteria(APPLICATION_ID, InvitationReferenceType.APPLICATION, null);
+        var sortable = new SortableBuilder().field("email").order(Order.ASC).build();
+        var repositoryPageable = new PageableBuilder().pageNumber(0).pageSize(10).build();
+        when(invitationRepository.search(repositoryCriteria, sortable, repositoryPageable)).thenThrow(new TechnicalException("error"));
+
+        assertThatThrownBy(() ->
+            cut.findByApplicationId(APPLICATION_ID, new SearchApplicationInvitationsCriteria(Optional.empty()), new PageableImpl(1, 10))
+        )
+            .isInstanceOf(TechnicalDomainException.class)
+            .hasMessage("An error occurs while trying to find application invitations");
+    }
+
+    private Invitation anInvitation(String id, String email, String applicationRole, OffsetDateTime createdAt, OffsetDateTime updatedAt) {
+        var invitation = new Invitation();
+        invitation.setId(id);
+        invitation.setReferenceType(InvitationReferenceType.APPLICATION.name());
+        invitation.setReferenceId(APPLICATION_ID);
+        invitation.setEmail(email);
+        invitation.setApplicationRole(applicationRole);
+        invitation.setCreatedAt(Date.from(createdAt.toInstant()));
+        invitation.setUpdatedAt(Date.from(updatedAt.toInstant()));
+        return invitation;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13761

## Description

Implements the backend read/search slice for application invitations as part of `APIM-12767 View Pending Invitation Dashboard`.

This PR adds support for:
`POST /applications/{applicationId}/invitations/_search`

The goal of this task is to provide the invitation dashboard read path in the portal backend, separated from invitation creation, mutation, resend, and acceptance flows.

- added a dedicated portal subresource for application invitations
- exposed the new read/search endpoint under `ApplicationResource`
- implemented the flow using Onion Architecture:
  - `Resource -> UseCase -> CrudService / QueryService`
- added `SearchApplicationInvitationsUseCase` as the application read/search entrypoint
- added dedicated invitation read models for search input and output

## Out of scope
This PR does not implement:
- invitation creation
- invitation role updates
- invitation deletion
- invitation resend
- invitation acceptance