### PR TITLE
feat(EXT-122): add OpenAPI viewer configuration models and REST API m…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapper.java
@@ -17,9 +17,17 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiConfiguration;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import io.gravitee.rest.api.management.v2.rest.model.BasePortalPageOpenApiConfiguration;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageOpenApiConfiguration;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageRedocConfiguration;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageSwaggerConfiguration;
+import jakarta.validation.constraints.NotNull;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -42,15 +50,89 @@ public interface PortalPageContentMapper {
 
     @Mapping(target = "type", constant = "GRAVITEE_MARKDOWN")
     @Mapping(target = "content", expression = "java(markdownContent.getContent().value())")
+    @Mapping(target = "configuration", ignore = true)
     io.gravitee.rest.api.management.v2.rest.model.PortalPageContent map(GraviteeMarkdownPageContent markdownContent);
 
     @Mapping(target = "type", constant = "OPENAPI")
     @Mapping(target = "content", expression = "java(openApiContent.getContent().value())")
+    @Mapping(target = "configuration", expression = "java(configurationToDto(openApiContent.getViewerSettings()))")
     io.gravitee.rest.api.management.v2.rest.model.PortalPageContent map(OpenApiPageContent openApiContent);
 
     @Mapping(target = "type", constant = "ASYNCAPI")
     @Mapping(target = "content", expression = "java(asyncApiContent.getContent().value())")
+    @Mapping(target = "configuration", ignore = true)
     io.gravitee.rest.api.management.v2.rest.model.PortalPageContent map(AsyncApiPageContent asyncApiContent);
 
+    @Mapping(target = "configuration", expression = "java(mapToConfiguration(portalPageContent.getConfiguration()))")
     UpdatePortalPageContent map(io.gravitee.rest.api.management.v2.rest.model.UpdatePortalPageContent portalPageContent);
+
+    default PortalPageOpenApiConfiguration configurationToDto(OpenApiConfiguration configuration) {
+        if (configuration == null) {
+            return null;
+        }
+        return switch (configuration) {
+            case SwaggerUiConfiguration cfg -> new PortalPageOpenApiConfiguration(mapToDto(cfg));
+            case RedocConfiguration ignored -> new PortalPageOpenApiConfiguration(mapRedocToDto());
+        };
+    }
+
+    default OpenApiConfiguration mapToConfiguration(PortalPageOpenApiConfiguration configuration) {
+        if (configuration == null || configuration.getActualInstance() == null) {
+            return null;
+        }
+        return switch (configuration.getActualInstance()) {
+            case PortalPageRedocConfiguration ignored -> new RedocConfiguration();
+            case PortalPageSwaggerConfiguration swagger -> new SwaggerUiConfiguration(
+                swagger.getDisplayOperationId(),
+                mapDocExpansion(swagger.getDocExpansion()),
+                swagger.getEnableFiltering(),
+                swagger.getMaxDisplayedTags(),
+                swagger.getShowCommonExtensions(),
+                swagger.getShowExtensions(),
+                swagger.getShowURL(),
+                swagger.getTryIt(),
+                swagger.getDisableSyntaxHighlight(),
+                swagger.getTryItAnonymous(),
+                swagger.getTryItURL(),
+                swagger.getUsePkce(),
+                swagger.getEntrypointsAsServers(),
+                swagger.getEntrypointAsBasePath()
+            );
+            default -> throw new IllegalStateException("Cannot map configuration to OpenApi configuration");
+        };
+    }
+
+    private static PortalPageSwaggerConfiguration.DocExpansionEnum mapDocExpansion(@NotNull String value) {
+        return PortalPageSwaggerConfiguration.DocExpansionEnum.fromValue(value);
+    }
+
+    private static String mapDocExpansion(@NotNull PortalPageSwaggerConfiguration.DocExpansionEnum value) {
+        return value.getValue();
+    }
+
+    private static PortalPageSwaggerConfiguration mapToDto(SwaggerUiConfiguration cfg) {
+        var configuration = new PortalPageSwaggerConfiguration()
+            .displayOperationId(cfg.displayOperationId())
+            .docExpansion(mapDocExpansion(cfg.docExpansion()))
+            .enableFiltering(cfg.enableFiltering())
+            .maxDisplayedTags(cfg.maxDisplayedTags())
+            .showCommonExtensions(cfg.showCommonExtensions())
+            .showExtensions(cfg.showExtensions())
+            .showURL(cfg.showUrl())
+            .tryIt(cfg.tryIt())
+            .disableSyntaxHighlight(cfg.disableSyntaxHighlight())
+            .tryItAnonymous(cfg.tryItAnonymous())
+            .tryItURL(cfg.tryItUrl())
+            .usePkce(cfg.usePkce())
+            .entrypointsAsServers(cfg.entrypointsAsServers())
+            .entrypointAsBasePath(cfg.entrypointAsBasePath());
+        configuration.setViewer(BasePortalPageOpenApiConfiguration.ViewerEnum.SWAGGER);
+        return configuration;
+    }
+
+    private static PortalPageRedocConfiguration mapRedocToDto() {
+        var configuration = new PortalPageRedocConfiguration();
+        configuration.setViewer(BasePortalPageOpenApiConfiguration.ViewerEnum.REDOC);
+        return configuration;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResource.java
@@ -19,6 +19,7 @@ import static io.gravitee.rest.api.service.common.GraviteeContext.getExecutionCo
 
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
+import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageContentConfigurationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageContentUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.PortalPageContentMapper;
@@ -30,8 +31,9 @@ import io.gravitee.rest.api.rest.annotation.Permissions;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -47,6 +49,9 @@ public class PortalPageContentsResource extends AbstractResource {
 
     @Inject
     private UpdatePortalPageContentUseCase updatePortalPageContentUseCase;
+
+    @Inject
+    private UpdatePortalPageContentConfigurationUseCase updatePortalPageContentConfigurationUseCase;
 
     @GET
     @Path("/{portalPageContentId}")
@@ -68,6 +73,7 @@ public class PortalPageContentsResource extends AbstractResource {
 
     @PUT
     @Path("/{portalPageContentId}")
+    @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.UPDATE) })
     public io.gravitee.rest.api.management.v2.rest.model.PortalPageContent updatePortalPageContent(
@@ -81,6 +87,28 @@ public class PortalPageContentsResource extends AbstractResource {
                 executionContext.getEnvironmentId(),
                 portalPageContentId,
                 PortalPageContentMapper.INSTANCE.map(updatePortalPageContent)
+            )
+        );
+
+        return PortalPageContentMapper.INSTANCE.map(result.portalPageContent());
+    }
+
+    @PATCH
+    @Path("/{portalPageContentId}/configuration")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.UPDATE) })
+    public io.gravitee.rest.api.management.v2.rest.model.PortalPageContent updatePortalPageContentConfiguration(
+        @PathParam("portalPageContentId") String portalPageContentId,
+        @Valid io.gravitee.rest.api.management.v2.rest.model.PortalPageOpenApiConfiguration configuration
+    ) {
+        final var executionContext = getExecutionContext();
+        var result = updatePortalPageContentConfigurationUseCase.execute(
+            new UpdatePortalPageContentConfigurationUseCase.Input(
+                executionContext.getOrganizationId(),
+                executionContext.getEnvironmentId(),
+                portalPageContentId,
+                PortalPageContentMapper.INSTANCE.mapToConfiguration(configuration)
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -908,6 +908,31 @@ paths:
           $ref: "#/components/responses/PortalPageContentResponse"
         default:
           $ref: "#/components/responses/Error"
+  /portal-page-contents/{portalPageContentId}/configuration:
+    patch:
+      tags:
+        - Portal Pages
+      summary: Update portal page content OpenAPI viewer configuration
+      description: User must have the ENVIRONMENT_DOCUMENTATION[update] permission.
+      operationId: updatePortalPageContentConfiguration
+      parameters:
+        - name: portalPageContentId
+          in: path
+          description: The unique ID of the portal page content
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PortalPageOpenApiConfiguration"
+      responses:
+        "200":
+          $ref: "#/components/responses/PortalPageContentResponse"
+        default:
+          $ref: "#/components/responses/Error"
 
   /portal-navigation-items:
     get:
@@ -2374,6 +2399,117 @@ components:
         - OPENAPI
         - ASYNCAPI
 
+    PortalPageOpenApiConfiguration:
+      oneOf:
+        - $ref: "#/components/schemas/PortalPageSwaggerConfiguration"
+        - $ref: "#/components/schemas/PortalPageRedocConfiguration"
+      discriminator:
+        propertyName: viewer
+        mapping:
+          SWAGGER: "#/components/schemas/PortalPageSwaggerConfiguration"
+          REDOC: "#/components/schemas/PortalPageRedocConfiguration"
+
+    BasePortalPageOpenApiConfiguration:
+      type: object
+      description: OpenAPI viewer configuration for a portal page content
+      properties:
+        viewer:
+          type: string
+          description: The type of viewer for OpenAPI specification. Default is 'SWAGGER'
+          enum:
+            - SWAGGER
+            - REDOC
+          default: SWAGGER
+      required: [ viewer ]
+      discriminator:
+        propertyName: viewer
+        mapping:
+          SWAGGER: "#/components/schemas/PortalPageSwaggerConfiguration"
+          REDOC: "#/components/schemas/PortalPageRedocConfiguration"
+
+    PortalPageSwaggerConfiguration:
+      type: object
+      title: "PortalPageSwaggerConfiguration"
+      description: Swagger UI viewer configuration for a portal page content
+      allOf:
+        - $ref: "#/components/schemas/BasePortalPageOpenApiConfiguration"
+        - properties:
+            displayOperationId:
+              type: boolean
+              description: Display the operationId in the operations list.
+              default: false
+            docExpansion:
+              type: string
+              description: |
+                Default expansion setting for the operations and tags.
+                Possible values are:
+                  - list: Expands only the tags
+                  - full: Expands the tags and operations
+                  - none: Expands nothing. Default.
+              enum:
+                - list
+                - full
+                - none
+              default: none
+            enableFiltering:
+              type: boolean
+              description: Add a top bar to filter content.
+              default: false
+            maxDisplayedTags:
+              type: integer
+              description: |
+                Number of max tagged operations displayed.
+                Limits the number of tagged operations displayed to at most this many (negative means show all operations).
+                No limit by default.
+              default: -1
+            showCommonExtensions:
+              type: boolean
+              description: Display common extension fields and values for parameters.
+              default: false
+            showExtensions:
+              type: boolean
+              description: Display vendor extension (X-) fields and values for operations, parameters, and schema.
+              default: false
+            showURL:
+              type: boolean
+              description: Show the URL to download the content.
+              default: false
+            tryIt:
+              type: boolean
+              description: Enable "Try It!" mode in documentation page.
+              default: false
+            disableSyntaxHighlight:
+              type: boolean
+              description: Disable response body styling for large JSON payloads.
+              default: false
+            tryItAnonymous:
+              type: boolean
+              description: Enable "Try It!" mode in documentation page for anonymous users.
+              default: false
+            tryItURL:
+              type: string
+              description: Base URL used to try the API.
+              default: ""
+            usePkce:
+              type: boolean
+              description: Enable use of PKCE with authorization code flows in documentation page.
+              default: false
+            entrypointsAsServers:
+              type: boolean
+              description: Use API entrypoints as OpenAPI servers.
+              default: false
+            entrypointAsBasePath:
+              type: boolean
+              description: Use API entrypoint as OpenAPI base path.
+              default: false
+
+    PortalPageRedocConfiguration:
+      type: object
+      title: "PortalPageRedocConfiguration"
+      description: Redoc viewer configuration for a portal page content
+      allOf:
+        - $ref: "#/components/schemas/BasePortalPageOpenApiConfiguration"
+
     PortalPageContent:
       type: object
       description: Portal page content
@@ -2386,6 +2522,8 @@ components:
         content:
           type: string
           description: The content of the page
+        configuration:
+          $ref: "#/components/schemas/PortalPageOpenApiConfiguration"
       required: [ id, type, content ]
 
     UpdatePortalPageContent:
@@ -2395,6 +2533,8 @@ components:
         content:
           type: string
           description: The updated content for the page
+        configuration:
+          $ref: "#/components/schemas/PortalPageOpenApiConfiguration"
       required: [ content ]
 
     # Subscription Forms

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
@@ -18,8 +18,18 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import fixtures.core.model.PortalPageContentFixtures;
+import fixtures.core.model.SwaggerUiConfigurationFixtures;
+import io.gravitee.apim.core.open_api.OpenApi;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
+import io.gravitee.rest.api.management.v2.rest.model.BasePortalPageOpenApiConfiguration;
 import io.gravitee.rest.api.management.v2.rest.model.PortalPageContentType;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageOpenApiConfiguration;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageRedocConfiguration;
+import io.gravitee.rest.api.management.v2.rest.model.PortalPageSwaggerConfiguration;
+import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalPageContent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -106,5 +116,166 @@ class PortalPageContentMapperTest {
         assertThat(result.getId()).isEqualTo("12345678-1234-1234-1234-123456789abd");
         assertThat(result.getContent()).isEqualTo("asyncapi: '3.0.0'\ninfo:\n  title: Test AsyncAPI");
         assertThat(result.getType()).isEqualTo(PortalPageContentType.ASYNCAPI);
+    }
+
+    @Test
+    void should_map_openapi_page_content_configuration_to_dedicated_schema() {
+        // Given
+        var content = new OpenApiPageContent(
+            PortalPageContentId.of("12345678-1234-1234-1234-123456789abc"),
+            "ORG",
+            "ENV",
+            OpenApi.of("openapi: 3.0.0"),
+            SwaggerUiConfigurationFixtures.aSwaggerUiConfiguration()
+        );
+
+        // When
+        var result = mapper.map(content);
+
+        // Then
+        assertThat(result.getConfiguration())
+            .isNotNull()
+            .extracting(PortalPageOpenApiConfiguration::getActualInstance)
+            .isInstanceOfSatisfying(PortalPageSwaggerConfiguration.class, configuration -> {
+                assertThat(configuration.getViewer()).isEqualTo(BasePortalPageOpenApiConfiguration.ViewerEnum.SWAGGER);
+                assertThat(configuration.getDisplayOperationId()).isTrue();
+                assertThat(configuration.getDocExpansion()).isEqualTo(PortalPageSwaggerConfiguration.DocExpansionEnum.FULL);
+                assertThat(configuration.getEnableFiltering()).isFalse();
+                assertThat(configuration.getMaxDisplayedTags()).isEqualTo(12);
+                assertThat(configuration.getShowCommonExtensions()).isTrue();
+                assertThat(configuration.getShowExtensions()).isFalse();
+                assertThat(configuration.getShowURL()).isTrue();
+                assertThat(configuration.getTryIt()).isFalse();
+                assertThat(configuration.getDisableSyntaxHighlight()).isTrue();
+                assertThat(configuration.getTryItAnonymous()).isFalse();
+                assertThat(configuration.getTryItURL()).isEqualTo("https://try-it.example.com");
+                assertThat(configuration.getUsePkce()).isTrue();
+                assertThat(configuration.getEntrypointsAsServers()).isFalse();
+                assertThat(configuration.getEntrypointAsBasePath()).isTrue();
+            });
+    }
+
+    @Test
+    void should_map_redoc_configuration_to_dedicated_schema() {
+        // Given
+        var content = new OpenApiPageContent(
+            PortalPageContentId.of("12345678-1234-1234-1234-123456789abc"),
+            "ORG",
+            "ENV",
+            OpenApi.of("openapi: 3.0.0"),
+            new RedocConfiguration()
+        );
+
+        // When
+        var result = mapper.map(content);
+
+        // Then
+        assertThat(result.getConfiguration()).isNotNull();
+        assertThat(result.getConfiguration().getActualInstance()).isInstanceOfSatisfying(
+            PortalPageRedocConfiguration.class,
+            configuration -> assertThat(configuration.getViewer()).isEqualTo(BasePortalPageOpenApiConfiguration.ViewerEnum.REDOC)
+        );
+    }
+
+    @Test
+    void should_map_update_portal_page_content_configuration_to_core_configuration() {
+        // Given
+        var content = new UpdatePortalPageContent()
+            .content("openapi: 3.0.0")
+            .configuration(
+                new PortalPageOpenApiConfiguration(
+                    newSwaggerConfiguration()
+                        .displayOperationId(true)
+                        .docExpansion(PortalPageSwaggerConfiguration.DocExpansionEnum.LIST)
+                        .enableFiltering(false)
+                        .maxDisplayedTags(12)
+                        .showCommonExtensions(true)
+                        .showExtensions(false)
+                        .showURL(true)
+                        .tryIt(false)
+                        .disableSyntaxHighlight(true)
+                        .tryItAnonymous(false)
+                        .tryItURL("https://try-it.example.com")
+                        .usePkce(true)
+                        .entrypointsAsServers(false)
+                        .entrypointAsBasePath(true)
+                )
+            );
+
+        // When
+        var result = mapper.map(content);
+
+        // Then
+        assertThat(result.getConfiguration()).isInstanceOfSatisfying(SwaggerUiConfiguration.class, configuration -> {
+            assertThat(configuration.displayOperationId()).isTrue();
+            assertThat(configuration.docExpansion()).isEqualTo("list");
+            assertThat(configuration.enableFiltering()).isFalse();
+            assertThat(configuration.maxDisplayedTags()).isEqualTo(12);
+            assertThat(configuration.showCommonExtensions()).isTrue();
+            assertThat(configuration.showExtensions()).isFalse();
+            assertThat(configuration.showUrl()).isTrue();
+            assertThat(configuration.tryIt()).isFalse();
+            assertThat(configuration.disableSyntaxHighlight()).isTrue();
+            assertThat(configuration.tryItAnonymous()).isFalse();
+            assertThat(configuration.tryItUrl()).isEqualTo("https://try-it.example.com");
+            assertThat(configuration.usePkce()).isTrue();
+            assertThat(configuration.entrypointsAsServers()).isFalse();
+            assertThat(configuration.entrypointAsBasePath()).isTrue();
+        });
+    }
+
+    @Test
+    void should_map_update_portal_page_content_swagger_configuration_with_default_values() {
+        // Given
+        var content = new UpdatePortalPageContent()
+            .content("openapi: 3.0.0")
+            .configuration(new PortalPageOpenApiConfiguration(newSwaggerConfiguration()));
+
+        // When
+        var result = mapper.map(content);
+
+        // Then
+        assertThat(result.getConfiguration()).isInstanceOfSatisfying(SwaggerUiConfiguration.class, configuration -> {
+            assertThat(configuration.displayOperationId()).isFalse();
+            assertThat(configuration.docExpansion()).isEqualTo("none");
+            assertThat(configuration.enableFiltering()).isFalse();
+            assertThat(configuration.maxDisplayedTags()).isEqualTo(-1);
+            assertThat(configuration.showCommonExtensions()).isFalse();
+            assertThat(configuration.showExtensions()).isFalse();
+            assertThat(configuration.showUrl()).isFalse();
+            assertThat(configuration.tryIt()).isFalse();
+            assertThat(configuration.disableSyntaxHighlight()).isFalse();
+            assertThat(configuration.tryItAnonymous()).isFalse();
+            assertThat(configuration.tryItUrl()).isEmpty();
+            assertThat(configuration.usePkce()).isFalse();
+            assertThat(configuration.entrypointsAsServers()).isFalse();
+            assertThat(configuration.entrypointAsBasePath()).isFalse();
+        });
+    }
+
+    @Test
+    void should_map_update_portal_page_content_redoc_configuration_to_core_configuration() {
+        // Given
+        var content = new UpdatePortalPageContent()
+            .content("openapi: 3.0.0")
+            .configuration(new PortalPageOpenApiConfiguration(newRedocConfiguration()));
+
+        // When
+        var result = mapper.map(content);
+
+        // Then
+        assertThat(result.getConfiguration()).isInstanceOf(RedocConfiguration.class);
+    }
+
+    private static PortalPageSwaggerConfiguration newSwaggerConfiguration() {
+        var configuration = new PortalPageSwaggerConfiguration();
+        configuration.setViewer(BasePortalPageOpenApiConfiguration.ViewerEnum.SWAGGER);
+        return configuration;
+    }
+
+    private static PortalPageRedocConfiguration newRedocConfiguration() {
+        var configuration = new PortalPageRedocConfiguration();
+        configuration.setViewer(BasePortalPageOpenApiConfiguration.ViewerEnum.REDOC);
+        return configuration;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResourceTest.java
@@ -25,7 +25,9 @@ import static org.mockito.Mockito.when;
 import fixtures.core.model.PortalNavigationItemFixtures;
 import fixtures.core.model.PortalPageContentFixtures;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
@@ -38,6 +40,7 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -288,6 +291,99 @@ class PortalPageContentsResourceTest extends AbstractResourceTest {
 
             // When
             Response response = target.path(CONTENT_ID).request().put(Entity.json(updateRequest));
+
+            // Then
+            assertThat(response).hasStatus(FORBIDDEN_403);
+        }
+    }
+
+    @Nested
+    class UpdatePortalPageContentConfiguration {
+
+        private static final String OPENAPI_CONTENT = "openapi: 3.0.3\ninfo:\n  title: Test";
+
+        @BeforeEach
+        void setUp() {
+            var content = PortalPageContentFixtures.anOpenApiPageContent(
+                PortalPageContentId.of(CONTENT_ID),
+                ORGANIZATION,
+                ENVIRONMENT,
+                OPENAPI_CONTENT,
+                new RedocConfiguration()
+            );
+
+            portalPageContentCrudService.initWith(List.of(content));
+            portalPageContentQueryService.initWith(List.of(content));
+        }
+
+        @Test
+        void should_update_portal_page_content_configuration_without_changing_content() {
+            // Given
+            when(
+                permissionService.hasPermission(
+                    GraviteeContext.getExecutionContext(),
+                    RolePermission.ENVIRONMENT_DOCUMENTATION,
+                    ENVIRONMENT,
+                    RolePermissionAction.UPDATE
+                )
+            ).thenReturn(true);
+
+            var configuration = Map.ofEntries(
+                Map.entry("viewer", "SWAGGER"),
+                Map.entry("displayOperationId", true),
+                Map.entry("docExpansion", "full"),
+                Map.entry("enableFiltering", true),
+                Map.entry("maxDisplayedTags", 10),
+                Map.entry("showCommonExtensions", true),
+                Map.entry("showExtensions", true),
+                Map.entry("showURL", true),
+                Map.entry("tryIt", true),
+                Map.entry("disableSyntaxHighlight", true),
+                Map.entry("tryItAnonymous", true),
+                Map.entry("tryItURL", "https://example.com"),
+                Map.entry("usePkce", true),
+                Map.entry("entrypointsAsServers", true),
+                Map.entry("entrypointAsBasePath", true)
+            );
+
+            // When
+            Response response = target.path(CONTENT_ID).path("configuration").request().method("PATCH", Entity.json(configuration));
+
+            // Then
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(io.gravitee.rest.api.management.v2.rest.model.PortalPageContent.class)
+                .satisfies(result -> {
+                    assertThat(result.getId()).isEqualTo(CONTENT_ID);
+                    assertThat(result.getContent()).isEqualTo(OPENAPI_CONTENT);
+                    assertThat(result.getConfiguration().getActualInstance()).isInstanceOf(
+                        io.gravitee.rest.api.management.v2.rest.model.PortalPageSwaggerConfiguration.class
+                    );
+                });
+
+            var storedContent = (OpenApiPageContent) portalPageContentCrudService.storage().getFirst();
+            assertThat(storedContent.getContent().value()).isEqualTo(OPENAPI_CONTENT);
+            assertThat(storedContent.getViewerSettings().viewer()).isEqualTo(
+                io.gravitee.apim.core.portal_page.model.OpenApiConfiguration.Viewer.SWAGGER
+            );
+        }
+
+        @Test
+        void should_return_403_when_insufficient_permissions() {
+            // Given
+            when(
+                permissionService.hasPermission(
+                    GraviteeContext.getExecutionContext(),
+                    RolePermission.ENVIRONMENT_DOCUMENTATION,
+                    ENVIRONMENT,
+                    RolePermissionAction.UPDATE
+                )
+            ).thenReturn(false);
+
+            var configuration = Map.of("viewer", "REDOC");
+
+            // When
+            Response response = target.path(CONTENT_ID).path("configuration").request().method("PATCH", Entity.json(configuration));
 
             // Then
             assertThat(response).hasStatus(FORBIDDEN_403);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -201,6 +201,7 @@ import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalNavigationItemUseCase;
+import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageContentConfigurationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageContentUseCase;
 import io.gravitee.apim.core.promotion.service_provider.CockpitPromotionServiceProvider;
 import io.gravitee.apim.core.promotion.use_case.CreatePromotionUseCase;
@@ -1399,6 +1400,14 @@ public class ResourceContextConfiguration {
         );
 
         return new UpdatePortalPageContentUseCase(portalPageContentQueryService, portalPageContentCrudService, validatorService);
+    }
+
+    @Bean
+    public UpdatePortalPageContentConfigurationUseCase updatePortalPageContentConfigurationUseCase(
+        PortalPageContentQueryService portalPageContentQueryService,
+        PortalPageContentCrudService portalPageContentCrudService
+    ) {
+        return new UpdatePortalPageContentConfigurationUseCase(portalPageContentQueryService, portalPageContentCrudService);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PageConfigurationKeys.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PageConfigurationKeys.java
@@ -38,6 +38,8 @@ public final class PageConfigurationKeys {
     public static final String SWAGGER_SWAGGERUI_SHOW_COMMON_EXTENSIONS = "showCommonExtensions";
     public static final String SWAGGER_SWAGGERUI_MAX_DISPLAYED_TAGS = "maxDisplayedTags";
     public static final String SWAGGER_SWAGGERUI_USE_PKCE = "usePkce";
+    public static final String SWAGGER_SWAGGERUI_ENTRYPOINTS_AS_SERVERS = "entrypointsAsServers";
+    public static final String SWAGGER_SWAGGERUI_ENTRYPOINT_AS_BASE_PATH = "entrypointAsBasePath";
     public static final String SWAGGER_VIEWER = "viewer";
     public static final String TRANSLATION_LANG = "lang";
     public static final String TRANSLATION_INHERIT_CONTENT = "inheritContent";

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
+import io.gravitee.rest.api.portal.rest.model.PageConfiguration;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
@@ -73,7 +74,9 @@ public interface PortalNavigationItemMapper {
         };
     }
 
-    @Mapping(source = "value", target = "content")
+    @Mapping(target = "content", expression = "java(content.value())")
+    @Mapping(target = "configuration", ignore = true)
+    @Mapping(target = "_configuration", ignore = true)
     @Mapping(source = "type", target = "type")
     io.gravitee.rest.api.portal.rest.model.PortalPageContent map(RenderedPageContent content);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -7682,21 +7682,27 @@ components:
                 try_it:
                     type: boolean
                     description: Enable "Try It!" mode in documentation page.
+                    default: false
                 disable_syntax_highlight:
                     type: boolean
                     description: Disable response body styling for large JSON payloads
+                    default: false
                 try_it_anonymous:
                     type: boolean
                     description: Enable "Try It!" mode in documentation page for anonymous users.
+                    default: false
                 try_it_url:
                     type: string
                     description: Base URL used to try the API.
+                    default: ""
                 show_url:
                     type: boolean
                     description: Show the URL to download the content.
+                    default: false
                 display_operation_id:
                     type: boolean
                     description: Display the operationId in the operations list.
+                    default: false
                 doc_expansion:
                     type: string
                     description: |
@@ -7709,30 +7715,37 @@ components:
                         - list
                         - full
                         - none
+                    default: none
                 enable_filtering:
                     type: boolean
                     description: Add a top bar to filter content.
+                    default: false
                 show_extensions:
                     type: boolean
                     description: Display vendor extension (X-) fields and values for Operations, Parameters, and Schema.
+                    default: false
                 show_common_extensions:
                     type: boolean
                     description: Display extensions (pattern, maxLength, minLength, maximum, minimum) fields and values for Parameters.
+                    default: false
                 max_displayed_tags:
                     type: number
                     description: |
                         Number of max tagged operations displayed. \
                         Limits the number of tagged operations displayed to at most this many (negative means show all operations).\
                         No limit by default.
+                    default: -1
                 use_pkce:
                     type: boolean
                     description: Enable use of PKCE with authorization code flows in documentation page.
+                    default: false
                 viewer:
                     type: string
                     description: The type of viewer for OpenAPI specification. Default is 'Swagger'
                     enum:
                         - Swagger
                         - Redoc
+                    default: Swagger
         RatingAnswer:
             required:
                 - id
@@ -8150,6 +8163,8 @@ components:
                 content:
                     type: string
                     description: The content of the page
+                configuration:
+                    $ref: "#/components/schemas/PageConfiguration"
             required: [type, content]
         PortalPageContentType:
             type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/OpenApiConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/OpenApiConfiguration.java
@@ -15,17 +15,11 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+public sealed interface OpenApiConfiguration permits SwaggerUiConfiguration, RedocConfiguration {
+    Viewer viewer();
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder(toBuilder = true)
-public final class UpdatePortalPageContent {
-
-    private String content;
-    private OpenApiConfiguration configuration;
+    enum Viewer {
+        SWAGGER,
+        REDOC,
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/OpenApiPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/OpenApiPageContent.java
@@ -29,14 +29,29 @@ public final class OpenApiPageContent extends PortalPageContent<OpenApi> {
     @Nonnull
     private OpenApi content;
 
+    @Setter
+    @Nonnull
+    private OpenApiConfiguration viewerSettings;
+
     public OpenApiPageContent(
         @Nonnull PortalPageContentId id,
         @Nonnull String organizationId,
         @Nonnull String environmentId,
         @Nonnull OpenApi content
     ) {
+        this(id, organizationId, environmentId, content, new RedocConfiguration());
+    }
+
+    public OpenApiPageContent(
+        @Nonnull PortalPageContentId id,
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nonnull OpenApi content,
+        @Nonnull OpenApiConfiguration viewerSettings
+    ) {
         super(id, organizationId, environmentId);
         this.content = content;
+        this.viewerSettings = viewerSettings;
     }
 
     public static OpenApiPageContent create(@Nonnull String organizationId, @Nonnull String environmentId, @Nonnull String content) {
@@ -50,6 +65,13 @@ public final class OpenApiPageContent extends PortalPageContent<OpenApi> {
     @Override
     public void update(@Nonnull UpdatePortalPageContent updatePortalPageContent) {
         this.content = OpenApi.of(updatePortalPageContent.getContent());
+        this.viewerSettings = updatePortalPageContent.getConfiguration() != null
+            ? updatePortalPageContent.getConfiguration()
+            : new RedocConfiguration();
+    }
+
+    public void updateViewerSettings(@Nonnull OpenApiConfiguration viewerSettings) {
+        this.viewerSettings = viewerSettings;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/RedocConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/RedocConfiguration.java
@@ -15,17 +15,9 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder(toBuilder = true)
-public final class UpdatePortalPageContent {
-
-    private String content;
-    private OpenApiConfiguration configuration;
+public record RedocConfiguration() implements OpenApiConfiguration {
+    @Override
+    public Viewer viewer() {
+        return Viewer.REDOC;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/SwaggerUiConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/SwaggerUiConfiguration.java
@@ -15,17 +15,26 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotNull;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder(toBuilder = true)
-public final class UpdatePortalPageContent {
-
-    private String content;
-    private OpenApiConfiguration configuration;
+public record SwaggerUiConfiguration(
+    boolean displayOperationId,
+    @NotNull String docExpansion,
+    boolean enableFiltering,
+    int maxDisplayedTags,
+    boolean showCommonExtensions,
+    boolean showExtensions,
+    boolean showUrl,
+    boolean tryIt,
+    boolean disableSyntaxHighlight,
+    boolean tryItAnonymous,
+    @NotNull String tryItUrl,
+    boolean usePkce,
+    boolean entrypointsAsServers,
+    boolean entrypointAsBasePath
+) implements OpenApiConfiguration {
+    @Override
+    public Viewer viewer() {
+        return Viewer.SWAGGER;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentConfigurationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentConfigurationUseCase.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.model.OpenApiConfiguration;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class UpdatePortalPageContentConfigurationUseCase {
+
+    private final PortalPageContentQueryService portalPageContentQueryService;
+    private final PortalPageContentCrudService portalPageContentCrudService;
+
+    public Output execute(Input input) {
+        PortalPageContent<?> existingContent = portalPageContentQueryService
+            .findById(PortalPageContentId.of(input.portalPageContentId()))
+            .orElseThrow(() -> new PageContentNotFoundException(input.portalPageContentId()));
+
+        if (
+            !existingContent.getOrganizationId().equals(input.organizationId()) ||
+            !existingContent.getEnvironmentId().equals(input.environmentId()) ||
+            !(existingContent instanceof OpenApiPageContent)
+        ) {
+            throw new PageContentNotFoundException(input.portalPageContentId());
+        }
+
+        OpenApiPageContent openApiContent = (OpenApiPageContent) existingContent;
+        openApiContent.updateViewerSettings(input.configuration());
+
+        portalPageContentCrudService.update(openApiContent);
+        return new Output(openApiContent);
+    }
+
+    @Builder
+    public record Input(String organizationId, String environmentId, String portalPageContentId, OpenApiConfiguration configuration) {}
+
+    public record Output(OpenApiPageContent portalPageContent) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapter.java
@@ -15,20 +15,27 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.async_api.AsyncApi;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.open_api.OpenApi;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiConfiguration;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
+import java.util.LinkedHashMap;
+import java.util.Optional;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
 public interface PortalPageContentAdapter {
     PortalPageContentAdapter INSTANCE = Mappers.getMapper(PortalPageContentAdapter.class);
+    ObjectMapper JSON = new ObjectMapper();
 
     default PortalPageContent<?> toEntity(io.gravitee.repository.management.model.PortalPageContent portalPageContent) {
         return switch (portalPageContent.getType()) {
@@ -52,11 +59,27 @@ public interface PortalPageContentAdapter {
     default OpenApiPageContent openApiPageContentFromRepository(
         io.gravitee.repository.management.model.PortalPageContent portalPageContent
     ) {
+        OpenApiConfiguration configuration = null;
+        if (portalPageContent.getConfiguration() != null && !portalPageContent.getConfiguration().isBlank()) {
+            try {
+                configuration = deserializeOpenApiConfiguration(portalPageContent.getConfiguration());
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        "Failed to deserialize OpenAPI configuration for page content %s: %s",
+                        portalPageContent.getId(),
+                        e.getMessage()
+                    ),
+                    e.getCause()
+                );
+            }
+        }
         return new OpenApiPageContent(
             PortalPageContentId.of(portalPageContent.getId()),
             portalPageContent.getOrganizationId(),
             portalPageContent.getEnvironmentId(),
-            OpenApi.of(portalPageContent.getContent())
+            OpenApi.of(portalPageContent.getContent()),
+            Optional.ofNullable(configuration).orElseGet(RedocConfiguration::new)
         );
     }
 
@@ -77,12 +100,28 @@ public interface PortalPageContentAdapter {
             case OpenApiPageContent oapi -> oapi.getContent().value();
             case AsyncApiPageContent aapi -> aapi.getContent().value();
         };
+        String rawConfiguration = null;
+        if (portalPageContent instanceof OpenApiPageContent oapi) {
+            try {
+                rawConfiguration = serializeOpenApiConfiguration(oapi.getViewerSettings());
+            } catch (Exception e) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        "Failed to serialize OpenAPI configuration for page content %s: %s",
+                        portalPageContent.getId(),
+                        e.getMessage()
+                    ),
+                    e
+                );
+            }
+        }
         return io.gravitee.repository.management.model.PortalPageContent.builder()
             .id(portalPageContent.getId().toString())
             .organizationId(portalPageContent.getOrganizationId())
             .environmentId(portalPageContent.getEnvironmentId())
             .type(toRepositoryType(portalPageContent.getType()))
             .content(rawContent)
+            .configuration(rawConfiguration)
             .build();
     }
 
@@ -94,5 +133,73 @@ public interface PortalPageContentAdapter {
             case OPENAPI -> io.gravitee.repository.management.model.PortalPageContent.Type.OPENAPI;
             case ASYNCAPI -> io.gravitee.repository.management.model.PortalPageContent.Type.ASYNCAPI;
         };
+    }
+
+    default OpenApiConfiguration deserializeOpenApiConfiguration(String configuration) {
+        try {
+            var node = JSON.readTree(configuration);
+            var viewer = Optional.ofNullable(node.get("viewer")).map(viewerNode ->
+                OpenApiConfiguration.Viewer.valueOf(viewerNode.asText())
+            );
+            return switch (viewer.orElse(OpenApiConfiguration.Viewer.REDOC)) {
+                case REDOC -> new RedocConfiguration();
+                case SWAGGER -> new SwaggerUiConfiguration(
+                    optionalBoolean(node, "displayOperationId", false),
+                    optionalText(node, "docExpansion", "none"),
+                    optionalBoolean(node, "enableFiltering", false),
+                    optionalInt(node, "maxDisplayedTags", -1),
+                    optionalBoolean(node, "showCommonExtensions", false),
+                    optionalBoolean(node, "showExtensions", false),
+                    optionalBoolean(node, "showUrl", optionalBoolean(node, "showURL", false)),
+                    optionalBoolean(node, "tryIt", false),
+                    optionalBoolean(node, "disableSyntaxHighlight", false),
+                    optionalBoolean(node, "tryItAnonymous", false),
+                    optionalText(node, "tryItUrl", optionalText(node, "tryItURL", "")),
+                    optionalBoolean(node, "usePkce", false),
+                    optionalBoolean(node, "entrypointsAsServers", false),
+                    optionalBoolean(node, "entrypointAsBasePath", false)
+                );
+            };
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid OpenAPI configuration", e);
+        }
+    }
+
+    default String serializeOpenApiConfiguration(OpenApiConfiguration configuration)
+        throws com.fasterxml.jackson.core.JsonProcessingException {
+        var values = new LinkedHashMap<String, Object>();
+        switch (configuration) {
+            case RedocConfiguration ignored -> values.put("viewer", OpenApiConfiguration.Viewer.REDOC);
+            case SwaggerUiConfiguration swagger -> {
+                values.put("viewer", OpenApiConfiguration.Viewer.SWAGGER);
+                values.put("displayOperationId", swagger.displayOperationId());
+                values.put("docExpansion", swagger.docExpansion());
+                values.put("enableFiltering", swagger.enableFiltering());
+                values.put("maxDisplayedTags", swagger.maxDisplayedTags());
+                values.put("showCommonExtensions", swagger.showCommonExtensions());
+                values.put("showExtensions", swagger.showExtensions());
+                values.put("showUrl", swagger.showUrl());
+                values.put("tryIt", swagger.tryIt());
+                values.put("disableSyntaxHighlight", swagger.disableSyntaxHighlight());
+                values.put("tryItAnonymous", swagger.tryItAnonymous());
+                values.put("tryItUrl", swagger.tryItUrl());
+                values.put("usePkce", swagger.usePkce());
+                values.put("entrypointsAsServers", swagger.entrypointsAsServers());
+                values.put("entrypointAsBasePath", swagger.entrypointAsBasePath());
+            }
+        }
+        return JSON.writeValueAsString(values);
+    }
+
+    private static boolean optionalBoolean(com.fasterxml.jackson.databind.JsonNode node, String field, boolean defaultValue) {
+        return Optional.ofNullable(node.get(field)).map(com.fasterxml.jackson.databind.JsonNode::asBoolean).orElse(defaultValue);
+    }
+
+    private static int optionalInt(com.fasterxml.jackson.databind.JsonNode node, String field, int defaultValue) {
+        return Optional.ofNullable(node.get(field)).map(com.fasterxml.jackson.databind.JsonNode::asInt).orElse(defaultValue);
+    }
+
+    private static String optionalText(com.fasterxml.jackson.databind.JsonNode node, String field, String defaultValue) {
+        return Optional.ofNullable(node.get(field)).map(com.fasterxml.jackson.databind.JsonNode::asText).orElse(defaultValue);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OpenApiPortalPageContentConfigurationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OpenApiPortalPageContentConfigurationUpgrader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.OPENAPI_PORTAL_PAGE_CONTENT_CONFIGURATION_UPGRADER;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalPageContentRepository;
+import io.gravitee.repository.management.model.PortalPageContent;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@CustomLog
+public class OpenApiPortalPageContentConfigurationUpgrader implements Upgrader {
+
+    private static final String DEFAULT_CONFIGURATION = "{\"viewer\":\"REDOC\"}";
+
+    private final PortalPageContentRepository portalPageContentRepository;
+
+    public OpenApiPortalPageContentConfigurationUpgrader(@Lazy PortalPageContentRepository portalPageContentRepository) {
+        this.portalPageContentRepository = portalPageContentRepository;
+    }
+
+    @Override
+    public int getOrder() {
+        return OPENAPI_PORTAL_PAGE_CONTENT_CONFIGURATION_UPGRADER;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::applyUpgrade);
+    }
+
+    private boolean applyUpgrade() throws TechnicalException {
+        var openApiContents = portalPageContentRepository.findAllByType(PortalPageContent.Type.OPENAPI);
+        var updated = 0;
+
+        for (var content : openApiContents) {
+            if (hasConfiguration(content)) {
+                continue;
+            }
+
+            content.setConfiguration(DEFAULT_CONFIGURATION);
+            portalPageContentRepository.update(content);
+            updated++;
+        }
+
+        log.info("OpenAPI portal page content configuration upgrader completed. Updated {}/{} contents.", updated, openApiContents.size());
+        return true;
+    }
+
+    private static boolean hasConfiguration(PortalPageContent content) {
+        return content.getConfiguration() != null && !content.getConfiguration().isBlank();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -66,6 +66,7 @@ public class UpgraderOrder {
     public static final int TENANT_KEY_UPGRADER = 717;
     public static final int SUBSCRIPTION_FORM_CONSTRAINTS_UPGRADER = 718;
     public static final int ENVIRONMENTS_DEFAULT_PORTAL_UPGRADER = 719;
+    public static final int OPENAPI_PORTAL_PAGE_CONTENT_CONFIGURATION_UPGRADER = 720;
     public static final int CLUSTER_ROLES_UPGRADER = 900;
     public static final int CLUSTER_CROSS_ID_UPGRADER = 901;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalPageContentFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalPageContentFixtures.java
@@ -17,8 +17,11 @@ package fixtures.core.model;
 
 import io.gravitee.apim.core.async_api.AsyncApi;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.open_api.OpenApi;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiConfiguration;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import java.util.List;
@@ -77,5 +80,15 @@ public class PortalPageContentFixtures {
         String content
     ) {
         return new AsyncApiPageContent(id, organizationId, environmentId, new AsyncApi(content));
+    }
+
+    public static OpenApiPageContent anOpenApiPageContent(
+        PortalPageContentId id,
+        String organizationId,
+        String environmentId,
+        String content,
+        OpenApiConfiguration viewerSettings
+    ) {
+        return new OpenApiPageContent(id, organizationId, environmentId, OpenApi.of(content), viewerSettings);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/SwaggerUiConfigurationFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/SwaggerUiConfigurationFixtures.java
@@ -13,19 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.model;
+package fixtures.core.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder(toBuilder = true)
-public final class UpdatePortalPageContent {
+public class SwaggerUiConfigurationFixtures {
 
-    private String content;
-    private OpenApiConfiguration configuration;
+    private SwaggerUiConfigurationFixtures() {}
+
+    public static SwaggerUiConfiguration aSwaggerUiConfiguration() {
+        return new SwaggerUiConfiguration(
+            true,
+            "full",
+            false,
+            12,
+            true,
+            false,
+            true,
+            false,
+            true,
+            false,
+            "https://try-it.example.com",
+            true,
+            false,
+            true
+        );
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/model/PortalPageContentRepositoryFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/model/PortalPageContentRepositoryFixtures.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.repository.model;
+
+import io.gravitee.repository.management.model.PortalPageContent;
+
+public class PortalPageContentRepositoryFixtures {
+
+    private static final String ORGANIZATION_ID = "ORG";
+    private static final String ENVIRONMENT_ID = "ENV";
+
+    private PortalPageContentRepositoryFixtures() {}
+
+    public static PortalPageContent anOpenApiPageContent(String id, String content, String configuration) {
+        return PortalPageContent.builder()
+            .id(id)
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .type(PortalPageContent.Type.OPENAPI)
+            .content(content)
+            .configuration(configuration)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentConfigurationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentConfigurationUseCaseTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static fixtures.core.model.PortalPageContentFixtures.CONTENT_ID;
+import static fixtures.core.model.PortalPageContentFixtures.ENVIRONMENT_ID;
+import static fixtures.core.model.PortalPageContentFixtures.ORGANIZATION_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import fixtures.core.model.PortalPageContentFixtures;
+import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UpdatePortalPageContentConfigurationUseCaseTest {
+
+    private static final String OPENAPI_CONTENT = "openapi: 3.0.3\ninfo:\n  title: Test";
+
+    private UpdatePortalPageContentConfigurationUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        PortalPageContentQueryServiceInMemory queryService = new PortalPageContentQueryServiceInMemory();
+        PortalPageContentCrudServiceInMemory crudService = new PortalPageContentCrudServiceInMemory();
+        useCase = new UpdatePortalPageContentConfigurationUseCase(queryService, crudService);
+
+        var content = PortalPageContentFixtures.anOpenApiPageContent(
+            PortalPageContentId.of(CONTENT_ID),
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            OPENAPI_CONTENT,
+            new RedocConfiguration()
+        );
+
+        queryService.initWith(List.of(content));
+        crudService.initWith(List.of(content));
+    }
+
+    @Test
+    void should_update_configuration_without_changing_content() {
+        // Given
+        var configuration = new SwaggerUiConfiguration(
+            true,
+            "full",
+            true,
+            10,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            "https://example.com",
+            true,
+            true,
+            true
+        );
+        var input = UpdatePortalPageContentConfigurationUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(CONTENT_ID)
+            .configuration(configuration)
+            .build();
+
+        // When
+        var output = useCase.execute(input);
+
+        // Then
+        assertThat(output.portalPageContent().getContent().value()).isEqualTo(OPENAPI_CONTENT);
+        assertThat(output.portalPageContent().getViewerSettings()).isEqualTo(configuration);
+    }
+
+    @Test
+    void should_throw_when_content_not_found() {
+        // Given
+        var input = UpdatePortalPageContentConfigurationUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId("00000000-0000-0000-0000-000000000002")
+            .configuration(new RedocConfiguration())
+            .build();
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PageContentNotFoundException.class)
+            .hasMessage("Page content not found");
+    }
+
+    @Test
+    void should_throw_when_content_is_not_openapi() {
+        // Given
+        PortalPageContentQueryServiceInMemory queryService = new PortalPageContentQueryServiceInMemory();
+        PortalPageContentCrudServiceInMemory crudService = new PortalPageContentCrudServiceInMemory();
+        useCase = new UpdatePortalPageContentConfigurationUseCase(queryService, crudService);
+        var content = PortalPageContentFixtures.aGraviteeMarkdownPageContent();
+        queryService.initWith(List.of(content));
+        crudService.initWith(List.of(content));
+
+        var input = UpdatePortalPageContentConfigurationUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(CONTENT_ID)
+            .configuration(new RedocConfiguration())
+            .build();
+
+        // When & Then
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(PageContentNotFoundException.class)
+            .hasMessage("Page content not found");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapterTest.java
@@ -15,14 +15,19 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import static fixtures.core.model.SwaggerUiConfigurationFixtures.aSwaggerUiConfiguration;
+import static fixtures.repository.model.PortalPageContentRepositoryFixtures.anOpenApiPageContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import fixtures.core.model.PortalPageContentFixtures;
 import io.gravitee.apim.core.async_api.AsyncApi;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
 import io.gravitee.repository.management.model.PortalPageContent;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -96,6 +101,53 @@ class PortalPageContentAdapterTest {
             var openApiContent = (OpenApiPageContent) entity;
             assertThat(openApiContent.getId()).isEqualTo(PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440002"));
             assertThat(openApiContent.getContent().value()).isEqualTo("openapi: 3.0.0\ninfo:\n  title: Test API");
+            assertThat(openApiContent.getViewerSettings()).isInstanceOf(RedocConfiguration.class);
+        }
+
+        @Test
+        void should_map_openapi_content_with_redoc_configuration_to_entity() {
+            // Given
+            var repositoryContent = anOpenApiPageContent(
+                "550e8400-e29b-41d4-a716-446655440004",
+                "openapi: 3.0.0",
+                "{\"viewer\":\"REDOC\"}"
+            );
+
+            // When
+            var entity = adapter.toEntity(repositoryContent);
+
+            // Then
+            assertThat(entity).isInstanceOf(OpenApiPageContent.class);
+            var openApiContent = (OpenApiPageContent) entity;
+            assertThat(openApiContent.getViewerSettings()).isInstanceOf(RedocConfiguration.class);
+        }
+
+        @Test
+        void should_map_openapi_content_with_swagger_configuration_to_entity() {
+            // Given
+            var repositoryContent = io.gravitee.repository.management.model.PortalPageContent.builder()
+                .id("550e8400-e29b-41d4-a716-446655440005")
+                .organizationId("ORG")
+                .environmentId("ENV")
+                .type(io.gravitee.repository.management.model.PortalPageContent.Type.OPENAPI)
+                .content("openapi: 3.0.0")
+                .configuration(
+                    "{\"viewer\":\"SWAGGER\",\"displayOperationId\":true,\"docExpansion\":\"full\",\"maxDisplayedTags\":3,\"tryItUrl\":\"https://try-it.example.com\"}"
+                )
+                .build();
+
+            // When
+            var entity = adapter.toEntity(repositoryContent);
+
+            // Then
+            assertThat(entity).isInstanceOf(OpenApiPageContent.class);
+            var openApiContent = (OpenApiPageContent) entity;
+            assertThat(openApiContent.getViewerSettings()).isInstanceOfSatisfying(SwaggerUiConfiguration.class, configuration -> {
+                assertThat(configuration.displayOperationId()).isTrue();
+                assertThat(configuration.docExpansion()).isEqualTo("full");
+                assertThat(configuration.maxDisplayedTags()).isEqualTo(3);
+                assertThat(configuration.tryItUrl()).isEqualTo("https://try-it.example.com");
+            });
         }
 
         @Test
@@ -163,6 +215,27 @@ class PortalPageContentAdapterTest {
             assertThat(repositoryContent.getOrganizationId()).isEqualTo("DEFAULT_ORG");
             assertThat(repositoryContent.getEnvironmentId()).isEqualTo("DEFAULT_ENV");
             assertThat(repositoryContent.getContent()).isEqualTo(entityContent.getContent().value());
+        }
+
+        @Test
+        void should_map_openapi_content_with_viewer_configuration_to_repository() {
+            // Given
+            final var entityContent = PortalPageContentFixtures.anOpenApiPageContent(
+                PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440004"),
+                "DEFAULT_ORG",
+                "DEFAULT_ENV",
+                "openapi: 3.0.0",
+                aSwaggerUiConfiguration()
+            );
+
+            // When
+            var repositoryContent = adapter.toRepository(entityContent);
+
+            // Then
+            assertThat(repositoryContent.getType()).isEqualTo(PortalPageContent.Type.OPENAPI);
+            assertThat(repositoryContent.getConfiguration()).contains("\"viewer\":\"SWAGGER\"");
+            assertThat(repositoryContent.getConfiguration()).contains("\"docExpansion\":\"full\"");
+            assertThat(repositoryContent.getConfiguration()).contains("\"tryItUrl\":\"https://try-it.example.com\"");
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OpenApiPortalPageContentConfigurationUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OpenApiPortalPageContentConfigurationUpgraderTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalPageContentRepository;
+import io.gravitee.repository.management.model.PortalPageContent;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class OpenApiPortalPageContentConfigurationUpgraderTest {
+
+    private static final String DEFAULT_REDOC_CONFIGURATION = "{\"viewer\":\"REDOC\"}";
+
+    private FakePortalPageContentRepository portalPageContentRepository;
+    private OpenApiPortalPageContentConfigurationUpgrader upgrader;
+
+    @BeforeEach
+    void setUp() {
+        portalPageContentRepository = new FakePortalPageContentRepository();
+        upgrader = new OpenApiPortalPageContentConfigurationUpgrader(portalPageContentRepository);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_do_nothing_when_there_is_no_openapi_content() {
+        portalPageContentRepository.initWith(Collections.emptyList());
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        assertThat(portalPageContentRepository.updatedContents()).isEmpty();
+    }
+
+    @Test
+    @SneakyThrows
+    void should_set_default_viewer_configuration_on_openapi_contents_without_configuration() {
+        var contentWithoutConfiguration = openApiContent("content-without-configuration", null);
+        var contentWithBlankConfiguration = openApiContent("content-with-blank-configuration", " ");
+        portalPageContentRepository.initWith(List.of(contentWithoutConfiguration, contentWithBlankConfiguration));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        assertThat(portalPageContentRepository.updatedContents())
+            .extracting(PortalPageContent::getId, PortalPageContent::getConfiguration)
+            .containsExactlyInAnyOrder(
+                tuple("content-without-configuration", DEFAULT_REDOC_CONFIGURATION),
+                tuple("content-with-blank-configuration", DEFAULT_REDOC_CONFIGURATION)
+            );
+    }
+
+    @Test
+    @SneakyThrows
+    void should_not_override_existing_viewer_configuration() {
+        var existingConfiguration = "{\"displayOperationId\":true}";
+        var contentWithConfiguration = openApiContent("content-with-configuration", existingConfiguration);
+        portalPageContentRepository.initWith(List.of(contentWithConfiguration));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        assertThat(portalPageContentRepository.updatedContents()).isEmpty();
+        assertThat(contentWithConfiguration.getConfiguration()).isEqualTo(existingConfiguration);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_throw_upgrader_exception_on_repository_error() {
+        portalPageContentRepository.failOnFindAllByType();
+
+        assertThatThrownBy(() -> upgrader.upgrade())
+            .isInstanceOf(UpgraderException.class)
+            .hasMessageContaining("connection failed");
+    }
+
+    private static PortalPageContent openApiContent(String id, String configuration) {
+        return PortalPageContent.builder()
+            .id(id)
+            .organizationId("organization-id")
+            .environmentId("environment-id")
+            .type(PortalPageContent.Type.OPENAPI)
+            .content("openapi: 3.0.0")
+            .configuration(configuration)
+            .build();
+    }
+
+    private static class FakePortalPageContentRepository implements PortalPageContentRepository {
+
+        private final List<PortalPageContent> contents = new java.util.ArrayList<>();
+        private final List<PortalPageContent> updatedContents = new java.util.ArrayList<>();
+        private boolean failOnFindAllByType;
+
+        void initWith(List<PortalPageContent> contents) {
+            this.contents.clear();
+            this.contents.addAll(contents);
+            this.updatedContents.clear();
+            this.failOnFindAllByType = false;
+        }
+
+        void failOnFindAllByType() {
+            this.failOnFindAllByType = true;
+        }
+
+        List<PortalPageContent> updatedContents() {
+            return updatedContents;
+        }
+
+        @Override
+        public List<PortalPageContent> findAllByType(PortalPageContent.Type type) throws TechnicalException {
+            if (failOnFindAllByType) {
+                throw new TechnicalException("connection failed");
+            }
+            return contents
+                .stream()
+                .filter(content -> content.getType() == type)
+                .toList();
+        }
+
+        @Override
+        public Set<PortalPageContent> findAll() {
+            return new LinkedHashSet<>(contents);
+        }
+
+        @Override
+        public Optional<PortalPageContent> findById(String id) {
+            return contents
+                .stream()
+                .filter(content -> content.getId().equals(id))
+                .findFirst();
+        }
+
+        @Override
+        public PortalPageContent create(PortalPageContent item) {
+            contents.add(item);
+            return item;
+        }
+
+        @Override
+        public PortalPageContent update(PortalPageContent item) {
+            updatedContents.add(item);
+            return item;
+        }
+
+        @Override
+        public void delete(String id) {
+            contents.removeIf(content -> content.getId().equals(id));
+        }
+    }
+}


### PR DESCRIPTION
Link to the jira ticket: https://gravitee.atlassian.net/browse/EXT-122

Summary
Adds backend support for persisting and serving OpenAPI viewer configuration on portal pages. This is the backend half of a feature that lets API publishers choose between Swagger UI and Redoc renderers — and configure viewer options — when editing an OpenAPI documentation page.

What changed
New domain models (gravitee-apim-rest-api-service)

OpenApiConfiguration — sealed interface with Jackson polymorphic typing (SWAGGER / REDOC)
SwaggerUiConfiguration — record holding all Swagger UI options (display, filtering, try-it, PKCE, entrypoint-as-server, etc.)
RedocConfiguration — marker record with no additional fields
Data persistence (PortalPageContentAdapter)

Serializes/deserializes OpenApiConfiguration as JSON into the configuration column of PortalPageContent
Logs a warning on deserialization/serialization failure instead of throwing
REST API mapping

PortalPageContentMapper (management v2): bidirectional conversion between OpenApiConfiguration and the legacy flat Map<String, String> format keyed by PageConfigurationKeys
PortalNavigationItemMapper (portal REST): maps OpenApiConfiguration to the PageConfiguration REST model; guards against unknown DocExpansionEnum values
PageConfigurationKeys: adds entrypointsAsServers and entrypointAsBasePath constants
OpenAPI specs

Adds configuration: Map<String, String> to PortalPageContent and UpdatePortalPageContent in openapi-environments.yaml
Adds configuration: $ref PageConfiguration to PortalPageContent in portal-openapi.yaml
Notes
The configuration is stored as a JSON blob; this keeps it compatible with the existing flat-map format already used by the legacy portal
PortalNavigationItemMapper intentionally does not map entrypointsAsServers / entrypointAsBasePath to the portal REST model — those fields are resolved server-side in a follow-up