### PR TITLE
fix: propagate allowedInApiProducts through v4 HTTP API create path

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,6 +54,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mapstruct.factory.Mappers;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class ApiMapperTest {
 
     private final ApiMapper apiMapper = Mappers.getMapper(ApiMapper.class);
@@ -155,6 +158,25 @@ public class ApiMapperTest {
         var mapped = apiMapper.mapToNewNativeApi(newApi);
         assertThat(mapped).isNotNull();
         assertThat(mapped.getVisibility()).isEqualTo(Api.Visibility.valueOf(visibility.name()));
+    }
+
+    static Stream<Boolean> allowedInApiProductsValues() {
+        return Stream.of(true, false, null);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allowedInApiProductsValues")
+    void should_pass_through_allowedInApiProducts(Boolean value) {
+        CreateApiV4 dto = new CreateApiV4();
+        dto.setName("Test API");
+        dto.setApiVersion("1.0.0");
+        dto.setDefinitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4);
+        dto.setType(io.gravitee.rest.api.management.v2.rest.model.ApiType.PROXY);
+        dto.setAllowedInApiProducts(value);
+
+        var mapped = apiMapper.mapToNewHttpApi(dto);
+
+        assertThat(mapped.getAllowedInApiProducts()).isEqualTo(value);
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewHttpApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/NewHttpApi.java
@@ -51,6 +51,8 @@ public class NewHttpApi extends AbstractNewApi {
 
     private Failover failover;
 
+    private Boolean allowedInApiProducts;
+
     /**
      * @return An instance of {@link io.gravitee.definition.model.v4.Api.ApiBuilder} based on the current state of this NewV4Api.
      */
@@ -67,7 +69,8 @@ public class NewHttpApi extends AbstractNewApi {
             .endpointGroups(endpointGroups)
             .flows(flows)
             .flowExecution(flowExecution)
-            .failover(failover);
+            .failover(failover)
+            .allowedInApiProducts(allowedInApiProducts);
 
         return builder;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/NewHttpApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/NewHttpApiTest.java
@@ -65,4 +65,22 @@ class NewHttpApiTest {
         assertThat(definition.getType()).isEqualTo(ApiType.PROXY);
         assertThat(definition.getAllowedInApiProducts()).isNull();
     }
+
+    @Test
+    void should_forward_allowedInApiProducts_true_into_domain_api_definition() {
+        NewHttpApi newHttpApi = NewApiFixtures.aProxyApiV4().toBuilder().allowedInApiProducts(true).build();
+
+        var definition = newHttpApi.toApiDefinitionBuilder().build();
+
+        assertThat(definition.getAllowedInApiProducts()).isTrue();
+    }
+
+    @Test
+    void should_forward_allowedInApiProducts_false_into_domain_api_definition() {
+        NewHttpApi newHttpApi = NewApiFixtures.aProxyApiV4().toBuilder().allowedInApiProducts(false).build();
+
+        var definition = newHttpApi.toApiDefinitionBuilder().build();
+
+        assertThat(definition.getAllowedInApiProducts()).isFalse();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCaseTest.java
@@ -100,6 +100,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class CreateHttpApiUseCaseTest {
@@ -586,6 +587,22 @@ class CreateHttpApiUseCaseTest {
                 .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
                 .build()
         );
+    }
+
+    static Stream<Boolean> allowedInApiProductsValues() {
+        return Stream.of(true, false, null);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allowedInApiProductsValues")
+    void should_persist_allowedInApiProducts(Boolean value) {
+        var newApi = NewApiFixtures.aProxyApiV4().toBuilder().allowedInApiProducts(value).build();
+
+        useCase.execute(new Input(newApi, AUDIT_INFO));
+
+        assertThat(apiCrudService.storage())
+            .extracting(api -> api.getApiDefinitionHttpV4().getAllowedInApiProducts())
+            .containsExactly(value);
     }
 
     private void enableApiPrimaryOwnerMode(ApiPrimaryOwnerMode mode) {


### PR DESCRIPTION
## Issue

[APIM-13786](https://gravitee.atlassian.net/browse/APIM-13786) — v4 API create path: propagate `allowedInApiProducts` through `NewHttpApi` to domain

Parent: [APIM-13738](https://gravitee.atlassian.net/browse/APIM-13738)

## Why

On the v4 HTTP Proxy API create path, `allowedInApiProducts` was silently dropped between the REST DTO and the domain model. The persisted value was always `null`; the subsequent GET only returned `false` because the read path coalesces `null → false`. Two problems: (1) the OpenAPI spec advertises a create default of `true`, but clients always observe `false` on GET — spec and behavior disagree; (2) explicit values from callers (`true` or `false`) were silently lost.

This change wires the field through the HTTP create bridge so the caller's value (or the OpenAPI-layer default) reaches the domain unchanged. Values survive verbatim: `true`, `false`, and `null` all pass through without coercion.

## What changed

- `NewHttpApi.java` — added `private Boolean allowedInApiProducts;` and chained `.allowedInApiProducts(allowedInApiProducts)` into `toApiDefinitionBuilder()`. No `@Builder.Default` — the OpenAPI-layer default on `CreateApiV4` remains the single source of truth.
- `ApiMapper.java` — no source edits. MapStruct auto-maps the field on `mapToNewHttpApi` via name-matching now that source (`CreateApiV4`) and target (`NewHttpApi`) share the field. `mapToNewNativeApi` stays silent — MapStruct's default policy does not warn on unmapped source properties, so no `@BeanMapping` suppression was needed. Generated `ApiMapperImpl` was inspected to confirm: HTTP mapper sets the field, native mapper does not.
- Tests — added behavioral coverage at all three layers (bridge builder, use case round-trip, REST DTO mapper). Native mapper is guarded at compile time via the type system (`NewNativeApi` has no accessor for the field).

## User-facing impact

⚠️ **Behavior change**: APIs created through `POST /management/v2/environments/{envId}/apis` without an explicit `allowedInApiProducts` value will now persist `true` (the OpenAPI default on `CreateApiV4`) instead of the previously-masked `false`. Clients that assumed the old masked default will see the stored value change after merge. This aligns stored state with the documented OpenAPI contract.

No API signature or config key changes. No docs update required — the OpenAPI spec already documents `true` as the default.

## How to test

1. Create a v4 HTTP Proxy API without `allowedInApiProducts` in the body; GET it — expect `"allowedInApiProducts": true`.
2. Create with `"allowedInApiProducts": false`; GET — expect `false`.
3. Create with `"allowedInApiProducts": true`; GET — expect `true`.

Automated coverage:

```
mvnd -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service,gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest -am -Dtest='NewHttpApiTest,CreateHttpApiUseCaseTest,ApiMapperTest' -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test
```

## Gotchas / Follow-up

- `ApiCRDSpec` has the same gap on a different entry point — explicitly out of scope here; no follow-up ticket filed per the action plan.
- `NewNativeApi` intentionally does not gain the field — `allowedInApiProducts` is HTTP-Proxy-only.

[APIM-13786]: https://gravitee.atlassian.net/browse/APIM-13786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-13738]: https://gravitee.atlassian.net/browse/APIM-13738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