### PR TITLE
test(management-api): verify allowedInApiProducts is preserved when validator returns null

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
@@ -208,4 +208,15 @@ class UpdateApiDomainServiceImplTest {
 
         assertThat(result.getApiDefinitionHttpV4().getResponseTemplates()).isEqualTo(sanitizedResponseTemplates);
     }
+
+    @Test
+    void should_preserve_original_allowed_in_api_products_when_validator_returns_null() {
+        var originalDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().allowedInApiProducts(true).build();
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
+        stubValidate(entity -> entity.setAllowedInApiProducts(null));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getAllowedInApiProducts()).isTrue();
+    }
 }


### PR DESCRIPTION
## Issue

[APIM-13738](https://gravitee.atlassian.net/browse/APIM-13738)

## Summary

- Adds a unit test to `UpdateApiDomainServiceImplTest` covering the null-guard branch in `UpdateApiDomainServiceImpl#applySanitizedValues`
- Asserts that when the validator sets `allowedInApiProducts` to `null` on the `UpdateApiEntity`, the original stored value (`true`) is preserved in the result

## Test plan

- [x] `UpdateApiDomainServiceImplTest` — all 14 tests pass

[APIM-13738]: https://gravitee.atlassian.net/browse/APIM-13738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