### PR TITLE
fix(rest-api): exclude reporterMetricsEnabled export for HTTP v4 APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3198,9 +3198,9 @@ components:
                 reporterMetricsEnabled:
                     type: boolean
                     description: |-
-                        Enable the connection-metrics reporter on the gateway. Only applies to Native v4 APIs. For HTTP v4 APIs this field is silently discarded by the server.
+                        Enable the connection-metrics reporter on the gateway. Only applicable to Native v4 APIs; ignored on HTTP v4 requests and omitted from HTTP v4 responses.
+                        Server-side default for Native v4 on create is `true`.
                         Independent of the parent `enabled` flag: event-metrics reporting and the connection-metrics reporter are gated separately.
-                    default: true
         Api:
             oneOf:
                 - $ref: "#/components/schemas/ApiV2"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ExportApiDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ExportApiDefinitionTest.java
@@ -53,6 +53,7 @@ import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
@@ -301,6 +302,7 @@ class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
             .properties(List.of(new Property()))
             .resources(List.of(new Resource()))
             .updatedAt(Instant.now())
+            .analytics(NativeAnalytics.builder().enabled(true).reporterMetricsEnabled(true).build())
             .endpointGroups(List.of(endpointGroup))
             .flows(List.of(flow))
             .build();
@@ -584,6 +586,10 @@ class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
 
         var conditionSelector = flow.getSelectors().get(2).getConditionSelector();
         assertThat(conditionSelector.getCondition()).isEqualTo("my-condition");
+
+        // reporterMetricsEnabled is Native-only; must not appear on HTTP v4 exports.
+        assertThat(responseApi.getAnalytics()).isNotNull();
+        assertThat(responseApi.getAnalytics().getReporterMetricsEnabled()).isNull();
     }
 
     private void testReturnedNativeApi(ApiV4 responseApi) {
@@ -627,6 +633,10 @@ class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
         assertThat(step.getCondition()).isEqualTo("my-condition");
 
         assertThat(flow.getSelectors()).isNotNull().isEmpty();
+
+        // reporterMetricsEnabled is Native-only; Native exports must carry it.
+        assertThat(responseApi.getAnalytics()).isNotNull();
+        assertThat(responseApi.getAnalytics().getReporterMetricsEnabled()).isEqualTo(true);
     }
 
     private void testReturnedMembers(Set<Member> members) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
@@ -241,6 +241,10 @@ public class ApiResource_getApiByIdTest extends ApiResourceTest {
         assertEquals(true, dynamicPropertyConfiguration.getOverrideConfiguration());
         assertNotNull(dynamicPropertyConfiguration.getConfiguration());
         assertEquals("dynamic-property", dynamicPropertyConfiguration.getType());
+
+        // reporterMetricsEnabled is Native-only; must not appear on HTTP v4 responses.
+        assertNotNull(responseApi.getAnalytics());
+        assertNull(responseApi.getAnalytics().getReporterMetricsEnabled());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiDescriptor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/import_definition/ApiDescriptor.java
@@ -33,6 +33,7 @@ import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.nativeapi.NativeListener;
@@ -146,6 +147,7 @@ public sealed interface ApiDescriptor {
         String background,
         List<NativeListener> listeners,
         List<NativeEndpointGroup> endpointGroups,
+        NativeAnalytics analytics,
         List<NativeFlow> flows,
         List<Property> properties,
         List<Resource> resources

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
@@ -132,6 +132,7 @@ public interface GraviteeDefinitionAdapter {
     @Mapping(target = "state", source = "apiEntity.lifecycleState")
     @Mapping(target = "lifecycleState", source = "apiEntity.apiLifecycleState")
     @Mapping(target = "listeners", source = "apiEntity.apiDefinitionNativeV4.listeners")
+    @Mapping(target = "analytics", source = "apiEntity.apiDefinitionNativeV4.analytics")
     @Mapping(target = "flows", source = "apiEntity.apiDefinitionNativeV4.flows")
     @Mapping(target = "properties", source = "apiEntity.apiDefinitionNativeV4.properties")
     @Mapping(target = "resources", source = "apiEntity.apiDefinitionNativeV4.resources")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
@@ -25,6 +25,9 @@ import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
+import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.nativeapi.NativePlan;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
@@ -150,6 +153,48 @@ class GraviteeDefinitionAdapterTest {
             soft.assertThat(descriptor.brokerRangeStart()).isEqualTo(9100);
             soft.assertThat(descriptor.brokerRangeEnd()).isEqualTo(9102);
         });
+    }
+
+    @Test
+    void mapNative_should_propagate_reporterMetricsEnabled_from_analytics() {
+        // Given a Native API whose analytics explicitly opts out of connection-metrics reporting
+        var nativeDefinition = new NativeApi();
+        nativeDefinition.setDefinitionVersion(DefinitionVersion.V4);
+        nativeDefinition.setType(ApiType.NATIVE);
+        nativeDefinition.setApiVersion("1.0.0");
+        nativeDefinition.setName("my-kafka");
+        nativeDefinition.setAnalytics(NativeAnalytics.builder().enabled(true).reporterMetricsEnabled(false).build());
+
+        Api coreApi = Api.builder()
+            .id("api-id")
+            .environmentId("env-id")
+            .version("1.0.0")
+            .definitionVersion(DefinitionVersion.V4)
+            .type(ApiType.NATIVE)
+            .apiDefinitionNativeV4(nativeDefinition)
+            .build();
+
+        var primaryOwner = PrimaryOwnerEntity.builder()
+            .id("po-id")
+            .email("po@acme.test")
+            .displayName("PO")
+            .type(PrimaryOwnerEntity.Type.USER)
+            .build();
+
+        // When
+        ApiDescriptor.Native descriptor = GraviteeDefinitionAdapter.INSTANCE.mapNative(
+            coreApi,
+            primaryOwner,
+            WorkflowState.REVIEW_OK,
+            Set.of("group-1"),
+            java.util.Collections.<NewApiMetadata>emptyList(),
+            List.of(new NativeFlow()),
+            false
+        );
+
+        // Then the descriptor carries the flag's non-default value end-to-end — proves the @Mapping wiring.
+        assertThat(descriptor.analytics()).isNotNull();
+        assertThat(descriptor.analytics().isReporterMetricsEnabled()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13797

## Description

This Pull Request updates the handling of the `reporterMetricsEnabled` field in the API definitions and enhances relevant test cases to validate its correct behavior. The changes ensure the field is only applicable to Native v4 APIs and excluded from HTTP v4 API responses and exports.

## Main changes

- Updates to OpenAPI Specification:
- Modified the description for the `reporterMetricsEnabled` field to clarify its behavior and default value handling.
- The field now defaults to true for Native v4 API when omitted on creation.

## Testing

- Added assertions in `ExportApiDefinitionTest` to ensure `reporterMetricsEnabled` does not appear in HTTP v4 API exports.
- Added assertions in `getApiByIdTest` to confirm that `reporterMetricsEnabled` is excluded from HTTP v4 API responses.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

