### PR TITLE
fix(e2e): increase sed line range for ApplicationApi SDK post-processing

### DIFF
--- a/gravitee-apim-e2e/scripts/update-portal-sdk.sh
+++ b/gravitee-apim-e2e/scripts/update-portal-sdk.sh
@@ -27,14 +27,26 @@ yarn dlx @openapitools/openapi-generator-cli@1.0.18-4.3.1 generate \
   --reserved-words-mappings=configuration=configuration
 
 sed -i.bak "s|export \* from './AnalyticsApi';||" lib/portal-webclient-sdk/src/lib/apis/index.ts
-sed -i.bak "1,30 s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalytics|CountAnalytics, DateHistoAnalytics, GroupByAnalytics|" lib/portal-webclient-sdk/src/lib/apis/AnalyticsApi.ts
-sed -i.bak "1,30 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsFromJSON,|GroupByAnalyticsFromJSON, CountAnalyticsFromJSON,|" lib/portal-webclient-sdk/src/lib/apis/AnalyticsApi.ts
-sed -i.bak "1,30 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsToJSON,|GroupByAnalyticsToJSON,|" lib/portal-webclient-sdk/src/lib/apis/AnalyticsApi.ts
+sed -i.bak "1,50 s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalytics|CountAnalytics, DateHistoAnalytics, GroupByAnalytics|" lib/portal-webclient-sdk/src/lib/apis/AnalyticsApi.ts
+sed -i.bak "1,50 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsFromJSON,|GroupByAnalyticsFromJSON, CountAnalyticsFromJSON,|" lib/portal-webclient-sdk/src/lib/apis/AnalyticsApi.ts
+sed -i.bak "1,50 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsToJSON,|GroupByAnalyticsToJSON,|" lib/portal-webclient-sdk/src/lib/apis/AnalyticsApi.ts
 sed -i.bak "s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalyticsFromJSON(|CountAnalyticsFromJSON(|" lib/portal-webclient-sdk/src/lib/apis/AnalyticsApi.ts
-sed -i.bak "1,50 s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalytics|CountAnalytics, DateHistoAnalytics, GroupByAnalytics|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
-sed -i.bak "1,50 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsFromJSON,|GroupByAnalyticsFromJSON, CountAnalyticsFromJSON,|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
-sed -i.bak "1,50 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsToJSON,|GroupByAnalyticsToJSON,|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
+sed -i.bak "1,100 s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalytics|CountAnalytics, DateHistoAnalytics, GroupByAnalytics|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
+sed -i.bak "1,100 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsFromJSON,|GroupByAnalyticsFromJSON, CountAnalyticsFromJSON,|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
+sed -i.bak "1,100 s|CountAnalytics, DateHistoAnalytics, GroupByAnalyticsToJSON,|GroupByAnalyticsToJSON,|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
 sed -i.bak "s|DateHistoAnalytics \| GroupByAnalytics \| CountAnalyticsFromJSON(|CountAnalyticsFromJSON(|" lib/portal-webclient-sdk/src/lib/apis/ApplicationApi.ts
