### PR TITLE
chore(bom): bump up bom version to 8.3.56

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
              https://github.com/awhitford/lombok.maven/issues/179 -->
         <maven-lombok.version>1.18.36</maven-lombok.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>8.3.49</gravitee-bom.version>
+        <gravitee-bom.version>8.3.56</gravitee-bom.version>
         <gravitee-alert-api.version>3.0.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>3.11.0</gravitee-cockpit-api.version>
         <gravitee-cloud-initializer.version>2.3.1</gravitee-cloud-initializer.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13242

## Description

Bumping up the version for gravitee-bom to 8.3.56