### PR TITLE
fix(console): align file picker accept with API format in V4 import flow

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/api-import-file-picker/api-import-file-picker.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/api-import-file-picker/api-import-file-picker.component.html
@@ -18,7 +18,7 @@
 <gio-form-file-picker
   class="file-picker"
   [class.file-picker--filled]="filePickerControl.value?.length > 0"
-  [accept]="accept"
+  [accept]="acceptMask()"
   [formControl]="filePickerControl"
 >
   <gio-form-file-picker-add-button>

--- a/gravitee-apim-console-webui/src/management/api/component/api-import-file-picker/api-import-file-picker.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/api-import-file-picker/api-import-file-picker.component.spec.ts
@@ -125,30 +125,13 @@ describe('FilePickerComponent', () => {
     });
   });
 
-  it('should clear selection and emit when allowedFileExtensions changes after a file was picked', async () => {
+  it('should recompute acceptMask when allowedFileExtensions input changes', () => {
     fixture.componentRef.setInput('allowedFileExtensions', ['json']);
     fixture.detectChanges();
+    expect(component.acceptMask()).toBe('.json');
 
-    const eventEmitterSpy = jest.spyOn(component.onFilePicked, 'emit');
-    const newFile = new File([`{ "api": { "definitionVersion": "V4" }}`], 'file.json', { type: 'application/json' });
-
-    await harness.dropFiles([newFile]);
-
-    expect(eventEmitterSpy).toHaveBeenCalledWith({
-      importFile: newFile,
-      importFileContent: `{ "api": { "definitionVersion": "V4" }}`,
-      importType: 'MAPI_V2',
-    });
-
-    eventEmitterSpy.mockClear();
     fixture.componentRef.setInput('allowedFileExtensions', ['yml', 'yaml']);
     fixture.detectChanges();
-
-    expect(eventEmitterSpy).toHaveBeenCalledTimes(1);
-    expect(eventEmitterSpy).toHaveBeenCalledWith({
-      importType: undefined,
-      importFile: undefined,
-      importFileContent: undefined,
-    });
+    expect(component.acceptMask()).toBe('.yml,.yaml');
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/component/api-import-file-picker/api-import-file-picker.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/api-import-file-picker/api-import-file-picker.component.ts
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, DestroyRef, effect, EventEmitter, inject, input, OnInit, Output, ViewEncapsulation } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, OnInit, output, ViewEncapsulation } from '@angular/core';
 import { GioFormFilePickerModule, NewFile } from '@gravitee/ui-particles-angular';
 import { CommonModule } from '@angular/common';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { distinctUntilChanged, skip, tap } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 
@@ -37,29 +36,15 @@ export class ApiImportFilePickerComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   allowedFileExtensions = input<string[]>(['yml', 'yaml', 'json', 'wsdl', 'xml', 'js']);
   fillDropZoneLayout = input(false);
+  onFilePicked = output<{ importFile: File; importFileContent: string; importType: string }>();
   filePickerControl = new FormControl();
   importType: string;
-  accept: string;
-  @Output() onFilePicked = new EventEmitter<{ importFile: File; importFileContent: string; importType: string }>();
 
-  constructor() {
-    effect(() => {
-      this.accept = this.allowedFileExtensions()
-        .map(ext => '.' + ext)
-        .join(',');
-    });
-
-    toObservable(this.allowedFileExtensions)
-      .pipe(
-        skip(1),
-        distinctUntilChanged(
-          (a, b) => [...a].sort((x, y) => x.localeCompare(y)).join(',') === [...b].sort((x, y) => x.localeCompare(y)).join(','),
-        ),
-        tap(() => this.clearSelectionAfterExtensionsChanged()),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe();
-  }
+  readonly acceptMask = computed(() =>
+    this.allowedFileExtensions()
+      .map(ext => '.' + ext)
+      .join(','),
+  );
 
   ngOnInit() {
     this.filePickerControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(value => this.onImportFile(value));
@@ -131,12 +116,6 @@ export class ApiImportFilePickerComponent implements OnInit {
     if (message) {
       this.snackBarService.error(message);
     }
-    this.onFilePicked.emit({ importType: undefined, importFile: undefined, importFileContent: undefined });
-  }
-
-  private clearSelectionAfterExtensionsChanged(): void {
-    this.importType = undefined;
-    this.filePickerControl.setValue(null, { emitEvent: false });
     this.onFilePicked.emit({ importType: undefined, importFile: undefined, importFileContent: undefined });
   }
 

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form-dialog/api-import-v4-form-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form-dialog/api-import-v4-form-dialog.component.scss
@@ -8,8 +8,8 @@
 .api-import-v4-form-dialog__content {
   flex: 1 1 auto;
   min-height: 0;
-  padding-top: 0;
   display: flex;
   flex-direction: column;
   overflow: auto;
+  max-height: unset;
 }

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form-dialog/api-import-v4-form-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form-dialog/api-import-v4-form-dialog.component.ts
@@ -23,7 +23,7 @@ export interface ApiImportV4FormDialogData {
   apiName: string;
 }
 
-export const API_IMPORT_V4_FORM_DIALOG_MAX_HEIGHT = '96dvh';
+export const API_IMPORT_V4_FORM_DIALOG_MAX_HEIGHT = '90dvh';
 
 @Component({
   selector: 'api-import-v4-form-dialog',

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
@@ -55,7 +55,7 @@
     <div class="import-api-v4-form__dialog-surface">
       @if (embeddedDialogApiName(); as dialogApiName) {
         <div class="import-api-v4-form__dialog-heading">
-          <h1 class="page-header__page-title">Update API</h1>
+          <h1 class="page-header__page-title">Update the API</h1>
           <span class="import-api-v4-form__dialog-heading-api-name">{{ dialogApiName }}</span>
         </div>
       }
@@ -70,7 +70,7 @@
   }
 
   <ng-template #importApiV4StepperTpl>
-    <mat-stepper linear color="accent" [disableRipple]="true">
+    <mat-stepper linear color="accent" [disableRipple]="true" (selectionChange)="onImportStepSelectionChange($event)">
       <!-- step 1-->
       <mat-step [stepControl]="selectApiFormatForm">
         <form [formGroup]="selectApiFormatForm" class="select-api-format">
@@ -130,19 +130,21 @@
                 @if (configureFileSourceForm.controls.source.value === 'local') {
                   <span class="configure-file-source__col-heading">File</span>
                   <div class="configure-file-source__detail-panel configure-file-source__detail-panel--file">
-                    <api-import-file-picker
-                      [allowedFileExtensions]="allowedImportFileExtensions()"
-                      [fillDropZoneLayout]="true"
-                      (onFilePicked)="onImportFile($event)"
-                    >
-                      <div class="configure-file-source__file-picker">
-                        <mat-icon svgIcon="gio:upload"></mat-icon>
-                        <p class="mat-body-strong">Drag and drop a file</p>
-                        <p class="mat-body" data-testid="supported-file-formats">
-                          Supported file formats: {{ allowedImportFileExtensionsLabel() }}
-                        </p>
-                      </div>
-                    </api-import-file-picker>
+                    @for (fmt of [importFormat() ?? 'gravitee']; track fmt) {
+                      <api-import-file-picker
+                        [allowedFileExtensions]="allowedImportFileExtensions()"
+                        [fillDropZoneLayout]="true"
+                        (onFilePicked)="onImportFile($event)"
+                      >
+                        <div class="configure-file-source__file-picker">
+                          <mat-icon svgIcon="gio:upload"></mat-icon>
+                          <p class="mat-body-strong">Drag and drop a file</p>
+                          <p class="mat-body" data-testid="supported-file-formats">
+                            Supported file formats: {{ allowedImportFileExtensionsLabel() }}
+                          </p>
+                        </div>
+                      </api-import-file-picker>
+                    }
                     @if (configureFileSourceForm.hasError('mismatchFileFormat')) {
                       <gio-banner-error>The file does not match the selected API format</gio-banner-error>
                     }

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
@@ -62,6 +62,59 @@ describe('ApiImportV4FormComponent', () => {
     expect(await harness.getSupportedFileFormatsBannerText()).toBe(expectedBanner);
   });
 
+  it('should align native file input accept with OpenAPI yaml extensions on the configure step', async () => {
+    await harness.selectFormat('openapi');
+    fixture.detectChanges();
+    await harness.clickNext();
+    fixture.detectChanges();
+    const accept = await harness.getFilePickerInputAccept();
+    expect(accept).toContain('.yml');
+    expect(accept).toContain('.yaml');
+  });
+
+  it('should keep picked file when going back from configure step to format step without changing API format', async () => {
+    const importDefinition = JSON.stringify({ api: fakeApiV4({ definitionVersion: 'V4' }) });
+
+    await harness.selectFormat('gravitee');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.pickFiles([new File([importDefinition], 'gravitee-api-definition.json', { type: 'application/json' })]);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(await harness.isConfigureSourceNextDisabled()).toBe(false);
+    expect(await harness.getPickedFilesCount()).toBe(1);
+
+    await harness.clickBack();
+    fixture.detectChanges();
+
+    await harness.clickNext();
+    fixture.detectChanges();
+    expect(await harness.isConfigureSourceNextDisabled()).toBe(false);
+    expect(await harness.getPickedFilesCount()).toBe(1);
+  });
+
+  it('should clear picked file only when API format changes on step 1 (e.g. OpenAPI → Gravitee → OpenAPI)', async () => {
+    await harness.selectFormat('openapi');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.pickFiles([new File(['openapi: 3.1.0'], 'openapi.yml', { type: 'application/x-yaml' })]);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(await harness.isConfigureSourceNextDisabled()).toBe(false);
+
+    await harness.clickBack();
+    fixture.detectChanges();
+
+    await harness.selectFormat('gravitee');
+    fixture.detectChanges();
+    await harness.selectFormat('openapi');
+    fixture.detectChanges();
+
+    await harness.clickNext();
+    fixture.detectChanges();
+    expect(await harness.isConfigureSourceNextDisabled()).toBe(true);
+  });
+
   it('should surface wsdl/xml in the supported-formats banner when format is wsdl', async () => {
     // WSDL is not yet selectable from the inline format cards (disabled in the template).
     fixture.componentInstance.selectApiFormatForm.patchValue({ format: 'wsdl' });
@@ -141,6 +194,26 @@ describe('ApiImportV4FormComponent', () => {
     await harness.selectFormat('openapi');
     fixture.detectChanges();
     expect(await harness.hasOptionsStep()).toBe(true);
+  });
+
+  it('should keep OpenAPI options when navigating back from options step to configure step', async () => {
+    await harness.selectFormat('openapi');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.pickFiles([new File(['openapi: 3.1.0'], 'openapi.yml', { type: 'application/x-yaml' })]);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await harness.clickNext();
+
+    await harness.toggleDocumentationImport();
+    expect(await harness.isDocumentationImportSelected()).toBe(false);
+
+    await harness.clickPrevious();
+    fixture.detectChanges();
+    await harness.clickNext();
+    fixture.detectChanges();
+
+    expect(await harness.isDocumentationImportSelected()).toBe(false);
   });
 
   it('should not start a second import while the first is in progress', async () => {
@@ -329,6 +402,27 @@ describe('ApiImportV4FormComponent (oas-validation policy installed)', () => {
 
     await harness.toggleDocumentationImport();
     expect(await harness.isDocumentationImportSelected()).toBe(true);
+  });
+
+  it('should keep picked file after toggling OpenAPI validation on options and returning to configure', async () => {
+    await harness.selectFormat('openapi');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.selectSource('local');
+    await harness.pickFiles([new File(['openapi: 3.1.0'], 'openapi.yml', { type: 'application/x-yaml' })]);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(await harness.getPickedFilesCount()).toBe(1);
+    await harness.clickNext();
+
+    await harness.toggleOasValidationPolicyImport();
+    expect(await harness.isOasValidationPolicyImportSelected()).toBe(false);
+
+    await harness.clickPrevious();
+    fixture.detectChanges();
+
+    expect(await harness.isConfigureSourceNextDisabled()).toBe(false);
+    expect(await harness.getPickedFilesCount()).toBe(1);
   });
 
   it('should still skip the options step for Gravitee definition when policy is installed', async () => {

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { StepperSelectionEvent } from '@angular/cdk/stepper';
 import { Component, computed, DestroyRef, effect, inject, input, output, signal, Signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { NgTemplateOutlet } from '@angular/common';
@@ -28,7 +29,7 @@ import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { GioBannerModule, GioFormSelectionInlineModule, GioFormSlideToggleModule, GioIconsModule } from '@gravitee/ui-particles-angular';
 import { combineLatest, defer, EMPTY, merge, Observable, of, throwError } from 'rxjs';
-import { catchError, finalize, map, startWith, switchMap, tap } from 'rxjs/operators';
+import { catchError, distinctUntilChanged, finalize, map, startWith, switchMap, tap } from 'rxjs/operators';
 
 import { ApiImportFilePickerComponent } from '../../component/api-import-file-picker/api-import-file-picker.component';
 import { ApiV4, PolicyPlugin } from '../../../../entities/management-api-v2';
@@ -138,12 +139,28 @@ export class ApiImportV4FormComponent {
   protected readonly hasOasValidationPolicy = signal(false);
 
   protected readonly importFormat = toSignal(
-    this.selectApiFormatForm.controls.format.valueChanges.pipe(startWith(this.selectApiFormatForm.controls.format.value)),
+    this.selectApiFormatForm.controls.format.valueChanges.pipe(
+      startWith(this.selectApiFormatForm.controls.format.value),
+      distinctUntilChanged(),
+    ),
     { initialValue: this.selectApiFormatForm.controls.format.value },
   );
 
+  private readonly resetConfigureStepWhenApiFormatChanges = (() => {
+    let previous = this.selectApiFormatForm.controls.format.value;
+    return effect(() => {
+      const current = this.importFormat();
+      if (current === previous) return;
+      previous = current;
+      this.resetConfigureFileSourceAfterApiFormatChange();
+    });
+  })();
+
   private readonly importSourceMode = toSignal(
-    this.configureFileSourceForm.controls.source.valueChanges.pipe(startWith(this.configureFileSourceForm.controls.source.value)),
+    this.configureFileSourceForm.controls.source.valueChanges.pipe(
+      startWith(this.configureFileSourceForm.controls.source.value),
+      distinctUntilChanged(),
+    ),
     { initialValue: this.configureFileSourceForm.controls.source.value },
   );
 
@@ -207,7 +224,11 @@ export class ApiImportV4FormComponent {
 
   private readonly formatAndPolicies = toSignal(
     combineLatest([
-      this.selectApiFormatForm.controls.format.valueChanges.pipe(startWith(this.selectApiFormatForm.controls.format.value)),
+      this.selectApiFormatForm.valueChanges.pipe(
+        map(() => this.selectApiFormatForm.controls.format.value),
+        startWith(this.selectApiFormatForm.controls.format.value),
+        distinctUntilChanged(),
+      ),
       this.policyV2Service.list().pipe(
         catchError((err: unknown) => {
           this.snackBarService.error(this.readPolicyListErrorMessage(err));
@@ -280,6 +301,27 @@ export class ApiImportV4FormComponent {
     this.importStepper()?.previous();
   }
 
+  protected onImportStepSelectionChange(event: StepperSelectionEvent): void {
+    const selectedIndex = event.selectedIndex;
+    const previousIndex = event.previouslySelectedIndex;
+    if (selectedIndex < previousIndex) {
+      this.importInProgress.set(false);
+    }
+  }
+
+  /** Clears picked file and remote URL fields when the user selects a different API format on step 1 (stepper navigation alone does not reset). */
+  private resetConfigureFileSourceAfterApiFormatChange(): void {
+    this.importFileContent.set(undefined);
+    this.importType.set(undefined);
+    if (this.configureFileSourceForm.controls.source.value !== 'local') {
+      this.configureFileSourceForm.controls.source.setValue('local', { emitEvent: true });
+    }
+    this.configureFileSourceForm.patchValue({ remoteUrl: '', authorizationHeader: '' }, { emitEvent: false });
+    this.configureFileSourceForm.controls.remoteUrl.markAsUntouched();
+    this.configureFileSourceForm.controls.authorizationHeader.markAsUntouched();
+    this.configureFileSourceForm.updateValueAndValidity({ emitEvent: true });
+  }
+
   private applyFileSourceMode(source: string | null): void {
     const urlCtrl = this.configureFileSourceForm.controls.remoteUrl;
     const authCtrl = this.configureFileSourceForm.controls.authorizationHeader;
@@ -293,6 +335,7 @@ export class ApiImportV4FormComponent {
       urlCtrl.setValue('', { emitEvent: false });
       authCtrl.setValue('', { emitEvent: false });
       urlCtrl.markAsUntouched();
+      authCtrl.markAsUntouched();
     }
     urlCtrl.updateValueAndValidity({ emitEvent: true });
     authCtrl.updateValueAndValidity({ emitEvent: false });

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.harness.ts
@@ -83,6 +83,16 @@ export class ApiImportV4FormHarness extends ComponentHarness {
     return picker.dropFiles(files);
   }
 
+  public async getFilePickerInputAccept(): Promise<string | null> {
+    const picker = await this.getFilePicker();
+    return picker.getInputFileAccept();
+  }
+
+  public async getPickedFilesCount(): Promise<number> {
+    const picker = await this.getFilePicker();
+    return (await picker.getPreviews()).length;
+  }
+
   public async clickNext(): Promise<void> {
     for (const ancestor of ['.select-api-format__actions', '.configure-file-source__actions', '.options-step__actions']) {
       const btn = await this.locatorForOptional(MatButtonHarness.with({ ancestor, text: 'Next' }))();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13744

## Description

OpenAPI (yml/yaml) no longer used the Gravitee (json) file filter after choosing the format. Use a computed accept mask, remount the picker with the right extensions, and reset file/remote fields when going back to the format step.