### PR TITLE
feat: support api key rotation in automation api

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionsResource.java
@@ -19,10 +19,12 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
 
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.model.crd.ApiKeyCRDSpec;
 import io.gravitee.apim.core.subscription.model.crd.SubscriptionCRDSpec;
 import io.gravitee.apim.core.subscription.model.crd.SubscriptionCRDStatus;
 import io.gravitee.apim.core.subscription.use_case.ImportSubscriptionCRDUseCase;
 import io.gravitee.apim.rest.api.automation.mapper.SubscriptionMapper;
+import io.gravitee.apim.rest.api.automation.model.ApiKeySpec;
 import io.gravitee.apim.rest.api.automation.model.SubscriptionSpec;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -42,6 +44,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
@@ -96,7 +99,7 @@ public class ApiSubscriptionsResource extends AbstractResource {
             )
             .endingAt(spec.getEndingAt() != null ? spec.getEndingAt().toZonedDateTime() : null)
             .metadata(spec.getMetadata())
-            .customApiKey(spec.getCustomApiKey())
+            .apiKeys(toApiKeyCRDSpecs(spec.getApiKeys()))
             .build();
 
         SubscriptionCRDStatus status = importSubscriptionCRDUseCase
@@ -104,5 +107,17 @@ public class ApiSubscriptionsResource extends AbstractResource {
             .status();
 
         return Response.ok(SubscriptionMapper.INSTANCE.subscriptionSpecAndStatusToSubscriptionState(apiHrid, spec, status)).build();
+    }
+
+    private static List<ApiKeyCRDSpec> toApiKeyCRDSpecs(List<ApiKeySpec> apiKeys) {
+        if (apiKeys == null || apiKeys.isEmpty()) {
+            return null;
+        }
+        return apiKeys
+            .stream()
+            .map(k ->
+                ApiKeyCRDSpec.builder().key(k.getKey()).expireAt(k.getExpireAt() != null ? k.getExpireAt().toZonedDateTime() : null).build()
+            )
+            .toList();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -873,15 +873,32 @@ components:
           examples:
             - key1: value1
               key2: value2
-        customApiKey:
-          type: string
+        apiKeys:
+          type: array
           writeOnly: true
-          description: Custom API key to assign when creating API-KEY plan subscription.
-          example: my-custom-api-key
+          description: List of custom API keys with optional expiry dates. Used for API-KEY plan subscriptions.
+          items:
+            $ref: "#/components/schemas/ApiKeySpec"
       required:
         - hrid
         - applicationHrid
         - planHrid
+
+    ApiKeySpec:
+      description: API key specification with optional expiry date
+      type: object
+      properties:
+        key:
+          type: string
+          description: The custom API key value.
+          example: my-custom-api-key
+        expireAt:
+          type: string
+          format: date-time
+          description: Optional expiry date for this API key.
+          example: "2040-12-25T09:12:28Z"
+      required:
+        - key
 
     SubscriptionState:
       description: State of subscription that has been created/update

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionsResourceTest.java
@@ -69,7 +69,8 @@ class ApiSubscriptionsResourceTest extends AbstractResourceTest {
                 soft.assertThat(state.getApiHrid()).isEqualTo(API_HRID);
                 soft.assertThat(state.getApplicationHrid()).isEqualTo("application_hrid");
                 soft.assertThat(state.getPlanHrid()).isEqualTo("plan_hrid");
-                soft.assertThat(state.getCustomApiKey()).isEqualTo("custom-api-key");
+                soft.assertThat(state.getApiKeys()).hasSize(1);
+                soft.assertThat(state.getApiKeys().get(0).getKey()).isEqualTo("custom-api-key");
                 soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
                 soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
             });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -69,6 +69,7 @@ import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
@@ -155,6 +156,7 @@ import io.gravitee.apim.core.shared_policy_group.use_case.SearchSharedPolicyGrou
 import io.gravitee.apim.core.shared_policy_group.use_case.UndeploySharedPolicyGroupUseCase;
 import io.gravitee.apim.core.shared_policy_group.use_case.UpdateSharedPolicyGroupUseCase;
 import io.gravitee.apim.core.specgen.use_case.SpecGenRequestUseCase;
