### PR TITLE
feat(APIM-13621/13622): capture OTel Logs in gateway & add Console UI toggle

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/otelLogsV4.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/otelLogsV4.ts
@@ -14,19 +14,6 @@
  * limitations under the License.
  */
 
-import { LoggingV4 } from './loggingV4';
-import { OtelLogsV4 } from './otelLogsV4';
-import { Sampling } from './sampling';
-import { TracingV4 } from './tracingV4';
-
-export interface Analytics {
-  /**
-   * Whether analytics is enabled.
-   */
-  enabled?: boolean;
-  sampling?: Sampling;
-  logging?: LoggingV4;
-  tracing?: TracingV4;
-  reporterMetricsEnabled?: boolean;
-  otelLogs?: OtelLogsV4;
+export interface OtelLogsV4 {
+  enabled: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.html
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.html
@@ -235,6 +235,12 @@
             Enable only for deep debugging - increases trace size significantly.
             <mat-slide-toggle gioFormSlideToggle formControlName="tracingVerbose"></mat-slide-toggle>
           </gio-form-slide-toggle>
+          <gio-form-slide-toggle>
+            <gio-form-label>OTel Logs</gio-form-label>
+            Emit message payloads as OpenTelemetry log records correlated to the active trace. Enables log-to-trace linking in Grafana and
+            other OTel-compatible backends. Capture is subject to the sampling strategy configured above.
+            <mat-slide-toggle gioFormSlideToggle formControlName="otelLogsEnabled"></mat-slide-toggle>
+          </gio-form-slide-toggle>
         </div>
       </mat-card-content>
     </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.spec.ts
@@ -167,6 +167,7 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
           ...testApi.analytics,
           logging: { ...testApi.analytics.logging, mode: { entrypoint: true, endpoint: true } },
           tracing: { enabled: true, verbose: false },
+          otelLogs: { enabled: false },
         },
       });
     });
@@ -195,6 +196,7 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
         analytics: {
           ...testApi.analytics,
           logging: { ...testApi.analytics.logging, mode: { entrypoint: false, endpoint: false } },
+          otelLogs: { enabled: false },
         },
       });
     });
@@ -258,6 +260,7 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
           mode: { entrypoint: true, endpoint: false },
           phase: { request: true, response: true },
         },
+        otelLogs: { enabled: false },
       },
     });
   });
@@ -293,6 +296,7 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
           mode: { entrypoint: true, endpoint: true },
           phase: { request: false, response: false },
         },
+        otelLogs: { enabled: false },
       },
     });
   });
@@ -322,6 +326,7 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
           mode: { entrypoint: true, endpoint: true },
           content: { messagePayload: true, messageHeaders: true, messageMetadata: true, headers: true },
         },
+        otelLogs: { enabled: false },
       },
     });
   });
@@ -345,6 +350,7 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
           condition: 'request condition',
           messageCondition: 'message condition',
         },
+        otelLogs: { enabled: false },
       },
     });
   });
@@ -365,6 +371,7 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
         analytics: {
           ...testApi.analytics,
           sampling: { type: 'PROBABILITY', value: '0.5' },
+          otelLogs: { enabled: false },
         },
       });
     });
@@ -522,130 +529,49 @@ describe('ApiRuntimeLogsSettingsComponent', () => {
           condition: 'request condition',
           messageCondition: 'message condition',
         },
-        tracing: {
-          enabled: false,
-          verbose: false,
-        },
+        tracing: { enabled: false, verbose: false },
         sampling: { type: 'COUNT', value: '50' },
       },
     });
 
