### PR TITLE
fix: fix undefined apiId in subscription fetch URL when closing a V2 apis

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/PlanConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/PlanConverter.java
@@ -58,6 +58,7 @@ public class PlanConverter {
         entity.setDescription(plan.getDescription());
         entity.setReferenceId(plan.getReferenceId());
         entity.setReferenceType(GenericPlanEntity.ReferenceType.valueOf(plan.getReferenceType().name()));
+        entity.setApi(plan.getReferenceId());
 
         entity.setEnvironmentId(plan.getEnvironmentId());
         entity.setCreatedAt(plan.getCreatedAt());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/PlanConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/PlanConverterTest.java
@@ -66,7 +66,7 @@ public class PlanConverterTest {
         assertEquals(plan.getValidation().name(), planEntity.getValidation().name());
         assertEquals(plan.getStatus().name(), planEntity.getStatus().name());
         assertEquals(plan.getReferenceId(), planEntity.getReferenceId());
-        assertEquals(plan.getApi(), planEntity.getApi());
+        assertEquals(plan.getReferenceId(), planEntity.getApi());
         assertEquals(plan.getGeneralConditions(), planEntity.getGeneralConditions());
         assertEquals(plan.getSecurity().name(), planEntity.getSecurity().name());
         assertSame(flows, planEntity.getFlows());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13775

## Description

undefined in URL -


<img width="1728" height="869" alt="Screenshot 2026-04-24 at 5 21 43 PM" src="https://github.com/user-attachments/assets/376e05f1-01f4-45a8-bff5-165c279f09c3" />


Fix:


https://github.com/user-attachments/assets/020708ac-10e8-43ff-8bc1-4f0d8ab89f8a




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

