### PR TITLE
Normalize allowedInApiProducts null to false in v4 ApiMapper

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
@@ -207,6 +207,44 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
     }
 
     @Test
+    public void should_return_false_for_allowedInApiProducts_when_entity_has_false() {
+        ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).allowedInApiProducts(null).build();
+        UpdateApiV4 updateApiV4 = ApiFixtures.anUpdateApiV4();
+
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(apiEntity);
+        when(
+            apiServiceV4.update(eq(GraviteeContext.getExecutionContext()), eq(API), any(UpdateApiEntity.class), eq(false), eq(USER_NAME))
+        ).thenReturn(apiEntity.toBuilder().allowedInApiProducts(false).build());
+        when(apiStateServiceV4.isSynchronized(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(true);
+
+        final Response response = rootTarget(API).request().put(Entity.json(updateApiV4));
+        assertEquals(OK_200, response.getStatus());
+
+        final ApiV4 apiV4 = response.readEntity(ApiV4.class);
+        assertNotNull(apiV4);
+        assertEquals(Boolean.FALSE, apiV4.getAllowedInApiProducts());
+    }
+
+    @Test
+    public void should_preserve_true_for_allowedInApiProducts_when_entity_has_true() {
+        ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).allowedInApiProducts(true).build();
+        UpdateApiV4 updateApiV4 = ApiFixtures.anUpdateApiV4();
+
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(apiEntity);
+        when(
+            apiServiceV4.update(eq(GraviteeContext.getExecutionContext()), eq(API), any(UpdateApiEntity.class), eq(false), eq(USER_NAME))
+        ).thenReturn(apiEntity);
+        when(apiStateServiceV4.isSynchronized(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(true);
+
+        final Response response = rootTarget(API).request().put(Entity.json(updateApiV4));
+        assertEquals(OK_200, response.getStatus());
+
+        final ApiV4 apiV4 = response.readEntity(ApiV4.class);
+        assertNotNull(apiV4);
+        assertEquals(Boolean.TRUE, apiV4.getAllowedInApiProducts());
+    }
+
+    @Test
     public void should_return_bad_request_when_updating_v4_api_with_v2_defition() {
         final ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).build();
         final UpdateApiV2 updateApiV2 = ApiFixtures.anUpdateApiV2();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
@@ -207,7 +207,7 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
     }
 
     @Test
-    public void should_return_false_for_allowedInApiProducts_when_entity_has_false() {
+    public void should_return_false_for_allowedInApiProducts_when_entity_has_null() {
         ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).allowedInApiProducts(null).build();
         UpdateApiV4 updateApiV4 = ApiFixtures.anUpdateApiV4();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
@@ -538,7 +538,7 @@ public class ApiResource_getApiByIdTest extends ApiResourceTest {
     }
 
     @Test
-    public void shouldNotGetApiBecauseNotFound() {
+    public void should_not_get_api_because_not_found() {
         final String UNKNOWN_API = "unknown";
 
         doThrow(ApiNotFoundException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.ApiFixtures;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -504,6 +505,36 @@ public class ApiResource_getApiByIdTest extends ApiResourceTest {
         assertNotNull(responseApi.getProxy());
         assertEquals("/test", responseApi.getProxy().getVirtualHosts().get(0).getPath());
         assertNull(responseApi.getProxy().getVirtualHosts().get(0).getHost());
+    }
+
+    @Test
+    public void should_return_false_for_allowedInApiProducts_when_entity_has_false() {
+        ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).name(API).allowedInApiProducts(false).build();
+
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, true, true, true)).thenReturn(apiEntity);
+        when(apiStateServiceV4.isSynchronized(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(true);
+
+        final Response response = rootTarget(API).request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        final ApiV4 responseApi = response.readEntity(ApiV4.class);
+        assertNotNull(responseApi);
+        assertEquals(Boolean.FALSE, responseApi.getAllowedInApiProducts());
+    }
+
+    @Test
+    public void should_preserve_true_for_allowedInApiProducts_when_entity_has_true() {
+        ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).name(API).allowedInApiProducts(true).build();
+
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, true, true, true)).thenReturn(apiEntity);
+        when(apiStateServiceV4.isSynchronized(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(true);
+
+        final Response response = rootTarget(API).request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        final ApiV4 responseApi = response.readEntity(ApiV4.class);
+        assertNotNull(responseApi);
+        assertEquals(Boolean.TRUE, responseApi.getAllowedInApiProducts());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformer.java
@@ -188,12 +188,11 @@ public class IndexableApiDocumentTransformer implements DocumentTransformer<Inde
             default -> {}
         }
 
-        // allowedInApiProducts - only for V4 HTTP Proxy APIs
+        // allowedInApiProducts - only for V4 HTTP Proxy APIs; null is normalized to false so existing APIs are
+        // always indexed and remain findable by a search for allowedInApiProducts=false.
         if (apiDefinitionV4 instanceof io.gravitee.definition.model.v4.Api v4Api) {
-            Boolean allowedInApiProducts = v4Api.getAllowedInApiProducts();
-            if (allowedInApiProducts != null) {
-                doc.add(new StringField(FIELD_ALLOW_IN_API_PRODUCTS, Boolean.toString(allowedInApiProducts), Field.Store.NO));
-            }
+            boolean allowedInApiProducts = Boolean.TRUE.equals(v4Api.getAllowedInApiProducts());
+            doc.add(new StringField(FIELD_ALLOW_IN_API_PRODUCTS, Boolean.toString(allowedInApiProducts), Field.Store.NO));
         }
 
         // tags

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -132,13 +132,7 @@ public class ApiMapper {
                 apiEntity.setResponseTemplates(apiDefinition.getResponseTemplates());
 
                 if (apiDefinition.getType() == ApiType.PROXY) {
-                    var jsonNode = objectMapper.readTree(api.getDefinition());
-                    boolean hasAllowedInApiProducts = jsonNode.has("allowedInApiProducts");
-                    if (hasAllowedInApiProducts) {
-                        apiEntity.setAllowedInApiProducts(apiDefinition.getAllowedInApiProducts());
-                    } else {
-                        apiEntity.setAllowedInApiProducts(false);
-                    }
+                    apiEntity.setAllowedInApiProducts(Boolean.TRUE.equals(apiDefinition.getAllowedInApiProducts()));
                 }
             } catch (IOException ioe) {
                 log.error(API_DEFINITION_UNEXPECTED_ERROR_MESSAGE, ioe);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
@@ -211,6 +211,45 @@ class ApiDocumentTransformerTest {
     }
 
     @Test
+    void transform_api_entity_v4_http_proxy_should_index_allow_in_api_products_as_false_when_null() {
+        var api = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        api.setId("api-uuid");
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setType(ApiType.PROXY);
+        api.setVisibility(Visibility.PUBLIC);
+        api.setAllowedInApiProducts(null);
+
+        Document doc = cut.transform(api);
+        assertThat(doc.get(FIELD_ALLOW_IN_API_PRODUCTS)).isEqualTo("false");
+    }
+
+    @Test
+    void transform_api_entity_v4_http_proxy_should_index_allow_in_api_products_as_false_when_false() {
+        var api = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        api.setId("api-uuid");
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setType(ApiType.PROXY);
+        api.setVisibility(Visibility.PUBLIC);
+        api.setAllowedInApiProducts(false);
+
+        Document doc = cut.transform(api);
+        assertThat(doc.get(FIELD_ALLOW_IN_API_PRODUCTS)).isEqualTo("false");
+    }
+
+    @Test
+    void transform_api_entity_v4_message_should_still_index_allow_in_api_products_as_false_when_null() {
+        var api = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        api.setId("api-uuid");
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setType(ApiType.MESSAGE);
+        api.setVisibility(Visibility.PUBLIC);
+        api.setAllowedInApiProducts(null);
+
+        Document doc = cut.transform(api);
+        assertThat(doc.get(FIELD_ALLOW_IN_API_PRODUCTS)).isEqualTo("false");
+    }
+
+    @Test
     void transform_api_entity_federated_verify_api_type() {
         var api = new io.gravitee.rest.api.model.v4.api.ApiEntity();
         api.setId("api-uuid");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
@@ -178,8 +178,8 @@ public class IndexableApiDocumentTransformerTest {
             // origin
             softly.assertThat(result.getField(FIELD_ORIGIN).stringValue()).isEqualTo("management");
 
-            // allow_in_api_products should not be indexed when missing in definition
-            softly.assertThat(result.getField(FIELD_ALLOW_IN_API_PRODUCTS)).isNull();
+            // null allowedInApiProducts is normalized to false so the API remains findable by allowedInApiProducts=false
+            softly.assertThat(result.getField(FIELD_ALLOW_IN_API_PRODUCTS).stringValue()).isEqualTo("false");
         });
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexableApiDocumentTransformerTest.java
@@ -184,6 +184,23 @@ public class IndexableApiDocumentTransformerTest {
     }
 
     @Test
+    void should_index_explicit_false_allowedInApiProducts() {
+        var indexable = new IndexableApi(
+            ApiFixtures.aProxyApiV4()
+                .toBuilder()
+                .apiDefinitionHttpV4(io.gravitee.definition.model.v4.Api.builder().allowedInApiProducts(false).build())
+                .build(),
+            PRIMARY_OWNER,
+            Map.of(),
+            Set.of()
+        );
+
+        var result = cut.transform(indexable);
+
+        assertThat(result.getField(FIELD_ALLOW_IN_API_PRODUCTS).stringValue()).isEqualTo("false");
+    }
+
+    @Test
     void should_transform_primary_owner_info() {
         // Given
         var indexable = new IndexableApi(ApiFixtures.aProxyApiV4(), PRIMARY_OWNER, Map.of(), Set.of());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
@@ -165,11 +166,9 @@ public class ApiMapperTest {
         def.setType(ApiType.PROXY);
         def.setName("name");
         def.setApiVersion("1");
-        String rawJson = objectMapper.writeValueAsString(def);
-        String defJson = rawJson
-            .replace(",\"allowedInApiProducts\":null", "")
-            .replace("\"allowedInApiProducts\":null,", "")
-            .replace("\"allowedInApiProducts\":null", "");
+        ObjectNode node = (ObjectNode) objectMapper.readTree(objectMapper.writeValueAsString(def));
+        node.remove("allowedInApiProducts");
+        String defJson = node.toString();
         Api repo = new Api();
         repo.setId("idAbsent");
         repo.setDefinition(defJson);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
@@ -141,6 +141,63 @@ public class ApiMapperTest {
     }
 
     @Test
+    public void shouldDefaultAllowedInApiProductsToFalseWhenStoredValueIsNull() throws Exception {
+        var def = new io.gravitee.definition.model.v4.Api();
+        def.setDefinitionVersion(DefinitionVersion.V4);
+        def.setType(ApiType.PROXY);
+        def.setAllowedInApiProducts(null);
+        def.setName("name");
+        def.setApiVersion("1");
+        Api repo = new Api();
+        repo.setId("idNull");
+        repo.setDefinition(objectMapper.writeValueAsString(def));
+        repo.setType(ApiType.PROXY);
+
+        var entity = apiMapper.toEntity(repo, new PrimaryOwnerEntity());
+
+        assertThat(entity.getAllowedInApiProducts()).isFalse();
+    }
+
+    @Test
+    public void shouldDefaultAllowedInApiProductsToFalseWhenKeyIsAbsentInDefinition() throws Exception {
+        var def = new io.gravitee.definition.model.v4.Api();
+        def.setDefinitionVersion(DefinitionVersion.V4);
+        def.setType(ApiType.PROXY);
+        def.setName("name");
+        def.setApiVersion("1");
+        String rawJson = objectMapper.writeValueAsString(def);
+        String defJson = rawJson
+            .replace(",\"allowedInApiProducts\":null", "")
+            .replace("\"allowedInApiProducts\":null,", "")
+            .replace("\"allowedInApiProducts\":null", "");
+        Api repo = new Api();
+        repo.setId("idAbsent");
+        repo.setDefinition(defJson);
+        repo.setType(ApiType.PROXY);
+
+        var entity = apiMapper.toEntity(repo, new PrimaryOwnerEntity());
+
+        assertThat(entity.getAllowedInApiProducts()).isFalse();
+    }
+
+    @Test
+    public void shouldNotSetAllowedInApiProductsForNonProxyType() throws Exception {
+        var def = new io.gravitee.definition.model.v4.Api();
+        def.setDefinitionVersion(DefinitionVersion.V4);
+        def.setType(ApiType.MESSAGE);
+        def.setName("name");
+        def.setApiVersion("1");
+        Api repo = new Api();
+        repo.setId("idMsg");
+        repo.setDefinition(objectMapper.writeValueAsString(def));
+        repo.setType(ApiType.MESSAGE);
+
+        var entity = apiMapper.toEntity(repo, new PrimaryOwnerEntity());
+
+        assertThat(entity.getAllowedInApiProducts()).isNull();
+    }
+
+    @Test
     public void shouldIncludeAllowedInApiProductsWhenToRepositoryFromApiEntity() throws Exception {
         ApiEntity apiEntity = new ApiEntity();
         apiEntity.setId("id");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13737

## Why

A v4 HTTP Proxy API can end up with `allowedInApiProducts = null` in its stored definition. Two separate paths were affected:

1. **`ApiMapper.toEntity`** — copied null verbatim into `ApiEntity`, so PUT/GET responses returned null instead of false.
2. **`IndexableApiDocumentTransformer`** — skipped writing `FIELD_ALLOW_IN_API_PRODUCTS` entirely when the value was null. Because the indexer receives its `ApiEntity` from the create/update use case flow (which does not go through `ApiMapper.toEntity`), the first fix alone left null-stored APIs invisible to `POST /apis/_search {"allowedInApiProducts": false}`.

## What changed

- **`ApiMapper.toEntity` (PROXY branch)** — replaced verbatim copy of `apiDefinition.getAllowedInApiProducts()` with `Boolean.TRUE.equals(...)`, collapsing absent-key, explicit-null, and explicit-false into `false`. The redundant `readTree` parse that only existed to check key presence was removed.
- **`IndexableApiDocumentTransformer`** — applied the same `Boolean.TRUE.equals(...)` normalization in `transformV4Api`. The field is now always written for V4 HTTP proxy APIs, so null-stored APIs are indexed as `false` and appear in `allowedInApiProducts=false` search results. Native, V2, and definition-less APIs are unaffected.
- No changes to the write path (tracked separately).

## How to test

1. Store a v4 HTTP Proxy API with `"allowedInApiProducts": null` in its definition.
2. `GET /management/v2/environments/{envId}/apis/{apiId}` — response must include `"allowedInApiProducts": false`.
3. `PUT /management/v2/environments/{envId}/apis/{apiId}` — response must include `"allowedInApiProducts": false`.
4. Re-index the API, then call `POST /apis/_search {"allowedInApiProducts": false}` — the API must appear in results.

Automated coverage: `ApiMapperTest`, `IndexableApiDocumentTransformerTest`, `ApiResource_getApiByIdTest`, `ApiResource_UpdateApiTest`.

## Gotchas / Follow-up

- Pre-existing Lucene documents indexed before this fix are unaffected until a full re-index is triggered. Release notes must flag this for operators who rely on the `allowedInApiProducts` search filter for legacy data.
- The write path (`toApiDefinition(UpdateApiEntity)`) is intentionally untouched — a null `allowedInApiProducts` on update still omits the key. Persisting a concrete Boolean on write is tracked in APIM-13738.