+
+# Fix broken generated analytics models from OpenAPI Generator 4.3.1
+sed -i.bak "s|return { ...numberFromJSONTyped(json, true), ...stringFromJSONTyped(json, true) };|return json;|" lib/portal-webclient-sdk/src/lib/models/AnalyticsInterval.ts
+sed -i.bak "s|return { ...numberToJSON(value), ...stringToJSON(value) };|return value;|" lib/portal-webclient-sdk/src/lib/models/AnalyticsInterval.ts
+sed -i.bak "s|return {...AnalyticsStringFilterFromJSONTyped(json, true), operator: 'EQ'};|return {...AnalyticsStringFilterFromJSONTyped(json, true), operator: 'EQ'} as AnalyticsFilter;|" lib/portal-webclient-sdk/src/lib/models/AnalyticsFilter.ts
+sed -i.bak "s|return {...AnalyticsArrayFilterFromJSONTyped(json, true), operator: 'IN'};|return {...AnalyticsArrayFilterFromJSONTyped(json, true), operator: 'IN'} as AnalyticsFilter;|" lib/portal-webclient-sdk/src/lib/models/AnalyticsFilter.ts
+sed -i.bak "s|return {...AnalyticsNumberFilterFromJSONTyped(json, true), operator: 'LTE'};|return {...AnalyticsNumberFilterFromJSONTyped(json, true), operator: 'LTE'} as AnalyticsFilter;|" lib/portal-webclient-sdk/src/lib/models/AnalyticsFilter.ts
+sed -i.bak "s|return {...AnalyticsNumberFilterFromJSONTyped(json, true), operator: 'GTE'};|return {...AnalyticsNumberFilterFromJSONTyped(json, true), operator: 'GTE'} as AnalyticsFilter;|" lib/portal-webclient-sdk/src/lib/models/AnalyticsFilter.ts
+sed -i.bak "s|return {...AnalyticsFacetBucketLeafFromJSONTyped(json, true), type: 'LEAF'};|return {...AnalyticsFacetBucketLeafFromJSONTyped(json, true), type: 'LEAF'} as AnalyticsFacetBucket;|" lib/portal-webclient-sdk/src/lib/models/AnalyticsFacetBucket.ts
+sed -i.bak "s|return {...AnalyticsFacetBucketGroupFromJSONTyped(json, true), type: 'GROUP'};|return {...AnalyticsFacetBucketGroupFromJSONTyped(json, true), type: 'GROUP'} as AnalyticsFacetBucket;|" lib/portal-webclient-sdk/src/lib/models/AnalyticsFacetBucket.ts
+sed -i.bak "s|return {...AnalyticsTimeSeriesBucketLeafFromJSONTyped(json, true), type: 'LEAF'};|return {...AnalyticsTimeSeriesBucketLeafFromJSONTyped(json, true), type: 'LEAF'} as AnalyticsTimeSeriesBucket;|" lib/portal-webclient-sdk/src/lib/models/AnalyticsTimeSeriesBucket.ts
+sed -i.bak "s|return {...AnalyticsTimeSeriesBucketGroupFromJSONTyped(json, true), type: 'GROUP'};|return {...AnalyticsTimeSeriesBucketGroupFromJSONTyped(json, true), type: 'GROUP'} as AnalyticsTimeSeriesBucket;|" lib/portal-webclient-sdk/src/lib/models/AnalyticsTimeSeriesBucket.ts
 #sed -i.bak "/export...from....AnalyticsApi.service';/d" lib/portal-webclient-sdk/src/lib/apis/ApiApi.ts
 find lib/portal-webclient-sdk/src -name "*.ts" -exec sed -i.bak "/* The version of the OpenAPI document/d" {} \;
 # must delete .bak files


### PR DESCRIPTION
## What

This PR fixes e2e / portal SDK generation issues caused by two recent `portal-openapi.yaml` changes.

## Root cause analysis

Two separate commits exposed two different weaknesses in `gravitee-apim-e2e/scripts/update-portal-sdk.sh`:

- `7468f6f1f1` by `Jaroslaw Lakomy`
  `feat(portal-openapi): APIM-13760 define application invitation management contract`

  This change added new invitation-related endpoints and schemas, and also extended the portal contract around user/member search. As a result, the generated import section in `ApplicationApi.ts` grew and the existing `sed` workaround in `update-portal-sdk.sh` no longer matched because it was limited to the first 50 lines.

  What had to be fixed:
  the `ApplicationApi.ts` patch range needed to be extended so the existing workaround still applies after the generated code shift.

- `3aa2a4b8c6` by `aqibmohammadkhan`
  `feat(portal): add analytics computation endpoints and mappers`

  This change introduced new analytics schemas using patterns that are not handled correctly by the old `typescript-fetch` generator version used in e2e (`@openapitools/openapi-generator-cli@1.0.18-4.3.1`).

  Problematic cases:
  - `AnalyticsInterval` uses `oneOf(string, integer)`, which generated invalid helper calls such as `numberFromJSONTyped` / `stringFromJSONTyped`
  - `AnalyticsFilter`, `AnalyticsFacetBucket`, and `AnalyticsTimeSeriesBucket` use `oneOf + discriminator`, which generated TypeScript branches later resolved to `never`

  What had to be fixed:
  post-generation patches were added for the generated analytics model files so the SDK compiles correctly with the current generator.

## Fix

This PR updates `gravitee-apim-e2e/scripts/update-portal-sdk.sh` to handle both regressions:

- keep the `ApplicationApi.ts` workaround effective after the invitation/member contract changes
- patch broken generated analytics model code after SDK generation

## Validation

Validated locally with:

- `yarn --cwd gravitee-apim-e2e update:sdk:portal`
- `yarn --cwd gravitee-apim-e2e tsc --noEmit`
- `yarn --cwd gravitee-apim-e2e build`

All commands pass after this change.