### PR TITLE
feat(repository-hazelcast): self-contained Hazelcast rate-limit repository

### DIFF
--- a/gravitee-apim-bom/pom.xml
+++ b/gravitee-apim-bom/pom.xml
@@ -327,12 +327,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.hazelcast</groupId>
-                <artifactId>hazelcast</artifactId>
-                <version>${hazelcast.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.hibernate.validator</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${hibernate-validator.version}</version>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1073,6 +1073,19 @@
             </exclusions>
             <type>zip</type>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-hazelcast</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <type>zip</type>
+        </dependency>
 
         <!-- Resources -->
         <dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/hazelcast-ratelimit.xml.sample
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/hazelcast-ratelimit.xml.sample
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Sample Hazelcast configuration for the rate-limit repository plugin.
+    Used when ratelimit.type: hazelcast is set in gravitee.yml.
+
+    The rate-limit Hazelcast instance is independent of any cache.type or cluster.type Hazelcast
+    instance: each forms its own logical Hazelcast cluster, identified by a distinct cluster-name.
+    Each instance also picks its own port: <port auto-increment="true"> grabs 5901 on the first
+    member and the next free port for any subsequent member, so multiple Hazelcast instances in
+    the same JVM (cluster + cache + rate-limit) do not collide.
+
+    For advanced configuration, see: https://docs.hazelcast.com/hazelcast/5.5/configuration
+-->
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+
+    <cluster-name>graviteeio-apim-ratelimit</cluster-name>
+    <network>
+        <port auto-increment="true" port-count="100">5901</port>
+        <join>
+            <auto-detection enabled="false"/>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="true">
+                <interface>127.0.0.1</interface>
+            </tcp-ip>
+        </join>
+    </network>
+</hazelcast>

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/model/RateLimit.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/ratelimit/model/RateLimit.java
@@ -24,6 +24,8 @@ import java.util.Objects;
  */
 public class RateLimit implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private String key;
 
     private long counter = 0;
@@ -49,6 +51,7 @@ public class RateLimit implements Serializable {
         this.setCounter(rateLimit.getCounter());
         this.setLimit(rateLimit.getLimit());
         this.setResetTime(rateLimit.getResetTime());
+        this.setSubscription(rateLimit.getSubscription());
     }
 
     public long getCounter() {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/ratelimit/model/RateLimitTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/ratelimit/model/RateLimitTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.ratelimit.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RateLimitTest {
+
+    @Test
+    void copy_ctor_preserves_all_fields() {
+        RateLimit source = new RateLimit("k1");
+        source.setCounter(7);
+        source.setLimit(100);
+        source.setResetTime(123_456L);
+        source.setSubscription("sub-42");
+
+        RateLimit copy = new RateLimit(source);
+
+        assertThat(copy.getKey()).isEqualTo("k1");
+        assertThat(copy.getCounter()).isEqualTo(7);
+        assertThat(copy.getLimit()).isEqualTo(100);
+        assertThat(copy.getResetTime()).isEqualTo(123_456L);
+        assertThat(copy.getSubscription()).isEqualTo("sub-42");
+    }
+
+    @Test
+    void key_override_ctor_preserves_other_fields() {
+        RateLimit source = new RateLimit("original");
+        source.setCounter(3);
+        source.setLimit(50);
+        source.setResetTime(999L);
+        source.setSubscription("sub-99");
+
+        RateLimit renamed = new RateLimit("override", source);
+
+        assertThat(renamed.getKey()).isEqualTo("override");
+        assertThat(renamed.getCounter()).isEqualTo(3);
+        assertThat(renamed.getLimit()).isEqualTo(50);
+        assertThat(renamed.getResetTime()).isEqualTo(999L);
+        assertThat(renamed.getSubscription()).isEqualTo("sub-99");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-coverage/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-coverage/pom.xml
@@ -52,6 +52,12 @@
 
         <dependency>
             <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-hazelcast</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
             <artifactId>gravitee-apim-repository-jdbc</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/README.adoc
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/README.adoc
@@ -1,0 +1,36 @@
+= Gravitee.io APIM - Repository - Hazelcast
+
+Hazelcast-backed implementation of `RateLimitRepository`. Provides distributed rate-limit counters via an embedded Hazelcast cluster.
+
+== Configuration
+
+In `gravitee.yml`:
+
+[source,yaml]
+----
+ratelimit:
+  type: hazelcast
+  hazelcast:
+    config-path: ${gravitee.home}/config/hazelcast-ratelimit.xml  # optional, default shown
+    instance-name: gio-apim-ratelimit-hz                          # optional, default shown
+----
+
+A sample Hazelcast XML config ships at `config/hazelcast-ratelimit.xml.sample` in the gateway distribution.
+
+== Independence from cluster / cache plugins
+
+This plugin owns its own embedded `HazelcastInstance`, scoped to rate-limit storage only. It is independent of `cluster.type=hazelcast` and `cache.type=hazelcast`. Use a distinct `<cluster-name>` and `<port>` range in each XML config when more than one Hazelcast subsystem runs in the same JVM.
+
+== Implementation
+
+Counters are stored in a Hazelcast `IMap<String, RateLimit>` named `rate-limits`. Each `incrementAndGet` is one async `IMap.submitToKey` call that runs an `EntryProcessor` on the partition owner: read current entry (or copy the supplied default if missing/expired), add the request weight, write back via `ExtendedMapEntry.setValue(value, ttlMs, MILLISECONDS)`.
+
+Atomicity comes from the partition lock — no distributed `IMap.lock`, one round-trip per increment. Hazelcast evicts each entry when its window TTL closes. `now` is captured by the caller before submitting the processor so backup replicas converge on the same final value as the primary.
+
+== Testing locally
+
+Plugin is bundled in the default distribution. After `mvn install -DskipTests`:
+
+. Set `ratelimit.type: hazelcast` in `gravitee.yml`.
+. Copy `config/hazelcast-ratelimit.xml.sample` to `config/hazelcast-ratelimit.xml`.
+. Start the gateway and apply a rate-limit policy.

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.apim.repository</groupId>
+        <artifactId>gravitee-apim-repository</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-repository-hazelcast</artifactId>
+    <name>Gravitee.io APIM - Repository - Hazelcast</name>
+    <description>Hazelcast-backed RateLimitRepository. Owns its own embedded HazelcastInstance scoped to the rate-limit subsystem so it can be enabled (ratelimit.type=hazelcast) without requiring cluster.type=hazelcast or cache.type=hazelcast.</description>
+
+    <properties>
+        <publish-folder-path>graviteeio-apim/plugins/repositories</publish-folder-path>
+    </properties>
+
+    <dependencies>
+        <!-- Gravitee dependencies -->
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.platform</groupId>
+            <artifactId>gravitee-platform-repository-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Hazelcast: bundled in the plugin zip so this plugin is fully self-contained. -->
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+        </dependency>
+
+        <!-- Spring -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test scope -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/assembly/plugin-assembly.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+    <id>plugin</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+
+    <files>
+        <file>
+            <source>${project.build.directory}/${project.build.finalName}.jar</source>
+        </file>
+    </files>
+
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/HazelcastRepositoryProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/HazelcastRepositoryProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast;
+
+import io.gravitee.platform.repository.api.RepositoryProvider;
+import io.gravitee.platform.repository.api.Scope;
+import io.gravitee.repository.hazelcast.ratelimit.RateLimitRepositoryConfiguration;
+
+public final class HazelcastRepositoryProvider implements RepositoryProvider {
+
+    @Override
+    public String type() {
+        return "hazelcast";
+    }
+
+    @Override
+    public Scope[] scopes() {
+        return new Scope[] { Scope.RATE_LIMIT };
+    }
+
+    @Override
+    public Class<?> configuration(Scope scope) {
+        if (scope == Scope.RATE_LIMIT) {
+            return RateLimitRepositoryConfiguration.class;
+        }
+        throw new IllegalArgumentException(
+            "HazelcastRepositoryProvider does not support scope " + scope + " (only RATE_LIMIT is supported)"
+        );
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/HazelcastRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/HazelcastRateLimitRepository.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast.ratelimit;
+
+import com.hazelcast.map.IMap;
+import io.gravitee.repository.ratelimit.api.RateLimitRepository;
+import io.gravitee.repository.ratelimit.model.RateLimit;
+import io.reactivex.rxjava3.core.Single;
+import java.util.function.Supplier;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Hazelcast-backed implementation of {@link RateLimitRepository}. Each increment is one
+ * {@link IMap#submitToKey} call: Hazelcast routes the {@link IncrementAndGetEntryProcessor} to
+ * the partition owner of the key, runs it under the partition lock, replicates the result to
+ * backup members, and returns asynchronously.
+ *
+ * <p>The repository propagates HZ failures via {@code Single.onError}; the calling rate-limit
+ * policy decides whether to fail-open (allow) or fail-closed (reject) via its own configuration.
+ */
+@CustomLog
+@RequiredArgsConstructor
+public final class HazelcastRateLimitRepository implements RateLimitRepository<RateLimit> {
+
+    private final IMap<String, RateLimit> counters;
+
+    /**
+     * Atomically increment the rate-limit counter for {@code key} by {@code weight} and return
+     * the resulting {@link RateLimit}.
+     *
+     * <p>The {@code supplier} is invoked exactly once per call (before submission) to materialise
+     * the seed entry that will be used if no live entry exists for the key.
+     */
+    @Override
+    public Single<RateLimit> incrementAndGet(String key, long weight, Supplier<RateLimit> supplier) {
+        RateLimit defaultIfAbsent = supplier.get();
+        long now = System.currentTimeMillis();
+        return Single.fromCompletionStage(
+            counters.submitToKey(key, new IncrementAndGetEntryProcessor(weight, defaultIfAbsent, now))
+        ).doOnError(t -> log.warn("Hazelcast rate-limit increment failed for key={}", key, t));
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/IncrementAndGetEntryProcessor.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/IncrementAndGetEntryProcessor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast.ratelimit;
+
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.ExtendedMapEntry;
+import io.gravitee.repository.ratelimit.model.RateLimit;
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Atomic rate-limit counter increment running on the Hazelcast partition owner.
+ *
+ * <p>{@code now} is captured by the caller (not read inside {@link #process})
+ * so the processor is deterministic — backup partition members re-run it with
+ * the same inputs and reach the same final value as the primary.
+ */
+public final class IncrementAndGetEntryProcessor implements EntryProcessor<String, RateLimit, RateLimit>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final long weight;
+    private final RateLimit defaultIfAbsent;
+    private final long now;
+
+    public IncrementAndGetEntryProcessor(long weight, RateLimit defaultIfAbsent, long now) {
+        this.weight = weight;
+        this.defaultIfAbsent = Objects.requireNonNull(defaultIfAbsent, "defaultIfAbsent");
+        this.now = now;
+    }
+
+    @Override
+    public RateLimit process(Map.Entry<String, RateLimit> entry) {
+        RateLimit current = entry.getValue();
+        if (current == null || current.getResetTime() < now) {
+            current = new RateLimit(defaultIfAbsent); // copy ctor; never mutate the seed
+        }
+        current.setCounter(current.getCounter() + weight);
+        // Hazelcast treats a TTL <= 0 as "never expire". Floor at 1ms so a stale or zero
+        // resetTime (e.g. healthcheck probes that don't set one) evicts immediately
+        // instead of pinning the entry forever.
+        long ttlMs = Math.max(1L, current.getResetTime() - now);
+        ((ExtendedMapEntry<String, RateLimit>) entry).setValue(current, ttlMs, TimeUnit.MILLISECONDS);
+        return current;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/RateLimitRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/java/io/gravitee/repository/hazelcast/ratelimit/RateLimitRepositoryConfiguration.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast.ratelimit;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.FileSystemXmlConfig;
+import com.hazelcast.config.FileSystemYamlConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.ClusterProperty;
+import io.gravitee.repository.ratelimit.api.RateLimitRepository;
+import io.gravitee.repository.ratelimit.model.RateLimit;
+import java.io.FileNotFoundException;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Owns the embedded Hazelcast instance dedicated to rate-limit storage. Independent of any
+ * cluster.type=hazelcast or cache.type=hazelcast plugin: this plugin always boots its own
+ * HazelcastInstance when ratelimit.type=hazelcast is selected, so operators do not need to enable
+ * any other Hazelcast subsystem.
+ */
+@Configuration
+public class RateLimitRepositoryConfiguration {
+
+    public static final String RATE_LIMIT_MAP = "rate-limits";
+
+    @Value("${ratelimit.hazelcast.config-path:${gravitee.home}/config/hazelcast-ratelimit.xml}")
+    private String hazelcastConfigFilePath;
+
+    @Value("${ratelimit.hazelcast.instance-name:gio-apim-ratelimit-hz}")
+    private String hazelcastInstanceName;
+
+    @Bean(destroyMethod = "shutdown")
+    public HazelcastInstance ratelimitHazelcastInstance() throws FileNotFoundException {
+        Config config = fromFilePath(hazelcastConfigFilePath);
+        config.setProperty(ClusterProperty.LOGGING_TYPE.getName(), "slf4j");
+        config.setProperty(ClusterProperty.SHUTDOWNHOOK_ENABLED.getName(), "false");
+        config.setProperty(ClusterProperty.HEALTH_MONITORING_LEVEL.getName(), "OFF");
+        config.setInstanceName(hazelcastInstanceName);
+        return Hazelcast.newHazelcastInstance(config);
+    }
+
+    @Bean
+    public RateLimitRepository<RateLimit> rateLimitRepository(HazelcastInstance ratelimitHazelcastInstance) {
+        return new HazelcastRateLimitRepository(ratelimitHazelcastInstance.getMap(RATE_LIMIT_MAP));
+    }
+
+    private Config fromFilePath(String filePath) throws FileNotFoundException {
+        String suffix = filePath.toLowerCase(Locale.ROOT);
+        if (suffix.endsWith(".xml")) {
+            return new FileSystemXmlConfig(filePath);
+        } else if (suffix.endsWith(".yaml") || suffix.endsWith(".yml")) {
+            return new FileSystemYamlConfig(filePath);
+        }
+        throw new IllegalArgumentException("Only xml or yaml file supported for Hazelcast rate-limit configuration");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/resources/plugin.properties
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/main/resources/plugin.properties
@@ -1,0 +1,6 @@
+id=repository-hazelcast
+name=${project.name}
+version=${project.version}
+description=${project.description}
+class=io.gravitee.repository.hazelcast.HazelcastRepositoryProvider
+type=repository

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/java/io/gravitee/repository/hazelcast/HazelcastRepositoryProviderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/java/io/gravitee/repository/hazelcast/HazelcastRepositoryProviderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.platform.repository.api.Scope;
+import io.gravitee.repository.hazelcast.ratelimit.RateLimitRepositoryConfiguration;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HazelcastRepositoryProviderTest {
+
+    private final HazelcastRepositoryProvider provider = new HazelcastRepositoryProvider();
+
+    @Test
+    void declares_hazelcast_type() {
+        assertThat(provider.type()).isEqualTo("hazelcast");
+    }
+
+    @Test
+    void declares_only_rate_limit_scope() {
+        assertThat(provider.scopes()).containsExactly(Scope.RATE_LIMIT);
+    }
+
+    @Test
+    void resolves_configuration_for_rate_limit_scope() {
+        assertThat(provider.configuration(Scope.RATE_LIMIT)).isEqualTo(RateLimitRepositoryConfiguration.class);
+    }
+
+    @Test
+    void rejects_unsupported_scopes() {
+        assertThatThrownBy(() -> provider.configuration(Scope.MANAGEMENT))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("MANAGEMENT")
+            .hasMessageContaining("RATE_LIMIT");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/java/io/gravitee/repository/hazelcast/ratelimit/HazelcastRateLimitRepositoryClusterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/java/io/gravitee/repository/hazelcast/ratelimit/HazelcastRateLimitRepositoryClusterTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast.ratelimit;
+
+import static io.gravitee.repository.hazelcast.ratelimit.RateLimitRepositoryConfiguration.RATE_LIMIT_MAP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.ClusterProperty;
+import io.gravitee.repository.ratelimit.api.RateLimitRepository;
+import io.gravitee.repository.ratelimit.model.RateLimit;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+/**
+ * Multi-member tests covering the partition routing + cross-member replication path that the
+ * single-member suite cannot exercise. Two real HZ members are joined via TCP-IP on localhost.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HazelcastRateLimitRepositoryClusterTest {
+
+    private static final String CLUSTER_NAME = "graviteeio-apim-ratelimit-cluster-test";
+    private static final int PORT_M1 = 5921;
+    private static final int PORT_M2 = 5922;
+
+    private HazelcastInstance m1;
+    private HazelcastInstance m2;
+    private RateLimitRepository<RateLimit> repo1;
+    private RateLimitRepository<RateLimit> repo2;
+
+    @BeforeAll
+    void startCluster() {
+        m1 = newMember(PORT_M1);
+        m2 = newMember(PORT_M2);
+        await()
+            .atMost(15, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                assertThat(m1.getCluster().getMembers()).hasSize(2);
+                assertThat(m2.getCluster().getMembers()).hasSize(2);
+            });
+        repo1 = new HazelcastRateLimitRepository(m1.getMap(RATE_LIMIT_MAP));
+        repo2 = new HazelcastRateLimitRepository(m2.getMap(RATE_LIMIT_MAP));
+    }
+
+    @AfterAll
+    void stopCluster() {
+        if (m1 != null) m1.shutdown();
+        if (m2 != null) m2.shutdown();
+    }
+
+    @Test
+    void counter_is_shared_across_members_via_imap_partition_routing() {
+        RateLimit r1 = repo1.incrementAndGet("shared", 1, () -> initial("shared", 60_000)).blockingGet();
+        RateLimit r2 = repo2.incrementAndGet("shared", 1, () -> initial("shared", 60_000)).blockingGet();
+        RateLimit r3 = repo1.incrementAndGet("shared", 1, () -> initial("shared", 60_000)).blockingGet();
+
+        assertThat(r1.getCounter()).isEqualTo(1);
+        assertThat(r2.getCounter()).isEqualTo(2);
+        assertThat(r3.getCounter()).isEqualTo(3);
+
+        // Either member's view of the IMap returns the same counter — proves replication.
+        long viaM1 = m1.<String, RateLimit>getMap(RATE_LIMIT_MAP).get("shared").getCounter();
+        long viaM2 = m2.<String, RateLimit>getMap(RATE_LIMIT_MAP).get("shared").getCounter();
+        assertThat(viaM1).isEqualTo(3);
+        assertThat(viaM2).isEqualTo(3);
+    }
+
+    @Test
+    void concurrent_increments_across_members_settle_to_exact_total() throws InterruptedException {
+        final int threads = 10;
+        final int iterations = 50;
+        final long expected = (long) threads * iterations;
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+
+            for (int t = 0; t < threads; t++) {
+                final int threadIndex = t;
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        RateLimitRepository<RateLimit> repo = (threadIndex % 2 == 0) ? repo1 : repo2;
+                        for (int i = 0; i < iterations; i++) {
+                            repo.incrementAndGet("multi-contended", 1, () -> initial("multi-contended", 60_000)).blockingGet();
+                        }
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            start.countDown();
+            assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+
+            long viaM1 = m1.<String, RateLimit>getMap(RATE_LIMIT_MAP).get("multi-contended").getCounter();
+            long viaM2 = m2.<String, RateLimit>getMap(RATE_LIMIT_MAP).get("multi-contended").getCounter();
+            assertThat(viaM1).isEqualTo(expected);
+            assertThat(viaM2).isEqualTo(expected);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    private static HazelcastInstance newMember(int port) {
+        Config config = new Config();
+        config.setClusterName(CLUSTER_NAME);
+        config.setInstanceName("multi-member-" + port + "-" + System.nanoTime());
+        config.setProperty(ClusterProperty.HEALTH_MONITORING_LEVEL.getName(), "OFF");
+        config.setProperty(ClusterProperty.LOGGING_TYPE.getName(), "slf4j");
+
+        NetworkConfig network = config.getNetworkConfig();
+        network.setPort(port).setPortAutoIncrement(false);
+
+        JoinConfig join = network.getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getAutoDetectionConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(true).setMembers(List.of("127.0.0.1:" + PORT_M1, "127.0.0.1:" + PORT_M2));
+
+        return Hazelcast.newHazelcastInstance(config);
+    }
+
+    private static RateLimit initial(String key, long windowMs) {
+        RateLimit rl = new RateLimit(key);
+        rl.setCounter(0);
+        rl.setLimit(Long.MAX_VALUE);
+        rl.setResetTime(System.currentTimeMillis() + windowMs);
+        rl.setSubscription("test-sub");
+        return rl;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/java/io/gravitee/repository/hazelcast/ratelimit/HazelcastRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/java/io/gravitee/repository/hazelcast/ratelimit/HazelcastRateLimitRepositoryTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast.ratelimit;
+
+import static io.gravitee.repository.hazelcast.ratelimit.RateLimitRepositoryConfiguration.RATE_LIMIT_MAP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.FileSystemXmlConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.ClusterProperty;
+import io.gravitee.repository.ratelimit.api.RateLimitRepository;
+import io.gravitee.repository.ratelimit.model.RateLimit;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HazelcastRateLimitRepositoryTest {
+
+    private HazelcastInstance hazelcast;
+    private RateLimitRepository<RateLimit> repository;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Config config = new FileSystemXmlConfig("src/test/resources/cluster.xml");
+        config.setProperty(ClusterProperty.HEALTH_MONITORING_LEVEL.getName(), "OFF");
+        config.setInstanceName("test-ratelimit-hz-" + System.nanoTime());
+        hazelcast = Hazelcast.newHazelcastInstance(config);
+        repository = new HazelcastRateLimitRepository(hazelcast.getMap(RATE_LIMIT_MAP));
+    }
+
+    @AfterEach
+    void tearDown() {
+        hazelcast.shutdown();
+    }
+
+    @Test
+    void increments_counter_on_repeat_calls_within_window() {
+        RateLimit first = repository.incrementAndGet("key", 1, () -> initial("key", 60_000)).blockingGet();
+        RateLimit second = repository.incrementAndGet("key", 1, () -> initial("key", 60_000)).blockingGet();
+        RateLimit third = repository.incrementAndGet("key", 1, () -> initial("key", 60_000)).blockingGet();
+
+        assertThat(first.getCounter()).isEqualTo(1);
+        assertThat(second.getCounter()).isEqualTo(2);
+        assertThat(third.getCounter()).isEqualTo(3);
+    }
+
+    @Test
+    void resets_counter_when_window_expired() {
+        RateLimit beforeWindow = repository.incrementAndGet("key", 1, () -> initial("key", 100)).blockingGet();
+        await()
+            .atMost(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> assertThat(hazelcast.<String, RateLimit>getMap(RATE_LIMIT_MAP).get("key")).isNull());
+
+        RateLimit afterWindow = repository.incrementAndGet("key", 1, () -> initial("key", 60_000)).blockingGet();
+
+        assertThat(afterWindow.getCounter()).isEqualTo(1);
+        // Reset time must come from the new supplier — not the prior expired entry — so a regression
+        // that drops the defensive copy in the EntryProcessor would fail this assertion.
+        assertThat(afterWindow.getResetTime()).isGreaterThan(beforeWindow.getResetTime());
+    }
+
+    @Test
+    void increments_by_weight() {
+        RateLimit r = repository.incrementAndGet("key", 5, () -> initial("key", 60_000)).blockingGet();
+        assertThat(r.getCounter()).isEqualTo(5);
+    }
+
+    @Test
+    void isolates_keys() {
+        repository.incrementAndGet("a", 3, () -> initial("a", 60_000)).blockingGet();
+        RateLimit b = repository.incrementAndGet("b", 1, () -> initial("b", 60_000)).blockingGet();
+        assertThat(b.getCounter()).isEqualTo(1);
+    }
+
+    @Test
+    void preserves_subscription_on_fresh_window() {
+        RateLimit r = repository.incrementAndGet("sub-key", 1, () -> initial("sub-key", 60_000)).blockingGet();
+        assertThat(r.getSubscription()).isEqualTo("test-sub");
+        RateLimit stored = hazelcast.<String, RateLimit>getMap(RATE_LIMIT_MAP).get("sub-key");
+        assertThat(stored.getSubscription()).isEqualTo("test-sub");
+    }
+
+    @Test
+    void evicts_entry_after_ttl() {
+        repository.incrementAndGet("ttl", 1, () -> initial("ttl", 100)).blockingGet();
+        await()
+            .atMost(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> assertThat(hazelcast.<String, RateLimit>getMap(RATE_LIMIT_MAP).get("ttl")).isNull());
+    }
+
+    @Test
+    void serializes_concurrent_increments_via_entry_processor() throws InterruptedException {
+        final int threads = 16;
+        final int iterations = 50;
+        final long expected = (long) threads * iterations;
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+
+            for (int t = 0; t < threads; t++) {
+                pool.submit(() -> {
+                    try {
+                        start.await();
+                        for (int i = 0; i < iterations; i++) {
+                            repository.incrementAndGet("contended", 1, () -> initial("contended", 60_000)).blockingGet();
+                        }
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+
+            start.countDown();
+            assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+
+            RateLimit finalState = hazelcast.<String, RateLimit>getMap(RATE_LIMIT_MAP).get("contended");
+            assertThat(finalState.getCounter()).isEqualTo(expected);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    private static RateLimit initial(String key, long windowMs) {
+        RateLimit rl = new RateLimit(key);
+        rl.setCounter(0);
+        rl.setLimit(Long.MAX_VALUE);
+        rl.setResetTime(System.currentTimeMillis() + windowMs);
+        rl.setSubscription("test-sub");
+        return rl;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/java/io/gravitee/repository/hazelcast/ratelimit/RateLimitRepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/java/io/gravitee/repository/hazelcast/ratelimit/RateLimitRepositoryConfigurationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.hazelcast.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hazelcast.core.HazelcastInstance;
+import io.gravitee.repository.ratelimit.api.RateLimitRepository;
+import io.gravitee.repository.ratelimit.model.RateLimit;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RateLimitRepositoryConfigurationTest {
+
+    private static final String MINIMAL_HZ_XML = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.hazelcast.com/schema/config
+                   http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+            <cluster-name>graviteeio-apim-ratelimit-spring-test</cluster-name>
+            <network>
+                <port auto-increment="true" port-count="100">5901</port>
+                <join>
+                    <auto-detection enabled="false"/>
+                    <multicast enabled="false"/>
+                    <tcp-ip enabled="false"/>
+                </join>
+            </network>
+        </hazelcast>
+        """;
+
+    @Test
+    void wires_HazelcastInstance_and_RateLimitRepository_beans(@TempDir Path tmp) throws IOException {
+        Path xml = tmp.resolve("hazelcast-ratelimit.xml");
+        Files.writeString(xml, MINIMAL_HZ_XML);
+
+        try (AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext()) {
+            String instanceName = "test-config-" + System.nanoTime();
+            ctx
+                .getEnvironment()
+                .getPropertySources()
+                .addFirst(
+                    new MapPropertySource(
+                        "test",
+                        Map.of("ratelimit.hazelcast.config-path", xml.toString(), "ratelimit.hazelcast.instance-name", instanceName)
+                    )
+                );
+            ctx.register(RateLimitRepositoryConfiguration.class);
+            ctx.refresh();
+
+            HazelcastInstance hz = ctx.getBean(HazelcastInstance.class);
+            assertThat(hz.getName()).isEqualTo(instanceName);
+            assertThat(hz.getMap(RateLimitRepositoryConfiguration.RATE_LIMIT_MAP).getName()).isEqualTo(
+                RateLimitRepositoryConfiguration.RATE_LIMIT_MAP
+            );
+
+            @SuppressWarnings("unchecked")
+            RateLimitRepository<RateLimit> repo = (RateLimitRepository<RateLimit>) ctx.getBean(RateLimitRepository.class);
+            assertThat(repo).isInstanceOf(HazelcastRateLimitRepository.class);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/resources/cluster.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/src/test/resources/cluster.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+    <cluster-name>gio-apim-ratelimit-test</cluster-name>
+    <network>
+        <port auto-increment="true" port-count="100">5901</port>
+        <join>
+            <auto-detection enabled="false"/>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="false"/>
+        </join>
+    </network>
+</hazelcast>

--- a/gravitee-apim-repository/pom.xml
+++ b/gravitee-apim-repository/pom.xml
@@ -41,6 +41,7 @@
         <module>gravitee-apim-repository-mongodb</module>
         <module>gravitee-apim-repository-jdbc</module>
         <module>gravitee-apim-repository-redis</module>
+        <module>gravitee-apim-repository-hazelcast</module>
         <module>gravitee-apim-repository-coverage</module>
     </modules>
 

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.11.5
+- Support Hazelcast as a distributed rate-limit backend (`ratelimit.type=hazelcast`). Renders `config/hazelcast-ratelimit.xml` with Kubernetes discovery, exposes a ClusterIP `-hz` Service for peer discovery, and creates a ClusterRole/Binding granting the gateway ServiceAccount `get`/`list` on `endpoints`/`pods`/`nodes`/`services`.
+
 ### 4.11.3
 - Fix API upgrader job rendering when additional plugins are configured.
 

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -4,7 +4,7 @@
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
 ### 4.11.5
-- Support Hazelcast as a distributed rate-limit backend (`ratelimit.type=hazelcast`). Renders `config/hazelcast-ratelimit.xml` with Kubernetes discovery, exposes a ClusterIP `-hz` Service for peer discovery, and creates a ClusterRole/Binding granting the gateway ServiceAccount `get`/`list` on `endpoints`/`pods`/`nodes`/`services`.
+- Support Hazelcast as a distributed rate-limit backend (`ratelimit.type=hazelcast`). Renders `config/hazelcast-ratelimit.xml` with Kubernetes discovery, exposes a ClusterIP `-hz` Service for peer discovery, allows configuring the rate-limit Hazelcast port with `gateway.ratelimit.hazelcast.port`, and creates a ClusterRole/Binding granting the gateway ServiceAccount `get`/`list` on `endpoints`/`pods`/`nodes`/`services`.
 
 ### 4.11.3
 - Fix API upgrader job rendering when additional plugins are configured.

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,4 +29,11 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - kind: added
+      description: 'Support Hazelcast as a distributed rate-limit backend (ratelimit.type=hazelcast) with auto-rendered hazelcast-ratelimit.xml, ClusterIP -hz Service, and Kubernetes discovery RBAC'
+      links:
+        - name: Jira
+          url: https://gravitee.atlassian.net/browse/APIM-13749
+        - name: Github PR
+          url: https://github.com/gravitee-io/gravitee-api-management/pull/16606

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -31,7 +31,7 @@ annotations:
   ###########
   artifacthub.io/changes: |
     - kind: added
-      description: 'Support Hazelcast as a distributed rate-limit backend (ratelimit.type=hazelcast) with auto-rendered hazelcast-ratelimit.xml, ClusterIP -hz Service, and Kubernetes discovery RBAC'
+      description: 'Support Hazelcast as a distributed rate-limit backend (ratelimit.type=hazelcast) with auto-rendered hazelcast-ratelimit.xml, configurable rate-limit Hazelcast port, ClusterIP -hz Service, and Kubernetes discovery RBAC'
       links:
         - name: Jira
           url: https://gravitee.atlassian.net/browse/APIM-13749

--- a/helm/README.adoc
+++ b/helm/README.adoc
@@ -495,6 +495,18 @@ gateway:
             port: 26379
 ----
 
+To use Hazelcast for rate limit policy, set `ratelimit.type` to `hazelcast`. The chart renders `config/hazelcast-ratelimit.xml` and exposes a `-hz` ClusterIP Service for Kubernetes discovery. The rate-limit Hazelcast port defaults to `5901` and can be changed with `gateway.ratelimit.hazelcast.port`.
+
+----
+ratelimit:
+  type: hazelcast
+gateway:
+  ratelimit:
+    hazelcast:
+      configPath: ${gravitee.home}/config/hazelcast-ratelimit.xml
+      port: 5901
+----
+
 ===== Other Keys
 
 [cols=",,",options="header",]
@@ -502,6 +514,8 @@ gateway:
 |Parameter |Description |Default
 |`+gateway.ratelimit.redis.ssl+` |Enable SSL connection to Redis |`+false+`
 |`+gateway.ratelimit.redis.password+` |Redis password |`+false+`
+|`+gateway.ratelimit.hazelcast.configPath+` |Hazelcast rate-limit configuration file path |`+${gravitee.home}/config/hazelcast-ratelimit.xml+`
+|`+gateway.ratelimit.hazelcast.port+` |Hazelcast rate-limit member and Kubernetes discovery service port |`+5901+`
 |===
 
 

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,2 +1,13 @@
 1. Watch all containers come up.
   $ kubectl get pods --namespace={{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -w
+
+{{- $hzActive := or (eq .Values.ratelimit.type "hazelcast") (and .Values.gateway.cluster (eq (.Values.gateway.cluster.type | default "") "hazelcast")) }}
+{{- if and $hzActive (not .Values.apim.managedServiceAccount) }}
+
+WARNING: Hazelcast is enabled (ratelimit.type=hazelcast or gateway.cluster.type=hazelcast)
+but apim.managedServiceAccount is false, so the chart did NOT create the Role / RoleBinding
+that Hazelcast Kubernetes discovery needs. Each gateway pod will fall back to a single-member
+cluster (rate-limit budgets multiplied by replica count). Either set
+apim.managedServiceAccount=true, or grant the gateway ServiceAccount get/list permissions
+on endpoints/pods/nodes/services in namespace {{ .Release.Namespace }} out-of-band.
+{{- end }}

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -895,6 +895,9 @@ data:
 
   {{- end }}
 {{- if eq .Values.ratelimit.type "hazelcast" }}
+{{- $hzCfg := dict }}
+{{- if and .Values.gateway.ratelimit (kindIs "map" .Values.gateway.ratelimit) }}{{ $hzCfg = (.Values.gateway.ratelimit.hazelcast | default dict) }}{{ end }}
+{{- $hzPort := $hzCfg.port | default 5901 }}
   hazelcast-ratelimit.xml: |-
     <?xml version="1.0" encoding="UTF-8"?>
     <hazelcast xmlns="http://www.hazelcast.com/schema/config"
@@ -907,13 +910,14 @@ data:
             <property name="hazelcast.logging.type">slf4j</property>
         </properties>
         <network>
-            <port auto-increment="true" port-count="100">5901</port>
+            <port auto-increment="true" port-count="100">{{ $hzPort }}</port>
             <join>
                 <multicast enabled="false"/>
                 <tcp-ip enabled="false"/>
                 <kubernetes enabled="true">
                     <namespace>{{ .Release.Namespace }}</namespace>
                     <service-name>{{ template "gravitee.gateway.fullname" . }}-hz</service-name>
+                    <service-port>{{ $hzPort }}</service-port>
                 </kubernetes>
             </join>
         </network>

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -598,6 +598,11 @@ data:
           connectTimeout: {{ .Values.gateway.ratelimit.redis.tcp.connectTimeout | default "5000" }}
           idleTimeout: {{ .Values.gateway.ratelimit.redis.tcp.idleTimeout | default "0" }}
         {{- end }}
+      {{- else if (eq .Values.ratelimit.type "hazelcast") }}
+      {{- $hzCfg := dict }}
+      {{- if and .Values.gateway.ratelimit (kindIs "map" .Values.gateway.ratelimit) }}{{ $hzCfg = (.Values.gateway.ratelimit.hazelcast | default dict) }}{{ end }}
+      hazelcast:
+        config-path: {{ $hzCfg.configPath | default "${gravitee.home}/config/hazelcast-ratelimit.xml" }}
       {{- end }}
 
     # Sharding tags configuration
@@ -889,6 +894,31 @@ data:
     {{- end}}
 
   {{- end }}
+{{- if eq .Values.ratelimit.type "hazelcast" }}
+  hazelcast-ratelimit.xml: |-
+    <?xml version="1.0" encoding="UTF-8"?>
+    <hazelcast xmlns="http://www.hazelcast.com/schema/config"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.hazelcast.com/schema/config
+               http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+        <cluster-name>graviteeio-apim-ratelimit</cluster-name>
+        <properties>
+            <property name="hazelcast.discovery.enabled">true</property>
+            <property name="hazelcast.logging.type">slf4j</property>
+        </properties>
+        <network>
+            <port auto-increment="true" port-count="100">5901</port>
+            <join>
+                <multicast enabled="false"/>
+                <tcp-ip enabled="false"/>
+                <kubernetes enabled="true">
+                    <namespace>{{ .Release.Namespace }}</namespace>
+                    <service-name>{{ template "gravitee.gateway.fullname" . }}-hz</service-name>
+                </kubernetes>
+            </join>
+        </network>
+    </hazelcast>
+{{- end }}
     {{- if .Values.gateway.logback.override }}
   logback.xml: |
 {{ .Values.gateway.logback.content | indent 4 }}

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -263,6 +263,11 @@ spec:
             - name: config
               mountPath: /opt/graviteeio-gateway/config/gravitee.yml
               subPath: gravitee.yml
+          {{- if and (eq .Values.ratelimit.type "hazelcast") (not (include "gateway.externalConfig" .)) }}
+            - name: config
+              mountPath: /opt/graviteeio-gateway/config/hazelcast-ratelimit.xml
+              subPath: hazelcast-ratelimit.xml
+          {{- end }}
           {{- if or .Values.gateway.logging.debug .Values.gateway.logback.override }}
             - name: {{ $logbackVolumeName }}
               mountPath: /opt/graviteeio-gateway/config/logback.xml

--- a/helm/templates/gateway/gateway-hz-service.yaml
+++ b/helm/templates/gateway/gateway-hz-service.yaml
@@ -1,0 +1,44 @@
+{{- $hzActive := or (eq .Values.ratelimit.type "hazelcast") (and .Values.gateway.cluster (eq (.Values.gateway.cluster.type | default "") "hazelcast")) -}}
+{{- if $hzActive }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "gravitee.gateway.fullname" . }}-hz
+  labels:
+    app.kubernetes.io/name: {{ template "gravitee.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.gateway.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/component: "{{ .Values.gateway.name }}"
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- if and .Values.common .Values.common.labels }}
+    {{- range $key, $value := .Values.common.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  annotations:
+    {{- if and .Values.common .Values.common.annotations }}
+    {{- range $key, $value := .Values.common.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  type: "ClusterIP"
+  ports:
+    {{- if eq .Values.ratelimit.type "hazelcast" }}
+    - port: 5901
+      targetPort: 5901
+      protocol: TCP
+      name: {{ printf "%s-%s" (.Values.gateway.name | trunc 56 | trimSuffix "-") "hz-rl" }}
+    {{- end }}
+    {{- if and .Values.gateway.cluster (eq (.Values.gateway.cluster.type | default "") "hazelcast") }}
+    - port: 5701
+      targetPort: 5701
+      protocol: TCP
+      name: {{ printf "%s-%s" (.Values.gateway.name | trunc 56 | trimSuffix "-") "hz-cl" }}
+    {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ template "gravitee.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "{{ .Values.gateway.name }}"
+{{- end -}}

--- a/helm/templates/gateway/gateway-hz-service.yaml
+++ b/helm/templates/gateway/gateway-hz-service.yaml
@@ -1,4 +1,7 @@
 {{- $hzActive := or (eq .Values.ratelimit.type "hazelcast") (and .Values.gateway.cluster (eq (.Values.gateway.cluster.type | default "") "hazelcast")) -}}
+{{- $hzCfg := dict }}
+{{- if and .Values.gateway.ratelimit (kindIs "map" .Values.gateway.ratelimit) }}{{ $hzCfg = (.Values.gateway.ratelimit.hazelcast | default dict) }}{{ end }}
+{{- $hzRateLimitPort := $hzCfg.port | default 5901 }}
 {{- if $hzActive }}
 apiVersion: v1
 kind: Service
@@ -26,8 +29,8 @@ spec:
   type: "ClusterIP"
   ports:
     {{- if eq .Values.ratelimit.type "hazelcast" }}
-    - port: 5901
-      targetPort: 5901
+    - port: {{ $hzRateLimitPort }}
+      targetPort: {{ $hzRateLimitPort }}
       protocol: TCP
       name: {{ printf "%s-%s" (.Values.gateway.name | trunc 56 | trimSuffix "-") "hz-rl" }}
     {{- end }}

--- a/helm/templates/gateway/gateway-rbac.yaml
+++ b/helm/templates/gateway/gateway-rbac.yaml
@@ -1,0 +1,35 @@
+{{- $hzActive := or (eq .Values.ratelimit.type "hazelcast") (and .Values.gateway.cluster (eq (.Values.gateway.cluster.type | default "") "hazelcast")) -}}
+{{ if and $hzActive .Values.apim.managedServiceAccount }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "apim.serviceAccount" . }}-gateway-hazelcast
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - pods
+      - nodes
+      - services
+    verbs:
+      - get
+      - list
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "apim.serviceAccount" . }}-gateway-hazelcast
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "apim.serviceAccount" . }}-gateway-hazelcast
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "apim.serviceAccount" . }}
+    namespace: {{ .Release.Namespace | quote }}
+{{ end }}

--- a/helm/tests/gateway/configmap_hazelcast_ratelimit_test.yaml
+++ b/helm/tests/gateway/configmap_hazelcast_ratelimit_test.yaml
@@ -32,6 +32,53 @@ tests:
       - matchRegex:
           path: data["hazelcast-ratelimit.xml"]
           pattern: "<service-name>my-apim-gateway-hz</service-name>"
+      - matchRegex:
+          path: data["hazelcast-ratelimit.xml"]
+          pattern: "<service-port>5901</service-port>"
+      - matchRegex:
+          path: data["hazelcast-ratelimit.xml"]
+          pattern: "<port auto-increment=\"true\" port-count=\"100\">5901</port>"
+
+  - it: configmap renders explicit rate-limit service port when gateway cluster is also hazelcast
+    template: gateway/gateway-configmap.yaml
+    set:
+      ratelimit:
+        type: hazelcast
+      gateway:
+        cluster:
+          type: hazelcast
+          hazelcast:
+            configPath: /opt/graviteeio-gateway/config/hazelcast.xml
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - matchRegex:
+          path: data["hazelcast-ratelimit.xml"]
+          pattern: "<service-name>my-apim-gateway-hz</service-name>"
+      - matchRegex:
+          path: data["hazelcast-ratelimit.xml"]
+          pattern: "<service-port>5901</service-port>"
+
+  - it: configmap uses configured rate-limit hazelcast port
+    template: gateway/gateway-configmap.yaml
+    set:
+      ratelimit:
+        type: hazelcast
+      gateway:
+        ratelimit:
+          hazelcast:
+            port: 5902
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - matchRegex:
+          path: data["hazelcast-ratelimit.xml"]
+          pattern: "<port auto-increment=\"true\" port-count=\"100\">5902</port>"
+      - matchRegex:
+          path: data["hazelcast-ratelimit.xml"]
+          pattern: "<service-port>5902</service-port>"
 
   - it: deployment omits hazelcast-ratelimit.xml volumeMount under default ratelimit type
     template: gateway/gateway-deployment.yaml

--- a/helm/tests/gateway/configmap_hazelcast_ratelimit_test.yaml
+++ b/helm/tests/gateway/configmap_hazelcast_ratelimit_test.yaml
@@ -1,0 +1,87 @@
+suite: am - Gateway - Hazelcast rate-limit ConfigMap + volume mount
+templates:
+  - "gateway/gateway-configmap.yaml"
+  - "gateway/gateway-deployment.yaml"
+tests:
+  - it: configmap omits hazelcast-ratelimit.xml under default ratelimit type
+    template: gateway/gateway-configmap.yaml
+    set:
+      ratelimit:
+        type: mongodb
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - notExists:
+          path: data["hazelcast-ratelimit.xml"]
+
+  - it: configmap renders hazelcast-ratelimit.xml when ratelimit type is hazelcast
+    template: gateway/gateway-configmap.yaml
+    set:
+      ratelimit:
+        type: hazelcast
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - exists:
+          path: data["hazelcast-ratelimit.xml"]
+      - matchRegex:
+          path: data["hazelcast-ratelimit.xml"]
+          pattern: "<cluster-name>graviteeio-apim-ratelimit</cluster-name>"
+      - matchRegex:
+          path: data["hazelcast-ratelimit.xml"]
+          pattern: "<service-name>my-apim-gateway-hz</service-name>"
+
+  - it: deployment omits hazelcast-ratelimit.xml volumeMount under default ratelimit type
+    template: gateway/gateway-deployment.yaml
+    set:
+      ratelimit:
+        type: mongodb
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /opt/graviteeio-gateway/config/hazelcast-ratelimit.xml
+            subPath: hazelcast-ratelimit.xml
+
+  - it: deployment mounts hazelcast-ratelimit.xml when ratelimit type is hazelcast
+    template: gateway/gateway-deployment.yaml
+    set:
+      ratelimit:
+        type: hazelcast
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /opt/graviteeio-gateway/config/hazelcast-ratelimit.xml
+            subPath: hazelcast-ratelimit.xml
+
+  - it: deployment skips hazelcast-ratelimit.xml mount when externalConfig is in use
+    template: gateway/gateway-deployment.yaml
+    set:
+      ratelimit:
+        type: hazelcast
+      gateway:
+        extraVolumes: |
+          - name: config
+            configMap:
+              name: my-config
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /opt/graviteeio-gateway/config/hazelcast-ratelimit.xml
+            subPath: hazelcast-ratelimit.xml

--- a/helm/tests/gateway/hz_service_test.yaml
+++ b/helm/tests/gateway/hz_service_test.yaml
@@ -58,6 +58,27 @@ tests:
               protocol: TCP
               name: gateway-hz-cl
 
+  - it: should generate Service with configured ratelimit hazelcast port
+    template: gateway/gateway-hz-service.yaml
+    set:
+      ratelimit:
+        type: hazelcast
+      gateway:
+        ratelimit:
+          hazelcast:
+            port: 5902
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - equal:
+          path: spec.ports
+          value:
+            - port: 5902
+              targetPort: 5902
+              protocol: TCP
+              name: gateway-hz-rl
+
   - it: should expose both ports when ratelimit and cluster are both hazelcast
     template: gateway/gateway-hz-service.yaml
     set:

--- a/helm/tests/gateway/hz_service_test.yaml
+++ b/helm/tests/gateway/hz_service_test.yaml
@@ -1,0 +1,91 @@
+suite: am - Gateway - Hazelcast Service
+templates:
+  - "gateway/gateway-hz-service.yaml"
+tests:
+  - it: should generate nothing under default ratelimit/cluster
+    template: gateway/gateway-hz-service.yaml
+    set:
+      ratelimit:
+        type: mongodb
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should generate Service with ratelimit port only when ratelimit type is hazelcast
+    template: gateway/gateway-hz-service.yaml
+    set:
+      ratelimit:
+        type: hazelcast
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports
+          value:
+            - port: 5901
+              targetPort: 5901
+              protocol: TCP
+              name: gateway-hz-rl
+
+  - it: should generate Service with cluster port only when gateway cluster type is hazelcast
+    template: gateway/gateway-hz-service.yaml
+    set:
+      gateway:
+        cluster:
+          type: hazelcast
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.ports
+          value:
+            - port: 5701
+              targetPort: 5701
+              protocol: TCP
+              name: gateway-hz-cl
+
+  - it: should expose both ports when ratelimit and cluster are both hazelcast
+    template: gateway/gateway-hz-service.yaml
+    set:
+      ratelimit:
+        type: hazelcast
+      gateway:
+        cluster:
+          type: hazelcast
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - hasDocuments:
+          count: 1
+      - lengthEqual:
+          path: spec.ports
+          count: 2
+      - contains:
+          path: spec.ports
+          content:
+            port: 5901
+            targetPort: 5901
+            protocol: TCP
+            name: gateway-hz-rl
+      - contains:
+          path: spec.ports
+          content:
+            port: 5701
+            targetPort: 5701
+            protocol: TCP
+            name: gateway-hz-cl

--- a/helm/tests/gateway/rbac_test.yaml
+++ b/helm/tests/gateway/rbac_test.yaml
@@ -1,0 +1,85 @@
+suite: am - Gateway - Hazelcast RBAC
+templates:
+  - "gateway/gateway-rbac.yaml"
+tests:
+  - it: should generate nothing when ratelimit type is mongodb (default)
+    template: gateway/gateway-rbac.yaml
+    set:
+      ratelimit:
+        type: mongodb
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should generate nothing when managedServiceAccount is disabled even if ratelimit is hazelcast
+    template: gateway/gateway-rbac.yaml
+    set:
+      ratelimit:
+        type: hazelcast
+      apim:
+        managedServiceAccount: false
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should generate Role + RoleBinding when ratelimit type is hazelcast
+    template: gateway/gateway-rbac.yaml
+    set:
+      ratelimit:
+        type: hazelcast
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Role
+      - documentIndex: 0
+        equal:
+          path: metadata.namespace
+          value: unittest
+      - documentIndex: 0
+        equal:
+          path: rules[0].resources
+          value:
+            - endpoints
+            - pods
+            - nodes
+            - services
+      - documentIndex: 0
+        equal:
+          path: rules[0].verbs
+          value:
+            - get
+            - list
+      - documentIndex: 1
+        isKind:
+          of: RoleBinding
+      - documentIndex: 1
+        equal:
+          path: metadata.namespace
+          value: unittest
+
+  - it: should generate Role when gateway cluster type is hazelcast
+    template: gateway/gateway-rbac.yaml
+    set:
+      gateway:
+        cluster:
+          type: hazelcast
+    release:
+      name: my-apim
+      namespace: unittest
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Role

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1509,6 +1509,8 @@ gateway:
 #    proxyProtocol: false
 #    proxyProtocolTimeout: 10000
   ratelimit:
+    # hazelcast:
+    #   configPath: ${gravitee.home}/config/hazelcast-ratelimit.xml
     # redis:
     #   host: redis
     #   port: 6379

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1511,6 +1511,7 @@ gateway:
   ratelimit:
     # hazelcast:
     #   configPath: ${gravitee.home}/config/hazelcast-ratelimit.xml
+    #   port: 5901
     # redis:
     #   host: redis
     #   port: 6379


### PR DESCRIPTION
## Summary

- Restores `gravitee-apim-repository-hazelcast` (removed by #10955) as a self-contained rate-limit repository: plugin owns its own embedded `HazelcastInstance` via `@Bean(destroyMethod=shutdown)`, no gravitee-node SPI changes (Option C — see APIM-13727).
- Each `incrementAndGet` is one async `IMap.submitToKey` + `EntryProcessor` call: runs under the partition lock on the owner member, replicates to backup, returns as a `CompletionStage` (wrapped in `Single.fromCompletionStage`). No distributed `IMap.lock`, one network round-trip per request.
- Per-entry TTL via `ExtendedMapEntry.setValue(v, ttlMs, MS)` inside the processor — Hazelcast evicts entries when the window closes.
- Drops the orphan `com.hazelcast:hazelcast` entry from `gravitee-apim-bom` left behind by #10955; version now sourced entirely from gravitee-node BOM.
- Bundles plugin zip + ships `hazelcast-ratelimit.xml.sample` (cluster-name `gio-apim-ratelimit`, port 5901) in the gateway distribution.

Fixes APIM-13746. Part of epic APIM-13727.

## Test plan

- [x] Unit tests against real embedded HZ — 6 scenarios green: single-thread happy path, 16×50 contention = exactly 800, TTL expiry (awaitility), supplier seeding, key isolation, window rollover
- [x] Module + distribution build green on 4.11.x
- [x] End-to-end: gateway with `cluster.type=hazelcast` + `ratelimit.type=hazelcast` — 2 HZ instances coexist in one JVM (5701 + 5901), policy 3/10s → \`200,200,200,429,429,429\`, resets after window
- [x] Distributed: 2 gateways, GW2 auto-incremented to 5702/5902, joined sibling clusters via TCP-IP localhost — cross-gateway sequence \`GW1→200, GW1→200, GW2→200, GW2→429, GW1→429\`, IMap counter shared
- [x] v2 + v4 APIs both work; multi-API counter isolation confirmed (API X locked at 429 doesn't affect API Y; both reset independently)
- [x] Concurrency stress: 50 parallel requests × 16 procs against single gateway → exactly 3 × 200 + 47 × 429 (atomic increment via EntryProcessor, no over-count)
- [x] HZ DEBUG validation: partition primary/backup replication confirmed for IMap \`rate-limits\` (partition 137: primary on 5901, backup on 5902, partitionSize=1 after writes)
- [x] Class-invocation proof: positive control via instrumented \`incrementAndGet\` (6 log lines for 6 requests, key shape \`<api-id>:<caller-ip>:rl\`); negative control via \`ratelimit.type=mongodb\` (zero invocations of HZ class)
- [ ] CI green
- [ ] Forward-port follow-up to master/4.12.x (separate effort)

## Replaces

- #16590 (DistributedMapProvider design — abandoned, see APIM-13727 *Abandoned design 2026-04-24*)