### PR TITLE
feat(native-kafka): add per-API OpenTelemetry tracing toggle

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.html
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.html
@@ -15,16 +15,37 @@
     limitations under the License.
 
 -->
-<mat-card>
-  <mat-card-content>
-    @if (reporterSettingsForm) {
-      <form [formGroup]="reporterSettingsForm">
+@if (reporterSettingsForm) {
+  <form [formGroup]="reporterSettingsForm">
+    <mat-card>
+      <mat-card-content>
         <gio-form-slide-toggle>
           <gio-form-label>Enable metrics reporting</gio-form-label>
           <mat-slide-toggle formControlName="enabled" gioFormSlideToggle aria-label="Report event metrics"></mat-slide-toggle>
           <mat-hint>Enabling it will report event metrics in ElasticSearch or OpenSearch</mat-hint>
         </gio-form-slide-toggle>
-      </form>
-    }
-  </mat-card-content>
-</mat-card>
+
+        <div class="settings__form-control">
+          <div class="settings__form-control__title">OpenTelemetry</div>
+          <div class="settings__form-control__subtitle">OpenTelemetry settings.</div>
+          <gio-form-slide-toggle>
+            <gio-form-label>Enabled</gio-form-label>
+            Enable OpenTelemetry tracing. Per-request spans are generated only for Kafka operations listed in the gateway-level
+            <code>services.opentelemetry.kafka.tracedApiKeys</code> configuration.
+            <mat-slide-toggle gioFormSlideToggle formControlName="tracingEnabled"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+          <gio-form-slide-toggle>
+            <gio-form-label>Verbose</gio-form-label>
+            Adds per-phase, per-flow, and per-policy spans within each traced Kafka request. Standard mode already captures connection
+            lifecycle, authentication, and per-request spans with protocol details.
+            <br />
+            <mat-icon svgIcon="gio:alert-circle" class="verbose-warning-icon"></mat-icon>
+            Enable only for deep debugging - increases trace volume significantly on high-throughput Kafka APIs.
+            <mat-slide-toggle gioFormSlideToggle formControlName="tracingVerbose"></mat-slide-toggle>
+          </gio-form-slide-toggle>
+        </div>
+      </mat-card-content>
+    </mat-card>
+    <gio-save-bar [form]="reporterSettingsForm" [formInitialValues]="defaultConfiguration" (submitted)="submit()"></gio-save-bar>
+  </form>
+}

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.scss
@@ -1,0 +1,39 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../../scss/gio-layout' as gio-layout;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+}
+
+.settings__form-control {
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+
+  &__title {
+    justify-items: center;
+    margin-bottom: 0;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'default');
+    @include mat.m2-typography-level($typography, 'subtitle-2');
+  }
+
+  &__subtitle {
+    margin-bottom: 16px;
+    color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+    @include mat.m2-typography-level($typography, 'body-2');
+  }
+}
+
+.verbose-warning-icon {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: text-bottom;
+  height: 20px;
+  width: 20px;
+  margin-right: 4px;
+  color: mat.m2-get-color-from-palette(mat.$m2-orange-palette, 600);
+}

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.spec.ts
@@ -22,6 +22,7 @@ import { ActivatedRoute } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatCardHarness } from '@angular/material/card/testing';
+import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
@@ -72,10 +73,11 @@ describe('ReporterSettingsComponent', () => {
       expectGetAPI('V4', 'NATIVE', API_ID, {
         enabled: true,
       });
-      const toggle = await harnessLoader.getHarness(MatSlideToggleHarness);
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      const enabledToggle = toggles[0];
 
-      expect(await toggle.isDisabled()).toEqual(true);
-      expect(await toggle.isChecked()).toEqual(true);
+      expect(await enabledToggle.isDisabled()).toEqual(true);
+      expect(await enabledToggle.isChecked()).toEqual(true);
     });
 
     it('should disable toggle when not V4 API', async () => {
@@ -93,10 +95,11 @@ describe('ReporterSettingsComponent', () => {
       await init(['api-definition-r', 'api-definition-u']);
       fixture.detectChanges();
       expectGetAPI('V4', 'NATIVE', API_ID, null);
-      const toggle = await harnessLoader.getHarness(MatSlideToggleHarness);
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      const enabledToggle = toggles[0];
 
-      expect(await toggle.isDisabled()).toEqual(false);
-      expect(await toggle.isChecked()).toEqual(false);
+      expect(await enabledToggle.isDisabled()).toEqual(false);
+      expect(await enabledToggle.isChecked()).toEqual(false);
     });
 
     it('should enable toggle when analytics is enabled', async () => {
@@ -105,16 +108,149 @@ describe('ReporterSettingsComponent', () => {
       expectGetAPI('V4', 'NATIVE', API_ID, {
         enabled: true,
       });
-      const toggle = await harnessLoader.getHarness(MatSlideToggleHarness);
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      const enabledToggle = toggles[0];
 
-      expect(await toggle.isDisabled()).toEqual(false);
-      expect(await toggle.isChecked()).toEqual(true);
+      expect(await enabledToggle.isDisabled()).toEqual(false);
+      expect(await enabledToggle.isChecked()).toEqual(true);
     });
   });
 
-  function expectGetAPI(definitionVersion: string, type: string, apiId: string, analytics: any) {
-    httpTestingController
-      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}`)
-      .flush({ definitionVersion: definitionVersion, type: type, analytics: analytics });
+  describe('OpenTelemetry tracing toggles', () => {
+    it('should disable tracing toggles when analytics is disabled', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: false });
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      const tracingEnabledToggle = toggles[1];
+      const tracingVerboseToggle = toggles[2];
+
+      expect(await tracingEnabledToggle.isDisabled()).toEqual(true);
+      expect(await tracingVerboseToggle.isDisabled()).toEqual(true);
+    });
+
+    it('should enable tracing-enabled toggle when analytics is enabled', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true });
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      const tracingEnabledToggle = toggles[1];
+
+      expect(await tracingEnabledToggle.isDisabled()).toEqual(false);
+      expect(await tracingEnabledToggle.isChecked()).toEqual(false);
+    });
+
+    it('should disable verbose when tracing is not enabled', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: false, verbose: false } });
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      const tracingVerboseToggle = toggles[2];
+
+      expect(await tracingVerboseToggle.isDisabled()).toEqual(true);
+    });
+
+    it('should enable verbose when tracing is enabled', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: true, verbose: false } });
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      const tracingVerboseToggle = toggles[2];
+
+      expect(await tracingVerboseToggle.isDisabled()).toEqual(false);
+      expect(await tracingVerboseToggle.isChecked()).toEqual(false);
+    });
+
+    it('should reflect tracing verbose checked state', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: true, verbose: true } });
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      const tracingVerboseToggle = toggles[2];
+
+      expect(await tracingVerboseToggle.isChecked()).toEqual(true);
+    });
+
+    it('should disable tracing toggles when read-only', async () => {
+      await init(['api-definition-r']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: true, verbose: true } });
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+      const tracingEnabledToggle = toggles[1];
+      const tracingVerboseToggle = toggles[2];
+
+      expect(await tracingEnabledToggle.isDisabled()).toEqual(true);
+      expect(await tracingVerboseToggle.isDisabled()).toEqual(true);
+    });
+
+    it('should disable tracing toggles when analytics enabled is toggled off', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: true, verbose: true } });
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+
+      await toggles[0].uncheck();
+
+      expect(await toggles[1].isDisabled()).toEqual(true);
+      expect(await toggles[2].isDisabled()).toEqual(true);
+    });
+
+    it('should enable tracing-enabled toggle when analytics enabled is toggled on', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: false });
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+
+      await toggles[0].check();
+
+      expect(await toggles[1].isDisabled()).toEqual(false);
+    });
+
+    it('should disable verbose when tracing-enabled is toggled off', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: true, verbose: true } });
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+
+      await toggles[1].uncheck();
+
+      expect(await toggles[2].isDisabled()).toEqual(true);
+    });
+
+    it('should enable verbose when tracing-enabled is toggled on', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: false, verbose: false } });
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+
+      await toggles[1].check();
+
+      expect(await toggles[2].isDisabled()).toEqual(false);
+    });
+
+    it('should submit tracing settings via API update', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: false, verbose: false } }, true);
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+
+      await toggles[1].check();
+      await toggles[2].check();
+
+      const saveBar = await harnessLoader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`, method: 'PUT' });
+      expect(req.request.body.analytics.tracing).toEqual({ enabled: true, verbose: true });
+      req.flush(req.request.body);
+    });
+  });
+
+  function expectGetAPI(definitionVersion: string, type: string, apiId: string, analytics: any, includeId = false) {
+    const body: any = { definitionVersion, type, analytics };
+    if (includeId) {
+      body.id = apiId;
+    }
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}`).flush(body);
   }
 });

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.ts
@@ -13,26 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, DestroyRef, inject, input, InputSignal, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, input, InputSignal, OnInit } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { map, switchMap } from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 import { MatCardModule } from '@angular/material/card';
-import { GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
+import { GioFormSlideToggleModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { MatHint } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
 
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { ApiV4 } from '../../../../entities/management-api-v2';
 
+type NativeReporterFormType = {
+  enabled: FormControl<boolean>;
+  tracingEnabled: FormControl<boolean>;
+  tracingVerbose: FormControl<boolean>;
+};
+
 @Component({
   selector: 'reporter-settings-native',
   templateUrl: './reporter-settings-native.component.html',
-  imports: [MatCardModule, FormsModule, GioFormSlideToggleModule, ReactiveFormsModule, MatSlideToggle, MatHint],
+  styleUrls: ['./reporter-settings-native.component.scss'],
+  imports: [MatCardModule, FormsModule, GioFormSlideToggleModule, GioSaveBarModule, ReactiveFormsModule, MatSlideToggle, MatHint, MatIcon],
 })
 export class ReporterSettingsNativeComponent implements OnInit {
-  reporterSettingsForm: FormGroup<{ enabled: FormControl<boolean> }>;
+  reporterSettingsForm: FormGroup<NativeReporterFormType>;
+  defaultConfiguration: Record<string, unknown>;
   api: InputSignal<ApiV4> = input.required<ApiV4>();
   private destroyRef = inject(DestroyRef);
 
@@ -42,31 +51,75 @@ export class ReporterSettingsNativeComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const formControlState = computed(() => {
-      const api = this.api();
-      return {
-        value: api.analytics ? api.analytics.enabled : false,
-        disabled: api.definitionVersion !== 'V4' || api.type !== 'NATIVE' || !this.permissionService.hasAnyMatching(['api-definition-u']),
-      };
+    const api = this.api();
+    const isReadOnly =
+      api.definitionVersion !== 'V4' || api.type !== 'NATIVE' || !this.permissionService.hasAnyMatching(['api-definition-u']);
+    const analyticsEnabled = api.analytics?.enabled ?? false;
+
+    this.reporterSettingsForm = new FormGroup<NativeReporterFormType>({
+      enabled: new FormControl<boolean>({ value: analyticsEnabled, disabled: isReadOnly }),
+      tracingEnabled: new FormControl<boolean>({
+        value: api.analytics?.tracing?.enabled ?? false,
+        disabled: !analyticsEnabled || isReadOnly,
+      }),
+      tracingVerbose: new FormControl<boolean>({
+        value: api.analytics?.tracing?.verbose ?? false,
+        disabled: !analyticsEnabled || !api.analytics?.tracing?.enabled || isReadOnly,
+      }),
     });
 
-    this.reporterSettingsForm = new FormGroup({
-      enabled: new FormControl<boolean>(formControlState()),
-    });
+    this.defaultConfiguration = this.reporterSettingsForm.getRawValue();
 
     this.reporterSettingsForm
       .get('enabled')!
       .valueChanges.pipe(
-        map(value => {
-          const currentApi = this.api();
-          return {
-            ...currentApi,
-            analytics: { ...(currentApi.analytics ?? {}), enabled: value },
-          };
+        tap((enabled: boolean) => {
+          if (enabled) {
+            this.reporterSettingsForm.get('tracingEnabled')!.enable();
+          } else {
+            this.reporterSettingsForm.get('tracingEnabled')!.disable();
+            this.reporterSettingsForm.get('tracingVerbose')!.disable();
+          }
         }),
-        switchMap(updatedApi => this.apiService.update(updatedApi.id, updatedApi)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
+
+    this.reporterSettingsForm
+      .get('tracingEnabled')!
+      .valueChanges.pipe(
+        tap((tracingEnabled: boolean) => {
+          if (tracingEnabled) {
+            this.reporterSettingsForm.get('tracingVerbose')!.enable();
+          } else {
+            this.reporterSettingsForm.get('tracingVerbose')!.disable();
+          }
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  submit(): void {
+    const values = this.reporterSettingsForm.getRawValue();
+    const currentApi = this.api();
+    const updatedApi: ApiV4 = {
+      ...currentApi,
+      analytics: {
+        ...(currentApi.analytics ?? {}),
+        enabled: values.enabled,
+        tracing: {
+          enabled: values.tracingEnabled,
+          verbose: values.tracingVerbose,
+        },
+      },
+    };
+
+    this.apiService
+      .update(updatedApi.id, updatedApi)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.defaultConfiguration = this.reporterSettingsForm.getRawValue();
+      });
   }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativeAnalytics.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/nativeapi/NativeAnalytics.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model.v4.nativeapi;
 
+import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -34,4 +35,7 @@ public class NativeAnalytics {
     /** Gates the connection-metrics reporter on the gateway. Independent of analytics.enabled. */
     @Builder.Default
     protected boolean reporterMetricsEnabled = true;
+
+    /** Per-API OpenTelemetry tracing toggle (enabled + verbose). */
+    private Tracing tracing;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13821
https://gravitee.atlassian.net/browse/APIM-13485

## Description

Add Tracing field to NativeAnalytics model and OpenTelemetry enabled/verbose toggles to the native Kafka reporter settings UI, matching the existing HTTP/proxy API tracing configuration.

## Additional context

<img width="1727" height="869" alt="image" src="https://github.com/user-attachments/assets/67054cb4-ebef-4f64-96c1-20082268fddd" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