+import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDDomainService;
@@ -759,17 +761,26 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public ReconcileApiKeysDomainService reconcileApiKeysDomainService() {
+        return mock(ReconcileApiKeysDomainService.class);
+    }
+
+    @Bean
     public SubscriptionCRDDomainService subscriptionSpecDomainService(
         SubscriptionService subscriptionService,
         SubscriptionAdapter subscriptionAdapter,
         AcceptSubscriptionDomainService acceptSubscriptionDomainService,
-        CloseSubscriptionDomainService closeSubscriptionDomainService
+        CloseSubscriptionDomainService closeSubscriptionDomainService,
+        ReconcileApiKeysDomainService reconcileApiKeysDomainService,
+        SubscriptionCrudService subscriptionCrudService
     ) {
         return new SubscriptionCRDDomainServiceImpl(
             subscriptionService,
             subscriptionAdapter,
             acceptSubscriptionDomainService,
-            closeSubscriptionDomainService
+            closeSubscriptionDomainService,
+            reconcileApiKeysDomainService,
+            subscriptionCrudService
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/subscription-with-hrid.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/subscription-with-hrid.json
@@ -2,5 +2,9 @@
   "hrid": "subscription_hrid",
   "applicationHrid":  "application_hrid",
   "planHrid": "plan_hrid",
-  "customApiKey": "custom-api-key"
+  "apiKeys": [
+    {
+      "key": "custom-api-key"
+    }
+  ]
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -78,6 +78,7 @@ import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
+import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeployApiProductUseCase;
@@ -196,6 +197,7 @@ import io.gravitee.apim.core.shared_policy_group.use_case.SearchSharedPolicyGrou
 import io.gravitee.apim.core.shared_policy_group.use_case.UndeploySharedPolicyGroupUseCase;
 import io.gravitee.apim.core.shared_policy_group.use_case.UpdateSharedPolicyGroupUseCase;
 import io.gravitee.apim.core.specgen.use_case.SpecGenRequestUseCase;
+import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDDomainService;
@@ -815,17 +817,26 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public ReconcileApiKeysDomainService reconcileApiKeysDomainService() {
+        return mock(ReconcileApiKeysDomainService.class);
+    }
+
+    @Bean
     public SubscriptionCRDDomainService subscriptionSpecDomainService(
         SubscriptionService subscriptionService,
         SubscriptionAdapter subscriptionAdapter,
         AcceptSubscriptionDomainService acceptSubscriptionDomainService,
-        CloseSubscriptionDomainService closeSubscriptionDomainService
+        CloseSubscriptionDomainService closeSubscriptionDomainService,
+        ReconcileApiKeysDomainService reconcileApiKeysDomainService,
+        SubscriptionCrudService subscriptionCrudService
     ) {
         return new SubscriptionCRDDomainServiceImpl(
             subscriptionService,
             subscriptionAdapter,
             acceptSubscriptionDomainService,
-            closeSubscriptionDomainService
+            closeSubscriptionDomainService,
+            reconcileApiKeysDomainService,
+            subscriptionCrudService
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -62,6 +62,7 @@ import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
@@ -146,6 +147,7 @@ import io.gravitee.apim.core.shared_policy_group.use_case.SearchSharedPolicyGrou
 import io.gravitee.apim.core.shared_policy_group.use_case.SearchSharedPolicyGroupUseCase;
 import io.gravitee.apim.core.shared_policy_group.use_case.UndeploySharedPolicyGroupUseCase;
 import io.gravitee.apim.core.shared_policy_group.use_case.UpdateSharedPolicyGroupUseCase;
+import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDDomainService;
@@ -964,17 +966,26 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public ReconcileApiKeysDomainService reconcileApiKeysDomainService() {
+        return mock(ReconcileApiKeysDomainService.class);
+    }
+
+    @Bean
     public SubscriptionCRDDomainService subscriptionSpecDomainService(
         SubscriptionService subscriptionService,
         SubscriptionAdapter subscriptionAdapter,
         AcceptSubscriptionDomainService acceptSubscriptionDomainService,
-        CloseSubscriptionDomainService closeSubscriptionDomainService
+        CloseSubscriptionDomainService closeSubscriptionDomainService,
+        ReconcileApiKeysDomainService reconcileApiKeysDomainService,
+        SubscriptionCrudService subscriptionCrudService
     ) {
         return new SubscriptionCRDDomainServiceImpl(
             subscriptionService,
             subscriptionAdapter,
             acceptSubscriptionDomainService,
-            closeSubscriptionDomainService
+            closeSubscriptionDomainService,
+            reconcileApiKeysDomainService,
+            subscriptionCrudService
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -62,6 +62,7 @@ import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
@@ -151,6 +152,7 @@ import io.gravitee.apim.core.shared_policy_group.use_case.SearchSharedPolicyGrou
 import io.gravitee.apim.core.shared_policy_group.use_case.SearchSharedPolicyGroupUseCase;
 import io.gravitee.apim.core.shared_policy_group.use_case.UndeploySharedPolicyGroupUseCase;
 import io.gravitee.apim.core.shared_policy_group.use_case.UpdateSharedPolicyGroupUseCase;
+import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDDomainService;
@@ -882,17 +884,26 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public ReconcileApiKeysDomainService reconcileApiKeysDomainService() {
+        return mock(ReconcileApiKeysDomainService.class);
+    }
+
+    @Bean
     public SubscriptionCRDDomainService subscriptionSpecDomainService(
         SubscriptionService subscriptionService,
         SubscriptionAdapter subscriptionAdapter,
         AcceptSubscriptionDomainService acceptSubscriptionDomainService,
-        CloseSubscriptionDomainService closeSubscriptionDomainService
+        CloseSubscriptionDomainService closeSubscriptionDomainService,
+        ReconcileApiKeysDomainService reconcileApiKeysDomainService,
+        SubscriptionCrudService subscriptionCrudService
     ) {
         return new SubscriptionCRDDomainServiceImpl(
             subscriptionService,
             subscriptionAdapter,
             acceptSubscriptionDomainService,
-            closeSubscriptionDomainService
+            closeSubscriptionDomainService,
+            reconcileApiKeysDomainService,
+            subscriptionCrudService
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/ReconcileApiKeysDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/ReconcileApiKeysDomainService.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_key.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_key.crud_service.ApiKeyCrudService;
+import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
+import io.gravitee.apim.core.api_key.query_service.ApiKeyQueryService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.subscription.model.crd.ApiKeyCRDSpec;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@CustomLog
+@RequiredArgsConstructor
+public class ReconcileApiKeysDomainService {
+
+    private final ApiKeyQueryService apiKeyQueryService;
+    private final ApiKeyCrudService apiKeyCrudService;
+    private final GenerateApiKeyDomainService generateApiKeyDomainService;
+    private final RevokeApiKeyDomainService revokeApiKeyDomainService;
+
+    /**
+     * Reconciles the desired API keys from the CRD spec against the actual keys in APIM for a given subscription.
+     *
+     * <ul>
+     *   <li>Key in spec, active in APIM: update expireAt if changed</li>
+     *   <li>Key in spec, revoked in APIM: reactivate it</li>
+     *   <li>Key in spec, not in APIM: create it</li>
+     *   <li>Key not in spec, active in APIM: revoke immediately</li>
+     *   <li>Key not in spec, revoked in APIM: no-op</li>
+     * </ul>
+     */
+    public void reconcile(SubscriptionEntity subscription, List<ApiKeyCRDSpec> desiredKeys, AuditInfo auditInfo) {
+        if (desiredKeys == null || desiredKeys.isEmpty()) {
+            return;
+        }
+
+        var existingByKey = apiKeyQueryService
+            .findBySubscription(subscription.getId())
+            .collect(Collectors.toMap(ApiKeyEntity::getKey, Function.identity(), (a, b) -> a));
+
+        var desiredByKey = desiredKeys.stream().collect(Collectors.toMap(ApiKeyCRDSpec::getKey, Function.identity()));
+
+        for (ApiKeyCRDSpec desired : desiredKeys) {
+            var existing = existingByKey.get(desired.getKey());
+            if (existing == null) {
+                createKey(subscription, desired, auditInfo);
+            } else if (existing.isRevoked()) {
+                reactivateKey(existing, desired);
+            } else {
+                updateExpiryIfChanged(existing, desired);
+            }
+        }
+
+        for (var entry : existingByKey.entrySet()) {
+            if (!desiredByKey.containsKey(entry.getKey()) && entry.getValue().canBeRevoked()) {
+                log.debug("Revoking API key [{}] not present in desired spec", entry.getKey());
+                revokeApiKeyDomainService.revoke(entry.getValue(), auditInfo);
+            }
+        }
+    }
+
+    private void createKey(SubscriptionEntity subscription, ApiKeyCRDSpec desired, AuditInfo auditInfo) {
+        log.debug("Creating API key [{}] for subscription [{}]", desired.getKey(), subscription.getId());
+        var created = generateApiKeyDomainService.generate(subscription, auditInfo, desired.getKey());
+        if (desired.getExpireAt() != null) {
+            apiKeyCrudService.update(created.toBuilder().expireAt(desired.getExpireAt()).build());
+        }
+    }
+
+    private void reactivateKey(ApiKeyEntity existing, ApiKeyCRDSpec desired) {
+        log.debug("Reactivating revoked API key [{}]", existing.getKey());
+        var reactivated = existing.reactivate();
+        if (desired.getExpireAt() != null) {
+            reactivated = reactivated.toBuilder().expireAt(desired.getExpireAt()).build();
+        }
+        apiKeyCrudService.update(reactivated);
+    }
+
+    private void updateExpiryIfChanged(ApiKeyEntity existing, ApiKeyCRDSpec desired) {
+        if (!Objects.equals(desired.getExpireAt(), existing.getExpireAt())) {
+            log.debug("Updating expireAt for API key [{}]", existing.getKey());
+            apiKeyCrudService.update(existing.toBuilder().expireAt(desired.getExpireAt()).build());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/model/ApiKeyEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/model/ApiKeyEntity.java
@@ -106,12 +106,17 @@ public class ApiKeyEntity {
     }
 
     public ApiKeyEntity revoke() {
-        var now = ZonedDateTime.now();
+        var now = TimeProvider.now();
         return this.toBuilder().revoked(true).updatedAt(now).revokedAt(now).build();
     }
 
+    public ApiKeyEntity reactivate() {
+        var now = TimeProvider.now();
+        return this.toBuilder().revoked(false).updatedAt(now).revokedAt(null).build();
+    }
+
     public boolean isExpired() {
-        return this.expireAt != null && ZonedDateTime.now().isAfter(this.getExpireAt());
+        return this.expireAt != null && TimeProvider.now().isAfter(this.getExpireAt());
     }
 
     public boolean canBeRevoked() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/ValidateSubscriptionCRDDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/ValidateSubscriptionCRDDomainService.java
@@ -18,9 +18,11 @@ package io.gravitee.apim.core.subscription.domain_service;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.subscription.model.crd.ApiKeyCRDSpec;
 import io.gravitee.apim.core.subscription.model.crd.SubscriptionCRDSpec;
-import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.apim.core.validation.Validator;
+import java.util.HashSet;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -37,15 +39,28 @@ public class ValidateSubscriptionCRDDomainService implements Validator<ValidateS
 
     @Override
     public Result<Input> validateAndSanitize(Input input) {
-        if (StringUtils.isEmpty(input.spec().getCustomApiKey())) {
+        List<ApiKeyCRDSpec> apiKeys = input.spec().getApiKeys();
+        if (apiKeys == null || apiKeys.isEmpty()) {
             return Result.ofValue(input);
         }
 
         var plan = planCrudService.getById(input.spec().getPlanId());
         if (!plan.isApiKey()) {
-            return Result.withError(
-                Error.severe("Subscription customApiKey is only allowed for API_KEY plans (plan: %s)", input.spec().getPlanId())
-            );
+            return Result.withError(Error.severe("apiKeys is only allowed for API_KEY plans (plan: %s)", input.spec().getPlanId()));
+        }
+
+        var seen = new HashSet<String>();
+        for (var keySpec : apiKeys) {
+            if (keySpec.getKey() == null || keySpec.getKey().isBlank()) {
+                return Result.withError(Error.severe("apiKeys entries must have a non-empty key"));
+            }
+            int keyLength = keySpec.getKey().length();
+            if (keyLength < 32 || keyLength > 256) {
+                return Result.withError(Error.severe("key length must be between 32 and 256 characters, got %d", keyLength));
+            }
+            if (!seen.add(keySpec.getKey())) {
+                return Result.withError(Error.severe("duplicate key [%s] in apiKeys", keySpec.getKey()));
+            }
         }
 
         return Result.ofValue(input);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/model/crd/ApiKeyCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/model/crd/ApiKeyCRDSpec.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription.model.crd;
+
+import java.time.ZonedDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApiKeyCRDSpec {
+
+    private String key;
+    private ZonedDateTime expireAt;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/model/crd/SubscriptionCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/model/crd/SubscriptionCRDSpec.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.subscription.model.crd;
 
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -58,5 +59,5 @@ public class SubscriptionCRDSpec {
     private String planId;
     private ZonedDateTime endingAt;
     private Map<String, String> metadata;
-    private String customApiKey;
+    private List<ApiKeyCRDSpec> apiKeys;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDDomainServiceImpl.java
@@ -15,13 +15,16 @@
  */
 package io.gravitee.apim.infra.domain_service.subscription;
 
+import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDDomainService;
 import io.gravitee.apim.core.subscription.exception.SubscriptionApplicationImmutableException;
 import io.gravitee.apim.core.subscription.exception.SubscriptionPlanImmutableException;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.subscription.model.crd.ApiKeyCRDSpec;
 import io.gravitee.apim.core.subscription.model.crd.SubscriptionCRDSpec;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
 import io.gravitee.rest.api.model.SubscriptionStatus;
@@ -29,6 +32,7 @@ import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.CustomLog;
@@ -53,6 +57,10 @@ public class SubscriptionCRDDomainServiceImpl implements SubscriptionCRDDomainSe
     private final AcceptSubscriptionDomainService acceptService;
 
     private final CloseSubscriptionDomainService closeSubscriptionDomainService;
+
+    private final ReconcileApiKeysDomainService reconcileApiKeysDomainService;
+
+    private final SubscriptionCrudService subscriptionCrudService;
 
     @Override
     public SubscriptionEntity createOrUpdate(AuditInfo auditInfo, SubscriptionCRDSpec spec) {
@@ -80,10 +88,12 @@ public class SubscriptionCRDDomainServiceImpl implements SubscriptionCRDDomainSe
         entity.setReasonMessage(ACCEPT_REASON);
         entity.setEndingAt(spec.getEndingAt());
 
+        String initialCustomKey = firstKeyOrNull(spec.getApiKeys());
+
         var subscription = subscriptionService.create(
             toExecutionContext(auditInfo),
             adapter.fromCoreForCreate(entity),
-            spec.getCustomApiKey(),
+            initialCustomKey,
             spec.getId()
         );
 
@@ -91,13 +101,18 @@ public class SubscriptionCRDDomainServiceImpl implements SubscriptionCRDDomainSe
             subscriptionService.update(toExecutionContext(auditInfo), adapter.fromCoreForUpdate(entity));
         }
 
+        SubscriptionEntity accepted;
         if (subscription.getStatus() == SubscriptionStatus.ACCEPTED) {
             log.debug("Subscription [{}] already accepted, skipping auto accept", spec.getId());
-            return adapter.toCore(subscription);
+            accepted = adapter.toCore(subscription);
+        } else {
+            log.debug("Auto accepting subscription [{}]", spec.getId());
+            accepted = getAutoAccept(auditInfo, spec, subscription.getId());
         }
 
-        log.debug("Auto accepting subscription [{}]", spec.getId());
-        return getAutoAccept(auditInfo, spec, subscription.getId());
+        reconcileApiKeys(accepted, auditInfo, spec);
+
+        return accepted;
     }
 
     private SubscriptionEntity update(AuditInfo auditInfo, SubscriptionEntity existing, SubscriptionCRDSpec spec) {
@@ -122,17 +137,35 @@ public class SubscriptionCRDDomainServiceImpl implements SubscriptionCRDDomainSe
 
         subscriptionService.update(toExecutionContext(auditInfo), adapter.fromCoreForUpdate(update));
 
+        reconcileApiKeys(update, auditInfo, spec);
+
         return update;
     }
 
     private SubscriptionEntity restoreAsAccepted(AuditInfo auditInfo, SubscriptionEntity existing, SubscriptionCRDSpec spec) {
         log.debug("Restoring closed subscription [{}]", spec.getId());
         subscriptionService.restore(toExecutionContext(auditInfo), existing.getId());
+        if (hasApiKeys(spec)) {
+            var pending = subscriptionCrudService.get(existing.getId());
+            var accepted = pending.acceptBy(auditInfo.actor().userId(), ZonedDateTime.now(), spec.getEndingAt(), ACCEPT_REASON);
+            return subscriptionCrudService.update(accepted);
+        }
         return getAutoAccept(auditInfo, spec, existing.getId());
     }
 
+    private static boolean hasApiKeys(SubscriptionCRDSpec spec) {
+        return spec.getApiKeys() != null && !spec.getApiKeys().isEmpty();
+    }
+
     private SubscriptionEntity getAutoAccept(AuditInfo auditInfo, SubscriptionCRDSpec spec, String id) {
-        return acceptService.autoAccept(id, ZonedDateTime.now(), spec.getEndingAt(), ACCEPT_REASON, "", auditInfo);
+        return acceptService.autoAccept(
+            id,
+            ZonedDateTime.now(),
+            spec.getEndingAt(),
+            ACCEPT_REASON,
+            firstKeyOrNull(spec.getApiKeys()),
+            auditInfo
+        );
     }
 
     private static void rejectImmutableFieldChanges(SubscriptionEntity existing, SubscriptionCRDSpec spec) {
@@ -151,6 +184,19 @@ public class SubscriptionCRDDomainServiceImpl implements SubscriptionCRDDomainSe
             log.debug("Subscription [{}] not found", id);
             return Optional.empty();
         }
+    }
+
+    private void reconcileApiKeys(SubscriptionEntity subscription, AuditInfo auditInfo, SubscriptionCRDSpec spec) {
+        if (spec.getApiKeys() != null && !spec.getApiKeys().isEmpty()) {
+            reconcileApiKeysDomainService.reconcile(subscription, spec.getApiKeys(), auditInfo);
+        }
+    }
+
+    private static String firstKeyOrNull(List<ApiKeyCRDSpec> apiKeys) {
+        if (apiKeys == null || apiKeys.isEmpty()) {
+            return null;
+        }
+        return apiKeys.getFirst().getKey();
     }
 
     private static ExecutionContext toExecutionContext(AuditInfo auditInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/ReconcileApiKeysDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/ReconcileApiKeysDomainServiceTest.java
@@ -1,0 +1,464 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_key.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.AuditInfoFixtures;
+import inmemory.ApiKeyCrudServiceInMemory;
+import inmemory.ApiKeyQueryServiceInMemory;
+import inmemory.ApplicationCrudServiceInMemory;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.SubscriptionCrudServiceInMemory;
+import inmemory.TriggerNotificationDomainServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.subscription.model.crd.ApiKeyCRDSpec;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ReconcileApiKeysDomainServiceTest {
+
+    private static final Instant THEN = Instant.parse("2023-10-22T10:15:30Z");
+    private static final ZonedDateTime FIXED_NOW = ZonedDateTime.ofInstant(THEN, ZoneId.systemDefault());
+
+    private static final String ORGANIZATION_ID = "org-id";
+    private static final String ENVIRONMENT_ID = "env-id";
+    private static final String USER_ID = "user-id";
+    private static final String SUBSCRIPTION_ID = "subscription-id";
+    private static final String APPLICATION_ID = "application-id";
+
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    private static final SubscriptionEntity SUBSCRIPTION = SubscriptionEntity.builder()
+        .id(SUBSCRIPTION_ID)
+        .applicationId(APPLICATION_ID)
+        .environmentId(ENVIRONMENT_ID)
+        .planId("plan-id")
+        .status(SubscriptionEntity.Status.ACCEPTED)
+        .build();
+
+    private final ApiKeyCrudServiceInMemory apiKeyCrudService = new ApiKeyCrudServiceInMemory();
+    private final ApiKeyQueryServiceInMemory apiKeyQueryService = new ApiKeyQueryServiceInMemory(apiKeyCrudService);
+    private final SubscriptionCrudServiceInMemory subscriptionCrudService = new SubscriptionCrudServiceInMemory();
+    private final AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
+    private final UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    private final TriggerNotificationDomainServiceInMemory notificationService = new TriggerNotificationDomainServiceInMemory();
+    private final ApplicationCrudServiceInMemory applicationCrudService = new ApplicationCrudServiceInMemory();
+
+    private ReconcileApiKeysDomainService cut;
+
+    @BeforeAll
+    static void init() {
+        UuidString.overrideGenerator(() -> "generated-id");
+        TimeProvider.overrideClock(Clock.fixed(THEN, ZoneId.systemDefault()));
+    }
+
+    @BeforeEach
+    void setUp() {
+        var auditDomainService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+        var generateApiKeyDomainService = new GenerateApiKeyDomainService(
+            apiKeyCrudService,
+            new ApiKeyQueryServiceInMemory(apiKeyCrudService),
+            applicationCrudService,
+            auditDomainService
+        );
+        var revokeApiKeyDomainService = new RevokeApiKeyDomainService(
+            apiKeyCrudService,
+            apiKeyQueryService,
+            subscriptionCrudService,
+            auditDomainService,
+            notificationService
+        );
+
+        cut = new ReconcileApiKeysDomainService(
+            apiKeyQueryService,
+            apiKeyCrudService,
+            generateApiKeyDomainService,
+            revokeApiKeyDomainService
+        );
+
+        applicationCrudService.initWith(
+            List.of(fixtures.ApplicationModelFixtures.anApplicationEntity().toBuilder().id(APPLICATION_ID).build())
+        );
+        subscriptionCrudService.initWith(List.of(SUBSCRIPTION));
+    }
+
+    @AfterEach
+    void tearDown() {
+        apiKeyCrudService.reset();
+        subscriptionCrudService.reset();
+        auditCrudService.reset();
+        userCrudService.reset();
+        notificationService.reset();
+        applicationCrudService.reset();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        UuidString.reset();
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @Test
+    void should_do_nothing_when_desired_keys_is_null() {
+        cut.reconcile(SUBSCRIPTION, null, AUDIT_INFO);
+
+        assertThat(apiKeyCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_do_nothing_when_desired_keys_is_empty() {
+        cut.reconcile(SUBSCRIPTION, List.of(), AUDIT_INFO);
+
+        assertThat(apiKeyCrudService.storage()).isEmpty();
+    }
+
+    @Nested
+    class CreateKeys {
+
+        @Test
+        void should_create_key_not_present_in_apim() {
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v1").build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            assertThat(apiKeyCrudService.storage()).hasSize(1);
+            assertThat(apiKeyCrudService.storage().get(0).getKey()).isEqualTo("key-v1");
+            assertThat(apiKeyCrudService.storage().get(0).isRevoked()).isFalse();
+        }
+
+        @Test
+        void should_create_key_with_expire_at() {
+            var expiry = FIXED_NOW.plusDays(30);
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v1").expireAt(expiry).build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            assertThat(apiKeyCrudService.storage()).hasSize(1);
+            assertThat(apiKeyCrudService.storage().get(0).getKey()).isEqualTo("key-v1");
+            assertThat(apiKeyCrudService.storage().get(0).getExpireAt()).isEqualTo(expiry);
+        }
+
+        @Test
+        void should_create_multiple_keys() {
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v1").build(), ApiKeyCRDSpec.builder().key("key-v2").build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            assertThat(apiKeyCrudService.storage()).hasSize(2);
+            assertThat(apiKeyCrudService.storage()).extracting(ApiKeyEntity::getKey).containsExactlyInAnyOrder("key-v1", "key-v2");
+        }
+    }
+
+    @Nested
+    class RevokeKeys {
+
+        @Test
+        void should_revoke_active_key_not_in_spec() {
+            givenExistingActiveKey("key-old", null);
+
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-new").build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            var oldKey = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-old"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(oldKey.isRevoked()).isTrue();
+            assertThat(oldKey.getRevokedAt()).isNotNull();
+        }
+
+        @Test
+        void should_not_revoke_already_revoked_key_not_in_spec() {
+            givenExistingRevokedKey("key-old");
+
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-new").build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            var oldKey = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-old"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(oldKey.isRevoked()).isTrue();
+        }
+    }
+
+    @Nested
+    class ReactivateKeys {
+
+        @Test
+        void should_reactivate_revoked_key_present_in_spec() {
+            givenExistingRevokedKey("key-v1");
+
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v1").build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            var key = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-v1"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(key.isRevoked()).isFalse();
+            assertThat(key.getRevokedAt()).isNull();
+        }
+
+        @Test
+        void should_reactivate_and_set_expire_at() {
+            givenExistingRevokedKey("key-v1");
+
+            var expiry = FIXED_NOW.plusDays(30);
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v1").expireAt(expiry).build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            var key = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-v1"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(key.isRevoked()).isFalse();
+            assertThat(key.getExpireAt()).isEqualTo(expiry);
+        }
+    }
+
+    @Nested
+    class UpdateExpiry {
+
+        @Test
+        void should_update_expire_at_when_changed() {
+            var oldExpiry = FIXED_NOW.plusDays(10);
+            givenExistingActiveKey("key-v1", oldExpiry);
+
+            var newExpiry = FIXED_NOW.plusDays(60);
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v1").expireAt(newExpiry).build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            var key = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-v1"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(key.getExpireAt()).isEqualTo(newExpiry);
+        }
+
+        @Test
+        void should_not_update_when_expire_at_unchanged() {
+            var expiry = FIXED_NOW.plusDays(10);
+            givenExistingActiveKey("key-v1", expiry);
+
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v1").expireAt(expiry).build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            var key = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-v1"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(key.getExpireAt()).isEqualTo(expiry);
+        }
+
+        @Test
+        void should_clear_expire_at_when_removed_from_spec() {
+            var expiry = FIXED_NOW.plusDays(10);
+            givenExistingActiveKey("key-v1", expiry);
+
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v1").expireAt(null).build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            var key = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-v1"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(key.getExpireAt()).isNull();
+        }
+    }
+
+    @Nested
+    class FullRotationScenario {
+
+        @Test
+        void should_create_new_and_revoke_old_in_single_reconciliation() {
+            givenExistingActiveKey("key-v1", null);
+
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v2").build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            var oldKey = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-v1"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(oldKey.isRevoked()).isTrue();
+
+            var newKey = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-v2"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(newKey.isRevoked()).isFalse();
+        }
+
+        @Test
+        void should_support_gradual_rotation_with_overlap() {
+            givenExistingActiveKey("key-v1", null);
+
+            var desired = List.of(
+                ApiKeyCRDSpec.builder().key("key-v1").expireAt(FIXED_NOW.plusHours(2)).build(),
+                ApiKeyCRDSpec.builder().key("key-v2").build()
+            );
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            var oldKey = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-v1"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(oldKey.isRevoked()).isFalse();
+            assertThat(oldKey.getExpireAt()).isEqualTo(FIXED_NOW.plusHours(2));
+
+            var newKey = apiKeyCrudService
+                .storage()
+                .stream()
+                .filter(k -> k.getKey().equals("key-v2"))
+                .findFirst()
+                .orElseThrow();
+            assertThat(newKey.isRevoked()).isFalse();
+        }
+
+        @Test
+        void should_handle_complete_key_replacement_revoking_multiple_old_keys() {
+            givenExistingActiveKey("key-v1", null);
+            givenExistingActiveKey("key-v2", null);
+
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v3").build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            assertThat(
+                apiKeyCrudService
+                    .storage()
+                    .stream()
+                    .filter(k -> k.getKey().equals("key-v1"))
+                    .findFirst()
+                    .orElseThrow()
+                    .isRevoked()
+            ).isTrue();
+            assertThat(
+                apiKeyCrudService
+                    .storage()
+                    .stream()
+                    .filter(k -> k.getKey().equals("key-v2"))
+                    .findFirst()
+                    .orElseThrow()
+                    .isRevoked()
+            ).isTrue();
+            assertThat(
+                apiKeyCrudService
+                    .storage()
+                    .stream()
+                    .filter(k -> k.getKey().equals("key-v3"))
+                    .findFirst()
+                    .orElseThrow()
+                    .isRevoked()
+            ).isFalse();
+        }
+
+        @Test
+        void should_be_idempotent_when_desired_matches_actual() {
+            givenExistingActiveKey("key-v1", null);
+            givenExistingActiveKey("key-v2", null);
+
+            var desired = List.of(ApiKeyCRDSpec.builder().key("key-v1").build(), ApiKeyCRDSpec.builder().key("key-v2").build());
+
+            cut.reconcile(SUBSCRIPTION, desired, AUDIT_INFO);
+
+            assertThat(apiKeyCrudService.storage()).hasSize(2);
+            assertThat(apiKeyCrudService.storage()).allMatch(k -> !k.isRevoked());
+        }
+    }
+
+    private void givenExistingActiveKey(String key, ZonedDateTime expireAt) {
+        apiKeyCrudService.create(
+            ApiKeyEntity.builder()
+                .id("id-" + key)
+                .key(key)
+                .applicationId(APPLICATION_ID)
+                .subscriptions(List.of(SUBSCRIPTION_ID))
+                .environmentId(ENVIRONMENT_ID)
+                .createdAt(FIXED_NOW)
+                .updatedAt(FIXED_NOW)
+                .expireAt(expireAt)
+                .revoked(false)
+                .build()
+        );
+    }
+
+    private void givenExistingRevokedKey(String key) {
+        apiKeyCrudService.create(
+            ApiKeyEntity.builder()
+                .id("id-" + key)
+                .key(key)
+                .applicationId(APPLICATION_ID)
+                .subscriptions(List.of(SUBSCRIPTION_ID))
+                .environmentId(ENVIRONMENT_ID)
+                .createdAt(FIXED_NOW)
+                .updatedAt(FIXED_NOW)
+                .revoked(true)
+                .revokedAt(FIXED_NOW)
+                .build()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/ValidateSubscriptionCRDDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/ValidateSubscriptionCRDDomainServiceTest.java
@@ -23,8 +23,10 @@ import fixtures.core.model.AuditInfoFixtures;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.model.crd.ApiKeyCRDSpec;
 import io.gravitee.apim.core.subscription.model.crd.SubscriptionCRDSpec;
 import io.gravitee.definition.model.DefinitionVersion;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,9 +41,12 @@ class ValidateSubscriptionCRDDomainServiceTest {
     private final PlanCrudService planCrudService = mock(PlanCrudService.class);
     private final ValidateSubscriptionCRDDomainService cut = new ValidateSubscriptionCRDDomainService(planCrudService);
 
+    private static final String VALID_KEY = "my-custom-key-with-at-least-32cc";
+    private static final String VALID_KEY_2 = "another-custom-key-at-least-32cc";
+
     @Test
-    void should_return_severe_error_when_custom_api_key_is_set_on_non_api_key_plan() {
-        var spec = aSpec().customApiKey("my-custom-key").build();
+    void should_return_severe_error_when_api_keys_is_set_on_non_api_key_plan() {
+        var spec = aSpec().apiKeys(List.of(ApiKeyCRDSpec.builder().key(VALID_KEY).build())).build();
         when(planCrudService.getById(PLAN_ID)).thenReturn(v2PlanWith("JWT"));
 
         var result = cut.validateAndSanitize(
@@ -49,12 +54,12 @@ class ValidateSubscriptionCRDDomainServiceTest {
         );
 
         assertThat(result.severe()).isPresent();
-        assertThat(result.severe().orElseThrow().getFirst().getMessage()).contains("customApiKey is only allowed for API_KEY plans");
+        assertThat(result.severe().orElseThrow().getFirst().getMessage()).contains("apiKeys is only allowed for API_KEY plans");
     }
 
     @Test
-    void should_accept_custom_api_key_on_api_key_plan() {
-        var spec = aSpec().customApiKey("my-custom-key").build();
+    void should_accept_api_keys_on_api_key_plan() {
+        var spec = aSpec().apiKeys(List.of(ApiKeyCRDSpec.builder().key(VALID_KEY).build())).build();
         when(planCrudService.getById(PLAN_ID)).thenReturn(v2PlanWith("API_KEY"));
 
         var result = cut.validateAndSanitize(
@@ -64,6 +69,60 @@ class ValidateSubscriptionCRDDomainServiceTest {
         assertThat(result.severe()).isEmpty();
         assertThat(result.value()).isPresent();
         assertThat(result.value().orElseThrow().spec()).isEqualTo(spec);
+    }
+
+    @Test
+    void should_return_severe_error_when_api_keys_has_duplicate_key() {
+        var spec = aSpec()
+            .apiKeys(List.of(ApiKeyCRDSpec.builder().key(VALID_KEY).build(), ApiKeyCRDSpec.builder().key(VALID_KEY).build()))
+            .build();
+        when(planCrudService.getById(PLAN_ID)).thenReturn(v2PlanWith("API_KEY"));
+
+        var result = cut.validateAndSanitize(
+            new ValidateSubscriptionCRDDomainService.Input(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, "user-id"), spec)
+        );
+
+        assertThat(result.severe()).isPresent();
+        assertThat(result.severe().orElseThrow().getFirst().getMessage()).contains("duplicate key");
+    }
+
+    @Test
+    void should_return_severe_error_when_api_keys_has_blank_key() {
+        var spec = aSpec().apiKeys(List.of(ApiKeyCRDSpec.builder().key("").build())).build();
+        when(planCrudService.getById(PLAN_ID)).thenReturn(v2PlanWith("API_KEY"));
+
+        var result = cut.validateAndSanitize(
+            new ValidateSubscriptionCRDDomainService.Input(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, "user-id"), spec)
+        );
+
+        assertThat(result.severe()).isPresent();
+        assertThat(result.severe().orElseThrow().getFirst().getMessage()).contains("non-empty key");
+    }
+
+    @Test
+    void should_return_severe_error_when_api_key_is_too_short() {
+        var spec = aSpec().apiKeys(List.of(ApiKeyCRDSpec.builder().key("short-key").build())).build();
+        when(planCrudService.getById(PLAN_ID)).thenReturn(v2PlanWith("API_KEY"));
+
+        var result = cut.validateAndSanitize(
+            new ValidateSubscriptionCRDDomainService.Input(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, "user-id"), spec)
+        );
+
+        assertThat(result.severe()).isPresent();
+        assertThat(result.severe().orElseThrow().getFirst().getMessage()).contains("between 32 and 256");
+    }
+
+    @Test
+    void should_return_severe_error_when_api_key_is_too_long() {
+        var spec = aSpec().apiKeys(List.of(ApiKeyCRDSpec.builder().key("k".repeat(257)).build())).build();
+        when(planCrudService.getById(PLAN_ID)).thenReturn(v2PlanWith("API_KEY"));
+
+        var result = cut.validateAndSanitize(
+            new ValidateSubscriptionCRDDomainService.Input(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, "user-id"), spec)
+        );
+
+        assertThat(result.severe()).isPresent();
+        assertThat(result.severe().orElseThrow().getFirst().getMessage()).contains("between 32 and 256");
     }
 
     private static SubscriptionCRDSpec.SubscriptionCRDSpecBuilder aSpec() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/ImportSubscriptionCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/ImportSubscriptionCRDUseCaseTest.java
@@ -29,6 +29,7 @@ import io.gravitee.apim.core.subscription.domain_service.SubscriptionCRDDomainSe
 import io.gravitee.apim.core.subscription.domain_service.ValidateSubscriptionCRDDomainService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.model.crd.ApiKeyCRDSpec;
 import io.gravitee.apim.core.subscription.model.crd.SubscriptionCRDSpec;
 import io.gravitee.apim.core.validation.Validator;
 import java.time.ZonedDateTime;
@@ -52,7 +53,7 @@ class ImportSubscriptionCRDUseCaseTest {
         .referenceType(SubscriptionReferenceType.API)
         .applicationId("application-id")
         .planId("plan-id")
-        .customApiKey("custom-key")
+        .apiKeys(List.of(ApiKeyCRDSpec.builder().key("custom-key").build()))
         .build();
 
     private final SubscriptionCRDDomainService subscriptionCRDDomainService = mock(SubscriptionCRDDomainService.class);
@@ -67,7 +68,7 @@ class ImportSubscriptionCRDUseCaseTest {
 
     @Test
     void should_import_with_sanitized_input() {
-        var sanitizedSpec = SPEC.toBuilder().customApiKey("another-custom-key").build();
+        var sanitizedSpec = SPEC.toBuilder().apiKeys(List.of(ApiKeyCRDSpec.builder().key("another-custom-key").build())).build();
         when(validateSubscriptionCRDDomainService.validateAndSanitize(any(ValidateSubscriptionCRDDomainService.Input.class))).thenReturn(
             Validator.Result.ofValue(new ValidateSubscriptionCRDDomainService.Input(AUDIT_INFO, sanitizedSpec))
         );
@@ -89,12 +90,12 @@ class ImportSubscriptionCRDUseCaseTest {
     @Test
     void should_reject_import_when_validation_contains_severe_errors() {
         when(validateSubscriptionCRDDomainService.validateAndSanitize(any(ValidateSubscriptionCRDDomainService.Input.class))).thenReturn(
-            Validator.Result.ofErrors(List.of(Validator.Error.severe("customApiKey requires an API_KEY plan")))
+            Validator.Result.ofErrors(List.of(Validator.Error.severe("apiKeys is only allowed for API_KEY plans")))
         );
 
         assertThatThrownBy(() -> cut.execute(new ImportSubscriptionCRDUseCase.Input(AUDIT_INFO, SPEC)))
             .isInstanceOf(ValidationDomainException.class)
             .hasMessageContaining("Unable to import because of errors")
-            .hasMessageContaining("customApiKey requires an API_KEY plan");
+            .hasMessageContaining("apiKeys is only allowed for API_KEY plans");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/subscription/SubscriptionCRDDomainServiceImplTest.java
@@ -45,6 +45,7 @@ import inmemory.TriggerNotificationDomainServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_key.domain_service.GenerateApiKeyDomainService;
+import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_key.domain_service.RevokeApiKeyDomainService;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
@@ -58,6 +59,7 @@ import io.gravitee.apim.core.subscription.exception.SubscriptionApplicationImmut
 import io.gravitee.apim.core.subscription.exception.SubscriptionPlanImmutableException;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.model.crd.ApiKeyCRDSpec;
 import io.gravitee.apim.core.subscription.model.crd.SubscriptionCRDSpec;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapterImpl;
@@ -103,7 +105,7 @@ class SubscriptionCRDDomainServiceImplTest {
     private static final String APPLICATION_ID = "application-id";
     private static final String PLAN_ID = "plan-id";
     private static final String SUBSCRIPTION_ID = "subscription-id";
-    private static final String CUSTOM_API_KEY = "my-custom-api-key";
+    private static final String CUSTOM_API_KEY = "my-custom-api-key-with-32-chars!!";
 
     private static final SubscriptionCRDSpec SPEC = SubscriptionCRDSpec.builder()
         .id(SUBSCRIPTION_ID)
@@ -122,7 +124,7 @@ class SubscriptionCRDDomainServiceImplTest {
     private final ApiKeyCrudServiceInMemory apiKeyCrudService = new ApiKeyCrudServiceInMemory();
     private final ApplicationCrudServiceInMemory applicationCrudService = new ApplicationCrudServiceInMemory();
     private final IntegrationAgentInMemory integrationAgent = new IntegrationAgentInMemory();
-    private final ApiKeyQueryServiceInMemory apiKeyQueryService = new ApiKeyQueryServiceInMemory();
+    private final ApiKeyQueryServiceInMemory apiKeyQueryService = new ApiKeyQueryServiceInMemory(apiKeyCrudService);
     private final SubscriptionAdapterImpl subscriptionAdapter = new SubscriptionAdapterImpl();
     private final GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
     private final MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory();
@@ -161,7 +163,9 @@ class SubscriptionCRDDomainServiceImplTest {
             subscriptionService,
             subscriptionAdapter,
             acceptSubscriptionDomainService(),
-            closeSubscriptionDomainService()
+            closeSubscriptionDomainService(),
+            reconcileApiKeysDomainService(),
+            subscriptionCrudService
         );
 
         membershipQueryService.initWith(List.of(anApplicationPrimaryOwnerUserMembership(APPLICATION_ID, USER_ID, ORGANIZATION_ID)));
@@ -264,18 +268,19 @@ class SubscriptionCRDDomainServiceImplTest {
     }
 
     @Test
-    void should_create_with_custom_api_key() {
+    void should_create_with_api_keys() {
         givenExistingApiKeyPlan();
 
-        var specWithCustomApiKey = SPEC.toBuilder().customApiKey(CUSTOM_API_KEY).build();
+        var apiKeys = List.of(ApiKeyCRDSpec.builder().key(CUSTOM_API_KEY).build());
+        var specWithApiKeys = SPEC.toBuilder().apiKeys(apiKeys).build();
         when(subscriptionService.create(eq(EXECUTION_CONTEXT), any(), eq(CUSTOM_API_KEY), eq(SUBSCRIPTION_ID))).thenReturn(
-            subscriptionAdapter.map(subscriptionAdapter.fromSpec(specWithCustomApiKey))
+            subscriptionAdapter.map(subscriptionAdapter.fromSpec(specWithApiKeys))
         );
 
         subscriptionCrudService.initWith(
             List.of(
                 subscriptionAdapter
-                    .fromSpec(specWithCustomApiKey)
+                    .fromSpec(specWithApiKeys)
                     .toBuilder()
                     .status(SubscriptionEntity.Status.PENDING)
                     .subscribedBy(USER_ID)
@@ -283,9 +288,120 @@ class SubscriptionCRDDomainServiceImplTest {
             )
         );
 
-        cut.createOrUpdate(AUDIT_INFO, specWithCustomApiKey);
+        cut.createOrUpdate(AUDIT_INFO, specWithApiKeys);
 
         verify(subscriptionService).create(eq(EXECUTION_CONTEXT), any(), eq(CUSTOM_API_KEY), eq(SUBSCRIPTION_ID));
+    }
+
+    @Test
+    void should_create_with_multiple_api_keys_and_reconcile() {
+        givenExistingApiKeyPlan();
+
+        var apiKeys = List.of(
+            ApiKeyCRDSpec.builder().key(CUSTOM_API_KEY).build(),
+            ApiKeyCRDSpec.builder().key("second-api-key-with-32-chars!!!!").build()
+        );
+        var specWithApiKeys = SPEC.toBuilder().apiKeys(apiKeys).build();
+        when(subscriptionService.create(eq(EXECUTION_CONTEXT), any(), eq(CUSTOM_API_KEY), eq(SUBSCRIPTION_ID))).thenReturn(
+            subscriptionAdapter.map(subscriptionAdapter.fromSpec(specWithApiKeys))
+        );
+
+        subscriptionCrudService.initWith(
+            List.of(
+                subscriptionAdapter
+                    .fromSpec(specWithApiKeys)
+                    .toBuilder()
+                    .status(SubscriptionEntity.Status.PENDING)
+                    .subscribedBy(USER_ID)
+                    .build()
+            )
+        );
+
+        cut.createOrUpdate(AUDIT_INFO, specWithApiKeys);
+
+        verify(subscriptionService).create(eq(EXECUTION_CONTEXT), any(), eq(CUSTOM_API_KEY), eq(SUBSCRIPTION_ID));
+
+        assertThat(apiKeyCrudService.storage()).extracting("key").contains("second-api-key-with-32-chars!!!!");
+    }
+
+    @Test
+    void should_reconcile_api_keys_on_update_revoking_removed_keys() {
+        givenExistingApiKeyPlan();
+
+        var existingEntity = subscriptionAdapter.map(
+            subscriptionAdapter.fromSpec(SPEC).toBuilder().status(SubscriptionEntity.Status.ACCEPTED).build()
+        );
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(existingEntity);
+
+        apiKeyCrudService.initWith(
+            List.of(
+                io.gravitee.apim.core.api_key.model.ApiKeyEntity.builder()
+                    .id("old-key-id")
+                    .key("old-api-key-value-with-32-chars!!")
+                    .applicationId(APPLICATION_ID)
+                    .subscriptions(List.of(SUBSCRIPTION_ID))
+                    .environmentId(ENVIRONMENT_ID)
+                    .createdAt(ZonedDateTime.now())
+                    .updatedAt(ZonedDateTime.now())
+                    .revoked(false)
+                    .build()
+            )
+        );
+
+        var specWithNewKeys = SPEC.toBuilder()
+            .apiKeys(List.of(ApiKeyCRDSpec.builder().key("new-api-key-value-with-32-chars!!").build()))
+            .build();
+
+        cut.createOrUpdate(AUDIT_INFO, specWithNewKeys);
+
+        var oldKey = apiKeyCrudService
+            .storage()
+            .stream()
+            .filter(k -> k.getKey().equals("old-api-key-value-with-32-chars!!"))
+            .findFirst()
+            .orElseThrow();
+        assertThat(oldKey.isRevoked()).isTrue();
+
+        var newKey = apiKeyCrudService
+            .storage()
+            .stream()
+            .filter(k -> k.getKey().equals("new-api-key-value-with-32-chars!!"))
+            .findFirst()
+            .orElseThrow();
+        assertThat(newKey.isRevoked()).isFalse();
+    }
+
+    @Test
+    void should_reconcile_api_keys_on_update_keeping_matching_keys() {
+        givenExistingApiKeyPlan();
+
+        var existingEntity = subscriptionAdapter.map(
+            subscriptionAdapter.fromSpec(SPEC).toBuilder().status(SubscriptionEntity.Status.ACCEPTED).build()
+        );
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(existingEntity);
+
+        apiKeyCrudService.initWith(
+            List.of(
+                io.gravitee.apim.core.api_key.model.ApiKeyEntity.builder()
+                    .id("key-id")
+                    .key(CUSTOM_API_KEY)
+                    .applicationId(APPLICATION_ID)
+                    .subscriptions(List.of(SUBSCRIPTION_ID))
+                    .environmentId(ENVIRONMENT_ID)
+                    .createdAt(ZonedDateTime.now())
+                    .updatedAt(ZonedDateTime.now())
+                    .revoked(false)
+                    .build()
+            )
+        );
+
+        var specWithSameKey = SPEC.toBuilder().apiKeys(List.of(ApiKeyCRDSpec.builder().key(CUSTOM_API_KEY).build())).build();
+
+        cut.createOrUpdate(AUDIT_INFO, specWithSameKey);
+
+        assertThat(apiKeyCrudService.storage()).hasSize(1);
+        assertThat(apiKeyCrudService.storage().get(0).isRevoked()).isFalse();
+        assertThat(apiKeyCrudService.storage().get(0).getKey()).isEqualTo(CUSTOM_API_KEY);
     }
 
     @Test
@@ -344,6 +460,88 @@ class SubscriptionCRDDomainServiceImplTest {
             soft.assertThat(result.getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
             soft.assertThat(subscriptionCrudService.get(SUBSCRIPTION_ID).getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
         });
+    }
+
+    @Test
+    void should_restore_closed_subscription_with_custom_api_keys_reactivating_revoked_key() {
+        givenExistingApiKeyPlan();
+
+        var apiKeys = List.of(ApiKeyCRDSpec.builder().key(CUSTOM_API_KEY).build());
+        var specWithApiKeys = SPEC.toBuilder().apiKeys(apiKeys).build();
+
+        var closedEntity = subscriptionAdapter.map(
+            subscriptionAdapter.fromSpec(specWithApiKeys).toBuilder().status(SubscriptionEntity.Status.CLOSED).subscribedBy(USER_ID).build()
+        );
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(closedEntity);
+
+        apiKeyCrudService.initWith(
+            List.of(
+                io.gravitee.apim.core.api_key.model.ApiKeyEntity.builder()
+                    .id("revoked-key-id")
+                    .key(CUSTOM_API_KEY)
+                    .applicationId(APPLICATION_ID)
+                    .subscriptions(List.of(SUBSCRIPTION_ID))
+                    .environmentId(ENVIRONMENT_ID)
+                    .createdAt(ZonedDateTime.now())
+                    .updatedAt(ZonedDateTime.now())
+                    .revoked(true)
+                    .revokedAt(ZonedDateTime.now())
+                    .build()
+            )
+        );
+
+        doAnswer(invocation -> {
+            subscriptionCrudService.update(
+                subscriptionCrudService.get(SUBSCRIPTION_ID).toBuilder().status(SubscriptionEntity.Status.PENDING).build()
+            );
+            return closedEntity;
+        })
+            .when(subscriptionService)
+            .restore(EXECUTION_CONTEXT, SUBSCRIPTION_ID);
+
+        var result = cut.createOrUpdate(AUDIT_INFO, specWithApiKeys);
+
+        verify(subscriptionService).restore(EXECUTION_CONTEXT, SUBSCRIPTION_ID);
+        assertThat(result.getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
+
+        assertThat(apiKeyCrudService.storage())
+            .as("Only the custom key should exist, no transient UUID key")
+            .hasSize(1)
+            .first()
+            .satisfies(key -> {
+                assertThat(key.getKey()).isEqualTo(CUSTOM_API_KEY);
+                assertThat(key.isRevoked()).isFalse();
+            });
+    }
+
+    @Test
+    void should_restore_closed_subscription_on_api_key_plan_without_custom_keys() {
+        givenExistingApiKeyPlan();
+
+        var closedEntity = subscriptionAdapter.map(
+            subscriptionAdapter.fromSpec(SPEC).toBuilder().status(SubscriptionEntity.Status.CLOSED).subscribedBy(USER_ID).build()
+        );
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(closedEntity);
+
+        doAnswer(invocation -> {
+            subscriptionCrudService.update(
+                subscriptionCrudService.get(SUBSCRIPTION_ID).toBuilder().status(SubscriptionEntity.Status.PENDING).build()
+            );
+            return closedEntity;
+        })
+            .when(subscriptionService)
+            .restore(EXECUTION_CONTEXT, SUBSCRIPTION_ID);
+
+        var result = cut.createOrUpdate(AUDIT_INFO, SPEC);
+
+        verify(subscriptionService).restore(EXECUTION_CONTEXT, SUBSCRIPTION_ID);
+        assertThat(result.getStatus()).isEqualTo(SubscriptionEntity.Status.ACCEPTED);
+
+        assertThat(apiKeyCrudService.storage())
+            .as("A UUID key should be generated when no custom keys are specified")
+            .hasSize(1)
+            .first()
+            .satisfies(key -> assertThat(key.isRevoked()).isFalse());
     }
 
     @Test
@@ -530,6 +728,15 @@ class SubscriptionCRDDomainServiceImplTest {
             new ApiKeyQueryServiceInMemory(apiKeyCrudService),
             applicationCrudService,
             auditDomainService()
+        );
+    }
+
+    private ReconcileApiKeysDomainService reconcileApiKeysDomainService() {
+        return new ReconcileApiKeysDomainService(
+            apiKeyQueryService,
+            apiKeyCrudService,
+            generateApiKeyDomainService(),
+            revokeApiKeyDomainService()
         );
     }
 }


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/GKO-2561

required by https://github.com/gravitee-io/gravitee-kubernetes-operator/pull/1656

## Support API key rotation in the Automation API

Add a `ReconcileApiKeysDomainService` that synchronizes the desired set of API keys from a subscription CRD spec with the actual keys in APIM, enabling declarative key rotation.

- Introduce `ReconcileApiKeysDomainService`: reactivate revoked keys that reappear in the spec, create missing keys, revoke keys no longer in the spec
- Add `ApiKeyCRDSpec` model and wire it through `SubscriptionCRDSpec` and the validation / import pipeline
- Fix subscription restore: use direct CRUD accept when custom keys exist (no transient UUID key), fall back to `autoAccept` when none are specified
- Add key length validation (32-256 chars) in `ValidateSubscriptionCRDDomainService`
- Comprehensive tests for reconciliation scenarios, restore paths, and validation edge cases

More info here https://gravitee.atlassian.net/browse/GKO-2550

