### PR TITLE
feat(portal): add analytics computation endpoints and mappers

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
@@ -98,9 +98,15 @@
                                 <dateLibrary>java8</dateLibrary>
                                 <enumPropertyNaming>legacy</enumPropertyNaming>
                                 <useBeanValidation>true</useBeanValidation>
+                                <disallowAdditionalPropertiesIfNotPresent>false</disallowAdditionalPropertiesIfNotPresent>
+                                <useOneOfDiscriminatorLookup>true</useOneOfDiscriminatorLookup>
                             </configOptions>
+                            <importMappings>
+                                <importMapping>AnalyticsInterval=io.gravitee.rest.api.portal.rest.model.CustomInterval</importMapping>
+                            </importMappings>
                             <typeMappings>
                                 <typeMapping>BigDecimal=Number</typeMapping>
+                                <typeMapping>AnalyticsInterval=CustomInterval</typeMapping>
                             </typeMappings>
                             <globalProperties>
                                 <skipFormModel>false</skipFormModel>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalAnalyticsDashboardMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalAnalyticsDashboardMapper.java
@@ -17,18 +17,27 @@ package io.gravitee.rest.api.portal.rest.mapper;
 
 import io.gravitee.apim.core.dashboard.model.Dashboard;
 import io.gravitee.apim.core.dashboard.model.DashboardWidget;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsArrayFilter;
 import io.gravitee.rest.api.portal.rest.model.AnalyticsDashboard;
 import io.gravitee.rest.api.portal.rest.model.AnalyticsFilter;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFilterName;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFilterOperator;
 import io.gravitee.rest.api.portal.rest.model.AnalyticsMetricRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsNumberFilter;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsStringFilter;
 import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeRange;
 import io.gravitee.rest.api.portal.rest.model.AnalyticsWidget;
 import io.gravitee.rest.api.portal.rest.model.AnalyticsWidgetLayout;
 import io.gravitee.rest.api.portal.rest.model.AnalyticsWidgetRequest;
 import io.gravitee.rest.api.portal.rest.model.AnalyticsWidgetType;
