### PR TITLE
fix: prevent redoc overflow with unwrappable content.

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/redoc-content-viewer/redoc-content-viewer.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/redoc-content-viewer/redoc-content-viewer.component.scss
@@ -26,4 +26,5 @@
 #redoc {
   width: 100%;
   overflow: visible;
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13823

### Description

When an OpenAPI spec contains very long unbreakable strings (such as base64-encoded certificates), Redoc renders them without line breaking. This caused the Redoc view to stretch horizontally, pushing the sidenav navigation outside the viewport and clipping content on the right side.

The fix forces word wrapping on all text content rendered inside the Redoc container so that long tokens break within the available width rather than overflowing.

### Changes

#### Redoc content viewer — overflow wrapping

Added `overflow-wrap: anywhere` to the `#redoc` element in `redoc-content-viewer.component.scss`.

### Screenshots / video

<img width="1508" height="752" alt="Screenshot 2026-04-27 at 19 37 36" src="https://github.com/user-attachments/assets/a8bc725a-28ac-4537-9978-ef4c63c55f30" />
