### PR TITLE
feat(management-api): add JSON Patch support to v4 HTTP Proxy API PATCH endpoint

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -58,6 +58,7 @@ import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.JsonMergePatchService;
+import io.gravitee.apim.core.api.domain_service.JsonPatchService;
 import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiCRDDomainService;
@@ -177,6 +178,7 @@ import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapterImpl;
 import io.gravitee.apim.infra.domain_service.analytics_engine.definition.AnalyticsDefinitionYAMLQueryService;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.UnitEnrichmentPostProcessorImpl;
+import io.gravitee.apim.infra.domain_service.api.ApiJsonPatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.api.JsonMergePatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
@@ -505,8 +507,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ApiPatchDomainService apiPatchDomainService(JsonMergePatchService jsonMergePatchService) {
-        return new ApiPatchDomainService(jsonMergePatchService);
+    public JsonPatchService jsonPatchService() {
+        return new ApiJsonPatchServiceImpl();
+    }
+
+    @Bean
+    public ApiPatchDomainService apiPatchDomainService(JsonMergePatchService jsonMergePatchService, JsonPatchService jsonPatchService) {
+        return new ApiPatchDomainService(jsonMergePatchService, jsonPatchService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -291,6 +291,7 @@ public interface ApiMapper {
         target = "responseTemplates",
         expression = "java(source != null && source.getApiDefinitionHttpV4() != null ? responseTemplateMapper.mapResponseTemplateToApiModel(source.getApiDefinitionHttpV4().getResponseTemplates()) : null)"
     )
+    @Mapping(target = "properties", source = "source.apiDefinitionHttpV4.properties")
     @Mapping(target = "services", source = "source.apiDefinitionHttpV4.services")
     @Mapping(target = "state", source = "source.lifecycleState")
     ApiV4 mapToHttpV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -181,6 +181,11 @@ import lombok.CustomLog;
 @CustomLog
 public class ApiResource extends AbstractResource {
 
+    private static final jakarta.ws.rs.core.MediaType JSON_PATCH_MEDIA_TYPE = new jakarta.ws.rs.core.MediaType(
+        "application",
+        "json-patch+json"
+    );
+
     private static final String REVIEWS_ACTION_ASK = "ask";
     private static final String REVIEWS_ACTION_ACCEPT = "accept";
     private static final String REVIEWS_ACTION_REJECT = "reject";
@@ -448,7 +453,7 @@ public class ApiResource extends AbstractResource {
     }
 
     @PATCH
-    @Consumes({ MediaType.APPLICATION_JSON, "application/merge-patch+json" })
+    @Consumes({ MediaType.APPLICATION_JSON, "application/merge-patch+json", "application/json-patch+json" })
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions(
         {
@@ -456,10 +461,20 @@ public class ApiResource extends AbstractResource {
             @Permission(value = RolePermission.API_GATEWAY_DEFINITION, acls = RolePermissionAction.UPDATE),
         }
     )
-    public Response patchApi(@PathParam("apiId") String apiId, @QueryParam("dryRun") @DefaultValue("false") boolean dryRun, String body) {
+    public Response patchApi(
+        @PathParam("apiId") String apiId,
+        @QueryParam("dryRun") @DefaultValue("false") boolean dryRun,
+        @Context HttpHeaders headers,
+        String body
+    ) {
+        var contentType = headers.getMediaType();
+        var patchType = contentType != null && JSON_PATCH_MEDIA_TYPE.isCompatible(contentType)
+            ? PatchApiUseCase.PatchType.JSON_PATCH
+            : PatchApiUseCase.PatchType.MERGE_PATCH;
+
         var input = PatchApiUseCase.Input.builder()
             .apiId(apiId)
-            .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
+            .patchType(patchType)
             .patchBody(body)
             .dryRun(dryRun)
             .auditInfo(getAuditInfo())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
@@ -25,18 +25,24 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.ApiFixtures;
 import inmemory.InMemoryAlternative;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.management.v2.rest.model.ApiServices;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.FlowExecution;
 import io.gravitee.rest.api.management.v2.rest.model.FlowMode;
+import io.gravitee.rest.api.management.v2.rest.model.MembershipMemberType;
+import io.gravitee.rest.api.management.v2.rest.model.Property;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -45,17 +51,24 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class ApiResource_PatchApiTest extends ApiResourceTest {
 
     private static final String MERGE_PATCH_TYPE = "application/merge-patch+json";
+    private static final String JSON_PATCH_TYPE = "application/json-patch+json";
 
     @Inject
     UpdateApiDomainService updateApiDomainService;
@@ -100,107 +113,13 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
         reset(updateApiDomainService);
     }
 
-    @Test
-    void should_return_200_when_merge_patch_updates_name() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"patched-via-merge\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("patched-via-merge");
-    }
-
-    @Test
-    void should_return_etag_and_last_modified_headers_on_successful_patch() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"hdr\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200);
-        org.assertj.core.api.Assertions.assertThat(response.getHeaderString("ETag")).isNotBlank();
-        org.assertj.core.api.Assertions.assertThat(response.getHeaderString("Last-Modified")).isNotBlank();
-    }
+    // ---- General (format-independent) tests ----
 
     @Test
     void should_return_415_when_content_type_is_unsupported() {
         var response = rootTarget(API).request().method("PATCH", Entity.entity("name=plain", MediaType.TEXT_PLAIN_TYPE));
 
         assertThat(response).hasStatus(UNSUPPORTED_MEDIA_TYPE_415);
-    }
-
-    @Test
-    void should_return_200_with_projected_result_when_dry_run() {
-        var response = rootTarget(API)
-            .queryParam("dryRun", "true")
-            .request()
-            .method("PATCH", Entity.entity("{\"name\":\"dry-run-result\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("dry-run-result");
-        org.mockito.Mockito.verify(updateApiDomainService).validateV4(any(), any());
-        org.mockito.Mockito.verify(updateApiDomainService, org.mockito.Mockito.never()).updateV4(any(), any());
-    }
-
-    @Test
-    void should_return_200_with_sanitized_tags_when_dry_run() {
-        doAnswer(inv -> {
-            io.gravitee.apim.core.api.model.Api api = inv.getArgument(0);
-            var sanitizedDef = api.getApiDefinitionHttpV4().toBuilder().tags(java.util.Set.of("allowed")).build();
-            return api.toBuilder().apiDefinitionValue(sanitizedDef).build();
-        })
-            .when(updateApiDomainService)
-            .validateV4(any(), any());
-
-        var response = rootTarget(API)
-            .queryParam("dryRun", "true")
-            .request()
-            .method("PATCH", Entity.entity("{\"tags\":[\"requested\",\"forbidden\"]}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getTags).asList().containsExactly("allowed");
-    }
-
-    @Test
-    void should_return_400_when_dry_run_fails_domain_validation() {
-        doThrow(new ValidationDomainException("tag 'forbidden' not allowed")).when(updateApiDomainService).validateV4(any(), any());
-
-        var response = rootTarget(API)
-            .queryParam("dryRun", "true")
-            .request()
-            .method("PATCH", Entity.entity("{\"tags\":[\"forbidden\"]}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining("forbidden");
-        org.mockito.Mockito.verify(updateApiDomainService, org.mockito.Mockito.never()).updateV4(any(), any());
-    }
-
-    @Test
-    void should_return_400_when_dry_run_rejects_allow_list_field() {
-        var response = rootTarget(API)
-            .queryParam("dryRun", "true")
-            .request()
-            .method("PATCH", Entity.entity("{\"state\":\"STARTED\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining("state");
-        org.mockito.Mockito.verify(updateApiDomainService, org.mockito.Mockito.never()).validateV4(any(), any());
-        org.mockito.Mockito.verify(updateApiDomainService, org.mockito.Mockito.never()).updateV4(any(), any());
-    }
-
-    @Test
-    void should_return_400_when_patching_state_field() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"state\":\"STARTED\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining("state");
-    }
-
-    @Test
-    void should_return_400_when_patching_listeners_field() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"listeners\":[]}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining("listeners");
-    }
-
-    @Test
-    void should_return_400_when_patched_api_fails_validation() {
-        doThrow(new ValidationDomainException("name must not be blank", Map.of("name", "must not be blank")))
-            .when(updateApiDomainService)
-            .updateV4(any(), any());
-
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400);
     }
 
     @Test
@@ -259,166 +178,12 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
     }
 
     @Test
-    void should_treat_application_json_as_merge_patch() {
-        var response = rootTarget(API).request().method("PATCH", Entity.json("{\"name\":\"patched-via-json\"}"));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("patched-via-json");
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_disable_membership_notifications() {
-        var response = rootTarget(API)
-            .request()
-            .method("PATCH", Entity.entity("{\"disableMembershipNotifications\":true}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getDisableMembershipNotifications).isEqualTo(true);
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_properties() {
-        var response = rootTarget(API)
-            .request()
-            .method("PATCH", Entity.entity("{\"properties\":[{\"key\":\"k1\",\"value\":\"v1\"}]}", MERGE_PATCH_TYPE));
+    void should_return_etag_and_last_modified_headers_on_successful_patch() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"hdr\"}", MERGE_PATCH_TYPE));
 
         assertThat(response).hasStatus(OK_200);
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_response_templates() {
-        var body = "{\"responseTemplates\":{\"FOO_KEY\":{\"application/json\":{\"status\":400,\"body\":\"{}\"}}}}";
-        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200);
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_description() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"description\":\"new-description\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getDescription).isEqualTo("new-description");
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_api_version() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"apiVersion\":\"2.0.0\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getApiVersion).isEqualTo("2.0.0");
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_visibility() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"visibility\":\"PRIVATE\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response)
-            .hasStatus(OK_200)
-            .asEntity(ApiV4.class)
-            .extracting(a -> a.getVisibility().name())
-            .isEqualTo("PRIVATE");
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_labels() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"labels\":[\"infra\",\"prod\"]}", MERGE_PATCH_TYPE));
-
-        assertThat(response)
-            .hasStatus(OK_200)
-            .asEntity(ApiV4.class)
-            .extracting(ApiV4::getLabels)
-            .asList()
-            .containsExactlyInAnyOrder("infra", "prod");
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_tags() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"tags\":[\"tag-a\",\"tag-b\"]}", MERGE_PATCH_TYPE));
-
-        assertThat(response)
-            .hasStatus(OK_200)
-            .asEntity(ApiV4.class)
-            .extracting(ApiV4::getTags)
-            .asList()
-            .containsExactlyInAnyOrder("tag-a", "tag-b");
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_lifecycle_state() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"lifecycleState\":\"DEPRECATED\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response)
-            .hasStatus(OK_200)
-            .asEntity(ApiV4.class)
-            .extracting(a -> a.getLifecycleState().name())
-            .isEqualTo("DEPRECATED");
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_categories() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"categories\":[\"cat-a\",\"cat-b\"]}", MERGE_PATCH_TYPE));
-
-        assertThat(response)
-            .hasStatus(OK_200)
-            .asEntity(ApiV4.class)
-            .extracting(ApiV4::getCategories)
-            .asList()
-            .containsExactlyInAnyOrder("cat-a", "cat-b");
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_analytics() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"analytics\":{\"enabled\":true}}", MERGE_PATCH_TYPE));
-
-        assertThat(response)
-            .hasStatus(OK_200)
-            .asEntity(ApiV4.class)
-            .extracting(a -> a.getAnalytics().getEnabled())
-            .isEqualTo(true);
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_failover() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"failover\":{\"enabled\":true}}", MERGE_PATCH_TYPE));
-
-        assertThat(response)
-            .hasStatus(OK_200)
-            .asEntity(ApiV4.class)
-            .extracting(a -> a.getFailover().getEnabled())
-            .isEqualTo(true);
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_flow_execution() {
-        var response = rootTarget(API)
-            .request()
-            .method("PATCH", Entity.entity("{\"flowExecution\":{\"mode\":\"best-match\",\"matchRequired\":true}}", MERGE_PATCH_TYPE));
-
-        assertThat(response)
-            .hasStatus(OK_200)
-            .asEntity(ApiV4.class)
-            .extracting(ApiV4::getFlowExecution)
-            .isEqualTo(new io.gravitee.rest.api.management.v2.rest.model.FlowExecution().mode(FlowMode.BEST_MATCH).matchRequired(true));
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_services() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"services\":{}}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getServices).isEqualTo(new ApiServices());
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_allowed_in_api_products() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"allowedInApiProducts\":true}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getAllowedInApiProducts).isEqualTo(true);
-    }
-
-    @Test
-    void should_return_200_when_merge_patch_updates_allow_multi_jwt_oauth2_subscriptions() {
-        var response = rootTarget(API)
-            .request()
-            .method("PATCH", Entity.entity("{\"allowMultiJwtOauth2Subscriptions\":true}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getAllowMultiJwtOauth2Subscriptions).isEqualTo(true);
+        Assertions.assertThat(response.getHeaderString("ETag")).isNotBlank();
+        Assertions.assertThat(response.getHeaderString("Last-Modified")).isNotBlank();
     }
 
     @Test
@@ -445,121 +210,21 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
             .extracting(ApiV4::getPrimaryOwner)
             .isNotNull()
             .actual();
-        org.assertj.core.api.Assertions.assertThat(primaryOwner.getId()).isEqualTo(USER_NAME);
-        org.assertj.core.api.Assertions.assertThat(primaryOwner.getEmail()).isEqualTo("jane.doe@gravitee.io");
-        org.assertj.core.api.Assertions.assertThat(primaryOwner.getDisplayName()).isEqualTo("Jane Doe");
-        org.assertj.core.api.Assertions.assertThat(primaryOwner.getType()).isEqualTo(
-            io.gravitee.rest.api.management.v2.rest.model.MembershipMemberType.USER
-        );
-    }
-
-    @Test
-    void should_return_400_when_merge_patch_visibility_is_invalid() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"visibility\":\"NOT_A_VISIBILITY\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400);
-    }
-
-    @Test
-    void should_return_400_when_merge_patch_lifecycle_state_is_invalid() {
-        var response = rootTarget(API)
-            .request()
-            .method("PATCH", Entity.entity("{\"lifecycleState\":\"NOT_A_LIFECYCLE_STATE\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400);
-    }
-
-    @Test
-    void patch_merge_null_on_name_returns_400() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":null}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("name").hasMessageContaining("null");
-    }
-
-    @Test
-    void patch_merge_null_on_description_returns_400() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"description\":null}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("description").hasMessageContaining("null");
-    }
-
-    @Test
-    void patch_merge_null_on_apiVersion_returns_400() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"apiVersion\":null}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("apiVersion").hasMessageContaining("null");
-    }
-
-    @Test
-    void patch_merge_null_on_visibility_returns_400() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"visibility\":null}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("visibility").hasMessageContaining("null");
-    }
-
-    @Test
-    void patch_merge_null_on_lifecycleState_returns_400() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"lifecycleState\":null}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("lifecycleState").hasMessageContaining("null");
-    }
-
-    @Test
-    void patch_merge_null_on_allowedInApiProducts_returns_400() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"allowedInApiProducts\":null}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining("allowedInApiProducts").hasMessageContaining("null");
-    }
-
-    @Test
-    void patch_merge_null_on_allowMultiJwtOauth2Subscriptions_returns_400() {
-        var response = rootTarget(API)
-            .request()
-            .method("PATCH", Entity.entity("{\"allowMultiJwtOauth2Subscriptions\":null}", MERGE_PATCH_TYPE));
-
-        assertThat(response)
-            .hasStatus(BAD_REQUEST_400)
-            .asError()
-            .hasMessageContaining("allowMultiJwtOauth2Subscriptions")
-            .hasMessageContaining("null");
-    }
-
-    @Test
-    void patch_merge_null_on_disableMembershipNotifications_returns_400() {
-        var response = rootTarget(API)
-            .request()
-            .method("PATCH", Entity.entity("{\"disableMembershipNotifications\":null}", MERGE_PATCH_TYPE));
-
-        assertThat(response)
-            .hasStatus(BAD_REQUEST_400)
-            .asError()
-            .hasMessageContaining("disableMembershipNotifications")
-            .hasMessageContaining("null");
-    }
-
-    @Test
-    void patch_merge_omitting_name_returns_200_with_name_unchanged() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"description\":\"changed\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("My Api");
-    }
-
-    @Test
-    void patch_merge_valid_name_returns_200_with_updated_name() {
-        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"updated-name\"}", MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("updated-name");
+        Assertions.assertThat(primaryOwner.getId()).isEqualTo(USER_NAME);
+        Assertions.assertThat(primaryOwner.getEmail()).isEqualTo("jane.doe@gravitee.io");
+        Assertions.assertThat(primaryOwner.getDisplayName()).isEqualTo("Jane Doe");
+        Assertions.assertThat(primaryOwner.getType()).isEqualTo(MembershipMemberType.USER);
     }
 
     @Test
     void should_render_null_allowed_in_api_products_as_false_in_patch_response() {
         var storedApi = ApiFixtures.aProxyApiV4();
-        org.assertj.core.api.Assertions.assertThat(storedApi.getApiDefinitionHttpV4().getAllowedInApiProducts())
+        Assertions.assertThat(storedApi.getApiDefinitionHttpV4().getAllowedInApiProducts())
             .as("precondition: fixture has null allowedInApiProducts")
             .isNull();
         apiCrudService.initWith(List.of(storedApi));
 
-        var capturedApi = new io.gravitee.apim.core.api.model.Api[] { null };
+        var capturedApi = new Api[] { null };
         doAnswer(inv -> {
             capturedApi[0] = inv.getArgument(0);
             return capturedApi[0];
@@ -570,8 +235,541 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
         var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"description\":\"changed\"}", MERGE_PATCH_TYPE));
 
         assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getAllowedInApiProducts).isEqualTo(false);
