### PR TITLE
API product transfer ownership group DB changes

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Group.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Group.java
@@ -55,5 +55,6 @@ public class Group {
     private boolean emailInvitation;
     private boolean disableMembershipNotifications;
     private String apiPrimaryOwner;
+    private String apiProductPrimaryOwner;
     private String origin;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcGroupRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcGroupRepository.java
@@ -79,6 +79,7 @@ public class JdbcGroupRepository extends JdbcAbstractCrudRepository<Group, Strin
             .addColumn("email_invitation", Types.BIT, boolean.class)
             .addColumn("disable_membership_notifications", Types.BIT, boolean.class)
             .addColumn("api_primary_owner", Types.NVARCHAR, String.class)
+            .addColumn("api_product_primary_owner", Types.NVARCHAR, String.class)
             .addColumn("origin", Types.NVARCHAR, String.class)
             .build();
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/07_add_api_product_primary_owner_to_groups.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/07_add_api_product_primary_owner_to_groups.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_07_add_api_product_primary_owner_to_groups
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}groups
+            columns:
+              - column:
+                  name: api_product_primary_owner
+                  type: nvarchar(64)
+                  constraints:
+                    nullable: true

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -341,3 +341,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/05_add_lifecycle_to_clusters_table.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/06_add_hrid_to_groups_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/07_add_api_product_primary_owner_to_groups.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/GroupMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/GroupMongo.java
@@ -46,5 +46,6 @@ public class GroupMongo extends DeprecatedAuditable {
     private boolean emailInvitation;
     private boolean disableMembershipNotifications;
     private String apiPrimaryOwner;
+    private String apiProductPrimaryOwner;
     private String origin;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/GroupRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/GroupRepositoryTest.java
@@ -91,6 +91,7 @@ public class GroupRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals(99, group.get().getMaxInvitation().intValue());
         assertEquals(2, group.get().getEventRules().size());
         assertEquals("api-primary-owner-id", group.get().getApiPrimaryOwner());
+        assertEquals("api-product-primary-owner-id", group.get().getApiProductPrimaryOwner());
     }
 
     @Test
@@ -115,6 +116,7 @@ public class GroupRepositoryTest extends AbstractManagementRepositoryTest {
         group.setDisableMembershipNotifications(false);
         group.setMaxInvitation(99);
         group.setApiPrimaryOwner("new-po-user-id");
+        group.setApiProductPrimaryOwner("new-product-po-user-id");
 
         Group update = groupRepository.update(group);
 
@@ -129,6 +131,7 @@ public class GroupRepositoryTest extends AbstractManagementRepositoryTest {
         assertFalse(update.isDisableMembershipNotifications());
         assertEquals(99, update.getMaxInvitation().intValue());
         assertEquals(group.getApiPrimaryOwner(), update.getApiPrimaryOwner());
+        assertEquals(group.getApiProductPrimaryOwner(), update.getApiProductPrimaryOwner());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/group-tests/groups.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/group-tests/groups.json
@@ -17,7 +17,8 @@
         "event": "APPLICATION_CREATE"
       }
     ],
-    "apiPrimaryOwner": "api-primary-owner-id"
+    "apiPrimaryOwner": "api-primary-owner-id",
+    "apiProductPrimaryOwner": "api-product-primary-owner-id"
   },
   {
     "id": "group-api-to-delete",


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13526

## Description

Schema (JDBC): Liquibase changelog adds api_product_primary_owner on groups; registered in master.yml.
Persistence: Group model and Jdbc / Mongo mappings updated for the new column.
