### PR TITLE
feat(portal): delete registered member from application

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.html
@@ -20,6 +20,9 @@
   <h4 class="next-gen-h4 members__title" data-testid="members-section-title" i18n="@@applicationMembersTitle">
     Members ({{ totalElements() }})
   </h4>
+  @if (error(); as errorText) {
+    <p class="members__error next-gen-small" data-testid="members-delete-error" role="alert">{{ errorText }}</p>
+  }
   @if (membersResource.isLoading()) {
     <app-loader />
   } @else if (membersResource.error()) {
@@ -44,9 +47,10 @@
       [currentPage]="currentPage()"
       [pageSize]="pageSize()"
       [navigable]="false"
-      [actions]="actions"
+      [actions]="actions()"
       (pageChange)="onPageChange($event)"
       (pageSizeChange)="onPageSizeChange($event)"
+      (actionClick)="onActionClick($event)"
     >
       <ng-template appTableCell="name" let-row>
         <app-user-cell [user]="row.user" [isCurrentUser]="row.isCurrentUser" />

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
@@ -13,15 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogModule } from '@angular/material/dialog';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 
 import { ApplicationTabMembersComponent } from './application-tab-members.component';
 import { ApplicationTabMembersComponentHarness } from './application-tab-members.component.harness';
+import { ConfirmDialogComponent } from '../../../../components/confirm-dialog/confirm-dialog.component';
+import { ConfirmDialogHarness } from '../../../../components/confirm-dialog/confirm-dialog.harness';
 import { MembersResponse } from '../../../../entities/member/member';
 import { fakeMember, fakeMembersResponse } from '../../../../entities/member/member.fixtures';
 import { fakeUserApplicationPermissions } from '../../../../entities/permission/permission.fixtures';
@@ -34,11 +39,12 @@ const CURRENT_USER_ID = 'current-user-id';
 describe('ApplicationTabMembersComponent', () => {
   let fixture: ComponentFixture<ApplicationTabMembersComponent>;
   let httpTestingController: HttpTestingController;
+  let rootLoader: HarnessLoader;
   const applicationId = 'app-1';
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ApplicationTabMembersComponent],
+      imports: [ApplicationTabMembersComponent, ConfirmDialogComponent, MatDialogModule],
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -47,10 +53,13 @@ describe('ApplicationTabMembersComponent', () => {
         { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
         { provide: CurrentUserService, useValue: { user: () => ({ id: CURRENT_USER_ID }) } },
       ],
-    }).compileComponents();
+    })
+      .overrideProvider(InteractivityChecker, { useValue: { isFocusable: () => true } })
+      .compileComponents();
 
     fixture = TestBed.createComponent(ApplicationTabMembersComponent);
     httpTestingController = TestBed.inject(HttpTestingController);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     fixture.componentRef.setInput('applicationId', applicationId);
     fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
   });
@@ -137,7 +146,7 @@ describe('ApplicationTabMembersComponent', () => {
     expect(await harness.getPaginatedTable()).toBeNull();
   });
 
