### PR TITLE
API product transfer ownership Member/Group changes

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductMembersResource.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.api_product.use_case.members.AddApiProductMemberUse
 import io.gravitee.apim.core.api_product.use_case.members.DeleteApiProductMemberUseCase;
 import io.gravitee.apim.core.api_product.use_case.members.GetApiProductMembersUseCase;
 import io.gravitee.apim.core.api_product.use_case.members.UpdateApiProductMemberUseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.MemberMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.MembershipMapper;
@@ -159,8 +160,9 @@ public class ApiProductMembersResource extends AbstractResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.API_PRODUCT_MEMBER, acls = RolePermissionAction.UPDATE) })
     public Response transferApiProductOwnership(@Valid @NotNull ApiProductTransferOwnership transferOwnership) {
+        AuditInfo audit = getAuditInfo();
         transferApiProductOwnershipUseCase.execute(
-            new TransferApiProductOwnershipUseCase.Input(MembershipMapper.INSTANCE.map(transferOwnership), apiProductId)
+            new TransferApiProductOwnershipUseCase.Input(MembershipMapper.INSTANCE.map(transferOwnership), apiProductId, audit)
         );
         return Response.noContent().build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -2021,6 +2021,15 @@ components:
           example:
             - "api-1"
             - "api-2"
+        groups:
+          type: array
+          description: |
+            When provided, replaces the API Product group assignments (same semantics as for APIs).
+            The Console Manage groups flow includes this field on PUT.
+          items:
+            type: string
+          example:
+            - "group-uuid-1"
       required:
         - name
         - version
@@ -2058,6 +2067,13 @@ components:
           example:
             - "api-1"
             - "api-2"
+        groups:
+          type: array
+          description: List of group IDs associated with the API Product
+          items:
+            type: string
+          example:
+            - "group-1"
         createdAt:
           type: string
           format: date-time

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -5994,12 +5994,16 @@ components:
                       apiPrimaryOwner:
                           type: string
                           description: The group member id with API primary owner role.
+                      apiProductPrimaryOwner:
+                          type: string
+                          description: The group member id with API Product primary owner role.
         GroupEvent:
             type: string
             description: Type of group event.
             enum:
                 - API_CREATE
                 - APPLICATION_CREATE
+                - API_PRODUCT_CREATE
         GroupSearchParams:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/GroupMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/GroupMapperTest.java
@@ -54,6 +54,7 @@ public class GroupMapperTest extends AbstractMapperTest {
         assertThat(group.getEmailInvitation()).isEqualTo(groupEntity.isEmailInvitation());
         assertThat(group.getDisableMembershipNotifications()).isEqualTo(groupEntity.isDisableMembershipNotifications());
         assertThat(group.getApiPrimaryOwner()).isEqualTo(groupEntity.getApiPrimaryOwner());
+        assertThat(group.getApiProductPrimaryOwner()).isEqualTo(groupEntity.getApiProductPrimaryOwner());
         assertThat(group.getPrimaryOwner()).isEqualTo(groupEntity.isPrimaryOwner());
     }
 
@@ -73,15 +74,17 @@ public class GroupMapperTest extends AbstractMapperTest {
     void should_map_GroupEventRuleEntities_to_GroupEvents() {
         List<GroupEventRuleEntity> eventRules = Arrays.asList(
             createGroupEventRuleEntity(io.gravitee.apim.core.group.model.Group.GroupEvent.API_CREATE.name()),
-            createGroupEventRuleEntity(io.gravitee.apim.core.group.model.Group.GroupEvent.APPLICATION_CREATE.name())
+            createGroupEventRuleEntity(io.gravitee.apim.core.group.model.Group.GroupEvent.APPLICATION_CREATE.name()),
+            createGroupEventRuleEntity(io.gravitee.apim.core.group.model.Group.GroupEvent.API_PRODUCT_CREATE.name())
         );
 
         List<GroupEvent> groupEvents = groupMapper.mapGroupEventRuleEntities(eventRules);
 
         assertThat(groupEvents).isNotNull();
-        assertThat(groupEvents).hasSize(2);
+        assertThat(groupEvents).hasSize(3);
         assertThat(groupEvents.get(0)).isEqualTo(GroupEvent.API_CREATE);
         assertThat(groupEvents.get(1)).isEqualTo(GroupEvent.APPLICATION_CREATE);
+        assertThat(groupEvents.get(2)).isEqualTo(GroupEvent.API_PRODUCT_CREATE);
     }
 
     @Test
@@ -167,6 +170,7 @@ public class GroupMapperTest extends AbstractMapperTest {
         assertThat(group.getEmailInvitation()).isEqualTo(coreGroup.isEmailInvitation());
         assertThat(group.getDisableMembershipNotifications()).isEqualTo(coreGroup.isDisableMembershipNotifications());
         assertThat(group.getApiPrimaryOwner()).isEqualTo(coreGroup.getApiPrimaryOwner());
+        assertThat(group.getApiProductPrimaryOwner()).isEqualTo(coreGroup.getApiProductPrimaryOwner());
     }
 
     @Test
@@ -185,15 +189,17 @@ public class GroupMapperTest extends AbstractMapperTest {
     void should_map_core_GroupEventRules_to_GroupEvents() {
         List<GroupEventRule> eventRules = Arrays.asList(
             new GroupEventRule(io.gravitee.apim.core.group.model.Group.GroupEvent.API_CREATE),
-            new GroupEventRule(io.gravitee.apim.core.group.model.Group.GroupEvent.APPLICATION_CREATE)
+            new GroupEventRule(io.gravitee.apim.core.group.model.Group.GroupEvent.APPLICATION_CREATE),
+            new GroupEventRule(io.gravitee.apim.core.group.model.Group.GroupEvent.API_PRODUCT_CREATE)
         );
 
         List<GroupEvent> groupEvents = groupMapper.mapCoreGroupEventRules(eventRules);
 
         assertThat(groupEvents).isNotNull();
-        assertThat(groupEvents).hasSize(2);
+        assertThat(groupEvents).hasSize(3);
         assertThat(groupEvents.get(0)).isEqualTo(GroupEvent.API_CREATE);
         assertThat(groupEvents.get(1)).isEqualTo(GroupEvent.APPLICATION_CREATE);
+        assertThat(groupEvents.get(2)).isEqualTo(GroupEvent.API_PRODUCT_CREATE);
     }
 
     @Test
@@ -224,6 +230,7 @@ public class GroupMapperTest extends AbstractMapperTest {
             .emailInvitation(true)
             .disableMembershipNotifications(false)
             .apiPrimaryOwner("user-id")
+            .apiProductPrimaryOwner("product-po-user-id")
             .primaryOwner(true)
             .build();
 
@@ -266,6 +273,7 @@ public class GroupMapperTest extends AbstractMapperTest {
             .emailInvitation(true)
             .disableMembershipNotifications(false)
             .apiPrimaryOwner("user-id")
+            .apiProductPrimaryOwner("product-po-user-id")
             .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
@@ -145,6 +145,7 @@ public class GroupsResourceTest extends AbstractResourceTest {
                 .eventRules(List.of(GroupEventRuleEntity.builder().event("API_CREATE").build()))
                 .roles(ofEntries(entry(RoleScope.API, "READ_ONLY"), entry(RoleScope.APPLICATION, "USER")))
                 .apiPrimaryOwner("api-owner-id")
+                .apiProductPrimaryOwner("product-owner-id")
                 .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00.00Z")))
                 .updatedAt(Date.from(Instant.parse("2020-01-01T00:00:00.00Z")))
                 .disableMembershipNotifications(true)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -46,6 +46,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.GroupInvitationForbiddenException;
 import io.gravitee.rest.api.service.exceptions.GroupMembersLimitationExceededException;
+import io.gravitee.rest.api.service.exceptions.StillApiProductPrimaryOwnerException;
 import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -324,7 +325,25 @@ public class GroupMembersResource extends AbstractResource {
                         GroupEntity::isLockApiProductRole,
                         hasPermission
                     );
-                    updateRole(RoleScope.API_PRODUCT, roleName, previousApiProductRole, membership, executionContext);
+
+                    // Validate: prevent changing from PRIMARY_OWNER if a group owns API products
+                    if (
+                        previousApiProductRole != null &&
+                        previousApiProductRole.getName().equals(SystemRole.PRIMARY_OWNER.name()) &&
+                        !roleName.equals(SystemRole.PRIMARY_OWNER.name())
+                    ) {
+                        List<ApiProductEntity> groupApiProducts = groupService.getApiProducts(executionContext.getEnvironmentId(), group);
+                        if (!groupApiProducts.isEmpty()) {
+                            throw new StillApiProductPrimaryOwnerException(groupApiProducts.size());
+                        }
+                    }
+
+                    updatedMembership = updateRole(RoleScope.API_PRODUCT, roleName, previousApiProductRole, membership, executionContext);
+                    if (previousApiProductRole != null && previousApiProductRole.getName().equals(SystemRole.PRIMARY_OWNER.name())) {
+                        groupService.updateApiProductPrimaryOwner(group, null);
+                    } else if (roleName.equals(SystemRole.PRIMARY_OWNER.name())) {
+                        groupService.updateApiProductPrimaryOwner(group, updatedMembership.getId());
+                    }
                 }
 
                 RoleEntity integrationRoleEntity = roleEntities.get(RoleScope.INTEGRATION);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResourceTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -667,7 +668,72 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
 
         final Response response = envTarget().request().post(Entity.json(Collections.singleton(groupMembership)));
 
-        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+        Assertions.assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenChangingFromApiProductPrimaryOwnerToOtherRoleIfGroupOwnsApiProducts() {
+        reset(roleService, groupService, membershipService);
+        when(groupService.findById(GraviteeContext.getExecutionContext(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
+
+        RoleEntity primaryOwnerRole = new RoleEntity();
+        primaryOwnerRole.setId("API_PRODUCT_PRIMARY_OWNER");
+        primaryOwnerRole.setName(SystemRole.PRIMARY_OWNER.name());
+        primaryOwnerRole.setScope(RoleScope.API_PRODUCT);
+
+        RoleEntity otherRole = new RoleEntity();
+        otherRole.setId("API_PRODUCT_USER");
+        otherRole.setName("USER");
+        otherRole.setScope(RoleScope.API_PRODUCT);
+
+        when(
+            roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
+        ).thenReturn(Optional.of(primaryOwnerRole));
+        when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, "USER", GraviteeContext.getCurrentOrganization())).thenReturn(
+            Optional.of(otherRole)
+        );
+
+        RoleEntity previousApiProductRole = new RoleEntity();
+        previousApiProductRole.setId("API_PRODUCT_PRIMARY_OWNER");
+        previousApiProductRole.setName(SystemRole.PRIMARY_OWNER.name());
+        previousApiProductRole.setScope(RoleScope.API_PRODUCT);
+
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, GROUP_ID, MembershipMemberType.USER, USERNAME)).thenReturn(
+            Set.of(previousApiProductRole)
+        );
+
+        ApiProductEntity product1 = new ApiProductEntity();
+        product1.setId("ap-1");
+        product1.setName("Product 1");
+        ApiProductEntity product2 = new ApiProductEntity();
+        product2.setId("ap-2");
+        product2.setName("Product 2");
+        when(groupService.getApiProducts(GraviteeContext.getExecutionContext().getEnvironmentId(), GROUP_ID)).thenReturn(
+            List.of(product1, product2)
+        );
+
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(ENVIRONMENT_GROUP),
+                eq("DEFAULT"),
+                eq(CREATE),
+                eq(UPDATE),
+                eq(DELETE)
+            )
+        ).thenReturn(true);
+
+        MemberRoleEntity newApiProductRole = new MemberRoleEntity();
+        newApiProductRole.setRoleScope(RoleScope.API_PRODUCT);
+        newApiProductRole.setRoleName("USER");
+
+        GroupMembership groupMembership = new GroupMembership();
+        groupMembership.setId(USERNAME);
+        groupMembership.setRoles(Collections.singletonList(newApiProductRole));
+
+        final Response response = envTarget().request().post(Entity.json(Collections.singleton(groupMembership)));
+
+        Assertions.assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
     }
 
     @Test
@@ -808,6 +874,214 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
             new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
             new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
             new MembershipService.MembershipRole(RoleScope.API, SystemRole.PRIMARY_OWNER.name())
+        );
+    }
+
+    @Test
+    public void shouldAllowChangingToApiProductPrimaryOwnerFromOtherRole() {
+        reset(roleService, groupService, membershipService);
+        when(groupService.findById(GraviteeContext.getExecutionContext(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
+
+        RoleEntity primaryOwnerRole = new RoleEntity();
+        primaryOwnerRole.setId("API_PRODUCT_PRIMARY_OWNER");
+        primaryOwnerRole.setName(SystemRole.PRIMARY_OWNER.name());
+        primaryOwnerRole.setScope(RoleScope.API_PRODUCT);
+
+        RoleEntity otherRole = new RoleEntity();
+        otherRole.setId("API_PRODUCT_USER");
+        otherRole.setName("USER");
+        otherRole.setScope(RoleScope.API_PRODUCT);
+
+        when(
+            roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
+        ).thenReturn(Optional.of(primaryOwnerRole));
+        when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, "USER", GraviteeContext.getCurrentOrganization())).thenReturn(
+            Optional.of(otherRole)
+        );
+
+        RoleEntity previousApiProductRole = new RoleEntity();
+        previousApiProductRole.setId("API_PRODUCT_USER");
+        previousApiProductRole.setName("USER");
+        previousApiProductRole.setScope(RoleScope.API_PRODUCT);
+
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, GROUP_ID, MembershipMemberType.USER, USERNAME)).thenReturn(
+            Set.of(previousApiProductRole)
+        );
+
+        MemberEntity memberEntity = new MemberEntity();
+        memberEntity.setId(USERNAME);
+        when(membershipService.addRoleToMemberOnReference(eq(GraviteeContext.getExecutionContext()), any(), any(), any())).thenReturn(
+            memberEntity
+        );
+
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(ENVIRONMENT_GROUP),
+                eq("DEFAULT"),
+                eq(CREATE),
+                eq(UPDATE),
+                eq(DELETE)
+            )
+        ).thenReturn(true);
+
+        MemberRoleEntity newApiProductRole = new MemberRoleEntity();
+        newApiProductRole.setRoleScope(RoleScope.API_PRODUCT);
+        newApiProductRole.setRoleName(SystemRole.PRIMARY_OWNER.name());
+
+        GroupMembership groupMembership = new GroupMembership();
+        groupMembership.setId(USERNAME);
+        groupMembership.setRoles(Collections.singletonList(newApiProductRole));
+
+        final Response response = envTarget().request().post(Entity.json(Collections.singleton(groupMembership)));
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        verify(groupService).updateApiProductPrimaryOwner(GROUP_ID, USERNAME);
+        verify(membershipService, times(1)).addRoleToMemberOnReference(
+            GraviteeContext.getExecutionContext(),
+            new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
+            new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
+            new MembershipService.MembershipRole(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name())
+        );
+    }
+
+    @Test
+    public void shouldClearApiProductPrimaryOwnerWhenDemotingFromPrimaryOwner() {
+        reset(roleService, groupService, membershipService);
+        when(groupService.findById(GraviteeContext.getExecutionContext(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
+
+        RoleEntity primaryOwnerRole = new RoleEntity();
+        primaryOwnerRole.setId("API_PRODUCT_PRIMARY_OWNER");
+        primaryOwnerRole.setName(SystemRole.PRIMARY_OWNER.name());
+        primaryOwnerRole.setScope(RoleScope.API_PRODUCT);
+
+        RoleEntity userRole = new RoleEntity();
+        userRole.setId("API_PRODUCT_USER");
+        userRole.setName("USER");
+        userRole.setScope(RoleScope.API_PRODUCT);
+
+        when(
+            roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), GraviteeContext.getCurrentOrganization())
+        ).thenReturn(Optional.of(primaryOwnerRole));
+        when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, "USER", GraviteeContext.getCurrentOrganization())).thenReturn(
+            Optional.of(userRole)
+        );
+
+        RoleEntity previousApiProductRole = new RoleEntity();
+        previousApiProductRole.setId("API_PRODUCT_PRIMARY_OWNER");
+        previousApiProductRole.setName(SystemRole.PRIMARY_OWNER.name());
+        previousApiProductRole.setScope(RoleScope.API_PRODUCT);
+
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, GROUP_ID, MembershipMemberType.USER, USERNAME)).thenReturn(
+            Set.of(previousApiProductRole)
+        );
+
+        when(groupService.getApiProducts(GraviteeContext.getExecutionContext().getEnvironmentId(), GROUP_ID)).thenReturn(
+            Collections.emptyList()
+        );
+
+        MemberEntity memberEntity = new MemberEntity();
+        memberEntity.setId(USERNAME);
+        when(membershipService.addRoleToMemberOnReference(eq(GraviteeContext.getExecutionContext()), any(), any(), any())).thenReturn(
+            memberEntity
+        );
+
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(ENVIRONMENT_GROUP),
+                eq("DEFAULT"),
+                eq(CREATE),
+                eq(UPDATE),
+                eq(DELETE)
+            )
+        ).thenReturn(true);
+
+        MemberRoleEntity newApiProductRole = new MemberRoleEntity();
+        newApiProductRole.setRoleScope(RoleScope.API_PRODUCT);
+        newApiProductRole.setRoleName("USER");
+
+        GroupMembership groupMembership = new GroupMembership();
+        groupMembership.setId(USERNAME);
+        groupMembership.setRoles(Collections.singletonList(newApiProductRole));
+
+        final Response response = envTarget().request().post(Entity.json(Collections.singleton(groupMembership)));
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        verify(groupService).updateApiProductPrimaryOwner(GROUP_ID, null);
+        verify(membershipService, times(1)).addRoleToMemberOnReference(
+            GraviteeContext.getExecutionContext(),
+            new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
+            new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
+            new MembershipService.MembershipRole(RoleScope.API_PRODUCT, "USER")
+        );
+    }
+
+    @Test
+    public void shouldNotModifyApiProductPrimaryOwnerWhenUpdatingNonPrimaryRoles() {
+        reset(roleService, groupService, membershipService);
+        when(groupService.findById(GraviteeContext.getExecutionContext(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
+
+        RoleEntity userRole = new RoleEntity();
+        userRole.setId("API_PRODUCT_USER");
+        userRole.setName("USER");
+        userRole.setScope(RoleScope.API_PRODUCT);
+
+        RoleEntity ownerRole = new RoleEntity();
+        ownerRole.setId("API_PRODUCT_OWNER");
+        ownerRole.setName("OWNER");
+        ownerRole.setScope(RoleScope.API_PRODUCT);
+
+        when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, "USER", GraviteeContext.getCurrentOrganization())).thenReturn(
+            Optional.of(userRole)
+        );
+        when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, "OWNER", GraviteeContext.getCurrentOrganization())).thenReturn(
+            Optional.of(ownerRole)
+        );
+
+        RoleEntity previousApiProductRole = new RoleEntity();
+        previousApiProductRole.setId("API_PRODUCT_USER");
+        previousApiProductRole.setName("USER");
+        previousApiProductRole.setScope(RoleScope.API_PRODUCT);
+
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, GROUP_ID, MembershipMemberType.USER, USERNAME)).thenReturn(
+            Set.of(previousApiProductRole)
+        );
+
+        MemberEntity memberEntity = new MemberEntity();
+        memberEntity.setId(USERNAME);
+        when(membershipService.addRoleToMemberOnReference(eq(GraviteeContext.getExecutionContext()), any(), any(), any())).thenReturn(
+            memberEntity
+        );
+
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(ENVIRONMENT_GROUP),
+                eq("DEFAULT"),
+                eq(CREATE),
+                eq(UPDATE),
+                eq(DELETE)
+            )
+        ).thenReturn(true);
+
+        MemberRoleEntity newApiProductRole = new MemberRoleEntity();
+        newApiProductRole.setRoleScope(RoleScope.API_PRODUCT);
+        newApiProductRole.setRoleName("OWNER");
+
+        GroupMembership groupMembership = new GroupMembership();
+        groupMembership.setId(USERNAME);
+        groupMembership.setRoles(Collections.singletonList(newApiProductRole));
+
+        final Response response = envTarget().request().post(Entity.json(Collections.singleton(groupMembership)));
+
+        Assertions.assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        verify(groupService, never()).updateApiProductPrimaryOwner(anyString(), any());
+        verify(membershipService, times(1)).addRoleToMemberOnReference(
+            GraviteeContext.getExecutionContext(),
+            new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
+            new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
+            new MembershipService.MembershipRole(RoleScope.API_PRODUCT, "OWNER")
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupEntity.java
@@ -82,6 +82,8 @@ public class GroupEntity {
 
     private String apiPrimaryOwner;
 
+    private String apiProductPrimaryOwner;
+
     @JsonProperty("primary_owner")
     private boolean primaryOwner;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
@@ -107,25 +107,29 @@ public class CreateApiProductUseCase {
                 );
             });
 