+import io.gravitee.rest.api.portal.rest.model.CustomInterval;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -55,11 +64,44 @@ public interface PortalAnalyticsDashboardMapper {
 
     AnalyticsWidgetLayout map(DashboardWidget.Layout layout);
 
+    @Mapping(target = "interval", source = "interval", qualifiedByName = "millisecondsToInterval")
     AnalyticsWidgetRequest map(DashboardWidget.Request request);
+
+    @Named("millisecondsToInterval")
+    default CustomInterval millisecondsToInterval(Long intervalMillis) {
+        return intervalMillis == null ? null : new CustomInterval(intervalMillis);
+    }
 
     AnalyticsTimeRange map(DashboardWidget.TimeRange timeRange);
 
     AnalyticsMetricRequest map(DashboardWidget.MetricRequest metric);
 
-    AnalyticsFilter map(DashboardWidget.Filter filter);
+    default AnalyticsFilter map(DashboardWidget.Filter filter) {
+        if (filter == null || filter.getOperator() == null) {
+            return null;
+        }
+        var name = AnalyticsFilterName.fromValue(filter.getName());
+        var wrapper = new AnalyticsFilter();
+        switch (filter.getOperator()) {
+            case "EQ" -> wrapper.setActualInstance(
+                new AnalyticsStringFilter().name(name).operator(AnalyticsFilterOperator.EQ).value(Objects.toString(filter.getValue(), null))
+            );
+            case "IN" -> {
+                if (!(filter.getValue() instanceof List<?> raw) || raw.stream().anyMatch(v -> !(v instanceof String))) {
+                    throw new IllegalArgumentException("IN filter value must be a list of strings");
+                }
+                @SuppressWarnings("unchecked")
+                var values = (List<String>) filter.getValue();
+                wrapper.setActualInstance(new AnalyticsArrayFilter().name(name).operator(AnalyticsFilterOperator.IN).value(values));
+            }
+            case "LTE", "GTE" -> {
+                Number num = filter.getValue() instanceof Number n ? n : Double.parseDouble(String.valueOf(filter.getValue()));
+                wrapper.setActualInstance(
+                    new AnalyticsNumberFilter().name(name).operator(AnalyticsFilterOperator.fromValue(filter.getOperator())).value(num)
+                );
+            }
+            default -> throw new IllegalArgumentException("Unsupported filter operator: " + filter.getOperator());
+        }
+        return wrapper;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalAnalyticsMeasuresMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalAnalyticsMeasuresMapper.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.analytics_engine.model.FacetBucketResponse;
+import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
+import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
+import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.Measure;
+import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricFacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import io.gravitee.apim.core.analytics_engine.model.TimeRange;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesBucketResponse;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesMetricResponse;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesResponse;
+import io.gravitee.apim.core.observability.model.FilterOperator;
+import io.gravitee.apim.core.observability.model.NumberRange;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsArrayFilter;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsComputationMetricRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetBucket;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetBucketGroup;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetBucketLeaf;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetMetricRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetName;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetsRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetsResponse;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetsResponseMetric;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFilter;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMeasure;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMeasureName;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMeasuresRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMeasuresResponse;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMeasuresResponseMetric;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMetricName;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsNumberFilter;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsNumberRange;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsSort;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsStringFilter;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeRange;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeSeriesBucket;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeSeriesBucketGroup;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeSeriesBucketLeaf;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeSeriesRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeSeriesResponse;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeSeriesResponseMetric;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsUnitName;
+import jakarta.ws.rs.BadRequestException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Converts portal analytics computation DTOs.
+ *
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface PortalAnalyticsMeasuresMapper {
+    PortalAnalyticsMeasuresMapper INSTANCE = Mappers.getMapper(PortalAnalyticsMeasuresMapper.class);
+
+    default MeasuresRequest toCoreRequest(AnalyticsMeasuresRequest request) {
+        return new MeasuresRequest(
+            toCoreTimeRange(request.getTimeRange()),
+            toCoreFilters(request.getFilters()),
+            request.getMetrics().stream().map(this::toCoreMetric).toList()
+        );
+    }
+
+    default FacetsRequest toCoreRequest(AnalyticsFacetsRequest request) {
+        return new FacetsRequest(
+            toCoreTimeRange(request.getTimeRange()),
+            toCoreFilters(request.getFilters()),
+            request.getMetrics().stream().map(this::toCoreMetric).toList(),
+            toCoreFacets(request.getBy()),
+            request.getLimit(),
+            toCoreNumberRanges(request.getRanges())
+        );
+    }
+
+    default TimeSeriesRequest toCoreRequest(AnalyticsTimeSeriesRequest request) {
+        return new TimeSeriesRequest(
+            toCoreTimeRange(request.getTimeRange()),
+            request.getInterval().toMillis(),
+            toCoreFilters(request.getFilters()),
+            request.getMetrics().stream().map(this::toCoreMetric).toList(),
+            toCoreFacets(request.getBy()),
+            request.getLimit(),
+            toCoreNumberRanges(request.getRanges())
+        );
+    }
+
+    default MetricMeasuresRequest toCoreMetric(AnalyticsComputationMetricRequest metric) {
+        return new MetricMeasuresRequest(
+            MetricSpec.Name.valueOf(metric.getName().name()),
+            toCoreMeasures(metric.getMeasures()),
+            toCoreFilters(metric.getFilters())
+        );
+    }
+
+    default FacetMetricMeasuresRequest toCoreMetric(AnalyticsFacetMetricRequest metric) {
+        var sorts = metric.getSorts() == null
+            ? List.<FacetMetricMeasuresRequest.Sort>of()
+            : metric.getSorts().stream().map(this::toCoreSort).toList();
+        return new FacetMetricMeasuresRequest(
+            MetricSpec.Name.valueOf(metric.getName().name()),
+            toCoreMeasures(metric.getMeasures()),
+            toCoreFilters(metric.getFilters()),
+            sorts
+        );
+    }
+
+    AnalyticsMeasuresResponse toPortalResponse(MeasuresResponse response);
+
+    AnalyticsFacetsResponse toPortalResponse(FacetsResponse response);
+
+    AnalyticsTimeSeriesResponse toPortalResponse(TimeSeriesResponse response);
+
+    default TimeRange toCoreTimeRange(AnalyticsTimeRange timeRange) {
+        return new TimeRange(timeRange.getFrom().toInstant(), timeRange.getTo().toInstant());
+    }
+
+    default Filter toCoreFilter(AnalyticsFilter filter) {
+        return switch (filter.getActualInstance()) {
+            case AnalyticsStringFilter s -> new Filter(
+                FilterSpec.Name.valueOf(s.getName().name()),
+                FilterOperator.valueOf(s.getOperator().name()),
+                s.getValue()
+            );
+            case AnalyticsNumberFilter n -> new Filter(
+                FilterSpec.Name.valueOf(n.getName().name()),
+                FilterOperator.valueOf(n.getOperator().name()),
+                n.getValue()
+            );
+            case AnalyticsArrayFilter a -> new Filter(
+                FilterSpec.Name.valueOf(a.getName().name()),
+                FilterOperator.valueOf(a.getOperator().name()),
+                a.getValue()
+            );
+            case null, default -> throw new BadRequestException("Unknown or unsupported analytics filter shape");
+        };
+    }
+
+    default NumberRange toCoreNumberRange(AnalyticsNumberRange range) {
+        return new NumberRange(range.getFrom(), range.getTo());
+    }
+
+    default FacetMetricMeasuresRequest.Sort toCoreSort(AnalyticsSort sort) {
+        return new FacetMetricMeasuresRequest.Sort(
+            MetricSpec.Measure.valueOf(sort.getMeasure().name()),
+            FacetMetricMeasuresRequest.Sort.Order.valueOf(sort.getOrder().name())
+        );
+    }
+
+    default List<Filter> toCoreFilters(List<AnalyticsFilter> filters) {
+        return filters == null ? List.of() : filters.stream().map(this::toCoreFilter).toList();
+    }
+
+    default List<NumberRange> toCoreNumberRanges(List<AnalyticsNumberRange> ranges) {
+        return ranges == null ? List.of() : ranges.stream().map(this::toCoreNumberRange).toList();
+    }
+
+    default List<MetricSpec.Measure> toCoreMeasures(List<AnalyticsMeasureName> measures) {
+        return measures == null
+            ? List.of()
+            : measures
+                .stream()
+                .map(m -> MetricSpec.Measure.valueOf(m.name()))
+                .toList();
+    }
+
+    default List<FacetSpec.Name> toCoreFacets(List<AnalyticsFacetName> by) {
+        return by == null
+            ? List.of()
+            : by
+                .stream()
+                .map(f -> FacetSpec.Name.valueOf(f.name()))
+                .toList();
+    }
+
+    default AnalyticsMeasuresResponseMetric toPortalMetric(MetricMeasuresResponse metric) {
+        var dto = new AnalyticsMeasuresResponseMetric();
+        dto.setName(AnalyticsMetricName.fromValue(metric.name().name()));
+        if (metric.unit() != null) {
+            dto.setUnit(AnalyticsUnitName.fromValue(metric.unit().name()));
+        }
+        dto.setMeasures(toPortalMeasures(metric.measures()));
+        return dto;
+    }
+
+    default AnalyticsFacetsResponseMetric toPortalMetric(MetricFacetsResponse metric) {
+        var dto = new AnalyticsFacetsResponseMetric();
+        dto.setName(AnalyticsMetricName.fromValue(metric.metric().name()));
+        if (metric.unit() != null) {
+            dto.setUnit(AnalyticsUnitName.fromValue(metric.unit().name()));
+        }
+        if (metric.buckets() != null) {
+            dto.setBuckets(metric.buckets().stream().map(this::toPortalFacetBucket).toList());
+        }
+        return dto;
+    }
+
+    default AnalyticsTimeSeriesResponseMetric toPortalMetric(TimeSeriesMetricResponse metric) {
+        var dto = new AnalyticsTimeSeriesResponseMetric();
+        dto.setName(AnalyticsMetricName.fromValue(metric.name().name()));
+        if (metric.unit() != null) {
+            dto.setUnit(AnalyticsUnitName.fromValue(metric.unit().name()));
+        }
+        if (metric.buckets() != null) {
+            dto.setBuckets(metric.buckets().stream().map(this::toPortalTimeSeriesBucket).toList());
+        }
+        return dto;
+    }
+
+    default AnalyticsFacetBucket toPortalFacetBucket(FacetBucketResponse bucket) {
+        var wrapper = new AnalyticsFacetBucket();
+        if (bucket.buckets() == null) {
+            var leaf = new AnalyticsFacetBucketLeaf()
+                .type(AnalyticsFacetBucketLeaf.TypeEnum.LEAF)
+                .key(bucket.key())
+                .name(bucket.name() != null ? bucket.name() : bucket.key())
+                .measures(toPortalMeasures(bucket.measures()));
+            wrapper.setActualInstance(leaf);
+            return wrapper;
+        }
+        var group = new AnalyticsFacetBucketGroup()
+            .type(AnalyticsFacetBucketGroup.TypeEnum.GROUP)
+            .key(bucket.key())
+            .name(bucket.name() != null ? bucket.name() : bucket.key());
+        group.setBuckets(bucket.buckets().stream().map(this::toPortalFacetBucket).toList());
+        wrapper.setActualInstance(group);
+        return wrapper;
+    }
+
+    default AnalyticsTimeSeriesBucket toPortalTimeSeriesBucket(TimeSeriesBucketResponse bucket) {
+        var wrapper = new AnalyticsTimeSeriesBucket();
+        if (bucket.buckets() == null) {
+            var leaf = new AnalyticsTimeSeriesBucketLeaf()
+                .type(AnalyticsTimeSeriesBucketLeaf.TypeEnum.LEAF)
+                .key(OffsetDateTime.parse(bucket.key()))
+                .timestamp(bucket.timestamp())
+                .measures(toPortalMeasures(bucket.measures()));
+            wrapper.setActualInstance(leaf);
+            return wrapper;
+        }
+        var group = new AnalyticsTimeSeriesBucketGroup()
+            .type(AnalyticsTimeSeriesBucketGroup.TypeEnum.GROUP)
+            .key(OffsetDateTime.parse(bucket.key()))
+            .timestamp(bucket.timestamp());
+        group.setBuckets(bucket.buckets().stream().map(this::toPortalFacetBucket).toList());
+        wrapper.setActualInstance(group);
+        return wrapper;
+    }
+
+    default AnalyticsMeasure toPortalMeasure(Measure measure) {
+        return new AnalyticsMeasure().name(AnalyticsMeasureName.fromValue(measure.name().name())).value(measure.value());
+    }
+
+    List<AnalyticsMeasure> toPortalMeasures(List<Measure> measures);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/model/CustomInterval.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/model/CustomInterval.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.time.Duration;
+
+/**
+ * Accepts interval as milliseconds (number) or duration shorthand (e.g. {@code 1s}, {@code 5m}).
+ *
+ * @author GraviteeSource Team
+ */
+@JsonDeserialize(using = CustomIntervalDeserializer.class)
+@JsonSerialize(using = CustomIntervalSerializer.class)
+public class CustomInterval {
+
+    private final Object instanceValue;
+
+    public CustomInterval(String interval) {
+        if (interval == null) {
+            throw new IllegalArgumentException("Interval cannot be null");
+        }
+        if (interval.isEmpty()) {
+            throw new IllegalArgumentException("Interval cannot be empty");
+        }
+        instanceValue = interval;
+    }
+
+    public CustomInterval(Long interval) {
+        if (interval == null) {
+            throw new IllegalArgumentException("Interval cannot be null");
+        }
+        instanceValue = interval;
+    }
+
+    public Long toMillis() {
+        return switch (instanceValue) {
+            case Long value -> value;
+            case String value -> parseDurationString(value).toMillis();
+            default -> throw new IllegalArgumentException("Interval value is of unknown type");
+        };
+    }
+
+    private Duration parseDurationString(String duration) {
+        if (duration == null || duration.isEmpty()) {
+            return Duration.ZERO;
+        }
+
+        duration = duration.toUpperCase();
+        if (duration.endsWith("D")) {
+            return Duration.parse("P" + duration);
+        }
+        return Duration.parse("PT" + duration);
+    }
+
+    public Object getActualInstance() {
+        return instanceValue;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/model/CustomIntervalDeserializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/model/CustomIntervalDeserializer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class CustomIntervalDeserializer extends StdDeserializer<CustomInterval> {
+
+    protected CustomIntervalDeserializer() {
+        super(CustomInterval.class);
+    }
+
+    @Override
+    public CustomInterval deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        JsonToken token = jp.currentToken();
+
+        if (token == JsonToken.VALUE_NUMBER_INT) {
+            return new CustomInterval(jp.getLongValue());
+        }
+
+        if (token == JsonToken.VALUE_STRING) {
+            String str = jp.getText();
+            if (str.isEmpty()) {
+                throw new JsonMappingException(ctxt.getParser(), "Interval cannot be empty");
+            }
+
+            try {
+                return new CustomInterval(Long.parseLong(str));
+            } catch (NumberFormatException e) {
+                return new CustomInterval(str);
+            }
+        }
+
+        throw new JsonMappingException(ctxt.getParser(), String.format("Failed deserialization for Interval: %s", token));
+    }
+
+    @Override
+    public CustomInterval getNullValue(DeserializationContext ctxt) throws JsonMappingException {
+        throw new JsonMappingException(ctxt.getParser(), "Interval cannot be null");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/model/CustomIntervalSerializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/model/CustomIntervalSerializer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.model;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import java.io.IOException;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class CustomIntervalSerializer extends StdSerializer<CustomInterval> {
+
+    public CustomIntervalSerializer(Class<CustomInterval> t) {
+        super(t);
+    }
+
+    public CustomIntervalSerializer() {
+        this(null);
+    }
+
+    @Override
+    public void serialize(CustomInterval value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        jgen.writeObject(value.getActualInstance());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsComputationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsComputationResource.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource.analytics;
+
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeFacetsUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeMeasuresUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeTimeSeriesUseCase;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.portal.rest.mapper.PortalAnalyticsMeasuresMapper;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetsRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetsResponse;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMeasuresRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMeasuresResponse;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeSeriesRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeSeriesResponse;
+import io.gravitee.rest.api.portal.rest.resource.AbstractResource;
+import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalAnalyticsComputationResource extends AbstractResource {
+
+    @Inject
+    private ComputeMeasuresUseCase computeMeasuresUseCase;
+
+    @Inject
+    private ComputeFacetsUseCase computeFacetsUseCase;
+
+    @Inject
+    private ComputeTimeSeriesUseCase computeTimeSeriesUseCase;
+
+    @POST
+    @Path("measures")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @RequirePortalAuth
+    public AnalyticsMeasuresResponse computeMeasures(@Valid AnalyticsMeasuresRequest request) {
+        var input = new ComputeMeasuresUseCase.Input(getAuditInfo(), PortalAnalyticsMeasuresMapper.INSTANCE.toCoreRequest(request));
+        var output = computeMeasuresUseCase.execute(input);
+        return PortalAnalyticsMeasuresMapper.INSTANCE.toPortalResponse(output.response());
+    }
+
+    @POST
+    @Path("facets")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @RequirePortalAuth
+    public AnalyticsFacetsResponse computeFacets(@Valid AnalyticsFacetsRequest request) {
+        var input = new ComputeFacetsUseCase.Input(getAuditInfo(), PortalAnalyticsMeasuresMapper.INSTANCE.toCoreRequest(request));
+        var output = computeFacetsUseCase.execute(input);
+        return PortalAnalyticsMeasuresMapper.INSTANCE.toPortalResponse(output.response());
+    }
+
+    @POST
+    @Path("time-series")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @RequirePortalAuth
+    public AnalyticsTimeSeriesResponse computeTimeSeries(@Valid AnalyticsTimeSeriesRequest request) {
+        var input = new ComputeTimeSeriesUseCase.Input(getAuditInfo(), PortalAnalyticsMeasuresMapper.INSTANCE.toCoreRequest(request));
+        var output = computeTimeSeriesUseCase.execute(input);
+        return PortalAnalyticsMeasuresMapper.INSTANCE.toPortalResponse(output.response());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/analytics/PortalAnalyticsResource.java
@@ -22,15 +22,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 
-/**
- * Entry point for {@code /portal/environments/{envId}/analytics/**} endpoints.
- *
- * <p>Acts as the single gate for the Next Gen Portal analytics feature: before routing to any sub-resource,
- * {@link PortalAnalyticsGate#requireAnalyticsEnabled} is invoked so every analytics endpoint (dashboards today,
- * computation tomorrow) inherits the {@code PORTAL_NEXT_ANALYTICS_ENABLED} check without repeating it.</p>
- *
- * @author GraviteeSource Team
- */
 public class PortalAnalyticsResource extends AbstractResource {
 
     @Context
@@ -43,5 +34,11 @@ public class PortalAnalyticsResource extends AbstractResource {
     public PortalAnalyticsDashboardsResource getDashboardsResource() {
         PortalAnalyticsGate.requireAnalyticsEnabled(parameterService);
         return resourceContext.getResource(PortalAnalyticsDashboardsResource.class);
+    }
+
+    @Path("/")
+    public PortalAnalyticsComputationResource getComputationResource() {
+        PortalAnalyticsGate.requireAnalyticsEnabled(parameterService);
+        return resourceContext.getResource(PortalAnalyticsComputationResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3265,6 +3265,229 @@ paths:
                 500:
                     $ref: "#/components/responses/InternalServerError"
 
+    /analytics/measures:
+        post:
+            tags:
+                - Analytics
+                - computation
+            summary: Query measures analytics
+            description: |
+                Return aggregated values for specified metrics within a time range.
+                Results are scoped to the APIs and applications the authenticated portal user is allowed to see.
+            operationId: queryMeasures
+            security:
+                - BasicAuth: []
+                - CookieAuth: []
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/AnalyticsMeasuresRequest"
+                        examples:
+                            single-metric:
+                                summary: Single metric with multiple measures request
+                                value:
+                                    timeRange:
+                                        from: "2025-01-01T00:00:00Z"
+                                        to: "2025-01-31T23:59:59Z"
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                            multiple-metrics:
+                                summary: Multiple metrics request
+                                value:
+                                    timeRange:
+                                        from: "2025-01-01T00:00:00Z"
+                                        to: "2025-01-31T23:59:59Z"
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                                        - name: "HTTP_GATEWAY_RESPONSE_TIME"
+                                          measures: ["AVG"]
+            responses:
+                200:
+                    description: Aggregated measures response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AnalyticsMeasuresResponse"
+                            examples:
+                                single-metric:
+                                    summary: Single metric with multiple values response
+                                    value:
+                                        metrics:
+                                            - name: "HTTP_REQUESTS"
+                                              measures:
+                                                  - name: "COUNT"
+                                                    value: 2984
+                                multiple-metrics:
+                                    summary: Multiple metrics response
+                                    value:
+                                        metrics:
+                                            - name: "HTTP_REQUESTS"
+                                              measures:
+                                                  - name: "COUNT"
+                                                    value: 2984
+                                            - name: "HTTP_GATEWAY_RESPONSE_TIME"
+                                              measures:
+                                                  - name: "AVG"
+                                                    value: 89.5
+                400:
+                    $ref: "#/components/responses/BadRequestError"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+
+    /analytics/facets:
+        post:
+            tags:
+                - Analytics
+                - computation
+            summary: Query facets analytics
+            description: |
+                Group data by facet values with optional ranging, sorting and limits.
+                Facet requests are limited to three dimensions in the `by` clause.
+                Results are scoped to the APIs and applications the authenticated portal user is allowed to see.
+            operationId: queryFacets
+            security:
+                - BasicAuth: []
+                - CookieAuth: []
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/AnalyticsFacetsRequest"
+                        examples:
+                            single-facet-with-sort:
+                                summary: Single facet with sort request
+                                value:
+                                    timeRange:
+                                        from: "2025-01-01T00:00:00Z"
+                                        to: "2025-01-31T23:59:59Z"
+                                    by: ["API"]
+                                    limit: 5
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                                          sorts: [{ "measure": "COUNT", "order": "DESC" }]
+                            multiple-facets:
+                                summary: Multiple facets request
+                                value:
+                                    timeRange:
+                                        from: "2025-01-01T00:00:00Z"
+                                        to: "2025-01-31T23:59:59Z"
+                                    by: ["API", "APPLICATION"]
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+            responses:
+                200:
+                    description: Facets response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AnalyticsFacetsResponse"
+                            examples:
+                                facets-response:
+                                    summary: Nested facet buckets
+                                    value:
+                                        metrics:
+                                            - name: "HTTP_REQUESTS"
+                                              unit: "NUMBER"
+                                              buckets:
+                                                  - key: "49ddd7db-35d6-497e-b497-2dc16af0cdcc"
+                                                    name: "api-1"
+                                                    type: GROUP
+                                                    buckets:
+                                                        - key: "e65289b0-35b2-40e7-8d41-711fba7fdc96"
+                                                          name: "app-1"
+                                                          type: LEAF
+                                                          measures:
+                                                              - name: "COUNT"
+                                                                value: 45
+                400:
+                    $ref: "#/components/responses/BadRequestError"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+
+    /analytics/time-series:
+        post:
+            tags:
+                - Analytics
+                - computation
+            summary: Query time series analytics
+            description: |
+                Return data points over time with optional grouping by facets (up to two facet dimensions).
+                Results are scoped to the APIs and applications the authenticated portal user is allowed to see.
+            operationId: queryTimeSeries
+            security:
+                - BasicAuth: []
+                - CookieAuth: []
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/AnalyticsTimeSeriesRequest"
+                        examples:
+                            hourly-by-api:
+                                summary: Hourly series grouped by API
+                                value:
+                                    timeRange:
+                                        from: "2025-01-01T00:00:00Z"
+                                        to: "2025-01-31T23:59:59Z"
+                                    interval: 3600000
+                                    by: ["API"]
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                            shorthand-interval:
+                                summary: Interval as duration string
+                                value:
+                                    timeRange:
+                                        from: "2025-01-01T00:00:00Z"
+                                        to: "2025-01-31T23:59:59Z"
+                                    interval: "1h"
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+            responses:
+                200:
+                    description: Time-series response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AnalyticsTimeSeriesResponse"
+                            examples:
+                                time-series-response:
+                                    summary: Time buckets with nested facet leaves
+                                    value:
+                                        metrics:
+                                            - name: "HTTP_REQUESTS"
+                                              unit: "NUMBER"
+                                              buckets:
+                                                  - key: "2025-01-01T00:00:00Z"
+                                                    timestamp: 1735689600000
+                                                    type: GROUP
+                                                    buckets:
+                                                        - key: "a5954f6e-1d95-463a-9a41-2442c575d022"
+                                                          name: "api-1"
+                                                          type: LEAF
+                                                          measures:
+                                                              - name: "COUNT"
+                                                                value: 1234
+                400:
+                    $ref: "#/components/responses/BadRequestError"
+                403:
+                    $ref: "#/components/responses/PermissionError"
+                500:
+                    $ref: "#/components/responses/InternalServerError"
+
     /auth/login:
         post:
             tags:
@@ -5660,6 +5883,200 @@ components:
                 y:
                     type: integer
                     format: int32
+        AnalyticsMetricName:
+            type: string
+            enum:
+                - HTTP_REQUESTS
+                - HTTP_ERRORS
+                - HTTP_ERROR_RATE
+                - HTTP_REQUEST_CONTENT_LENGTH
+                - HTTP_RESPONSE_CONTENT_LENGTH
+                - HTTP_ENDPOINT_RESPONSE_TIME
+                - HTTP_GATEWAY_RESPONSE_TIME
+                - HTTP_GATEWAY_LATENCY
+                - LLM_PROMPT_TOKEN_SENT
+                - LLM_PROMPT_TOKEN_RECEIVED
+                - LLM_PROMPT_TOKEN_SENT_COST
+                - LLM_PROMPT_TOKEN_RECEIVED_COST
+                - LLM_PROMPT_TOTAL_TOKEN
+                - LLM_PROMPT_TOKEN_TOTAL_COST
+                - MESSAGE_PAYLOAD_SIZE
+                - MESSAGES
+                - MESSAGE_ERRORS
+                - MESSAGE_GATEWAY_LATENCY
+            description: Available metric names for analytics queries
+        AnalyticsFacetName:
+            type: string
+            enum:
+                - API
+                - APPLICATION
+                - PLAN
+                - API_PRODUCT
+                - GATEWAY
+                - TENANT
+                - ZONE
+                - HTTP_METHOD
+                - HTTP_STATUS_CODE_GROUP
+                - HTTP_STATUS
+                - HTTP_PATH
+                - HTTP_PATH_MAPPING
+                - HOST
+                - GEO_IP_COUNTRY
+                - GEO_IP_REGION
+                - GEO_IP_CITY
+                - GEO_IP_CONTINENT
+                - CONSUMER_IP
+                - HTTP_USER_AGENT_OS_NAME
+                - HTTP_USER_AGENT_DEVICE
+                - MESSAGE_CONNECTOR_TYPE
+                - MESSAGE_CONNECTOR_ID
+                - MESSAGE_OPERATION_TYPE
+                - LLM_PROXY_MODEL
+                - LLM_PROXY_PROVIDER
+                - MCP_PROXY_METHOD
+                - MCP_PROXY_TOOL
+                - MCP_PROXY_RESOURCE
+                - MCP_PROXY_PROMPT
+            description: Available facet names for grouping analytics data
+        AnalyticsFilterName:
+            type: string
+            enum:
+                - API
+                - APPLICATION
+                - PLAN
+                - API_PRODUCT
+                - GATEWAY
+                - TENANT
+                - ZONE
+                - HTTP_METHOD
+                - HTTP_STATUS_CODE_GROUP
+                - HTTP_STATUS
+                - HTTP_PATH
+                - HTTP_PATH_MAPPING
+                - HOST
+                - GEO_IP_COUNTRY
+                - GEO_IP_REGION
+                - GEO_IP_CITY
+                - GEO_IP_CONTINENT
+                - CONSUMER_IP
+                - HTTP_USER_AGENT_OS_NAME
+                - HTTP_USER_AGENT_DEVICE
+                - MESSAGE_CONNECTOR_TYPE
+                - MESSAGE_CONNECTOR_ID
+                - MESSAGE_OPERATION_TYPE
+                - MESSAGE_SIZE
+                - MESSAGE_COUNT
+                - MESSAGE_ERROR_COUNT
+                - HTTP_ENDPOINT_RESPONSE_TIME
+                - HTTP_GATEWAY_LATENCY
+                - HTTP_GATEWAY_RESPONSE_TIME
+                - HTTP_REQUEST_CONTENT_LENGTH
+                - HTTP_RESPONSE_CONTENT_LENGTH
+                - LLM_PROXY_MODEL
+                - LLM_PROXY_PROVIDER
+                - MCP_PROXY_METHOD
+                - MCP_PROXY_TOOL
+                - MCP_PROXY_RESOURCE
+                - MCP_PROXY_PROMPT
+                - API_TYPE
+                - ERROR_KEY
+            description: Available filter names for filtering analytics data
+        AnalyticsFilterOperator:
+            type: string
+            enum:
+                - EQ
+                - IN
+                - LTE
+                - GTE
+            description: Filter operator
+        AnalyticsMeasureName:
+            type: string
+            enum:
+                - AVG
+                - MIN
+                - MAX
+                - P50
+                - P90
+                - P95
+                - P99
+                - COUNT
+                - PERCENTAGE
+            description: Measure / aggregation name
+            example: "COUNT"
+        AnalyticsUnitName:
+            type: string
+            enum:
+                - BYTES
+                - MILLISECONDS
+                - NUMBER
+                - PERCENT
+            description: Unit of measurement for metric values
+            example: "NUMBER"
+        AnalyticsInterval:
+            description: |
+                Interval for time-series queries as milliseconds (integer) or duration shorthand (`10s`, `1m`, `5h`, `1d`),
+                aligned with the Management API analytics contract.
+            oneOf:
+                - type: string
+                  pattern: ^\d+[smhd]$
+                  example: "1h"
+                - type: integer
+                  format: int64
+                  description: Interval in milliseconds
+                  example: 3600000
+        AnalyticsFilter:
+            description: |
+                Typed filter for analytics queries (same semantics as the Management API).
+            oneOf:
+                - $ref: "#/components/schemas/AnalyticsStringFilter"
+                - $ref: "#/components/schemas/AnalyticsNumberFilter"
+                - $ref: "#/components/schemas/AnalyticsArrayFilter"
+            discriminator:
+                propertyName: operator
+                mapping:
+                    EQ: "#/components/schemas/AnalyticsStringFilter"
+                    IN: "#/components/schemas/AnalyticsArrayFilter"
+                    LTE: "#/components/schemas/AnalyticsNumberFilter"
+                    GTE: "#/components/schemas/AnalyticsNumberFilter"
+            example:
+                name: "API"
+                operator: "EQ"
+                value: "7b6ebef3-6236-4ac5-815e-d3dcef83df5d"
+        AnalyticsStringFilter:
+            description: Filter for string values (operator EQ)
+            type: object
+            required: [name, operator, value]
+            properties:
+                name:
+                    $ref: "#/components/schemas/AnalyticsFilterName"
+                operator:
+                    $ref: "#/components/schemas/AnalyticsFilterOperator"
+                value:
+                    type: string
+        AnalyticsNumberFilter:
+            description: Filter for numeric values (operators LTE, GTE)
+            type: object
+            required: [name, operator, value]
+            properties:
+                name:
+                    $ref: "#/components/schemas/AnalyticsFilterName"
+                operator:
+                    $ref: "#/components/schemas/AnalyticsFilterOperator"
+                value:
+                    type: number
+        AnalyticsArrayFilter:
+            description: Filter for array values (operator IN)
+            type: object
+            required: [name, operator, value]
+            properties:
+                name:
+                    $ref: "#/components/schemas/AnalyticsFilterName"
+                operator:
+                    $ref: "#/components/schemas/AnalyticsFilterOperator"
+                value:
+                    type: array
+                    items:
+                        type: string
         AnalyticsWidgetRequest:
             properties:
                 type:
@@ -5669,26 +6086,32 @@ components:
                     $ref: "#/components/schemas/AnalyticsTimeRange"
                 metrics:
                     type: array
+                    minItems: 1
                     items:
                         $ref: "#/components/schemas/AnalyticsMetricRequest"
                 interval:
-                    description: Interval in milliseconds for time-series widgets.
-                    type: integer
-                    format: int64
+                    $ref: "#/components/schemas/AnalyticsInterval"
                 by:
                     description: Facets used to group analytics data.
                     type: array
+                    maxItems: 3
                     items:
-                        type: string
+                        $ref: "#/components/schemas/AnalyticsFacetName"
                 limit:
                     description: Maximum number of buckets to return.
                     type: integer
                     format: int32
+                    minimum: 1
                 filters:
                     type: array
                     items:
                         $ref: "#/components/schemas/AnalyticsFilter"
         AnalyticsTimeRange:
+            type: object
+            required:
+                - from
+                - to
+            description: Time range for analytics queries
             properties:
                 from:
                     type: string
@@ -5697,30 +6120,20 @@ components:
                     type: string
                     format: date-time
         AnalyticsMetricRequest:
+            type: object
+            required:
+                - name
             properties:
                 name:
-                    description: Analytics metric identifier.
-                    type: string
+                    $ref: "#/components/schemas/AnalyticsMetricName"
                 measures:
-                    description: Measures requested for the metric.
                     type: array
                     items:
-                        type: string
+                        $ref: "#/components/schemas/AnalyticsMeasureName"
                 filters:
                     type: array
                     items:
                         $ref: "#/components/schemas/AnalyticsFilter"
-        AnalyticsFilter:
-            properties:
-                name:
-                    description: Analytics filter identifier.
-                    type: string
-                operator:
-                    description: Operator applied to the filter.
-                    type: string
-                value:
-                    description: Value applied to the filter.
-                    type: object
         AnalyticsWidgetType:
             type: string
             enum:
@@ -5732,6 +6145,346 @@ components:
                 - time-series-bar
                 - vertical-bar
                 - horizontal-bar
+        AnalyticsMeasuresRequest:
+            description: |
+                Request for aggregated measures over a time range. Each entry in `metrics` describes
+                a metric and the list of measures to compute for it. Top-level `filters` apply to all
+                metrics; metric-level filters refine a specific metric.
+            type: object
+            required:
+                - timeRange
+                - metrics
+            properties:
+                timeRange:
+                    $ref: "#/components/schemas/AnalyticsTimeRange"
+                filters:
+                    description: Top-level filters applied to every metric.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFilter"
+                metrics:
+                    description: Metrics to compute measures for.
+                    type: array
+                    minItems: 1
+                    items:
+                        $ref: "#/components/schemas/AnalyticsComputationMetricRequest"
+        AnalyticsFacetsRequest:
+            description: |
+                Request for measures grouped by one or more facet dimensions. The `by` array controls
+                the grouping order and produces a tree of buckets in the response. Up to three facet dimensions.
+            type: object
+            required:
+                - timeRange
+                - by
+                - metrics
+            properties:
+                timeRange:
+                    $ref: "#/components/schemas/AnalyticsTimeRange"
+                by:
+                    description: Facet dimensions to group by. Applies to all metrics.
+                    type: array
+                    minItems: 1
+                    maxItems: 3
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFacetName"
+                limit:
+                    description: Maximum number of buckets to return.
+                    type: integer
+                    format: int32
+                    minimum: 1
+                filters:
+                    description: Top-level filters applied to every metric.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFilter"
+                metrics:
+                    description: Metrics to compute facets for. May carry metric-level filters and sorts.
+                    type: array
+                    minItems: 1
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFacetMetricRequest"
+                ranges:
+                    description: Optional numeric ranges to bucket values into (applied to the last facet).
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsNumberRange"
+        AnalyticsTimeSeriesRequest:
+            description: |
+                Request for measures spread over time, optionally grouped by facets (at most two facet dimensions).
+            type: object
+            required:
+                - timeRange
+                - interval
+                - metrics
+            properties:
+                timeRange:
+                    $ref: "#/components/schemas/AnalyticsTimeRange"
+                interval:
+                    $ref: "#/components/schemas/AnalyticsInterval"
+                by:
+                    description: Facet dimensions to nest inside each time bucket.
+                    type: array
+                    maxItems: 2
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFacetName"
+                limit:
+                    description: Maximum number of nested buckets to return.
+                    type: integer
+                    format: int32
+                    minimum: 1
+                filters:
+                    description: Top-level filters applied to every metric.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFilter"
+                metrics:
+                    description: Metrics to compute time series for. May carry metric-level filters and sorts.
+                    type: array
+                    minItems: 1
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFacetMetricRequest"
+                ranges:
+                    description: Optional numeric ranges to bucket values into (applied to the last facet).
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsNumberRange"
+        AnalyticsComputationMetricRequest:
+            description: A metric request for a measures query (no grouping or sorting).
+            type: object
+            required:
+                - name
+            properties:
+                name:
+                    $ref: "#/components/schemas/AnalyticsMetricName"
+                measures:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsMeasureName"
+                filters:
+                    description: Metric-level filters.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFilter"
+        AnalyticsFacetMetricRequest:
+            description: A metric request for faceted/time-series queries with optional sorts.
+            type: object
+            required:
+                - name
+            properties:
+                name:
+                    $ref: "#/components/schemas/AnalyticsMetricName"
+                measures:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsMeasureName"
+                filters:
+                    description: Metric-level filters.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFilter"
+                sorts:
+                    description: Sort criteria applied to the last facet.
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsSort"
+        AnalyticsSort:
+            description: Sort criteria over a measure.
+            type: object
+            required:
+                - measure
+                - order
+            properties:
+                measure:
+                    $ref: "#/components/schemas/AnalyticsMeasureName"
+                order:
+                    type: string
+                    enum:
+                        - ASC
+                        - DESC
+                    description: Sort direction
+        AnalyticsNumberRange:
+            description: A numeric range used to break down facet buckets.
+            type: object
+            required:
+                - from
+                - to
+            properties:
+                from:
+                    type: number
+                to:
+                    type: number
+        AnalyticsMeasure:
+            description: A single measure value.
+            type: object
+            required:
+                - name
+                - value
+            properties:
+                name:
+                    $ref: "#/components/schemas/AnalyticsMeasureName"
+                value:
+                    description: Measure value.
+                    type: number
+        AnalyticsMeasuresResponse:
+            description: Response containing one entry per metric with their aggregated measures.
+            type: object
+            required:
+                - metrics
+            properties:
+                metrics:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsMeasuresResponseMetric"
+        AnalyticsMeasuresResponseMetric:
+            description: Aggregated measures for a single metric.
+            type: object
+            required:
+                - name
+            properties:
+                name:
+                    $ref: "#/components/schemas/AnalyticsMetricName"
+                unit:
+                    $ref: "#/components/schemas/AnalyticsUnitName"
+                measures:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsMeasure"
+        AnalyticsFacetsResponse:
+            description: Response containing one entry per metric with their faceted buckets.
+            type: object
+            required:
+                - metrics
+            properties:
+                metrics:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsFacetsResponseMetric"
+        AnalyticsFacetsResponseMetric:
+            description: Faceted buckets for a single metric.
+            type: object
+            required:
+                - name
+            properties:
+                name:
+                    $ref: "#/components/schemas/AnalyticsMetricName"
+                unit:
+                    $ref: "#/components/schemas/AnalyticsUnitName"
+                buckets:
+                    $ref: "#/components/schemas/AnalyticsFacetBucketList"
+        AnalyticsFacetBucket:
+            description: Facet bucket node — either a leaf with measures or a group with nested buckets.
+            oneOf:
+                - $ref: "#/components/schemas/AnalyticsFacetBucketLeaf"
+                - $ref: "#/components/schemas/AnalyticsFacetBucketGroup"
+            discriminator:
+                propertyName: type
+                mapping:
+                    LEAF: "#/components/schemas/AnalyticsFacetBucketLeaf"
+                    GROUP: "#/components/schemas/AnalyticsFacetBucketGroup"
+        AnalyticsFacetBucketLeaf:
+            description: Leaf facet bucket with measure values.
+            type: object
+            required: [key, name, type, measures]
+            properties:
+                key:
+                    type: string
+                name:
+                    type: string
+                type:
+                    type: string
+                    enum: [LEAF]
+                measures:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsMeasure"
+        AnalyticsFacetBucketGroup:
+            description: Group facet bucket containing nested buckets.
+            type: object
+            required: [key, name, type, buckets]
+            properties:
+                key:
+                    type: string
+                name:
+                    type: string
+                type:
+                    type: string
+                    enum: [GROUP]
+                buckets:
+                    $ref: "#/components/schemas/AnalyticsFacetBucketList"
+        AnalyticsFacetBucketList:
+            type: array
+            items:
+                $ref: "#/components/schemas/AnalyticsFacetBucket"
+        AnalyticsTimeSeriesResponse:
+            description: Response containing one entry per metric with their time-series buckets.
+            type: object
+            required:
+                - metrics
+            properties:
+                metrics:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsTimeSeriesResponseMetric"
+        AnalyticsTimeSeriesResponseMetric:
+            description: Time-series buckets for a single metric.
+            type: object
+            required:
+                - name
+            properties:
+                name:
+                    $ref: "#/components/schemas/AnalyticsMetricName"
+                unit:
+                    $ref: "#/components/schemas/AnalyticsUnitName"
+                buckets:
+                    $ref: "#/components/schemas/AnalyticsTimeSeriesBucketList"
+        AnalyticsTimeSeriesBucket:
+            description: Time-series bucket — leaf with measures at a timestamp or group nesting facet buckets.
+            oneOf:
+                - $ref: "#/components/schemas/AnalyticsTimeSeriesBucketLeaf"
+                - $ref: "#/components/schemas/AnalyticsTimeSeriesBucketGroup"
+            discriminator:
+                propertyName: type
+                mapping:
+                    LEAF: "#/components/schemas/AnalyticsTimeSeriesBucketLeaf"
+                    GROUP: "#/components/schemas/AnalyticsTimeSeriesBucketGroup"
+        AnalyticsTimeSeriesBucketLeaf:
+            description: Time-series leaf bucket.
+            type: object
+            required: [key, timestamp, type, measures]
+            properties:
+                type:
+                    type: string
+                    enum: [LEAF]
+                key:
+                    type: string
+                    format: date-time
+                timestamp:
+                    type: integer
+                    format: int64
+                measures:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AnalyticsMeasure"
+        AnalyticsTimeSeriesBucketGroup:
+            description: Time-series group bucket with nested facet buckets.
+            type: object
+            required: [key, timestamp, type, buckets]
+            properties:
+                type:
+                    type: string
+                    enum: [GROUP]
+                key:
+                    type: string
+                    format: date-time
+                timestamp:
+                    type: integer
+                    format: int64
+                buckets:
+                    $ref: "#/components/schemas/AnalyticsFacetBucketList"
+        AnalyticsTimeSeriesBucketList:
+            type: array
+            items:
+                $ref: "#/components/schemas/AnalyticsTimeSeriesBucket"
         Info:
             properties:
                 name:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalAnalyticsComputationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalAnalyticsComputationResourceTest.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.analytics_engine.model.FacetBucketResponse;
+import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.Measure;
+import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricFacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesBucketResponse;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesMetricResponse;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesResponse;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeFacetsUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeMeasuresUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeTimeSeriesUseCase;
+import io.gravitee.apim.core.observability.model.FilterOperator;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.idp.api.authentication.UserDetails;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsComputationMetricRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetBucketGroup;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetBucketLeaf;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetMetricRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetName;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetsRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFacetsResponse;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFilter;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFilterName;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsFilterOperator;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMeasureName;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMeasuresRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMeasuresResponse;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsMetricName;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsStringFilter;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeRange;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeSeriesRequest;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsTimeSeriesResponse;
+import io.gravitee.rest.api.portal.rest.model.AnalyticsUnitName;
+import io.gravitee.rest.api.portal.rest.model.CustomInterval;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class PortalAnalyticsComputationResourceTest extends AbstractResourceTest {
+
+    @Autowired
+    private ComputeMeasuresUseCase computeMeasuresUseCase;
+
+    @Autowired
+    private ComputeFacetsUseCase computeFacetsUseCase;
+
+    @Autowired
+    private ComputeTimeSeriesUseCase computeTimeSeriesUseCase;
+
+    @Override
+    protected String contextPath() {
+        return "analytics";
+    }
+
+    @BeforeEach
+    void setUp() {
+        resetAllMocks();
+        reset(computeMeasuresUseCase, computeFacetsUseCase, computeTimeSeriesUseCase);
+        when(
+            parameterService.findAsBoolean(any(), eq(Key.PORTAL_NEXT_ANALYTICS_ENABLED), eq(ParameterReferenceType.ENVIRONMENT))
+        ).thenReturn(true);
+    }
+
+    /**
+     * The base {@link io.gravitee.rest.api.portal.rest.JerseySpringTest.AuthenticationFilter} only populates
+     * {@link SecurityContextHolder} as a side-effect when {@code getUserPrincipal()} is invoked. Since
+     * {@link io.gravitee.rest.api.portal.rest.resource.AbstractResource#getAuditInfo()} reads the
+     * holder directly, we eagerly populate it on the Jetty worker thread so the endpoint can resolve
+     * the authenticated caller without having to call {@code getAuthenticatedUser()} first.
+     */
+    @Override
+    protected void decorate(ResourceConfig resourceConfig) {
+        super.decorate(resourceConfig);
+        resourceConfig.register(
+            (ContainerRequestFilter) requestContext -> {
+                final var principal = new UsernamePasswordAuthenticationToken(
+                    new UserDetails(USER_NAME, "", Collections.emptyList()),
+                    new Object()
+                );
+                SecurityContextHolder.getContext().setAuthentication(principal);
+            },
+            10
+        );
+    }
+
+    @Test
+    void post_measures_returns_response_and_delegates_to_compute_measures_use_case() {
+        when(computeMeasuresUseCase.execute(any())).thenReturn(
+            new ComputeMeasuresUseCase.Output(
+                new MeasuresResponse(
+                    List.of(
+                        new MetricMeasuresResponse(
+                            MetricSpec.Name.HTTP_REQUESTS,
+                            MetricSpec.Unit.NUMBER,
+                            List.of(new Measure(MetricSpec.Measure.COUNT, 42))
+                        )
+                    )
+                )
+            )
+        );
+
+        final var response = target().path("measures").request().post(Entity.json(aMeasuresRequest()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        final var body = response.readEntity(AnalyticsMeasuresResponse.class);
+        assertThat(body.getMetrics()).hasSize(1);
+        assertThat(body.getMetrics().getFirst().getName()).isEqualTo(AnalyticsMetricName.HTTP_REQUESTS);
+        assertThat(body.getMetrics().getFirst().getUnit()).isEqualTo(AnalyticsUnitName.NUMBER);
+        assertThat(body.getMetrics().getFirst().getMeasures()).hasSize(1);
+        assertThat(body.getMetrics().getFirst().getMeasures().getFirst().getName()).isEqualTo(AnalyticsMeasureName.COUNT);
+        verify(computeMeasuresUseCase).execute(any());
+    }
+
+    @Test
+    void post_measures_forbidden_when_portal_next_analytics_disabled() {
+        when(
+            parameterService.findAsBoolean(any(), eq(Key.PORTAL_NEXT_ANALYTICS_ENABLED), eq(ParameterReferenceType.ENVIRONMENT))
+        ).thenReturn(false);
+
+        final var response = target().path("measures").request().post(Entity.json(aMeasuresRequest()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        verify(computeMeasuresUseCase, never()).execute(any());
+    }
+
+    @Test
+    void post_facets_returns_response_and_delegates_to_compute_facets_use_case() {
+        when(computeFacetsUseCase.execute(any())).thenReturn(new ComputeFacetsUseCase.Output(new FacetsResponse(List.of())));
+
+        final var response = target().path("facets").request().post(Entity.json(aFacetsRequest()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        final var body = response.readEntity(AnalyticsFacetsResponse.class);
+        assertThat(body.getMetrics()).isEmpty();
+        verify(computeFacetsUseCase).execute(any());
+    }
+
+    @Test
+    void post_facets_forbidden_when_portal_next_analytics_disabled() {
+        when(
+            parameterService.findAsBoolean(any(), eq(Key.PORTAL_NEXT_ANALYTICS_ENABLED), eq(ParameterReferenceType.ENVIRONMENT))
+        ).thenReturn(false);
+
+        final var response = target().path("facets").request().post(Entity.json(aFacetsRequest()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        verify(computeFacetsUseCase, never()).execute(any());
+    }
+
+    @Test
+    void post_time_series_returns_response_and_delegates_to_compute_time_series_use_case() {
+        when(computeTimeSeriesUseCase.execute(any())).thenReturn(new ComputeTimeSeriesUseCase.Output(new TimeSeriesResponse(List.of())));
+
+        final var response = target().path("time-series").request().post(Entity.json(aTimeSeriesRequest()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        final var body = response.readEntity(AnalyticsTimeSeriesResponse.class);
+        assertThat(body.getMetrics()).isEmpty();
+        verify(computeTimeSeriesUseCase).execute(any());
+    }
+
+    @Test
+    void post_time_series_forbidden_when_portal_next_analytics_disabled() {
+        when(
+            parameterService.findAsBoolean(any(), eq(Key.PORTAL_NEXT_ANALYTICS_ENABLED), eq(ParameterReferenceType.ENVIRONMENT))
+        ).thenReturn(false);
+
+        final var response = target().path("time-series").request().post(Entity.json(aTimeSeriesRequest()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+        verify(computeTimeSeriesUseCase, never()).execute(any());
+    }
+
+    @Test
+    void post_measures_maps_string_filter_to_core_filter() {
+        when(computeMeasuresUseCase.execute(any())).thenReturn(new ComputeMeasuresUseCase.Output(new MeasuresResponse(List.of())));
+
+        final var apiId = "7b6ebef3-6236-4ac5-815e-d3dcef83df5d";
+        final var request = aMeasuresRequest().filters(
+            List.of(
+                new AnalyticsFilter(
+                    new AnalyticsStringFilter().name(AnalyticsFilterName.API).operator(AnalyticsFilterOperator.EQ).value(apiId)
+                )
+            )
+        );
+
+        final var response = target().path("measures").request().post(Entity.json(request));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        final var captor = ArgumentCaptor.forClass(ComputeMeasuresUseCase.Input.class);
+        verify(computeMeasuresUseCase).execute(captor.capture());
+        assertThat(captor.getValue().request().filters()).containsExactly(
+            new io.gravitee.apim.core.analytics_engine.model.Filter(FilterSpec.Name.API, FilterOperator.EQ, apiId)
+        );
+    }
+
+    @Test
+    void post_measures_returns_400_for_unknown_filter_shape() {
+        final var json = """
+            {
+              "timeRange": {"from": "2026-01-01T00:00:00Z", "to": "2026-01-02T00:00:00Z"},
+              "filters": [{"name": "API", "operator": "UNKNOWN_OP", "value": "abc"}],
+              "metrics": [{"name": "HTTP_REQUESTS", "measures": ["COUNT"]}]
+            }
+            """;
+
+        final var response = target().path("measures").request().post(Entity.json(json));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        verify(computeMeasuresUseCase, never()).execute(any());
+    }
+
+    @Test
+    void post_time_series_accepts_interval_as_milliseconds() {
+        when(computeTimeSeriesUseCase.execute(any())).thenReturn(new ComputeTimeSeriesUseCase.Output(new TimeSeriesResponse(List.of())));
+
+        final var request = aTimeSeriesRequest().interval(new CustomInterval(3_600_000L));
+
+        final var response = target().path("time-series").request().post(Entity.json(request));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        final var captor = ArgumentCaptor.forClass(ComputeTimeSeriesUseCase.Input.class);
+        verify(computeTimeSeriesUseCase).execute(captor.capture());
+        assertThat(captor.getValue().request().interval()).isEqualTo(3_600_000L);
+    }
+
+    @Test
+    void post_time_series_accepts_interval_as_duration_shorthand() {
+        when(computeTimeSeriesUseCase.execute(any())).thenReturn(new ComputeTimeSeriesUseCase.Output(new TimeSeriesResponse(List.of())));
+
+        final var json = """
+            {
+              "timeRange": {"from": "2026-01-01T00:00:00Z", "to": "2026-01-02T00:00:00Z"},
+              "interval": "1h",
+              "metrics": [{"name": "HTTP_REQUESTS", "measures": ["COUNT"]}]
+            }
+            """;
+
+        final var response = target().path("time-series").request().post(Entity.json(json));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        final var captor = ArgumentCaptor.forClass(ComputeTimeSeriesUseCase.Input.class);
+        verify(computeTimeSeriesUseCase).execute(captor.capture());
+        assertThat(captor.getValue().request().interval()).isEqualTo(3_600_000L);
+    }
+
+    @Test
+    void post_facets_maps_leaf_and_group_buckets_in_response() {
+        final var leaf = new FacetBucketResponse("/api-x", null, null, List.of(new Measure(MetricSpec.Measure.COUNT, 5)));
+        final var group = new FacetBucketResponse("APP-1", null, List.of(leaf), null);
+        when(computeFacetsUseCase.execute(any())).thenReturn(
+            new ComputeFacetsUseCase.Output(
+                new FacetsResponse(List.of(new MetricFacetsResponse(MetricSpec.Name.HTTP_REQUESTS, MetricSpec.Unit.NUMBER, List.of(group))))
+            )
+        );
+
+        final var response = target().path("facets").request().post(Entity.json(aFacetsRequest()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        final var body = response.readEntity(AnalyticsFacetsResponse.class);
+        assertThat(body.getMetrics()).hasSize(1);
+        final var topBucket = body.getMetrics().getFirst().getBuckets().getFirst().getActualInstance();
+        assertThat(topBucket).isInstanceOf(AnalyticsFacetBucketGroup.class);
+        final var topGroup = (AnalyticsFacetBucketGroup) topBucket;
+        assertThat(topGroup.getType()).isEqualTo(AnalyticsFacetBucketGroup.TypeEnum.GROUP);
+        assertThat(topGroup.getKey()).isEqualTo("APP-1");
+        assertThat(topGroup.getBuckets()).hasSize(1);
+        final var nestedBucket = topGroup.getBuckets().getFirst().getActualInstance();
+        assertThat(nestedBucket).isInstanceOf(AnalyticsFacetBucketLeaf.class);
+        final var nestedLeaf = (AnalyticsFacetBucketLeaf) nestedBucket;
+        assertThat(nestedLeaf.getType()).isEqualTo(AnalyticsFacetBucketLeaf.TypeEnum.LEAF);
+        assertThat(nestedLeaf.getKey()).isEqualTo("/api-x");
+        assertThat(nestedLeaf.getMeasures()).hasSize(1);
+    }
+
+    @Test
+    void post_time_series_maps_leaf_bucket_in_response() {
+        final var bucket = new TimeSeriesBucketResponse(
+            "2026-01-01T00:00:00Z",
+            null,
+            1_735_689_600_000L,
+            null,
+            List.of(new Measure(MetricSpec.Measure.COUNT, 7))
+        );
+        when(computeTimeSeriesUseCase.execute(any())).thenReturn(
+            new ComputeTimeSeriesUseCase.Output(
+                new TimeSeriesResponse(
+                    List.of(new TimeSeriesMetricResponse(MetricSpec.Name.HTTP_REQUESTS, MetricSpec.Unit.NUMBER, List.of(bucket)))
+                )
+            )
+        );
+
+        final var response = target().path("time-series").request().post(Entity.json(aTimeSeriesRequest()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        final var body = response.readEntity(AnalyticsTimeSeriesResponse.class);
+        assertThat(body.getMetrics()).hasSize(1);
+        assertThat(body.getMetrics().getFirst().getBuckets()).hasSize(1);
+    }
+
+    private static AnalyticsTimeRange aTimeRange() {
+        final var now = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+        return new AnalyticsTimeRange().from(now.minusDays(1)).to(now);
+    }
+
+    private static AnalyticsMeasuresRequest aMeasuresRequest() {
+        return new AnalyticsMeasuresRequest()
+            .timeRange(aTimeRange())
+            .metrics(
+                List.of(
+                    new AnalyticsComputationMetricRequest()
+                        .name(AnalyticsMetricName.HTTP_REQUESTS)
+                        .measures(List.of(AnalyticsMeasureName.COUNT))
+                )
+            );
+    }
+
+    private static AnalyticsFacetsRequest aFacetsRequest() {
+        return new AnalyticsFacetsRequest()
+            .timeRange(aTimeRange())
+            .by(List.of(AnalyticsFacetName.API))
+            .metrics(
+                List.of(
+                    new AnalyticsFacetMetricRequest().name(AnalyticsMetricName.HTTP_REQUESTS).measures(List.of(AnalyticsMeasureName.COUNT))
+                )
+            );
+    }
+
+    private static AnalyticsTimeSeriesRequest aTimeSeriesRequest() {
+        return new AnalyticsTimeSeriesRequest()
+            .timeRange(aTimeRange())
+            .interval(new CustomInterval(60_000L))
+            .metrics(
+                List.of(
+                    new AnalyticsFacetMetricRequest().name(AnalyticsMetricName.HTTP_REQUESTS).measures(List.of(AnalyticsMeasureName.COUNT))
+                )
+            );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -41,6 +41,9 @@ import io.gravitee.apim.core.analytics_engine.domain_service.QueryFilterTransfor
 import io.gravitee.apim.core.analytics_engine.domain_service.UnitEnrichmentPostProcessor;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeFacetsUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeMeasuresUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeTimeSeriesUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiMetricSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetApiSpecUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetMetricFacetSpecUseCase;
@@ -1289,6 +1292,21 @@ public class ResourceContextConfiguration {
     @Bean
     public GetDashboardUseCase getDashboardUseCase() {
         return mock(GetDashboardUseCase.class);
+    }
+
+    @Bean
+    public ComputeMeasuresUseCase computeMeasuresUseCase() {
+        return mock(ComputeMeasuresUseCase.class);
+    }
+
+    @Bean
+    public ComputeFacetsUseCase computeFacetsUseCase() {
+        return mock(ComputeFacetsUseCase.class);
+    }
+
+    @Bean
+    public ComputeTimeSeriesUseCase computeTimeSeriesUseCase() {
+        return mock(ComputeTimeSeriesUseCase.class);
     }
 
     @Bean


### PR DESCRIPTION
Introduce new REST endpoints for analytics measures, facets, and time-series computations. Update OpenAPI spec, add request/response mappers, and include relevant services with tests. Handle null filters and facets defensively in core services.

## Issue

https://gravitee.atlassian.net/browse/APIM-13534

## Description

This PR introduces portal-facing analytics computation endpoints to support the Next Gen Portal dashboards experience. It adds dedicated REST endpoints to compute measures, facets, and time-series analytics, backed by the shared core analytics-engine use cases, and updates the Portal OpenAPI contract accordingly.

New endpoints under /portal/environments/{envId}/analytics:

- POST /analytics/measures
- POST /analytics/facets
- POST /analytics/time-series

Feature-flag gated via PORTAL_NEXT_ANALYTICS_ENABLED at the analytics root resource, so all analytics endpoints inherit the same access check.

Portal ↔ Core mapping layer (PortalAnalyticsMeasuresMapper) converting Portal DTOs to core models (metrics/measures/filters/facets/time range) and returning mapped responses; unknown enum values return 400 Bad Request.

Core robustness hardening:

- Validator improvements around filter validation and request constraints.
- Tests covering the new endpoints (successful mapping/delegation + 403 when the feature is disabled).

OpenAPI
Portal contract updated to document the new analytics computation operations (computeAnalyticsMeasures, computeAnalyticsFacets, computeAnalyticsTimeSeries) with request/response schemas and standard error responses.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

