### PR TITLE
fix(e2e): extend portal SDK patch range in update-portal-sdk.sh

### DIFF
--- a/gravitee-apim-e2e/scripts/update-portal-sdk.sh
+++ b/gravitee-apim-e2e/scripts/update-portal-sdk.sh
@@ -31,9 +31,9 @@ sed -i.bak "1,30 s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalytics|Coun
 sed -i.bak "1,30 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsFromJSON,|GroupByAnalyticsFromJSON, CountAnalyticsFromJSON,|" lib/portal-webclient-sdk/src/lib/apis/AnalyticsApi.ts
 sed -i.bak "1,30 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsToJSON,|GroupByAnalyticsToJSON,|" lib/portal-webclient-sdk/src/lib/apis/AnalyticsApi.ts
 sed -i.bak "s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalyticsFromJSON(|CountAnalyticsFromJSON(|" lib/portal-webclient-sdk/src/lib/apis/AnalyticsApi.ts
-sed -i.bak "1,50 s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalytics|CountAnalytics, DateHistoAnalytics, GroupByAnalytics|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
-sed -i.bak "1,50 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsFromJSON,|GroupByAnalyticsFromJSON, CountAnalyticsFromJSON,|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
-sed -i.bak "1,50 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsToJSON,|GroupByAnalyticsToJSON,|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
+sed -i.bak "1,100 s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalytics|CountAnalytics, DateHistoAnalytics, GroupByAnalytics|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
+sed -i.bak "1,100 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsFromJSON,|GroupByAnalyticsFromJSON, CountAnalyticsFromJSON,|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
+sed -i.bak "1,100 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsToJSON,|GroupByAnalyticsToJSON,|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
 sed -i.bak "s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalyticsFromJSON(|CountAnalyticsFromJSON(|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
 #sed -i.bak "/export...from....AnalyticsApi.service';/d" lib/portal-webclient-sdk/src/lib/apis/ApiApi.ts
 find lib/portal-webclient-sdk/src -name "*.ts" -exec sed -i.bak "/* The version of the OpenAPI document/d" {} \;


### PR DESCRIPTION
## What

This PR fixes failing e2e builds caused by portal SDK generation.

## Root cause

`gravitee-apim-e2e/scripts/update-portal-sdk.sh` applies a few `sed` fixes on the generated
`lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts`.

Those replacements were limited to the first 50 lines:

```sh
sed -i.bak "1,50 s|...|...|" ...
```

After new schemas were added to the portal OpenAPI, the generated imports in ApplicationApi.ts shifted below line 50. As a result, the patch was no longer applied and the generated SDK was left in an invalid state, which then broke e2e builds.

## Fix
Increase the sed range from 1,50 to 1,100 for the three existing replacements in update-portal-sdk.sh.
This keeps the current workaround unchanged in behavior, but makes it resilient to the larger generated import section.

## Validation
- The issue was reproduced locally
- The updated sed range fixes the generated SDK locally
- CI confirmation is in progress