-        Set<String> defaultGroups = groupQueryService
-            .findByEvent(auditInfo.environmentId(), Group.GroupEvent.API_PRODUCT_CREATE)
-            .stream()
-            .filter(group -> StringUtils.isEmpty(group.getApiPrimaryOwner()))
-            .map(Group::getId)
-            .collect(toSet());
-        if (!defaultGroups.isEmpty()) {
-            Set<String> sanitizedGroups = new HashSet<>(apiProduct.getGroups() != null ? apiProduct.getGroups() : Set.of());
-            sanitizedGroups.addAll(defaultGroups);
-            apiProduct.setGroups(sanitizedGroups);
-        }
-
-        ApiProduct created = apiProductCrudService.create(apiProduct);
-
         PrimaryOwnerEntity primaryOwner = apiProductPrimaryOwnerFactory.createForNewApiProduct(
             auditInfo.organizationId(),
             auditInfo.environmentId(),
             auditInfo.actor().userId()
         );
+
+        Set<String> defaultGroups = groupQueryService
+            .findByEvent(auditInfo.environmentId(), Group.GroupEvent.API_PRODUCT_CREATE)
+            .stream()
+            .filter(group -> StringUtils.isEmpty(group.getApiProductPrimaryOwner()))
+            .map(Group::getId)
+            .collect(toSet());
+        Set<String> sanitizedGroups = new HashSet<>(apiProduct.getGroups() != null ? apiProduct.getGroups() : Set.of());
+        sanitizedGroups.addAll(defaultGroups);
+        if (PrimaryOwnerEntity.Type.GROUP.equals(primaryOwner.type())) {
+            sanitizedGroups.add(primaryOwner.id());
+        }
+        if (!sanitizedGroups.isEmpty()) {
+            apiProduct.setGroups(sanitizedGroups);
+        }
+
+        ApiProduct created = apiProductCrudService.create(apiProduct);
+
         apiProductPrimaryOwnerDomainService.createApiProductPrimaryOwnerMembership(created.getId(), primaryOwner, auditInfo);
 
         apiProductIndexerDomainService.index(oneShotIndexation(auditInfo), created, primaryOwner);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/TransferApiProductOwnershipUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/TransferApiProductOwnershipUseCase.java
@@ -15,24 +15,55 @@
  */
 package io.gravitee.apim.core.api_product.use_case;
 
+import static io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService.oneShotIndexation;
+
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
+import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.membership.model.TransferOwnership;
 import io.gravitee.rest.api.model.permissions.RoleScope;
-import lombok.AllArgsConstructor;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
 
-@AllArgsConstructor
 @UseCase
