### PR TITLE
feat (console): open context menu with right click in portal navigation items tree.

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -35,6 +35,7 @@
       (cdkDragStarted)="onDragStarted($event)"
       (click)="onNodeClick(node)"
       (keydown.enter)="onNodeClick(node)"
+      (contextmenu)="onContextMenu($event, node)"
       [class.unpublished]="isUnpublished(node)"
       [class.selected]="isSelected(node)"
     >
@@ -59,6 +60,7 @@
       (cdkDragStarted)="onDragStarted($event)"
       (click)="onNodeClick(node)"
       (keydown.enter)="onNodeClick(node)"
+      (contextmenu)="onContextMenu($event, node)"
       [class.unpublished]="isUnpublished(node)"
       [class.selected]="isSelected(node)"
     >
@@ -110,81 +112,7 @@
     }
 
     <mat-menu #moreMenu="matMenu">
-      @if (node.type === 'FOLDER' || node.type === 'API') {
-        @if (canCreate) {
-          <button mat-menu-item (click)="onCreate(node, 'PAGE')">
-            <mat-icon [svgIcon]="'PAGE' | portalNavigationItemIcon"></mat-icon>
-            Add Page
-          </button>
-
-          @if (node.type != 'API') {
-            <button mat-menu-item (click)="onCreate(node, 'API')">
-              <mat-icon [svgIcon]="'API' | portalNavigationItemIcon"></mat-icon>
-              Add API
-            </button>
-          }
-
-          <button mat-menu-item (click)="onCreate(node, 'FOLDER')">
-            <mat-icon [svgIcon]="'FOLDER' | portalNavigationItemIcon"></mat-icon>
-            Add Folder
-          </button>
-          <button mat-menu-item (click)="onCreate(node, 'LINK')">
-            <mat-icon [svgIcon]="'LINK' | portalNavigationItemIcon"></mat-icon>
-            Add Link
-          </button>
-          @if (canUpdate || canDelete) {
-            <mat-divider></mat-divider>
-          }
-        }
-      }
-      @if (canUpdate) {
-        <button mat-menu-item (click)="onEdit(node)" data-testid="edit-node-button">
-          <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
-          Edit
-        </button>
-
-        @if (isUnpublished(node)) {
-          @let publishState = publishStateByNodeId().get(node.id) ?? publishActionEnabledState;
-          <span [matTooltip]="publishState.tooltip" [matTooltipDisabled]="!publishState.disabled" matTooltipPosition="right">
-            <button
-              mat-menu-item
-              [disabled]="publishState.disabled"
-              [attr.aria-disabled]="publishState.ariaDisabled"
-              [attr.tabindex]="publishState.tabIndex"
-              (click)="onPublish(node)"
-              data-testid="publish-node-button"
-            >
-              <mat-icon svgIcon="gio:eye-empty"></mat-icon>
-              Publish
-            </button>
-          </span>
-        } @else {
-          <button mat-menu-item (click)="onUnpublish(node)" data-testid="unpublish-node-button">
-            <mat-icon svgIcon="gio:eye-off"></mat-icon>
-            Unpublish
-          </button>
-        }
-      }
-
-      @if (canDelete) {
-        <span matTooltip="Only empty folders can be deleted" [matTooltipDisabled]="!hasChildren(node)" matTooltipPosition="right">
-          <button
-            mat-menu-item
-            [disabled]="hasChildren(node)"
-            [attr.aria-disabled]="hasChildren(node)"
-            [attr.tabindex]="hasChildren(node) ? -1 : null"
-            [class.tree__menu-item-delete]="!hasChildren(node)"
-            [class.tree__menu-item-delete--disabled]="hasChildren(node)"
-            (click)="onDelete(node)"
-            data-testid="delete-node-button"
-          >
-            <mat-icon [class.tree__menu-item-delete]="!hasChildren(node)" [class.tree__menu-item-delete--disabled]="hasChildren(node)"
-              >delete</mat-icon
-            >
-            Delete
-          </button>
-        </span>
-      }
+      <ng-container *ngTemplateOutlet="menuItems; context: { $implicit: node }"></ng-container>
     </mat-menu>
   </ng-template>
 } @else {
@@ -192,3 +120,99 @@
     <empty-state iconName="gio:page" title="Items" message="Start by adding your first page." />
   </div>
 }