-    const apiWithTracingEnabled = fakeApiV4({
-      id: API_ID,
-      analytics: {
-        enabled: true,
-        tracing: {
-          enabled: true,
-          verbose: true,
-        },
-      },
+    it('should initialize otelLogsEnabled as enabled and unchecked when message API tracing is active', async () => {
+      await initComponent();
+      expect(await componentHarness.isOtelLogsEnabledDisabled()).toBe(false);
+      expect(await componentHarness.isOtelLogsEnabledChecked()).toBe(false);
     });
 
-    const apiWithTracingEnabledAndVerboseFalse = fakeApiV4({
-      id: API_ID,
-      analytics: {
-        enabled: true,
-        tracing: {
-          enabled: true,
-          verbose: false,
-        },
-      },
-    });
-
-    beforeEach(async () => {
-      await initComponent(apiWithTracingEnabled);
-    });
-
-    it('should reflect the initial state of OpenTelemetry controls', async () => {
-      expect(await componentHarness.isTracingEnabledChecked()).toStrictEqual(true);
-      expect(await componentHarness.isTracingVerboseChecked()).toStrictEqual(true);
-      expect(await componentHarness.isTracingVerboseDisabled()).toStrictEqual(false);
-    });
-
-    it('should disable tracingVerbose when tracingEnabled is toggled off from enabled state where tracingVerbose was enabled', async () => {
-      expect(await componentHarness.isTracingEnabledChecked()).toBe(true);
-      expect(await componentHarness.isTracingVerboseChecked()).toBe(true);
-      expect(await componentHarness.isTracingVerboseDisabled()).toBe(false);
+    it('should disable otelLogsEnabled when tracingEnabled is switched off on a message API', async () => {
+      await initComponent();
+      expect(await componentHarness.isOtelLogsEnabledDisabled()).toBe(false);
 
       await componentHarness.toggleTracingEnabled();
 
-      expect(await componentHarness.isTracingEnabledChecked()).toBe(false);
-      expect(await componentHarness.isTracingVerboseChecked()).toBe(false);
-      expect(await componentHarness.isTracingVerboseDisabled()).toBe(true);
+      expect(await componentHarness.isOtelLogsEnabledChecked()).toBe(false);
+      expect(await componentHarness.isOtelLogsEnabledDisabled()).toBe(true);
     });
 
-    it('should disable tracingVerbose when tracingEnabled is toggled off from enabled state where tracingVerbose was disabled', async () => {
-      await initComponent(apiWithTracingEnabledAndVerboseFalse);
-
-      expect(await componentHarness.isTracingEnabledChecked()).toBe(true);
-      expect(await componentHarness.isTracingVerboseChecked()).toBe(false);
-      expect(await componentHarness.isTracingVerboseDisabled()).toBe(false);
-
-      await componentHarness.toggleTracingEnabled();
-
-      expect(await componentHarness.isTracingEnabledChecked()).toBe(false);
-      expect(await componentHarness.isTracingVerboseChecked()).toBe(false);
-      expect(await componentHarness.isTracingVerboseDisabled()).toBe(true);
-    });
-
-    it('should enable tracingVerbose when tracingEnabled is toggled on from disabled state, with tracingVerbose set to false', async () => {
+    it('should persist otelLogs.enabled in message API analytics on save', async () => {
       await initComponent(apiWithTracingDisabled);
-
-      expect(await componentHarness.isTracingEnabledChecked()).toBe(false);
-      expect(await componentHarness.isTracingVerboseChecked()).toBe(false);
-      expect(await componentHarness.isTracingVerboseDisabled()).toBe(true);
-
       await componentHarness.toggleTracingEnabled();
-
-      expect(await componentHarness.isTracingEnabledChecked()).toBe(true);
-      expect(await componentHarness.isTracingVerboseChecked()).toBe(false);
-      expect(await componentHarness.isTracingVerboseDisabled()).toBe(false);
-    });
-
-    it('should save API proxy OpenTelemetry settings', async () => {
-      await initComponent(apiWithTracingDisabled);
-
-      await componentHarness.toggleTracingEnabled();
-      await componentHarness.toggleTracingVerbose();
-
+      await componentHarness.toggleOtelLogsEnabled();
       await componentHarness.saveSettings();
 
-      expectApiGetRequest(apiWithTracingDisabled);
-      expectApiPutRequest({
+      expectOtelApiGetRequest(apiWithTracingDisabled);
+      expectOtelApiPutRequest({
         ...apiWithTracingDisabled,
         analytics: {
           ...apiWithTracingDisabled.analytics,
-          tracing: {
-            enabled: true,
-            verbose: true,
-          },
+          tracing: { enabled: true, verbose: false },
+          otelLogs: { enabled: true },
         },
       });
     });
 
-    it('should discard changes in OpenTelemetry controls', async () => {
-      await componentHarness.toggleTracingEnabled();
-      await componentHarness.toggleTracingVerbose();
-
-      expect(await componentHarness.isTracingEnabledChecked()).toStrictEqual(false);
-      expect(await componentHarness.isTracingVerboseChecked()).toStrictEqual(false);
-
-      await componentHarness.resetSettings();
-
-      expect(await componentHarness.isTracingEnabledChecked()).toStrictEqual(true);
-      expect(await componentHarness.isTracingVerboseChecked()).toStrictEqual(true);
-    });
-
-    function expectApiGetRequest(api: ApiV4) {
-      httpTestingController
-        .expectOne({
-          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`,
-          method: 'GET',
-        })
-        .flush(api);
+    function expectOtelApiGetRequest(api: ApiV4) {
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
     }
 
-    function expectApiPutRequest(api: ApiV4) {
+    function expectOtelApiPutRequest(api: ApiV4) {
       const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'PUT' });
       expect(req.request.body).toStrictEqual(api);
       req.flush(api);

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.component.ts
@@ -133,6 +133,9 @@ export class ReporterSettingsMessageComponent implements OnInit {
               enabled: formValues.tracingEnabled,
               verbose: formValues.tracingVerbose,
             },
+            otelLogs: {
+              enabled: formValues.otelLogsEnabled,
+            },
             sampling: sampling,
           };
           return this.apiService.update(api.id, { ...api, analytics });
@@ -178,6 +181,10 @@ export class ReporterSettingsMessageComponent implements OnInit {
       }),
       tracingVerbose: new UntypedFormControl({
         value: api.analytics?.tracing?.verbose ?? false,
+        disabled: !analyticsEnabled || !api.analytics?.tracing?.enabled || isReadOnly,
+      }),
+      otelLogsEnabled: new UntypedFormControl({
+        value: api.analytics?.otelLogs?.enabled ?? false,
         disabled: !analyticsEnabled || !api.analytics?.tracing?.enabled || isReadOnly,
       }),
       request: new UntypedFormControl({
@@ -244,6 +251,10 @@ export class ReporterSettingsMessageComponent implements OnInit {
                 if (!loggingModeDisabled) {
                   control.enable();
                 }
+              } else if (key === 'otelLogsEnabled' || key === 'tracingVerbose') {
+                if (this.form.get('tracingEnabled').value) {
+                  control.enable();
+                }
               } else {
                 control.enable();
               }
@@ -265,8 +276,10 @@ export class ReporterSettingsMessageComponent implements OnInit {
       .subscribe(tracingEnabled => {
         if (tracingEnabled) {
           this.form.get('tracingVerbose').enable();
+          this.form.get('otelLogsEnabled').enable();
         } else {
           this.disableAndUncheck('tracingVerbose');
+          this.disableAndUncheck('otelLogsEnabled');
         }
       });
   }

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-message/reporter-settings-message.harness.ts
@@ -42,6 +42,7 @@ export class ReporterSettingsMessageHarness extends ComponentHarness {
   private getSamplingValueFormField = this.locatorFor(MatFormFieldHarness.with({ selector: '[data-testid=sampling_value]' }));
   private getTracingEnabledToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="tracingEnabled"]' }));
   private getTracingVerboseToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="tracingVerbose"]' }));
+  private getOtelLogsEnabledToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="otelLogsEnabled"]' }));
 
   public isEnabledChecked = async () => (await this.getEnabledToggle()).isChecked();
   public toggleEnabled = async () => (await this.getEnabledToggle()).toggle();
@@ -211,4 +212,7 @@ export class ReporterSettingsMessageHarness extends ComponentHarness {
   public isTracingVerboseChecked = async () => (await this.getTracingVerboseToggle()).isChecked();
   public toggleTracingVerbose = async () => (await this.getTracingVerboseToggle()).toggle();
   public isTracingVerboseDisabled = async () => (await this.getTracingVerboseToggle()).isDisabled();
+  public isOtelLogsEnabledChecked = async () => (await this.getOtelLogsEnabledToggle()).isChecked();
+  public toggleOtelLogsEnabled = async () => (await this.getOtelLogsEnabledToggle()).toggle();
+  public isOtelLogsEnabledDisabled = async () => (await this.getOtelLogsEnabledToggle()).isDisabled();
 }

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.html
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.html
@@ -106,6 +106,12 @@
           Enable only for deep debugging - increases trace size significantly.
           <mat-slide-toggle gioFormSlideToggle formControlName="tracingVerbose"></mat-slide-toggle>
         </gio-form-slide-toggle>
+        <gio-form-slide-toggle>
+          <gio-form-label>OTel Logs</gio-form-label>
+          Emit request and response payloads as OpenTelemetry log records correlated to the active trace. Enables log-to-trace linking in
+          Grafana and other OTel-compatible backends.
+          <mat-slide-toggle gioFormSlideToggle formControlName="otelLogsEnabled"></mat-slide-toggle>
+        </gio-form-slide-toggle>
       </div>
     </mat-card-content>
 

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.spec.ts
@@ -128,6 +128,7 @@ describe('ApiRuntimeLogsProxySettingsComponent', () => {
             condition: 'condition',
           },
           tracing: { enabled: false, verbose: false },
+          otelLogs: { enabled: false },
         },
       });
     });
@@ -365,6 +366,7 @@ describe('ApiRuntimeLogsProxySettingsComponent', () => {
             enabled: true,
             verbose: true,
           },
+          otelLogs: { enabled: false },
         },
       });
     });
@@ -418,10 +420,61 @@ describe('ApiRuntimeLogsProxySettingsComponent', () => {
               ],
             },
           },
+          otelLogs: { enabled: false },
         },
       });
     });
 
+    it('should re-enable otelLogsEnabled when analytics enabled is toggled back on while tracingEnabled is active', async () => {
+      expect(await componentHarness.isOtelLogsEnabledDisabled()).toBe(false);
+
+      await componentHarness.toggleEnabled();
+      expect(await componentHarness.isOtelLogsEnabledDisabled()).toBe(true);
+
+      await componentHarness.toggleEnabled();
+      expect(await componentHarness.isOtelLogsEnabledDisabled()).toBe(false);
+    });
+
+    it('should disable otelLogsEnabled when tracingEnabled is toggled off', async () => {
+      expect(await componentHarness.isTracingEnabledChecked()).toBe(true);
+      expect(await componentHarness.isOtelLogsEnabledDisabled()).toBe(false);
+
+      await componentHarness.toggleTracingEnabled();
+
+      expect(await componentHarness.isTracingEnabledChecked()).toBe(false);
+      expect(await componentHarness.isOtelLogsEnabledChecked()).toBe(false);
+      expect(await componentHarness.isOtelLogsEnabledDisabled()).toBe(true);
+    });
+
+    it('should enable otelLogsEnabled when tracingEnabled is toggled on', async () => {
+      await initComponent(apiWithTracingDisabled);
+
+      expect(await componentHarness.isTracingEnabledChecked()).toBe(false);
+      expect(await componentHarness.isOtelLogsEnabledDisabled()).toBe(true);
+
+      await componentHarness.toggleTracingEnabled();
+
+      expect(await componentHarness.isTracingEnabledChecked()).toBe(true);
+      expect(await componentHarness.isOtelLogsEnabledDisabled()).toBe(false);
+    });
+
+    it('should save otelLogs enabled setting', async () => {
+      await initComponent(apiWithTracingDisabled);
+
+      await componentHarness.toggleTracingEnabled();
+      await componentHarness.toggleOtelLogsEnabled();
+      await componentHarness.clickOnSaveButton();
+
+      expectApiGetRequest(apiWithTracingDisabled);
+      expectApiPutRequest({
+        ...apiWithTracingDisabled,
+        analytics: {
+          ...apiWithTracingDisabled.analytics,
+          tracing: { enabled: true, verbose: false },
+          otelLogs: { enabled: true },
+        },
+      });
+    });
     it('should discard changes in OpenTelemetry controls', async () => {
       await componentHarness.toggleTracingEnabled();
       await componentHarness.toggleTracingVerbose();
@@ -472,6 +525,7 @@ describe('ApiRuntimeLogsProxySettingsComponent', () => {
               rules: [{ attributeNamePattern: 'api-key', maskingStrategy: { type: 'FULL' } }],
             },
           },
+          otelLogs: { enabled: false },
         },
       });
     });
@@ -507,6 +561,7 @@ describe('ApiRuntimeLogsProxySettingsComponent', () => {
             enabled: true,
             verbose: true,
           },
+          otelLogs: { enabled: false },
         },
       });
     });

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.ts
@@ -45,6 +45,7 @@ type DefaultConfiguration = {
   condition: string;
   tracingEnabled: boolean;
   tracingVerbose: boolean;
+  otelLogsEnabled: boolean;
 };
 
 @Component({
@@ -132,6 +133,9 @@ export class ReporterSettingsProxyComponent implements OnInit {
                     }
                   : {}),
               },
+              otelLogs: {
+                enabled: configurationValues.otelLogsEnabled,
+              },
             },
           };
 
@@ -181,6 +185,10 @@ export class ReporterSettingsProxyComponent implements OnInit {
         value: api.analytics?.tracing?.verbose ?? false,
         disabled: !analyticsEnabled || !api.analytics?.tracing?.enabled || isReadOnly,
       }),
+      otelLogsEnabled: new UntypedFormControl({
+        value: api.analytics?.otelLogs?.enabled ?? false,
+        disabled: !analyticsEnabled || !api.analytics?.tracing?.enabled || isReadOnly,
+      }),
       endpoint: new UntypedFormControl({ value: api.analytics?.logging?.mode?.endpoint, disabled: !analyticsEnabled || isReadOnly }),
       request: new UntypedFormControl({
         value: api.analytics?.logging?.phase?.request,
@@ -208,8 +216,10 @@ export class ReporterSettingsProxyComponent implements OnInit {
 
     if (!analyticsEnabled || !this.form.get('tracingEnabled').value || isReadOnly) {
       this.form.get('tracingVerbose').disable();
+      this.form.get('otelLogsEnabled').disable();
     } else {
       this.form.get('tracingVerbose').enable();
+      this.form.get('otelLogsEnabled').enable();
     }
 
     this.handleTracingEnabledChanges();
@@ -224,6 +234,7 @@ export class ReporterSettingsProxyComponent implements OnInit {
             this.form.get('tracingEnabled').enable();
             if (this.form.get('tracingEnabled').value) {
               this.form.get('tracingVerbose').enable();
+              this.form.get('otelLogsEnabled').enable();
             }
           } else {
             this.form.get('entrypoint').disable();
@@ -235,6 +246,7 @@ export class ReporterSettingsProxyComponent implements OnInit {
             this.form.get('condition').disable();
             this.form.get('tracingEnabled').disable();
             this.form.get('tracingVerbose').disable();
+            this.disableAndUncheck('otelLogsEnabled');
           }
         }),
         takeUntilDestroyed(this.destroyRef),
@@ -262,8 +274,10 @@ export class ReporterSettingsProxyComponent implements OnInit {
         tap((tracingEnabled: boolean) => {
           if (!tracingEnabled) {
             this.form.get('tracingVerbose').disable();
+            this.disableAndUncheck('otelLogsEnabled');
           } else {
             this.form.get('tracingVerbose').enable();
+            this.form.get('otelLogsEnabled').enable();
           }
         }),
         takeUntilDestroyed(this.destroyRef),
@@ -290,5 +304,10 @@ export class ReporterSettingsProxyComponent implements OnInit {
     this.form.get('payload').disable();
     this.form.get('condition').setValue('');
     this.form.get('condition').disable();
+  }
+
+  private disableAndUncheck(controlName: string): void {
+    this.form.get(controlName).setValue(false);
+    this.form.get(controlName).disable();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.harness.ts
@@ -30,6 +30,7 @@ export class ReporterSettingsProxyHarness extends ComponentHarness {
   private getPayloadToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="payload"]' }));
   private getTracingEnabledToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="tracingEnabled"]' }));
   private getTracingVerboseToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="tracingVerbose"]' }));
+  private getOtelLogsEnabledToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="otelLogsEnabled"]' }));
   private getConditionInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="condition"]' }));
   private getSaveBar = this.locatorFor(GioSaveBarHarness);
 
@@ -64,4 +65,7 @@ export class ReporterSettingsProxyHarness extends ComponentHarness {
   public isTracingVerboseChecked = async () => (await this.getTracingVerboseToggle()).isChecked();
   public isTracingVerboseDisabled = async () => (await this.getTracingVerboseToggle()).isDisabled();
   public toggleTracingVerbose = async () => (await this.getTracingVerboseToggle()).toggle();
+  public isOtelLogsEnabledChecked = async () => (await this.getOtelLogsEnabledToggle()).isChecked();
+  public toggleOtelLogsEnabled = async () => (await this.getOtelLogsEnabledToggle()).toggle();
+  public isOtelLogsEnabledDisabled = async () => (await this.getOtelLogsEnabledToggle()).isDisabled();
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/logging/OtelLogs.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/logging/OtelLogs.java
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.definition.model.v4.analytics;
+package io.gravitee.definition.model.v4.analytics.logging;
 
-import io.gravitee.definition.model.v4.analytics.logging.Logging;
-import io.gravitee.definition.model.v4.analytics.logging.OtelLogs;
-import io.gravitee.definition.model.v4.analytics.sampling.Sampling;
-import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,22 +24,15 @@ import lombok.Setter;
 import lombok.ToString;
 
 /**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
-@Builder(toBuilder = true)
 @Setter
 @ToString
 @EqualsAndHashCode
-@Schema(name = "AnalyticsV4")
-public class Analytics implements Serializable {
+@Schema(name = "OtelLogsV4")
+public class OtelLogs implements Serializable {
 
-    private boolean enabled = true;
-    private Sampling messageSampling;
-    private Logging logging;
-    private Tracing tracing;
-    private OtelLogs otelLogs;
+    private boolean enabled;
 }

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1683,6 +1683,19 @@
                         </exclusion>
                     </exclusions>
                 </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.reporter</groupId>
+                    <artifactId>gravitee-reporter-otel</artifactId>
+                    <version>${gravitee-reporter-otel.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
 
                 <!-- Resources -->
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsUtils.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsUtils.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.reactive.core.v4.analytics;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
+import io.gravitee.definition.model.v4.analytics.logging.OtelLogs;
 import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import io.gravitee.gateway.report.guard.LogGuardService;
@@ -80,8 +81,19 @@ public class AnalyticsUtils {
             Logging logging = analytics.getLogging();
             if (logging != null) {
                 final LoggingMode loggingMode = logging.getMode();
-                return loggingMode != null && loggingMode.isEnabled();
+                if (loggingMode != null && loggingMode.isEnabled()) {
+                    return true;
+                }
             }
+            return isOtelLogsEnabled(analytics);
+        }
+        return false;
+    }
+
+    public static boolean isOtelLogsEnabled(final Analytics analytics) {
+        if (analytics != null && analytics.isEnabled()) {
+            OtelLogs otelLogs = analytics.getOtelLogs();
+            return otelLogs != null && otelLogs.isEnabled();
         }
         return false;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
@@ -56,7 +56,7 @@ public class LoggingContext implements ConditionSupplier {
 
     @Override
     public String getCondition() {
-        return logging != null ? logging.getCondition() : null;
+        return logging != null ? logging.getCondition() : "";
     }
 
     public boolean entrypointRequest() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
@@ -42,6 +42,11 @@ public class LoggingContext implements ConditionSupplier {
     @Setter
     private LogGuardService logGuardService;
 
+    /** When true, payload capture is enabled for all 4 directions regardless of ES logging configuration. */
+    @Getter
+    @Setter
+    private boolean otelLogsEnabled = false;
+
     private final LoggableContentType loggableContentType;
 
     public LoggingContext(Logging logging) {
@@ -51,55 +56,67 @@ public class LoggingContext implements ConditionSupplier {
 
     @Override
     public String getCondition() {
-        return logging.getCondition();
+        return logging != null ? logging.getCondition() : null;
     }
 
     public boolean entrypointRequest() {
-        return logging.getMode().isEntrypoint() && logging.getPhase().isRequest();
+        return otelLogsEnabled || (logging != null && logging.getMode().isEntrypoint() && logging.getPhase().isRequest());
     }
 
     public boolean entrypointResponse() {
-        return logging.getMode().isEntrypoint() && logging.getPhase().isResponse();
+        return otelLogsEnabled || (logging != null && logging.getMode().isEntrypoint() && logging.getPhase().isResponse());
     }
 
     public boolean endpointRequest() {
-        return logging.getMode().isEndpoint() && logging.getPhase().isRequest();
+        return otelLogsEnabled || (logging != null && logging.getMode().isEndpoint() && logging.getPhase().isRequest());
     }
 
     public boolean endpointResponse() {
-        return logging.getMode().isEndpoint() && logging.getPhase().isResponse();
+        return otelLogsEnabled || (logging != null && logging.getMode().isEndpoint() && logging.getPhase().isResponse());
     }
 
     public boolean entrypointRequestHeaders() {
-        return logging.getMode().isEntrypoint() && logging.getPhase().isRequest() && logging.getContent().isHeaders();
+        return logging != null && logging.getMode().isEntrypoint() && logging.getPhase().isRequest() && logging.getContent().isHeaders();
     }
 
     public boolean entrypointRequestPayload() {
-        return logging.getMode().isEntrypoint() && logging.getPhase().isRequest() && logging.getContent().isPayload();
+        return (
+            otelLogsEnabled ||
+            (logging != null && logging.getMode().isEntrypoint() && logging.getPhase().isRequest() && logging.getContent().isPayload())
+        );
     }
 
     public boolean endpointRequestHeaders() {
-        return logging.getMode().isEndpoint() && logging.getPhase().isRequest() && logging.getContent().isHeaders();
+        return logging != null && logging.getMode().isEndpoint() && logging.getPhase().isRequest() && logging.getContent().isHeaders();
     }
 
     public boolean endpointRequestPayload() {
-        return logging.getMode().isEndpoint() && logging.getPhase().isRequest() && logging.getContent().isPayload();
+        return (
+            otelLogsEnabled ||
+            (logging != null && logging.getMode().isEndpoint() && logging.getPhase().isRequest() && logging.getContent().isPayload())
+        );
     }
 
     public boolean entrypointResponseHeaders() {
-        return logging.getMode().isEntrypoint() && logging.getPhase().isResponse() && logging.getContent().isHeaders();
+        return logging != null && logging.getMode().isEntrypoint() && logging.getPhase().isResponse() && logging.getContent().isHeaders();
     }
 
     public boolean entrypointResponsePayload() {
-        return logging.getMode().isEntrypoint() && logging.getPhase().isResponse() && logging.getContent().isPayload();
+        return (
+            otelLogsEnabled ||
+            (logging != null && logging.getMode().isEntrypoint() && logging.getPhase().isResponse() && logging.getContent().isPayload())
+        );
     }
 
     public boolean endpointResponseHeaders() {
-        return logging.getMode().isEndpoint() && logging.getPhase().isResponse() && logging.getContent().isHeaders();
+        return logging != null && logging.getMode().isEndpoint() && logging.getPhase().isResponse() && logging.getContent().isHeaders();
     }
 
     public boolean endpointResponsePayload() {
-        return logging.getMode().isEndpoint() && logging.getPhase().isResponse() && logging.getContent().isPayload();
+        return (
+            otelLogsEnabled ||
+            (logging != null && logging.getMode().isEndpoint() && logging.getPhase().isResponse() && logging.getContent().isPayload())
+        );
     }
 
     public String getExcludedResponseTypes() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsUtilsTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsUtilsTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.v4.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.logging.Logging;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
+import io.gravitee.definition.model.v4.analytics.logging.OtelLogs;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AnalyticsUtilsTest {
+
+    // --- isOtelLogsEnabled ---
+
+    @Test
+    void isOtelLogsEnabled_should_return_false_when_analytics_is_null() {
+        assertThat(AnalyticsUtils.isOtelLogsEnabled(null)).isFalse();
+    }
+
+    @Test
+    void isOtelLogsEnabled_should_return_false_when_analytics_disabled() {
+        Analytics analytics = new Analytics();
+        analytics.setEnabled(false);
+        OtelLogs otelLogs = new OtelLogs();
+        otelLogs.setEnabled(true);
+        analytics.setOtelLogs(otelLogs);
+
+        assertThat(AnalyticsUtils.isOtelLogsEnabled(analytics)).isFalse();
+    }
+
+    @Test
+    void isOtelLogsEnabled_should_return_false_when_otelLogs_is_null() {
+        Analytics analytics = new Analytics();
+        analytics.setEnabled(true);
+        analytics.setOtelLogs(null);
+
+        assertThat(AnalyticsUtils.isOtelLogsEnabled(analytics)).isFalse();
+    }
+
+    @Test
+    void isOtelLogsEnabled_should_return_false_when_otelLogs_disabled() {
+        Analytics analytics = new Analytics();
+        analytics.setEnabled(true);
+        OtelLogs otelLogs = new OtelLogs();
+        otelLogs.setEnabled(false);
+        analytics.setOtelLogs(otelLogs);
+
+        assertThat(AnalyticsUtils.isOtelLogsEnabled(analytics)).isFalse();
+    }
+
+    @Test
+    void isOtelLogsEnabled_should_return_true_when_analytics_enabled_and_otelLogs_enabled() {
+        Analytics analytics = new Analytics();
+        analytics.setEnabled(true);
+        OtelLogs otelLogs = new OtelLogs();
+        otelLogs.setEnabled(true);
+        analytics.setOtelLogs(otelLogs);
+
+        assertThat(AnalyticsUtils.isOtelLogsEnabled(analytics)).isTrue();
+    }
+
+    // --- isLoggingEnabled: otelLogs path ---
+
+    @Test
+    void isLoggingEnabled_should_return_true_when_only_otelLogs_enabled() {
+        Analytics analytics = new Analytics();
+        analytics.setEnabled(true);
+        analytics.setLogging(null); // no ES logging configured
+        OtelLogs otelLogs = new OtelLogs();
+        otelLogs.setEnabled(true);
+        analytics.setOtelLogs(otelLogs);
+
+        assertThat(AnalyticsUtils.isLoggingEnabled(analytics)).isTrue();
+    }
+
+    @Test
+    void isLoggingEnabled_should_return_false_when_no_logging_and_no_otelLogs() {
+        Analytics analytics = new Analytics();
+        analytics.setEnabled(true);
+        analytics.setLogging(null);
+        analytics.setOtelLogs(null);
+
+        assertThat(AnalyticsUtils.isLoggingEnabled(analytics)).isFalse();
+    }
+
+    @Test
+    void isLoggingEnabled_should_return_true_when_es_logging_enabled() {
+        Analytics analytics = new Analytics();
+        analytics.setEnabled(true);
+        Logging logging = new Logging();
+        logging.getMode().setEntrypoint(true);
+        analytics.setLogging(logging);
+
+        assertThat(AnalyticsUtils.isLoggingEnabled(analytics)).isTrue();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContextOtelTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContextOtelTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.v4.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests LoggingContext.otelLogsEnabled flag behaviour:
+ * when otelLogsEnabled=true, all payload methods return true even with null Logging config.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LoggingContextOtelTest {
+
+    @Test
+    void entrypointRequestPayload_should_return_true_when_otelLogsEnabled_and_logging_is_null() {
+        LoggingContext ctx = new LoggingContext(null);
+        ctx.setOtelLogsEnabled(true);
+        assertThat(ctx.entrypointRequestPayload()).isTrue();
+    }
+
+    @Test
+    void endpointRequestPayload_should_return_true_when_otelLogsEnabled_and_logging_is_null() {
+        LoggingContext ctx = new LoggingContext(null);
+        ctx.setOtelLogsEnabled(true);
+        assertThat(ctx.endpointRequestPayload()).isTrue();
+    }
+
+    @Test
+    void entrypointResponsePayload_should_return_true_when_otelLogsEnabled_and_logging_is_null() {
+        LoggingContext ctx = new LoggingContext(null);
+        ctx.setOtelLogsEnabled(true);
+        assertThat(ctx.entrypointResponsePayload()).isTrue();
+    }
+
+    @Test
+    void endpointResponsePayload_should_return_true_when_otelLogsEnabled_and_logging_is_null() {
+        LoggingContext ctx = new LoggingContext(null);
+        ctx.setOtelLogsEnabled(true);
+        assertThat(ctx.endpointResponsePayload()).isTrue();
+    }
+
+    @Test
+    void entrypointRequest_should_return_true_when_otelLogsEnabled_and_logging_is_null() {
+        LoggingContext ctx = new LoggingContext(null);
+        ctx.setOtelLogsEnabled(true);
+        assertThat(ctx.entrypointRequest()).isTrue();
+    }
+
+    @Test
+    void entrypointResponse_should_return_true_when_otelLogsEnabled_and_logging_is_null() {
+        LoggingContext ctx = new LoggingContext(null);
+        ctx.setOtelLogsEnabled(true);
+        assertThat(ctx.entrypointResponse()).isTrue();
+    }
+
+    @Test
+    void endpointRequest_should_return_true_when_otelLogsEnabled_and_logging_is_null() {
+        LoggingContext ctx = new LoggingContext(null);
+        ctx.setOtelLogsEnabled(true);
+        assertThat(ctx.endpointRequest()).isTrue();
+    }
+
+    @Test
+    void endpointResponse_should_return_true_when_otelLogsEnabled_and_logging_is_null() {
+        LoggingContext ctx = new LoggingContext(null);
+        ctx.setOtelLogsEnabled(true);
+        assertThat(ctx.endpointResponse()).isTrue();
+    }
+
+    @Test
+    void all_direction_methods_should_return_false_when_otelLogsEnabled_false_and_logging_null() {
+        LoggingContext ctx = new LoggingContext(null);
+        ctx.setOtelLogsEnabled(false);
+
+        assertThat(ctx.entrypointRequest()).isFalse();
+        assertThat(ctx.entrypointResponse()).isFalse();
+        assertThat(ctx.endpointRequest()).isFalse();
+        assertThat(ctx.endpointResponse()).isFalse();
+        assertThat(ctx.entrypointRequestPayload()).isFalse();
+        assertThat(ctx.endpointRequestPayload()).isFalse();
+        assertThat(ctx.entrypointResponsePayload()).isFalse();
+        assertThat(ctx.endpointResponsePayload()).isFalse();
+    }
+
+    @Test
+    void headers_methods_should_return_false_when_only_otelLogsEnabled_and_logging_null() {
+        // Header capture is NOT widened by otelLogs — only payloads are
+        LoggingContext ctx = new LoggingContext(null);
+        ctx.setOtelLogsEnabled(true);
+
+        assertThat(ctx.entrypointRequestHeaders()).isFalse();
+        assertThat(ctx.endpointRequestHeaders()).isFalse();
+        assertThat(ctx.entrypointResponseHeaders()).isFalse();
+        assertThat(ctx.endpointResponseHeaders()).isFalse();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -66,6 +66,7 @@ import io.gravitee.gateway.reactive.core.processor.ProcessorChain;
 import io.gravitee.gateway.reactive.core.tracing.InvokerTracingHook;
 import io.gravitee.gateway.reactive.core.tracing.TracingHook;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
+import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsUtils;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.gravitee.gateway.reactive.core.v4.endpoint.EndpointManager;
 import io.gravitee.gateway.reactive.core.v4.entrypoint.DefaultEntrypointConnectorResolver;
@@ -740,6 +741,7 @@ public class DefaultApiReactor extends AbstractApiReactor {
         LoggingContext loggingContext = Optional.ofNullable(api.getDefinition().getAnalytics())
             .map(analytics -> {
                 var context = new LoggingContext(analytics.getLogging());
+                context.setOtelLogsEnabled(AnalyticsUtils.isOtelLogsEnabled(analytics));
                 context.setMaxSizeLogMessage(loggingMaxSize);
                 context.setExcludedResponseTypes(loggingExcludedResponseType);
                 context.setLogGuardService(logGuardService);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -424,7 +424,7 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         if (tracingEnabled) {
             Tracer tracer = openTelemetryFactory.createTracer(
                 api.getId(),
-                api.getName(),
+                node.application(),
                 serviceNameSpace,
                 api.getApiVersion(),
                 instrumenterTracerFactories,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.handlers.api.v4;
 
 import io.gravitee.common.event.EventManager;
+import io.gravitee.common.util.Version;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.ListenerType;
@@ -70,6 +71,7 @@ import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import io.gravitee.plugin.policy.PolicyClassLoaderFactory;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import java.util.List;
+import java.util.Map;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.ResolvableType;
@@ -423,11 +425,12 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
         boolean tracingEnabled = isApiTracingEnabled(api);
         if (tracingEnabled) {
             Tracer tracer = openTelemetryFactory.createTracer(
-                api.getId(),
+                node.id(),
                 node.application(),
                 serviceNameSpace,
-                api.getApiVersion(),
+                Version.RUNTIME_VERSION.MAJOR_VERSION,
                 instrumenterTracerFactories,
+                Map.of("gravitee.api.id", api.getId(), "gravitee.api.name", api.getName()),
                 TracingRedactionMapper.toRedactionConfig(api)
             );
             return new TracingContext(tracer, true, isApiTracingVerboseEnabled(api));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactorFactory.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.v4;
 
+import io.gravitee.common.util.Version;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.ListenerType;
@@ -36,6 +37,7 @@ import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
 import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -96,11 +98,12 @@ public class TcpApiReactorFactory implements ReactorFactory<Api> {
         boolean tracingEnabled = isApiTracingEnabled(api);
         if (tracingEnabled) {
             Tracer tracer = openTelemetryFactory.createTracer(
-                api.getId(),
-                api.getName(),
+                node.id(),
+                node.application(),
                 "API_V4_TCP",
-                api.getApiVersion(),
+                Version.RUNTIME_VERSION.MAJOR_VERSION,
                 instrumenterTracerFactories,
+                Map.of("gravitee.api.id", api.getId(), "gravitee.api.name", api.getName()),
                 TracingRedactionMapper.toRedactionConfig(api)
             );
             return new TracingContext(tracer, true, isApiTracingVerboseEnabled(api));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequest.java
@@ -39,6 +39,12 @@ public class LogEndpointRequest extends LogRequest {
     }
 
     public void setupCapture(HttpExecutionContextInternal ctx) {
+        if (loggingContext.isOtelLogsEnabled()) {
+            var tracer = ctx.getTracer();
+            this.setTraceId(tracer != null ? tracer.traceId() : null);
+            this.setSpanId(tracer != null ? tracer.spanId() : null);
+        }
+
         final Buffer buffer = Buffer.buffer();
 
         if (isLogPayload() && loggingContext.isContentTypeLoggable(request.headers().get(HttpHeaderNames.CONTENT_TYPE), ctx)) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequest.java
@@ -41,8 +41,8 @@ public class LogEndpointRequest extends LogRequest {
     public void setupCapture(HttpExecutionContextInternal ctx) {
         if (loggingContext.isOtelLogsEnabled()) {
             var tracer = ctx.getTracer();
-            this.setTraceId(tracer != null ? tracer.traceId() : null);
-            this.setSpanId(tracer != null ? tracer.spanId() : null);
+            this.setTraceId(tracer.traceId());
+            this.setSpanId(tracer.spanId());
         }
 
         final Buffer buffer = Buffer.buffer();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequest.java
@@ -37,6 +37,12 @@ public class LogEntrypointRequest extends LogRequest {
     }
 
     public void capture(HttpExecutionContextInternal ctx) {
+        if (loggingContext.isOtelLogsEnabled()) {
+            var tracer = ctx.getTracer();
+            this.setTraceId(tracer != null ? tracer.traceId() : null);
+            this.setSpanId(tracer != null ? tracer.spanId() : null);
+        }
+
         if (isLogPayload() && loggingContext.isContentTypeLoggable(request.headers().get(HttpHeaderNames.CONTENT_TYPE), ctx)) {
             final Buffer buffer = Buffer.buffer();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponse.java
@@ -60,6 +60,12 @@ public class LogEndpointResponse extends LogResponse {
     }
 
     public void finalizeCapture(HttpExecutionContextInternal ctx) {
+        if (loggingContext.isOtelLogsEnabled()) {
+            var tracer = ctx.getTracer();
+            this.setTraceId(tracer != null ? tracer.traceId() : null);
+            this.setSpanId(tracer != null ? tracer.spanId() : null);
+        }
+
         if (isLogHeaders()) {
             this.setHeaders(response.headers());
             response.setHeaders(((LogHeadersCaptor) response.headers()).getDelegate());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponse.java
@@ -35,6 +35,12 @@ public class LogEntrypointResponse extends LogResponse {
     }
 
     public void capture(HttpExecutionContextInternal ctx) {
+        if (loggingContext.isOtelLogsEnabled()) {
+            var tracer = ctx.getTracer();
+            this.setTraceId(tracer != null ? tracer.traceId() : null);
+            this.setSpanId(tracer != null ? tracer.spanId() : null);
+        }
+
         if (isLogPayload() && loggingContext.isContentTypeLoggable(response.headers().get(HttpHeaderNames.CONTENT_TYPE), ctx)) {
             final Buffer buffer = Buffer.buffer();
             if (loggingContext.isBodyLoggable()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
@@ -82,6 +82,7 @@ import io.gravitee.plugin.resource.ResourcePlugin;
 import io.gravitee.resource.api.ResourceManager;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -436,16 +437,15 @@ class DefaultApiReactorFactoryTest {
             when(api.getDefinition()).thenReturn(def);
             when(api.getId()).thenReturn("api-id");
             when(api.getName()).thenReturn("api-name");
-            when(api.getApiVersion()).thenReturn("1.0");
             when(openTelemetryConfiguration.isTracesEnabled()).thenReturn(true);
-            when(openTelemetryFactory.createTracer(any(), any(), any(), any(), any(), any(RedactionConfig.class))).thenReturn(
-                mock(Tracer.class)
-            );
+            when(
+                openTelemetryFactory.createTracer(any(), any(), any(), any(), any(), any(Map.class), any(RedactionConfig.class))
+            ).thenReturn(mock(Tracer.class));
 
             cut.createTracingContext(api, "test-namespace");
 
             ArgumentCaptor<RedactionConfig> captor = ArgumentCaptor.forClass(RedactionConfig.class);
-            verify(openTelemetryFactory).createTracer(any(), any(), any(), any(), any(), captor.capture());
+            verify(openTelemetryFactory).createTracer(any(), any(), any(), any(), any(), any(Map.class), captor.capture());
             assertThat(captor.getValue().rules()).hasSize(1);
             assertThat(captor.getValue().rules().get(0).attributeNamePattern()).isEqualTo("enduser.id");
             assertThat(captor.getValue().rules().get(0).maskingStrategy()).isInstanceOf(FullMaskingStrategy.class);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/TcpApiReactorFactoryTest.java
@@ -47,6 +47,7 @@ import io.gravitee.node.opentelemetry.configuration.OpenTelemetryConfiguration;
 import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -171,16 +172,15 @@ class TcpApiReactorFactoryTest {
             when(api.getDefinition()).thenReturn(def);
             when(api.getId()).thenReturn("api-id");
             when(api.getName()).thenReturn("api-name");
-            when(api.getApiVersion()).thenReturn("1.0");
             when(openTelemetryConfiguration.isTracesEnabled()).thenReturn(true);
-            when(openTelemetryFactory.createTracer(any(), any(), any(), any(), any(), any(RedactionConfig.class))).thenReturn(
-                mock(Tracer.class)
-            );
+            when(
+                openTelemetryFactory.createTracer(any(), any(), any(), any(), any(), any(Map.class), any(RedactionConfig.class))
+            ).thenReturn(mock(Tracer.class));
 
             cut.createTracingContext(api);
 
             ArgumentCaptor<RedactionConfig> captor = ArgumentCaptor.forClass(RedactionConfig.class);
-            verify(openTelemetryFactory).createTracer(any(), any(), any(), any(), any(), captor.capture());
+            verify(openTelemetryFactory).createTracer(any(), any(), any(), any(), any(), any(Map.class), captor.capture());
             assertThat(captor.getValue().rules()).hasSize(1);
             assertThat(captor.getValue().rules().get(0).attributeNamePattern()).isEqualTo("enduser.id");
             assertThat(captor.getValue().rules().get(0).maskingStrategy()).isInstanceOf(FullMaskingStrategy.class);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequestTest.java
@@ -26,6 +26,7 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
@@ -219,6 +220,40 @@ class LogEndpointRequestTest {
 
         assertNull(cut.getHeaders());
         assertThat(cut.getBody()).isEqualTo("BODY NOT CAPTURED");
+    }
+
+    @Test
+    void should_capture_traceId_and_spanId_from_tracer() {
+        var mockTracer = mock(Tracer.class);
+        when(mockTracer.traceId()).thenReturn("abc123traceId00000000000000000000");
+        when(mockTracer.spanId()).thenReturn("def456spanId0000");
+        when(ctx.getTracer()).thenReturn(mockTracer);
+        when(loggingContext.isOtelLogsEnabled()).thenReturn(true);
+        when(loggingContext.endpointRequestHeaders()).thenReturn(false);
+        when(loggingContext.endpointRequestPayload()).thenReturn(false);
+
+        cut.setupCapture(ctx);
+        triggerRequestToBackend(null, false);
+
+        assertThat(cut.getTraceId()).isEqualTo("abc123traceId00000000000000000000");
+        assertThat(cut.getSpanId()).isEqualTo("def456spanId0000");
+    }
+
+    @Test
+    void should_set_empty_traceId_and_spanId_when_noop_tracer() {
+        var noopTracer = mock(Tracer.class);
+        when(noopTracer.traceId()).thenReturn("");
+        when(noopTracer.spanId()).thenReturn("");
+        when(ctx.getTracer()).thenReturn(noopTracer);
+        when(loggingContext.isOtelLogsEnabled()).thenReturn(true);
+        when(loggingContext.endpointRequestHeaders()).thenReturn(false);
+        when(loggingContext.endpointRequestPayload()).thenReturn(false);
+
+        cut.setupCapture(ctx);
+        triggerRequestToBackend(null, false);
+
+        assertThat(cut.getTraceId()).isEmpty();
+        assertThat(cut.getSpanId()).isEmpty();
     }
 
     private void triggerRequestToBackend(HttpHeaders backendHeaders, boolean expectCaptureBody) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
@@ -190,6 +190,7 @@ class LogEntrypointRequestTest {
         when(mockTracer.traceId()).thenReturn("abc123traceId00000000000000000000");
         when(mockTracer.spanId()).thenReturn("def456spanId0000");
         when(ctx.getTracer()).thenReturn(mockTracer);
+        when(loggingContext.isOtelLogsEnabled()).thenReturn(true);
         when(request.method()).thenReturn(io.gravitee.common.http.HttpMethod.GET);
         when(request.uri()).thenReturn(URI);
         when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
@@ -205,6 +206,7 @@ class LogEntrypointRequestTest {
     @Test
     void should_set_null_traceId_and_spanId_when_tracer_is_null() {
         when(ctx.getTracer()).thenReturn(null);
+        when(loggingContext.isOtelLogsEnabled()).thenReturn(true);
         when(request.method()).thenReturn(io.gravitee.common.http.HttpMethod.GET);
         when(request.uri()).thenReturn(URI);
         when(loggingContext.entrypointRequestHeaders()).thenReturn(false);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,6 +30,7 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
@@ -180,5 +182,38 @@ class LogEntrypointRequestTest {
 
         assertNull(logRequest.getHeaders());
         assertThat(logRequest.getBody()).isEqualTo("BODY NOT CAPTURED");
+    }
+
+    @Test
+    void should_capture_traceId_and_spanId_from_tracer() {
+        var mockTracer = mock(Tracer.class);
+        when(mockTracer.traceId()).thenReturn("abc123traceId00000000000000000000");
+        when(mockTracer.spanId()).thenReturn("def456spanId0000");
+        when(ctx.getTracer()).thenReturn(mockTracer);
+        when(request.method()).thenReturn(io.gravitee.common.http.HttpMethod.GET);
+        when(request.uri()).thenReturn(URI);
+        when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
+        when(loggingContext.entrypointRequestPayload()).thenReturn(false);
+
+        final var logRequest = new LogEntrypointRequest(loggingContext, request);
+        logRequest.capture(ctx);
+
+        assertThat(logRequest.getTraceId()).isEqualTo("abc123traceId00000000000000000000");
+        assertThat(logRequest.getSpanId()).isEqualTo("def456spanId0000");
+    }
+
+    @Test
+    void should_set_null_traceId_and_spanId_when_tracer_is_null() {
+        when(ctx.getTracer()).thenReturn(null);
+        when(request.method()).thenReturn(io.gravitee.common.http.HttpMethod.GET);
+        when(request.uri()).thenReturn(URI);
+        when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
+        when(loggingContext.entrypointRequestPayload()).thenReturn(false);
+
+        final var logRequest = new LogEntrypointRequest(loggingContext, request);
+        logRequest.capture(ctx);
+
+        assertNull(logRequest.getTraceId());
+        assertNull(logRequest.getSpanId());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
@@ -24,12 +24,14 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
@@ -241,6 +243,39 @@ class LogEndpointResponseTest {
         assertNull(cut.getHeaders());
         // The last character is missing due to the error before completion.
         assertThat(cut.getBody()).isEqualTo(BODY_CONTENT.substring(0, BODY_CONTENT.length() - 1));
+    }
+
+    @Test
+    void should_capture_traceId_and_spanId_from_tracer() {
+        var mockTracer = mock(Tracer.class);
+        when(mockTracer.traceId()).thenReturn("abc123traceId00000000000000000000");
+        when(mockTracer.spanId()).thenReturn("def456spanId0000");
+        when(ctx.getTracer()).thenReturn(mockTracer);
+        when(loggingContext.isOtelLogsEnabled()).thenReturn(true);
+        initializeHeaders(HttpHeaders.create());
+        when(loggingContext.endpointResponseHeaders()).thenReturn(false);
+        when(loggingContext.endpointResponsePayload()).thenReturn(false);
+
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(null);
+
+        assertThat(cut.getTraceId()).isEqualTo("abc123traceId00000000000000000000");
+        assertThat(cut.getSpanId()).isEqualTo("def456spanId0000");
+    }
+
+    @Test
+    void should_set_null_traceId_and_spanId_when_tracer_is_null() {
+        when(ctx.getTracer()).thenReturn(null);
+        when(loggingContext.isOtelLogsEnabled()).thenReturn(true);
+        initializeHeaders(HttpHeaders.create());
+        when(loggingContext.endpointResponseHeaders()).thenReturn(false);
+        when(loggingContext.endpointResponsePayload()).thenReturn(false);
+
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(null);
+
+        assertNull(cut.getTraceId());
+        assertNull(cut.getSpanId());
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
@@ -162,6 +164,39 @@ class LogEntrypointResponseTest {
 
         assertNull(logResponse.getHeaders());
         assertThat(logResponse.getBody()).isEqualTo(BODY_CONTENT.substring(0, maxPayloadSize));
+    }
+
+    @Test
+    void should_capture_traceId_and_spanId_from_tracer() {
+        var mockTracer = mock(Tracer.class);
+        when(mockTracer.traceId()).thenReturn("abc123traceId00000000000000000000");
+        when(mockTracer.spanId()).thenReturn("def456spanId0000");
+        when(ctx.getTracer()).thenReturn(mockTracer);
+        when(loggingContext.isOtelLogsEnabled()).thenReturn(true);
+        when(response.status()).thenReturn(200);
+        when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
+        when(loggingContext.entrypointResponsePayload()).thenReturn(false);
+
+        final var logResponse = new LogEntrypointResponse(loggingContext, response);
+        logResponse.capture(ctx);
+
+        assertThat(logResponse.getTraceId()).isEqualTo("abc123traceId00000000000000000000");
+        assertThat(logResponse.getSpanId()).isEqualTo("def456spanId0000");
+    }
+
+    @Test
+    void should_set_null_traceId_and_spanId_when_tracer_is_null() {
+        when(ctx.getTracer()).thenReturn(null);
+        when(loggingContext.isOtelLogsEnabled()).thenReturn(true);
+        when(response.status()).thenReturn(200);
+        when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
+        when(loggingContext.entrypointResponsePayload()).thenReturn(false);
+
+        final var logResponse = new LogEntrypointResponse(loggingContext, response);
+        logResponse.capture(ctx);
+
+        assertNull(logResponse.getTraceId());
+        assertNull(logResponse.getSpanId());
     }
 
     @Test

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
@@ -164,7 +164,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                 var client = container.client(vertx.getDelegate());
                 var response = client
                     .get("/api/traces")
-                    .addQueryParam("service", "my-api-v4")
+                    .addQueryParam("service", "gio-apim-gateway")
                     .send()
                     .toCompletionStage()
                     .toCompletableFuture()
@@ -220,7 +220,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                 var client = container.client(vertx.getDelegate());
                 var response = client
                     .get("/api/traces")
-                    .addQueryParam("service", "my-api")
+                    .addQueryParam("service", "gio-apim-gateway")
                     .send()
                     .toCompletionStage()
                     .toCompletableFuture()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3263,6 +3263,9 @@ components:
                         Enable the connection-metrics reporter on the gateway. Only applicable to Native v4 APIs; ignored on HTTP v4 requests and omitted from HTTP v4 responses.
                         Server-side default for Native v4 on create is `true`.
                         Independent of the parent `enabled` flag: event-metrics reporting and the connection-metrics reporter are gated separately.
+                    default: true
+                otelLogs:
+                    $ref: "#/components/schemas/OtelLogsV4"
         Api:
             oneOf:
                 - $ref: "#/components/schemas/ApiV2"
@@ -5010,6 +5013,12 @@ components:
                     description: PARTIAL only — number of trailing characters to keep visible.
                     default: 0
                     minimum: 0
+        OtelLogsV4:
+            type: object
+            properties:
+                enabled:
+                    type: boolean
+                    description: Enable OpenTelemetry log export for this API (payload capture with traceId/spanId correlation).
         ResponseMetadata:
             description: Generic object to handle additional information about an entity. Can also be used for pagination data.
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3263,7 +3263,6 @@ components:
                         Enable the connection-metrics reporter on the gateway. Only applicable to Native v4 APIs; ignored on HTTP v4 requests and omitted from HTTP v4 responses.
                         Server-side default for Native v4 on create is `true`.
                         Independent of the parent `enabled` flag: event-metrics reporting and the connection-metrics reporter are gated separately.
-                    default: true
                 otelLogs:
                     $ref: "#/components/schemas/OtelLogsV4"
         Api:

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <gravitee-exchange.version>3.0.0-alpha.2</gravitee-exchange.version>
         <gravitee-expression-language.version>4.3.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>6.0.0-alpha.4</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>6.0.0-alpha.5</gravitee-gateway-api.version>
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
@@ -71,7 +71,7 @@
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.3.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>2.2.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>2.3.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
         <gravitee-resource-cache-provider-api.version>2.1.0</gravitee-resource-cache-provider-api.version>
@@ -265,6 +265,7 @@
         <!-- Gateway Only -->
         <gravitee-reporter-tcp.version>5.0.0-alpha.1</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>4.0.0-alpha.1</gravitee-reporter-cloud.version>
+        <gravitee-reporter-otel.version>1.0.0</gravitee-reporter-otel.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>3.0.0</gravitee-gateway-services-ratelimit.version>    -->
         <gravitee-tracer-jaeger.version>3.0.1</gravitee-tracer-jaeger.version>
@@ -577,6 +578,7 @@
                 </property>
             </activation>
             <modules>
+                <module>gravitee-apim-definition</module>
                 <module>gravitee-apim-gateway</module>
             </modules>
         </profile>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13621
https://gravitee.atlassian.net/browse/APIM-13622

## Description

Implements per-API OTel log capture and the Console UI toggle to enable it

## Additional context

 _**Gateway (APIM-13621):**_
 - Adds OtelLogs model and analytics.otelLogs field to the v4 API definition
 - Extends LoggingContext and AnalyticsUtils to propagate otelLogsEnabled
 - Injects traceId/spanId into the 4 log capture classes (LogEntrypointRequest, LogEndpointRequest, LogEndpointResponse, LogEntrypointResponse) when OTel logs are enabled
- Wires the OtelReporter in DefaultApiReactorFactory
- Adds OpenAPI spec OtelLogsV4 and updates openapi-apis.yaml

**_Console UI (APIM-13622):_**
- Adds OTel Logs toggle in Reporter Settings under the OpenTelemetry section
- Toggle is enabled only when Analytics + Tracing are both on
- Saving triggers API update and shows the Deploy banner

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