+@RequiredArgsConstructor
+@CustomLog
 public class TransferApiProductOwnershipUseCase {
 
     private final MembershipDomainService membershipDomainService;
+    private final ApiProductQueryService apiProductQueryService;
+    private final ApiProductIndexerDomainService apiProductIndexerDomainService;
+    private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
 
-    public record Input(TransferOwnership transferOwnership, String apiProductId) {}
+    public record Input(TransferOwnership transferOwnership, String apiProductId, AuditInfo auditInfo) {}
 
     public record Output() {}
 
     public Output execute(Input input) {
         membershipDomainService.transferOwnership(input.transferOwnership(), RoleScope.API_PRODUCT, input.apiProductId());
+
+        ApiProduct apiProduct = apiProductQueryService
+            .findById(input.apiProductId())
+            .orElseThrow(() -> new ApiProductNotFoundException(input.apiProductId()));
+
+        PrimaryOwnerEntity primaryOwner = null;
+        try {
+            primaryOwner = apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(
+                input.auditInfo().organizationId(),
+                apiProduct.getId()
+            );
+        } catch (ApiProductPrimaryOwnerNotFoundException ex) {
+            log.debug("Failed to retrieve API Product primary owner, will index without primary owner", ex);
+        }
+        apiProductIndexerDomainService.index(oneShotIndexation(input.auditInfo()), apiProduct, primaryOwner);
+
         return new Output();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/DeleteApiProductMemberUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/DeleteApiProductMemberUseCase.java
@@ -15,10 +15,17 @@
  */
 package io.gravitee.apim.core.api_product.use_case.members;
 
+import static io.gravitee.rest.api.model.permissions.SystemRole.PRIMARY_OWNER;
+
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.member.model.Member;
 import io.gravitee.apim.core.member.model.MembershipMemberType;
 import io.gravitee.apim.core.member.model.MembershipReferenceType;
 import io.gravitee.apim.core.member.query_service.MemberQueryService;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.exceptions.PrimaryOwnerRemovalException;
+import java.util.List;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 
 @UseCase
@@ -32,6 +39,17 @@ public class DeleteApiProductMemberUseCase {
     public record Output() {}
 
     public Output execute(Input input) {
+        Member member = memberQueryService.getUserMember(MembershipReferenceType.API_PRODUCT, input.apiProductId, input.memberId);
+        if (
+            member != null &&
+            Optional.ofNullable(member.getRoles())
+                .orElse(List.of())
+                .stream()
+                .anyMatch(r -> RoleScope.API_PRODUCT.equals(r.getScope()) && PRIMARY_OWNER.name().equals(r.getName()))
+        ) {
+            throw new PrimaryOwnerRemovalException();
+        }
+
         memberQueryService.deleteReferenceMember(
             MembershipReferenceType.API_PRODUCT,
             input.apiProductId,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/UpdateApiProductMemberUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/members/UpdateApiProductMemberUseCase.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.member.model.MembershipReferenceType;
 import io.gravitee.apim.core.member.model.MembershipRole;
 import io.gravitee.apim.core.member.query_service.MemberQueryService;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.exceptions.PrimaryOwnerRemovalException;
 import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
 import lombok.AllArgsConstructor;
 
@@ -44,11 +45,22 @@ public class UpdateApiProductMemberUseCase {
             throw new SinglePrimaryOwnerException(RoleScope.API_PRODUCT);
         }
 
+        Member userMember = memberQueryService.getUserMember(MembershipReferenceType.API_PRODUCT, input.apiProductId, input.memberId);
+        if (userMember == null || userMember.getRoles() == null || userMember.getRoles().isEmpty()) {
+            return new Output(null);
+        }
+        boolean isPrimaryOwner = userMember
+            .getRoles()
+            .stream()
+            .anyMatch(r -> RoleScope.API_PRODUCT.equals(r.getScope()) && PRIMARY_OWNER.name().equals(r.getName()));
+        if (isPrimaryOwner && !PRIMARY_OWNER.name().equals(input.newRole)) {
+            throw new PrimaryOwnerRemovalException();
+        }
+
         var reference = new MembershipReference(MembershipReferenceType.API_PRODUCT, input.apiProductId);
         var member = MembershipMember.builder().memberId(input.memberId).memberType(MembershipMemberType.USER).build();
         var role = MembershipRole.builder().scope(io.gravitee.apim.core.member.model.RoleScope.API_PRODUCT).name(input.newRole).build();
         Member updatedMember = memberQueryService.updateRoleToMemberOnReference(reference, member, role);
-
         return new Output(updatedMember);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/Group.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/Group.java
@@ -45,6 +45,9 @@ public class Group {
     /** User id that will be the PrimaryOwner of API */
     private String apiPrimaryOwner;
 
+    /** User id that will be the PrimaryOwner of API Product */
+    private String apiProductPrimaryOwner;
+
     @Builder.Default
     private String origin = Origin.MANAGEMENT.name();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/crd/GroupCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/crd/GroupCRDSpec.java
@@ -57,6 +57,7 @@ public class GroupCRDSpec {
             .name(name)
             .environmentId(environmentId)
             .apiPrimaryOwner(null)
+            .apiProductPrimaryOwner(null)
             .eventRules(List.of())
             .lockApiRole(false)
             .lockApplicationRole(false)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerFactory.java
@@ -71,7 +71,7 @@ public class ApiProductPrimaryOwnerFactory {
         var group = groupQueryService
             .findByIds(userGroupIds)
             .stream()
-            .filter(g -> g.getApiPrimaryOwner() != null && !g.getApiPrimaryOwner().isBlank())
+            .filter(g -> g.getApiProductPrimaryOwner() != null && !g.getApiProductPrimaryOwner().isBlank())
             .findFirst();
 
         return group

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
@@ -58,5 +58,6 @@ public interface GroupService {
     boolean isUserAuthorizedToAccessApiData(GenericApiEntity api, List<String> excludedGroups, String username);
     GroupEntity update(ExecutionContext executionContext, String groupId, UpdateGroupEntity group);
     void updateApiPrimaryOwner(String groupId, String newApiPrimaryOwner);
+    void updateApiProductPrimaryOwner(String groupId, String newApiProductPrimaryOwner);
     Set<Group> findAllByEnvironment(String environmentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/NotifierService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/NotifierService.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.rest.api.model.notification.NotifierEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.notification.ApplicationHook;
 import io.gravitee.rest.api.service.notification.PortalHook;
 import java.util.List;
@@ -41,6 +42,7 @@ public interface NotifierService {
         String referenceId,
         Map<String, Object> params
     );
+    void trigger(ExecutionContext executionContext, ApiProductHook hook, String apiProductId, Map<String, Object> params);
     void trigger(ExecutionContext executionContext, final ApplicationHook hook, final String applicationId, Map<String, Object> params);
     void trigger(
         ExecutionContext executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/StillApiProductPrimaryOwnerException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/StillApiProductPrimaryOwnerException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import static java.lang.String.valueOf;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Thrown when a group can remain API Product primary owner for existing API products
+ * but a membership update would remove the API Product PRIMARY_OWNER role from the designated user.
+ */
+public class StillApiProductPrimaryOwnerException extends AbstractManagementException {
+
+    private final long apiProductCount;
+
+    public StillApiProductPrimaryOwnerException(long apiProductCount) {
+        this.apiProductCount = apiProductCount;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return "The group is still primary owner of '" + apiProductCount + "' API products";
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "group.api_product.notDeletable";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("apiProductCount", valueOf(apiProductCount));
+        return parameters;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -1103,6 +1103,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         group.setEnvironmentId(environmentId);
         group.setDisableMembershipNotifications(entity.isDisableMembershipNotifications());
         group.setApiPrimaryOwner(entity.getApiPrimaryOwner());
+        group.setApiProductPrimaryOwner(entity.getApiProductPrimaryOwner());
 
         return group;
     }
@@ -1161,6 +1162,9 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         if (group.getApiPrimaryOwner() != null && !group.getApiPrimaryOwner().isEmpty()) {
             entity.setApiPrimaryOwner(group.getApiPrimaryOwner());
             entity.setPrimaryOwner(true);
+        }
+        if (group.getApiProductPrimaryOwner() != null && !group.getApiProductPrimaryOwner().isEmpty()) {
+            entity.setApiProductPrimaryOwner(group.getApiProductPrimaryOwner());
         }
 
         if (group.getEventRules() != null && !group.getEventRules().isEmpty()) {
@@ -1223,6 +1227,9 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         if (group.getApiPrimaryOwner() != null && !group.getApiPrimaryOwner().isEmpty()) {
             entity.setApiPrimaryOwner(group.getApiPrimaryOwner());
             entity.setPrimaryOwner(true);
+        }
+        if (group.getApiProductPrimaryOwner() != null && !group.getApiProductPrimaryOwner().isEmpty()) {
+            entity.setApiProductPrimaryOwner(group.getApiProductPrimaryOwner());
         }
 
         if (group.getEventRules() != null && !group.getEventRules().isEmpty()) {
@@ -1329,6 +1336,9 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         if (existingGroup.getApiPrimaryOwner() != null && existingGroup.getApiPrimaryOwner().equals(username)) {
             updateApiPrimaryOwner(groupId, username);
         }
+        if (existingGroup.getApiProductPrimaryOwner() != null && existingGroup.getApiProductPrimaryOwner().equals(username)) {
+            updateApiProductPrimaryOwner(groupId, username);
+        }
     }
 
     private RoleEntity getDefaultRole(String groupId, RoleScope scope) {
@@ -1355,6 +1365,17 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         try {
             Group group = groupRepository.findById(groupId).orElseThrow(() -> new GroupNotFoundException(groupId));
             group.setApiPrimaryOwner(newApiPrimaryOwner);
+            groupRepository.update(group);
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException("An error occurs while trying to find or update a group", ex);
+        }
+    }
+
+    @Override
+    public void updateApiProductPrimaryOwner(String groupId, String newApiProductPrimaryOwner) {
+        try {
+            Group group = groupRepository.findById(groupId).orElseThrow(() -> new GroupNotFoundException(groupId));
+            group.setApiProductPrimaryOwner(newApiProductPrimaryOwner);
             groupRepository.update(group);
         } catch (TechnicalException ex) {
             throw new TechnicalManagementException("An error occurs while trying to find or update a group", ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -100,6 +100,7 @@ import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiGroupService;
+import io.gravitee.rest.api.service.v4.ApiProductGroupService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
 import java.time.Instant;
@@ -181,6 +182,8 @@ public class MembershipServiceImpl extends AbstractService implements Membership
     private final ObjectMapper objectMapper;
     private final CommandRepository commandRepository;
 
+    private final ApiProductGroupService apiProductGroupService;
+
     private final ApiMetadataService apiMetadataService;
     private final SearchEngineService searchEngineService;
 
@@ -206,7 +209,8 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         @Autowired ObjectMapper objectMapper,
         @Autowired @Lazy CommandRepository commandRepository,
         @Autowired @Lazy ApiMetadataService apiMetadataService,
-        @Autowired @Lazy SearchEngineService searchEngineService
+        @Autowired @Lazy SearchEngineService searchEngineService,
+        @Autowired @Lazy ApiProductGroupService apiProductGroupService
     ) {
         this.identityService = identityService;
         this.userService = userService;
@@ -230,6 +234,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         this.commandRepository = commandRepository;
         this.apiMetadataService = apiMetadataService;
         this.searchEngineService = searchEngineService;
+        this.apiProductGroupService = apiProductGroupService;
     }
 
     @Override
@@ -782,6 +787,18 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 ) {
                     throw new NotAuthorizedMembershipException(roleEntity.getName());
                 }
+            } else if (roleEntity.getScope() == RoleScope.API_PRODUCT) {
+                if (
+                    !membershipRepository
+                        .findByReferenceAndRoleId(
+                            io.gravitee.repository.management.model.MembershipReferenceType.GROUP,
+                            reference.getId(),
+                            roleEntity.getId()
+                        )
+                        .isEmpty()
+                ) {
+                    throw new NotAuthorizedMembershipException(roleEntity.getName());
+                }
             }
         }
     }
@@ -905,6 +922,20 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                         membership.getMemberId(),
                         executionContext
                     );
+
+                    //if the API Primary owner of a group has been deleted, we must update the apiPrimaryOwnerField of this group
+                    if (
+                        membership.getReferenceType() == io.gravitee.repository.management.model.MembershipReferenceType.GROUP &&
+                        membership.getRoleId().equals(apiPORole.getId())
+                    ) {
+                        groupService.updateApiPrimaryOwner(membership.getReferenceId(), null);
+                    }
+                    if (
+                        membership.getReferenceType() == io.gravitee.repository.management.model.MembershipReferenceType.GROUP &&
+                        membership.getRoleId().equals(apiProductPORole.getId())
+                    ) {
+                        groupService.updateApiProductPrimaryOwner(membership.getReferenceId(), null);
+                    }
                 }
 
                 if (MembershipReferenceType.APPLICATION.equals(referenceType) && MembershipMemberType.USER.equals(memberType)) {
@@ -913,14 +944,6 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                         new MembershipMember(memberId, null, memberType)
                     );
                     applicationAlertService.deleteMemberFromApplication(executionContext, referenceId, userEntity.getEmail());
-                }
-
-                //if the API Primary owner of a group has been deleted, we must update the apiPrimaryOwnerField of this group
-                if (
-                    membership.getReferenceType() == io.gravitee.repository.management.model.MembershipReferenceType.GROUP &&
-                    membership.getRoleId().equals(apiPORole.getId())
-                ) {
-                    groupService.updateApiPrimaryOwner(membership.getReferenceId(), null);
                 }
             }
         } catch (TechnicalException ex) {
@@ -1480,12 +1503,17 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         MembershipEntity primaryOwner = getPrimaryOwner(organizationId, referenceType, referenceId);
         String primaryOwnerId = primaryOwner.getMemberId();
         if (primaryOwner.getMemberType() == MembershipMemberType.GROUP) {
+            Function<GroupEntity, String> poExtractor = referenceType == MembershipReferenceType.API_PRODUCT
+                ? GroupEntity::getApiProductPrimaryOwner
+                : GroupEntity::getApiPrimaryOwner;
             primaryOwnerId = groupService
                 .findByIds(Set.of(primaryOwnerId))
                 .stream()
                 .findFirst()
-                .map(GroupEntity::getApiPrimaryOwner)
-                .orElseThrow(() -> new NoSuchElementException("Can't find ApiPrimaryOwner for group " + primaryOwner.getMemberId()));
+                .map(poExtractor)
+                .orElseThrow(() ->
+                    new NoSuchElementException("Can't find PrimaryOwner for " + referenceType + " group " + primaryOwner.getMemberId())
+                );
         }
 
         return primaryOwnerId;
@@ -1945,9 +1973,12 @@ public class MembershipServiceImpl extends AbstractService implements Membership
             new MembershipRole(roleScope, PRIMARY_OWNER.name())
         );
 
-        // If the new PO is a group and the reference is an API, add the group as a member of the API
-        if (membershipReferenceType == MembershipReferenceType.API && newOwnerMember.getMemberType() == MembershipMemberType.GROUP) {
-            apiGroupService.addGroup(executionContext, itemId, newOwnerMember.getMemberId());
+        if (newOwnerMember.getMemberType() == MembershipMemberType.GROUP) {
+            if (membershipReferenceType == MembershipReferenceType.API) {
+                apiGroupService.addGroup(executionContext, itemId, newOwnerMember.getMemberId());
+            } else if (membershipReferenceType == MembershipReferenceType.API_PRODUCT) {
+                apiProductGroupService.addGroup(executionContext, itemId, newOwnerMember.getMemberId());
+            }
         }
 
         RoleEntity poRoleEntity = roleService.findPrimaryOwnerRoleByOrganization(executionContext.getOrganizationId(), roleScope);
@@ -1993,9 +2024,10 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                     }
                 }
             } else if (previousPrimaryOwner.getMemberType() == MembershipMemberType.GROUP) {
-                // remove this group from the api's group list (only relevant for API references)
                 if (membershipReferenceType == MembershipReferenceType.API) {
                     apiGroupService.removeGroup(executionContext, itemId, previousPrimaryOwner.getMemberId());
+                } else if (membershipReferenceType == MembershipReferenceType.API_PRODUCT) {
+                    apiProductGroupService.removeGroup(executionContext, itemId, previousPrimaryOwner.getMemberId());
                 }
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotifierServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotifierServiceImpl.java
@@ -40,6 +40,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.NotifierNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.notification.ApplicationHook;
 import io.gravitee.rest.api.service.notification.Hook;
 import io.gravitee.rest.api.service.notification.PortalHook;
@@ -159,6 +160,24 @@ public class NotifierServiceImpl extends AbstractService implements NotifierServ
             .hook(hook)
             .referenceType(referenceType)
             .referenceId(referenceId)
+            .params(params)
+            .build();
+        triggerPortalNotifications(executionContext, triggerNotificationsData);
+        triggerGenericNotifications(executionContext, triggerNotificationsData);
+    }
+
+    @Override
+    @Async
+    public void trigger(
+        final ExecutionContext executionContext,
+        final ApiProductHook hook,
+        final String apiProductId,
+        final Map<String, Object> params
+    ) {
+        var triggerNotificationsData = TriggerNotificationsData.builder()
+            .hook(hook)
+            .referenceType(NotificationReferenceType.API_PRODUCT)
+            .referenceId(apiProductId)
             .params(params)
             .build();
         triggerPortalNotifications(executionContext, triggerNotificationsData);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/ApiProductHook.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/ApiProductHook.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.notification;
+
+/**
+ * Notification hooks for API Product–scoped events ({@link HookScope#API_PRODUCT}).
+ * Use these instead of {@link ApiHook} when the reference is an API Product so subscribers
+ * and portal/generic config lookups match the correct {@code HookScope}.
+ *
+ * @author GraviteeSource Team
+ */
+public enum ApiProductHook implements Hook {
+    API_PRODUCT_UPDATED("API Product Updated", "Triggered when an API Product is updated.", "LIFECYCLE");
+
+    private final String label;
+    private final String description;
+    private final String category;
+
+    ApiProductHook(String label, String description, String category) {
+        this.label = label;
+        this.description = description;
+        this.category = category;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public HookScope getScope() {
+        return HookScope.API_PRODUCT;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiProductGroupService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiProductGroupService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4;
+
+import io.gravitee.rest.api.service.common.ExecutionContext;
+
+public interface ApiProductGroupService {
+    void addGroup(ExecutionContext executionContext, String apiProductId, String groupId);
+
+    void removeGroup(ExecutionContext executionContext, String apiProductId, String groupId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiProductNotificationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiProductNotificationService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4;
+
+import io.gravitee.repository.management.model.ApiProduct;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+
+/**
+ * Triggers user-facing and generic notifications for API Product events.
+ *
+ * @author GraviteeSource Team
+ */
+public interface ApiProductNotificationService {
+    void triggerUpdateNotification(ExecutionContext executionContext, ApiProduct apiProduct);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiProductGroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiProductGroupServiceImpl.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiProductsRepository;
+import io.gravitee.repository.management.model.ApiProduct;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.v4.ApiProductGroupService;
+import io.gravitee.rest.api.service.v4.ApiProductNotificationService;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@CustomLog
+@Component
+public class ApiProductGroupServiceImpl implements ApiProductGroupService {
+
+    private final ApiProductsRepository apiProductsRepository;
+    private final ApiProductNotificationService apiProductNotificationService;
+
+    public ApiProductGroupServiceImpl(
+        @Lazy final ApiProductsRepository apiProductsRepository,
+        final ApiProductNotificationService apiProductNotificationService
+    ) {
+        this.apiProductsRepository = apiProductsRepository;
+        this.apiProductNotificationService = apiProductNotificationService;
+    }
+
+    @Override
+    public void addGroup(ExecutionContext executionContext, String apiProductId, String groupId) {
+        try {
+            log.debug("Add group {} to API Product {}", groupId, apiProductId);
+
+            ApiProduct apiProduct = findApiProductInEnvironment(executionContext, apiProductId);
+            if (!apiProduct.addGroup(groupId)) {
+                return;
+            }
+            apiProductsRepository.update(apiProduct);
+            apiProductNotificationService.triggerUpdateNotification(executionContext, apiProduct);
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException(
+                "An error occurs while trying to add group " + groupId + " to API Product " + apiProductId,
+                ex
+            );
+        }
+    }
+
+    @Override
+    public void removeGroup(ExecutionContext executionContext, String apiProductId, String groupId) {
+        try {
+            log.debug("Remove group {} from API Product {}", groupId, apiProductId);
+
+            ApiProduct apiProduct = findApiProductInEnvironment(executionContext, apiProductId);
+            if (apiProduct.getGroups() != null && apiProduct.getGroups().remove(groupId)) {
+                apiProductsRepository.update(apiProduct);
+                apiProductNotificationService.triggerUpdateNotification(executionContext, apiProduct);
+            }
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException(
+                "An error occurs while trying to remove group " + groupId + " from API Product " + apiProductId,
+                ex
+            );
+        }
+    }
+
+    private ApiProduct findApiProductInEnvironment(ExecutionContext executionContext, String apiProductId) throws TechnicalException {
+        Optional<ApiProduct> optProduct = apiProductsRepository.findById(apiProductId);
+
+        if (executionContext.hasEnvironmentId()) {
+            optProduct = optProduct.filter(p -> executionContext.getEnvironmentId().equals(p.getEnvironmentId()));
+        }
+
+        return optProduct.orElseThrow(() -> new ApiProductNotFoundException("API Product not found: " + apiProductId));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiProductNotificationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiProductNotificationServiceImpl.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import io.gravitee.repository.management.model.ApiProduct;
+import io.gravitee.rest.api.idp.api.authentication.UserDetails;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.NotifierService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.impl.AbstractService;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
+import io.gravitee.rest.api.service.notification.ApiProductTemplateModel;
+import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
+import io.gravitee.rest.api.service.v4.ApiProductNotificationService;
+import java.util.NoSuchElementException;
+import lombok.CustomLog;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * Sends API Product update notifications when a user triggers the change: only if the security context has a
+ * non-null, non-system authenticated user. Notification params include that user as {@code user} and an
+ * {@link ApiProductTemplateModel} whose {@link ApiProductTemplateModel#primaryOwner} is filled when the API Product
+ * primary owner can be resolved from membership and user lookup.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Component
+public class ApiProductNotificationServiceImpl extends AbstractService implements ApiProductNotificationService {
+
+    private final NotifierService notifierService;
+    private final MembershipService membershipService;
+    private final UserService userService;
+
+    public ApiProductNotificationServiceImpl(
+        final NotifierService notifierService,
+        final MembershipService membershipService,
+        final UserService userService
+    ) {
+        this.notifierService = notifierService;
+        this.membershipService = membershipService;
+        this.userService = userService;
+    }
+
+    @Override
+    @Async("asyncNotificationThreadPoolTaskExecutor")
+    public void triggerUpdateNotification(final ExecutionContext executionContext, final ApiProduct apiProduct) {
+        triggerNotification(executionContext, apiProduct);
+    }
+
+    private void triggerNotification(final ExecutionContext executionContext, final ApiProduct apiProduct) {
+        UserDetails auth = getAuthenticatedUser();
+        if (auth != null && !auth.isSystem()) {
+            UserEntity userEntity = userService.findById(executionContext, auth.getUsername());
+            PrimaryOwnerEntity primaryOwner = resolvePrimaryOwner(executionContext, apiProduct);
+            ApiProductTemplateModel model = ApiProductTemplateModel.builder()
+                .id(apiProduct.getId())
+                .name(apiProduct.getName())
+                .version(apiProduct.getVersion())
+                .primaryOwner(primaryOwner)
+                .build();
+            notifierService.trigger(
+                executionContext,
+                ApiProductHook.API_PRODUCT_UPDATED,
+                apiProduct.getId(),
+                new NotificationParamsBuilder().apiProduct(model).user(userEntity).build()
+            );
+        }
+    }
+
+    private PrimaryOwnerEntity resolvePrimaryOwner(final ExecutionContext executionContext, final ApiProduct apiProduct) {
+        try {
+            String ownerUserId = membershipService.getPrimaryOwnerUserId(
+                executionContext.getOrganizationId(),
+                MembershipReferenceType.API_PRODUCT,
+                apiProduct.getId()
+            );
+            if (ownerUserId != null) {
+                return new PrimaryOwnerEntity(userService.findById(executionContext, ownerUserId));
+            }
+        } catch (NoSuchElementException e) {
+            log.debug("Could not resolve primary owner for API Product {} notification", apiProduct.getId(), e);
+        }
+        return null;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.api_product.use_case;
 
+import static fixtures.core.model.RoleFixtures.apiProductPrimaryOwnerRoleId;
+import static fixtures.core.model.RoleFixtures.groupAdminRoleId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -50,6 +52,7 @@ import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerFactory;
+import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.node.api.license.LicenseManager;
@@ -92,6 +95,8 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
 
     @BeforeEach
     void setUp() {
+        membershipQueryService.reset();
+        groupQueryService.reset();
         userCrudService.initWith(
             List.of(
                 io.gravitee.apim.core.user.model.BaseUserEntity.builder()
@@ -445,13 +450,13 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
     }
 
     @Test
-    void should_not_attach_group_with_api_primary_owner_set() {
+    void should_not_attach_group_with_api_product_primary_owner_set() {
         groupQueryService.initWith(
             List.of(
                 Group.builder()
                     .id("group-with-po")
                     .environmentId(ENV_ID)
-                    .apiPrimaryOwner("some-user-id")
+                    .apiProductPrimaryOwner("some-user-id")
                     .eventRules(List.of(new Group.GroupEventRule(Group.GroupEvent.API_PRODUCT_CREATE)))
                     .build(),
                 Group.builder()
@@ -467,6 +472,70 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
         var output = createApiProductUseCase.execute(new CreateApiProductUseCase.Input(toCreate, AUDIT_INFO));
 
         assertThat(output.apiProduct().getGroups()).containsExactly("group-no-po");
+    }
+
+    @Test
+    void should_attach_primary_owner_group_when_api_product_primary_owner_mode_is_group() {
+        final String poGroupId = "po-group-id";
+        final String designatedPoUserId = "designated-po-user";
+
+        roleQueryService.resetSystemRoles(ORG_ID);
+        parametersQueryService.initWith(
+            List.of(
+                new Parameter(
+                    Key.API_PRODUCT_PRIMARY_OWNER_MODE.key(),
+                    ENV_ID,
+                    ParameterReferenceType.ENVIRONMENT,
+                    ApiPrimaryOwnerMode.GROUP.name()
+                )
+            )
+        );
+
+        userCrudService.initWith(
+            List.of(
+                io.gravitee.apim.core.user.model.BaseUserEntity.builder()
+                    .id(USER_ID)
+                    .email("user@example.com")
+                    .firstname("Test")
+                    .lastname("User")
+                    .build(),
+                io.gravitee.apim.core.user.model.BaseUserEntity.builder()
+                    .id(designatedPoUserId)
+                    .email("po@example.com")
+                    .firstname("Po")
+                    .lastname("User")
+                    .build()
+            )
+        );
+
+        groupQueryService.initWith(
+            List.of(Group.builder().id(poGroupId).environmentId(ENV_ID).name("PO Group").apiProductPrimaryOwner(designatedPoUserId).build())
+        );
+
+        membershipQueryService.initWith(
+            List.of(
+                Membership.builder()
+                    .referenceType(Membership.ReferenceType.GROUP)
+                    .referenceId(poGroupId)
+                    .memberType(Membership.Type.USER)
+                    .memberId(designatedPoUserId)
+                    .roleId(apiProductPrimaryOwnerRoleId(ORG_ID))
+                    .build(),
+                Membership.builder()
+                    .referenceType(Membership.ReferenceType.GROUP)
+                    .referenceId(poGroupId)
+                    .memberType(Membership.Type.USER)
+                    .memberId(USER_ID)
+                    .roleId(groupAdminRoleId(ORG_ID))
+                    .build()
+            )
+        );
+
+        var toCreate = CreateApiProduct.builder().name("API Product 1").version("1.0.0").description("desc").apiIds(List.of()).build();
+
+        var output = createApiProductUseCase.execute(new CreateApiProductUseCase.Input(toCreate, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getGroups()).contains(poGroupId);
     }
 
     private Api createV4ProxyApi(String id, Boolean allowedInApiProducts) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/TransferApiProductOwnershipUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/TransferApiProductOwnershipUseCaseTest.java
@@ -17,18 +17,30 @@ package io.gravitee.apim.core.api_product.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import inmemory.AbstractUseCaseTest;
 import inmemory.MembershipDomainServiceInMemory;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.member.model.MembershipMemberType;
+import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.membership.model.TransferOwnership;
 import io.gravitee.rest.api.model.MemberEntity;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 class TransferApiProductOwnershipUseCaseTest extends AbstractUseCaseTest {
 
@@ -37,10 +49,26 @@ class TransferApiProductOwnershipUseCaseTest extends AbstractUseCaseTest {
     private TransferApiProductOwnershipUseCase transferApiProductOwnershipUseCase;
     private final MembershipDomainServiceInMemory membershipDomainService = new MembershipDomainServiceInMemory();
 
+    @Mock
+    private ApiProductQueryService apiProductQueryService;
+
+    @Mock
+    private ApiProductIndexerDomainService apiProductIndexerDomainService;
+
+    @Mock
+    private ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
+
     @BeforeEach
     void setUp() {
-        transferApiProductOwnershipUseCase = new TransferApiProductOwnershipUseCase(membershipDomainService);
+        MockitoAnnotations.openMocks(this);
+        transferApiProductOwnershipUseCase = new TransferApiProductOwnershipUseCase(
+            membershipDomainService,
+            apiProductQueryService,
+            apiProductIndexerDomainService,
+            apiProductPrimaryOwnerDomainService
+        );
         initData();
+        stubApiProductInIndex();
     }
 
     @Test
@@ -53,7 +81,8 @@ class TransferApiProductOwnershipUseCaseTest extends AbstractUseCaseTest {
         transferApiProductOwnershipUseCase.execute(
             new TransferApiProductOwnershipUseCase.Input(
                 TransferOwnership.builder().currentPrimaryOwnerNewRole("USER").newPrimaryOwnerId("user-2").build(),
-                API_PRODUCT_ID
+                API_PRODUCT_ID,
+                AUDIT_INFO
             )
         );
 
@@ -61,6 +90,7 @@ class TransferApiProductOwnershipUseCaseTest extends AbstractUseCaseTest {
             () -> assertThat(currentRoleOf("user-1")).isEqualTo("USER"),
             () -> assertThat(currentRoleOf("user-2")).isEqualTo("PRIMARY_OWNER")
         );
+        verify(apiProductIndexerDomainService).index(any(ApiProductIndexerDomainService.Context.class), any(ApiProduct.class), any());
     }
 
     @Test
@@ -70,7 +100,8 @@ class TransferApiProductOwnershipUseCaseTest extends AbstractUseCaseTest {
         transferApiProductOwnershipUseCase.execute(
             new TransferApiProductOwnershipUseCase.Input(
                 TransferOwnership.builder().currentPrimaryOwnerNewRole("OWNER").newPrimaryOwnerId("user-new").build(),
-                API_PRODUCT_ID
+                API_PRODUCT_ID,
+                AUDIT_INFO
             )
         );
 
@@ -78,6 +109,7 @@ class TransferApiProductOwnershipUseCaseTest extends AbstractUseCaseTest {
             () -> assertThat(currentRoleOf("user-1")).isEqualTo("OWNER"),
             () -> assertThat(currentRoleOf("user-new")).isEqualTo("PRIMARY_OWNER")
         );
+        verify(apiProductIndexerDomainService).index(any(ApiProductIndexerDomainService.Context.class), any(ApiProduct.class), any());
     }
 
     @Test
@@ -91,7 +123,8 @@ class TransferApiProductOwnershipUseCaseTest extends AbstractUseCaseTest {
                     .newPrimaryOwnerId("group-1")
                     .memberType(MembershipMemberType.GROUP)
                     .build(),
-                API_PRODUCT_ID
+                API_PRODUCT_ID,
+                AUDIT_INFO
             )
         );
 
@@ -100,9 +133,43 @@ class TransferApiProductOwnershipUseCaseTest extends AbstractUseCaseTest {
             () -> assertThat(currentRoleOf("group-1")).isEqualTo("PRIMARY_OWNER"),
             () -> assertThat(memberTypeOf("group-1")).isEqualTo(io.gravitee.rest.api.model.MembershipMemberType.GROUP)
         );
+        verify(apiProductIndexerDomainService).index(any(ApiProductIndexerDomainService.Context.class), any(ApiProduct.class), any());
+    }
+
+    @Test
+    void should_reindex_with_resolved_primary_owner_after_transfer() {
+        var newPo = PrimaryOwnerEntity.builder()
+            .id("user-2")
+            .displayName("User Two")
+            .email("u2@example.com")
+            .type(PrimaryOwnerEntity.Type.USER)
+            .build();
+        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(ORG_ID, API_PRODUCT_ID)).thenReturn(newPo);
+
+        transferApiProductOwnershipUseCase.execute(
+            new TransferApiProductOwnershipUseCase.Input(
+                TransferOwnership.builder().currentPrimaryOwnerNewRole("USER").newPrimaryOwnerId("user-2").build(),
+                API_PRODUCT_ID,
+                AUDIT_INFO
+            )
+        );
+
+        verify(apiProductIndexerDomainService).index(
+            any(ApiProductIndexerDomainService.Context.class),
+            eq(ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENV_ID).name("product-under-test").build()),
+            eq(newPo)
+        );
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
+
+    private void stubApiProductInIndex() {
+        var product = ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENV_ID).name("product-under-test").build();
+        when(apiProductQueryService.findById(API_PRODUCT_ID)).thenReturn(Optional.of(product));
+        when(apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(ORG_ID, API_PRODUCT_ID)).thenReturn(
+            PrimaryOwnerEntity.builder().id("user-1").displayName("User One").type(PrimaryOwnerEntity.Type.USER).build()
+        );
+    }
 
     private String currentRoleOf(String userId) {
         var member = membershipDomainService

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/DeleteApiProductMemberUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/DeleteApiProductMemberUseCaseTest.java
@@ -15,12 +15,16 @@
  */
 package io.gravitee.apim.core.api_product.use_case.members;
 
+import static io.gravitee.rest.api.model.permissions.SystemRole.PRIMARY_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import inmemory.MemberQueryServiceInMemory;
 import io.gravitee.apim.core.member.model.Member;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.exceptions.PrimaryOwnerRemovalException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,10 +42,24 @@ class DeleteApiProductMemberUseCaseTest {
 
     @Test
     void should_delete_member() {
-        assertThat(memberQueryService.storage()).hasSize(3);
+        assertThat(memberQueryService.storage()).hasSize(4);
         deleteApiProductMemberUseCase.execute(new DeleteApiProductMemberUseCase.Input("ap-1", "member-1"));
-        assertThat(memberQueryService.storage()).hasSize(2);
-        assertThat(memberQueryService.storage()).map(Member::getId).containsExactlyInAnyOrder("member-2", "member-3");
+        assertThat(memberQueryService.storage()).hasSize(3);
+        assertThat(memberQueryService.storage()).map(Member::getId).containsExactlyInAnyOrder("member-2", "member-3", "primary-owner");
+    }
+
+    @Test
+    void should_complete_without_error_when_member_unknown() {
+        deleteApiProductMemberUseCase.execute(new DeleteApiProductMemberUseCase.Input("ap-1", "member-unknown"));
+        assertThat(memberQueryService.storage()).hasSize(4);
+    }
+
+    @Test
+    void should_throw_exception_when_deleting_primary_owner() {
+        assertThatThrownBy(() ->
+            deleteApiProductMemberUseCase.execute(new DeleteApiProductMemberUseCase.Input("ap-1", "primary-owner"))
+        ).isInstanceOf(PrimaryOwnerRemovalException.class);
+        assertThat(memberQueryService.storage()).hasSize(4);
     }
 
     private void initMembers() {
@@ -67,6 +85,13 @@ class DeleteApiProductMemberUseCaseTest {
                     .referenceId("ap-1")
                     .type(MembershipMemberType.USER)
                     .roles(List.of())
+                    .build(),
+                Member.builder()
+                    .id("primary-owner")
+                    .referenceType(MembershipReferenceType.API_PRODUCT)
+                    .referenceId("ap-1")
+                    .type(MembershipMemberType.USER)
+                    .roles(List.of(Member.Role.builder().name(PRIMARY_OWNER.name()).scope(RoleScope.API_PRODUCT).build()))
                     .build()
             )
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/UpdateApiProductMemberUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/members/UpdateApiProductMemberUseCaseTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.api_product.use_case.members;
 
+import static io.gravitee.rest.api.model.permissions.SystemRole.PRIMARY_OWNER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -23,6 +24,7 @@ import io.gravitee.apim.core.member.model.Member;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.exceptions.PrimaryOwnerRemovalException;
 import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +60,22 @@ class UpdateApiProductMemberUseCaseTest {
         ).isInstanceOf(SinglePrimaryOwnerException.class);
     }
 
+    @Test
+    void should_throw_exception_when_downgrading_primary_owner() {
+        assertThatThrownBy(() ->
+            updateApiProductMemberUseCase.execute(new UpdateApiProductMemberUseCase.Input("API_PRODUCT_USER", "primary-owner", "ap-1"))
+        ).isInstanceOf(PrimaryOwnerRemovalException.class);
+    }
+
+    @Test
+    void should_return_null_when_member_unknown() {
+        var output = updateApiProductMemberUseCase.execute(
+            new UpdateApiProductMemberUseCase.Input("API_PRODUCT_USER", "member-unknown", "ap-1")
+        );
+
+        assertThat(output.updatedMember()).isNull();
+    }
+
     private void initMembers() {
         List<Member> members = List.of(
             Member.builder()
@@ -65,7 +83,14 @@ class UpdateApiProductMemberUseCaseTest {
                 .referenceId("ap-1")
                 .type(MembershipMemberType.USER)
                 .id("member-1")
-                .roles(List.of(Member.Role.builder().name("OWNER").build()))
+                .roles(List.of(Member.Role.builder().name("OWNER").scope(RoleScope.API_PRODUCT).build()))
+                .build(),
+            Member.builder()
+                .referenceType(MembershipReferenceType.API_PRODUCT)
+                .referenceId("ap-1")
+                .type(MembershipMemberType.USER)
+                .id("primary-owner")
+                .roles(List.of(Member.Role.builder().name(PRIMARY_OWNER.name()).scope(RoleScope.API_PRODUCT).build()))
                 .build()
         );
         memberQueryService.initWith(members);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/membership/domain_service/ApiProductPrimaryOwnerFactoryTest.java
@@ -124,7 +124,7 @@ class ApiProductPrimaryOwnerFactoryTest {
         @Test
         void should_build_a_group_primary_owner_with_the_1st_group_having_primary_owner() {
             // Given
-            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("My Group").apiPrimaryOwner(MEMBER_ID).build()));
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("My Group").apiProductPrimaryOwner(MEMBER_ID).build()));
             givenExistingMemberships(
                 List.of(
                     // PO role for member-id
@@ -182,7 +182,7 @@ class ApiProductPrimaryOwnerFactoryTest {
         void should_throw_when_primary_owner_role_does_not_exist_for_organization() {
             // Given
             roleQueryService.reset();
-            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("My Group").apiPrimaryOwner(MEMBER_ID).build()));
+            givenExistingGroup(List.of(Group.builder().id(GROUP_ID).name("My Group").apiProductPrimaryOwner(MEMBER_ID).build()));
             givenExistingMemberships(
                 List.of(
                     // PO role for member-id

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/group/GroupQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/group/GroupQueryServiceImplTest.java
@@ -81,6 +81,7 @@ class GroupQueryServiceImplTest {
                     .emailInvitation(true)
                     .disableMembershipNotifications(true)
                     .apiPrimaryOwner("api-po-id")
+                    .apiProductPrimaryOwner("api-product-po-id")
                     .build()
             );
         }
@@ -153,6 +154,7 @@ class GroupQueryServiceImplTest {
                         .emailInvitation(true)
                         .disableMembershipNotifications(true)
                         .apiPrimaryOwner("api-po-id")
+                        .apiProductPrimaryOwner("api-product-po-id")
                         .build()
                 );
         }
@@ -222,6 +224,7 @@ class GroupQueryServiceImplTest {
                         .emailInvitation(true)
                         .disableMembershipNotifications(true)
                         .apiPrimaryOwner("api-po-id")
+                        .apiProductPrimaryOwner("api-product-po-id")
                         .build()
                 );
         }
@@ -271,6 +274,7 @@ class GroupQueryServiceImplTest {
                         .emailInvitation(true)
                         .disableMembershipNotifications(true)
                         .apiPrimaryOwner("api-po-id")
+                        .apiProductPrimaryOwner("api-product-po-id")
                         .origin("MANAGEMENT")
                         .build()
                 );
@@ -292,6 +296,7 @@ class GroupQueryServiceImplTest {
             .emailInvitation(true)
             .disableMembershipNotifications(true)
             .apiPrimaryOwner("api-po-id")
+            .apiProductPrimaryOwner("api-product-po-id")
             .origin("MANAGEMENT");
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupServiceImplTest.java
@@ -385,4 +385,31 @@ public class GroupServiceImplTest {
             StillPrimaryOwnerException.class
         );
     }
+
+    @Test
+    public void update_api_product_primary_owner_should_set_field_on_group() throws Exception {
+        String groupId = "group-1";
+        String newPrimaryOwner = "user-po-1";
+
+        Group group = Group.builder().id(groupId).build();
+        when(groupRepository.findById(groupId)).thenReturn(Optional.of(group));
+
+        service.updateApiProductPrimaryOwner(groupId, newPrimaryOwner);
+
+        assertThat(group.getApiProductPrimaryOwner()).isEqualTo(newPrimaryOwner);
+        verify(groupRepository).update(group);
+    }
+
+    @Test
+    public void update_api_product_primary_owner_should_clear_field_with_null() throws Exception {
+        String groupId = "group-1";
+
+        Group group = Group.builder().id(groupId).apiProductPrimaryOwner("old-user").build();
+        when(groupRepository.findById(groupId)).thenReturn(Optional.of(group));
+
+        service.updateApiProductPrimaryOwner(groupId, null);
+
+        assertThat(group.getApiProductPrimaryOwner()).isNull();
+        verify(groupRepository).update(group);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_AddRoleToMemberOnReferenceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_AddRoleToMemberOnReferenceTest.java
@@ -137,6 +137,7 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
             objectMapper,
             commandRepository,
             null,
+            null,
             null
         );
     }
@@ -493,6 +494,28 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
                 new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
                 new MembershipService.MembershipMember("xxxxx", null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.APPLICATION, "PRIMARY_OWNER")
+            )
+        ).isInstanceOf(NotAuthorizedMembershipException.class);
+    }
+
+    @Test
+    public void shouldDisallowAddApiProductPrimaryOwnerRoleOnGroupIfAlreadyOnePrimaryOwner() throws Exception {
+        RoleEntity role = RoleEntity.builder().id("API_PRODUCT_PRIMARY_OWNER").name("PRIMARY_OWNER").scope(RoleScope.API_PRODUCT).build();
+        when(roleService.findByScopeAndName(any(), any(), any())).thenReturn(Optional.of(role));
+        when(
+            membershipRepository.findByReferenceAndRoleId(
+                io.gravitee.repository.management.model.MembershipReferenceType.GROUP,
+                GROUP_ID,
+                "API_PRODUCT_PRIMARY_OWNER"
+            )
+        ).thenReturn(Collections.singleton(mock(Membership.class)));
+
+        assertThatThrownBy(() ->
+            membershipService.addRoleToMemberOnReference(
+                GraviteeContext.getExecutionContext(),
+                new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
+                new MembershipService.MembershipMember("xxxxx", null, MembershipMemberType.USER),
+                new MembershipService.MembershipRole(RoleScope.API_PRODUCT, "PRIMARY_OWNER")
             )
         ).isInstanceOf(NotAuthorizedMembershipException.class);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiProductTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiProductTest.java
@@ -124,6 +124,7 @@ class MembershipService_CreateNewMembershipForApiProductTest {
             objectMapper,
             commandRepository,
             null,
+            null,
             null
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiTest.java
@@ -130,6 +130,7 @@ public class MembershipService_CreateNewMembershipForApiTest {
             objectMapper,
             commandRepository,
             null,
+            null,
             null
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
@@ -86,6 +86,7 @@ public class MembershipService_DeleteMemberTest {
             null,
             null,
             null,
+            null,
             null
         );
         when(roleService.findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
@@ -86,6 +86,7 @@ public class MembershipService_EditMemberTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipMetadataTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipMetadataTest.java
@@ -97,6 +97,7 @@ public class MembershipService_FindUserMembershipMetadataTest {
             null,
             null,
             null,
+            null,
             null
         );
         USER_MEMBERSHIP = new UserMembership();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipTest.java
@@ -107,6 +107,7 @@ public class MembershipService_FindUserMembershipTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMemberPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMemberPermissionsTest.java
@@ -111,6 +111,7 @@ public class MembershipService_GetMemberPermissionsTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembersTest.java
@@ -87,6 +87,7 @@ public class MembershipService_GetMembersTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembershipsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembershipsTest.java
@@ -72,6 +72,7 @@ public class MembershipService_GetMembershipsTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberPermissionsTest.java
@@ -80,6 +80,7 @@ public class MembershipService_GetUserMemberPermissionsTest {
             objectMapper,
             commandRepository,
             null,
+            null,
             null
         );
         membershipService = spy(membershipService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberTest.java
@@ -78,6 +78,7 @@ public class MembershipService_GetUserMemberTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_IntegrationMembershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_IntegrationMembershipTest.java
@@ -148,6 +148,7 @@ public class MembershipService_IntegrationMembershipTest {
             objectMapper,
             commandRepository,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_InvalidateCacheForRoleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_InvalidateCacheForRoleTest.java
@@ -72,6 +72,7 @@ public class MembershipService_InvalidateCacheForRoleTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_TransferOwnershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_TransferOwnershipTest.java
@@ -52,6 +52,7 @@ import io.gravitee.rest.api.service.exceptions.ApiOwnershipTransferException;
 import io.gravitee.rest.api.service.exceptions.RoleNotFoundException;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiGroupService;
+import io.gravitee.rest.api.service.v4.ApiProductGroupService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import java.util.Collections;
 import java.util.List;
@@ -125,6 +126,9 @@ public class MembershipService_TransferOwnershipTest {
     @Mock
     private GroupService groupService;
 
+    @Mock
+    private ApiProductGroupService apiProductGroupService;
+
     @BeforeEach
     public void setUp() throws TechnicalException {
         membershipService = new MembershipServiceImpl(
@@ -149,7 +153,8 @@ public class MembershipService_TransferOwnershipTest {
             objectMapper,
             commandRepository,
             apiMetadataService,
-            searchEngineService
+            searchEngineService,
+            apiProductGroupService
         );
         newPrimaryOwnerRole.setId(USER_ROLE_ID);
         newPrimaryOwnerRole.setName(USER_ROLE_NAME);
@@ -408,7 +413,7 @@ public class MembershipService_TransferOwnershipTest {
     }
 
     @Test
-    public void shouldNotRemoveGroupFromApiProductWhenTransferringOwnershipFromGroup() throws TechnicalException {
+    public void should_remove_group_from_api_product_when_transferring_ownership_from_group() throws TechnicalException {
         String apiProductId = "api-product-id-1";
         String apiProductPoRoleId = "API_PRODUCT_PRIMARY_OWNER";
 
@@ -425,7 +430,6 @@ public class MembershipService_TransferOwnershipTest {
             .when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID))
             .thenReturn(Optional.of(poRole));
 
-        // Group is the current primary owner of the API Product
         Membership groupPoMembership = new Membership();
         groupPoMembership.setId("ap-membership-id-1");
         groupPoMembership.setReferenceType(MembershipReferenceType.API_PRODUCT);
@@ -437,7 +441,6 @@ public class MembershipService_TransferOwnershipTest {
         lenient()
             .when(membershipRepository.findByReferenceAndRoleId(MembershipReferenceType.API_PRODUCT, apiProductId, apiProductPoRoleId))
             .thenReturn(Set.of(groupPoMembership));
-        // Allow repository lookups for role assignment/removal to return empty (no pre-existing roles)
         lenient()
             .when(
                 membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceIdAndRoleId(any(), any(), any(), any(), any())
@@ -458,8 +461,59 @@ public class MembershipService_TransferOwnershipTest {
             List.of(fallbackRole)
         );
 
-        // removeGroup must NOT be called for API_PRODUCT — only API references trigger the group cleanup
         verify(apiGroupService, never()).removeGroup(any(), any(), any());
+        verify(apiProductGroupService).removeGroup(EXECUTION_CONTEXT, apiProductId, GROUP_ID);
+    }
+
+    @Test
+    public void should_add_group_to_api_product_when_transferring_ownership_to_group() throws TechnicalException {
+        String apiProductId = "api-product-id-1";
+        String apiProductPoRoleId = "API_PRODUCT_PRIMARY_OWNER";
+
+        RoleEntity poRole = new RoleEntity();
+        poRole.setId(apiProductPoRoleId);
+        poRole.setScope(RoleScope.API_PRODUCT);
+        poRole.setName(SystemRole.PRIMARY_OWNER.name());
+
+        lenient()
+            .when(roleService.findScopeByMembershipReferenceType(io.gravitee.rest.api.model.MembershipReferenceType.API_PRODUCT))
+            .thenReturn(RoleScope.API_PRODUCT);
+        lenient().when(roleService.findPrimaryOwnerRoleByOrganization(ORGANIZATION_ID, RoleScope.API_PRODUCT)).thenReturn(poRole);
+        lenient()
+            .when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID))
+            .thenReturn(Optional.of(poRole));
+
+        Membership userPoMembership = new Membership();
+        userPoMembership.setReferenceType(MembershipReferenceType.API_PRODUCT);
+        userPoMembership.setRoleId(apiProductPoRoleId);
+        userPoMembership.setReferenceId(apiProductId);
+        userPoMembership.setMemberId(USER_ID);
+        userPoMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.USER);
+
+        when(
+            membershipRepository.findByReferenceAndRoleId(MembershipReferenceType.API_PRODUCT, apiProductId, apiProductPoRoleId)
+        ).thenReturn(Set.of(userPoMembership));
+
+        RoleEntity fallbackRole = new RoleEntity();
+        fallbackRole.setId("API_PRODUCT_USER");
+        fallbackRole.setName("USER");
+        fallbackRole.setScope(RoleScope.API_PRODUCT);
+
+        lenient()
+            .when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, USER_ROLE_NAME, ORGANIZATION_ID))
+            .thenReturn(Optional.of(fallbackRole));
+
+        membershipService.transferOwnership(
+            EXECUTION_CONTEXT,
+            io.gravitee.rest.api.model.MembershipReferenceType.API_PRODUCT,
+            RoleScope.API_PRODUCT,
+            apiProductId,
+            new MembershipService.MembershipMember(GROUP_ID, null, MembershipMemberType.GROUP),
+            List.of(fallbackRole)
+        );
+
+        verify(apiGroupService, never()).addGroup(any(), any(), any());
+        verify(apiProductGroupService).addGroup(EXECUTION_CONTEXT, apiProductId, GROUP_ID);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
@@ -116,6 +116,7 @@ public class MembershipService_UpdateMembershipForApiTest {
             objectMapper,
             commandRepository,
             null,
+            null,
             null
         );
         mockApi();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/NotifierServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/NotifierServiceImplTest.java
@@ -29,6 +29,9 @@ import io.gravitee.repository.management.api.GenericNotificationConfigRepository
 import io.gravitee.repository.management.api.PortalNotificationConfigRepository;
 import io.gravitee.repository.management.model.GenericNotificationConfig;
 import io.gravitee.repository.management.model.NotificationReferenceType;
+import io.gravitee.repository.management.model.PortalNotificationConfig;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.EmailRecipientsService;
@@ -37,6 +40,8 @@ import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.PortalNotificationService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
+import io.gravitee.rest.api.service.notification.PortalHook;
 import io.gravitee.rest.api.service.notifiers.EmailNotifierService;
 import io.gravitee.rest.api.service.notifiers.WebhookNotifierService;
 import java.util.*;
@@ -280,6 +285,247 @@ class NotifierServiceImplTest {
 
             verifyNoInteractions(emailNotifierService);
             verifyNoInteractions(webhookNotifierService);
+        }
+    }
+
+    @Nested
+    class TriggerWebhook {
+
+        @Test
+        @SneakyThrows
+        void should_trigger_webhook_notifier() {
+            final Map<String, Object> params = Map.of("key", "value");
+            final ExecutionContext executionContext = new ExecutionContext();
+
+            GenericNotificationConfig webhookConfig = GenericNotificationConfig.builder()
+                .notifier("default-webhook")
+                .id("wh-1")
+                .config("{\"url\":\"https://hooks.example.com/notify\"}")
+                .build();
+
+            when(
+                genericNotificationConfigRepository.findByReferenceAndHook(
+                    ApiHook.API_STARTED.name(),
+                    NotificationReferenceType.API,
+                    "api-id"
+                )
+            ).thenReturn(List.of(webhookConfig));
+
+            when(emailRecipientsService.processTemplatedRecipients(eq(Collections.emptyList()), eq(params))).thenReturn(
+                Collections.emptySet()
+            );
+            when(parameterService.findAsBoolean(executionContext, Key.TRIAL_INSTANCE, ParameterReferenceType.SYSTEM)).thenReturn(false);
+
+            cut.triggerGenericNotifications(
+                executionContext,
+                NotifierServiceImpl.TriggerNotificationsData.builder()
+                    .hook(ApiHook.API_STARTED)
+                    .referenceType(NotificationReferenceType.API)
+                    .referenceId("api-id")
+                    .params(params)
+                    .build()
+            );
+
+            verify(webhookNotifierService).trigger(eq(ApiHook.API_STARTED), eq(webhookConfig), eq(params));
+            verify(emailNotifierService).trigger(
+                eq(executionContext),
+                eq(ApiHook.API_STARTED),
+                eq(params),
+                argThat(c -> c != null && c.isEmpty())
+            );
+        }
+    }
+
+    @Nested
+    class TriggerPortal {
+
+        @Test
+        @SneakyThrows
+        void should_deliver_portal_notifications_for_environment_scoped_hook() {
+            final Map<String, Object> params = Map.of();
+            final ExecutionContext executionContext = new ExecutionContext("org-1", "env-1");
+
+            PortalNotificationConfig portalCfg = PortalNotificationConfig.builder()
+                .user("user-direct")
+                .referenceType(NotificationReferenceType.ENVIRONMENT)
+                .referenceId("env-1")
+                .build();
+
+            when(
+                portalNotificationConfigRepository.findByReferenceAndHook(
+                    PortalHook.GROUP_INVITATION.name(),
+                    NotificationReferenceType.ENVIRONMENT,
+                    "env-1"
+                )
+            ).thenReturn(List.of(portalCfg));
+
+            when(
+                genericNotificationConfigRepository.findByReferenceAndHook(
+                    PortalHook.GROUP_INVITATION.name(),
+                    NotificationReferenceType.ENVIRONMENT,
+                    "env-1"
+                )
+            ).thenReturn(Collections.emptyList());
+
+            cut.trigger(executionContext, PortalHook.GROUP_INVITATION, params);
+
+            verify(portalNotificationService).create(
+                eq(executionContext),
+                eq(PortalHook.GROUP_INVITATION),
+                argThat(users -> users.equals(List.of("user-direct"))),
+                eq(params)
+            );
+        }
+
+        @Test
+        @SneakyThrows
+        void should_deliver_portal_notifications_for_organization_scoped_hook() {
+            final Map<String, Object> params = Map.of();
+            final ExecutionContext executionContext = new ExecutionContext("org-1");
+
+            PortalNotificationConfig portalCfg = PortalNotificationConfig.builder().user("org-user").build();
+
+            when(portalNotificationConfigRepository.findByHookAndOrganizationId(PortalHook.USER_REGISTERED.name(), "org-1")).thenReturn(
+                List.of(portalCfg)
+            );
+
+            when(genericNotificationConfigRepository.findByHookAndOrganizationId(PortalHook.USER_REGISTERED.name(), "org-1")).thenReturn(
+                Collections.emptyList()
+            );
+
+            cut.trigger(executionContext, PortalHook.USER_REGISTERED, params);
+
+            verify(portalNotificationService).create(
+                eq(executionContext),
+                eq(PortalHook.USER_REGISTERED),
+                argThat(users -> users.equals(List.of("org-user"))),
+                eq(params)
+            );
+        }
+
+        @Test
+        @SneakyThrows
+        void should_include_group_members_in_portal_notification_recipients() {
+            final Map<String, Object> params = Map.of();
+            final ExecutionContext executionContext = new ExecutionContext("org-1", "env-1");
+
+            PortalNotificationConfig portalCfg = PortalNotificationConfig.builder()
+                .user("user-direct")
+                .groups(Set.of("group-a"))
+                .referenceType(NotificationReferenceType.ENVIRONMENT)
+                .referenceId("env-1")
+                .build();
+
+            when(
+                portalNotificationConfigRepository.findByReferenceAndHook(
+                    PortalHook.GROUP_INVITATION.name(),
+                    NotificationReferenceType.ENVIRONMENT,
+                    "env-1"
+                )
+            ).thenReturn(List.of(portalCfg));
+
+            when(
+                genericNotificationConfigRepository.findByReferenceAndHook(
+                    PortalHook.GROUP_INVITATION.name(),
+                    NotificationReferenceType.ENVIRONMENT,
+                    "env-1"
+                )
+            ).thenReturn(Collections.emptyList());
+
+            MemberEntity fromGroup = new MemberEntity();
+            fromGroup.setId("user-from-group");
+            when(
+                membershipService.getMembersByReferencesAndRole(executionContext, MembershipReferenceType.GROUP, List.of("group-a"), null)
+            ).thenReturn(Set.of(fromGroup));
+
+            cut.trigger(executionContext, PortalHook.GROUP_INVITATION, params);
+
+            verify(portalNotificationService).create(
+                eq(executionContext),
+                eq(PortalHook.GROUP_INVITATION),
+                argThat(users -> new HashSet<>(users).equals(Set.of("user-direct", "user-from-group"))),
+                eq(params)
+            );
+        }
+    }
+
+    @Nested
+    class TriggerApiHookWithReference {
+
+        @Test
+        @SneakyThrows
+        void should_lookup_configs_when_api_hook_targets_api_product_reference() {
+            final Map<String, Object> params = Map.of();
+            final ExecutionContext executionContext = new ExecutionContext("org-1", "env-1");
+
+            when(
+                portalNotificationConfigRepository.findByReferenceAndHook(
+                    ApiHook.API_UPDATED.name(),
+                    NotificationReferenceType.API_PRODUCT,
+                    "product-1"
+                )
+            ).thenReturn(Collections.emptyList());
+
+            when(
+                genericNotificationConfigRepository.findByReferenceAndHook(
+                    ApiHook.API_UPDATED.name(),
+                    NotificationReferenceType.API_PRODUCT,
+                    "product-1"
+                )
+            ).thenReturn(Collections.emptyList());
+
+            cut.trigger(executionContext, ApiHook.API_UPDATED, NotificationReferenceType.API_PRODUCT, "product-1", params);
+
+            verify(genericNotificationConfigRepository).findByReferenceAndHook(
+                ApiHook.API_UPDATED.name(),
+                NotificationReferenceType.API_PRODUCT,
+                "product-1"
+            );
+            verify(portalNotificationConfigRepository).findByReferenceAndHook(
+                ApiHook.API_UPDATED.name(),
+                NotificationReferenceType.API_PRODUCT,
+                "product-1"
+            );
+        }
+    }
+
+    @Nested
+    class TriggerApiProductHook {
+
+        @Test
+        @SneakyThrows
+        void should_lookup_configs_for_api_product_hook() {
+            final Map<String, Object> params = Map.of();
+            final ExecutionContext executionContext = new ExecutionContext("org-1", "env-1");
+
+            when(
+                portalNotificationConfigRepository.findByReferenceAndHook(
+                    ApiProductHook.API_PRODUCT_UPDATED.name(),
+                    NotificationReferenceType.API_PRODUCT,
+                    "product-1"
+                )
+            ).thenReturn(Collections.emptyList());
+
+            when(
+                genericNotificationConfigRepository.findByReferenceAndHook(
+                    ApiProductHook.API_PRODUCT_UPDATED.name(),
+                    NotificationReferenceType.API_PRODUCT,
+                    "product-1"
+                )
+            ).thenReturn(Collections.emptyList());
+
+            cut.trigger(executionContext, ApiProductHook.API_PRODUCT_UPDATED, "product-1", params);
+
+            verify(genericNotificationConfigRepository).findByReferenceAndHook(
+                ApiProductHook.API_PRODUCT_UPDATED.name(),
+                NotificationReferenceType.API_PRODUCT,
+                "product-1"
+            );
+            verify(portalNotificationConfigRepository).findByReferenceAndHook(
+                ApiProductHook.API_PRODUCT_UPDATED.name(),
+                NotificationReferenceType.API_PRODUCT,
+                "product-1"
+            );
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductGroupServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductGroupServiceImplTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiProductsRepository;
+import io.gravitee.repository.management.model.ApiProduct;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.v4.ApiProductNotificationService;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ApiProductGroupServiceImplTest {
+
+    private static final String ORGANIZATION_ID = "org-1";
+    private static final String ENVIRONMENT_ID = "env-1";
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+
+    @InjectMocks
+    private ApiProductGroupServiceImpl service;
+
+    @Mock
+    private ApiProductsRepository apiProductsRepository;
+
+    @Mock
+    private ApiProductNotificationService apiProductNotificationService;
+
+    @Test
+    void should_add_group_to_api_product() throws TechnicalException {
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("api-product-1");
+        apiProduct.setEnvironmentId(ENVIRONMENT_ID);
+
+        when(apiProductsRepository.findById("api-product-1")).thenReturn(Optional.of(apiProduct));
+
+        service.addGroup(EXECUTION_CONTEXT, "api-product-1", "group-1");
+
+        assertThat(apiProduct.getGroups()).contains("group-1");
+        verify(apiProductsRepository).update(apiProduct);
+        verify(apiProductNotificationService).triggerUpdateNotification(EXECUTION_CONTEXT, apiProduct);
+    }
+
+    @Test
+    void should_add_group_to_api_product_with_existing_groups() throws TechnicalException {
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("api-product-1");
+        apiProduct.setEnvironmentId(ENVIRONMENT_ID);
+        apiProduct.setGroups(new HashSet<>(Set.of("existing-group")));
+
+        when(apiProductsRepository.findById("api-product-1")).thenReturn(Optional.of(apiProduct));
+
+        service.addGroup(EXECUTION_CONTEXT, "api-product-1", "group-1");
+
+        assertThat(apiProduct.getGroups()).containsExactlyInAnyOrder("existing-group", "group-1");
+        verify(apiProductsRepository).update(apiProduct);
+        verify(apiProductNotificationService).triggerUpdateNotification(EXECUTION_CONTEXT, apiProduct);
+    }
+
+    @Test
+    void should_not_update_or_notify_when_adding_already_associated_group() throws TechnicalException {
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("api-product-1");
+        apiProduct.setEnvironmentId(ENVIRONMENT_ID);
+        apiProduct.setGroups(new HashSet<>(Set.of("group-1")));
+
+        when(apiProductsRepository.findById("api-product-1")).thenReturn(Optional.of(apiProduct));
+
+        service.addGroup(EXECUTION_CONTEXT, "api-product-1", "group-1");
+
+        verify(apiProductsRepository, never()).update(same(apiProduct));
+        verify(apiProductNotificationService, never()).triggerUpdateNotification(any(), any());
+    }
+
+    @Test
+    void should_remove_group_from_api_product() throws TechnicalException {
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("api-product-1");
+        apiProduct.setEnvironmentId(ENVIRONMENT_ID);
+        apiProduct.setGroups(new HashSet<>(Set.of("group-1", "group-2")));
+
+        when(apiProductsRepository.findById("api-product-1")).thenReturn(Optional.of(apiProduct));
+
+        service.removeGroup(EXECUTION_CONTEXT, "api-product-1", "group-1");
+
+        assertThat(apiProduct.getGroups()).containsExactly("group-2");
+        verify(apiProductsRepository).update(apiProduct);
+        verify(apiProductNotificationService).triggerUpdateNotification(EXECUTION_CONTEXT, apiProduct);
+    }
+
+    @Test
+    void should_not_update_when_group_not_in_set() throws TechnicalException {
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("api-product-1");
+        apiProduct.setEnvironmentId(ENVIRONMENT_ID);
+        apiProduct.setGroups(new HashSet<>(Set.of("group-2")));
+
+        when(apiProductsRepository.findById("api-product-1")).thenReturn(Optional.of(apiProduct));
+
+        service.removeGroup(EXECUTION_CONTEXT, "api-product-1", "group-1");
+
+        assertThat(apiProduct.getGroups()).containsExactly("group-2");
+        verify(apiProductsRepository, never()).update(same(apiProduct));
+        verify(apiProductNotificationService, never()).triggerUpdateNotification(any(), any());
+    }
+
+    @Test
+    void should_throw_when_api_product_not_found_on_add() throws TechnicalException {
+        when(apiProductsRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.addGroup(EXECUTION_CONTEXT, "missing", "group-1")).isInstanceOf(ApiProductNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_when_api_product_not_found_on_remove() throws TechnicalException {
+        when(apiProductsRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.removeGroup(EXECUTION_CONTEXT, "missing", "group-1")).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+    }
+
+    @Test
+    void should_throw_when_api_product_in_different_environment() throws TechnicalException {
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("api-product-1");
+        apiProduct.setEnvironmentId("other-env");
+
+        when(apiProductsRepository.findById("api-product-1")).thenReturn(Optional.of(apiProduct));
+
+        assertThatThrownBy(() -> service.addGroup(EXECUTION_CONTEXT, "api-product-1", "group-1")).isInstanceOf(
+            ApiProductNotFoundException.class
+        );
+
+        verify(apiProductsRepository, never()).update(same(apiProduct));
+    }
+
+    @Test
+    void should_wrap_technical_exception_on_add() throws TechnicalException {
+        when(apiProductsRepository.findById("api-product-1")).thenThrow(new TechnicalException("db error"));
+
+        assertThatThrownBy(() -> service.addGroup(EXECUTION_CONTEXT, "api-product-1", "group-1"))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasCauseInstanceOf(TechnicalException.class);
+    }
+
+    @Test
+    void should_wrap_technical_exception_on_remove() throws TechnicalException {
+        when(apiProductsRepository.findById("api-product-1")).thenThrow(new TechnicalException("db error"));
+
+        assertThatThrownBy(() -> service.removeGroup(EXECUTION_CONTEXT, "api-product-1", "group-1"))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasCauseInstanceOf(TechnicalException.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductNotificationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductNotificationServiceImplTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static io.gravitee.rest.api.service.common.SecurityContextHelper.authenticateAs;
+import static io.gravitee.rest.api.service.common.SecurityContextHelper.authenticateAsSystem;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.PARAM_API_PRODUCT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.management.model.ApiProduct;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.NotifierService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
+import io.gravitee.rest.api.service.notification.ApiProductTemplateModel;
+import io.gravitee.rest.api.service.notification.HookScope;
+import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
+import java.util.Collections;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class ApiProductNotificationServiceImplTest {
+
+    private static final ExecutionContext CTX = new ExecutionContext("org-1", "env-1");
+
+    @Mock
+    private NotifierService notifierService;
+
+    @Mock
+    private MembershipService membershipService;
+
+    @Mock
+    private UserService userService;
+
+    private ApiProductNotificationServiceImpl service;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void buildService() {
+        service = new ApiProductNotificationServiceImpl(notifierService, membershipService, userService);
+    }
+
+    @Test
+    void should_expose_api_product_hook_metadata() {
+        assertThat(ApiProductHook.API_PRODUCT_UPDATED.getScope()).isEqualTo(HookScope.API_PRODUCT);
+        assertThat(ApiProductHook.API_PRODUCT_UPDATED.getLabel()).isEqualTo("API Product Updated");
+        assertThat(ApiProductHook.API_PRODUCT_UPDATED.getCategory()).isEqualTo("LIFECYCLE");
+    }
+
+    @Test
+    void should_not_trigger_when_user_not_authenticated() {
+        buildService();
+        SecurityContextHolder.clearContext();
+
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("ap-1");
+        apiProduct.setName("P1");
+        apiProduct.setVersion("1.0");
+
+        service.triggerUpdateNotification(CTX, apiProduct);
+
+        verifyNoInteractions(notifierService);
+        verifyNoInteractions(userService);
+        verifyNoInteractions(membershipService);
+    }
+
+    @Test
+    void should_not_trigger_when_authenticated_as_system() {
+        buildService();
+        authenticateAsSystem("system-user", Collections.emptySet());
+
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("ap-1");
+        apiProduct.setName("P1");
+        apiProduct.setVersion("1.0");
+
+        service.triggerUpdateNotification(CTX, apiProduct);
+
+        verifyNoInteractions(notifierService);
+        verifyNoInteractions(userService);
+        verifyNoInteractions(membershipService);
+    }
+
+    @Test
+    void should_trigger_with_api_product_primary_owner_and_acting_user_when_authenticated() {
+        buildService();
+
+        UserEntity actor = new UserEntity();
+        actor.setId("actor-1");
+        actor.setEmail("actor@example.com");
+        authenticateAs(actor);
+
+        UserEntity loadedActor = new UserEntity();
+        loadedActor.setId("actor-1");
+        loadedActor.setEmail("actor@example.com");
+        when(userService.findById(CTX, "actor-1")).thenReturn(loadedActor);
+
+        when(membershipService.getPrimaryOwnerUserId("org-1", MembershipReferenceType.API_PRODUCT, "ap-1")).thenReturn("po-1");
+        UserEntity poUser = new UserEntity();
+        poUser.setId("po-1");
+        poUser.setEmail("po@example.com");
+        poUser.setFirstname("Pat");
+        poUser.setLastname("Owner");
+        when(userService.findById(CTX, "po-1")).thenReturn(poUser);
+
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("ap-1");
+        apiProduct.setName("My Product");
+        apiProduct.setVersion("2.0");
+
+        service.triggerUpdateNotification(CTX, apiProduct);
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notifierService).trigger(eq(CTX), eq(ApiProductHook.API_PRODUCT_UPDATED), eq("ap-1"), paramsCaptor.capture());
+
+        ApiProductTemplateModel model = (ApiProductTemplateModel) paramsCaptor.getValue().get(PARAM_API_PRODUCT);
+        assertThat(model.getId()).isEqualTo("ap-1");
+        assertThat(model.getName()).isEqualTo("My Product");
+        assertThat(model.getVersion()).isEqualTo("2.0");
+        assertThat(model.getPrimaryOwner()).isNotNull();
+        assertThat(model.getPrimaryOwner().getId()).isEqualTo("po-1");
+
+        assertThat(paramsCaptor.getValue().get(NotificationParamsBuilder.PARAM_USER)).isSameAs(loadedActor);
+    }
+
+    @Test
+    void should_leave_primary_owner_null_when_not_resolvable() {
+        buildService();
+
+        UserEntity actor = new UserEntity();
+        actor.setId("actor-1");
+        authenticateAs(actor);
+        when(userService.findById(CTX, "actor-1")).thenReturn(actor);
+
+        when(membershipService.getPrimaryOwnerUserId("org-1", MembershipReferenceType.API_PRODUCT, "ap-x")).thenReturn("missing-po");
+        when(userService.findById(CTX, "missing-po")).thenThrow(new NoSuchElementException());
+
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("ap-x");
+        apiProduct.setName("Px");
+        apiProduct.setVersion("1");
+
+        service.triggerUpdateNotification(CTX, apiProduct);
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notifierService).trigger(eq(CTX), eq(ApiProductHook.API_PRODUCT_UPDATED), eq("ap-x"), paramsCaptor.capture());
+        assertThat(((ApiProductTemplateModel) paramsCaptor.getValue().get(PARAM_API_PRODUCT)).getPrimaryOwner()).isNull();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13526

## Description


Commit | Area | What changed
-- | -- | --
feat: transfer ownership api product DB changes | Schema (JDBC) | Liquibase changelog adds api_product_primary_owner on groups; registered in master.yml.
  | Persistence | Group model and Jdbc / Mongo mappings updated for the new column.
feat: transfer ownership api product add/update tests | Tests |  Add/update test-cases for Transfer ownership to Member/Group
feat: transfer ownership api product BE changes | API & docs | OpenAPI for API products (and related apis spec where applicable) for transfer ownership / group semantics.
  | REST (v1) | Group members resource behaviour aligned with API product primary owner on groups.
  | Domain & use cases | Create / update / delete API product member flows and API product creation updated for group + api product primary owner rules; core Group / GroupCRDSpec; ApiProductPrimaryOwnerFactory behaviour.
  | Services | GroupService / GroupServiceImpl (e.g. API product primary owner on groups); MembershipServiceImpl transfer ownership for API products (including ApiProductGroupService integration).
  | New service | ApiProductGroupService: add/remove API product ↔ group links with environment-scoped product resolution, API_UPDATED notifications for API_PRODUCT (aligned with existing API product update notification pattern).
  | Model | GroupEntity exposes API product primary owner for management API.