+
+<ng-template #menuItems let-node>
+  @if (node.type === 'FOLDER' || node.type === 'API') {
+    @if (canCreate) {
+      <button mat-menu-item (click)="onCreate(node, 'PAGE')">
+        <mat-icon [svgIcon]="'PAGE' | portalNavigationItemIcon"></mat-icon>
+        Add Page
+      </button>
+
+      @if (node.type != 'API') {
+        <button mat-menu-item (click)="onCreate(node, 'API')">
+          <mat-icon [svgIcon]="'API' | portalNavigationItemIcon"></mat-icon>
+          Add API
+        </button>
+      }
+
+      <button mat-menu-item (click)="onCreate(node, 'FOLDER')">
+        <mat-icon [svgIcon]="'FOLDER' | portalNavigationItemIcon"></mat-icon>
+        Add Folder
+      </button>
+      <button mat-menu-item (click)="onCreate(node, 'LINK')">
+        <mat-icon [svgIcon]="'LINK' | portalNavigationItemIcon"></mat-icon>
+        Add Link
+      </button>
+      @if (canUpdate || canDelete) {
+        <mat-divider></mat-divider>
+      }
+    }
+  }
+  @if (canUpdate) {
+    <button mat-menu-item (click)="onEdit(node)" data-testid="edit-node-button">
+      <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+      Edit
+    </button>
+
+    @if (isUnpublished(node)) {
+      @let publishState = publishStateByNodeId().get(node.id) ?? publishActionEnabledState;
+      <span [matTooltip]="publishState.tooltip" [matTooltipDisabled]="!publishState.disabled" matTooltipPosition="right">
+        <button
+          mat-menu-item
+          [disabled]="publishState.disabled"
+          [attr.aria-disabled]="publishState.ariaDisabled"
+          [attr.tabindex]="publishState.tabIndex"
+          (click)="onPublish(node)"
+          data-testid="publish-node-button"
+        >
+          <mat-icon svgIcon="gio:eye-empty"></mat-icon>
+          Publish
+        </button>
+      </span>
+    } @else {
+      <button mat-menu-item (click)="onUnpublish(node)" data-testid="unpublish-node-button">
+        <mat-icon svgIcon="gio:eye-off"></mat-icon>
+        Unpublish
+      </button>
+    }
+  }
+
+  @if (canDelete) {
+    <span matTooltip="Only empty folders can be deleted" [matTooltipDisabled]="!hasChildren(node)" matTooltipPosition="right">
+      <button
+        mat-menu-item
+        [disabled]="hasChildren(node)"
+        [attr.aria-disabled]="hasChildren(node)"
+        [attr.tabindex]="hasChildren(node) ? -1 : null"
+        [class.tree__menu-item-delete]="!hasChildren(node)"
+        [class.tree__menu-item-delete--disabled]="hasChildren(node)"
+        (click)="onDelete(node)"
+        data-testid="delete-node-button"
+      >
+        <mat-icon [class.tree__menu-item-delete]="!hasChildren(node)" [class.tree__menu-item-delete--disabled]="hasChildren(node)"
+          >delete</mat-icon
+        >
+        Delete
+      </button>
+    </span>
+  }
+</ng-template>
+
+<!-- Hidden anchor positioned at the cursor; opened programmatically on right-click -->
+<button
+  #contextMenuTrigger="matMenuTrigger"
+  type="button"
+  class="context-menu-anchor"
+  aria-hidden="true"
+  tabindex="-1"
+  [matMenuTriggerFor]="contextMenu"
+></button>
+
+<mat-menu #contextMenu="matMenu">
+  <ng-template matMenuContent>
+    @if (contextMenuNode(); as node) {
+      <ng-container *ngTemplateOutlet="menuItems; context: { $implicit: node }"></ng-container>
+    }
+  </ng-template>
+</mat-menu>

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.scss
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.scss
@@ -168,6 +168,17 @@ mat-icon {
   justify-content: center;
 }
 
+.context-menu-anchor {
+  position: fixed;
+  width: 0;
+  height: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  visibility: hidden;
+  pointer-events: none;
+}
+
 /**
  * Drag and drop animation handling
  */

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.spec.ts
@@ -861,6 +861,85 @@ describe('FlatTreeComponent', () => {
     });
   });
 