-  it('should render no action buttons in phase 01', async () => {
+  it('should not show delete button when user lacks MEMBER[D] permission', async () => {
     const harness = await flush(fakeMembersResponse([fakeMember(), fakeMember({ id: 'member-2', role: 'PRIMARY_OWNER' })]));
     const table = await harness.getPaginatedTable();
     const actions = await table!.getActionButtons();
@@ -308,6 +317,84 @@ describe('ApplicationTabMembersComponent', () => {
     it('should not mark other roles as PRIMARY_OWNER', async () => {
       const harness = await flush(fakeMembersResponse([fakeMember({ role: 'USER' })]));
       expect(await harness.isPrimaryOwnerRoleVisible()).toBe(false);
+    });
+  });
+
+  describe('delete action', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'D'] }));
+    });
+
+    it('should show delete button when user has MEMBER[D] permission', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+      const table = await harness.getPaginatedTable();
+      const deleteButton = await table!.getActionButton('delete');
+      expect(deleteButton).not.toBeNull();
+    });
+
+    it('should hide delete button for PRIMARY_OWNER', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ role: 'PRIMARY_OWNER' })]));
+      const table = await harness.getPaginatedTable();
+      const deleteButton = await table!.getActionButton('delete');
+      expect(deleteButton).toBeNull();
+    });
+
+    it('should disable delete button for current user', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ user: { id: CURRENT_USER_ID, _links: {} } })]));
+      const table = await harness.getPaginatedTable();
+      const deleteButton = await table!.getActionButton('delete');
+      expect(await deleteButton!.isDisabled()).toBe(true);
+    });
+
+    it('should not disable delete button for other members', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+      const table = await harness.getPaginatedTable();
+      const deleteButton = await table!.getActionButton('delete');
+      expect(await deleteButton!.isDisabled()).toBe(false);
+    });
+
+    it('should open confirmation dialog on delete click', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+      const table = await harness.getPaginatedTable();
+      await table!.getActionButton('delete').then(btn => btn!.click());
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      expect(dialog).not.toBeNull();
+    });
+
+    it('should send DELETE request and reload list on confirm', async () => {
+      const member = fakeMember({ id: 'member-1' });
+      const harness = await flush(fakeMembersResponse([member]));
+      const table = await harness.getPaginatedTable();
+      await table!.getActionButton('delete').then(btn => btn!.click());
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      await dialog!.confirm();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne(r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/members/${member.id}` && r.method === 'DELETE')
+        .flush(null, { status: 204, statusText: 'No Content' });
+      fixture.detectChanges();
+
+      // reload() triggers a new _search request; flush it before calling whenStable()
+      httpTestingController.expectOne(r => r.url.includes('members/_search')).flush(fakeMembersResponse([member]));
+      await fixture.whenStable();
+    });
+
+    it('should not send DELETE request when dialog is cancelled', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+      const table = await harness.getPaginatedTable();
+      await table!.getActionButton('delete').then(btn => btn!.click());
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      await dialog!.cancel();
+      fixture.detectChanges();
+
+      httpTestingController.expectNone(r => r.method === 'DELETE');
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, inject, input, signal } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
-import { of } from 'rxjs';
+import { Component, computed, DestroyRef, inject, input, signal } from '@angular/core';
+import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { EMPTY, of, switchMap, tap } from 'rxjs';
 
+import { ConfirmDialogComponent, ConfirmDialogData } from '../../../../components/confirm-dialog/confirm-dialog.component';
 import { LoaderComponent } from '../../../../components/loader/loader.component';
 import { PaginatedTableComponent, TableAction, TableColumn } from '../../../../components/paginated-table/paginated-table.component';
 import { TableCellDirective } from '../../../../components/paginated-table/table-cell.directive';
@@ -45,13 +47,15 @@ interface MembersRequestParams {
 @Component({
   selector: 'app-application-tab-members',
   standalone: true,
-  imports: [LoaderComponent, PaginatedTableComponent, SearchBarComponent, TableCellDirective, UserCellComponent],
+  imports: [LoaderComponent, MatDialogModule, PaginatedTableComponent, SearchBarComponent, TableCellDirective, UserCellComponent],
   templateUrl: './application-tab-members.component.html',
   styleUrl: './application-tab-members.component.scss',
 })
 export class ApplicationTabMembersComponent {
   private readonly membershipService = inject(MembershipService);
   private readonly currentUserService = inject(CurrentUserService);
+  private readonly matDialog = inject(MatDialog);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly applicationId = input.required<string>();
   readonly userApplicationPermissions = input.required<UserApplicationPermissions>();
@@ -59,16 +63,30 @@ export class ApplicationTabMembersComponent {
   readonly currentPage = signal(1);
   readonly pageSize = signal(10);
   readonly searchTerm = signal('');
+  readonly error = signal<string | null>(null);
 
   readonly tableColumns: TableColumn[] = [
     { id: 'name', label: $localize`:@@memberColumnName:Name` },
     { id: 'role', label: $localize`:@@memberColumnRole:Role` },
   ];
 
-  // Empty in phase 01; update/delete will be added in phase 02 (APIM-12770).
-  readonly actions: TableAction<MemberTableRow>[] = [];
-
   readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
+  readonly canDelete = computed(() => this.userApplicationPermissions().MEMBER?.includes('D') ?? false);
+
+  readonly actions = computed<TableAction<MemberTableRow>[]>(() =>
+    this.canDelete()
+      ? [
+          {
+            id: 'delete',
+            icon: 'delete_outline',
+            ariaLabel: $localize`:@@deleteMemberAriaLabel:Delete member`,
+            color: 'warn',
+            isVisible: (row: MemberTableRow) => !row.isPrimaryOwner,
+            isDisabled: (row: MemberTableRow) => row.isCurrentUser,
+          },
+        ]
+      : [],
+  );
 
   protected readonly membersResource = rxResource<MembersResponse | undefined, MembersRequestParams | null>({
     params: () =>
@@ -112,6 +130,35 @@ export class ApplicationTabMembersComponent {
   onSearchTermChange(term: string): void {
     this.searchTerm.set(term);
     this.currentPage.set(1);
+  }
+
+  onActionClick({ actionId, row }: { actionId: string; row: MemberTableRow }): void {
+    if (actionId === 'delete') {
+      this.openDeleteConfirmation(row);
+    }
+  }
+
+  private openDeleteConfirmation(member: MemberTableRow): void {
+    this.error.set(null);
+    this.matDialog
+      .open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
+        role: 'alertdialog',
+        data: {
+          title: $localize`:@@deleteMemberDialogTitle:Delete member?`,
+          content: $localize`:@@deleteMemberDialogContent:Are you sure you want to remove ${member.user.displayName}:memberName: from this application? They will lose all access.`,
+          confirmLabel: $localize`:@@deleteMemberDialogConfirm:Delete`,
+          cancelLabel: $localize`:@@deleteMemberDialogCancel:Cancel`,
+        },
+      })
+      .afterClosed()
+      .pipe(
+        switchMap(confirmed => (confirmed ? this.membershipService.deleteApplicationMember(this.applicationId(), member.id) : EMPTY)),
+        tap(() => this.membersResource.reload()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        error: () => this.error.set($localize`:@@deleteMemberError:An error occurred while removing the member. Please try again.`),
+      });
   }
 
   private toRow(member: Member): MemberTableRow {

--- a/gravitee-apim-portal-webui-next/src/services/membership.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/membership.service.spec.ts
@@ -78,4 +78,15 @@ describe('MembershipService', () => {
     expect(req.request.body).toEqual({ filters: { displayName: 'Ada' } });
     req.flush(response);
   });
+
+  it('should delete an application member', done => {
+    const memberId = 'member-1';
+
+    service.deleteApplicationMember(applicationId, memberId).subscribe(() => done());
+
+    const req = httpTestingController.expectOne(
+      r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/members/${memberId}` && r.method === 'DELETE',
+    );
+    req.flush(null, { status: 204, statusText: 'No Content' });
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/membership.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/membership.service.ts
@@ -34,4 +34,8 @@ export class MembershipService {
       { params: { page, size } },
     );
   }
+
+  deleteApplicationMember(applicationId: string, memberId: string): Observable<void> {
+    return this.http.delete<void>(`${this.configService.baseURL}/applications/${applicationId}/members/${memberId}`);
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11532

## Description

- Added `MembershipService.deleteApplicationMember()` calling `DELETE /applications/{id}/members/{memberId}`
- Added delete action to `ApplicationTabMembersComponent`, visible only to users with `MEMBER:D` permission
- PRIMARY_OWNER rows have no delete button (`isVisible: false`); current user's own row is visible but disabled
- Confirmation dialog shows the member's name and warns they will lose all access; on confirm sends DELETE and reloads the list via `rxResource.reload()`
- Added service unit test and 6 new component tests covering permission gating, PRIMARY_OWNER/self-row behaviour, and confirm/cancel dialog flow

https://github.com/user-attachments/assets/fb2e4061-a916-4795-b1e5-a13f56703123