-        org.assertj.core.api.Assertions.assertThat(capturedApi[0].getApiDefinitionHttpV4().getAllowedInApiProducts())
+        Assertions.assertThat(capturedApi[0].getApiDefinitionHttpV4().getAllowedInApiProducts())
             .as("stored value must not be coalesced before persistence")
             .isNull();
+    }
+
+    @Test
+    void patch_merge_omitting_name_returns_200_with_name_unchanged() {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"description\":\"changed\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("My Api");
+    }
+
+    // ---- Format-specific validation ----
+
+    @Nested
+    class FormatSpecificValidation {
+
+        @Test
+        void should_treat_application_json_as_merge_patch() {
+            var response = rootTarget(API).request().method("PATCH", Entity.json("{\"name\":\"patched-via-json\"}"));
+
+            assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("patched-via-json");
+        }
+
+        @Test
+        void should_return_400_when_json_patch_body_is_malformed() {
+            var response = rootTarget(API).request().method("PATCH", Entity.entity("this is not json", JSON_PATCH_TYPE));
+
+            assertThat(response).hasStatus(BAD_REQUEST_400);
+        }
+    }
+
+    // ---- Validation common to both formats ----
+
+    @ParameterizedTest
+    @MethodSource("disallowedFieldCases")
+    void should_return_400_when_patching_disallowed_field(String body, String contentType, String fieldName) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining(fieldName);
+    }
+
+    static Stream<Arguments> disallowedFieldCases() {
+        return Stream.of(
+            Arguments.of("{\"state\":\"STARTED\"}", MERGE_PATCH_TYPE, "state"),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/state\",\"value\":\"STARTED\"}]", JSON_PATCH_TYPE, "state"),
+            Arguments.of("{\"listeners\":[]}", MERGE_PATCH_TYPE, "listeners"),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/listeners\",\"value\":[]}]", JSON_PATCH_TYPE, "listeners")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidEnumValueCases")
+    void should_return_400_when_enum_field_has_invalid_value(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+
+    static Stream<Arguments> invalidEnumValueCases() {
+        return Stream.of(
+            Arguments.of("{\"visibility\":\"NOT_A_VISIBILITY\"}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/visibility\",\"value\":\"NOT_A_VISIBILITY\"}]", JSON_PATCH_TYPE),
+            Arguments.of("{\"lifecycleState\":\"NOT_A_LIFECYCLE_STATE\"}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/lifecycleState\",\"value\":\"NOT_A_LIFECYCLE_STATE\"}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("domainValidationFailureCases")
+    void should_return_400_when_domain_validation_fails(String body, String contentType) {
+        doThrow(new ValidationDomainException("name must not be blank", Map.of("name", "must not be blank")))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400);
+    }
+
+    static Stream<Arguments> domainValidationFailureCases() {
+        return Stream.of(
+            Arguments.of("{\"name\":\"\"}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"\"}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    // ---- Dry-run ----
+
+    @Nested
+    class DryRun {
+
+        @ParameterizedTest
+        @MethodSource("withoutPersistingCases")
+        void should_apply_patch_without_persisting(String body, String contentType, String expectedDescription) {
+            var response = rootTarget(API).queryParam("dryRun", "true").request().method("PATCH", Entity.entity(body, contentType));
+
+            assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getDescription).isEqualTo(expectedDescription);
+            verify(updateApiDomainService).validateV4(any(), any());
+            verify(updateApiDomainService, never()).updateV4(any(), any());
+        }
+
+        static Stream<Arguments> withoutPersistingCases() {
+            return Stream.of(
+                Arguments.of("{\"description\":\"dry\"}", MERGE_PATCH_TYPE, "dry"),
+                Arguments.of("[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"dry\"}]", JSON_PATCH_TYPE, "dry")
+            );
+        }
+
+        @Test
+        void should_return_200_with_sanitized_tags() {
+            doAnswer(inv -> {
+                Api api = inv.getArgument(0);
+                var sanitizedDef = api.getApiDefinitionHttpV4().toBuilder().tags(Set.of("allowed")).build();
+                return api.toBuilder().apiDefinitionValue(sanitizedDef).build();
+            })
+                .when(updateApiDomainService)
+                .validateV4(any(), any());
+
+            var response = rootTarget(API)
+                .queryParam("dryRun", "true")
+                .request()
+                .method("PATCH", Entity.entity("{\"tags\":[\"requested\",\"forbidden\"]}", MERGE_PATCH_TYPE));
+
+            assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getTags).asList().containsExactly("allowed");
+        }
+
+        @ParameterizedTest
+        @MethodSource("allowListRejectionCases")
+        void should_return_400_when_allow_list_field_rejected(String body, String contentType) {
+            var response = rootTarget(API).queryParam("dryRun", "true").request().method("PATCH", Entity.entity(body, contentType));
+
+            assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining("state");
+            verify(updateApiDomainService, never()).validateV4(any(), any());
+            verify(updateApiDomainService, never()).updateV4(any(), any());
+        }
+
+        static Stream<Arguments> allowListRejectionCases() {
+            return Stream.of(
+                Arguments.of("{\"state\":\"STARTED\"}", MERGE_PATCH_TYPE),
+                Arguments.of("[{\"op\":\"replace\",\"path\":\"/state\",\"value\":\"STARTED\"}]", JSON_PATCH_TYPE)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("domainValidationFailureCases")
+        void should_return_400_when_domain_validation_fails(String body, String contentType) {
+            doThrow(new ValidationDomainException("tag 'forbidden' not allowed")).when(updateApiDomainService).validateV4(any(), any());
+
+            var response = rootTarget(API).queryParam("dryRun", "true").request().method("PATCH", Entity.entity(body, contentType));
+
+            assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400).hasMessageContaining("forbidden");
+            verify(updateApiDomainService, never()).updateV4(any(), any());
+        }
+
+        static Stream<Arguments> domainValidationFailureCases() {
+            return Stream.of(
+                Arguments.of("{\"tags\":[\"forbidden\"]}", MERGE_PATCH_TYPE),
+                Arguments.of("[{\"op\":\"replace\",\"path\":\"/tags\",\"value\":[\"forbidden\"]}]", JSON_PATCH_TYPE)
+            );
+        }
+    }
+
+    // ---- Null field behavior ----
+
+    @ParameterizedTest
+    @MethodSource("nullOnRequiredFieldCases")
+    void setting_required_field_to_null_returns_400(String body, String contentType, String fieldName) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasMessageContaining(fieldName).hasMessageContaining("null");
+    }
+
+    static Stream<Arguments> nullOnRequiredFieldCases() {
+        return Stream.of(
+            Arguments.of("{\"name\":null}", MERGE_PATCH_TYPE, "name"),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":null}]", JSON_PATCH_TYPE, "name"),
+            Arguments.of("{\"apiVersion\":null}", MERGE_PATCH_TYPE, "apiVersion"),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/apiVersion\",\"value\":null}]", JSON_PATCH_TYPE, "apiVersion"),
+            Arguments.of("{\"visibility\":null}", MERGE_PATCH_TYPE, "visibility"),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/visibility\",\"value\":null}]", JSON_PATCH_TYPE, "visibility"),
+            Arguments.of("{\"lifecycleState\":null}", MERGE_PATCH_TYPE, "lifecycleState"),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/lifecycleState\",\"value\":null}]", JSON_PATCH_TYPE, "lifecycleState"),
+            Arguments.of("{\"allowedInApiProducts\":null}", MERGE_PATCH_TYPE, "allowedInApiProducts"),
+            Arguments.of("[{\"op\":\"add\",\"path\":\"/allowedInApiProducts\",\"value\":null}]", JSON_PATCH_TYPE, "allowedInApiProducts"),
+            Arguments.of("{\"allowMultiJwtOauth2Subscriptions\":null}", MERGE_PATCH_TYPE, "allowMultiJwtOauth2Subscriptions"),
+            Arguments.of(
+                "[{\"op\":\"replace\",\"path\":\"/allowMultiJwtOauth2Subscriptions\",\"value\":null}]",
+                JSON_PATCH_TYPE,
+                "allowMultiJwtOauth2Subscriptions"
+            ),
+            Arguments.of("{\"disableMembershipNotifications\":null}", MERGE_PATCH_TYPE, "disableMembershipNotifications"),
+            Arguments.of(
+                "[{\"op\":\"replace\",\"path\":\"/disableMembershipNotifications\",\"value\":null}]",
+                JSON_PATCH_TYPE,
+                "disableMembershipNotifications"
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullOnOptionalFieldCases")
+    void setting_optional_field_to_null_clears_it(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getDescription).isNull();
+    }
+
+    static Stream<Arguments> nullOnOptionalFieldCases() {
+        return Stream.of(
+            Arguments.of("{\"description\":null}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/description\",\"value\":null}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    // ---- Field update tests (both formats) ----
+
+    @ParameterizedTest
+    @MethodSource("nameUpdateVariants")
+    void should_update_name(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getName).isEqualTo("patched");
+    }
+
+    static Stream<Arguments> nameUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"name\":\"patched\"}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"patched\"}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("descriptionUpdateVariants")
+    void should_update_description(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getDescription).isEqualTo("new-description");
+    }
+
+    static Stream<Arguments> descriptionUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"description\":\"new-description\"}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"new-description\"}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("apiVersionUpdateVariants")
+    void should_update_api_version(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getApiVersion).isEqualTo("2.0.0");
+    }
+
+    static Stream<Arguments> apiVersionUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"apiVersion\":\"2.0.0\"}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/apiVersion\",\"value\":\"2.0.0\"}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("visibilityUpdateVariants")
+    void should_update_visibility(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(a -> a.getVisibility().name())
+            .isEqualTo("PRIVATE");
+    }
+
+    static Stream<Arguments> visibilityUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"visibility\":\"PRIVATE\"}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/visibility\",\"value\":\"PRIVATE\"}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("labelsUpdateVariants")
+    void should_update_labels(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getLabels)
+            .asList()
+            .containsExactlyInAnyOrder("infra", "prod");
+    }
+
+    static Stream<Arguments> labelsUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"labels\":[\"infra\",\"prod\"]}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/labels\",\"value\":[\"infra\",\"prod\"]}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("tagsUpdateVariants")
+    void should_update_tags(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getTags)
+            .asList()
+            .containsExactlyInAnyOrder("tag-a", "tag-b");
+    }
+
+    static Stream<Arguments> tagsUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"tags\":[\"tag-a\",\"tag-b\"]}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/tags\",\"value\":[\"tag-a\",\"tag-b\"]}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("lifecycleStateUpdateVariants")
+    void should_update_lifecycle_state(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(a -> a.getLifecycleState().name())
+            .isEqualTo("DEPRECATED");
+    }
+
+    static Stream<Arguments> lifecycleStateUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"lifecycleState\":\"DEPRECATED\"}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/lifecycleState\",\"value\":\"DEPRECATED\"}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("categoriesUpdateVariants")
+    void should_update_categories(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getCategories)
+            .asList()
+            .containsExactlyInAnyOrder("cat-a", "cat-b");
+    }
+
+    static Stream<Arguments> categoriesUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"categories\":[\"cat-a\",\"cat-b\"]}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/categories\",\"value\":[\"cat-a\",\"cat-b\"]}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("analyticsUpdateVariants")
+    void should_update_analytics(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(a -> a.getAnalytics().getEnabled())
+            .isEqualTo(true);
+    }
+
+    static Stream<Arguments> analyticsUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"analytics\":{\"enabled\":true}}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/analytics\",\"value\":{\"enabled\":true}}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("failoverUpdateVariants")
+    void should_update_failover(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(a -> a.getFailover().getEnabled())
+            .isEqualTo(true);
+    }
+
+    static Stream<Arguments> failoverUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"failover\":{\"enabled\":true}}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/failover\",\"value\":{\"enabled\":true}}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("flowExecutionUpdateVariants")
+    void should_update_flow_execution(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getFlowExecution)
+            .isEqualTo(new FlowExecution().mode(FlowMode.BEST_MATCH).matchRequired(true));
+    }
+
+    static Stream<Arguments> flowExecutionUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"flowExecution\":{\"mode\":\"BEST_MATCH\",\"matchRequired\":true}}", MERGE_PATCH_TYPE),
+            Arguments.of(
+                "[{\"op\":\"replace\",\"path\":\"/flowExecution\",\"value\":{\"mode\":\"BEST_MATCH\",\"matchRequired\":true}}]",
+                JSON_PATCH_TYPE
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("servicesUpdateVariants")
+    void should_update_services(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getServices).isEqualTo(new ApiServices());
+    }
+
+    static Stream<Arguments> servicesUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"services\":{}}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/services\",\"value\":{}}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("allowedInApiProductsUpdateVariants")
+    void should_update_allowed_in_api_products(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getAllowedInApiProducts).isEqualTo(true);
+    }
+
+    static Stream<Arguments> allowedInApiProductsUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"allowedInApiProducts\":true}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/allowedInApiProducts\",\"value\":true}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("allowMultiJwtOauth2UpdateVariants")
+    void should_update_allow_multi_jwt_oauth2_subscriptions(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getAllowMultiJwtOauth2Subscriptions).isEqualTo(true);
+    }
+
+    static Stream<Arguments> allowMultiJwtOauth2UpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"allowMultiJwtOauth2Subscriptions\":true}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/allowMultiJwtOauth2Subscriptions\",\"value\":true}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("disableMembershipNotificationsUpdateVariants")
+    void should_update_disable_membership_notifications(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).extracting(ApiV4::getDisableMembershipNotifications).isEqualTo(true);
+    }
+
+    static Stream<Arguments> disableMembershipNotificationsUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"disableMembershipNotifications\":true}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/disableMembershipNotifications\",\"value\":true}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("propertiesUpdateVariants")
+    void should_update_properties(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getProperties)
+            .asList()
+            .hasSize(1)
+            .first()
+            .satisfies(p -> {
+                var prop = (Property) p;
+                Assertions.assertThat(prop.getKey()).isEqualTo("foo");
+                Assertions.assertThat(prop.getValue()).isEqualTo("bar");
+            });
+    }
+
+    static Stream<Arguments> propertiesUpdateVariants() {
+        return Stream.of(
+            Arguments.of("{\"properties\":[{\"key\":\"foo\",\"value\":\"bar\"}]}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"add\",\"path\":\"/properties\",\"value\":[{\"key\":\"foo\",\"value\":\"bar\"}]}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("responseTemplatesUpdateVariants")
+    void should_update_response_templates(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getResponseTemplates)
+            .satisfies(templates -> {
+                Assertions.assertThat(templates).containsKey("FOO_KEY");
+                var fooTemplate = templates.get("FOO_KEY");
+                Assertions.assertThat(fooTemplate).containsKey("application/json");
+                var rt = fooTemplate.get("application/json");
+                Assertions.assertThat(rt.getStatusCode()).isEqualTo(400);
+                Assertions.assertThat(rt.getBody()).isEqualTo("{}");
+            });
+    }
+
+    static Stream<Arguments> responseTemplatesUpdateVariants() {
+        return Stream.of(
+            Arguments.of(
+                "{\"responseTemplates\":{\"FOO_KEY\":{\"application/json\":{\"statusCode\":400,\"body\":\"{}\"}}}}",
+                MERGE_PATCH_TYPE
+            ),
+            Arguments.of(
+                "[{\"op\":\"replace\",\"path\":\"/responseTemplates\",\"value\":{\"FOO_KEY\":{\"application/json\":{\"statusCode\":400,\"body\":\"{}\"}}}}]",
+                JSON_PATCH_TYPE
+            )
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -66,6 +66,7 @@ import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.JsonMergePatchService;
+import io.gravitee.apim.core.api.domain_service.JsonPatchService;
 import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiCRDDomainService;
@@ -225,6 +226,7 @@ import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapterImpl;
 import io.gravitee.apim.infra.domain_service.analytics_engine.definition.AnalyticsDefinitionYAMLQueryService;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.UnitEnrichmentPostProcessorImpl;
+import io.gravitee.apim.infra.domain_service.api.ApiJsonPatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.api.JsonMergePatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
@@ -573,8 +575,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ApiPatchDomainService apiPatchDomainService(JsonMergePatchService jsonMergePatchService) {
-        return new ApiPatchDomainService(jsonMergePatchService);
+    public JsonPatchService jsonPatchService() {
+        return new ApiJsonPatchServiceImpl();
+    }
+
+    @Bean
+    public ApiPatchDomainService apiPatchDomainService(JsonMergePatchService jsonMergePatchService, JsonPatchService jsonPatchService) {
+        return new ApiPatchDomainService(jsonMergePatchService, jsonPatchService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -170,6 +170,7 @@ import io.gravitee.apim.infra.adapter.SubscriptionAdapterImpl;
 import io.gravitee.apim.infra.domain_service.analytics_engine.definition.AnalyticsDefinitionYAMLQueryService;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.UnitEnrichmentPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.api.ApiHostValidatorDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.api.ApiJsonPatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.api.JsonMergePatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
@@ -781,8 +782,16 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ApiPatchDomainService apiPatchDomainService(JsonMergePatchService jsonMergePatchService) {
-        return new ApiPatchDomainService(jsonMergePatchService);
+    public io.gravitee.apim.core.api.domain_service.JsonPatchService domainJsonPatchService() {
+        return new ApiJsonPatchServiceImpl();
+    }
+
+    @Bean
+    public ApiPatchDomainService apiPatchDomainService(
+        JsonMergePatchService jsonMergePatchService,
+        io.gravitee.apim.core.api.domain_service.JsonPatchService jsonPatchService
+    ) {
+        return new ApiPatchDomainService(jsonMergePatchService, jsonPatchService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -58,6 +58,7 @@ import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.JsonMergePatchService;
+import io.gravitee.apim.core.api.domain_service.JsonPatchService;
 import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
@@ -177,6 +178,7 @@ import io.gravitee.apim.infra.adapter.SubscriptionAdapterImpl;
 import io.gravitee.apim.infra.domain_service.analytics_engine.definition.AnalyticsDefinitionYAMLQueryService;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.UnitEnrichmentPostProcessorImpl;
 import io.gravitee.apim.infra.domain_service.api.ApiHostValidatorDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.api.ApiJsonPatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.api.JsonMergePatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
@@ -748,8 +750,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ApiPatchDomainService apiPatchDomainService(JsonMergePatchService jsonMergePatchService) {
-        return new ApiPatchDomainService(jsonMergePatchService);
+    public JsonPatchService jsonPatchService() {
+        return new ApiJsonPatchServiceImpl();
+    }
+
+    @Bean
+    public ApiPatchDomainService apiPatchDomainService(JsonMergePatchService jsonMergePatchService, JsonPatchService jsonPatchService) {
+        return new ApiPatchDomainService(jsonMergePatchService, jsonPatchService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/JsonPatchService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/JsonPatchService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+public interface JsonPatchService {
+    JsonNode applyJsonPatch(JsonNode patch, JsonNode target) throws ValidationDomainException;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.api.use_case;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,8 +38,12 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.logging.Logging;
+import io.gravitee.definition.model.v4.analytics.sampling.Sampling;
+import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import java.util.ArrayList;
@@ -45,6 +51,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 
@@ -55,10 +62,18 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PatchApiUseCase {
 
+    private static final String FIELD_NAME = "name";
     private static final String FIELD_DESCRIPTION = "description";
     private static final String FIELD_API_VERSION = "apiVersion";
     private static final String FIELD_VISIBILITY = "visibility";
+    private static final String FIELD_LABELS = "labels";
+    private static final String FIELD_TAGS = "tags";
     private static final String FIELD_LIFECYCLE_STATE = "lifecycleState";
+    private static final String FIELD_CATEGORIES = "categories";
+    private static final String FIELD_ANALYTICS = "analytics";
+    private static final String FIELD_FAILOVER = "failover";
+    private static final String FIELD_FLOW_EXECUTION = "flowExecution";
+    private static final String FIELD_SERVICES = "services";
     private static final String FIELD_ALLOWED_IN_API_PRODUCTS = "allowedInApiProducts";
     private static final String FIELD_ALLOW_MULTI_JWT_OAUTH2_SUBSCRIPTIONS = "allowMultiJwtOauth2Subscriptions";
     private static final String FIELD_DISABLE_MEMBERSHIP_NOTIFICATIONS = "disableMembershipNotifications";
@@ -66,18 +81,18 @@ public class PatchApiUseCase {
     private static final String FIELD_RESPONSE_TEMPLATES = "responseTemplates";
 
     private static final Set<String> ALLOWED_FIELDS = Set.of(
-        "name",
+        FIELD_NAME,
         FIELD_DESCRIPTION,
         FIELD_API_VERSION,
         FIELD_VISIBILITY,
-        "labels",
-        "tags",
+        FIELD_LABELS,
+        FIELD_TAGS,
         FIELD_LIFECYCLE_STATE,
-        "categories",
-        "analytics",
-        "failover",
-        "flowExecution",
-        "services",
+        FIELD_CATEGORIES,
+        FIELD_ANALYTICS,
+        FIELD_FAILOVER,
+        FIELD_FLOW_EXECUTION,
+        FIELD_SERVICES,
         FIELD_ALLOWED_IN_API_PRODUCTS,
         FIELD_ALLOW_MULTI_JWT_OAUTH2_SUBSCRIPTIONS,
         FIELD_DISABLE_MEMBERSHIP_NOTIFICATIONS,
@@ -85,8 +100,13 @@ public class PatchApiUseCase {
         FIELD_RESPONSE_TEMPLATES
     );
 
+    private static final int MAX_PATCH_OPS = 200;
+
     private static final Set<String> BLOCKED_WITH_HINT = Set.of("state");
     private static final Set<String> BLOCKED_WITHOUT_HINT = Set.of("flows", "endpointGroups", "listeners", "resources");
+
+    private static final String NULL_NOT_ALLOWED_MESSAGE_FORMAT =
+        "'%s' cannot be null; omit the field to leave it unchanged, or send an explicit value";
 
     private final ApiCrudService apiCrudService;
     private final ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService;
@@ -108,16 +128,16 @@ public class PatchApiUseCase {
         var currentNode = toJsonNode(existingApi);
         var patchNode = parseBody(input.patchBody());
 
-        enforceAllowList(patchNode);
+        enforceAllowList(input.patchType(), patchNode);
 
-        var patchedNode = apiPatchDomainService.applyMergePatch(patchNode, currentNode);
+        var patchedNode = applyPatch(input.patchType(), patchNode, currentNode);
 
         var primaryOwner = apiPrimaryOwnerDomainService.getApiPrimaryOwner(input.auditInfo().organizationId(), input.apiId());
 
         var workflows = workflowQueryService.findAllByApiIdAndType(input.apiId(), Workflow.Type.REVIEW);
         var workflowState = workflows.isEmpty() ? null : workflows.get(0).getState();
 
-        var updatedApi = applyPatchedValues(existingApi, patchedNode, patchNode);
+        var updatedApi = applyPatchedValues(existingApi, patchedNode, input.patchType(), patchNode);
 
         if (input.dryRun()) {
             var validated = updateApiDomainService.validateV4(updatedApi, input.auditInfo());
@@ -129,33 +149,14 @@ public class PatchApiUseCase {
     }
 
     private JsonNode toJsonNode(Api api) {
-        var view = buildPatchableView(api);
-        return objectMapper.valueToTree(view);
+        return objectMapper.valueToTree(PatchableView.from(api, requireHttpV4(api)));
     }
 
-    private PatchableView buildPatchableView(Api api) {
-        if (!(api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api httpV4)) {
-            throw new IllegalStateException("API definition is not an HTTP v4 definition");
+    private static io.gravitee.definition.model.v4.Api requireHttpV4(Api api) {
+        if (api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api httpV4) {
+            return httpV4;
         }
-        return new PatchableView(
-            api.getName(),
-            api.getDescription(),
-            api.getVersion(),
-            api.getVisibility() != null ? api.getVisibility().name() : null,
-            api.getLabels(),
-            httpV4.getTags(),
-            api.getApiLifecycleState() != null ? api.getApiLifecycleState().name() : null,
-            api.getCategories(),
-            httpV4.getAnalytics(),
-            httpV4.getFailover(),
-            httpV4.getFlowExecution(),
-            httpV4.getServices(),
-            httpV4.getAllowedInApiProducts(),
-            api.isAllowMultiJwtOauth2Subscriptions(),
-            api.isDisableMembershipNotifications(),
-            httpV4.getProperties(),
-            httpV4.getResponseTemplates()
-        );
+        throw new IllegalStateException("API definition is not an HTTP v4 definition");
     }
 
     private JsonNode parseBody(String body) {
@@ -169,14 +170,89 @@ public class PatchApiUseCase {
         }
     }
 
-    private void enforceAllowList(JsonNode patchNode) {
-        if (!patchNode.isObject()) {
+    private void enforceAllowList(PatchType patchType, JsonNode patchNode) {
+        if (patchType == PatchType.JSON_PATCH) {
+            enforceAllowListJsonPatch(patchNode);
+        } else {
+            enforceAllowListMergePatch(patchNode);
+        }
+    }
+
+    private void enforceAllowListJsonPatch(JsonNode patchArray) {
+        if (!patchArray.isArray()) {
+            throw new ValidationDomainException("JSON Patch body must be a JSON array");
+        }
+        if (patchArray.size() > MAX_PATCH_OPS) {
+            throw new ValidationDomainException("JSON Patch request exceeds maximum of " + MAX_PATCH_OPS + " operations");
+        }
+        var index = 0;
+        for (JsonNode op : patchArray) {
+            var pathNode = op.path("path");
+            if (pathNode.isMissingNode() || !pathNode.isTextual()) {
+                throw new ValidationDomainException("JSON Patch operation at index " + index + " is missing required 'path' field");
+            }
+            validateJsonPatchField(index, "path", pathNode.asText());
+            var opType = op.path("op").asText();
+            if ("move".equals(opType) || "copy".equals(opType)) {
+                var fromNode = op.path("from");
+                if (fromNode.isMissingNode()) {
+                    throw new ValidationDomainException("JSON Patch operation at index " + index + " is missing required 'from' field");
+                }
+                if (!fromNode.isTextual()) {
+                    throw new ValidationDomainException(
+                        "JSON Patch operation at index " + index + " has invalid 'from' field: must be a string"
+                    );
+                }
+                validateJsonPatchField(index, "from", fromNode.asText());
+            }
+            index++;
+        }
+    }
+
+    private void validateJsonPatchField(int opIndex, String pointerName, String pointer) {
+        if (!pointer.isEmpty() && !pointer.startsWith("/")) {
+            throw new ValidationDomainException(
+                "JSON Patch operation at index " +
+                    opIndex +
+                    " has '" +
+                    pointerName +
+                    "' value '" +
+                    pointer +
+                    "' which is not a valid JSON Pointer: must start with '/'"
+            );
+        }
+        var field = extractTopLevelField(pointer);
+        if (field.isEmpty()) {
+            throw new ValidationDomainException(
+                "JSON Patch operation at index " +
+                    opIndex +
+                    " has '" +
+                    pointerName +
+                    "' value '" +
+                    pointer +
+                    "' which does not target a specific field"
+            );
+        }
+        validateField(field);
+    }
+
+    private void enforceAllowListMergePatch(JsonNode mergePatchNode) {
+        if (!mergePatchNode.isObject()) {
             throw new ValidationDomainException("JSON Merge Patch body must be a JSON object");
         }
-        var fieldNames = patchNode.fieldNames();
+        var fieldNames = mergePatchNode.fieldNames();
         while (fieldNames.hasNext()) {
             validateField(fieldNames.next());
         }
+    }
+
+    private String extractTopLevelField(String jsonPointer) {
+        if (jsonPointer == null || jsonPointer.isEmpty()) {
+            return "";
+        }
+        var withoutLeadingSlash = jsonPointer.startsWith("/") ? jsonPointer.substring(1) : jsonPointer;
+        var slashIndex = withoutLeadingSlash.indexOf('/');
+        return slashIndex < 0 ? withoutLeadingSlash : withoutLeadingSlash.substring(0, slashIndex);
     }
 
     private void validateField(String field) {
@@ -191,74 +267,75 @@ public class PatchApiUseCase {
         }
     }
 
-    private Api applyPatchedValues(Api existingApi, JsonNode patchedNode, JsonNode rawPatchNode) {
-        if (!(existingApi.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api httpV4)) {
-            throw new IllegalStateException("API definition is not an HTTP v4 definition");
+    private JsonNode applyPatch(PatchType patchType, JsonNode patchNode, JsonNode currentNode) {
+        if (patchType == PatchType.JSON_PATCH) {
+            return apiPatchDomainService.applyJsonPatch(patchNode, currentNode);
         }
+        return apiPatchDomainService.applyMergePatch(patchNode, currentNode);
+    }
 
-        rejectExplicitNullOnNonNullable(rawPatchNode, "name");
-        var name = textOrDefault(patchedNode, "name", existingApi.getName());
-        rejectExplicitNullOnNonNullable(rawPatchNode, FIELD_DESCRIPTION);
-        var description = textOrDefault(patchedNode, FIELD_DESCRIPTION, existingApi.getDescription());
-        rejectExplicitNullOnNonNullable(rawPatchNode, FIELD_API_VERSION);
+    private Api applyPatchedValues(Api existingApi, JsonNode patchedNode, PatchType patchType, JsonNode rawPatchNode) {
+        var httpV4 = requireHttpV4(existingApi);
+
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, FIELD_NAME);
+        var name = textOrDefault(patchedNode, FIELD_NAME, existingApi.getName());
+        var description = resolveNullableString(patchType, rawPatchNode, patchedNode, FIELD_DESCRIPTION, existingApi.getDescription());
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, FIELD_API_VERSION);
         var apiVersion = textOrDefault(patchedNode, FIELD_API_VERSION, existingApi.getVersion());
 
-        rejectExplicitNullOnNonNullable(rawPatchNode, FIELD_VISIBILITY);
-        var visibility = readVisibility(patchedNode, existingApi.getVisibility());
-        rejectExplicitNullOnNonNullable(rawPatchNode, FIELD_LIFECYCLE_STATE);
-        var lifecycleState = readLifecycleState(patchedNode, existingApi.getApiLifecycleState());
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, FIELD_VISIBILITY);
+        var visibility = readEnum(patchedNode, FIELD_VISIBILITY, Api.Visibility.class, existingApi.getVisibility(), FIELD_VISIBILITY);
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, FIELD_LIFECYCLE_STATE);
+        var lifecycleState = readEnum(
+            patchedNode,
+            FIELD_LIFECYCLE_STATE,
+            Api.ApiLifecycleState.class,
+            existingApi.getApiLifecycleState(),
+            FIELD_LIFECYCLE_STATE
+        );
 
-        var labels = resolveNullableList(rawPatchNode, patchedNode, "labels", existingApi.getLabels());
-        var categories = resolveNullableSet(rawPatchNode, patchedNode, "categories", existingApi.getCategories());
-        var tags = resolveNullableSet(rawPatchNode, patchedNode, "tags", httpV4.getTags());
+        var labels = resolveNullableList(patchType, rawPatchNode, patchedNode, FIELD_LABELS, existingApi.getLabels());
+        var categories = resolveNullableSet(patchType, rawPatchNode, patchedNode, FIELD_CATEGORIES, existingApi.getCategories());
+        var tags = resolveNullableSet(patchType, rawPatchNode, patchedNode, FIELD_TAGS, httpV4.getTags());
 
-        var analytics = resolveNullableObject(rawPatchNode, patchedNode, "analytics", Analytics.class, httpV4.getAnalytics());
-        var failover = resolveNullableObject(rawPatchNode, patchedNode, "failover", Failover.class, httpV4.getFailover());
-        var flowExecution = resolveNullableObject(
+        var patchableAnalytics = resolveNullableObject(
+            patchType,
             rawPatchNode,
             patchedNode,
-            "flowExecution",
-            FlowExecution.class,
-            httpV4.getFlowExecution()
+            FIELD_ANALYTICS,
+            PatchableAnalytics.class,
+            PatchableAnalytics.from(httpV4.getAnalytics())
         );
-        var services = resolveNullableObject(rawPatchNode, patchedNode, "services", ApiServices.class, httpV4.getServices());
+        var analytics = patchableAnalytics != null ? patchableAnalytics.toDomain() : null;
+        var failover = resolveNullableObject(patchType, rawPatchNode, patchedNode, FIELD_FAILOVER, Failover.class, httpV4.getFailover());
+        var patchableFlowExecution = resolveNullableObject(
+            patchType,
+            rawPatchNode,
+            patchedNode,
+            FIELD_FLOW_EXECUTION,
+            PatchableFlowExecution.class,
+            PatchableFlowExecution.from(httpV4.getFlowExecution())
+        );
+        var flowExecution = patchableFlowExecution != null ? patchableFlowExecution.toDomain() : null;
+        var services = resolveNullableObject(patchType, rawPatchNode, patchedNode, FIELD_SERVICES, ApiServices.class, httpV4.getServices());
 
-        rejectExplicitNullOnNonNullable(rawPatchNode, FIELD_ALLOWED_IN_API_PRODUCTS);
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, FIELD_ALLOWED_IN_API_PRODUCTS);
         var allowedInApiProducts = readBooleanObject(patchedNode, FIELD_ALLOWED_IN_API_PRODUCTS, httpV4.getAllowedInApiProducts());
-        rejectExplicitNullOnNonNullable(rawPatchNode, FIELD_ALLOW_MULTI_JWT_OAUTH2_SUBSCRIPTIONS);
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, FIELD_ALLOW_MULTI_JWT_OAUTH2_SUBSCRIPTIONS);
         var allowMultiJwt = readBoolean(
             patchedNode,
             FIELD_ALLOW_MULTI_JWT_OAUTH2_SUBSCRIPTIONS,
             existingApi.isAllowMultiJwtOauth2Subscriptions()
         );
-        rejectExplicitNullOnNonNullable(rawPatchNode, FIELD_DISABLE_MEMBERSHIP_NOTIFICATIONS);
+        rejectExplicitNullOnNonNullable(patchType, rawPatchNode, FIELD_DISABLE_MEMBERSHIP_NOTIFICATIONS);
         var disableMembershipNotifications = readBoolean(
             patchedNode,
             FIELD_DISABLE_MEMBERSHIP_NOTIFICATIONS,
             existingApi.isDisableMembershipNotifications()
         );
 
-        var properties = httpV4.getProperties();
-        if (rawPatchNode.has(FIELD_PROPERTIES)) {
-            if (rawPatchNode.get(FIELD_PROPERTIES).isNull()) {
-                properties = List.of();
-            } else {
-                properties = readList(patchedNode, FIELD_PROPERTIES, Property.class, null);
-            }
-        }
-
-        var responseTemplates = httpV4.getResponseTemplates();
-        if (rawPatchNode.has(FIELD_RESPONSE_TEMPLATES)) {
-            if (rawPatchNode.get(FIELD_RESPONSE_TEMPLATES).isNull()) {
-                responseTemplates = null;
-            } else {
-                try {
-                    responseTemplates = objectMapper.treeToValue(patchedNode.get(FIELD_RESPONSE_TEMPLATES), new TypeReference<>() {});
-                } catch (Exception e) {
-                    throw new ValidationDomainException("Invalid value for field 'responseTemplates': " + e.getMessage());
-                }
-            }
-        }
+        var properties = resolveProperties(patchType, rawPatchNode, patchedNode, httpV4.getProperties());
+        var responseTemplates = resolveResponseTemplates(patchType, rawPatchNode, patchedNode, httpV4.getResponseTemplates());
 
         var updatedDefinition = httpV4
             .toBuilder()
@@ -290,37 +367,186 @@ public class PatchApiUseCase {
             .build();
     }
 
-    private boolean isExplicitNull(JsonNode rawPatchNode, String field) {
-        return rawPatchNode.has(field) && rawPatchNode.get(field).isNull();
+    private List<Property> resolveProperties(PatchType patchType, JsonNode rawPatchNode, JsonNode patchedNode, List<Property> existing) {
+        if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has(FIELD_PROPERTIES)) {
+            if (rawPatchNode.get(FIELD_PROPERTIES).isNull()) {
+                return null;
+            }
+            return readList(patchedNode, FIELD_PROPERTIES, Property.class, null);
+        }
+        if (patchType == PatchType.JSON_PATCH) {
+            if (patchedNode.get(FIELD_PROPERTIES) == null && isRemovedByJsonPatch(patchType, rawPatchNode, FIELD_PROPERTIES)) {
+                return null;
+            }
+            if (patchedNode.has(FIELD_PROPERTIES)) {
+                if (patchedNode.get(FIELD_PROPERTIES).isNull() && isNullReplacedByJsonPatch(rawPatchNode, FIELD_PROPERTIES)) {
+                    return null;
+                }
+                return readList(patchedNode, FIELD_PROPERTIES, Property.class, existing);
+            }
+        }
+        return existing;
     }
 
-    private void rejectExplicitNullOnNonNullable(JsonNode rawPatchNode, String field) {
-        if (isExplicitNull(rawPatchNode, field)) {
-            throw new ValidationDomainException(
-                "'" + field + "' cannot be null; omit the field to leave it unchanged, or send an explicit value"
+    private Map<String, Map<String, ResponseTemplate>> resolveResponseTemplates(
+        PatchType patchType,
+        JsonNode rawPatchNode,
+        JsonNode patchedNode,
+        Map<String, Map<String, ResponseTemplate>> existing
+    ) {
+        if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has(FIELD_RESPONSE_TEMPLATES)) {
+            if (rawPatchNode.get(FIELD_RESPONSE_TEMPLATES).isNull()) {
+                return null;
+            }
+            return parseResponseTemplates(patchedNode);
+        }
+        if (patchType == PatchType.JSON_PATCH) {
+            if (
+                patchedNode.get(FIELD_RESPONSE_TEMPLATES) == null && isRemovedByJsonPatch(patchType, rawPatchNode, FIELD_RESPONSE_TEMPLATES)
+            ) {
+                return null;
+            }
+            if (patchedNode.has(FIELD_RESPONSE_TEMPLATES)) {
+                if (
+                    patchedNode.get(FIELD_RESPONSE_TEMPLATES).isNull() && isNullReplacedByJsonPatch(rawPatchNode, FIELD_RESPONSE_TEMPLATES)
+                ) {
+                    return null;
+                }
+                return parseResponseTemplates(patchedNode);
+            }
+        }
+        return existing;
+    }
+
+    private Map<String, Map<String, ResponseTemplate>> parseResponseTemplates(JsonNode patchedNode) {
+        try {
+            var patchable = objectMapper.treeToValue(
+                patchedNode.get(FIELD_RESPONSE_TEMPLATES),
+                new TypeReference<Map<String, Map<String, PatchableResponseTemplate>>>() {}
             );
+            return fromPatchableResponseTemplates(patchable);
+        } catch (JsonProcessingException e) {
+            throw new ValidationDomainException("Invalid value for field 'responseTemplates': " + e.getMessage());
         }
     }
 
-    private List<String> resolveNullableList(JsonNode rawPatchNode, JsonNode patchedNode, String field, List<String> existing) {
-        if (isExplicitNull(rawPatchNode, field)) {
+    private static Map<String, Map<String, ResponseTemplate>> fromPatchableResponseTemplates(
+        Map<String, Map<String, PatchableResponseTemplate>> patchable
+    ) {
+        if (patchable == null) {
+            return null;
+        }
+        return patchable
+            .entrySet()
+            .stream()
+            .collect(
+                Collectors.toMap(Map.Entry::getKey, e ->
+                    (e.getValue() == null ? Map.<String, PatchableResponseTemplate>of() : e.getValue()).entrySet()
+                        .stream()
+                        .filter(inner -> inner.getValue() != null)
+                        .collect(Collectors.toMap(Map.Entry::getKey, inner -> inner.getValue().toDomain()))
+                )
+            );
+    }
+
+    private boolean isExplicitNull(PatchType patchType, JsonNode rawPatchNode, String field) {
+        return patchType == PatchType.MERGE_PATCH && rawPatchNode.has(field) && rawPatchNode.get(field).isNull();
+    }
+
+    private boolean isRemovedByJsonPatch(PatchType patchType, JsonNode rawPatchNode, String field) {
+        if (patchType != PatchType.JSON_PATCH) {
+            return false;
+        }
+        for (JsonNode op : rawPatchNode) {
+            if ("remove".equals(op.path("op").asText()) && ("/" + field).equals(op.path("path").asText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isNullReplacedByJsonPatch(JsonNode rawPatchNode, String field) {
+        for (JsonNode op : rawPatchNode) {
+            String opType = op.path("op").asText();
+            JsonNode value = op.get("value");
+            if (
+                ("/" + field).equals(op.path("path").asText()) &&
+                ("replace".equals(opType) || "add".equals(opType)) &&
+                value != null &&
+                value.isNull()
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void rejectExplicitNullOnNonNullable(PatchType patchType, JsonNode rawPatchNode, String field) {
+        boolean nullified = switch (patchType) {
+            case MERGE_PATCH -> isExplicitNull(patchType, rawPatchNode, field);
+            case JSON_PATCH -> isRemovedByJsonPatch(patchType, rawPatchNode, field) || isNullReplacedByJsonPatch(rawPatchNode, field);
+        };
+        if (nullified) {
+            throw new ValidationDomainException(NULL_NOT_ALLOWED_MESSAGE_FORMAT.formatted(field));
+        }
+    }
+
+    private boolean shouldNullify(PatchType patchType, JsonNode rawPatchNode, JsonNode patchedNode, String field) {
+        if (isExplicitNull(patchType, rawPatchNode, field)) {
+            return true;
+        }
+        var fieldNode = patchedNode.get(field);
+        if (fieldNode != null && fieldNode.isNull()) {
+            return true;
+        }
+        return fieldNode == null && isRemovedByJsonPatch(patchType, rawPatchNode, field);
+    }
+
+    private List<String> resolveNullableList(
+        PatchType patchType,
+        JsonNode rawPatchNode,
+        JsonNode patchedNode,
+        String field,
+        List<String> existing
+    ) {
+        if (shouldNullify(patchType, rawPatchNode, patchedNode, field)) {
             return new ArrayList<>();
         }
         return readStringList(patchedNode, field, existing);
     }
 
-    private Set<String> resolveNullableSet(JsonNode rawPatchNode, JsonNode patchedNode, String field, Set<String> existing) {
-        if (isExplicitNull(rawPatchNode, field)) {
+    private Set<String> resolveNullableSet(
+        PatchType patchType,
+        JsonNode rawPatchNode,
+        JsonNode patchedNode,
+        String field,
+        Set<String> existing
+    ) {
+        if (shouldNullify(patchType, rawPatchNode, patchedNode, field)) {
             return new HashSet<>();
         }
         return readStringSet(patchedNode, field, existing);
     }
 
-    private <T> T resolveNullableObject(JsonNode rawPatchNode, JsonNode patchedNode, String field, Class<T> type, T existing) {
-        if (isExplicitNull(rawPatchNode, field)) {
+    private <T> T resolveNullableObject(
+        PatchType patchType,
+        JsonNode rawPatchNode,
+        JsonNode patchedNode,
+        String field,
+        Class<T> type,
+        T existing
+    ) {
+        if (shouldNullify(patchType, rawPatchNode, patchedNode, field)) {
             return null;
         }
         return readObject(patchedNode, field, type, existing);
+    }
+
+    private String resolveNullableString(PatchType patchType, JsonNode rawPatchNode, JsonNode patchedNode, String field, String existing) {
+        if (shouldNullify(patchType, rawPatchNode, patchedNode, field)) {
+            return null;
+        }
+        return textOrDefault(patchedNode, field, existing);
     }
 
     private String textOrDefault(JsonNode node, String field, String defaultValue) {
@@ -331,27 +557,15 @@ public class PatchApiUseCase {
         return fieldNode.asText(defaultValue);
     }
 
-    private Api.Visibility readVisibility(JsonNode node, Api.Visibility defaultValue) {
-        var fieldNode = node.get(FIELD_VISIBILITY);
+    private <E extends Enum<E>> E readEnum(JsonNode node, String field, Class<E> type, E defaultValue, String errorLabel) {
+        var fieldNode = node.get(field);
         if (fieldNode == null || fieldNode.isNull()) {
             return defaultValue;
         }
         try {
-            return Api.Visibility.valueOf(fieldNode.asText());
+            return Enum.valueOf(type, fieldNode.asText());
         } catch (IllegalArgumentException e) {
-            throw new ValidationDomainException("Invalid visibility value: " + fieldNode.asText());
-        }
-    }
-
-    private Api.ApiLifecycleState readLifecycleState(JsonNode node, Api.ApiLifecycleState defaultValue) {
-        var fieldNode = node.get(FIELD_LIFECYCLE_STATE);
-        if (fieldNode == null || fieldNode.isNull()) {
-            return defaultValue;
-        }
-        try {
-            return Api.ApiLifecycleState.valueOf(fieldNode.asText());
-        } catch (IllegalArgumentException e) {
-            throw new ValidationDomainException("Invalid lifecycleState value: " + fieldNode.asText());
+            throw new ValidationDomainException("Invalid " + errorLabel + " value: " + fieldNode.asText());
         }
     }
 
@@ -423,6 +637,7 @@ public class PatchApiUseCase {
     }
 
     public enum PatchType {
+        JSON_PATCH,
         MERGE_PATCH,
     }
 
@@ -431,6 +646,71 @@ public class PatchApiUseCase {
 
     public record Output(Api api, PrimaryOwnerEntity primaryOwner, Workflow.State workflowState) {}
 
+    record PatchableFlowExecution(String mode, boolean matchRequired) {
+        static PatchableFlowExecution from(FlowExecution domain) {
+            if (domain == null) {
+                return null;
+            }
+            return new PatchableFlowExecution(
+                domain.getMode() != null ? domain.getMode().name() : FlowMode.DEFAULT.name(),
+                domain.isMatchRequired()
+            );
+        }
+
+        FlowExecution toDomain() {
+            if (mode == null) {
+                throw new ValidationDomainException("Invalid flowExecution.mode value: null");
+            }
+            FlowMode resolvedMode;
+            try {
+                resolvedMode = FlowMode.valueOf(mode);
+            } catch (IllegalArgumentException e) {
+                throw new ValidationDomainException("Invalid flowExecution.mode value: " + mode);
+            }
+            var execution = new FlowExecution();
+            execution.setMode(resolvedMode);
+            execution.setMatchRequired(matchRequired);
+            return execution;
+        }
+    }
+
+    record PatchableAnalytics(boolean enabled, Sampling sampling, Logging logging, Tracing tracing) {
+        static PatchableAnalytics from(Analytics domain) {
+            if (domain == null) {
+                return null;
+            }
+            return new PatchableAnalytics(domain.isEnabled(), domain.getMessageSampling(), domain.getLogging(), domain.getTracing());
+        }
+
+        Analytics toDomain() {
+            return Analytics.builder().enabled(enabled).messageSampling(sampling).logging(logging).tracing(tracing).build();
+        }
+    }
+
+    record PatchableResponseTemplate(Integer statusCode, Map<String, String> headers, String body, Boolean propagateErrorKeyToLogs) {
+        static PatchableResponseTemplate from(ResponseTemplate domain) {
+            if (domain == null) {
+                return null;
+            }
+            return new PatchableResponseTemplate(
+                domain.getStatusCode(),
+                domain.getHeaders(),
+                domain.getBody(),
+                domain.isPropagateErrorKeyToLogs()
+            );
+        }
+
+        ResponseTemplate toDomain() {
+            return ResponseTemplate.builder()
+                .statusCode(statusCode != null ? statusCode : 0)
+                .headers(headers)
+                .body(body)
+                .propagateErrorKeyToLogs(propagateErrorKeyToLogs != null && propagateErrorKeyToLogs)
+                .build();
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     record PatchableView(
         String name,
         String description,
@@ -440,14 +720,55 @@ public class PatchApiUseCase {
         Set<String> tags,
         String lifecycleState,
         Set<String> categories,
-        Analytics analytics,
+        PatchableAnalytics analytics,
         Failover failover,
-        FlowExecution flowExecution,
+        PatchableFlowExecution flowExecution,
         ApiServices services,
         Boolean allowedInApiProducts,
         boolean allowMultiJwtOauth2Subscriptions,
         boolean disableMembershipNotifications,
         List<Property> properties,
-        Map<String, Map<String, ResponseTemplate>> responseTemplates
-    ) {}
+        Map<String, Map<String, PatchableResponseTemplate>> responseTemplates
+    ) {
+        static PatchableView from(Api api, io.gravitee.definition.model.v4.Api httpV4) {
+            return new PatchableView(
+                api.getName(),
+                api.getDescription(),
+                api.getVersion(),
+                api.getVisibility() != null ? api.getVisibility().name() : null,
+                api.getLabels(),
+                httpV4.getTags(),
+                api.getApiLifecycleState() != null ? api.getApiLifecycleState().name() : null,
+                api.getCategories(),
+                PatchableAnalytics.from(httpV4.getAnalytics()),
+                httpV4.getFailover(),
+                PatchableFlowExecution.from(httpV4.getFlowExecution()),
+                httpV4.getServices(),
+                httpV4.getAllowedInApiProducts(),
+                api.isAllowMultiJwtOauth2Subscriptions(),
+                api.isDisableMembershipNotifications(),
+                httpV4.getProperties(),
+                toPatchableResponseTemplates(httpV4.getResponseTemplates())
+            );
+        }
+
+        private static Map<String, Map<String, PatchableResponseTemplate>> toPatchableResponseTemplates(
+            Map<String, Map<String, ResponseTemplate>> templates
+        ) {
+            if (templates == null) {
+                return null;
+            }
+            return templates
+                .entrySet()
+                .stream()
+                .collect(
+                    Collectors.toMap(Map.Entry::getKey, e ->
+                        (e.getValue() == null ? Map.<String, ResponseTemplate>of() : e.getValue()).entrySet()
+                            .stream()
+                            .filter(inner -> inner.getValue() != null)
+                            .collect(Collectors.toMap(Map.Entry::getKey, inner -> PatchableResponseTemplate.from(inner.getValue())))
+                    )
+                );
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiJsonPatchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiJsonPatchServiceImpl.java
@@ -13,34 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.api.domain_service;
+package io.gravitee.apim.infra.domain_service.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import io.gravitee.apim.core.DomainService;
+import com.github.fge.jsonpatch.JsonPatch;
+import com.github.fge.jsonpatch.JsonPatchException;
+import io.gravitee.apim.core.api.domain_service.JsonPatchService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
-import lombok.RequiredArgsConstructor;
+import java.io.IOException;
+import org.springframework.stereotype.Service;
 
 /**
  * @author GraviteeSource Team
  */
-@DomainService
-@RequiredArgsConstructor
-public class ApiPatchDomainService {
+@Service
+public class ApiJsonPatchServiceImpl implements JsonPatchService {
 
-    private final JsonMergePatchService jsonMergePatchService;
-    private final JsonPatchService jsonPatchService;
-
-    public JsonNode applyMergePatch(JsonNode patch, JsonNode target) throws ValidationDomainException {
-        if (!patch.isObject()) {
-            throw new ValidationDomainException("Invalid patch: a merge patch must be a JSON object");
-        }
-        return jsonMergePatchService.applyMergePatch(patch, target);
-    }
-
+    @Override
     public JsonNode applyJsonPatch(JsonNode patch, JsonNode target) throws ValidationDomainException {
-        if (!patch.isArray()) {
-            throw new ValidationDomainException("Invalid patch: a JSON patch must be an array");
+        try {
+            return JsonPatch.fromJson(patch).apply(target);
+        } catch (JsonPatchException e) {
+            throw new ValidationDomainException("Failed to apply patch: " + e.getMessage(), e);
+        } catch (IOException e) {
+            throw new ValidationDomainException("Invalid patch: " + e.getMessage(), e);
         }
-        return jsonPatchService.applyJsonPatch(patch, target);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.api.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,7 +26,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.AuditInfoFixtures;
 import inmemory.ApiCrudServiceInMemory;
@@ -35,19 +38,35 @@ import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.exception.ApiInvalidDefinitionVersionException;
 import io.gravitee.apim.core.api.exception.ApiInvalidTypeException;
 import io.gravitee.apim.core.api.exception.ApiPatchNotAllowedException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.infra.domain_service.api.ApiJsonPatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.api.JsonMergePatchServiceImpl;
+import io.gravitee.apim.infra.json.jackson.JsonMapperFactory;
 import io.gravitee.definition.model.ResponseTemplate;
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.sampling.SamplingType;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
+import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.service.ApiServices;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PatchApiUseCaseTest {
@@ -57,11 +76,12 @@ class PatchApiUseCaseTest {
     private static final String ENVIRONMENT_ID = "environment-id";
     private static final String USER_ID = "user-id";
 
+    static final ObjectMapper OBJECT_MAPPER = JsonMapperFactory.build();
+
     ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     WorkflowQueryServiceInMemory workflowQueryService = new WorkflowQueryServiceInMemory();
     ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService = mock(ApiPrimaryOwnerDomainService.class);
     UpdateApiDomainService updateApiDomainService = mock(UpdateApiDomainService.class);
-    ObjectMapper objectMapper = new ObjectMapper();
 
     PatchApiUseCase cut;
 
@@ -71,318 +91,165 @@ class PatchApiUseCaseTest {
             apiCrudService,
             apiPrimaryOwnerDomainService,
             updateApiDomainService,
-            new ApiPatchDomainService(new JsonMergePatchServiceImpl()),
+            new ApiPatchDomainService(new JsonMergePatchServiceImpl(), new ApiJsonPatchServiceImpl()),
             workflowQueryService,
-            objectMapper
+            OBJECT_MAPPER
         );
 
         var primaryOwner = PrimaryOwnerEntity.builder().id(USER_ID).type(PrimaryOwnerEntity.Type.USER).build();
         when(apiPrimaryOwnerDomainService.getApiPrimaryOwner(any(), eq(API_ID))).thenReturn(primaryOwner);
+
+        givenExistingApi(ApiFixtures.aProxyApiV4());
+        stubUpdateV4ReturnsArgument();
     }
 
-    @Test
-    void merge_patch_updates_allowed_field_and_persists() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
+    void givenExistingApi(Api api) {
+        apiCrudService.initWith(List.of(api));
+    }
+
+    void stubUpdateV4ReturnsArgument() {
         when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
-
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"name\":\"patched-name\"}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
-
-        assertThat(output.api().getName()).isEqualTo("patched-name");
-        verify(updateApiDomainService).updateV4(any(), any());
     }
 
-    @Test
-    void dry_run_returns_projected_result_without_persistence() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
+    void stubValidateV4ReturnsArgument() {
         when(updateApiDomainService.validateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+    }
 
-        var output = cut.execute(
+    PatchApiUseCase.Output execute(PatchApiUseCase.PatchType type, String body, boolean dryRun) {
+        return cut.execute(
             PatchApiUseCase.Input.builder()
                 .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"name\":\"dry-run-name\"}")
-                .dryRun(true)
+                .patchType(type)
+                .patchBody(body)
+                .dryRun(dryRun)
                 .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
                 .build()
         );
-
-        assertThat(output.api().getName()).isEqualTo("dry-run-name");
-        verify(updateApiDomainService).validateV4(any(), any());
-        verify(updateApiDomainService, never()).updateV4(any(), any());
     }
 
-    @Test
-    void dry_run_invokes_validation_with_patched_api_and_primary_owner() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.validateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+    static String mergePatch(String key, Object value) {
+        var node = OBJECT_MAPPER.createObjectNode();
+        if (value == null) {
+            node.putNull(key);
+        } else {
+            node.set(key, OBJECT_MAPPER.valueToTree(value));
+        }
+        return node.toString();
+    }
 
-        cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"description\":\"dry-run-desc\"}")
-                .dryRun(true)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
+    static String patch(String op, String path) {
+        return patchNodes(patchOp(op, path));
+    }
+
+    static String patch(String op, String path, Object value) {
+        return patchNodes(patchOp(op, path, value));
+    }
+
+    static String copyPatch(String from, String path) {
+        return patchNodes(OBJECT_MAPPER.createObjectNode().put("op", "copy").put("from", from).put("path", path));
+    }
+
+    static String movePatch(String from, String path) {
+        return patchNodes(OBJECT_MAPPER.createObjectNode().put("op", "move").put("from", from).put("path", path));
+    }
+
+    static String patchNodes(ObjectNode... nodes) {
+        var arr = OBJECT_MAPPER.createArrayNode();
+        for (var n : nodes) {
+            arr.add(n);
+        }
+        return arr.toString();
+    }
+
+    static ObjectNode patchOp(String op, String path) {
+        return OBJECT_MAPPER.createObjectNode().put("op", op).put("path", path);
+    }
+
+    static ObjectNode patchOp(String op, String path, Object value) {
+        var node = patchOp(op, path);
+        if (value == null) {
+            node.putNull("value");
+        } else {
+            node.set("value", OBJECT_MAPPER.copy().setSerializationInclusion(JsonInclude.Include.ALWAYS).valueToTree(value));
+        }
+        return node;
+    }
+
+    static String setField(PatchApiUseCase.PatchType type, String field, Object value) {
+        return switch (type) {
+            case MERGE_PATCH -> mergePatch(field, value);
+            case JSON_PATCH -> patch("replace", "/" + field, value);
+        };
+    }
+
+    static Stream<Arguments> clearFieldVariants(String field) {
+        return Stream.of(
+            Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch(field, null)),
+            Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/" + field, null)),
+            Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/" + field))
         );
-
-        var apiCaptor = org.mockito.ArgumentCaptor.forClass(io.gravitee.apim.core.api.model.Api.class);
-        verify(updateApiDomainService).validateV4(apiCaptor.capture(), any());
-        assertThat(apiCaptor.getValue().getDescription()).isEqualTo("dry-run-desc");
     }
 
-    @Test
-    void dry_run_propagates_validation_failure() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        doThrow(new ValidationDomainException("tag not allowed")).when(updateApiDomainService).validateV4(any(), any());
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"tags\":[\"forbidden\"]}")
-                    .dryRun(true)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        )
-            .isInstanceOf(ValidationDomainException.class)
-            .hasMessageContaining("tag not allowed");
-        verify(updateApiDomainService, never()).updateV4(any(), any());
+    static Stream<Arguments> clearAnalyticsVariants() {
+        return clearFieldVariants("analytics");
     }
 
-    @Test
-    void patching_state_field_is_rejected_with_hint() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"state\":\"STARTED\"}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        )
-            .isInstanceOf(ApiPatchNotAllowedException.class)
-            .hasMessageContaining("state")
-            .hasMessageContaining("_start");
+    static Stream<Arguments> clearFailoverVariants() {
+        return clearFieldVariants("failover");
     }
 
-    @Test
-    void patching_listeners_is_rejected() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"listeners\":[]}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        )
-            .isInstanceOf(ApiPatchNotAllowedException.class)
-            .hasMessageContaining("listeners");
+    static Stream<Arguments> clearFlowExecutionVariants() {
+        return clearFieldVariants("flowExecution");
     }
 
-    @Test
-    void patching_endpointGroups_is_rejected() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"endpointGroups\":[]}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        )
-            .isInstanceOf(ApiPatchNotAllowedException.class)
-            .hasMessageContaining("endpointGroups");
+    static Stream<Arguments> clearServicesVariants() {
+        return clearFieldVariants("services");
     }
 
-    @Test
-    void patching_flows_is_rejected() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"flows\":[]}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        )
-            .isInstanceOf(ApiPatchNotAllowedException.class)
-            .hasMessageContaining("flows");
+    static Stream<Arguments> clearResponseTemplatesVariants() {
+        return clearFieldVariants("responseTemplates");
     }
 
-    @Test
-    void patching_resources_is_rejected() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"resources\":[]}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        )
-            .isInstanceOf(ApiPatchNotAllowedException.class)
-            .hasMessageContaining("resources");
+    static Stream<Arguments> clearPropertiesVariants() {
+        return clearFieldVariants("properties");
     }
 
-    @Test
-    void patching_unknown_field_is_rejected() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"unknownField\":\"value\"}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        )
-            .isInstanceOf(ApiPatchNotAllowedException.class)
-            .hasMessageContaining("unknownField");
+    static Stream<Arguments> clearLabelsVariants() {
+        return clearFieldVariants("labels");
     }
 
-    @Test
-    void non_v4_api_is_rejected_with_scope_error() {
-        var v2Api = ApiFixtures.aProxyApiV2();
-        apiCrudService.initWith(List.of(v2Api));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"name\":\"new-name\"}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        ).isInstanceOf(ApiInvalidDefinitionVersionException.class);
+    static Stream<Arguments> clearCategoriesVariants() {
+        return clearFieldVariants("categories");
     }
 
-    @Test
-    void v4_message_api_is_rejected_with_scope_error() {
-        var messageApi = ApiFixtures.aMessageApiV4();
-        apiCrudService.initWith(List.of(messageApi));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"name\":\"new-name\"}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        ).isInstanceOf(ApiInvalidTypeException.class);
+    static Stream<Arguments> clearTagsVariants() {
+        return clearFieldVariants("tags");
     }
 
-    @Test
-    void federated_api_is_rejected_with_scope_error() {
-        var federatedApi = ApiFixtures.aFederatedApi();
-        apiCrudService.initWith(List.of(federatedApi));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"name\":\"new-name\"}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        ).isInstanceOf(ApiInvalidDefinitionVersionException.class);
+    static Stream<Arguments> clearDescriptionVariants() {
+        return clearFieldVariants("description");
     }
 
-    @Test
-    void validation_failure_after_patch_surfaces_as_400() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        doThrow(new ValidationDomainException("name must not be blank", Map.of("name", "must not be blank")))
-            .when(updateApiDomainService)
-            .updateV4(any(), any());
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"name\":\"\"}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        )
-            .isInstanceOf(ValidationDomainException.class)
-            .hasMessageContaining("name");
+    static Api apiWithServices(ApiServices services) {
+        var base = ApiFixtures.aProxyApiV4();
+        return base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().services(services).build()).build();
     }
 
-    @Test
-    void merge_patch_preserves_every_non_patched_field() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+    static Api apiWithResponseTemplates(Map<String, Map<String, ResponseTemplate>> templates) {
+        var base = ApiFixtures.aProxyApiV4();
+        return base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().responseTemplates(templates).build()).build();
+    }
 
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"name\":\"only-name-changed\"}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
+    static Api apiWithProperties(List<Property> properties) {
+        var base = ApiFixtures.aProxyApiV4();
+        return base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().properties(properties).build()).build();
+    }
 
-        var api = output.api();
+    static void assertNonPatchedFieldsPreserved(Api api, Api existing, String expectedName) {
         var httpV4 = api.getApiDefinitionHttpV4();
         var originalHttpV4 = existing.getApiDefinitionHttpV4();
 
-        assertThat(api.getName()).isEqualTo("only-name-changed");
+        assertThat(api.getName()).isEqualTo(expectedName);
         assertThat(api.getDescription()).isEqualTo(existing.getDescription());
         assertThat(api.getVersion()).isEqualTo(existing.getVersion());
         assertThat(api.getVisibility()).isEqualTo(existing.getVisibility());
@@ -402,311 +269,791 @@ class PatchApiUseCaseTest {
         assertThat(httpV4.getResponseTemplates()).isEqualTo(originalHttpV4.getResponseTemplates());
     }
 
-    @Test
-    void update_domain_service_is_called_when_not_dry_run() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+    @Nested
+    class ApiScopeValidation {
 
-        cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"name\":\"new-name\"}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
+        @Test
+        void non_v4_api_is_rejected() {
+            givenExistingApi(ApiFixtures.aProxyApiV2());
 
-        verify(updateApiDomainService).updateV4(any(), any());
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "new-name"), false)).isInstanceOf(
+                ApiInvalidDefinitionVersionException.class
+            );
+        }
+
+        @Test
+        void v4_message_api_is_rejected() {
+            givenExistingApi(ApiFixtures.aMessageApiV4());
+
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "new-name"), false)).isInstanceOf(
+                ApiInvalidTypeException.class
+            );
+        }
+
+        @Test
+        void federated_api_is_rejected() {
+            givenExistingApi(ApiFixtures.aFederatedApi());
+
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "new-name"), false)).isInstanceOf(
+                ApiInvalidDefinitionVersionException.class
+            );
+        }
     }
 
-    @Test
-    void update_domain_service_is_not_called_when_dry_run() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
+    @Nested
+    class UseCaseBehavior {
 
-        cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"name\":\"new-name\"}")
-                .dryRun(true)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void updates_allowed_field_and_persists(PatchApiUseCase.PatchType type) {
+            var output = execute(type, setField(type, "name", "patched-name"), false);
 
-        verify(updateApiDomainService, never()).updateV4(any(), any());
+            assertThat(output.api().getName()).isEqualTo("patched-name");
+            verify(updateApiDomainService).updateV4(any(), any());
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void dry_run_returns_result_without_persistence(PatchApiUseCase.PatchType type) {
+            stubValidateV4ReturnsArgument();
+
+            var output = execute(type, setField(type, "name", "dry-run-name"), true);
+
+            assertThat(output.api().getName()).isEqualTo("dry-run-name");
+            verify(updateApiDomainService).validateV4(any(), any());
+            verify(updateApiDomainService, never()).updateV4(any(), any());
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void dry_run_invokes_validation_with_patched_api(PatchApiUseCase.PatchType type) {
+            stubValidateV4ReturnsArgument();
+
+            execute(type, setField(type, "description", "dry-run-desc"), true);
+
+            var apiCaptor = ArgumentCaptor.forClass(Api.class);
+            verify(updateApiDomainService).validateV4(apiCaptor.capture(), any());
+            assertThat(apiCaptor.getValue().getDescription()).isEqualTo("dry-run-desc");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void dry_run_propagates_validation_failure(PatchApiUseCase.PatchType type) {
+            doThrow(new ValidationDomainException("tag not allowed")).when(updateApiDomainService).validateV4(any(), any());
+
+            assertThatThrownBy(() -> execute(type, setField(type, "tags", List.of("forbidden")), true))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("tag not allowed");
+            verify(updateApiDomainService, never()).updateV4(any(), any());
+        }
+
+        @Test
+        void update_domain_service_is_called_when_not_dry_run() {
+            execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "new-name"), false);
+
+            verify(updateApiDomainService).updateV4(any(), any());
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void update_domain_service_is_not_called_when_dry_run(PatchApiUseCase.PatchType type) {
+            execute(type, setField(type, "name", "new-name"), true);
+
+            verify(updateApiDomainService, never()).updateV4(any(), any());
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void primary_owner_is_included_in_output(PatchApiUseCase.PatchType type) {
+            var output = execute(type, setField(type, "name", "new-name"), false);
+
+            assertThat(output.primaryOwner()).isNotNull();
+            assertThat(output.primaryOwner().id()).isEqualTo(USER_ID);
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void audit_info_is_forwarded_to_update(PatchApiUseCase.PatchType type) {
+            var auditInfoCaptor = ArgumentCaptor.forClass(AuditInfo.class);
+
+            execute(type, setField(type, "name", "patched-name"), false);
+
+            verify(updateApiDomainService).updateV4(any(), auditInfoCaptor.capture());
+            var auditInfo = auditInfoCaptor.getValue();
+            assertThat(auditInfo.organizationId()).isEqualTo(ORGANIZATION_ID);
+            assertThat(auditInfo.environmentId()).isEqualTo(ENVIRONMENT_ID);
+            assertThat(auditInfo.actor().userId()).isEqualTo(USER_ID);
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void validation_failure_after_patch_surfaces_as_400(PatchApiUseCase.PatchType type) {
+            doThrow(new ValidationDomainException("name must not be blank", Map.of("name", "must not be blank")))
+                .when(updateApiDomainService)
+                .updateV4(any(), any());
+
+            assertThatThrownBy(() -> execute(type, setField(type, "name", ""), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("name");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void preserves_every_non_patched_field(PatchApiUseCase.PatchType type) {
+            var existing = apiCrudService.storage().get(0);
+
+            var output = execute(type, setField(type, "name", "only-name-changed"), false);
+
+            assertNonPatchedFieldsPreserved(output.api(), existing, "only-name-changed");
+        }
     }
 
-    @Test
-    void primary_owner_is_included_in_output() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+    @Nested
+    class BlockedFields {
 
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"name\":\"new-name\"}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void state_field_is_rejected_with_hint(PatchApiUseCase.PatchType type) {
+            assertThatThrownBy(() -> execute(type, setField(type, "state", "STARTED"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("state")
+                .hasMessageContaining("_start");
+        }
 
-        assertThat(output.primaryOwner()).isNotNull();
-        assertThat(output.primaryOwner().id()).isEqualTo(USER_ID);
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void listeners_field_is_rejected(PatchApiUseCase.PatchType type) {
+            assertThatThrownBy(() -> execute(type, setField(type, "listeners", List.of()), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("listeners");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void endpointGroups_field_is_rejected(PatchApiUseCase.PatchType type) {
+            assertThatThrownBy(() -> execute(type, setField(type, "endpointGroups", List.of()), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("endpointGroups");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void flows_field_is_rejected(PatchApiUseCase.PatchType type) {
+            assertThatThrownBy(() -> execute(type, setField(type, "flows", List.of()), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("flows");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void resources_field_is_rejected(PatchApiUseCase.PatchType type) {
+            assertThatThrownBy(() -> execute(type, setField(type, "resources", List.of()), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("resources");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void definitionVersion_field_is_rejected(PatchApiUseCase.PatchType type) {
+            assertThatThrownBy(() -> execute(type, setField(type, "definitionVersion", "V4"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("definitionVersion");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void type_field_is_rejected(PatchApiUseCase.PatchType type) {
+            assertThatThrownBy(() -> execute(type, setField(type, "type", "MESSAGE"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("type");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void groups_field_is_rejected(PatchApiUseCase.PatchType type) {
+            givenExistingApi(ApiFixtures.aProxyApiV4().toBuilder().groups(new HashSet<>(List.of("g-1"))).build());
+
+            assertThatThrownBy(() -> execute(type, setField(type, "groups", List.of("g-2")), false)).isInstanceOf(
+                ValidationDomainException.class
+            );
+        }
     }
 
-    @Test
-    void validation_failure_during_dry_run_still_surfaces() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
+    @Nested
+    class AllowedFields {
 
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"responseTemplates\":42}")
-                    .dryRun(true)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void name_field_is_updated(PatchApiUseCase.PatchType type) {
+            var output = execute(type, setField(type, "name", "new-name"), false);
+
+            assertThat(output.api().getName()).isEqualTo("new-name");
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearDescriptionVariants")
+        void description_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getDescription()).isNull();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void visibility_field_is_updated(PatchApiUseCase.PatchType type) {
+            var output = execute(type, setField(type, "visibility", "PRIVATE"), false);
+
+            assertThat(output.api().getVisibility()).isEqualTo(Api.Visibility.PRIVATE);
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void invalid_visibility_value_produces_400(PatchApiUseCase.PatchType type) {
+            assertThatThrownBy(() -> execute(type, setField(type, "visibility", "NOT_A_VISIBILITY"), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("visibility")
+                .hasMessageContaining("NOT_A_VISIBILITY");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void lifecycleState_field_is_updated(PatchApiUseCase.PatchType type) {
+            var output = execute(type, setField(type, "lifecycleState", "DEPRECATED"), false);
+
+            assertThat(output.api().getApiLifecycleState()).isEqualTo(Api.ApiLifecycleState.DEPRECATED);
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void invalid_lifecycleState_value_produces_400(PatchApiUseCase.PatchType type) {
+            assertThatThrownBy(() -> execute(type, setField(type, "lifecycleState", "NOT_A_LIFECYCLE_STATE"), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("lifecycleState")
+                .hasMessageContaining("NOT_A_LIFECYCLE_STATE");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void allowMultiJwtOauth2Subscriptions_field_is_updated(PatchApiUseCase.PatchType type) {
+            var output = execute(type, setField(type, "allowMultiJwtOauth2Subscriptions", true), false);
+
+            assertThat(output.api().isAllowMultiJwtOauth2Subscriptions()).isTrue();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void disableMembershipNotifications_field_is_updated(PatchApiUseCase.PatchType type) {
+            var output = execute(type, setField(type, "disableMembershipNotifications", false), false);
+
+            assertThat(output.api().isDisableMembershipNotifications()).isFalse();
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearLabelsVariants")
+        void labels_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getLabels()).isEmpty();
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearCategoriesVariants")
+        void categories_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getCategories()).isEmpty();
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearTagsVariants")
+        void tags_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getTags()).isEmpty();
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearAnalyticsVariants")
+        void analytics_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getAnalytics()).isNull();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void analytics_sampling_sets_message_sampling(PatchApiUseCase.PatchType type) {
+            var base = ApiFixtures.aProxyApiV4();
+            givenExistingApi(
+                base
+                    .toBuilder()
+                    .apiDefinitionValue(
+                        base.getApiDefinitionHttpV4().toBuilder().analytics(Analytics.builder().enabled(true).build()).build()
+                    )
                     .build()
+            );
+            var body = switch (type) {
+                case MERGE_PATCH -> mergePatch("analytics", Map.of("sampling", Map.of("type", "count", "value", "50")));
+                case JSON_PATCH -> patch("add", "/analytics/sampling", Map.of("type", "count", "value", "50"));
+            };
+
+            var output = execute(type, body, false);
+
+            var messageSampling = output.api().getApiDefinitionHttpV4().getAnalytics().getMessageSampling();
+            assertThat(messageSampling).isNotNull();
+            assertThat(messageSampling.getType()).isEqualTo(SamplingType.COUNT);
+            assertThat(messageSampling.getValue()).isEqualTo("50");
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearFailoverVariants")
+        void failover_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getFailover()).isNull();
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearFlowExecutionVariants")
+        void flowExecution_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getFlowExecution()).isNull();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void flowExecution_mode_is_updated(PatchApiUseCase.PatchType type) {
+            var body = switch (type) {
+                case MERGE_PATCH -> mergePatch("flowExecution", Map.of("mode", "BEST_MATCH"));
+                case JSON_PATCH -> patch("replace", "/flowExecution/mode", "BEST_MATCH");
+            };
+
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getFlowExecution().getMode()).isEqualTo(FlowMode.BEST_MATCH);
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearServicesVariants")
+        void services_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(apiWithServices(new ApiServices()));
+
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getServices()).isNull();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void responseTemplates_map_is_replaced(PatchApiUseCase.PatchType type) {
+            var value = Map.of("DEFAULT", Map.of("application/json", Map.of("statusCode", 400, "body", "patched")));
+
+            var output = execute(type, setField(type, "responseTemplates", value), false);
+
+            var templates = output.api().getApiDefinitionHttpV4().getResponseTemplates();
+            assertThat(templates).containsKey("DEFAULT");
+            assertThat(templates.get("DEFAULT").get("application/json").getStatusCode()).isEqualTo(400);
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearResponseTemplatesVariants")
+        void responseTemplates_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(apiWithResponseTemplates(Map.of("KEY", Map.of("application/json", new ResponseTemplate()))));
+
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getResponseTemplates()).isNull();
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearPropertiesVariants")
+        void properties_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            var existing = new Property();
+            existing.setKey("k1");
+            existing.setValue("v1");
+            givenExistingApi(apiWithProperties(List.of(existing)));
+
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getProperties()).isNull();
+        }
+    }
+
+    @Nested
+    class JsonPatchSpecific {
+
+        @Test
+        void malformed_body_produces_validation_exception() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, "not valid json", false)).isInstanceOf(
+                ValidationDomainException.class
+            );
+        }
+
+        @Test
+        void operation_without_path_field_is_rejected() {
+            var noPathOp = OBJECT_MAPPER.createObjectNode().put("op", "replace").put("value", "x");
+
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patchNodes(noPathOp), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("path");
+        }
+
+        @Test
+        void path_without_leading_slash_produces_validation_exception() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "name", "test"), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("/");
+        }
+
+        @Test
+        void root_pointer_path_produces_clear_validation_error() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "", "test"), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("does not target a specific field");
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/", "test"), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("does not target a specific field");
+        }
+
+        @Test
+        void more_than_200_operations_is_rejected() {
+            var ops = new ObjectNode[201];
+            for (int i = 0; i < 201; i++) {
+                ops[i] = patchOp("replace", "/name", "name-" + i);
+            }
+
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patchNodes(ops), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("exceeds maximum");
+        }
+
+        @Test
+        void move_op_without_from_field_is_rejected() {
+            assertThatThrownBy(() ->
+                execute(
+                    PatchApiUseCase.PatchType.JSON_PATCH,
+                    patchNodes(OBJECT_MAPPER.createObjectNode().put("op", "move").put("path", "/name")),
+                    false
+                )
             )
-        ).isInstanceOf(ValidationDomainException.class);
-    }
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("missing");
+        }
 
-    @Test
-    void merge_patch_groups_field_is_rejected() {
-        var existing = ApiFixtures.aProxyApiV4().toBuilder().groups(new HashSet<>(List.of("g-1"))).build();
-        apiCrudService.initWith(List.of(existing));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"groups\":[\"g-2\"]}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
+        @Test
+        void copy_op_without_from_field_is_rejected() {
+            assertThatThrownBy(() ->
+                execute(
+                    PatchApiUseCase.PatchType.JSON_PATCH,
+                    patchNodes(OBJECT_MAPPER.createObjectNode().put("op", "copy").put("path", "/name")),
+                    false
+                )
             )
-        ).isInstanceOf(ValidationDomainException.class);
-    }
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("missing");
+        }
 
-    @Test
-    void merge_patch_replaces_response_templates_map() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
-
-        var body = "{\"responseTemplates\":{\"FOO_KEY\":{\"application/json\":{\"status\":400,\"body\":\"{}\"}}}}";
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody(body)
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
-
-        var templates = output.api().getApiDefinitionHttpV4().getResponseTemplates();
-        assertThat(templates).containsKey("FOO_KEY");
-        assertThat(templates.get("FOO_KEY")).containsKey("application/json");
-    }
-
-    @Test
-    void merge_patch_updates_visibility() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
-
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"visibility\":\"PRIVATE\"}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
-
-        assertThat(output.api().getVisibility()).isEqualTo(io.gravitee.apim.core.api.model.Api.Visibility.PRIVATE);
-    }
-
-    @Test
-    void merge_patch_updates_lifecycle_state() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
-
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"lifecycleState\":\"DEPRECATED\"}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
-
-        assertThat(output.api().getApiLifecycleState()).isEqualTo(io.gravitee.apim.core.api.model.Api.ApiLifecycleState.DEPRECATED);
-    }
-
-    @Test
-    void merge_patch_invalid_visibility_value_produces_400() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"visibility\":\"NOT_A_VISIBILITY\"}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
+        @Test
+        void move_op_with_non_string_from_field_is_rejected() {
+            assertThatThrownBy(() ->
+                execute(
+                    PatchApiUseCase.PatchType.JSON_PATCH,
+                    patchNodes(OBJECT_MAPPER.createObjectNode().put("op", "move").put("path", "/name").put("from", 123)),
+                    false
+                )
             )
-        )
-            .isInstanceOf(ValidationDomainException.class)
-            .hasMessageContaining("visibility")
-            .hasMessageContaining("NOT_A_VISIBILITY");
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("must be a string");
+        }
+
+        @Test
+        void move_op_with_disallowed_from_field_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, movePatch("/listeners/0", "/name"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("listeners");
+        }
+
+        @Test
+        void copy_op_with_disallowed_from_field_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, copyPatch("/listeners/0", "/name"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("listeners");
+        }
+
+        @Test
+        void move_op_with_disallowed_destination_path_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, movePatch("/name", "/listeners/0"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("listeners");
+        }
+
+        @Test
+        void copy_op_with_disallowed_destination_path_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, copyPatch("/name", "/endpointGroups"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("endpointGroups");
+        }
+
+        @Test
+        void disallowed_field_via_path_segment_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/listeners/0/type", "HTTP"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("listeners");
+        }
+
+        @Test
+        void test_op_passes_when_assertion_matches() {
+            var existing = ApiFixtures.aProxyApiV4();
+            givenExistingApi(existing);
+
+            var output = execute(
+                PatchApiUseCase.PatchType.JSON_PATCH,
+                patchNodes(patchOp("test", "/name", existing.getName()), patchOp("replace", "/name", "new-name")),
+                false
+            );
+
+            assertThat(output.api().getName()).isEqualTo("new-name");
+        }
+
+        @Test
+        void test_op_throws_when_assertion_fails() {
+            assertThatThrownBy(() ->
+                execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("test", "/name", "wrong-value"), false)
+            ).isInstanceOf(ValidationDomainException.class);
+        }
+
+        @Test
+        void test_op_on_blocked_path_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("test", "/state", "STOPPED"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("state");
+        }
+
+        @Test
+        void add_op_updates_field_like_replace() {
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/name", "new-name-via-add"), false);
+
+            assertThat(output.api().getName()).isEqualTo("new-name-via-add");
+        }
+
+        @Test
+        void copy_op_copies_value_to_target_path() {
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, copyPatch("/description", "/name"), false);
+
+            assertThat(output.api().getName()).isEqualTo("api-description");
+            assertThat(output.api().getDescription()).isEqualTo("api-description");
+        }
+
+        @Test
+        void remove_op_on_name_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/name"), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("name");
+        }
+
+        @Test
+        void remove_op_on_apiVersion_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/apiVersion"), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("apiVersion");
+        }
+
+        @Test
+        void add_op_on_blocked_path_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/listeners/0", Map.of()), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("listeners");
+        }
+
+        @Test
+        void remove_op_on_flows_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/flows"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("flows");
+        }
+
+        @Test
+        void remove_op_on_endpointGroups_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/endpointGroups"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("endpointGroups");
+        }
+
+        @Test
+        void add_op_on_state_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/state", "STARTED"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("state")
+                .hasMessageContaining("_start");
+        }
+
+        @Test
+        void add_op_on_flows_subpath_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/flows/-", Map.of()), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("flows");
+        }
+
+        @Test
+        void null_flowExecution_is_preserved_when_patching_other_fields() {
+            var base = ApiFixtures.aProxyApiV4();
+            givenExistingApi(
+                base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().flowExecution(null).build()).build()
+            );
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/name", "patched-name"), false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getFlowExecution()).isNull();
+        }
+
+        @Test
+        void replace_null_on_null_responseTemplates_passes_null_to_domain_service() {
+            givenExistingApi(apiWithResponseTemplates(null));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/responseTemplates", null), false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getResponseTemplates()).isNull();
+        }
+
+        @Test
+        void remove_op_on_null_responseTemplates_sets_responseTemplates_to_null() {
+            givenExistingApi(apiWithResponseTemplates(null));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/responseTemplates"), false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getResponseTemplates()).isNull();
+        }
+
+        @Test
+        void add_op_on_null_responseTemplates_sets_them() {
+            givenExistingApi(apiWithResponseTemplates(null));
+            var value = Map.of("DEFAULT", Map.of("application/json", Map.of("statusCode", 201, "body", "created")));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/responseTemplates", value), false);
+
+            var templates = output.api().getApiDefinitionHttpV4().getResponseTemplates();
+            assertThat(templates).containsKey("DEFAULT");
+            assertThat(templates.get("DEFAULT").get("application/json").getStatusCode()).isEqualTo(201);
+        }
+
+        @Test
+        void add_null_inner_map_for_responseTemplates_key_does_not_throw_npe() {
+            givenExistingApi(apiWithResponseTemplates(null));
+            var value = new HashMap<String, Object>();
+            value.put("DEFAULT", null);
+
+            assertThatCode(() ->
+                execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/responseTemplates", value), false)
+            ).doesNotThrowAnyException();
+        }
+
+        @Test
+        void any_patch_on_api_with_null_inner_responseTemplates_map_in_storage_does_not_throw_npe() {
+            var templates = new HashMap<String, Map<String, ResponseTemplate>>();
+            templates.put("DEFAULT", null);
+            givenExistingApi(apiWithResponseTemplates(templates));
+
+            assertThatCode(() ->
+                execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/name", "patched-name"), false)
+            ).doesNotThrowAnyException();
+        }
+
+        @Test
+        void replace_responseTemplates_with_null_leaf_template_does_not_throw_npe() {
+            var innerMap = new HashMap<String, Object>();
+            innerMap.put("application/json", null);
+            var value = new HashMap<String, Object>();
+            value.put("DEFAULT", innerMap);
+
+            assertThatCode(() ->
+                execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/responseTemplates", value), false)
+            ).doesNotThrowAnyException();
+        }
+
+        @Test
+        void any_patch_on_api_with_null_leaf_responseTemplate_in_storage_does_not_throw_npe() {
+            var innerMap = new HashMap<String, ResponseTemplate>();
+            innerMap.put("application/json", null);
+            var templates = new HashMap<String, Map<String, ResponseTemplate>>();
+            templates.put("DEFAULT", innerMap);
+            givenExistingApi(apiWithResponseTemplates(templates));
+
+            assertThatCode(() ->
+                execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/name", "patched-name"), false)
+            ).doesNotThrowAnyException();
+        }
+
+        @Test
+        void replace_null_on_null_services_passes_null_to_domain_service() {
+            givenExistingApi(apiWithServices(null));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/services", null), false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getServices()).isNull();
+        }
+
+        @Test
+        void remove_op_on_null_services_sets_services_to_null() {
+            givenExistingApi(apiWithServices(null));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/services"), false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getServices()).isNull();
+        }
+
+        @Test
+        void replace_on_null_properties_sets_properties() {
+            givenExistingApi(apiWithProperties(null));
+
+            var output = execute(
+                PatchApiUseCase.PatchType.JSON_PATCH,
+                patch("replace", "/properties", List.of(Map.of("key", "k", "value", "v"))),
+                false
+            );
+
+            assertThat(output.api().getApiDefinitionHttpV4().getProperties()).hasSize(1);
+        }
+
+        @Test
+        void replace_null_on_null_properties_is_a_noop() {
+            givenExistingApi(apiWithProperties(null));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/properties", null), false);
+
+            assertThat(output.api().getApiDefinitionHttpV4().getProperties()).isNull();
+        }
+
+        @Test
+        void remove_op_on_null_categories_clears_categories() {
+            givenExistingApi(ApiFixtures.aProxyApiV4().toBuilder().categories(null).build());
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/categories"), false);
+
+            assertThat(output.api().getCategories()).isEmpty();
+        }
+    }
+
+    @Nested
+    class MergePatchSpecific {
+
+        @Test
+        void unknown_field_is_rejected() {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("unknownField", "value"), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("unknownField");
+        }
+
+        @Test
+        void validation_failure_during_dry_run_still_surfaces() {
+            assertThatThrownBy(() ->
+                execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("responseTemplates", 42), true)
+            ).isInstanceOf(ValidationDomainException.class);
+        }
     }
 
     @Test
-    void merge_patch_invalid_lifecycle_state_value_produces_400() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-
-        assertThatThrownBy(() ->
-            cut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                    .patchBody("{\"lifecycleState\":\"NOT_A_LIFECYCLE_STATE\"}")
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            )
-        )
-            .isInstanceOf(ValidationDomainException.class)
-            .hasMessageContaining("lifecycleState")
-            .hasMessageContaining("NOT_A_LIFECYCLE_STATE");
-    }
-
-    // -------------------------------------------------------------------------
-    // Null-behaviour characterisation tests for object fields
-    //
-    // These tests document what PATCH passes to the domain service when each
-    // field is set to null.  The mock returns the argument unchanged, so the
-    // assertion captures the value produced by applyPatchedValues() before any
-    // downstream validation (e.g. AnalyticsValidationServiceImpl) runs.
-    // They serve as a baseline for aligning PATCH behaviour with PUT.
-    // -------------------------------------------------------------------------
-
-    @Test
-    void merge_patch_null_on_analytics_passes_null_to_domain_service() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
-
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"analytics\":null}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
-
-        assertThat(output.api().getApiDefinitionHttpV4().getAnalytics()).isNull();
-    }
-
-    @Test
-    void merge_patch_null_on_failover_passes_null_to_domain_service() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
-
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"failover\":null}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
-
-        assertThat(output.api().getApiDefinitionHttpV4().getFailover()).isNull();
-    }
-
-    @Test
-    void merge_patch_null_on_flowExecution_passes_null_to_domain_service() {
-        var existing = ApiFixtures.aProxyApiV4();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
-
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"flowExecution\":null}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
-
-        assertThat(output.api().getApiDefinitionHttpV4().getFlowExecution()).isNull();
-    }
-
-    @Test
-    void merge_patch_null_on_services_passes_null_to_domain_service() {
-        var services = new ApiServices();
-        var existing = ApiFixtures.aProxyApiV4()
-            .toBuilder()
-            .apiDefinitionValue(ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().services(services).build())
-            .build();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
-
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"services\":null}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
-
-        assertThat(output.api().getApiDefinitionHttpV4().getServices()).isNull();
-    }
-
-    @Test
-    void merge_patch_null_on_responseTemplates_passes_null_to_domain_service() {
-        var templates = Map.of("KEY", Map.of("application/json", new ResponseTemplate()));
-        var existing = ApiFixtures.aProxyApiV4()
-            .toBuilder()
-            .apiDefinitionValue(ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().responseTemplates(templates).build())
-            .build();
-        apiCrudService.initWith(List.of(existing));
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
-
-        var output = cut.execute(
-            PatchApiUseCase.Input.builder()
-                .apiId(API_ID)
-                .patchType(PatchApiUseCase.PatchType.MERGE_PATCH)
-                .patchBody("{\"responseTemplates\":null}")
-                .dryRun(false)
-                .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                .build()
-        );
-
-        assertThat(output.api().getApiDefinitionHttpV4().getResponseTemplates()).isNull();
+    void patchable_response_template_from_returns_null_when_domain_is_null() {
+        assertThat(PatchApiUseCase.PatchableResponseTemplate.from(null)).isNull();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiJsonPatchServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiJsonPatchServiceImplTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiJsonPatchServiceImplTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ApiJsonPatchServiceImpl cut = new ApiJsonPatchServiceImpl();
+
+    @Test
+    void runtime_exception_from_library_propagates_without_wrapping_as_validation_exception() throws Exception {
+        var patch = objectMapper.readTree("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"new\"}]");
+
+        assertThatThrownBy(() -> cut.applyJsonPatch(patch, null)).isInstanceOf(NullPointerException.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiPatchDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiPatchDomainServiceTest.java
@@ -29,7 +29,37 @@ import org.junit.jupiter.api.Test;
 class ApiPatchDomainServiceTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final ApiPatchDomainService cut = new ApiPatchDomainService(new JsonMergePatchServiceImpl());
+    private final ApiPatchDomainService cut = new ApiPatchDomainService(new JsonMergePatchServiceImpl(), new ApiJsonPatchServiceImpl());
+
+    @Test
+    void applyJsonPatch_applies_replace_operation() throws Exception {
+        var target = objectMapper.readTree("{\"name\":\"old\"}");
+        var patch = objectMapper.readTree("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"new\"}]");
+
+        var result = cut.applyJsonPatch(patch, target);
+
+        assertThat(result.get("name").asText()).isEqualTo("new");
+    }
+
+    @Test
+    void applyJsonPatch_wraps_failed_operation_in_validation_exception() throws Exception {
+        var target = objectMapper.readTree("{}");
+        var patch = objectMapper.readTree("[{\"op\":\"replace\",\"path\":\"/missing\",\"value\":\"x\"}]");
+
+        assertThatThrownBy(() -> cut.applyJsonPatch(patch, target))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageStartingWith("Failed to apply patch:");
+    }
+
+    @Test
+    void applyJsonPatch_wraps_malformed_patch_in_validation_exception() throws Exception {
+        var target = objectMapper.readTree("{}");
+        var patch = objectMapper.readTree("{\"not\":\"an array\"}");
+
+        assertThatThrownBy(() -> cut.applyJsonPatch(patch, target))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageStartingWith("Invalid patch:");
+    }
 
     @Test
     void applyMergePatch_applies_field_override() throws Exception {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/FreemarkerTemplateResolverTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/FreemarkerTemplateResolverTest.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -44,16 +45,20 @@ class FreemarkerTemplateResolverTest {
     FreemarkerTemplateResolver resolver = new FreemarkerTemplateResolver();
 
     private static Locale defaultLocale;
+    private static TimeZone defaultTimeZone;
 
     @BeforeAll
     static void beforeAll() {
         defaultLocale = Locale.getDefault();
         Locale.setDefault(Locale.US);
+        defaultTimeZone = TimeZone.getDefault();
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     }
 
     @AfterAll
     static void afterAll() {
         Locale.setDefault(defaultLocale);
+        TimeZone.setDefault(defaultTimeZone);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Extends the `PATCH /environments/{envId}/apis/{apiId}` endpoint with **JSON Patch** (RFC 6902, `application/json-patch+json`) support alongside the existing merge-patch.

Depends on: #16577

- `JsonPatchService` (core domain) + `ApiJsonPatchServiceImpl` (infra) — applies a RFC 6902 patch array using `JsonPatch.fromJson`, wrapping `JsonPatchException`/`IOException` as `ValidationDomainException`
- `ApiPatchDomainService.applyJsonPatch` — validates the patch is a JSON array and delegates to `JsonPatchService`
- `PatchApiUseCase.PatchType.JSON_PATCH` — allow-list enforcement via top-level path segment extraction from each operation's `path` field
- `ApiResource.patchApi` — content-type detection dispatches to the correct patch strategy

## Test plan

- [x] `PatchApiUseCaseTest` — additional JSON Patch use-case tests (replace op, path-segment allow-list, null semantics, malformed body)
- [x] `ApiPatchDomainServiceTest` — JSON Patch unit tests
- [x] `ApiJsonPatchServiceImplTest` — infra-level test that runtime exceptions from the underlying library propagate without being wrapped
- [x] `ApiResource_PatchApiTest` — additional REST integration tests (200/400 for JSON Patch operations, dry-run with JSON Patch, null rejections)
