### PR TITLE
fix(console): sync group add-members default roles before submit

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.html
@@ -20,7 +20,7 @@
   <form [formGroup]="addMemberForm" class="add-member__form">
     <mat-form-field aria-hidden="false" aria-label="Select default API role">
       <mat-label>Default API Role</mat-label>
-      <mat-select formControlName="defaultAPIRole" (selectionChange)="onAPIRoleChange()">
+      <mat-select formControlName="defaultAPIRole" (selectionChange)="onDefaultRoleChange()">
         @for (role of defaultAPIRoles; track role.id) {
           <mat-option [value]="role.name" [disabled]="disabledAPIRoles.has(role.id)">{{ role.name }}</mat-option>
         }
@@ -29,7 +29,7 @@
 
     <mat-form-field aria-hidden="false" aria-label="Select default API product role">
       <mat-label>Default API Product Role</mat-label>
-      <mat-select formControlName="defaultAPIProductRole">
+      <mat-select formControlName="defaultAPIProductRole" (selectionChange)="onDefaultRoleChange()">
         @for (role of defaultAPIProductRoles; track role.id) {
           <mat-option [value]="role.name" [disabled]="role.system">{{ role.name }}</mat-option>
         }
@@ -38,7 +38,7 @@
 
     <mat-form-field aria-hidden="false" aria-label="Select default application role">
       <mat-label>Default Application Role</mat-label>
-      <mat-select formControlName="defaultApplicationRole">
+      <mat-select formControlName="defaultApplicationRole" (selectionChange)="onDefaultRoleChange()">
         @for (role of defaultApplicationRoles; track role.id) {
           <mat-option [value]="role.name" [disabled]="role.system">{{ role.name }}</mat-option>
         }
@@ -47,7 +47,7 @@
 
     <mat-form-field aria-hidden="false" aria-label="Select default integration role">
       <mat-label>Default Integration Role</mat-label>
-      <mat-select formControlName="defaultIntegrationRole">
+      <mat-select formControlName="defaultIntegrationRole" (selectionChange)="onDefaultRoleChange()">
         @for (role of defaultIntegrationRoles; track role.id) {
           <mat-option [value]="role.name" [disabled]="role.system">{{ role.name }}</mat-option>
         }
@@ -56,7 +56,7 @@
 
     <mat-form-field aria-hidden="false" aria-label="Select default cluster role">
       <mat-label>Default Cluster Role</mat-label>
-      <mat-select formControlName="defaultClusterRole">
+      <mat-select formControlName="defaultClusterRole" (selectionChange)="onDefaultRoleChange()">
         @for (role of defaultClusterRoles; track role.id) {
           <mat-option [value]="role.name" [disabled]="role.system">{{ role.name }}</mat-option>
         }

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.spec.ts
@@ -13,36 +13,121 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
 
 import { AddMembersDialogComponent } from './add-members-dialog.component';
 
+import { Group } from '../../../../../entities/group/group';
+import { Role } from '../../../../../entities/role/role';
+import { SearchableUser } from '../../../../../entities/user/searchableUser';
+import { GioTestingPermissionProvider } from '../../../../../shared/components/gio-permission/gio-permission.service';
 import { GioTestingModule } from '../../../../../shared/testing';
