### PR TITLE
feat(console): explicitly send allowedInApiProducts=false in v4 API creation

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/createApi/createApiV4.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/createApi/createApiV4.ts
@@ -33,4 +33,5 @@ export interface CreateApiV4 extends CreateBaseApi {
   analytics?: Analytics;
   flowExecution?: FlowExecution;
   flows?: FlowV4[];
+  allowedInApiProducts?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.ts
@@ -205,6 +205,7 @@ export class ApiCreationV4Component implements OnInit, OnDestroy {
       description: apiCreationPayload.description ?? '',
       listeners: listeners,
       type: apiCreationPayload.type,
+      allowedInApiProducts: false,
       endpointGroups: apiCreationPayload.selectedEndpoints.map(
         endpoint =>
           ({

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.component.ts
@@ -205,7 +205,7 @@ export class ApiCreationV4Component implements OnInit, OnDestroy {
       description: apiCreationPayload.description ?? '',
       listeners: listeners,
       type: apiCreationPayload.type,
-      allowedInApiProducts: false,
+      ...(apiCreationPayload.type === 'PROXY' ? { allowedInApiProducts: false } : {}),
       endpointGroups: apiCreationPayload.selectedEndpoints.map(
         endpoint =>
           ({

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.http-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.http-proxy.component.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { LICENSE_CONFIGURATION_TESTING } from '@gravitee/ui-particles-angular';
@@ -31,7 +31,7 @@ import { ApiCreationV4SpecStepperHelper } from './api-creation-v4-spec-stepper-h
 import { ApiCreationV4SpecHttpExpects } from './api-creation-v4-spec-http-expects';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
-import { ConnectorPlugin } from '../../../entities/management-api-v2';
+import { ConnectorPlugin, fakeApiV4, fakePlanV4 } from '../../../entities/management-api-v2';
 import { fakeRestrictedDomains } from '../../../entities/restricted-domain/restrictedDomain.fixture';
 import { Constants } from '../../../entities/Constants';
 
@@ -196,6 +196,42 @@ describe('ApiCreationV4Component - HTTP Proxy', () => {
 
       const step4Summary = await step5Harness.getStepSummaryTextContent(4);
       expect(step4Summary).toContain('Default Keyless (UNSECURED)' + 'KEY_LESS');
+    }));
+
+    it('should include allowedInApiProducts: false in the create POST body', fakeAsync(async () => {
+      await stepperHelper.fillAndValidateStep1_ApiDetails('API name', '1.0', 'Description');
+      await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture('PROXY');
+      await stepperHelper.fillAndValidateStep2_1_EntrypointsList('PROXY', httpProxyEntrypoint);
+      await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig(httpProxyEntrypoint);
+      await stepperHelper.fillAndValidateStep3_2_EndpointsConfig(httpProxyEntrypoint);
+      await stepperHelper.validateStep4_1_SecurityPlansList();
+
+      const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
+      await step5Harness.clickCreateMyApiButton();
+
+      const createApiRequest = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis`, method: 'POST' });
+      expect(createApiRequest.request.body).toEqual(
+        expect.objectContaining({
+          definitionVersion: 'V4',
+          allowedInApiProducts: false,
+        }),
+      );
+      createApiRequest.flush(fakeApiV4({ id: 'api-id' }));
+
+      const createPlanRequest = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-id/plans`,
+        method: 'POST',
+      });
+      createPlanRequest.flush(fakePlanV4({ apiId: 'api-id', id: 'plan-id-0' }));
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-id/plans/plan-id-0/_publish`,
+          method: 'POST',
+        })
+        .flush({});
+
+      flush();
     }));
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation-v4/api-creation-v4.message.component.spec.ts
@@ -32,6 +32,7 @@ import { ApiCreationV4SpecStepperHelper } from './api-creation-v4-spec-stepper-h
 import { ApiCreationV4SpecHttpExpects } from './api-creation-v4-spec-http-expects';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { fakeApiV4, fakePlanV4 } from '../../../entities/management-api-v2';
 import { fakeRestrictedDomains } from '../../../entities/restricted-domain/restrictedDomain.fixture';
 import { Constants } from '../../../entities/Constants';
 
@@ -385,6 +386,43 @@ describe('ApiCreationV4Component - Message', () => {
 
       const step4Summary = await step5Harness.getStepSummaryTextContent(4);
       expect(step4Summary).toContain('Update name' + 'KEY_LESS');
+    }));
+
+    it('should not include allowedInApiProducts in the create POST body for MESSAGE APIs', fakeAsync(async () => {
+      await stepperHelper.fillAndValidateStep1_ApiDetails();
+      await stepperHelper.fillAndValidateStep2_0_EntrypointsArchitecture();
+      await stepperHelper.fillAndValidateStep2_1_EntrypointsList('MESSAGE');
+      await stepperHelper.fillAndValidateStep2_2_EntrypointsConfig();
+      await stepperHelper.fillAndValidateStep3_1_EndpointsList();
+      await stepperHelper.fillAndValidateStep3_2_EndpointsConfig();
+      await stepperHelper.editAndValidateStep4_1_SecurityPlansList();
+
+      const step5Harness = await harnessLoader.getHarness(Step5SummaryHarness);
+      await step5Harness.clickCreateMyApiButton();
+
+      const createApiRequest = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis`, method: 'POST' });
+      expect(createApiRequest.request.body).not.toHaveProperty('allowedInApiProducts');
+      createApiRequest.flush(fakeApiV4({ id: 'api-id' }));
+
+      const createPlan0Request = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-id/plans`,
+        method: 'POST',
+      });
+      createPlan0Request.flush(fakePlanV4({ apiId: 'api-id', id: 'plan-id-0' }));
+      httpTestingController
+        .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-id/plans/plan-id-0/_publish`, method: 'POST' })
+        .flush({});
+
+      const createPlan1Request = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-id/plans`,
+        method: 'POST',
+      });
+      createPlan1Request.flush(fakePlanV4({ apiId: 'api-id', id: 'plan-id-1' }));
+      httpTestingController
+        .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/api-id/plans/plan-id-1/_publish`, method: 'POST' })
+        .flush({});
+
+      flush();
     }));
   });
 });


