### PR TITLE
feat: expose group resources in the automation API

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Group.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Group.java
@@ -43,6 +43,7 @@ public class Group {
     private String id;
     private String environmentId;
     private String name;
+    private String hrid;
     private List<GroupEventRule> eventRules;
     private Date createdAt;
     private Date updatedAt;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcGroupRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcGroupRepository.java
@@ -68,6 +68,7 @@ public class JdbcGroupRepository extends JdbcAbstractCrudRepository<Group, Strin
             .addColumn("id", Types.NVARCHAR, String.class)
             .addColumn("environment_id", Types.NVARCHAR, String.class)
             .addColumn("name", Types.NVARCHAR, String.class)
+            .addColumn("hrid", Types.NVARCHAR, String.class)
             .addColumn("created_at", Types.TIMESTAMP, Date.class)
             .addColumn("updated_at", Types.TIMESTAMP, Date.class)
             .addColumn("max_invitation", Types.INTEGER, Integer.class)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/06_add_hrid_to_groups_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/06_add_hrid_to_groups_table.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_06-add_hrid_groups_table
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}groups
+            columns:
+              - column:
+                  name: hrid
+                  type: nvarchar(256)
+                  constraints:
+                    nullable: true

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -339,3 +339,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/04_add_cross_id_to_clusters_table.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/05_add_lifecycle_to_clusters_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/06_add_hrid_to_groups_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/GroupMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/GroupMongo.java
@@ -35,6 +35,7 @@ public class GroupMongo extends DeprecatedAuditable {
 
     private String environmentId;
     private String name;
+    private String hrid;
     private List<String> administrators;
     private List<GroupEventRuleMongo> eventRules;
     private Integer maxInvitation;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
@@ -22,6 +22,8 @@ import io.gravitee.apim.rest.api.automation.resource.ApisResource;
 import io.gravitee.apim.rest.api.automation.resource.ApplicationsResource;
 import io.gravitee.apim.rest.api.automation.resource.EnvironmentResource;
 import io.gravitee.apim.rest.api.automation.resource.EnvironmentsResource;
+import io.gravitee.apim.rest.api.automation.resource.GroupResource;
+import io.gravitee.apim.rest.api.automation.resource.GroupsResource;
 import io.gravitee.apim.rest.api.automation.resource.OpenAPIResource;
 import io.gravitee.apim.rest.api.automation.resource.OrganizationResource;
 import io.gravitee.apim.rest.api.automation.resource.SharedPolicyGroupsResource;
@@ -52,6 +54,8 @@ public class GraviteeAutomationApplication extends ResourceConfig {
         register(ApisResource.class);
         register(ApiSubscriptionsResource.class);
         register(ApplicationsResource.class);
+        register(GroupResource.class);
+        register(GroupsResource.class);
         register(SharedPolicyGroupsResource.class);
 
         register(ValidationDomainMapper.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/helpers/CrdIdHelper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/helpers/CrdIdHelper.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.api.model.crd.PageCRD;
 import io.gravitee.apim.core.api.model.crd.PlanCRD;
 import io.gravitee.apim.core.application.model.crd.ApplicationCRDSpec;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
 import io.gravitee.apim.core.shared_policy_group.model.SharedPolicyGroupCRD;
 import io.gravitee.rest.api.service.common.HRIDToUUID;
 import java.util.Map;
@@ -78,6 +79,12 @@ public class CrdIdHelper {
                 pageCRD.setParentId(HRIDToUUID.page().context(audit).api(apiHrid).page(pageCRD.getParentHrid()).id());
             }
         });
+    }
+
+    public static void generateGroupId(GroupCRDSpec spec, AuditInfo audit) {
+        if (spec.getId() == null) {
+            spec.setId(HRIDToUUID.group().context(audit).hrid(spec.getName()).id());
+        }
     }
 
     public static void generateApplicationId(ApplicationCRDSpec spec, AuditInfo audit) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/helpers/CrdIdHelper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/helpers/CrdIdHelper.java
