### PR TITLE
feat: dictionary CRUD in automation API

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 # Console
 gravitee-apim-console-webui/src/docs
 .circleci
+**/target

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMembershipRepository.java
@@ -31,6 +31,7 @@ import java.sql.Types;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -211,7 +212,7 @@ public class JdbcMembershipRepository extends JdbcAbstractCrudRepository<Members
                 },
                 getOrm().getRowMapper()
             );
-            return new HashSet<>(items);
+            return new LinkedHashSet<>(items);
         } catch (final Exception ex) {
             log.error("Failed to find membership by references and membership role_id", ex);
             throw new TechnicalException("Failed to find membership by references and membership role_id", ex);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMembershipRepository.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.management.model.MembershipReferenceType;
 import io.gravitee.repository.mongodb.management.internal.membership.MembershipMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.MembershipMongo;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -174,7 +175,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         } else {
             membershipMongos = internalMembershipRepo.findByReferencesAndRoleId(referenceType.name(), referenceIds, roleId);
         }
-        Set<Membership> memberships = membershipMongos.stream().map(this::map).collect(Collectors.toSet());
+        Set<Membership> memberships = membershipMongos.stream().map(this::map).collect(Collectors.toCollection(LinkedHashSet::new));
         log.debug("Find membership by references and roleId [{}, {}, {}] = {}", referenceType, referenceIds, roleId, memberships);
         return memberships;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/pom.xml
@@ -231,6 +231,7 @@
                         <typeMapping>BigDecimal=Number</typeMapping>
                     </typeMappings>
                     <additionalProperties>removeEnumValuePrefix=false</additionalProperties>
+                    <instantiationTypes>map=java.util.LinkedHashMap</instantiationTypes>
                 </configuration>
                 <executions>
                     <execution>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
@@ -20,6 +20,8 @@ import io.gravitee.apim.rest.api.automation.exception.mapping.ValidationDomainMa
 import io.gravitee.apim.rest.api.automation.resource.ApiSubscriptionsResource;
 import io.gravitee.apim.rest.api.automation.resource.ApisResource;
 import io.gravitee.apim.rest.api.automation.resource.ApplicationsResource;
+import io.gravitee.apim.rest.api.automation.resource.DictionariesResource;
+import io.gravitee.apim.rest.api.automation.resource.DictionaryResource;
 import io.gravitee.apim.rest.api.automation.resource.EnvironmentResource;
 import io.gravitee.apim.rest.api.automation.resource.EnvironmentsResource;
 import io.gravitee.apim.rest.api.automation.resource.GroupResource;