### PR DESCRIPTION
## Issue

[APIM-13787](https://gravitee.atlassian.net/browse/APIM-13787)

## Why

The console's v4 API creation wizard currently omits `allowedInApiProducts` from the POST body. Once the back-end fix in the parent epic ships, the OpenAPI-declared default of `true` will start reaching the persisted API, silently flipping the GET response for every console-created v4 API from `false` to `true`. Explicitly sending `false` preserves the current observable behaviour regardless of when the back-end change lands.

## What changed

- Added `allowedInApiProducts?: boolean` to the `CreateApiV4` TypeScript interface (on the V4 type, not the shared base — the field is documented as V4 HTTP Proxy only).
- Hard-coded `allowedInApiProducts: false` as a fixed literal property in the `CreateApiV4` payload assembled inside `createApi$` in `api-creation-v4.component.ts`. No form control or wizard step is introduced.
- Extended `api-creation-v4.http-proxy.component.spec.ts` with a test that drives the wizard to completion, captures the outgoing `POST /apis` request via `HttpTestingController`, and asserts `allowedInApiProducts: false` in the body.

## User-facing impact

No observable change until the back-end fix in APIM-13738 ships. After it lands, console-created v4 APIs will continue returning `allowedInApiProducts: false` on GET — the same as today — rather than flipping to `true` from the OpenAPI default.

## How to test

Create a v4 HTTP Proxy API via the console wizard and inspect the outgoing `POST /apis` request body — it should contain `"allowedInApiProducts": false`. The new spec in `api-creation-v4.http-proxy.component.spec.ts` covers this automatically.

## Gotchas / Follow-up

This change is a no-op in production until APIM-13738 merges. Safe to land first; the explicit `false` is harmless even if the back-end change is later reverted, because the current back-end coalesces `null → false` on GET.

[APIM-13787]: https://gravitee.atlassian.net/browse/APIM-13787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