@@ -83,7 +83,7 @@ public class CrdIdHelper {
 
     public static void generateGroupId(GroupCRDSpec spec, AuditInfo audit) {
         if (spec.getId() == null) {
-            spec.setId(HRIDToUUID.group().context(audit).hrid(spec.getName()).id());
+            spec.setId(HRIDToUUID.group().context(audit).hrid(spec.getHrid()).id());
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/GroupMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/GroupMapper.java
@@ -66,6 +66,7 @@ public interface GroupMapper {
 
     default GroupState groupToGroupState(Group group, Set<GroupCRDSpec.Member> members) {
         GroupSpec spec = new GroupSpec();
+        spec.setHrid(group.getHrid());
         spec.setName(group.getName());
         spec.setNotifyMembers(!group.isDisableMembershipNotifications());
         spec.setMembers(members != null ? members.stream().map(this::memberToGroupMember).toList() : List.of());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/GroupMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/GroupMapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.mapper;
+
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
+import io.gravitee.apim.core.group.model.crd.GroupCRDStatus;
+import io.gravitee.apim.core.member.model.RoleScope;
+import io.gravitee.apim.rest.api.automation.model.Errors;
+import io.gravitee.apim.rest.api.automation.model.GroupMember;
+import io.gravitee.apim.rest.api.automation.model.GroupSpec;
+import io.gravitee.apim.rest.api.automation.model.GroupState;
+import io.gravitee.apim.rest.api.automation.model.GroupStatus;
+import io.gravitee.definition.model.Origin;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface GroupMapper {
+    GroupMapper INSTANCE = Mappers.getMapper(GroupMapper.class);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "origin", expression = "java(io.gravitee.definition.model.Origin.KUBERNETES.name())")
+    GroupCRDSpec groupSpecToGroupCRDSpec(GroupSpec groupSpec);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "roles", qualifiedByName = "stringMapToRoleScopeMap")
+    GroupCRDSpec.Member groupMemberToMember(GroupMember groupMember);
+
+    @Mapping(target = "roles", qualifiedByName = "roleScopeMapToStringMap")
+    GroupMember memberToGroupMember(GroupCRDSpec.Member member);
+
+    GroupStatus toGroupStatus(GroupCRDStatus status);
+
+    Errors toErrors(GroupCRDStatus.Errors errors);
+
+    default GroupState groupSpecAndStatusToGroupState(GroupSpec spec, GroupCRDStatus status) {
+        GroupState state = new GroupState();
+        state.setSpec(spec);
+        state.setStatus(toGroupStatus(status));
+        return state;
+    }
+
+    default GroupState groupToGroupState(Group group, Set<GroupCRDSpec.Member> members) {
+        GroupSpec spec = new GroupSpec();
+        spec.setName(group.getName());
+        spec.setNotifyMembers(!group.isDisableMembershipNotifications());
+        spec.setMembers(members != null ? members.stream().map(this::memberToGroupMember).toList() : List.of());
+
+        GroupStatus status = new GroupStatus();
+        status.setId(group.getId());
+        status.setMembers(members != null ? (long) members.size() : 0L);
+
+        GroupState state = new GroupState();
+        state.setSpec(spec);
+        state.setStatus(status);
+        return state;
+    }
+
+    @Named("stringMapToRoleScopeMap")
+    default Map<RoleScope, String> stringMapToRoleScopeMap(Map<String, String> roles) {
+        if (roles == null) {
+            return null;
+        }
+        return roles.entrySet().stream().collect(Collectors.toMap(e -> RoleScope.valueOf(e.getKey()), Map.Entry::getValue));
+    }
+
+    @Named("roleScopeMapToStringMap")
+    default Map<String, String> roleScopeMapToStringMap(Map<RoleScope, String> roles) {
+        if (roles == null) {
+            return null;
+        }
+        return roles.entrySet().stream().collect(Collectors.toMap(e -> e.getKey().name(), Map.Entry::getValue));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/AbstractResource.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
@@ -29,6 +30,10 @@ public abstract class AbstractResource {
 
     protected UserDetails getAuthenticatedUserDetails() {
         return (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+
+    protected AuditInfo getAuditInfo() {
+        return buildAuditInfo(GraviteeContext.getExecutionContext(), getAuthenticatedUserDetails());
     }
 
     protected static AuditInfo buildAuditInfo(ExecutionContext executionContext, UserDetails userDetails) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/EnvironmentResource.java
@@ -38,6 +38,11 @@ public class EnvironmentResource {
         return resourceContext.getResource(ApplicationsResource.class);
     }
 
+    @Path("/groups")
+    public GroupsResource getGroupsResource() {
+        return resourceContext.getResource(GroupsResource.class);
+    }
+
     @Path("/shared-policy-groups")
     public SharedPolicyGroupsResource getSharedPolicyGroupsResource() {
         return resourceContext.getResource(SharedPolicyGroupsResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupResource.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
+import io.gravitee.apim.core.group.query_service.GroupQueryService;
+import io.gravitee.apim.core.member.model.RoleScope;
+import io.gravitee.apim.rest.api.automation.exception.HRIDNotFoundException;
+import io.gravitee.apim.rest.api.automation.mapper.GroupMapper;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GroupResource extends AbstractResource {
+
+    @Inject
+    private GroupQueryService groupQueryService;
+
+    @Inject
+    private GroupService groupService;
+
+    @Inject
+    private MembershipService membershipService;
+
+    @Inject
+    private UserService userService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = { RolePermissionAction.READ }) })
+    public Response getGroupByHRID(@PathParam("hrid") String hrid, @QueryParam("hridContainsUUID") boolean hridContainsUUID) {
+        var executionContext = GraviteeContext.getExecutionContext();
+        var groupId = hridContainsUUID ? hrid : HRIDToUUID.group().context(executionContext).hrid(hrid).id();
+        var group = groupQueryService.findById(groupId).orElseThrow(() -> new HRIDNotFoundException(hrid));
+
+        Set<MemberEntity> memberEntities = membershipService.getMembersByReference(
+            executionContext,
+            MembershipReferenceType.GROUP,
+            groupId
+        );
+
+        var members = buildGroupMembers(executionContext, memberEntities);
+
+        return Response.ok(GroupMapper.INSTANCE.groupToGroupState(group, members)).build();
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.DELETE) })
+    public Response deleteGroupByHrid(@PathParam("hrid") String hrid, @QueryParam("hridContainsUUID") boolean hridContainsUUID) {
+        var executionContext = GraviteeContext.getExecutionContext();
+        try {
+            String groupId = hridContainsUUID ? hrid : HRIDToUUID.group().context(executionContext).hrid(hrid).id();
+            groupService.delete(executionContext, groupId);
+        } catch (GroupNotFoundException e) {
+            throw new HRIDNotFoundException(hrid);
+        }
+        return Response.noContent().build();
+    }
+
+    private Set<GroupCRDSpec.Member> buildGroupMembers(ExecutionContext executionContext, Set<MemberEntity> memberEntities) {
+        var memberRolesById = new HashMap<String, Map<RoleScope, String>>();
+
+        for (MemberEntity member : memberEntities) {
+            var roles = memberRolesById.computeIfAbsent(member.getId(), k -> new HashMap<>());
+
+            Optional.ofNullable(member.getRoles())
+                .orElse(List.of())
+                .forEach(role -> roles.put(RoleScope.valueOf(role.getScope().name()), role.getName()));
+        }
+
+        return userService
+            .findByIds(executionContext, memberRolesById.keySet())
+            .stream()
+            .map(user ->
+                GroupCRDSpec.Member.builder()
+                    .source(user.getSource())
+                    .sourceId(user.getSourceId())
+                    .roles(memberRolesById.getOrDefault(user.getId(), Map.of()))
+                    .build()
+            )
+            .collect(Collectors.toSet());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupResource.java
@@ -99,6 +99,10 @@ public class GroupResource extends AbstractResource {
     }
 
     private Set<GroupCRDSpec.Member> buildGroupMembers(ExecutionContext executionContext, Set<MemberEntity> memberEntities) {
+        if (memberEntities.isEmpty()) {
+            return Set.of();
+        }
+
         var memberRolesById = new HashMap<String, Map<RoleScope, String>>();
 
         for (MemberEntity member : memberEntities) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupsResource.java
@@ -76,7 +76,8 @@ public class GroupsResource extends AbstractResource {
         var groupCRDSpec = GroupMapper.INSTANCE.groupSpecToGroupCRDSpec(spec);
 
         if (hridContainsUUID) {
-            groupCRDSpec.setId(spec.getName());
+            groupCRDSpec.setId(spec.getHrid());
+            groupCRDSpec.setHrid(null);
         } else {
             CrdIdHelper.generateGroupId(groupCRDSpec, auditInfo);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupsResource.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
+
+import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
+import io.gravitee.apim.core.group.model.crd.GroupCRDStatus;
+import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
+import io.gravitee.apim.core.group.use_case.ValidateGroupCRDUseCase;
+import io.gravitee.apim.rest.api.automation.helpers.CrdIdHelper;
+import io.gravitee.apim.rest.api.automation.mapper.GroupMapper;
+import io.gravitee.apim.rest.api.automation.model.GroupSpec;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GroupsResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private ImportGroupCRDUseCase importGroupCRDUseCase;
+
+    @Inject
+    private ValidateGroupCRDUseCase validateGroupCRDUseCase;
+
+    @Path("/{hrid}")
+    public GroupResource getGroupResource() {
+        return resourceContext.getResource(GroupResource.class);
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = { CREATE, UPDATE }) })
+    public Response createOrUpdate(
+        @Valid @NotNull GroupSpec spec,
+        @QueryParam("dryRun") boolean dryRun,
+        @QueryParam("hridContainsUUID") boolean hridContainsUUID
+    ) {
+        var auditInfo = getAuditInfo();
+
+        var groupCRDSpec = GroupMapper.INSTANCE.groupSpecToGroupCRDSpec(spec);
+
+        if (hridContainsUUID) {
+            groupCRDSpec.setId(spec.getName());
+        } else {
+            CrdIdHelper.generateGroupId(groupCRDSpec, auditInfo);
+        }
+
+        if (dryRun) {
+            var status = validateGroupCRDUseCase.execute(new ImportGroupCRDUseCase.Input(auditInfo, groupCRDSpec)).status();
+
+            return Response.ok(GroupMapper.INSTANCE.groupSpecAndStatusToGroupState(spec, status)).build();
+        }
+
+        var status = importGroupCRDUseCase.execute(new ImportGroupCRDUseCase.Input(auditInfo, groupCRDSpec)).status();
+
+        return Response.ok(GroupMapper.INSTANCE.groupSpecAndStatusToGroupState(spec, status)).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -36,6 +36,8 @@ tags:
     description: Everything about Applications
   - name: Shared Policy Group
     description: Everything about Shared Policy Groups
+  - name: Groups
+    description: Everything about Groups
   - name: Subscriptions
     description: Everything about subscriptions
 paths:
@@ -204,6 +206,95 @@ paths:
       responses:
         "204":
           description: Application successfully deleted
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Error"
+
+  # Groups
+  /organizations/{orgId}/environments/{envId}/groups:
+    put:
+      operationId: createOrUpdateGroup
+      tags:
+        - Groups
+      summary: Create or update a Group from an automation GroupSpec
+      description: Create/update a Group from an automation Group Spec
+      parameters:
+        - $ref: "#/components/parameters/orgIdParam"
+        - $ref: "#/components/parameters/envIdParam"
+        - $ref: "#/components/parameters/dryRunQueryParam"
+        - $ref: "#/components/parameters/hridContainsUUIDQueryParam"
+      requestBody:
+        description: Group specification
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/GroupSpec"
+        required: true
+      responses:
+        "200":
+          description: State of the successfully created/updated Group
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupState"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/Error"
+  /organizations/{orgId}/environments/{envId}/groups/{hrid}:
+    parameters:
+      - $ref: "#/components/parameters/orgIdParam"
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/hridParam"
+    get:
+      operationId: getGroup
+      tags:
+        - Groups
+      summary: Get one Group
+      description: Get a Group using HRID
+      parameters:
+        - $ref: "#/components/parameters/orgIdParam"
+        - $ref: "#/components/parameters/envIdParam"
+        - $ref: "#/components/parameters/hridParam"
+        - $ref: "#/components/parameters/hridContainsUUIDQueryParam"
+      responses:
+        "200":
+          description: Group successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroupState"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Error"
+    delete:
+      operationId: deleteGroup
+      tags:
+        - Groups
+      summary: Delete one Group
+      description: Delete a Group using HRID
+      parameters:
+        - $ref: "#/components/parameters/orgIdParam"
+        - $ref: "#/components/parameters/envIdParam"
+        - $ref: "#/components/parameters/hridParam"
+        - $ref: "#/components/parameters/hridContainsUUIDQueryParam"
+      responses:
+        "204":
+          description: Group successfully deleted
         "401":
           $ref: "#/components/responses/Unauthenticated"
         "403":
@@ -846,6 +937,82 @@ components:
               default: DEFAULT
               examples:
                 - DEFAULT
+
+    GroupSpec:
+      description: |
+        Defines the desired state of a Group.
+        Groups allow organizing users and managing their access to APIs and applications collectively.
+      type: object
+      properties:
+        name:
+          type: string
+          description: Group's name.
+          examples:
+            - developers
+          minLength: 1
+          maxLength: 512
+        members:
+          type: array
+          description: Members of this group with their IDP source and role assignments.
+          items:
+            $ref: "#/components/schemas/GroupMember"
+          default: []
+        notifyMembers:
+          type: boolean
+          description: If true, members will be notified when the group is synced with APIM.
+          default: true
+      required:
+        - name
+    GroupMember:
+      description: A member of a group, identified by an external IDP source.
+      type: object
+      properties:
+        source:
+          type: string
+          description: The identity provider source of the member.
+          examples:
+            - gravitee
+        sourceId:
+          type: string
+          description: The member's identifier in the identity provider.
+          examples:
+            - "john.doe@example.com"
+        roles:
+          type: object
+          description: Map of role scope to role name defining what the member can do.
+          additionalProperties:
+            type: string
+          examples:
+            - API: USER
+              APPLICATION: ADMIN
+      required:
+        - source
+        - sourceId
+    GroupStatus:
+      description: Status information for a group after import.
+      type: object
+      properties:
+        id:
+          type: string
+          description: Group's uuid.
+          examples:
+            - 550e8400-e29b-41d4-a716-446655440000
+        members:
+          type: integer
+          format: int64
+          description: Number of members in the group.
+          examples:
+            - 5
+        errors:
+          $ref: "#/components/schemas/Errors"
+    GroupState:
+      description: Group state combining spec and status after creation/update.
+      type: object
+      properties:
+        spec:
+          $ref: "#/components/schemas/GroupSpec"
+        status:
+          $ref: "#/components/schemas/GroupStatus"
 
     SubscriptionSpec:
       description: Subscription specification
@@ -2380,6 +2547,16 @@ components:
           - keyless_demo_plan
           - demo_subscription
           - demo_shared_policy_groups
+    hridContainsUUIDQueryParam:
+      name: hridContainsUUID
+      in: query
+      description: |
+        When true, the HRID path or spec value is treated as an existing UUID rather than
+        a human-readable identifier. This is to support backward compatibility for resources
+        created before migration to the automation API and should not be used for new resources.
+      schema:
+        type: boolean
+        default: false
     apiHridParam:
       name: apiHrid
       in: path

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -944,6 +944,8 @@ components:
         Groups allow organizing users and managing their access to APIs and applications collectively.
       type: object
       properties:
+        hrid:
+          $ref: "#/components/schemas/Hrid"
         name:
           type: string
           description: Group's name.
@@ -962,6 +964,7 @@ components:
           description: If true, members will be notified when the group is synced with APIM.
           default: true
       required:
+        - hrid
         - name
     GroupMember:
       description: A member of a group, identified by an external IDP source.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/helpers/CrdIdHelperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/helpers/CrdIdHelperTest.java
@@ -33,8 +33,8 @@ class CrdIdHelperTest {
     class GenerateGroupId {
 
         @Test
-        void should_generate_id_from_name() {
-            var spec = GroupCRDSpec.builder().name("my-group").build();
+        void should_generate_id_from_hrid() {
+            var spec = GroupCRDSpec.builder().hrid("my-group").name("My Group").build();
 
             CrdIdHelper.generateGroupId(spec, AUDIT_INFO);
 
@@ -44,7 +44,7 @@ class CrdIdHelperTest {
         @Test
         void should_not_override_existing_id() {
             var existingId = "existing-uuid";
-            var spec = GroupCRDSpec.builder().id(existingId).name("my-group").build();
+            var spec = GroupCRDSpec.builder().id(existingId).hrid("my-group").name("My Group").build();
 
             CrdIdHelper.generateGroupId(spec, AUDIT_INFO);
 
@@ -53,8 +53,8 @@ class CrdIdHelperTest {
 
         @Test
         void should_generate_deterministic_id() {
-            var spec1 = GroupCRDSpec.builder().name("my-group").build();
-            var spec2 = GroupCRDSpec.builder().name("my-group").build();
+            var spec1 = GroupCRDSpec.builder().hrid("my-group").name("My Group").build();
+            var spec2 = GroupCRDSpec.builder().hrid("my-group").name("My Group").build();
 
             CrdIdHelper.generateGroupId(spec1, AUDIT_INFO);
             CrdIdHelper.generateGroupId(spec2, AUDIT_INFO);
@@ -63,9 +63,9 @@ class CrdIdHelperTest {
         }
 
         @Test
-        void should_generate_different_ids_for_different_names() {
-            var spec1 = GroupCRDSpec.builder().name("group-a").build();
-            var spec2 = GroupCRDSpec.builder().name("group-b").build();
+        void should_generate_different_ids_for_different_hrids() {
+            var spec1 = GroupCRDSpec.builder().hrid("group-a").name("Group A").build();
+            var spec2 = GroupCRDSpec.builder().hrid("group-b").name("Group B").build();
 
             CrdIdHelper.generateGroupId(spec1, AUDIT_INFO);
             CrdIdHelper.generateGroupId(spec2, AUDIT_INFO);
@@ -78,8 +78,8 @@ class CrdIdHelperTest {
             var audit1 = AuditInfo.builder().organizationId(ORGANIZATION).environmentId("env-1").build();
             var audit2 = AuditInfo.builder().organizationId(ORGANIZATION).environmentId("env-2").build();
 
-            var spec1 = GroupCRDSpec.builder().name("my-group").build();
-            var spec2 = GroupCRDSpec.builder().name("my-group").build();
+            var spec1 = GroupCRDSpec.builder().hrid("my-group").name("My Group").build();
+            var spec2 = GroupCRDSpec.builder().hrid("my-group").name("My Group").build();
 
             CrdIdHelper.generateGroupId(spec1, audit1);
             CrdIdHelper.generateGroupId(spec2, audit2);
@@ -92,8 +92,8 @@ class CrdIdHelperTest {
             var audit1 = AuditInfo.builder().organizationId("org-1").environmentId(ENVIRONMENT).build();
             var audit2 = AuditInfo.builder().organizationId("org-2").environmentId(ENVIRONMENT).build();
 
-            var spec1 = GroupCRDSpec.builder().name("my-group").build();
-            var spec2 = GroupCRDSpec.builder().name("my-group").build();
+            var spec1 = GroupCRDSpec.builder().hrid("my-group").name("My Group").build();
+            var spec2 = GroupCRDSpec.builder().hrid("my-group").name("My Group").build();
 
             CrdIdHelper.generateGroupId(spec1, audit1);
             CrdIdHelper.generateGroupId(spec2, audit2);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/helpers/CrdIdHelperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/helpers/CrdIdHelperTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CrdIdHelperTest {
+
+    private static final String ORGANIZATION = "org-id";
+    private static final String ENVIRONMENT = "env-id";
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder().organizationId(ORGANIZATION).environmentId(ENVIRONMENT).build();
+
+    @Nested
+    class GenerateGroupId {
+
+        @Test
+        void should_generate_id_from_name() {
+            var spec = GroupCRDSpec.builder().name("my-group").build();
+
+            CrdIdHelper.generateGroupId(spec, AUDIT_INFO);
+
+            assertThat(spec.getId()).isNotNull().isEqualTo(HRIDToUUID.group().context(AUDIT_INFO).hrid("my-group").id());
+        }
+
+        @Test
+        void should_not_override_existing_id() {
+            var existingId = "existing-uuid";
+            var spec = GroupCRDSpec.builder().id(existingId).name("my-group").build();
+
+            CrdIdHelper.generateGroupId(spec, AUDIT_INFO);
+
+            assertThat(spec.getId()).isEqualTo(existingId);
+        }
+
+        @Test
+        void should_generate_deterministic_id() {
+            var spec1 = GroupCRDSpec.builder().name("my-group").build();
+            var spec2 = GroupCRDSpec.builder().name("my-group").build();
+
+            CrdIdHelper.generateGroupId(spec1, AUDIT_INFO);
+            CrdIdHelper.generateGroupId(spec2, AUDIT_INFO);
+
+            assertThat(spec1.getId()).isEqualTo(spec2.getId());
+        }
+
+        @Test
+        void should_generate_different_ids_for_different_names() {
+            var spec1 = GroupCRDSpec.builder().name("group-a").build();
+            var spec2 = GroupCRDSpec.builder().name("group-b").build();
+
+            CrdIdHelper.generateGroupId(spec1, AUDIT_INFO);
+            CrdIdHelper.generateGroupId(spec2, AUDIT_INFO);
+
+            assertThat(spec1.getId()).isNotEqualTo(spec2.getId());
+        }
+
+        @Test
+        void should_generate_different_ids_for_different_environments() {
+            var audit1 = AuditInfo.builder().organizationId(ORGANIZATION).environmentId("env-1").build();
+            var audit2 = AuditInfo.builder().organizationId(ORGANIZATION).environmentId("env-2").build();
+
+            var spec1 = GroupCRDSpec.builder().name("my-group").build();
+            var spec2 = GroupCRDSpec.builder().name("my-group").build();
+
+            CrdIdHelper.generateGroupId(spec1, audit1);
+            CrdIdHelper.generateGroupId(spec2, audit2);
+
+            assertThat(spec1.getId()).isNotEqualTo(spec2.getId());
+        }
+
+        @Test
+        void should_generate_different_ids_for_different_organizations() {
+            var audit1 = AuditInfo.builder().organizationId("org-1").environmentId(ENVIRONMENT).build();
+            var audit2 = AuditInfo.builder().organizationId("org-2").environmentId(ENVIRONMENT).build();
+
+            var spec1 = GroupCRDSpec.builder().name("my-group").build();
+            var spec2 = GroupCRDSpec.builder().name("my-group").build();
+
+            CrdIdHelper.generateGroupId(spec1, audit1);
+            CrdIdHelper.generateGroupId(spec2, audit2);
+
+            assertThat(spec1.getId()).isNotEqualTo(spec2.getId());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupResourceTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import inmemory.GroupQueryServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.rest.api.automation.model.GroupState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Set;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class GroupResourceTest extends AbstractResourceTest {
+
+    @Inject
+    private UserService userService;
+
+    static final String HRID = "my-group";
+    static final String GUID = "raw-legacy-uuid";
+    static final AuditInfo auditInfo = AuditInfo.builder().organizationId(ORGANIZATION).environmentId(ENVIRONMENT).build();
+
+    @AfterEach
+    void tearDown() {
+        groupQueryServiceInMemory.reset();
+        reset(groupService, membershipService, userService);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/groups";
+    }
+
+    private String groupIdFromHrid(String hrid) {
+        return HRIDToUUID.group().context(new ExecutionContext(ORGANIZATION, ENVIRONMENT)).hrid(hrid).id();
+    }
+
+    private void givenExistingGroup() {
+        groupQueryServiceInMemory.initWith(
+            List.of(
+                Group.builder()
+                    .id(groupIdFromHrid(HRID))
+                    .name("My Group")
+                    .environmentId(ENVIRONMENT)
+                    .disableMembershipNotifications(false)
+                    .build()
+            )
+        );
+    }
+
+    private void givenExistingGroupWithLegacyId() {
+        groupQueryServiceInMemory.initWith(
+            List.of(Group.builder().id(GUID).name("Legacy Group").environmentId(ENVIRONMENT).disableMembershipNotifications(false).build())
+        );
+    }
+
+    @Nested
+    class Get {
+
+        @Test
+        void should_get_group_from_known_hrid() {
+            givenExistingGroup();
+            givenNoMembers();
+
+            try (var response = rootTarget().path(HRID).request().get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                var state = response.readEntity(GroupState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getStatus().getId()).isEqualTo(groupIdFromHrid(HRID));
+                    soft.assertThat(state.getSpec().getName()).isEqualTo("My Group");
+                    soft.assertThat(state.getSpec().getNotifyMembers()).isTrue();
+                });
+            }
+        }
+
+        @Test
+        void should_get_group_from_known_guid() {
+            givenExistingGroupWithLegacyId();
+            givenNoMembers();
+
+            try (var response = rootTarget().path(GUID).queryParam("hridContainsUUID", true).request().get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                var state = response.readEntity(GroupState.class);
+                assertThat(state.getStatus().getId()).isEqualTo(GUID);
+            }
+        }
+
+        @Test
+        void should_get_group_with_members() {
+            givenExistingGroup();
+            givenGroupMembers();
+
+            try (var response = rootTarget().path(HRID).request().get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                var state = response.readEntity(GroupState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getSpec().getMembers()).hasSize(1);
+                    soft.assertThat(state.getStatus().getMembers()).isEqualTo(1L);
+                });
+            }
+        }
+
+        @Test
+        void should_return_a_404_status_code_with_unknown_hrid() {
+            try (var response = rootTarget().path("unknown").request().get()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+
+        private void givenNoMembers() {
+            when(membershipService.getMembersByReference(any(), eq(MembershipReferenceType.GROUP), any())).thenReturn(Set.of());
+        }
+
+        private void givenGroupMembers() {
+            var groupId = groupIdFromHrid(HRID);
+            var role = RoleEntity.builder().scope(RoleScope.API).name("USER").build();
+            var member = MemberEntity.builder()
+                .id("user-1")
+                .type(MembershipMemberType.USER)
+                .referenceType(MembershipReferenceType.GROUP)
+                .referenceId(groupId)
+                .roles(List.of(role))
+                .build();
+
+            when(membershipService.getMembersByReference(any(), eq(MembershipReferenceType.GROUP), eq(groupId))).thenReturn(Set.of(member));
+
+            var user = new UserEntity();
+            user.setId("user-1");
+            user.setSource("gravitee");
+            user.setSourceId("user-source-1");
+
+            when(userService.findByIds(any(), eq(Set.of("user-1")))).thenReturn(Set.of(user));
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_group_and_return_no_content() {
+            try (var response = rootTarget().path(HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+            }
+
+            verify(groupService).delete(any(), eq(groupIdFromHrid(HRID)));
+        }
+
+        @Test
+        void should_delete_group_with_guid() {
+            try (var response = rootTarget().path(GUID).queryParam("hridContainsUUID", true).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+            }
+
+            verify(groupService).delete(any(), eq(GUID));
+        }
+
+        @Test
+        void should_return_a_404_status_code_with_unknown_hrid() {
+            doThrow(new GroupNotFoundException("unknown")).when(groupService).delete(any(), eq(groupIdFromHrid("unknown")));
+
+            try (var response = rootTarget().path("unknown").request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupResourceTest.java
@@ -77,6 +77,7 @@ class GroupResourceTest extends AbstractResourceTest {
             List.of(
                 Group.builder()
                     .id(groupIdFromHrid(HRID))
+                    .hrid(HRID)
                     .name("My Group")
                     .environmentId(ENVIRONMENT)
                     .disableMembershipNotifications(false)
@@ -104,6 +105,7 @@ class GroupResourceTest extends AbstractResourceTest {
                 var state = response.readEntity(GroupState.class);
                 SoftAssertions.assertSoftly(soft -> {
                     soft.assertThat(state.getStatus().getId()).isEqualTo(groupIdFromHrid(HRID));
+                    soft.assertThat(state.getSpec().getHrid()).isEqualTo(HRID);
                     soft.assertThat(state.getSpec().getName()).isEqualTo("My Group");
                     soft.assertThat(state.getSpec().getNotifyMembers()).isTrue();
                 });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupResourceTest.java
@@ -140,6 +140,21 @@ class GroupResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_get_group_with_no_members() {
+            givenExistingGroup();
+            givenNoMembers();
+
+            try (var response = rootTarget().path(HRID).request().get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                var state = response.readEntity(GroupState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getSpec().getMembers()).isEmpty();
+                    soft.assertThat(state.getStatus().getMembers()).isEqualTo(0L);
+                });
+            }
+        }
+
+        @Test
         void should_return_a_404_status_code_with_unknown_hrid() {
             try (var response = rootTarget().path("unknown").request().get()) {
                 assertThat(response.getStatus()).isEqualTo(404);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupsResourceTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.group.model.crd.GroupCRDStatus;
+import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
+import io.gravitee.apim.core.group.use_case.ValidateGroupCRDUseCase;
+import io.gravitee.apim.rest.api.automation.model.GroupState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GroupsResourceTest extends AbstractResourceTest {
+
+    @Inject
+    private ImportGroupCRDUseCase importGroupCRDUseCase;
+
+    @Inject
+    private ValidateGroupCRDUseCase validateGroupCRDUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(importGroupCRDUseCase);
+        reset(validateGroupCRDUseCase);
+    }
+
+    @Nested
+    class Run {
+
+        @BeforeEach
+        void setUp() {
+            when(importGroupCRDUseCase.execute(any(ImportGroupCRDUseCase.Input.class))).thenReturn(
+                new ImportGroupCRDUseCase.Output(GroupCRDStatus.builder().id("group-id").members(0).build())
+            );
+        }
+
+        @Test
+        void should_return_state_from_name() {
+            var state = expectEntity("group-with-name.json");
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(state.getStatus().getId()).isEqualTo("group-id");
+                soft.assertThat(state.getSpec().getName()).isEqualTo("my-group");
+                soft.assertThat(state.getSpec().getNotifyMembers()).isTrue();
+            });
+        }
+
+        @Test
+        void should_return_state_with_members() {
+            when(importGroupCRDUseCase.execute(any(ImportGroupCRDUseCase.Input.class))).thenReturn(
+                new ImportGroupCRDUseCase.Output(GroupCRDStatus.builder().id("group-id").members(1).build())
+            );
+
+            var state = expectEntity("group-with-members.json");
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(state.getStatus().getId()).isEqualTo("group-id");
+                soft.assertThat(state.getStatus().getMembers()).isEqualTo(1L);
+                soft.assertThat(state.getSpec().getMembers()).hasSize(1);
+            });
+        }
+
+        @Test
+        void should_use_name_as_id_when_hrid_contains_uuid() {
+            when(importGroupCRDUseCase.execute(any(ImportGroupCRDUseCase.Input.class))).thenAnswer(call -> {
+                ImportGroupCRDUseCase.Input input = call.getArgument(0, ImportGroupCRDUseCase.Input.class);
+                return new ImportGroupCRDUseCase.Output(GroupCRDStatus.builder().id(input.spec().getId()).members(0).build());
+            });
+
+            var state = expectEntity("group-with-name.json", false, true);
+            assertThat(state.getStatus().getId()).isEqualTo("my-group");
+        }
+    }
+
+    @Nested
+    class DryRun {
+
+        boolean dryRun = true;
+
+        @Test
+        void should_return_state_from_validation() {
+            when(validateGroupCRDUseCase.execute(any(ImportGroupCRDUseCase.Input.class))).thenReturn(
+                new ImportGroupCRDUseCase.Output(GroupCRDStatus.builder().id("generated-id").members(0).build())
+            );
+
+            var state = expectEntity("group-with-name.json", dryRun);
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(state.getStatus().getId()).isEqualTo("generated-id");
+                soft.assertThat(state.getSpec().getName()).isEqualTo("my-group");
+            });
+        }
+
+        @Test
+        void should_return_state_with_errors() {
+            when(validateGroupCRDUseCase.execute(any(ImportGroupCRDUseCase.Input.class))).thenReturn(
+                new ImportGroupCRDUseCase.Output(
+                    GroupCRDStatus.builder()
+                        .id("generated-id")
+                        .members(0)
+                        .errors(new GroupCRDStatus.Errors(java.util.List.of(), java.util.List.of("unknown role")))
+                        .build()
+                )
+            );
+
+            var state = expectEntity("group-with-name.json", dryRun);
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(state.getStatus().getId()).isEqualTo("generated-id");
+                soft.assertThat(state.getStatus().getErrors()).isNotNull();
+                soft.assertThat(state.getStatus().getErrors().getWarning()).contains("unknown role");
+            });
+        }
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/groups";
+    }
+
+    private GroupState expectEntity(String spec) {
+        return expectEntity(spec, false, false);
+    }
+
+    private GroupState expectEntity(String spec, boolean dryRun) {
+        return expectEntity(spec, dryRun, false);
+    }
+
+    private GroupState expectEntity(String spec, boolean dryRun, boolean hridContainsUUID) {
+        try (
+            var response = rootTarget()
+                .queryParam("dryRun", dryRun)
+                .queryParam("hridContainsUUID", hridContainsUUID)
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .put(Entity.json(readJSON(spec)))
+        ) {
+            assertThat(response.getStatus()).isEqualTo(200);
+            return response.readEntity(GroupState.class);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupsResourceTest.java
@@ -63,6 +63,7 @@ class GroupsResourceTest extends AbstractResourceTest {
             var state = expectEntity("group-with-name.json");
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(state.getStatus().getId()).isEqualTo("group-id");
+                soft.assertThat(state.getSpec().getHrid()).isEqualTo("my-group");
                 soft.assertThat(state.getSpec().getName()).isEqualTo("my-group");
                 soft.assertThat(state.getSpec().getNotifyMembers()).isTrue();
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -99,14 +99,13 @@ import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageAccessControlsDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDomainService;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
-import io.gravitee.apim.core.group.crud_service.GroupCrudService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
+import io.gravitee.apim.core.group.use_case.ValidateGroupCRDUseCase;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.license.domain_service.GraviteeLicenseDomainService;
 import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
-import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.MemberDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.member.query_service.MemberQueryService;
@@ -843,13 +842,14 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public ImportGroupCRDUseCase importGroupCRDUseCase(
-        ValidateGroupCRDDomainService validateGroupCRDDomainService,
-        GroupQueryService groupQueryService,
-        GroupCrudService groupCrudService,
-        CRDMembersDomainService crdMembersDomainService
-    ) {
-        return new ImportGroupCRDUseCase(validateGroupCRDDomainService, groupQueryService, groupCrudService, crdMembersDomainService);
+    public ImportGroupCRDUseCase importGroupCRDUseCase() {
+        return mock(ImportGroupCRDUseCase.class);
+    }
+
+    @Bean
+    @Primary
+    public ValidateGroupCRDUseCase validateGroupCRDUseCase() {
+        return mock(ValidateGroupCRDUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/group-with-members.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/group-with-members.json
@@ -1,4 +1,5 @@
 {
+  "hrid": "my-group",
   "name": "my-group",
   "members": [
     {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/group-with-members.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/group-with-members.json
@@ -1,0 +1,13 @@
+{
+  "name": "my-group",
+  "members": [
+    {
+      "source": "gravitee",
+      "sourceId": "user@example.com",
+      "roles": {
+        "API": "USER"
+      }
+    }
+  ],
+  "notifyMembers": true
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/group-with-name.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/group-with-name.json
@@ -1,4 +1,5 @@
 {
+  "hrid": "my-group",
   "name": "my-group",
   "notifyMembers": true
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/group-with-name.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/group-with-name.json
@@ -1,0 +1,4 @@
+{
+  "name": "my-group",
+  "notifyMembers": true
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/Group.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/Group.java
@@ -28,6 +28,7 @@ import lombok.With;
 public class Group {
 
     private String id;
+    private String hrid;
     private String environmentId;
     private String name;
     private List<GroupEventRule> eventRules;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/crd/GroupCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/crd/GroupCRDSpec.java
@@ -38,6 +38,8 @@ public class GroupCRDSpec {
 
     private String id;
 
+    private String hrid;
+
     private String name;
 
     private Set<Member> members;
@@ -51,6 +53,7 @@ public class GroupCRDSpec {
         return Group.builder()
             .origin(origin)
             .id(id)
+            .hrid(hrid)
             .name(name)
             .environmentId(environmentId)
             .apiPrimaryOwner(null)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCase.java
@@ -25,6 +25,7 @@ import io.gravitee.apim.core.group.model.crd.GroupCRDStatus;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.validation.Validator;
+import java.util.List;
 import lombok.CustomLog;
 
 /**
@@ -57,14 +58,9 @@ public class ImportGroupCRDUseCase {
     }
 
     public Output execute(Input input) {
-        return queryService
-            .findById(input.spec.getId())
-            .map(existing -> this.update(input))
-            .orElseGet(() -> this.create(input));
-    }
-
-    private Output create(Input input) {
-        var validationResult = validationService.validateAndSanitize(new ValidateGroupCRDDomainService.Input(input.auditInfo, input.spec));
+        var validationResult = validationService
+            .validateAndSanitize(new ValidateGroupCRDDomainService.Input(input.auditInfo, input.spec))
+            .map(sanitized -> new Input(sanitized.auditInfo(), sanitized.spec()));
 
         validationResult
             .severe()
@@ -72,26 +68,28 @@ public class ImportGroupCRDUseCase {
                 throw new TechnicalDomainException(errors.iterator().next().getMessage());
             });
 
-        var errors = validationResult.errors().map(GroupCRDStatus.Errors::fromErrorList).orElse(GroupCRDStatus.Errors.EMPTY);
+        var warnings = validationResult.warning().orElseGet(List::of);
+        var sanitizedInput = validationResult.value().orElseThrow(() -> new TechnicalDomainException("Unable to sanitize CRD spec"));
 
+        var status = queryService
+            .findById(sanitizedInput.spec.getId())
+            .map(existing -> this.update(sanitizedInput))
+            .orElseGet(() -> this.create(sanitizedInput));
+
+        status.setErrors(GroupCRDStatus.Errors.fromErrorList(warnings));
+
+        return new Output(status);
+    }
+
+    private GroupCRDStatus create(Input input) {
         crudService.create(input.spec.toGroup(input.auditInfo.environmentId()));
         membersService.updateGroupMembers(input.auditInfo, input.spec.getId(), input.spec.getMembers());
-        return new Output(new GroupCRDStatus(input.spec.getId(), input.spec.getMembers().size(), errors));
+        return GroupCRDStatus.builder().id(input.spec.getId()).members(input.spec.getMembers().size()).build();
     }
 
-    private Output update(Input input) {
-        var validationResult = validationService.validateAndSanitize(new ValidateGroupCRDDomainService.Input(input.auditInfo, input.spec));
-
-        validationResult
-            .severe()
-            .ifPresent(errors -> {
-                throw new TechnicalDomainException(errors.iterator().next().getMessage());
-            });
-
-        var errors = validationResult.errors().map(GroupCRDStatus.Errors::fromErrorList).orElse(GroupCRDStatus.Errors.EMPTY);
-
+    private GroupCRDStatus update(Input input) {
         crudService.update(input.spec.toGroup(input.auditInfo.environmentId()));
         membersService.updateGroupMembers(input.auditInfo, input.spec.getId(), input.spec.getMembers());
-        return new Output(new GroupCRDStatus(input.spec.getId(), input.spec.getMembers().size(), errors));
+        return GroupCRDStatus.builder().id(input.spec.getId()).members(input.spec.getMembers().size()).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -20,7 +20,7 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 /**
  * Fluent DSL for generating deterministic UUIDs from HRIDs.
  * <p>
- * Top-level resources (API, Application, SharedPolicyGroup) produce both {@code id()} and {@code crossId()}.
+ * Top-level resources (API, Application, SharedPolicyGroup, Group) produce both {@code id()} and {@code crossId()}.
  * Sub-resources (Plan, Page, Subscription) are scoped to a parent API and only produce {@code id()}.
  * <p>
  * Examples:
@@ -45,6 +45,10 @@ public final class HRIDToUUID {
     }
 
     public static TopLevelBuilder sharedPolicyGroup() {
+        return new TopLevelBuilder();
+    }
+
+    public static TopLevelBuilder group() {
         return new TopLevelBuilder();
     }
 


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-2551

Expose groups through the Automation API (`/automation/organizations/{orgId}/environments/{envId}/groups`), allowing the operator to manage groups without relying on the legacy v1/v2 endpoints.

**Endpoints:**
- `PUT /groups` — create or update a group from a `GroupSpec` (supports `dryRun` and `hridContainsUUID`)
- `GET /groups/{hrid}` — get a group by HRID (includes members)
- `DELETE /groups/{hrid}` — delete a group by HRID

Group IDs are derived deterministically from the group name via `HRIDToUUID.group()`. The `hridContainsUUID` query param supports backward compatibility for groups created before migration.