@@ -57,6 +59,8 @@ public class GraviteeAutomationApplication extends ResourceConfig {
         register(GroupResource.class);
         register(GroupsResource.class);
         register(SharedPolicyGroupsResource.class);
+        register(DictionariesResource.class);
+        register(DictionaryResource.class);
 
         register(ValidationDomainMapper.class);
         register(HRIDNotFoundMapper.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApplicationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApplicationMapper.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.rest.api.automation.model.ApplicationSpec;
 import io.gravitee.apim.rest.api.automation.model.ApplicationState;
 import io.gravitee.apim.rest.api.automation.model.ClientCertificate;
 import io.gravitee.apim.rest.api.automation.model.Metadata;
+import io.gravitee.rest.api.management.v2.rest.mapper.CollectionFactory;
 import io.gravitee.rest.api.management.v2.rest.mapper.DateMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.OriginContextMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ApplicationCRDSpec;
@@ -30,13 +31,12 @@ import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
-import org.springframework.util.StringUtils;
 
 /**
  * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Mapper(uses = { DateMapper.class, OriginContextMapper.class, ServiceMapper.class })
+@Mapper(uses = { DateMapper.class, OriginContextMapper.class, ServiceMapper.class, CollectionFactory.class })
 public interface ApplicationMapper {
     ApplicationMapper INSTANCE = Mappers.getMapper(ApplicationMapper.class);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/DictionaryMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/DictionaryMapper.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.mapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.dictionary.model.Dictionary;
+import io.gravitee.apim.rest.api.automation.model.DictionaryProvider;
+import io.gravitee.apim.rest.api.automation.model.DictionarySpec;
+import io.gravitee.apim.rest.api.automation.model.DictionaryState;
+import io.gravitee.apim.rest.api.automation.model.DictionaryTrigger;
+import io.gravitee.apim.rest.api.automation.model.DictionaryType;
+import io.gravitee.apim.rest.api.automation.model.DynamicDictionarySpec;
+import io.gravitee.apim.rest.api.automation.model.HttpDictionaryProvider;
+import io.gravitee.apim.rest.api.automation.model.ManualDictionarySpec;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryProviderEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryTriggerEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface DictionaryMapper {
+    DictionaryMapper INSTANCE = Mappers.getMapper(DictionaryMapper.class);
+
+    ObjectMapper GRAVITEE_MAPPER = new GraviteeMapper();
+
+    // ===== DictionarySpec → Dictionary (core) =====
+
+    @Mapping(source = "type", target = "type")
+    @Mapping(source = "manual.properties", target = "properties")
+    @Mapping(source = "dynamic.provider", target = "provider")
+    @Mapping(source = "dynamic.trigger", target = "trigger")
+    Dictionary toDictionary(DictionarySpec spec);
+
+    io.gravitee.apim.core.dictionary.model.DictionaryType toCoreType(DictionaryType type);
+
+    @Mapping(source = "unit", target = "unit", qualifiedByName = "specTriggerUnitToTimeUnit")
+    io.gravitee.apim.core.dictionary.model.DictionaryTrigger toCoreTrigger(DictionaryTrigger trigger);
+
+    default io.gravitee.apim.core.dictionary.model.DictionaryProvider toCoreProvider(DictionaryProvider provider) {
+        if (provider == null) return null;
+        Object actual = provider.getActualInstance();
+        if (actual instanceof HttpDictionaryProvider http) {
+            return io.gravitee.apim.core.dictionary.model.DictionaryProvider.builder()
+                .type(http.getType().getValue())
+                .configuration(GRAVITEE_MAPPER.valueToTree(http))
+                .build();
+        }
+        return null;
+    }
+
+    // ===== DictionaryEntity → DictionaryState =====
+
+    default DictionaryState toDictionaryState(DictionaryEntity entity, ExecutionContext executionContext) {
+        DictionaryState state = new DictionaryState(
+            entity.getId(),
+            executionContext.getEnvironmentId(),
+            executionContext.getOrganizationId()
+        );
+        state.setHrid(entity.getKey() != null ? entity.getKey() : entity.getId());
+        state.setName(entity.getName());
+        state.setDescription(entity.getDescription());
+        state.setType(toSpecType(entity.getType()));
+        if (entity.getType() == io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL) {
+            state.setDeployed(entity.getDeployedAt() != null);
+            ManualDictionarySpec manual = new ManualDictionarySpec();
+            manual.setProperties(entity.getProperties() != null ? entity.getProperties() : Map.of());
+            state.setManual(manual);
+        } else {
+            state.setDeployed(isEntityStarted(entity));
+            DynamicDictionarySpec dynamic = new DynamicDictionarySpec();
+            dynamic.setProvider(toSpecProvider(entity.getProvider()));
+            dynamic.setTrigger(toSpecTrigger(entity.getTrigger()));
+            state.setDynamic(dynamic);
+        }
+        return state;
+    }
+
+    DictionaryState toDictionaryState(DictionarySpec entity);
+
+    DictionaryType toSpecType(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType type);
+
+    @Mapping(source = "unit", target = "unit", qualifiedByName = "timeUnitToSpecTriggerUnit")
+    DictionaryTrigger toSpecTrigger(DictionaryTriggerEntity entity);
+
+    default DictionaryProvider toSpecProvider(DictionaryProviderEntity entity) {
+        if (entity == null) return null;
+        try {
+            HttpDictionaryProvider http = GRAVITEE_MAPPER.treeToValue(entity.getConfiguration(), HttpDictionaryProvider.class);
+            http.setType(HttpDictionaryProvider.TypeEnum.fromValue(entity.getType()));
+            return new DictionaryProvider(http);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to deserialize provider configuration", e);
+        }
+    }
+
+    // ===== @Named conversion helpers =====
+
+    @Named("specTriggerUnitToTimeUnit")
+    default TimeUnit specTriggerUnitToTimeUnit(DictionaryTrigger.UnitEnum unit) {
+        return unit != null ? TimeUnit.valueOf(unit.getValue()) : null;
+    }
+
+    @Named("timeUnitToSpecTriggerUnit")
+    default DictionaryTrigger.UnitEnum timeUnitToSpecTriggerUnit(TimeUnit unit) {
+        return unit != null ? DictionaryTrigger.UnitEnum.fromValue(unit.name()) : null;
+    }
+
+    default boolean isEntityStarted(DictionaryEntity entity) {
+        return entity.getState() != null && "STARTED".equals(entity.getState().name());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/GroupMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/GroupMapper.java
@@ -23,8 +23,8 @@ import io.gravitee.apim.rest.api.automation.model.Errors;
 import io.gravitee.apim.rest.api.automation.model.GroupMember;
 import io.gravitee.apim.rest.api.automation.model.GroupSpec;
 import io.gravitee.apim.rest.api.automation.model.GroupState;
-import io.gravitee.definition.model.Origin;
-import java.util.List;
+import io.gravitee.rest.api.management.v2.rest.mapper.CollectionFactory;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,7 +37,7 @@ import org.mapstruct.factory.Mappers;
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Mapper
+@Mapper(uses = { CollectionFactory.class })
 public interface GroupMapper {
     GroupMapper INSTANCE = Mappers.getMapper(GroupMapper.class);
 
@@ -54,26 +54,32 @@ public interface GroupMapper {
 
     Errors toErrors(GroupCRDStatus.Errors errors);
 
-    default GroupState groupSpecAndStatusToGroupState(GroupSpec spec, GroupCRDStatus status) {
-        GroupState state = new GroupState();
+    default GroupState groupSpecAndStatusToGroupState(GroupSpec spec, GroupCRDStatus status, ExecutionContext executionContext) {
+        GroupState state = new GroupState(
+            status.getId(),
+            executionContext.getEnvironmentId(),
+            executionContext.getOrganizationId(),
+            status.getMembers()
+        );
         state.setHrid(spec.getHrid());
         state.setName(spec.getName());
         state.setMembers(spec.getMembers());
         state.setNotifyMembers(spec.getNotifyMembers());
-        state.setId(status.getId());
-        state.setMemberCount(status.getMembers());
         state.setErrors(toErrors(status.getErrors()));
         return state;
     }
 
-    default GroupState groupToGroupState(Group group, Set<GroupCRDSpec.Member> members) {
-        GroupState state = new GroupState();
+    default GroupState groupToGroupState(Group group, Set<GroupCRDSpec.Member> members, ExecutionContext executionContext) {
+        GroupState state = new GroupState(
+            group.getId(),
+            executionContext.getEnvironmentId(),
+            executionContext.getOrganizationId(),
+            members != null ? (long) members.size() : 0L
+        );
         state.setHrid(group.getHrid());
         state.setName(group.getName());
         state.setNotifyMembers(!group.isDisableMembershipNotifications());
-        state.setMembers(members != null ? members.stream().map(this::memberToGroupMember).toList() : List.of());
-        state.setId(group.getId());
-        state.setMemberCount(members != null ? (long) members.size() : 0L);
+        state.setMembers(members != null ? members.stream().map(this::memberToGroupMember).toList() : null);
         return state;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/AbstractResource.java
@@ -18,8 +18,12 @@ package io.gravitee.apim.rest.api.automation.resource;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.PermissionService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
@@ -27,6 +31,18 @@ import org.springframework.security.core.context.SecurityContextHolder;
  * @author GraviteeSource Team
  */
 public abstract class AbstractResource {
+
+    @Inject
+    private PermissionService permissionService;
+
+    protected boolean hasPermission(
+        ExecutionContext executionContext,
+        RolePermission permission,
+        String referenceId,
+        RolePermissionAction... acls
+    ) {
+        return permissionService.hasPermission(executionContext, permission, referenceId, acls);
+    }
 
     protected UserDetails getAuthenticatedUserDetails() {
         return (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/DictionariesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/DictionariesResource.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
+
+import io.gravitee.apim.core.dictionary.domain_service.ValidateDictionaryDomainService;
+import io.gravitee.apim.core.dictionary.use_case.CreateOrUpdateDictionaryUseCase;
+import io.gravitee.apim.rest.api.automation.mapper.DictionaryMapper;
+import io.gravitee.apim.rest.api.automation.model.DictionarySpec;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author Benoit Bordigoni (benoit.bordigoni at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DictionariesResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private ValidateDictionaryDomainService validateDictionaryDomainService;
+
+    @Inject
+    private CreateOrUpdateDictionaryUseCase createOrUpdateDictionaryCRDUseCase;
+
+    @Path("/{hrid}")
+    public DictionaryResource getDictionaryResource() {
+        return resourceContext.getResource(DictionaryResource.class);
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DICTIONARY, acls = { CREATE, UPDATE }) })
+    public Response createOrUpdate(@Valid @NotNull DictionarySpec spec, @QueryParam("dryRun") boolean dryRun) {
+        var dictionary = DictionaryMapper.INSTANCE.toDictionary(spec);
+        validateDictionaryDomainService.validate(dictionary);
+
+        if (dryRun) {
+            return Response.ok(DictionaryMapper.INSTANCE.toDictionaryState(spec)).build();
+        }
+
+        dictionary.setId(HRIDToUUID.dictionary().context(getAuditInfo()).hrid(spec.getHrid()).id());
+        var executionContext = GraviteeContext.getExecutionContext();
+        var result = createOrUpdateDictionaryCRDUseCase.execute(
+            new CreateOrUpdateDictionaryUseCase.Input(executionContext, dictionary, spec.getDeployed())
+        );
+
+        return Response.ok(DictionaryMapper.INSTANCE.toDictionaryState(result.dictionary(), executionContext)).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/DictionaryResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/DictionaryResource.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.DELETE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
+
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
+import io.gravitee.apim.core.dictionary.use_case.DeleteDictionaryUseCase;
+import io.gravitee.apim.rest.api.automation.exception.HRIDNotFoundException;
+import io.gravitee.apim.rest.api.automation.mapper.DictionaryMapper;
+import io.gravitee.apim.rest.api.automation.model.DictionaryState;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import io.gravitee.rest.api.service.impl.configuration.dictionary.DictionaryNotFoundException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author Benoit Bordigoni (benoit.bordigoni at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DictionaryResource extends AbstractResource {
+
+    @Inject
+    private DeleteDictionaryUseCase deleteDictionaryUseCase;
+
+    @Inject
+    private DictionaryAutomationDomainService dictionaryService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DICTIONARY, acls = { RolePermissionAction.READ }) })
+    public Response getDictionaryByHRID(@PathParam("hrid") String hrid) {
+        var executionContext = GraviteeContext.getExecutionContext();
+        String id = HRIDToUUID.dictionary().context(getAuditInfo()).hrid(hrid).id();
+
+        DictionaryEntity entity = dictionaryService.findById(executionContext, id).orElseThrow(() -> new HRIDNotFoundException(hrid));
+
+        DictionaryState state = DictionaryMapper.INSTANCE.toDictionaryState(entity, executionContext);
+
+        boolean canWrite = hasPermission(
+            executionContext,
+            RolePermission.ENVIRONMENT_DICTIONARY,
+            executionContext.getEnvironmentId(),
+            CREATE,
+            UPDATE,
+            DELETE
+        );
+        if (!canWrite) {
+            state.setDynamic(null);
+        }
+
+        return Response.ok(state).build();
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DICTIONARY, acls = RolePermissionAction.DELETE) })
+    public Response deleteDictionaryByHrid(@PathParam("hrid") String hrid) {
+        var executionContext = GraviteeContext.getExecutionContext();
+        try {
+            String id = HRIDToUUID.dictionary().context(getAuditInfo()).hrid(hrid).id();
+            deleteDictionaryUseCase.execute(new DeleteDictionaryUseCase.Input(executionContext, id));
+        } catch (DictionaryNotFoundException e) {
+            throw new HRIDNotFoundException(hrid);
+        }
+        return Response.noContent().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/EnvironmentResource.java
@@ -47,4 +47,9 @@ public class EnvironmentResource {
     public SharedPolicyGroupsResource getSharedPolicyGroupsResource() {
         return resourceContext.getResource(SharedPolicyGroupsResource.class);
     }
+
+    @Path("/dictionaries")
+    public DictionariesResource getDictionariesResource() {
+        return resourceContext.getResource(DictionariesResource.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupResource.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.rest.api.automation.mapper.GroupMapper;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.MemberEntity;
 import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
@@ -41,10 +42,12 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -82,7 +85,7 @@ public class GroupResource extends AbstractResource {
 
         var members = buildGroupMembers(executionContext, memberEntities);
 
-        return Response.ok(GroupMapper.INSTANCE.groupToGroupState(group, members)).build();
+        return Response.ok(GroupMapper.INSTANCE.groupToGroupState(group, members, executionContext)).build();
     }
 
     @DELETE
@@ -98,24 +101,31 @@ public class GroupResource extends AbstractResource {
         return Response.noContent().build();
     }
 
-    private Set<GroupCRDSpec.Member> buildGroupMembers(ExecutionContext executionContext, Set<MemberEntity> memberEntities) {
+    private SequencedSet<GroupCRDSpec.Member> buildGroupMembers(ExecutionContext executionContext, Set<MemberEntity> memberEntities) {
         if (memberEntities.isEmpty()) {
-            return Set.of();
+            return new LinkedHashSet<>();
         }
 
-        var memberRolesById = new HashMap<String, Map<RoleScope, String>>();
+        var memberRolesById = new LinkedHashMap<String, Map<RoleScope, String>>();
 
         for (MemberEntity member : memberEntities) {
-            var roles = memberRolesById.computeIfAbsent(member.getId(), k -> new HashMap<>());
+            var roles = memberRolesById.computeIfAbsent(member.getId(), k -> new LinkedHashMap<>());
 
             Optional.ofNullable(member.getRoles())
                 .orElse(List.of())
                 .forEach(role -> roles.put(RoleScope.valueOf(role.getScope().name()), role.getName()));
         }
 
-        return userService
+        var usersByIds = userService
             .findByIds(executionContext, memberRolesById.keySet())
             .stream()
+            .collect(Collectors.groupingBy(UserEntity::getId));
+
+        return memberRolesById
+            .keySet()
+            .stream()
+            .map(usersByIds::get)
+            .map(List::getFirst)
             .map(user ->
                 GroupCRDSpec.Member.builder()
                     .source(user.getSource())
@@ -123,6 +133,6 @@ public class GroupResource extends AbstractResource {
                     .roles(memberRolesById.getOrDefault(user.getId(), Map.of()))
                     .build()
             )
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/GroupsResource.java
@@ -18,8 +18,6 @@ package io.gravitee.apim.rest.api.automation.resource;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
 
-import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
-import io.gravitee.apim.core.group.model.crd.GroupCRDStatus;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.group.use_case.ValidateGroupCRDUseCase;
 import io.gravitee.apim.rest.api.automation.helpers.CrdIdHelper;
@@ -29,6 +27,7 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
@@ -82,14 +81,16 @@ public class GroupsResource extends AbstractResource {
             CrdIdHelper.generateGroupId(groupCRDSpec, auditInfo);
         }
 
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+
         if (dryRun) {
             var status = validateGroupCRDUseCase.execute(new ImportGroupCRDUseCase.Input(auditInfo, groupCRDSpec)).status();
 
-            return Response.ok(GroupMapper.INSTANCE.groupSpecAndStatusToGroupState(spec, status)).build();
+            return Response.ok(GroupMapper.INSTANCE.groupSpecAndStatusToGroupState(spec, status, executionContext)).build();
         }
 
         var status = importGroupCRDUseCase.execute(new ImportGroupCRDUseCase.Input(auditInfo, groupCRDSpec)).status();
 
-        return Response.ok(GroupMapper.INSTANCE.groupSpecAndStatusToGroupState(spec, status)).build();
+        return Response.ok(GroupMapper.INSTANCE.groupSpecAndStatusToGroupState(spec, status, executionContext)).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1047,10 +1047,11 @@ components:
           maxLength: 512
         members:
           type: array
-          description: Members of this group with their IDP source and role assignments.
+          description: | 
+            Members of this group with their IDP source and role assignments.
+            Members that do not already exist in the IDP will be ignored.
           items:
             $ref: "#/components/schemas/GroupMember"
-          default: []
         notifyMembers:
           type: boolean
           description: If true, members will be notified when the group is synced with APIM.
@@ -1059,7 +1060,7 @@ components:
         - hrid
         - name
     GroupMember:
-      description: A member of a group, identified by an external IDP source.
+      description: A member of a group, possibly identified by an external IDP source.
       type: object
       properties:
         source:
@@ -1067,19 +1068,24 @@ components:
           description: The identity provider source of the member.
           examples:
             - gravitee
+            - google
+            - memory
         sourceId:
           type: string
-          description: The member's identifier in the identity provider.
+          description: The member's identifier within the identity provider.
           examples:
-            - "john.doe@example.com"
+            - "john.doe@acme.com"
+            - "john.doe@gmail.com"
+            - "admin"
         roles:
           type: object
-          description: Map of role scope to role name defining what the member can do.
+          description: Map of scopes to role name defining what the member can do.
           additionalProperties:
             type: string
           examples:
             - API: USER
               APPLICATION: ADMIN
+              INTEGRATION: ACME_READ_ONLY
       required:
         - source
         - sourceId
@@ -1090,16 +1096,27 @@ components:
         id:
           type: string
           description: Group's uuid.
+          readOnly: true
           examples:
             - 550e8400-e29b-41d4-a716-446655440000
+        environmentId:
+          type: string
+          description: The environment ID of the API.
+          readOnly: true
+        organizationId:
+          type: string
+          description: The organization ID of the API.
+          readOnly: true
         memberCount:
           type: integer
           format: int64
           description: Number of members in the group.
           examples:
             - 5
+          readOnly: true
         errors:
           $ref: "#/components/schemas/Errors"
+
     GroupState:
       description: Group state combining spec and status after creation/update.
       allOf:
@@ -1531,16 +1548,19 @@ components:
       properties:
         source:
           type: string
-          description: Where the memeber was created (system, idp, etc.)
+          description: Where the member was created (system, idp, etc.)
           examples:
-            - system
+            - gravitee
+            - google
+            - memory
         sourceId:
           description: Id of the user in the source
           type: string
           examples:
-            - "john.doe@example.com"
+            - john.doe@example.com
+            - admin
         role:
-          description: The role of the user in regards of the managed oject (API, Application, etc.)
+          description: The role of the user in regards of the managed object (API, Application, etc.)
           examples:
             - REVIEWER
           type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -38,6 +38,8 @@ tags:
     description: Everything about Shared Policy Groups
   - name: Groups
     description: Everything about Groups
+  - name: Dictionaries
+    description: Everything about Dictionaries
   - name: Subscriptions
     description: Everything about subscriptions
 paths:
@@ -304,6 +306,94 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  # Dictionnaries
+  /organizations/{orgId}/environments/{envId}/dictionaries:
+    put:
+      operationId: createOrUpdateDictionaries
+      tags:
+        - Dictionaries
+      summary: Create or update Dictionaries from Dictionaries Spec
+      description: Create/update Dictionaries from Dictionaries Spec
+      parameters:
+        - $ref: "#/components/parameters/orgIdParam"
+        - $ref: "#/components/parameters/envIdParam"
+        - $ref: "#/components/parameters/dryRunQueryParam"
+      requestBody:
+        description: Dictionary specification
+        content:
+          "application/json":
+            schema:
+              $ref: "#/components/schemas/DictionarySpec"
+        required: true
+      responses:
+        "200":
+          description: State of the successfully created/updated Dictionary
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DictionaryState"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Error"
+  /organizations/{orgId}/environments/{envId}/dictionaries/{hrid}:
+    parameters:
+      - $ref: "#/components/parameters/orgIdParam"
+      - $ref: "#/components/parameters/envIdParam"
+      - $ref: "#/components/parameters/hridParam"
+    get:
+      operationId: getDictionary
+      tags:
+        - Dictionaries
+      summary: Get one Dictionary
+      description: Get an Dictionary using HRID
+      parameters:
+        - $ref: "#/components/parameters/orgIdParam"
+        - $ref: "#/components/parameters/envIdParam"
+        - $ref: "#/components/parameters/hridParam"
+      responses:
+        "200":
+          description: Dictionary successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DictionaryState"
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Error"
+    delete:
+      operationId: deleteDictionary
+      tags:
+        - Dictionaries
+      summary: Delete one Dictionary
+      description: Delete an Dictionary using HRID
+      parameters:
+        - $ref: "#/components/parameters/orgIdParam"
+        - $ref: "#/components/parameters/envIdParam"
+        - $ref: "#/components/parameters/hridParam"
+      responses:
+        "204":
+          description: Dictionary successfully deleted
+        "401":
+          $ref: "#/components/responses/Unauthenticated"
+        "403":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/Error"
+
   # API Subscription
   /organizations/{orgId}/environments/{envId}/apis/{apiHrid}/subscriptions:
     put:
@@ -483,11 +573,13 @@ components:
       pattern: '^[a-zA-Z0-9][a-zA-Z0-9_-]+[a-zA-Z0-9]$'
       description: A unique human readable id identifying this resource
       examples:
-        - my_demo_api
-        - simple_demo_app
+        - demo_api
+        - demo_app
         - keyless_demo_plan
+        - demo_page
         - demo_subscription
         - demo_shared_policy_groups
+        - demo_dictionary
       maxLength: 256
     ApiV4Spec:
       description: ApiV4DefinitionSpec defines the desired state of ApiDefinition.
@@ -1013,6 +1105,167 @@ components:
       allOf:
         - $ref: "#/components/schemas/GroupSpec"
         - $ref: "#/components/schemas/GroupStatus"
+
+    DictionaryState:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/DictionarySpec"
+        - type: object
+          properties:
+            id:
+              type: string
+              readOnly: true
+            environmentId:
+              type: string
+              description: The environment ID of the API.
+              readOnly: true
+            organizationId:
+              type: string
+              description: The organization ID of the API.
+              readOnly: true
+          required:
+            - id
+    DictionarySpec:
+      description: |
+        Specification of a dictionary resource. Allow users to create, update and delete dictionaries. Dictionaries
+        can the be used using Gravitee EL expression such `{#dictionaries['hrid'][#EL expression |'property key']`
+      type: object
+      properties:
+        hrid:
+          $ref: "#/components/schemas/Hrid"
+        name:
+          type: string
+          description: Display name of the dictionary
+        deployed:
+          type: boolean
+          description: |
+            If true, a `MANUAL` type dictionary is deployed in the gateway, a `DYNAMIC` type dictionary is started. 
+            Changing this value back to false will stop the dictionary or undeploy it.
+        description:
+          type: string
+          description: Detailed description of the dictionary
+        type:
+          $ref: "#/components/schemas/DictionaryType"
+        manual:
+          $ref: "#/components/schemas/ManualDictionarySpec"
+        dynamic:
+          $ref: "#/components/schemas/DynamicDictionarySpec"
+      required:
+        - hrid
+        - name
+        - type
+        - deployed
+    ManualDictionarySpec:
+      description: A manual dictionary with static key/value properties.
+      properties:
+        properties:
+          type: object
+          description: Dictionary data are key/value pairs for `MANUAL` properties
+          additionalProperties:
+            type: string
+      required:
+        - properties
+    DynamicDictionarySpec:
+      description: A dynamic dictionary populated from an external provider on a schedule.
+      type: object
+      properties:
+        provider:
+          $ref: "#/components/schemas/DictionaryProvider"
+        trigger:
+          $ref: "#/components/schemas/DictionaryTrigger"
+      required:
+        - provider
+        - trigger
+    DictionaryProvider:
+      description: Provider of a 'DYNAMIC' type dictionary
+      oneOf:
+        - $ref: "#/components/schemas/HttpDictionaryProvider"
+      discriminator:
+        propertyName: type
+        mapping:
+          HTTP: "#/components/schemas/HttpDictionaryProvider"
+    HttpDictionaryProvider:
+      type: object
+      description: HTTP dictionary provider configuration
+      properties:
+        type:
+          type: string
+          description: Type of dictionary provider.
+          enum:
+            - HTTP
+        url:
+          type: string
+          format: uri
+          description: URL of the provider
+        specification:
+          type: string
+          description: "Transformation of the returned payload (JOLT Specification)"
+        headers:
+          type: array
+          description: HTTP Headers
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: Header name
+              value:
+                type: string
+                description: Header value
+            required:
+              - name
+              - value
+            additionalProperties: false
+        useSystemProxy:
+          type: boolean
+          title: Use system proxy
+        method:
+          type: string
+          title: HTTP Method
+          enum:
+            - GET
+            - POST
+            - PUT
+            - PATCH
+            - DELETE
+            - HEAD
+            - OPTIONS
+            - TRACE
+            - CONNECT
+        body:
+          type: string
+          description: Optional request payload
+      required:
+        - type
+        - url
+        - method
+        - specification
+      additionalProperties: false
+    DictionaryTrigger:
+      type: object
+      description: Renewal configuration for a 'DYNAMIC' dictionary
+      properties:
+        rate:
+          type: integer
+          format: int64
+        unit:
+          type: string
+          enum:
+            - MICROSECONDS
+            - MILLISECONDS
+            - SECONDS
+            - MINUTES
+            - HOURS
+            - DAYS
+      required:
+        - rate
+        - unit
+    DictionaryType:
+      type: string
+      description: Type of dictionary. MANUAL is to be updated manually, DYNAMIC is updated and deployed automatically.
+      enum:
+        - MANUAL
+        - DYNAMIC
 
     SubscriptionSpec:
       description: Subscription specification

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1524,7 +1524,6 @@ components:
         - type
         - mode
         - validation
-        - security
 
     Member:
       description: Users that can manage an object (API, Application, etc.)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/DictionariesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/DictionariesResourceTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.dictionary.domain_service.ValidateDictionaryDomainService;
+import io.gravitee.apim.core.dictionary.use_case.CreateOrUpdateDictionaryUseCase;
+import io.gravitee.apim.rest.api.automation.model.DictionaryState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import java.util.Date;
+import java.util.Map;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DictionariesResourceTest extends AbstractResourceTest {
+
+    @Inject
+    private CreateOrUpdateDictionaryUseCase createOrUpdateDictionaryUseCase;
+
+    @Inject
+    private ValidateDictionaryDomainService validateDictionaryDomainService;
+
+    @AfterEach
+    void tearDown() {
+        reset(createOrUpdateDictionaryUseCase, validateDictionaryDomainService);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/dictionaries";
+    }
+
+    @Nested
+    class DryRun {
+
+        @Test
+        void should_return_spec_without_calling_use_case() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("manual-dictionary.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verifyNoInteractions(createOrUpdateDictionaryUseCase);
+            }
+        }
+
+        @Test
+        void should_return_400_when_dictionary_is_invalid() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("invalid-dictionary.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+                verifyNoInteractions(createOrUpdateDictionaryUseCase);
+            }
+        }
+    }
+
+    @Nested
+    class Run {
+
+        @Test
+        void should_create_or_update_manual_dictionary() {
+            var entity = DictionaryEntity.builder()
+                .id("dict-id")
+                .name("My Dictionary")
+                .key("my-dict")
+                .type(DictionaryType.MANUAL)
+                .state(Lifecycle.State.STOPPED)
+                .properties(Map.of("key1", "value1"))
+                .createdAt(new Date())
+                .updatedAt(new Date())
+                .deployedAt(new Date())
+                .build();
+            when(createOrUpdateDictionaryUseCase.execute(any())).thenReturn(new CreateOrUpdateDictionaryUseCase.Output(entity));
+
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("manual-dictionary.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(validateDictionaryDomainService).validate(any());
+                verify(createOrUpdateDictionaryUseCase).execute(any(CreateOrUpdateDictionaryUseCase.Input.class));
+
+                var state = response.readEntity(DictionaryState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getId()).isEqualTo("dict-id");
+                    soft.assertThat(state.getHrid()).isEqualTo("my-dict");
+                    soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
+                    soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
+                    soft.assertThat(state.getDeployed()).isTrue();
+                    soft.assertThat(state.getManual()).isNotNull();
+                    soft.assertThat(state.getManual().getProperties()).containsEntry("key1", "value1");
+                });
+            }
+        }
+
+        @Test
+        void should_create_or_update_dynamic_dictionary() {
+            var entity = DictionaryEntity.builder()
+                .id("dyn-dict-id")
+                .name("My Dynamic Dictionary")
+                .key("my-dynamic-dict")
+                .type(DictionaryType.DYNAMIC)
+                .state(Lifecycle.State.STOPPED)
+                .createdAt(new Date())
+                .updatedAt(new Date())
+                .build();
+            when(createOrUpdateDictionaryUseCase.execute(any())).thenReturn(new CreateOrUpdateDictionaryUseCase.Output(entity));
+
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("dynamic-dictionary.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(createOrUpdateDictionaryUseCase).execute(any(CreateOrUpdateDictionaryUseCase.Input.class));
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/DictionaryResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/DictionaryResourceTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
+import io.gravitee.apim.core.dictionary.use_case.DeleteDictionaryUseCase;
+import io.gravitee.apim.rest.api.automation.model.DictionaryState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryProviderEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryTriggerEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import io.gravitee.rest.api.service.impl.configuration.dictionary.DictionaryNotFoundException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class DictionaryResourceTest extends AbstractResourceTest {
+
+    @Inject
+    private DictionaryAutomationDomainService dictionaryAutomationDomainService;
+
+    @Inject
+    private DeleteDictionaryUseCase deleteDictionaryUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(dictionaryAutomationDomainService, deleteDictionaryUseCase);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/dictionaries";
+    }
+
+    @Nested
+    class GetByHrid {
+
+        @Test
+        void should_return_dictionary_state() {
+            var id = HRIDToUUID.dictionary().context(new ExecutionContext(ORGANIZATION, ENVIRONMENT)).hrid("my-dict").id();
+            var entity = DictionaryEntity.builder()
+                .id(id)
+                .name("My Dictionary")
+                .key("my-dict")
+                .type(DictionaryType.MANUAL)
+                .state(Lifecycle.State.STOPPED)
+                .properties(Map.of("key1", "value1"))
+                .createdAt(new Date())
+                .updatedAt(new Date())
+                .deployedAt(new Date())
+                .build();
+            when(dictionaryAutomationDomainService.findById(any(), eq(id))).thenReturn(Optional.of(entity));
+
+            try (var response = rootTarget("my-dict").request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                var state = response.readEntity(DictionaryState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getId()).isEqualTo(id);
+                    soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
+                    soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
+                    soft.assertThat(state.getHrid()).isEqualTo("my-dict");
+                    soft.assertThat(state.getName()).isEqualTo("My Dictionary");
+                    soft.assertThat(state.getDeployed()).isTrue();
+                    soft.assertThat(state.getManual()).isNotNull();
+                    soft.assertThat(state.getManual().getProperties()).isNotNull();
+                    soft.assertThat(state.getManual().getProperties()).containsEntry("key1", "value1");
+                });
+            }
+        }
+
+        @Test
+        void should_strip_dynamic_fields_for_readonly_user() {
+            var trigger = new DictionaryTriggerEntity();
+            trigger.setRate(5L);
+            trigger.setUnit(TimeUnit.SECONDS);
+            var provider = new DictionaryProviderEntity();
+            provider.setType("HTTP");
+            provider.setConfiguration(new ObjectMapper().createObjectNode().put("url", "http://example.com").put("method", "GET"));
+
+            var entity = DictionaryEntity.builder()
+                .id("dyn-id")
+                .name("Dynamic Dict")
+                .key("dyn-dict")
+                .type(DictionaryType.DYNAMIC)
+                .state(Lifecycle.State.STARTED)
+                .provider(provider)
+                .trigger(trigger)
+                .createdAt(new Date())
+                .updatedAt(new Date())
+                .build();
+            when(dictionaryAutomationDomainService.findById(any(), any())).thenReturn(Optional.of(entity));
+            when(
+                permissionService.hasPermission(
+                    any(),
+                    eq(RolePermission.ENVIRONMENT_DICTIONARY),
+                    any(),
+                    eq(RolePermissionAction.CREATE),
+                    eq(RolePermissionAction.UPDATE),
+                    eq(RolePermissionAction.DELETE)
+                )
+            ).thenReturn(false);
+
+            try (var response = rootTarget("dyn-dict").request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                var state = response.readEntity(DictionaryState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getId()).isEqualTo("dyn-id");
+                    soft.assertThat(state.getDynamic()).isNull();
+                });
+            }
+        }
+
+        @Test
+        void should_return_404_when_not_found() {
+            when(dictionaryAutomationDomainService.findById(any(), any())).thenReturn(Optional.empty());
+
+            try (var response = rootTarget("unknown").request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    @Nested
+    class DeleteByHrid {
+
+        @Test
+        void should_delete_dictionary() {
+            var id = HRIDToUUID.dictionary().context(new ExecutionContext(ORGANIZATION, ENVIRONMENT)).hrid("my-dict").id();
+            var entity = DictionaryEntity.builder()
+                .id("dict-id")
+                .name("My Dictionary")
+                .key("my-dict")
+                .type(DictionaryType.MANUAL)
+                .state(Lifecycle.State.STOPPED)
+                .createdAt(new Date())
+                .updatedAt(new Date())
+                .build();
+            when(dictionaryAutomationDomainService.findById(any(), eq(id))).thenReturn(Optional.of(entity));
+
+            try (var response = rootTarget("my-dict").request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+                verify(deleteDictionaryUseCase).execute(any(DeleteDictionaryUseCase.Input.class));
+            }
+        }
+
+        @Test
+        void should_return_404_when_not_found() {
+            Mockito.doThrow(new DictionaryNotFoundException("unknown")).when(deleteDictionaryUseCase).execute(any());
+
+            try (var response = rootTarget("unknown").request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupResourceTest.java
@@ -108,6 +108,8 @@ class GroupResourceTest extends AbstractResourceTest {
                     soft.assertThat(state.getHrid()).isEqualTo(HRID);
                     soft.assertThat(state.getName()).isEqualTo("My Group");
                     soft.assertThat(state.getNotifyMembers()).isTrue();
+                    soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
+                    soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
                 });
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/GroupsResourceTest.java
@@ -66,6 +66,8 @@ class GroupsResourceTest extends AbstractResourceTest {
                 soft.assertThat(state.getHrid()).isEqualTo("my-group");
                 soft.assertThat(state.getName()).isEqualTo("my-group");
                 soft.assertThat(state.getNotifyMembers()).isTrue();
+                soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
+                soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
             });
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/PermissionsFilterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/PermissionsFilterTest.java
@@ -23,9 +23,11 @@ import static io.gravitee.rest.api.model.permissions.RolePermission.API_DEFINITI
 import static io.gravitee.rest.api.model.permissions.RolePermission.API_SUBSCRIPTION;
 import static io.gravitee.rest.api.model.permissions.RolePermission.APPLICATION_DEFINITION;
 import static io.gravitee.rest.api.model.permissions.RolePermission.ENVIRONMENT_API;
+import static io.gravitee.rest.api.model.permissions.RolePermission.ENVIRONMENT_DICTIONARY;
 import static io.gravitee.rest.api.model.permissions.RolePermission.ENVIRONMENT_SHARED_POLICY_GROUP;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -344,6 +346,137 @@ class PermissionsFilterTest {
             permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
 
             verify(permissionService, times(1)).hasPermission(any(), eq(ENVIRONMENT_SHARED_POLICY_GROUP), eq(ENVIRONMENT_ID), eq(CREATE));
+        }
+    }
+
+    @Nested
+    class Dictionaries {
+
+        @Nested
+        class CreateOrUpdate {
+
+            @BeforeEach
+            void initMocks() {
+                Permission perm = mock(Permission.class);
+                when(perm.value()).thenReturn(ENVIRONMENT_DICTIONARY);
+                when(perm.acls()).thenReturn(new RolePermissionAction[] { CREATE, UPDATE });
+                when(permissions.value()).thenReturn(new Permission[] { perm });
+                UriInfo uriInfo = mock(UriInfo.class);
+                when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+            }
+
+            @Test
+            void shouldThrowForbiddenExceptionWhenNoDictionaryPermissions() {
+                when(permissionService.hasPermission(any(), eq(ENVIRONMENT_DICTIONARY), eq(ENVIRONMENT_ID))).thenReturn(false);
+
+                ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+                assertThrows(
+                    ForbiddenAccessException.class,
+                    () -> permissionFilter.filter(permissions, containerRequestContext, executionContext),
+                    "You do not have sufficient rights to access this resource"
+                );
+            }
+
+            @Test
+            void shouldBeAuthorizedWhenDictionaryCreatePermissions() {
+                when(
+                    permissionService.hasPermission(any(), eq(ENVIRONMENT_DICTIONARY), eq(ENVIRONMENT_ID), eq(CREATE), eq(UPDATE))
+                ).thenReturn(true);
+
+                permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+
+                verify(permissionService, times(1)).hasPermission(
+                    any(),
+                    eq(ENVIRONMENT_DICTIONARY),
+                    eq(ENVIRONMENT_ID),
+                    eq(CREATE),
+                    eq(UPDATE)
+                );
+            }
+        }
+
+        @Nested
+        class Read {
+
+            @BeforeEach
+            void initMocks() {
+                Permission perm = mock(Permission.class);
+                when(perm.value()).thenReturn(ENVIRONMENT_DICTIONARY);
+                when(perm.acls()).thenReturn(new RolePermissionAction[] { RolePermissionAction.READ });
+                when(permissions.value()).thenReturn(new Permission[] { perm });
+                UriInfo uriInfo = mock(UriInfo.class);
+                when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+            }
+
+            @Test
+            void shouldThrowForbiddenExceptionWhenNoReadPermissions() {
+                when(permissionService.hasPermission(any(), eq(ENVIRONMENT_DICTIONARY), eq(ENVIRONMENT_ID))).thenReturn(false);
+
+                ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+                assertThrows(
+                    ForbiddenAccessException.class,
+                    () -> permissionFilter.filter(permissions, containerRequestContext, executionContext),
+                    "You do not have sufficient rights to access this resource"
+                );
+            }
+
+            @Test
+            void shouldBeAuthorizedWhenDictionaryReadPermissions() {
+                when(
+                    permissionService.hasPermission(any(), eq(ENVIRONMENT_DICTIONARY), eq(ENVIRONMENT_ID), eq(RolePermissionAction.READ))
+                ).thenReturn(true);
+
+                permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+
+                verify(permissionService, times(1)).hasPermission(
+                    any(),
+                    eq(ENVIRONMENT_DICTIONARY),
+                    eq(ENVIRONMENT_ID),
+                    eq(RolePermissionAction.READ)
+                );
+            }
+        }
+
+        @Nested
+        class Delete {
+
+            @BeforeEach
+            void initMocks() {
+                Permission perm = mock(Permission.class);
+                when(perm.value()).thenReturn(ENVIRONMENT_DICTIONARY);
+                when(perm.acls()).thenReturn(new RolePermissionAction[] { RolePermissionAction.DELETE });
+                when(permissions.value()).thenReturn(new Permission[] { perm });
+                UriInfo uriInfo = mock(UriInfo.class);
+                when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+            }
+
+            @Test
+            void shouldThrowForbiddenExceptionWhenNoDeletePermissions() {
+                when(permissionService.hasPermission(any(), eq(ENVIRONMENT_DICTIONARY), eq(ENVIRONMENT_ID))).thenReturn(false);
+
+                ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+                assertThrows(
+                    ForbiddenAccessException.class,
+                    () -> permissionFilter.filter(permissions, containerRequestContext, executionContext),
+                    "You do not have sufficient rights to access this resource"
+                );
+            }
+
+            @Test
+            void shouldBeAuthorizedWhenDictionaryDeletePermissions() {
+                when(
+                    permissionService.hasPermission(any(), eq(ENVIRONMENT_DICTIONARY), eq(ENVIRONMENT_ID), eq(RolePermissionAction.DELETE))
+                ).thenReturn(true);
+
+                permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+
+                verify(permissionService, times(1)).hasPermission(
+                    any(),
+                    eq(ENVIRONMENT_DICTIONARY),
+                    eq(ENVIRONMENT_ID),
+                    eq(RolePermissionAction.DELETE)
+                );
+            }
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -99,6 +99,10 @@ import io.gravitee.apim.core.cluster.use_case.members.GetClusterMembersUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.GetClusterPermissionsUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.TransferClusterOwnershipUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.UpdateClusterMemberUseCase;
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
+import io.gravitee.apim.core.dictionary.domain_service.ValidateDictionaryDomainService;
+import io.gravitee.apim.core.dictionary.use_case.CreateOrUpdateDictionaryUseCase;
+import io.gravitee.apim.core.dictionary.use_case.DeleteDictionaryUseCase;
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageAccessControlsDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDomainService;
@@ -212,6 +216,7 @@ import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
+import io.gravitee.rest.api.service.configuration.dictionary.DictionaryService;
 import io.gravitee.rest.api.service.impl.configuration.application.ApplicationTypeServiceImpl;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
@@ -1171,5 +1176,25 @@ public class ResourceContextConfiguration {
     @Bean
     public SubscriptionFormSchemaGenerator subscriptionFormSchemaGenerator() {
         return mock(SubscriptionFormSchemaGenerator.class);
+    }
+
+    @Bean
+    public ValidateDictionaryDomainService validateDictionaryDomainService() {
+        return mock(ValidateDictionaryDomainService.class);
+    }
+
+    @Bean
+    public CreateOrUpdateDictionaryUseCase createOrUpdateDictionaryUseCase() {
+        return mock(CreateOrUpdateDictionaryUseCase.class);
+    }
+
+    @Bean
+    public DeleteDictionaryUseCase deleteDictionaryUseCase() {
+        return mock(DeleteDictionaryUseCase.class);
+    }
+
+    @Bean
+    public DictionaryAutomationDomainService dictionaryAutomationDomainService() {
+        return mock(DictionaryAutomationDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/dynamic-dictionary.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/dynamic-dictionary.json
@@ -1,0 +1,18 @@
+{
+  "hrid": "my-dynamic-dict",
+  "name": "My Dynamic Dictionary",
+  "type": "DYNAMIC",
+  "deployed": false,
+  "dynamic": {
+    "provider": {
+      "type": "HTTP",
+      "url": "http://example.com/data",
+      "method": "GET",
+      "specification": "[{\"operation\": \"default\"}]"
+    },
+    "trigger": {
+      "rate": 5,
+      "unit": "SECONDS"
+    }
+  }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/invalid-dictionary.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/invalid-dictionary.json
@@ -1,0 +1,25 @@
+{
+  "hrid": "my-dict",
+  "name": "My Dictionary",
+  "description": "A test dictionary",
+  "type": "MANUAL",
+  "deployed": true,
+  "manual": {
+    "properties": {
+      "key1": "value1"
+    }
+  },
+  "dynamic": {
+    "provider": {
+      "type": "HTTP",
+      "configuration": {
+        "url": "http://example.com",
+        "method": "GET"
+      }
+    },
+    "trigger": {
+      "rate": 5,
+      "condition": "true"
+    }
+  }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/manual-dictionary.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/manual-dictionary.json
@@ -1,0 +1,12 @@
+{
+  "hrid": "my-dict",
+  "name": "My Dictionary",
+  "description": "A test dictionary",
+  "type": "MANUAL",
+  "deployed": true,
+  "manual": {
+    "properties": {
+      "key1": "value1"
+    }
+  }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -75,7 +75,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.Predicate;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -103,6 +103,7 @@ import org.slf4j.Logger;
         ServiceMapper.class,
         CorsMapper.class,
         ConfigurationSerializationMapper.class,
+        CollectionFactory.class,
     }
 )
 public interface ApiMapper {
@@ -158,20 +159,20 @@ public interface ApiMapper {
         return api;
     }
 
-    default List<Api> map(List<GenericApiEntity> apiEntities, UriInfo uriInfo, Function<GenericApiEntity, Boolean> isSynchronized) {
+    default List<Api> map(List<GenericApiEntity> apiEntities, UriInfo uriInfo, Predicate<GenericApiEntity> isSynchronized) {
         return map(apiEntities, uriInfo, isSynchronized, null);
     }
 
     default List<Api> map(
         List<GenericApiEntity> apiEntities,
         UriInfo uriInfo,
-        Function<GenericApiEntity, Boolean> isSynchronized,
+        Predicate<GenericApiEntity> isSynchronized,
         Set<String> expands
     ) {
         var result = new ArrayList<Api>();
         apiEntities.forEach(api -> {
             try {
-                result.add(this.map(api, uriInfo, isSynchronized.apply(api), expands));
+                result.add(this.map(api, uriInfo, isSynchronized.test(api), expands));
             } catch (Exception e) {
                 // Ignore APIs throwing conversion issues in the list
                 // As v4 was out there in alpha version, we still want to build the list event if some APIs cannot be converted
@@ -566,6 +567,6 @@ public interface ApiMapper {
                 return null;
             })
             .filter(Objects::nonNull)
-            .collect(java.util.stream.Collectors.toList());
+            .toList();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -75,7 +75,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Predicate;
+import java.util.function.Function;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -159,20 +159,20 @@ public interface ApiMapper {
         return api;
     }
 
-    default List<Api> map(List<GenericApiEntity> apiEntities, UriInfo uriInfo, Predicate<GenericApiEntity> isSynchronized) {
+    default List<Api> map(List<GenericApiEntity> apiEntities, UriInfo uriInfo, Function<GenericApiEntity, Boolean> isSynchronized) {
         return map(apiEntities, uriInfo, isSynchronized, null);
     }
 
     default List<Api> map(
         List<GenericApiEntity> apiEntities,
         UriInfo uriInfo,
-        Predicate<GenericApiEntity> isSynchronized,
+        Function<GenericApiEntity, Boolean> isSynchronized,
         Set<String> expands
     ) {
         var result = new ArrayList<Api>();
         apiEntities.forEach(api -> {
             try {
-                result.add(this.map(api, uriInfo, isSynchronized.test(api), expands));
+                result.add(this.map(api, uriInfo, isSynchronized.apply(api), expands));
             } catch (Exception e) {
                 // Ignore APIs throwing conversion issues in the list
                 // As v4 was out there in alpha version, we still want to build the list event if some APIs cannot be converted

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApplicationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApplicationMapper.java
@@ -30,7 +30,7 @@ import org.mapstruct.factory.Mappers;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Mapper(uses = { DateMapper.class })
+@Mapper(uses = { DateMapper.class, CollectionFactory.class })
 public interface ApplicationMapper {
     ApplicationMapper INSTANCE = Mappers.getMapper(ApplicationMapper.class);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/CollectionFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/CollectionFactory.java
@@ -1,0 +1,31 @@
+/*
+ *
+ *  * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import java.util.LinkedHashSet;
+import java.util.SequencedSet;
+import org.mapstruct.ObjectFactory;
+
+public class CollectionFactory {
+
+    @ObjectFactory
+    public <T> SequencedSet<T> createSequencedSet() {
+        return new LinkedHashSet<>();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/CollectionFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/CollectionFactory.java
@@ -1,21 +1,18 @@
 /*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
- *  * Copyright © 2015 The Gravitee team (http://gravitee.io)
- *  *
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *     http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import java.util.LinkedHashSet;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/GroupCRDMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/GroupCRDMapper.java
@@ -23,7 +23,7 @@ import org.mapstruct.factory.Mappers;
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Mapper
+@Mapper(uses = { CollectionFactory.class })
 public interface GroupCRDMapper {
     GroupCRDMapper INSTANCE = Mappers.getMapper(GroupCRDMapper.class);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -125,6 +125,7 @@ import io.gravitee.apim.core.cluster.use_case.members.GetClusterMembersUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.GetClusterPermissionsUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.TransferClusterOwnershipUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.UpdateClusterMemberUseCase;
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.domain_service.DocumentationValidationDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageAccessControlsDomainService;
@@ -1466,5 +1467,10 @@ public class ResourceContextConfiguration {
     @Bean
     public SubscriptionFormSchemaGenerator subscriptionFormSchemaGenerator() {
         return mock(SubscriptionFormSchemaGenerator.class);
+    }
+
+    @Bean
+    public DictionaryAutomationDomainService dictionaryAutomationDomainService() {
+        return mock(DictionaryAutomationDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -97,6 +97,7 @@ import io.gravitee.apim.core.cluster.use_case.members.GetClusterMembersUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.GetClusterPermissionsUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.TransferClusterOwnershipUseCase;
 import io.gravitee.apim.core.cluster.use_case.members.UpdateClusterMemberUseCase;
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDomainService;
 import io.gravitee.apim.core.group.crud_service.GroupCrudService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
@@ -1360,5 +1361,10 @@ public class ResourceContextConfiguration {
     @Bean
     public ClientCertificateValidationDomainService clientCertificateValidationDomainService() {
         return mock(ClientCertificateValidationDomainService.class);
+    }
+
+    @Bean
+    public DictionaryAutomationDomainService dictionaryAutomationDomainService() {
+        return mock(DictionaryAutomationDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -102,6 +102,7 @@ import io.gravitee.apim.core.cluster.use_case.members.TransferClusterOwnershipUs
 import io.gravitee.apim.core.cluster.use_case.members.UpdateClusterMemberUseCase;
 import io.gravitee.apim.core.dashboard.use_case.GetDashboardUseCase;
 import io.gravitee.apim.core.dashboard.use_case.ListDashboardsUseCase;
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDomainService;
 import io.gravitee.apim.core.group.crud_service.GroupCrudService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
@@ -1398,5 +1399,10 @@ public class ResourceContextConfiguration {
     @Bean
     SubscriptionFormSchemaGenerator subscriptionFormSchemaGenerator() {
         return new SubscriptionFormSchemaGeneratorImpl();
+    }
+
+    @Bean
+    public DictionaryAutomationDomainService dictionaryAutomationDomainService() {
+        return mock(DictionaryAutomationDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainService.java
@@ -73,7 +73,7 @@ public class ValidateApiCRDDomainService implements Validator<ValidateApiCRDDoma
 
         if (input.spec.isNative()) {
             validateAndSanitizeNativeV4ForCreation(input, sanitizedBuilder, errors);
-        } else {
+        } else if (!input.spec.isOnlySubscription()) {
             validateAndSanitizeHttpV4ForCreation(input, sanitizedBuilder, errors);
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
@@ -36,6 +36,7 @@ import io.gravitee.definition.model.v4.listener.AbstractListener;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.entrypoint.AbstractEntrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
 import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
@@ -49,12 +50,10 @@ import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.model.notification.PortalNotificationConfigEntity;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -288,6 +287,10 @@ public class ApiCRDSpec {
                     LinkedHashMap::new
                 )
             );
+    }
+
+    public boolean isOnlySubscription() {
+        return this.listeners.size() == this.listeners.stream().filter(SubscriptionListener.class::isInstance).count();
     }
 
     public static class ApiCRDSpecBuilder {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -118,7 +119,7 @@ public class ApiCRDSpec {
 
     private Set<String> groups;
 
-    private Set<MemberCRD> members;
+    private SequencedSet<MemberCRD> members;
 
     private boolean notifyMembers;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/domain_service/ValidateApplicationCRDDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/domain_service/ValidateApplicationCRDDomainService.java
@@ -24,7 +24,6 @@ import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainServi
 import io.gravitee.apim.core.member.model.MembershipReferenceType;
 import io.gravitee.apim.core.validation.Validator;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -62,11 +61,7 @@ public class ValidateApplicationCRDDomainService implements Validator<ValidateAp
 
         membersValidator
             .validateAndSanitize(
-                new ValidateCRDMembersDomainService.Input(
-                    input.auditInfo,
-                    MembershipReferenceType.APPLICATION,
-                    new LinkedHashSet<>(input.spec.getMembers())
-                )
+                new ValidateCRDMembersDomainService.Input(input.auditInfo, MembershipReferenceType.APPLICATION, input.spec.getMembers())
             )
             .peek(sanitized -> sanitizedBuilder.members(sanitized.members()), errors::addAll);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/domain_service/ValidateApplicationCRDDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/domain_service/ValidateApplicationCRDDomainService.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainServi
 import io.gravitee.apim.core.member.model.MembershipReferenceType;
 import io.gravitee.apim.core.validation.Validator;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -61,7 +62,11 @@ public class ValidateApplicationCRDDomainService implements Validator<ValidateAp
 
         membersValidator
             .validateAndSanitize(
-                new ValidateCRDMembersDomainService.Input(input.auditInfo, MembershipReferenceType.APPLICATION, input.spec.getMembers())
+                new ValidateCRDMembersDomainService.Input(
+                    input.auditInfo,
+                    MembershipReferenceType.APPLICATION,
+                    new LinkedHashSet<>(input.spec.getMembers())
+                )
             )
             .peek(sanitized -> sanitizedBuilder.members(sanitized.members()), errors::addAll);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/model/crd/ApplicationCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/model/crd/ApplicationCRDSpec.java
@@ -21,7 +21,7 @@ import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.NewApplicationEntity;
 import io.gravitee.rest.api.model.UpdateApplicationEntity;
 import java.util.List;
-import java.util.Set;
+import java.util.SequencedSet;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -44,7 +44,7 @@ import lombok.experimental.SuperBuilder;
 public class ApplicationCRDSpec extends ApplicationEntity {
 
     private List<ApplicationMetadataCRD> metadata;
-    private Set<MemberCRD> members;
+    private SequencedSet<MemberCRD> members;
 
     public NewApplicationEntity toNewApplicationEntity() {
         NewApplicationEntity nae = new NewApplicationEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/domain_service/DictionaryAutomationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/domain_service/DictionaryAutomationDomainService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.dictionary.domain_service;
+
+import io.gravitee.apim.core.dictionary.model.Dictionary;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Optional;
+
+public interface DictionaryAutomationDomainService {
+    DictionaryEntity create(ExecutionContext executionContext, Dictionary dictionary);
+
+    DictionaryEntity update(ExecutionContext executionContext, String id, Dictionary dictionary);
+
+    void delete(ExecutionContext executionContext, String id);
+
+    DictionaryEntity handleDeployment(ExecutionContext executionContext, DictionaryEntity dictionary, boolean deploy);
+
+    Optional<DictionaryEntity> findById(ExecutionContext executionContext, String id);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/domain_service/ValidateDictionaryDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/domain_service/ValidateDictionaryDomainService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.dictionary.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.dictionary.model.Dictionary;
+import io.gravitee.apim.core.dictionary.model.DictionaryType;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+@DomainService
+public class ValidateDictionaryDomainService {
+
+    public void validate(Dictionary dictionary) {
+        if (dictionary.getType() == DictionaryType.MANUAL) {
+            if (dictionary.getProperties() == null || dictionary.getProperties().isEmpty()) {
+                throw new ValidationDomainException("Manual dictionary must have at least one property.");
+            }
+            if (dictionary.getProvider() != null || dictionary.getTrigger() != null) {
+                throw new ValidationDomainException(
+                    "Manual dictionary must not have 'dynamic' properties (provider, trigger). Set type to 'DYNAMIC' or remove them."
+                );
+            }
+        } else if (dictionary.getType() == DictionaryType.DYNAMIC) {
+            if (dictionary.getProvider() == null || dictionary.getTrigger() == null) {
+                throw new ValidationDomainException("Dynamic dictionary must have a provider and a trigger.");
+            }
+            if (dictionary.getProperties() != null && !dictionary.getProperties().isEmpty()) {
+                throw new ValidationDomainException(
+                    "Dynamic dictionary must not have 'manual' properties. Set type to 'MANUAL' or remove them."
+                );
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/model/Dictionary.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/model/Dictionary.java
@@ -13,36 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.configuration.dictionary;
+package io.gravitee.apim.core.dictionary.model;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
 @Data
-public class NewDictionaryEntity {
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Dictionary {
 
     private String id;
-
-    private String key;
-
-    @NotNull
-    @Size(min = 3)
+    private String hrid;
     private String name;
-
     private String description;
-
-    @NotNull
     private DictionaryType type;
-
-    private DictionaryProviderEntity provider;
-
-    private DictionaryTriggerEntity trigger;
-
     private Map<String, String> properties;
+    private DictionaryProvider provider;
+    private DictionaryTrigger trigger;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/model/DictionaryProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/model/DictionaryProvider.java
@@ -13,36 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.configuration.dictionary;
+package io.gravitee.apim.core.dictionary.model;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-import java.util.Map;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
 @Data
-public class NewDictionaryEntity {
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DictionaryProvider {
 
-    private String id;
-
-    private String key;
-
-    @NotNull
-    @Size(min = 3)
-    private String name;
-
-    private String description;
-
-    @NotNull
-    private DictionaryType type;
-
-    private DictionaryProviderEntity provider;
-
-    private DictionaryTriggerEntity trigger;
-
-    private Map<String, String> properties;
+    private String type;
+    private JsonNode configuration;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/model/DictionaryTrigger.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/model/DictionaryTrigger.java
@@ -13,36 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.configuration.dictionary;
+package io.gravitee.apim.core.dictionary.model;
 
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
 @Data
-public class NewDictionaryEntity {
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DictionaryTrigger {
 
-    private String id;
-
-    private String key;
-
-    @NotNull
-    @Size(min = 3)
-    private String name;
-
-    private String description;
-
-    @NotNull
-    private DictionaryType type;
-
-    private DictionaryProviderEntity provider;
-
-    private DictionaryTriggerEntity trigger;
-
-    private Map<String, String> properties;
+    private long rate;
+    private TimeUnit unit;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/model/DictionaryType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/model/DictionaryType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.dictionary.model;
+
+public enum DictionaryType {
+    MANUAL,
+    DYNAMIC,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/use_case/CreateOrUpdateDictionaryUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/use_case/CreateOrUpdateDictionaryUseCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.dictionary.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
+import io.gravitee.apim.core.dictionary.model.Dictionary;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateOrUpdateDictionaryUseCase {
+
+    private final DictionaryAutomationDomainService dictionaryAutomationDomainService;
+
+    public record Input(ExecutionContext executionContext, Dictionary dictionary, boolean deploy) {}
+
+    public record Output(DictionaryEntity dictionary) {}
+
+    public Output execute(Input input) {
+        var dictionary = input.dictionary();
+        var existing = dictionaryAutomationDomainService.findById(input.executionContext(), dictionary.getId());
+
+        DictionaryEntity result;
+        if (existing.isPresent()) {
+            result = dictionaryAutomationDomainService.update(input.executionContext(), dictionary.getId(), dictionary);
+        } else {
+            result = dictionaryAutomationDomainService.create(input.executionContext(), dictionary);
+        }
+
+        result = dictionaryAutomationDomainService.handleDeployment(input.executionContext(), result, input.deploy());
+        return new Output(result);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/use_case/DeleteDictionaryUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/dictionary/use_case/DeleteDictionaryUseCase.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.dictionary.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class DeleteDictionaryUseCase {
+
+    private final DictionaryAutomationDomainService dictionaryAutomationDomainService;
+
+    public record Input(ExecutionContext executionContext, String id) {}
+
+    public void execute(Input input) {
+        dictionaryAutomationDomainService.delete(input.executionContext(), input.id());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/crd/GroupCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/crd/GroupCRDSpec.java
@@ -20,7 +20,7 @@ import io.gravitee.apim.core.member.model.RoleScope;
 import io.gravitee.definition.model.Origin;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.SequencedSet;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -42,7 +42,7 @@ public class GroupCRDSpec {
 
     private String name;
 
-    private Set<Member> members;
+    private SequencedSet<Member> members;
 
     private boolean notifyMembers;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/domain_service/ValidateCRDMembersDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/domain_service/ValidateCRDMembersDomainService.java
@@ -29,8 +29,9 @@ import io.gravitee.apim.core.user.domain_service.UserDomainService;
 import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.rest.api.service.common.ReferenceContext;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.UUID;
 import lombok.CustomLog;
@@ -48,15 +49,16 @@ public class ValidateCRDMembersDomainService implements Validator<ValidateCRDMem
     private final UserDomainService userDomainService;
     private final RoleQueryService roleQueryService;
 
-    public record Input(AuditInfo auditInfo, MembershipReferenceType referenceType, Set<MemberCRD> members) implements Validator.Input {
-        Input sanitized(Set<MemberCRD> sanitizedMembers) {
+    public record Input(AuditInfo auditInfo, MembershipReferenceType referenceType, SequencedSet<MemberCRD> members) implements
+        Validator.Input {
+        Input sanitized(SequencedSet<MemberCRD> sanitizedMembers) {
             return new Input(auditInfo, referenceType, sanitizedMembers);
         }
     }
 
     @Override
     public Result<Input> validateAndSanitize(Input input) {
-        var sanitizedMembers = input.members == null ? new HashSet<MemberCRD>() : new HashSet<>(input.members);
+        var sanitizedMembers = input.members == null ? new LinkedHashSet<MemberCRD>() : new LinkedHashSet<>(input.members);
         var errors = new ArrayList<Error>();
 
         validateAndSanitizeMemberId(input, sanitizedMembers, errors);
@@ -66,7 +68,7 @@ public class ValidateCRDMembersDomainService implements Validator<ValidateCRDMem
         return Result.ofBoth(input.sanitized(sanitizedMembers), errors);
     }
 
-    private void validateAndSanitizeMemberId(Input input, Set<MemberCRD> sanitized, ArrayList<Error> errors) {
+    private void validateAndSanitizeMemberId(Input input, SequencedSet<MemberCRD> sanitized, ArrayList<Error> errors) {
         var members = sanitized.iterator();
         while (members.hasNext()) {
             var member = members.next();
@@ -89,7 +91,7 @@ public class ValidateCRDMembersDomainService implements Validator<ValidateCRDMem
         }
     }
 
-    private void validateMemberRole(Input input, Set<MemberCRD> sanitized, ArrayList<Error> errors) {
+    private void validateMemberRole(Input input, SequencedSet<MemberCRD> sanitized, ArrayList<Error> errors) {
         for (var member : sanitized) {
             findRole(input.auditInfo.organizationId(), input.referenceType, member.getRole()).ifPresentOrElse(
                 role -> log.debug("Role {} found for scope {}", member.getRole(), input.referenceType),
@@ -113,7 +115,7 @@ public class ValidateCRDMembersDomainService implements Validator<ValidateCRDMem
         }
     }
 
-    private void validatePrimaryOwner(Input input, Set<MemberCRD> sanitized, ArrayList<Error> errors) {
+    private void validatePrimaryOwner(Input input, SequencedSet<MemberCRD> sanitized, ArrayList<Error> errors) {
         var actor = input.auditInfo.actor();
         var members = sanitized.iterator();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiCRDAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiCRDAdapter.java
@@ -38,9 +38,10 @@ import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import java.util.SequencedSet;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.mapstruct.Mapper;
@@ -168,13 +169,13 @@ public interface ApiCRDAdapter {
         }
     }
 
-    default Set<MemberCRD> mapMembers(ExportApiEntity definition) {
+    default SequencedSet<MemberCRD> mapMembers(ExportApiEntity definition) {
         return definition.getMembers() != null
             ? definition
                 .getMembers()
                 .stream()
                 .map(me -> new MemberCRD(me.getId(), null, null, me.getRoles().getFirst().getName()))
-                .collect(Collectors.toSet())
+                .collect(Collectors.toCollection(LinkedHashSet::new))
             : null;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GroupCRDAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GroupCRDAdapter.java
@@ -18,8 +18,8 @@ package io.gravitee.apim.infra.adapter;
 import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
 import io.gravitee.apim.core.member.model.RoleScope;
 import io.gravitee.apim.core.member.model.crd.MemberCRD;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
@@ -33,33 +33,19 @@ import org.mapstruct.factory.Mappers;
 public interface GroupCRDAdapter {
     GroupCRDAdapter INSTANCE = Mappers.getMapper(GroupCRDAdapter.class);
 
-    default Set<MemberCRD> toApiMemberCRDSet(Set<GroupCRDSpec.Member> members) {
+    default SequencedSet<MemberCRD> toApiMemberCRDSet(Set<GroupCRDSpec.Member> members) {
         return toMemberCRDSet(members, RoleScope.API);
     }
 
-    default Set<MemberCRD> toApplicationMemberCRDSet(Set<GroupCRDSpec.Member> members) {
+    default SequencedSet<MemberCRD> toApplicationMemberCRDSet(Set<GroupCRDSpec.Member> members) {
         return toMemberCRDSet(members, RoleScope.APPLICATION);
     }
 
-    default Set<MemberCRD> toIntegrationMemberCRDSet(Set<GroupCRDSpec.Member> members) {
+    default SequencedSet<MemberCRD> toIntegrationMemberCRDSet(Set<GroupCRDSpec.Member> members) {
         return toMemberCRDSet(members, RoleScope.INTEGRATION);
     }
 
-    default Set<GroupCRDSpec.Member> toGroupMembers(Set<MemberCRD> apiMembers) {
-        var groupMembers = new HashMap<String, GroupCRDSpec.Member>();
-        for (var member : apiMembers) {
-            groupMembers.put(member.getId(), initGroupMember(member, RoleScope.API));
-        }
-        return new HashSet<>(groupMembers.values());
-    }
-
-    private GroupCRDSpec.Member initGroupMember(MemberCRD memberCRD, RoleScope roleScope) {
-        var memberRoles = new HashMap<RoleScope, String>();
-        memberRoles.put(roleScope, memberCRD.getRole());
-        return new GroupCRDSpec.Member(memberCRD.getId(), memberCRD.getSourceId(), memberCRD.getSource(), memberRoles);
-    }
-
-    private static Set<MemberCRD> toMemberCRDSet(Set<GroupCRDSpec.Member> members, RoleScope roleScope) {
+    private static SequencedSet<MemberCRD> toMemberCRDSet(Set<GroupCRDSpec.Member> members, RoleScope roleScope) {
         return members
             .stream()
             .flatMap(member ->
@@ -70,6 +56,6 @@ public interface GroupCRDAdapter {
                     .filter(roleEntry -> roleEntry.getKey() == roleScope)
                     .map(roleEntry -> new MemberCRD(member.getId(), member.getSource(), member.getSourceId(), roleEntry.getValue()))
             )
-            .collect(Collectors.toSet());
+            .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/dictionary/DictionaryAutomationDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/dictionary/DictionaryAutomationDomainServiceLegacyWrapper.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.dictionary;
+
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
+import io.gravitee.apim.core.dictionary.model.Dictionary;
+import io.gravitee.apim.core.dictionary.model.DictionaryProvider;
+import io.gravitee.apim.core.dictionary.model.DictionaryTrigger;
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryProviderEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryTriggerEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryType;
+import io.gravitee.rest.api.model.configuration.dictionary.NewDictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.configuration.dictionary.DictionaryService;
+import io.gravitee.rest.api.service.impl.configuration.dictionary.DictionaryNotFoundException;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class DictionaryAutomationDomainServiceLegacyWrapper implements DictionaryAutomationDomainService {
+
+    private final DictionaryService dictionaryService;
+
+    @Override
+    public DictionaryEntity create(ExecutionContext executionContext, Dictionary dictionary) {
+        return dictionaryService.create(executionContext, toNewDictionaryEntity(dictionary));
+    }
+
+    @Override
+    public DictionaryEntity update(ExecutionContext executionContext, String id, Dictionary dictionary) {
+        return dictionaryService.update(executionContext, id, toUpdateDictionaryEntity(dictionary));
+    }
+
+    public Optional<DictionaryEntity> findById(ExecutionContext executionContext, String id) {
+        try {
+            return Optional.of(dictionaryService.findById(executionContext, id));
+        } catch (DictionaryNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void delete(ExecutionContext executionContext, String id) {
+        dictionaryService.delete(executionContext, id);
+    }
+
+    @Override
+    public DictionaryEntity handleDeployment(ExecutionContext executionContext, DictionaryEntity dictionary, boolean deploy) {
+        if (dictionary.getType() == DictionaryType.MANUAL) {
+            if (deploy) {
+                return dictionaryService.deploy(executionContext, dictionary.getId());
+            } else {
+                return dictionaryService.undeploy(executionContext, dictionary.getId());
+            }
+        } else if (dictionary.getType() == DictionaryType.DYNAMIC) {
+            if (deploy && !isStarted(dictionary)) {
+                return dictionaryService.start(executionContext, dictionary.getId());
+            } else if (!deploy && isStarted(dictionary)) {
+                return dictionaryService.stop(executionContext, dictionary.getId());
+            }
+        }
+        return dictionary;
+    }
+
+    private static boolean isStarted(DictionaryEntity dictionary) {
+        return dictionary.getState() != null && Objects.equals(dictionary.getState().name(), Lifecycle.State.STARTED.name());
+    }
+
+    private static NewDictionaryEntity toNewDictionaryEntity(Dictionary dictionary) {
+        NewDictionaryEntity entity = new NewDictionaryEntity();
+        entity.setId(dictionary.getId());
+        entity.setKey(dictionary.getHrid());
+        entity.setName(dictionary.getName());
+        entity.setDescription(dictionary.getDescription());
+        entity.setType(toEntityType(dictionary.getType()));
+        entity.setProperties(dictionary.getProperties());
+        entity.setProvider(toEntity(dictionary.getProvider()));
+        entity.setTrigger(toEntity(dictionary.getTrigger()));
+        return entity;
+    }
+
+    private static UpdateDictionaryEntity toUpdateDictionaryEntity(Dictionary dictionary) {
+        UpdateDictionaryEntity entity = new UpdateDictionaryEntity();
+        entity.setName(dictionary.getName());
+        entity.setDescription(dictionary.getDescription());
+        entity.setType(toEntityType(dictionary.getType()));
+        entity.setProperties(dictionary.getProperties());
+        entity.setProvider(toEntity(dictionary.getProvider()));
+        entity.setTrigger(toEntity(dictionary.getTrigger()));
+        return entity;
+    }
+
+    private static DictionaryType toEntityType(io.gravitee.apim.core.dictionary.model.DictionaryType type) {
+        if (type == null) return null;
+        return DictionaryType.valueOf(type.name());
+    }
+
+    private static DictionaryProviderEntity toEntity(DictionaryProvider provider) {
+        if (provider == null) return null;
+        DictionaryProviderEntity entity = new DictionaryProviderEntity();
+        entity.setType(provider.getType());
+        entity.setConfiguration(provider.getConfiguration());
+        return entity;
+    }
+
+    private static DictionaryTriggerEntity toEntity(DictionaryTrigger trigger) {
+        if (trigger == null) return null;
+        DictionaryTriggerEntity entity = new DictionaryTriggerEntity();
+        entity.setRate(trigger.getRate());
+        entity.setUnit(trigger.getUnit());
+        return entity;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/group/ValidateGroupCRDDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/group/ValidateGroupCRDDomainServiceImpl.java
@@ -28,12 +28,12 @@ import io.gravitee.apim.infra.adapter.GroupCRDAdapter;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.service.RoleService;
 import java.util.ArrayList;
-import java.util.EnumMap;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.SequencedMap;
+import java.util.SequencedSet;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -80,18 +80,18 @@ public class ValidateGroupCRDDomainServiceImpl implements ValidateGroupCRDDomain
         return Result.ofValue(name);
     }
 
-    private Result<Set<GroupCRDSpec.Member>> validateAndSanitizeMembers(ValidateGroupCRDDomainService.Input input) {
+    private Result<SequencedSet<GroupCRDSpec.Member>> validateAndSanitizeMembers(ValidateGroupCRDDomainService.Input input) {
         if (CollectionUtils.isEmpty(input.spec().getMembers())) {
-            return Result.ofBoth(Set.of(), List.of());
+            return Result.ofBoth(new LinkedHashSet<>(), List.of());
         }
 
-        var sanitizedGroupMembers = new HashMap<String, GroupCRDSpec.Member>();
+        var sanitizedGroupMembers = new LinkedHashMap<String, GroupCRDSpec.Member>();
         var errors = new ArrayList<Error>();
 
         var defaultRoles = getDefaultRoles(input.auditInfo());
 
         for (var member : input.spec().getMembers()) {
-            member.setRoles(member.getRoles() == null ? new HashMap<>() : new HashMap<>(member.getRoles()));
+            member.setRoles(member.getRoles() == null ? new LinkedHashMap<>() : new LinkedHashMap<>(member.getRoles()));
             member.getRoles().computeIfAbsent(RoleScope.API, scope -> defaultRoles.get(scope).getName());
             member.getRoles().computeIfAbsent(RoleScope.APPLICATION, scope -> defaultRoles.get(scope).getName());
             member.getRoles().computeIfAbsent(RoleScope.INTEGRATION, scope -> defaultRoles.get(scope).getName());
@@ -117,10 +117,10 @@ public class ValidateGroupCRDDomainServiceImpl implements ValidateGroupCRDDomain
             )
             .peek(output -> groupMembersById(RoleScope.INTEGRATION, output.members(), sanitizedGroupMembers), errors::addAll);
 
-        return Result.ofBoth(new HashSet<>(sanitizedGroupMembers.values()), errors);
+        return Result.ofBoth(new LinkedHashSet<>(sanitizedGroupMembers.values()), errors);
     }
 
-    private Map<RoleScope, RoleEntity> getDefaultRoles(AuditInfo auditInfo) {
+    private SequencedMap<RoleScope, RoleEntity> getDefaultRoles(AuditInfo auditInfo) {
         return roleService
             .findDefaultRoleByScopes(
                 auditInfo.organizationId(),
@@ -129,10 +129,16 @@ public class ValidateGroupCRDDomainServiceImpl implements ValidateGroupCRDDomain
                 io.gravitee.rest.api.model.permissions.RoleScope.INTEGRATION
             )
             .stream()
-            .collect(Collectors.toMap(role -> RoleScope.valueOf(role.getScope().name()), Function.identity()));
+            .collect(
+                Collectors.toMap(role -> RoleScope.valueOf(role.getScope().name()), Function.identity(), (a, b) -> a, LinkedHashMap::new)
+            );
     }
 
-    private static void groupMembersById(RoleScope roleScope, Set<MemberCRD> members, HashMap<String, GroupCRDSpec.Member> groups) {
+    private static void groupMembersById(
+        RoleScope roleScope,
+        SequencedSet<MemberCRD> members,
+        HashMap<String, GroupCRDSpec.Member> groups
+    ) {
         for (var member : members) {
             groups.computeIfPresent(member.getId(), (id, groupMember) -> addMemberRole(roleScope, groupMember, member));
             groups.computeIfAbsent(member.getId(), id -> initGroupMember(roleScope, member));
@@ -153,8 +159,8 @@ public class ValidateGroupCRDDomainServiceImpl implements ValidateGroupCRDDomain
             .build();
     }
 
-    private static Map<RoleScope, String> initMemberRoles(RoleScope roleScope, String roleName) {
-        var roles = new EnumMap<RoleScope, String>(RoleScope.class);
+    private static SequencedMap<RoleScope, String> initMemberRoles(RoleScope roleScope, String roleName) {
+        SequencedMap<RoleScope, String> roles = new LinkedHashMap<>();
         roles.put(roleScope, roleName);
         return roles;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/member/CRDMembersDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/member/CRDMembersDomainServiceImpl.java
@@ -33,7 +33,7 @@ import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.RoleNotFoundException;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -149,7 +149,7 @@ public class CRDMembersDomainServiceImpl implements CRDMembersDomainService {
 
         var givenMemberIds = members.stream().map(MemberCRD::getId).collect(Collectors.toSet());
 
-        var existingMemberIds = new HashSet<>(
+        var existingMemberIds = new LinkedHashSet<>(
             membershipService
                 .getMembersByReference(executionContext, referenceType, referenceId)
                 .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -40,6 +40,10 @@ public final class HRIDToUUID {
         return new TopLevelBuilder();
     }
 
+    public static TopLevelBuilder dictionary() {
+        return new TopLevelBuilder();
+    }
+
     public static TopLevelBuilder application() {
         return new TopLevelBuilder();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/dictionary/DictionaryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/dictionary/DictionaryService.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.model.configuration.dictionary.NewDictionaryEntity;
 import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -33,6 +34,8 @@ public interface DictionaryService {
     DictionaryEntity updateProperties(String id, Map<String, String> properties);
 
     DictionaryEntity findById(ExecutionContext executionContext, String id);
+
+    Optional<DictionaryEntity> findByKeyAndEnvironment(ExecutionContext executionContext, String key);
 
     void delete(ExecutionContext executionContext, String id);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiValidationServiceImpl.java
@@ -36,6 +36,7 @@ import io.gravitee.rest.api.service.ApiValidationService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import jakarta.inject.Inject;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
@@ -96,7 +97,7 @@ public class ApiValidationServiceImpl extends AbstractService implements ApiVali
                 new ValidateCRDMembersDomainService.Input(
                     auditInfo,
                     MembershipReferenceType.API,
-                    ApiCRDEntityAdapter.INSTANCE.toMemberCRDs(api.getMembers())
+                    new LinkedHashSet<>(ApiCRDEntityAdapter.INSTANCE.toMemberCRDs(api.getMembers()))
                 )
             )
             .peek(sanitized -> api.setMembers(ApiCRDEntityAdapter.INSTANCE.toApiCRDMembers(sanitized.members())), errors::addAll);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiValidationServiceImpl.java
@@ -92,12 +92,13 @@ public class ApiValidationServiceImpl extends AbstractService implements ApiVali
             .validateAndSanitize(new ValidateCategoryIdsDomainService.Input(executionContext.getEnvironmentId(), api.getCategories()))
             .peek(sanitized -> api.setCategories(sanitized.idOrKeys()), errors::addAll);
 
+        var members = ApiCRDEntityAdapter.INSTANCE.toMemberCRDs(api.getMembers());
         validateCRDMembersDomainService
             .validateAndSanitize(
                 new ValidateCRDMembersDomainService.Input(
                     auditInfo,
                     MembershipReferenceType.API,
-                    new LinkedHashSet<>(ApiCRDEntityAdapter.INSTANCE.toMemberCRDs(api.getMembers()))
+                    members != null ? new LinkedHashSet<>(members) : null
                 )
             )
             .peek(sanitized -> api.setMembers(ApiCRDEntityAdapter.INSTANCE.toApiCRDMembers(sanitized.members())), errors::addAll);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -103,7 +103,6 @@ import io.gravitee.rest.api.service.v4.ApiGroupService;
 import io.gravitee.rest.api.service.v4.ApiProductGroupService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
-import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -112,6 +111,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -648,7 +648,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         List<MemberEntity> members
     ) {
         if (memberships != null && !memberships.isEmpty()) {
-            final Set<UserEntity> userEntities = new HashSet<>();
+            final Set<UserEntity> userEntities = new LinkedHashSet<>();
             final List<String> userIds = members
                 .stream()
                 .filter(m -> m.getType() == MembershipMemberType.USER)
@@ -1197,7 +1197,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         String referenceId,
         String role
     ) {
-        return new HashSet<>(getMembersByReference(executionContext, referenceType, referenceId, role, null).getContent());
+        return new LinkedHashSet<>(getMembersByReference(executionContext, referenceType, referenceId, role, null).getContent());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -160,6 +160,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -470,7 +471,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
                 return users
                     .stream()
                     .map(u -> this.convert(u, false, withUserMetadata ? userMetadataService.findAllByUserId(u.getId()) : emptyList(), true))
-                    .collect(toSet());
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
             }
 
             Optional<String> idsAsString = ids.stream().reduce((a, b) -> a + '/' + b);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
@@ -134,7 +134,7 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
 
             // add deployment date
             dictionary.setUpdatedAt(new Date());
-            dictionary.setDeployedAt(dictionary.getUpdatedAt());
+            dictionary.setDeployedAt(null);
 
             dictionary = dictionaryRepository.update(dictionary);
 
@@ -236,19 +236,40 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
     public DictionaryEntity create(ExecutionContext executionContext, NewDictionaryEntity newDictionaryEntity) {
         try {
             log.debug("Create dictionary {}", newDictionaryEntity);
+            final Dictionary dictionary;
+            if (newDictionaryEntity.getKey() == null) {
+                String key = IdGenerator.generate(newDictionaryEntity.getName());
 
-            String key = IdGenerator.generate(newDictionaryEntity.getName());
-            Optional<Dictionary> idDictionary = dictionaryRepository.findById(key);
-            if (idDictionary.isPresent() && idDictionary.get().getEnvironmentId().equalsIgnoreCase(executionContext.getEnvironmentId())) {
-                throw new DictionaryAlreadyExistsException(newDictionaryEntity.getName());
+                // Make sure the derived key does not already exist in the same environment
+                // That would mean that a legacy dictionary (prior to multi tenant management) was created with the same name.
+                Optional<Dictionary> idDictionary = dictionaryRepository.findById(key);
+                if (
+                    idDictionary.isPresent() && idDictionary.get().getEnvironmentId().equalsIgnoreCase(executionContext.getEnvironmentId())
+                ) {
+                    throw new DictionaryAlreadyExistsException(newDictionaryEntity.getName());
+                }
+                // Make sure the derived key does not already exist in any environment using the key field which is how it is checked
+                // uniqueness after the multi tenant management is implemented.
+                Optional<Dictionary> optDictionary = dictionaryRepository.findByKeyAndEnvironment(key, executionContext.getEnvironmentId());
+                if (optDictionary.isPresent()) {
+                    throw new DictionaryAlreadyExistsException(newDictionaryEntity.getName());
+                }
+                dictionary = convert(newDictionaryEntity, key, idDictionary.isEmpty());
+            } else {
+                String key = newDictionaryEntity.getKey();
+                // We shouldn't be here if the caller checked the key uniqueness
+                // But for to respect the contract, we check again
+                Optional<Dictionary> optDictionary = dictionaryRepository.findByKeyAndEnvironment(key, executionContext.getEnvironmentId());
+                if (optDictionary.isPresent()) {
+                    throw new DictionaryAlreadyExistsException(newDictionaryEntity.getName());
+                }
+                dictionary = convert(newDictionaryEntity, key, false);
+                // if ID is already set, let's use it
+                if (newDictionaryEntity.getId() != null) {
+                    dictionary.setId(newDictionaryEntity.getId());
+                }
             }
-            Optional<Dictionary> optDictionary = dictionaryRepository.findByKeyAndEnvironment(key, executionContext.getEnvironmentId());
-            if (optDictionary.isPresent()) {
-                throw new DictionaryAlreadyExistsException(newDictionaryEntity.getName());
-            }
-
-            //if dictionary with this name exists, we generate a UUID, otherwise we use the name as ID to be backward compatible
-            Dictionary dictionary = convert(newDictionaryEntity, dictionaryRepository.findById(key).isEmpty());
+            // Convert by setting a UUID as ID and key if not an id in the DB
 
             dictionary.setEnvironmentId(executionContext.getEnvironmentId());
 
@@ -359,13 +380,22 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
         try {
             log.debug("Find dictionary by ID: {}", id);
             Optional<Dictionary> byId = dictionaryRepository.findById(id);
-            //FIXME filter should be always applied but DictionaryManager (sync service) does not handle environments for dictionaries
             if (executionContext.hasEnvironmentId()) {
                 byId = byId.filter(d -> d.getEnvironmentId().equalsIgnoreCase(executionContext.getEnvironmentId()));
             }
             return byId.map(this::convert).orElseThrow(() -> new DictionaryNotFoundException(id));
         } catch (TechnicalException ex) {
             throw new TechnicalManagementException("An error occurs while trying to delete a dictionary using its ID " + id, ex);
+        }
+    }
+
+    @Override
+    public Optional<DictionaryEntity> findByKeyAndEnvironment(ExecutionContext executionContext, String key) {
+        try {
+            log.debug("Find dictionary by key: {} and environment: {}", key, executionContext.getEnvironmentId());
+            return dictionaryRepository.findByKeyAndEnvironment(key, executionContext.getEnvironmentId()).map(this::convert);
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException("An error occurs while trying to find a dictionary using its key " + key, ex);
         }
     }
 
@@ -459,12 +489,12 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
         return dictionary;
     }
 
-    private Dictionary convert(NewDictionaryEntity newDictionaryEntity, boolean legacy) {
+    private Dictionary convert(NewDictionaryEntity newDictionaryEntity, String key, boolean keyIsUniqueAcrossAllEnvs) {
         Dictionary dictionary = new Dictionary();
-        String key = IdGenerator.generate(newDictionaryEntity.getName());
-        //create legacy dictionaries to be backward compatible
-        dictionary.setId(legacy ? key : UuidString.generateRandom());
-        dictionary.setKey(legacy ? null : key);
+        // This is for legacy dictionaries to be backward compatible
+        dictionary.setId(keyIsUniqueAcrossAllEnvs ? key : UuidString.generateRandom());
+        dictionary.setKey(keyIsUniqueAcrossAllEnvs ? null : key);
+
         dictionary.setName(newDictionaryEntity.getName());
         dictionary.setDescription(newDictionaryEntity.getDescription());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateCRDMembersDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateCRDMembersDomainServiceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.member.model.crd.MemberCRD;
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.core.validation.Validator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -99,7 +100,7 @@ class ValidateCRDMembersDomainServiceTest {
 
     @Test
     void should_return_no_warning_with_existing_member() {
-        var members = Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(USER_ID).role("USER").build());
+        var members = new LinkedHashSet<>(Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(USER_ID).role("USER").build()));
         var expectedMembers = Set.of(MemberCRD.builder().id(USER_ID).source(USER_SOURCE).sourceId(USER_ID).role("USER").build());
         var result = cut.validateAndSanitize(
             new ValidateCRDMembersDomainService.Input(AUDIT_INFO, MembershipReferenceType.APPLICATION, members)
@@ -113,10 +114,9 @@ class ValidateCRDMembersDomainServiceTest {
 
     @Test
     void should_return_warning_with_unknown_member() {
-        var members = Set.of(
-            MemberCRD.builder().source(USER_SOURCE).sourceId(USER_ID).role("USER").build(),
-            MemberCRD.builder().source(USER_SOURCE).sourceId("unknown-id").role("USER").build()
-        );
+        var members = new LinkedHashSet<MemberCRD>();
+        members.add(MemberCRD.builder().source(USER_SOURCE).sourceId(USER_ID).role("USER").build());
+        members.add(MemberCRD.builder().source(USER_SOURCE).sourceId("unknown-id").role("USER").build());
         var expectedMembers = Set.of(MemberCRD.builder().id(USER_ID).source(USER_SOURCE).sourceId(USER_ID).role("USER").build());
         var result = cut.validateAndSanitize(
             new ValidateCRDMembersDomainService.Input(AUDIT_INFO, MembershipReferenceType.APPLICATION, members)
@@ -134,7 +134,7 @@ class ValidateCRDMembersDomainServiceTest {
     @ParameterizedTest
     @EnumSource(value = MembershipReferenceType.class, names = { "APPLICATION", "API" })
     void should_return_warning_with_unknown_member_role(MembershipReferenceType referenceType) {
-        var members = Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(USER_ID).role("UNKNOWN").build());
+        var members = new LinkedHashSet<>(Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(USER_ID).role("UNKNOWN").build()));
         var expectedMembers = Set.copyOf(members);
         var result = cut.validateAndSanitize(new ValidateCRDMembersDomainService.Input(AUDIT_INFO, referenceType, members));
 
@@ -147,7 +147,7 @@ class ValidateCRDMembersDomainServiceTest {
     @ParameterizedTest
     @EnumSource(value = MembershipReferenceType.class, names = { "APPLICATION", "API" })
     void should_not_return_warning_with_known_member_role(MembershipReferenceType referenceType) {
-        var members = Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(USER_ID).role(ROLE_ID).build());
+        var members = new LinkedHashSet<>(Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(USER_ID).role(ROLE_ID).build()));
         var expectedMembers = Set.copyOf(members);
         var result = cut.validateAndSanitize(new ValidateCRDMembersDomainService.Input(AUDIT_INFO, referenceType, members));
 
@@ -160,7 +160,7 @@ class ValidateCRDMembersDomainServiceTest {
     @ParameterizedTest
     @EnumSource(value = MembershipReferenceType.class, names = { "APPLICATION", "API" })
     void should_return_error_with_primary_owner_role(MembershipReferenceType referenceType) {
-        var members = Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(USER_ID).role("PRIMARY_OWNER").build());
+        var members = new LinkedHashSet<>(Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(USER_ID).role("PRIMARY_OWNER").build()));
         var expectedMembers = Set.of();
         var result = cut.validateAndSanitize(new ValidateCRDMembersDomainService.Input(AUDIT_INFO, referenceType, members));
 
@@ -177,7 +177,7 @@ class ValidateCRDMembersDomainServiceTest {
         userDomainService.initWith(
             List.of(BaseUserEntity.builder().organizationId(ORG_ID).id(USER_ID).source(USER_SOURCE).sourceId(USER_ID).build())
         );
-        var members = Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(ACTOR_USER_ID).role("USER").build());
+        var members = new LinkedHashSet<>(Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(ACTOR_USER_ID).role("USER").build()));
         var expectedMembers = Set.of();
         var result = cut.validateAndSanitize(new ValidateCRDMembersDomainService.Input(AUDIT_INFO, referenceType, members));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -186,10 +186,10 @@ import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
@@ -801,7 +801,7 @@ class ImportApiCRDUseCaseTest {
 
             var member = MemberCRD.builder().source(USER_ENTITY_SOURCE).sourceId(USER_ENTITY_SOURCE_ID).role("USER").build();
 
-            useCase.execute(new ImportApiCRDUseCase.Input(AUDIT_INFO, aCRD().members(Set.of(member)).build()));
+            useCase.execute(new ImportApiCRDUseCase.Input(AUDIT_INFO, aCRD().members(new LinkedHashSet<>(Set.of(member))).build()));
 
             assertThat(crdMembersDomainService.getApiMembers(API_ID)).contains(member.toBuilder().id(USER_ID).build());
         }
@@ -822,7 +822,9 @@ class ImportApiCRDUseCaseTest {
 
             var member = MemberCRD.builder().source(USER_ENTITY_SOURCE).sourceId(USER_ENTITY_SOURCE_ID).role("USER").build();
 
-            useCase.execute(new ImportApiCRDUseCase.Input(AUDIT_INFO, aNativeApiCRD().members(Set.of(member)).build()));
+            useCase.execute(
+                new ImportApiCRDUseCase.Input(AUDIT_INFO, aNativeApiCRD().members(new LinkedHashSet<>(Set.of(member))).build())
+            );
 
             assertThat(crdMembersDomainService.getApiMembers(API_ID)).contains(member.toBuilder().id(USER_ID).build());
         }
@@ -918,7 +920,7 @@ class ImportApiCRDUseCaseTest {
 
         @Test
         void should_handle_empty_members() {
-            useCase.execute(new ImportApiCRDUseCase.Input(AUDIT_INFO, aCRD().members(Set.of()).build()));
+            useCase.execute(new ImportApiCRDUseCase.Input(AUDIT_INFO, aCRD().members(new LinkedHashSet<>()).build()));
 
             assertThat(crdMembersDomainService.getApiMembers(API_ID)).isEmpty();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
@@ -55,7 +55,9 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.assertj.core.api.SoftAssertions;
@@ -307,10 +309,12 @@ class ImportApplicationCRDUseCaseTest {
             .build();
     }
 
-    private Set<MemberCRD> applicationMembers() {
-        return Set.of(
-            MemberCRD.builder().source(MEMBER_SOURCE).sourceId(MEMBER_SOURCE_ID_2).role("USER").build(),
-            MemberCRD.builder().source(MEMBER_SOURCE).sourceId(MEMBER_SOURCE_ID_1).role("OWNER").build()
+    private SequencedSet<MemberCRD> applicationMembers() {
+        return new LinkedHashSet<>(
+            Set.of(
+                MemberCRD.builder().source(MEMBER_SOURCE).sourceId(MEMBER_SOURCE_ID_2).role("USER").build(),
+                MemberCRD.builder().source(MEMBER_SOURCE).sourceId(MEMBER_SOURCE_ID_1).role("OWNER").build()
+            )
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/dictionary/CreateOrUpdateDictionaryUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/dictionary/CreateOrUpdateDictionaryUseCaseTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.dictionary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
+import io.gravitee.apim.core.dictionary.model.Dictionary;
+import io.gravitee.apim.core.dictionary.model.DictionaryType;
+import io.gravitee.apim.core.dictionary.use_case.CreateOrUpdateDictionaryUseCase;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateOrUpdateDictionaryUseCaseTest {
+
+    private final DictionaryAutomationDomainService domainService = mock(DictionaryAutomationDomainService.class);
+    private final CreateOrUpdateDictionaryUseCase useCase = new CreateOrUpdateDictionaryUseCase(domainService);
+    private final ExecutionContext executionContext = new ExecutionContext("org", "env");
+
+    @Test
+    void should_create_when_dictionary_does_not_exist() {
+        var dictionary = Dictionary.builder().hrid("my-hrid").name("test").type(DictionaryType.MANUAL).build();
+        var created = DictionaryEntity.builder()
+            .id("new-id")
+            .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+            .build();
+        var deployed = DictionaryEntity.builder()
+            .id("new-id")
+            .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+            .build();
+
+        when(domainService.findById(executionContext, "new-id")).thenReturn(Optional.empty());
+        when(domainService.create(executionContext, dictionary)).thenReturn(created);
+        when(domainService.handleDeployment(executionContext, created, true)).thenReturn(deployed);
+
+        var output = useCase.execute(new CreateOrUpdateDictionaryUseCase.Input(executionContext, dictionary, true));
+
+        assertThat(output.dictionary()).isSameAs(deployed);
+        verify(domainService).create(executionContext, dictionary);
+        verify(domainService, never()).update(any(), any(), any());
+    }
+
+    @Test
+    void should_update_when_dictionary_already_exists() {
+        var dictionary = Dictionary.builder().id("existing-id").name("test").type(DictionaryType.MANUAL).build();
+        var existing = DictionaryEntity.builder()
+            .id("existing-id")
+            .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+            .build();
+        var updated = DictionaryEntity.builder()
+            .id("existing-id")
+            .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+            .build();
+        var deployed = DictionaryEntity.builder()
+            .id("existing-id")
+            .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+            .build();
+
+        when(domainService.findById(executionContext, "existing-id")).thenReturn(Optional.of(existing));
+        when(domainService.update(executionContext, "existing-id", dictionary)).thenReturn(updated);
+        when(domainService.handleDeployment(executionContext, updated, false)).thenReturn(deployed);
+
+        var output = useCase.execute(new CreateOrUpdateDictionaryUseCase.Input(executionContext, dictionary, false));
+
+        assertThat(output.dictionary()).isSameAs(deployed);
+        verify(domainService).update(executionContext, "existing-id", dictionary);
+        verify(domainService, never()).create(any(), any());
+    }
+
+    @Test
+    void should_create_new_dictionary_when_hrid_changes() {
+        var dictionary = Dictionary.builder().hrid("new-hrid").name("test").type(DictionaryType.MANUAL).build();
+        var created = DictionaryEntity.builder()
+            .id("new-id")
+            .key("new-hrid")
+            .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+            .build();
+        var deployed = DictionaryEntity.builder()
+            .id("new-id")
+            .key("new-hrid")
+            .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+            .build();
+
+        when(domainService.findById(executionContext, "new-id")).thenReturn(Optional.empty());
+        when(domainService.create(executionContext, dictionary)).thenReturn(created);
+        when(domainService.handleDeployment(executionContext, created, true)).thenReturn(deployed);
+
+        var output = useCase.execute(new CreateOrUpdateDictionaryUseCase.Input(executionContext, dictionary, true));
+
+        assertThat(output.dictionary()).isSameAs(deployed);
+        verify(domainService).create(executionContext, dictionary);
+        verify(domainService, never()).update(any(), any(), any());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/dictionary/DictionaryAutomationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/dictionary/DictionaryAutomationDomainServiceTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.dictionary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
+import io.gravitee.apim.core.dictionary.model.Dictionary;
+import io.gravitee.apim.core.dictionary.model.DictionaryProvider;
+import io.gravitee.apim.core.dictionary.model.DictionaryTrigger;
+import io.gravitee.apim.core.dictionary.model.DictionaryType;
+import io.gravitee.apim.infra.domain_service.dictionary.DictionaryAutomationDomainServiceLegacyWrapper;
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.NewDictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.configuration.dictionary.DictionaryService;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DictionaryAutomationDomainServiceTest {
+
+    private final DictionaryService dictionaryService = mock(DictionaryService.class);
+    private final DictionaryAutomationDomainService domainService = new DictionaryAutomationDomainServiceLegacyWrapper(dictionaryService);
+    private final ExecutionContext executionContext = new ExecutionContext("org", "env");
+
+    @Nested
+    class Create {
+
+        @Test
+        void should_convert_dictionary_to_new_entity_with_key() {
+            var dictionary = Dictionary.builder()
+                .hrid("my-hrid")
+                .name("My Dict")
+                .description("A description")
+                .type(DictionaryType.MANUAL)
+                .properties(Map.of("k", "v"))
+                .build();
+            var created = DictionaryEntity.builder().id("new-id").build();
+            when(dictionaryService.create(any(), any())).thenReturn(created);
+
+            var result = domainService.create(executionContext, dictionary);
+
+            assertThat(result).isSameAs(created);
+            var captor = ArgumentCaptor.forClass(NewDictionaryEntity.class);
+            verify(dictionaryService).create(eq(executionContext), captor.capture());
+            var entity = captor.getValue();
+            assertThat(entity.getKey()).isEqualTo("my-hrid");
+            assertThat(entity.getName()).isEqualTo("My Dict");
+            assertThat(entity.getDescription()).isEqualTo("A description");
+            assertThat(entity.getType()).isEqualTo(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL);
+            assertThat(entity.getProperties()).containsEntry("k", "v");
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        void should_convert_dictionary_to_update_entity_without_key() {
+            var trigger = DictionaryTrigger.builder().rate(10L).unit(TimeUnit.MINUTES).build();
+            var provider = DictionaryProvider.builder()
+                .type("HTTP")
+                .configuration(new ObjectMapper().createObjectNode().put("url", "http://example.com"))
+                .build();
+
+            var dictionary = Dictionary.builder()
+                .hrid("my-hrid")
+                .name("Updated Dict")
+                .description("Updated desc")
+                .type(DictionaryType.DYNAMIC)
+                .provider(provider)
+                .trigger(trigger)
+                .build();
+            var updated = DictionaryEntity.builder().id("existing-id").build();
+            when(dictionaryService.update(any(), any(), any())).thenReturn(updated);
+
+            var result = domainService.update(executionContext, "existing-id", dictionary);
+
+            assertThat(result).isSameAs(updated);
+            var captor = ArgumentCaptor.forClass(UpdateDictionaryEntity.class);
+            verify(dictionaryService).update(eq(executionContext), eq("existing-id"), captor.capture());
+            var entity = captor.getValue();
+            assertThat(entity.getName()).isEqualTo("Updated Dict");
+            assertThat(entity.getDescription()).isEqualTo("Updated desc");
+            assertThat(entity.getType()).isEqualTo(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC);
+            assertThat(entity.getProvider().getType()).isEqualTo("HTTP");
+            assertThat(entity.getTrigger().getRate()).isEqualTo(10L);
+            assertThat(entity.getTrigger().getUnit()).isEqualTo(TimeUnit.MINUTES);
+        }
+    }
+
+    @Nested
+    class HandleDeployment_Manual {
+
+        private final DictionaryEntity dictionary = DictionaryEntity.builder()
+            .id("dict-id")
+            .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+            .build();
+
+        @Test
+        void should_deploy_when_deploy_is_true() {
+            var deployed = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+                .build();
+            when(dictionaryService.deploy(executionContext, "dict-id")).thenReturn(deployed);
+
+            var result = domainService.handleDeployment(executionContext, dictionary, true);
+
+            assertThat(result).isSameAs(deployed);
+            verify(dictionaryService).deploy(executionContext, "dict-id");
+            verify(dictionaryService, never()).undeploy(executionContext, "dict-id");
+        }
+
+        @Test
+        void should_undeploy_when_deploy_is_false() {
+            var undeployed = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.MANUAL)
+                .build();
+            when(dictionaryService.undeploy(executionContext, "dict-id")).thenReturn(undeployed);
+
+            var result = domainService.handleDeployment(executionContext, dictionary, false);
+
+            assertThat(result).isSameAs(undeployed);
+            verify(dictionaryService).undeploy(executionContext, "dict-id");
+            verify(dictionaryService, never()).deploy(executionContext, "dict-id");
+        }
+    }
+
+    @Nested
+    class HandleDeployment_Dynamic {
+
+        @Test
+        void should_start_when_deploy_is_true_and_not_started() {
+            var dictionary = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
+                .state(Lifecycle.State.STOPPED)
+                .build();
+            var started = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
+                .state(Lifecycle.State.STARTED)
+                .build();
+            when(dictionaryService.start(executionContext, "dict-id")).thenReturn(started);
+
+            var result = domainService.handleDeployment(executionContext, dictionary, true);
+
+            assertThat(result).isSameAs(started);
+            verify(dictionaryService).start(executionContext, "dict-id");
+        }
+
+        @Test
+        void should_not_start_when_deploy_is_true_and_already_started() {
+            var dictionary = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
+                .state(Lifecycle.State.STARTED)
+                .build();
+
+            var result = domainService.handleDeployment(executionContext, dictionary, true);
+
+            assertThat(result).isSameAs(dictionary);
+            verify(dictionaryService, never()).start(executionContext, "dict-id");
+        }
+
+        @Test
+        void should_stop_when_deploy_is_false_and_started() {
+            var dictionary = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
+                .state(Lifecycle.State.STARTED)
+                .build();
+            var stopped = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
+                .state(Lifecycle.State.STOPPED)
+                .build();
+            when(dictionaryService.stop(executionContext, "dict-id")).thenReturn(stopped);
+
+            var result = domainService.handleDeployment(executionContext, dictionary, false);
+
+            assertThat(result).isSameAs(stopped);
+            verify(dictionaryService).stop(executionContext, "dict-id");
+        }
+
+        @Test
+        void should_not_stop_when_deploy_is_false_and_not_started() {
+            var dictionary = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
+                .state(Lifecycle.State.STOPPED)
+                .build();
+
+            var result = domainService.handleDeployment(executionContext, dictionary, false);
+
+            assertThat(result).isSameAs(dictionary);
+            verify(dictionaryService, never()).stop(executionContext, "dict-id");
+        }
+
+        @Test
+        void should_start_when_state_is_null_and_deploy_is_true() {
+            var dictionary = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
+                .build();
+            var started = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
+                .state(Lifecycle.State.STARTED)
+                .build();
+            when(dictionaryService.start(executionContext, "dict-id")).thenReturn(started);
+
+            var result = domainService.handleDeployment(executionContext, dictionary, true);
+
+            assertThat(result).isSameAs(started);
+            verify(dictionaryService).start(executionContext, "dict-id");
+        }
+
+        @Test
+        void should_not_stop_when_state_is_null_and_deploy_is_false() {
+            var dictionary = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
+                .build();
+
+            var result = domainService.handleDeployment(executionContext, dictionary, false);
+
+            assertThat(result).isSameAs(dictionary);
+            verifyNoInteractions(dictionaryService);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/dictionary/ValidateDictionaryDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/dictionary/ValidateDictionaryDomainServiceTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.dictionary;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.apim.core.dictionary.domain_service.ValidateDictionaryDomainService;
+import io.gravitee.apim.core.dictionary.model.Dictionary;
+import io.gravitee.apim.core.dictionary.model.DictionaryProvider;
+import io.gravitee.apim.core.dictionary.model.DictionaryTrigger;
+import io.gravitee.apim.core.dictionary.model.DictionaryType;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ValidateDictionaryDomainServiceTest {
+
+    private final ValidateDictionaryDomainService service = new ValidateDictionaryDomainService();
+
+    @Nested
+    class MutualExclusion {
+
+        @Test
+        void should_reject_when_both_provider_trigger_and_properties_are_set() {
+            var dictionary = Dictionary.builder()
+                .type(DictionaryType.DYNAMIC)
+                .provider(new DictionaryProvider())
+                .trigger(aTrigger())
+                .properties(Map.of("key1", "v1", "key2", "v2"))
+                .build();
+
+            assertThatThrownBy(() -> service.validate(dictionary))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("must not have 'manual' properties");
+        }
+
+        @Test
+        void should_reject_when_both_properties_and_provider_trigger_are_set() {
+            var dictionary = Dictionary.builder()
+                .type(DictionaryType.MANUAL)
+                .properties(Map.of("key", "value"))
+                .provider(new DictionaryProvider())
+                .trigger(aTrigger())
+                .build();
+
+            assertThatThrownBy(() -> service.validate(dictionary))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("must not have 'dynamic' properties");
+        }
+    }
+
+    @Nested
+    class ManualDictionary {
+
+        @Test
+        void should_reject_with_null_properties() {
+            var dictionary = Dictionary.builder().type(DictionaryType.MANUAL).build();
+
+            assertThatThrownBy(() -> service.validate(dictionary))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("at least one property");
+        }
+
+        @Test
+        void should_reject_with_empty_properties() {
+            var dictionary = Dictionary.builder().type(DictionaryType.MANUAL).properties(Map.of()).build();
+
+            assertThatThrownBy(() -> service.validate(dictionary))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("at least one property");
+        }
+
+        @Test
+        void should_reject_when_provider_is_set() {
+            var dictionary = Dictionary.builder()
+                .type(DictionaryType.MANUAL)
+                .properties(Map.of("key", "value"))
+                .provider(new DictionaryProvider())
+                .build();
+
+            assertThatThrownBy(() -> service.validate(dictionary))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("must not have 'dynamic' properties");
+        }
+
+        @Test
+        void should_reject_when_trigger_is_set() {
+            var dictionary = Dictionary.builder()
+                .type(DictionaryType.MANUAL)
+                .properties(Map.of("key", "value"))
+                .trigger(new DictionaryTrigger())
+                .build();
+
+            assertThatThrownBy(() -> service.validate(dictionary))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("must not have 'dynamic' properties");
+        }
+
+        @Test
+        void should_accept_with_properties_only() {
+            var dictionary = Dictionary.builder().type(DictionaryType.MANUAL).properties(Map.of("key", "value")).build();
+
+            assertThatNoException().isThrownBy(() -> service.validate(dictionary));
+        }
+    }
+
+    @Nested
+    class DynamicDictionary {
+
+        @Test
+        void should_reject_without_provider() {
+            var dictionary = Dictionary.builder().type(DictionaryType.DYNAMIC).trigger(aTrigger()).build();
+
+            assertThatThrownBy(() -> service.validate(dictionary))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("must have a provider and a trigger");
+        }
+
+        @Test
+        void should_reject_without_trigger() {
+            var dictionary = Dictionary.builder().type(DictionaryType.DYNAMIC).provider(new DictionaryProvider()).build();
+
+            assertThatThrownBy(() -> service.validate(dictionary))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("must have a provider and a trigger");
+        }
+
+        @Test
+        void should_reject_when_properties_are_set() {
+            var dictionary = Dictionary.builder()
+                .type(DictionaryType.DYNAMIC)
+                .provider(new DictionaryProvider())
+                .trigger(aTrigger())
+                .properties(Map.of("key", "value"))
+                .build();
+
+            assertThatThrownBy(() -> service.validate(dictionary))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("must not have 'manual' properties");
+        }
+
+        @Test
+        void should_accept_with_provider_and_trigger() {
+            var dictionary = Dictionary.builder()
+                .type(DictionaryType.DYNAMIC)
+                .provider(new DictionaryProvider())
+                .trigger(aTrigger())
+                .build();
+
+            assertThatNoException().isThrownBy(() -> service.validate(dictionary));
+        }
+    }
+
+    private DictionaryTrigger aTrigger() {
+        return DictionaryTrigger.builder().rate(5L).unit(TimeUnit.SECONDS).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCaseTest.java
@@ -29,8 +29,8 @@ import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainServi
 import io.gravitee.apim.core.member.model.RoleScope;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
 import io.gravitee.rest.api.model.context.OriginContext;
-import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +44,7 @@ import org.mockito.Mockito;
  * @author GraviteeSource Team
  */
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class ImportGroupCRDUseCaseTest {
+class ImportGroupCRDUseCaseTest {
 
     private static final String ORGANIZATION_ID = "organization-id";
     private static final String ENVIRONMENT_ID = "environment-id";
@@ -62,8 +62,6 @@ public class ImportGroupCRDUseCaseTest {
     private final RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
 
     private final CRDMembersDomainServiceInMemory membersService = new CRDMembersDomainServiceInMemory();
-
-    private final MembershipService membershipService = Mockito.mock(MembershipService.class);
 
     private final RoleService roleService = Mockito.mock(RoleService.class);
 
@@ -85,12 +83,14 @@ public class ImportGroupCRDUseCaseTest {
             .id("abc0a85b-9924-4981-bd71-69295353f5ff")
             .name("kubernetes-spec")
             .members(
-                Set.of(
-                    GroupCRDSpec.Member.builder()
-                        .source("memory")
-                        .sourceId("api1")
-                        .roles(Map.of(RoleScope.API, "OWNER", RoleScope.APPLICATION, "OWNER", RoleScope.INTEGRATION, "OWNER"))
-                        .build()
+                new LinkedHashSet<>(
+                    Set.of(
+                        GroupCRDSpec.Member.builder()
+                            .source("memory")
+                            .sourceId("api1")
+                            .roles(Map.of(RoleScope.API, "OWNER", RoleScope.APPLICATION, "OWNER", RoleScope.INTEGRATION, "OWNER"))
+                            .build()
+                    )
                 )
             );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_CreateTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.configuration.dictionary;
+
+import static io.gravitee.repository.management.model.Dictionary.AuditEvent.DICTIONARY_CREATED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.DictionaryRepository;
+import io.gravitee.repository.management.model.Dictionary;
+import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryType;
+import io.gravitee.rest.api.model.configuration.dictionary.NewDictionaryEntity;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.EventService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DictionaryServiceImpl_CreateTest {
+
+    private static final String ENVIRONMENT_ID = GraviteeContext.getCurrentEnvironment();
+
+    @InjectMocks
+    private DictionaryServiceImpl dictionaryService = new DictionaryServiceImpl();
+
+    @Mock
+    private DictionaryRepository dictionaryRepository;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private AuditService auditService;
+
+    @Test
+    public void shouldCreateWithExplicitKeyLegacy() throws TechnicalException {
+        NewDictionaryEntity newDictionary = new NewDictionaryEntity();
+        newDictionary.setKey("my-key");
+        newDictionary.setName("My Dictionary");
+        newDictionary.setType(DictionaryType.MANUAL);
+        newDictionary.setProperties(Map.of("foo", "bar"));
+
+        when(dictionaryRepository.findByKeyAndEnvironment("my-key", ENVIRONMENT_ID)).thenReturn(Optional.empty());
+        when(dictionaryRepository.create(any(Dictionary.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DictionaryEntity result = dictionaryService.create(GraviteeContext.getExecutionContext(), newDictionary);
+
+        assertThat(result.getId()).isNotBlank().isNotEqualTo("my-key");
+        assertThat(result.getKey()).isEqualTo("my-key");
+        assertThat(result.getName()).isEqualTo("My Dictionary");
+        assertThat(result.getProperties()).containsEntry("foo", "bar");
+
+        verify(dictionaryRepository).create(argThat(dict -> "my-key".equals(dict.getKey()) && dict.getId() != null));
+        verify(auditService).createAuditLog(any(), argThat(data -> data.getEvent().equals(DICTIONARY_CREATED)));
+    }
+
+    @Test
+    public void shouldCreateWithExplicitKeyWhenIdAlreadyTaken() throws TechnicalException {
+        NewDictionaryEntity newDictionary = new NewDictionaryEntity();
+        newDictionary.setKey("my-key");
+        newDictionary.setName("My Dictionary");
+        newDictionary.setType(DictionaryType.MANUAL);
+        newDictionary.setProperties(Map.of("foo", "bar"));
+
+        Dictionary existingById = new Dictionary();
+        existingById.setId("my-key");
+        existingById.setEnvironmentId("OTHER_ENV");
+        when(dictionaryRepository.findByKeyAndEnvironment("my-key", ENVIRONMENT_ID)).thenReturn(Optional.empty());
+        when(dictionaryRepository.create(any(Dictionary.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DictionaryEntity result = dictionaryService.create(GraviteeContext.getExecutionContext(), newDictionary);
+
+        assertThat(result.getKey()).isEqualTo("my-key");
+        assertThat(result.getId()).isNotEqualTo("my-key");
+
+        verify(dictionaryRepository).create(argThat(dict -> !"my-key".equals(dict.getId()) && "my-key".equals(dict.getKey())));
+    }
+
+    @Test
+    public void shouldCreateWithGeneratedKeyWhenKeyIsNull() throws TechnicalException {
+        NewDictionaryEntity newDictionary = new NewDictionaryEntity();
+        newDictionary.setName("My Dictionary");
+        newDictionary.setType(DictionaryType.MANUAL);
+        newDictionary.setProperties(Map.of("foo", "bar"));
+
+        when(dictionaryRepository.findById(any())).thenReturn(Optional.empty());
+        when(dictionaryRepository.findByKeyAndEnvironment(any(), any())).thenReturn(Optional.empty());
+        when(dictionaryRepository.create(any(Dictionary.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DictionaryEntity result = dictionaryService.create(GraviteeContext.getExecutionContext(), newDictionary);
+
+        assertThat(result.getId()).isNotNull();
+        assertThat(result.getName()).isEqualTo("My Dictionary");
+    }
+
+    @Test
+    public void shouldNotCreateWhenKeyAlreadyExistsInSameEnvironment() throws TechnicalException {
+        NewDictionaryEntity newDictionary = new NewDictionaryEntity();
+        newDictionary.setKey("my-key");
+        newDictionary.setName("My Dictionary");
+        newDictionary.setType(DictionaryType.MANUAL);
+
+        Dictionary existing = new Dictionary();
+        existing.setEnvironmentId(ENVIRONMENT_ID);
+        when(dictionaryRepository.findByKeyAndEnvironment("my-key", ENVIRONMENT_ID)).thenReturn(Optional.of(existing));
+
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        assertThatThrownBy(() -> dictionaryService.create(executionContext, newDictionary)).isInstanceOf(
+            DictionaryAlreadyExistsException.class
+        );
+    }
+
+    @Test
+    public void shouldNotCreateWhenIdAlreadyExistsInSameEnvironment() throws TechnicalException {
+        NewDictionaryEntity newDictionary = new NewDictionaryEntity();
+        newDictionary.setKey("my-key");
+        newDictionary.setName("My Dictionary");
+        newDictionary.setType(DictionaryType.MANUAL);
+
+        Dictionary existingById = new Dictionary();
+        existingById.setKey("my-key");
+        existingById.setEnvironmentId(ENVIRONMENT_ID);
+        when(dictionaryRepository.findByKeyAndEnvironment("my-key", ENVIRONMENT_ID)).thenReturn(Optional.of(existingById));
+
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        assertThatThrownBy(() -> dictionaryService.create(executionContext, newDictionary)).isInstanceOf(
+            DictionaryAlreadyExistsException.class
+        );
+    }
+
+    @Test
+    public void shouldSetStoppedStateOnCreate() throws TechnicalException {
+        NewDictionaryEntity newDictionary = new NewDictionaryEntity();
+        newDictionary.setKey("my-key");
+        newDictionary.setName("My Dictionary");
+        newDictionary.setType(DictionaryType.DYNAMIC);
+
+        when(dictionaryRepository.findByKeyAndEnvironment("my-key", ENVIRONMENT_ID)).thenReturn(Optional.empty());
+        when(dictionaryRepository.create(any(Dictionary.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        dictionaryService.create(GraviteeContext.getExecutionContext(), newDictionary);
+
+        verify(dictionaryRepository).create(
+            argThat(
+                dict ->
+                    dict.getState() == LifecycleState.STOPPED &&
+                    dict.getCreatedAt() != null &&
+                    dict.getUpdatedAt() != null &&
+                    ENVIRONMENT_ID.equals(dict.getEnvironmentId())
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2579
https://gravitee.atlassian.net/browse/GKO-2580

## Description
- Add dictionary CRUD endpoints to the automation API (`PUT`, `GET`, `DELETE`)
- OAS: `DictionarySpec` is a flat object with `type` discriminator and `manual`/`dynamic` sub-objects (no `oneOf` inheritance)
- OAS: `DictionaryState` extends `DictionarySpec` via `allOf` with a readonly `id` field
- OAS: `DictionaryProvider` uses `oneOf` discriminated by `type` — `HttpDictionaryProvider` has flat HTTP config fields (no generic `configuration` wrapper)
- `DictionaryMapper` (MapStruct) converts between OAS models and `NewDictionaryEntity`/`UpdateDictionaryEntity`/`DictionaryEntity`
- `CreateOrUpdateDictionaryUseCase` — idempotent PUT: lookup by HRID, create or update, then handle deployment
- `DeleteDictionaryUseCase` — delete by internal ID after HRID resolution
- `ValidateDictionaryUseCase` — rejects empty properties for MANUAL, enforces mutual exclusivity between `manual` and `dynamic` fields based on `type`
- `DictionaryAutomationDomainService` — wraps `DictionaryService`, handles deploy/undeploy (MANUAL) and start/stop (DYNAMIC) via the `deployed` boolean
- `DictionaryService.findByKeyAndEnvironment` — new method for HRID-based lookup
- `NewDictionaryEntity.key` — new field to set the HRID as the dictionary key on creation
- Permission tests for `ENVIRONMENT_DICTIONARY` (CREATE, UPDATE, READ, DELETE)
