### PR TITLE
chore(console, portal): update nginx version to 1.30.0

### DIFF
--- a/gravitee-apim-console-webui/docker/Dockerfile
+++ b/gravitee-apim-console-webui/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/nginx:1.27.5
+FROM graviteeio/nginx:1.30.0
 LABEL maintainer="contact@graviteesource.com"
 
 ENV CONSOLE_BASE_HREF="/"

--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/nginx:1.27.5
+FROM graviteeio/nginx:1.30.0
 LABEL maintainer="contact@graviteesource.com"
 
 EXPOSE 8080


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13245

## Description

This bumps us the base docker nginx image for the front-end modules.

## Additional context

### Pre fix: 

<img width="1495" height="854" alt="image" src="https://github.com/user-attachments/assets/c746bd4a-ff3f-453e-9a61-28b4f265501c" />

### Post fix: 

<img width="1236" height="751" alt="image" src="https://github.com/user-attachments/assets/8d8ce653-f509-4b2c-ab41-ece2c1ff99e8" />

