### PR TITLE
fix(test): resolve flaky ApiLogsResourceTest NPE

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/EnvironmentAnalyticsResourceTest.java
@@ -100,7 +100,7 @@ class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @AfterEach
     void teardown() {
-        Stream.of(apiQueryService, applicationQueryService).forEach(InMemoryAlternative::reset);
+        Stream.of(apiQueryService, applicationQueryService, connectionLogsCrudService).forEach(InMemoryAlternative::reset);
         analyticsQueryService.reset();
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13799

## Description

This Pull Request updates a test file to include the cleanup of an additional service during the teardown phase of test execution.

## Main Changes

- Modified the `teardown` method in `EnvironmentAnalyticsResourceTest` to reset the `connectionLogsCrudService` alongside existing services during cleanup.