+  describe('Right-click context menu', () => {
+    const setupPermissions = (permissions: string[]) => {
+      (permissionService.hasAnyMatching as jest.Mock).mockImplementation((requestedPermissions: string[]) => {
+        return requestedPermissions.some(p => permissions.includes(p));
+      });
+    };
+
+    it('should preventDefault, update the active node, and position the anchor on right-click when actions are available', () => {
+      const links = [makeItem('p1', 'PAGE', 'Page 1', 0)];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const node = component.tree()[0] as any;
+      const event = new MouseEvent('contextmenu', { clientX: 123, clientY: 456 });
+      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+      component.onContextMenu(event, node);
+
+      expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+      expect(component.contextMenuNode()?.id).toBe('p1');
+      const anchor = fixture.nativeElement.querySelector('.context-menu-anchor') as HTMLElement;
+      expect(anchor.style.left).toBe('123px');
+      expect(anchor.style.top).toBe('456px');
+    });
+
+    it('should call openMenu on the trigger when actions are available', () => {
+      const links = [makeItem('p1', 'PAGE', 'Page 1', 0)];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const trigger = component.contextMenuTrigger();
+      expect(trigger).toBeTruthy();
+      const openMenuSpy = jest.spyOn(trigger!, 'openMenu');
+
+      const node = component.tree()[0] as any;
+      component.onContextMenu(new MouseEvent('contextmenu', { clientX: 1, clientY: 2 }), node);
+
+      expect(openMenuSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not open the custom one when the user has no actions on the node', () => {
+      setupPermissions([]);
+      fixture = TestBed.createComponent(FlatTreeComponent);
+      component = fixture.componentInstance;
+
+      const links = [makeItem('p1', 'PAGE', 'Page 1', 0)];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+
+      const trigger = component.contextMenuTrigger();
+      const openMenuSpy = trigger ? jest.spyOn(trigger, 'openMenu') : null;
+
+      const node = component.tree()[0] as any;
+      const event = new MouseEvent('contextmenu', { clientX: 10, clientY: 20 });
+      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+      component.onContextMenu(event, node);
+
+      expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+      expect(component.contextMenuNode()).toBeNull();
+      expect(openMenuSpy).not.toHaveBeenCalled();
+    });
+
+    it('should be wired to the (contextmenu) event on tree rows', async () => {
+      const links = [makeItem('p1', 'PAGE', 'Page 1', 0)];
+      fixture.componentRef.setInput('links', links);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const onContextMenuSpy = jest.spyOn(component, 'onContextMenu');
+      const row = fixture.nativeElement.querySelector('mat-tree-node.tree__row') as HTMLElement;
+      expect(row).toBeTruthy();
+
+      row.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 5, clientY: 6 }));
+
+      expect(onContextMenuSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   function createDropEvent(itemData: any, currentIndex: number, previousIndex: number): CdkDragDrop<SectionNode[]> {
     return {
       item: { data: itemData },

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, effect, inject, input, output, viewChild } from '@angular/core';
+import { Component, computed, effect, ElementRef, inject, input, output, signal, viewChild } from '@angular/core';
 import { MatTree, MatTreeModule } from '@angular/material/tree';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
-import { MatMenuModule } from '@angular/material/menu';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { MatDivider } from '@angular/material/divider';
 import { MatTooltip } from '@angular/material/tooltip';
 import { CommonModule } from '@angular/common';
@@ -92,7 +92,7 @@ type ProcessingNode = SectionNode & {
   styleUrls: ['./flat-tree.component.scss'],
 })
 export class FlatTreeComponent {
-  private permissionService = inject(GioPermissionService);
+  private readonly permissionService = inject(GioPermissionService);
 
   links = input<PortalNavigationItem[] | null>(null);
   selectedId = input<string | null>(null);
@@ -187,6 +187,9 @@ export class FlatTreeComponent {
   }
 
   treeBase = viewChild(MatTree);
+  contextMenuTrigger = viewChild('contextMenuTrigger', { read: MatMenuTrigger });
+  contextMenuAnchor = viewChild('contextMenuTrigger', { read: ElementRef });
+  contextMenuNode = signal<FlatTreeNode | null>(null);
 
   canCreate: boolean;
   canUpdate: boolean;
@@ -307,6 +310,22 @@ export class FlatTreeComponent {
     }
 
     this.nodeMoved.emit({ node: nodeToMove, newParentId, newOrder });
+  }
+
+  onContextMenu(event: MouseEvent, node: FlatTreeNode): void {
+    event.preventDefault();
+    if (!this.canShowMoreActions(node)) {
+      return;
+    }
+    const trigger = this.contextMenuTrigger();
+    const anchor = this.contextMenuAnchor()?.nativeElement as HTMLElement | undefined;
+    if (!trigger || !anchor) {
+      return;
+    }
+    this.contextMenuNode.set(node);
+    anchor.style.left = `${event.clientX}px`;
+    anchor.style.top = `${event.clientY}px`;
+    trigger.openMenu();
   }
 
   onDragStarted(event: CdkDragStart<SectionNode>) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13827

## Description

The action menu was previously only accessible through the "more" button. This change wires a Material context menu to the right-click event so users can reach the same actions via a context menu.

## Changes

- Added a `(contextmenu)` binding on both `mat-tree-node` rows (leaf and nested) that calls a new `onContextMenu(event, node)` handler.
- Extracted the existing menu items (Add Page/API/Folder/Link, Edit, Publish/Unpublish, Delete, with their permission, tooltip and disabled-state logic) into a single `#menuItems` ng-template.
- A hidden `button` with `matMenuTriggerFor` acts as the anchor for the right-click menu.

## Screenshots / video

https://github.com/user-attachments/assets/5f6511c2-697e-4072-908d-21fb91b2d18c