+import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
+import { UsersService } from '../../../../../services-ngx/users.service';
+import { GroupMembership } from '../../../../../entities/group/groupMember';
 
 describe('AddMembersDialogComponent', () => {
-  TestBed.configureTestingModule({
-    imports: [AddMembersDialogComponent, MatDialogModule, GioTestingModule],
-    declarations: [],
-    providers: [
-      {
-        provide: MatDialogRef,
-        useValue: {
-          close: jest.fn(),
+  const SETTINGS_SNAPSHOT = {
+    api: {
+      primaryOwnerMode: 'USER',
+    },
+  };
+
+  const GROUP: Group = {
+    id: 'g1',
+    manageable: true,
+    max_invitation: 10,
+    lock_api_role: false,
+    lock_api_product_role: false,
+    lock_application_role: false,
+    roles: { API: 'USER', API_PRODUCT: 'USER', APPLICATION: 'USER' },
+  };
+
+  const DEFAULT_API_ROLES: Role[] = [{ id: '1', name: 'USER', scope: 'API' }];
+  const DEFAULT_API_PRODUCT_ROLES: Role[] = [
+    { id: 'ap1', name: 'USER', scope: 'API_PRODUCT' },
+    { id: 'ap2', name: 'REVIEWER', scope: 'API_PRODUCT' },
+  ];
+  const DEFAULT_APP_ROLES: Role[] = [{ id: 'a1', name: 'USER', scope: 'APPLICATION' }];
+  const DEFAULT_INTEGRATION_ROLES: Role[] = [{ id: 'i1', name: 'USER', scope: 'INTEGRATION' }];
+  const DEFAULT_CLUSTER_ROLES: Role[] = [{ id: 'c1', name: 'USER', scope: 'CLUSTER' }];
+
+  const SEARCH_USER: SearchableUser = {
+    id: 'u99',
+    reference: 'ref-u99',
+    displayName: 'New Member',
+  };
+
+  let fixture: ComponentFixture<AddMembersDialogComponent>;
+  let component: AddMembersDialogComponent;
+  let matDialogRef: MatDialogRef<AddMembersDialogComponent>;
+
+  beforeEach(async () => {
+    matDialogRef = { close: jest.fn() } as unknown as MatDialogRef<AddMembersDialogComponent>;
+
+    await TestBed.configureTestingModule({
+      imports: [AddMembersDialogComponent, MatDialogModule, GioTestingModule, NoopAnimationsModule],
+      providers: [
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            group: GROUP,
+            members: [],
+            defaultAPIRoles: DEFAULT_API_ROLES,
+            defaultAPIProductRoles: DEFAULT_API_PRODUCT_ROLES,
+            defaultApplicationRoles: DEFAULT_APP_ROLES,
+            defaultIntegrationRoles: DEFAULT_INTEGRATION_ROLES,
+            defaultClusterRoles: DEFAULT_CLUSTER_ROLES,
+          },
         },
-      },
-      {
-        provide: MAT_DIALOG_DATA,
-        useValue: {
-          /* mock data */
-        },
-      },
-    ],
-  }).compileComponents();
+        { provide: MatDialogRef, useValue: matDialogRef },
+        { provide: GioTestingPermissionProvider, useValue: ['environment-group-u'] },
+        { provide: EnvironmentSettingsService, useValue: { getSnapshot: () => SETTINGS_SNAPSHOT } },
+        { provide: UsersService, useValue: { search: () => of([]) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddMembersDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should create', () => {
-    const fixture = TestBed.createComponent(AddMembersDialogComponent);
-    const component = fixture.componentInstance;
     expect(component).toBeTruthy();
+  });
+
+  it('should clear selected users and memberships when default role selection changes', () => {
+    component.selectedUsers = [SEARCH_USER];
+    const internal = component as unknown as { memberships: GroupMembership[] };
+    internal.memberships = [component.mapGroupMembership(SEARCH_USER)];
+    component.disableSubmit = false;
+
+    component.onDefaultRoleChange();
+
+    expect(component.selectedUsers).toEqual([]);
+    expect(internal.memberships).toEqual([]);
+    expect(component.disableSubmit).toBe(true);
+  });
+
+  it('should close with memberships built from current form values on submit', () => {
+    component.addMemberForm.patchValue({ defaultAPIProductRole: 'REVIEWER' });
+    component.selectedUsers = [SEARCH_USER];
+    const internal = component as unknown as { memberships: GroupMembership[] };
+    internal.memberships = [component.mapGroupMembership(SEARCH_USER)];
+    component.disableSubmit = false;
+
+    component.submit();
+
+    expect(matDialogRef.close).toHaveBeenCalledWith({
+      memberships: [
+        expect.objectContaining({
+          id: SEARCH_USER.id,
+          roles: expect.arrayContaining([{ name: 'REVIEWER', scope: 'API_PRODUCT' }]),
+        }),
+      ],
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.ts
@@ -206,7 +206,12 @@ export class AddMembersDialogComponent implements OnInit {
   }
 
   submit() {
+    this.syncMembershipsFromForm();
     this.matDialogRef.close({ memberships: this.memberships });
+  }
+
+  private syncMembershipsFromForm(): void {
+    this.memberships = this.selectedUsers.map(user => this.mapGroupMembership(user));
   }
 
   mapGroupMembership(user: SearchableUser): GroupMembership {
@@ -269,7 +274,7 @@ export class AddMembersDialogComponent implements OnInit {
       const membershipIndex = this.memberships.findIndex(member => member.id === user.id);
 
       if (membershipIndex >= 0) {
-        this.memberships.splice(index, 1);
+        this.memberships.splice(membershipIndex, 1);
       }
     }
     this.changeFormState();
@@ -296,7 +301,8 @@ export class AddMembersDialogComponent implements OnInit {
     return this.memberships.filter(membership => membership.roles.find(role => role.scope === 'API').name === RoleName.PRIMARY_OWNER);
   }
 
-  onAPIRoleChange() {
+  /** Clears user chips and memberships when any default role changes; refreshes PRIMARY_OWNER search rules via changeFormState. */
+  onDefaultRoleChange(): void {
     this.selectedUsers = [];
     this.memberships = [];
     this.changeFormState();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13783

## Description
Rebuild memberships from selected users and current form when non-API default roles change and before closing the dialog, so API_PRODUCT (and other scopes) match the dropdowns. Fix chip removal splice index.

## Additional context

https://github.com/user-attachments/assets/dcccce05-ffda-4d14-824a-b4d7b3327ea4


