### PR TITLE
feat(portal): add analytics dashboards

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-breadcrumbs.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-breadcrumbs.spec.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { analyticsListBreadcrumb } from './analytics-breadcrumbs';
+
+describe('analyticsListBreadcrumb', () => {
+  it('should_return_breadcrumb_without_url_by_default', () => {
+    expect(analyticsListBreadcrumb()).toEqual({ id: 'analytics', label: 'Analytics', url: undefined });
+  });
+
+  it('should_return_breadcrumb_with_url_when_includeLink_is_true', () => {
+    expect(analyticsListBreadcrumb(true)).toEqual({ id: 'analytics', label: 'Analytics', url: '/dashboard/analytics' });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.html
@@ -15,3 +15,45 @@
     limitations under the License.
 
 -->
+
+<div class="analytics-list__header">
+  <div class="analytics-list__header__title">
+    <div class="title next-gen-h3" i18n="@@analyticsTitle">Analytics</div>
+    <p class="next-gen-body" i18n="@@analyticsDescription">Browse analytics dashboards to monitor and analyze your API traffic</p>
+  </div>
+</div>
+
+<div class="analytics-list__content">
+  @if (dashboardsResource.isLoading()) {
+    <app-loader class="analytics-list__loader" />
+  } @else if (dashboardsResource.error()) {
+    <div class="analytics-list__error next-gen-body" role="alert" data-testid="analytics-list-error" i18n="@@analyticsListError">
+      An error occurred while loading analytics dashboards. Try again later or contact your Portal administrator.
+    </div>
+  } @else {
+    <app-cards-grid
+      class="analytics-list__grid"
+      [cards]="dashboardPaginator().data"
+      [showEmptyState]="dashboardPaginator().data.length === 0"
+    >
+      <ng-template #cardTemplate let-dashboard>
+        <app-analytics-dashboard-card [dashboard]="dashboard" (cardSelect)="navigateToDashboard($event)" />
+      </ng-template>
+
+      <ng-container slot="empty-state">
+        <span class="material-icons icon-with-background" aria-hidden="true">bar_chart</span>
+        <h2 class="next-gen-h5" i18n="@@noAnalyticsDashboards">No analytics dashboards available yet</h2>
+        <p class="next-gen-body" i18n="@@noAnalyticsDashboardsDescription">No dashboards have been configured for this environment.</p>
+      </ng-container>
+    </app-cards-grid>
+  }
+  @if (dashboardPaginator().totalResults > 0) {
+    <app-pagination
+      class="analytics-list__pagination"
+      [totalResults]="dashboardPaginator().totalResults"
+      [currentPage]="dashboardPaginator().page"
+      [pageSize]="pageSize"
+      (selectPage)="onPageChange($event)"
+    />
+  }
+</div>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
@@ -13,3 +13,63 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use '../../../scss/theme' as app-theme;
+
+:host {
+  display: flex;
+  flex-direction: column;
+  max-width: app-theme.$inner-content-width;
+  overflow: hidden;
+  gap: 32px;
+  padding-top: 24px;
+  width: 100%;
+}
+
+.analytics-list {
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+
+    &__title {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+
+      p {
+        margin: 0;
+      }
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: hidden;
+    flex: 1;
+  }
+
+  &__grid {
+    overflow-y: auto;
+  }
+
+  &__loader {
+    position: absolute;
+    inset: 0;
+    background: app-theme.$background-overlay-color;
+  }
+
+  &__pagination {
+    margin-top: 16px;
+  }
+
+  &__error {
+    padding: 12px 16px;
+    margin-bottom: 16px;
+    background: app-theme.$banner-error-background-color;
+    color: app-theme.$banner-error-text-color;
+    border-radius: 4px;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { Router, provideRouter } from '@angular/router';
+
+import { analyticsListBreadcrumb } from './analytics-breadcrumbs';
+import AnalyticsComponent from './analytics.component';
+import { AnalyticsComponentHarness } from './analytics.harness';
+import { AnalyticsDashboardsResponse } from '../../../entities/analytics-dashboard/analytics-dashboard';
+import { fakeDashboard, fakeAnalyticsDashboardsResponse } from '../../../entities/analytics-dashboard/analytics-dashboard.fixtures';
+import { BreadcrumbService } from '../../../services/breadcrumb.service';
+import { ConfigService } from '../../../services/config.service';
+import { TESTING_BASE_URL } from '../../../testing/app-testing.module';
+
+describe('AnalyticsComponent', () => {
+  let fixture: ComponentFixture<AnalyticsComponent>;
+  let httpTestingController: HttpTestingController;
+  let harness: AnalyticsComponentHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AnalyticsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL, configuration: {} } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AnalyticsComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  async function setup(response: AnalyticsDashboardsResponse = fakeAnalyticsDashboardsResponse()) {
+    fixture.detectChanges();
+    httpTestingController
+      .expectOne(r => r.url === `${TESTING_BASE_URL}/analytics/dashboards` && r.params.get('page') === '1' && r.params.get('size') === '20')
+      .flush(response);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AnalyticsComponentHarness);
+  }
+
+  it('should_set_breadcrumbs_for_analytics_list', async () => {
+    await setup();
+    const breadcrumbService = TestBed.inject(BreadcrumbService);
+    expect(breadcrumbService.breadcrumbs()).toEqual([analyticsListBreadcrumb()]);
+  });
+
+  describe('populated dashboard list', () => {
+    it('should_show_analytics_title', async () => {
+      await setup();
+      expect(await harness.getTitle()).toContain('Analytics');
+    });
+
+    it('should_show_dashboard_cards', async () => {
+      await setup(
+        fakeAnalyticsDashboardsResponse({
+          data: [
+            fakeDashboard({ id: 'dash-1', name: 'HTTP Overview', labels: { type: 'http' } }),
+            fakeDashboard({ id: 'dash-2', name: 'API Performance', labels: {} }),
+          ],
+        }),
+      );
+      const cards = await harness.getCards();
+      expect(cards.length).toBe(2);
+      expect(await cards[0].getTitle()).toContain('HTTP Overview');
+    });
+
+    it('should_navigate_to_dashboard_on_card_select', async () => {
+      await setup();
+      const router = TestBed.inject(Router);
+      const navigateSpy = jest.spyOn(router, 'navigate');
+
+      fixture.componentInstance.navigateToDashboard('dash-1');
+
+      expect(navigateSpy).toHaveBeenCalledWith(['dash-1'], expect.anything());
+    });
+  });
+
+  describe('empty dashboard list', () => {
+    it('should_show_empty_state', async () => {
+      await setup(fakeAnalyticsDashboardsResponse({ data: [] }));
+      expect(await harness.isEmptyStateDisplayed()).toBe(true);
+    });
+  });
+
+  describe('partial response', () => {
+    it('should_apply_fallbacks_when_metadata_is_missing', async () => {
+      await setup({ data: [] });
+      const vm = fixture.componentInstance['dashboardPaginator']();
+      expect(vm.page).toBe(1);
+      expect(vm.totalResults).toBe(0);
+    });
+
+    it('should_default_data_to_empty_array_when_field_missing', async () => {
+      await setup({});
+      expect(fixture.componentInstance['dashboardPaginator']().data).toEqual([]);
+    });
+  });
+
+  describe('failed dashboard list', () => {
+    it('should_show_inline_error_alert_when_request_fails', async () => {
+      fixture.detectChanges();
+      httpTestingController
+        .expectOne(r => r.url === `${TESTING_BASE_URL}/analytics/dashboards`)
+        .error(new ProgressEvent('Network error'), { status: 500, statusText: 'Server Error' });
+      await fixture.whenStable();
+      fixture.detectChanges();
+      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AnalyticsComponentHarness);
+
+      const errorMessage = await harness.getErrorMessage();
+      expect(errorMessage).toBeTruthy();
+      expect(errorMessage).toContain('error occurred');
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.ts
@@ -13,22 +13,73 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, inject } from '@angular/core';
 
-import { BreadcrumbService } from 'src/services/breadcrumb.service';
+import { Component, computed, inject, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { Dashboard } from '@gravitee/gravitee-dashboard';
 
 import { analyticsListBreadcrumb } from './analytics-breadcrumbs';
+import { AnalyticsDashboardCardComponent } from '../../../components/analytics-dashboard-card/analytics-dashboard-card.component';
+import { CardsGridComponent } from '../../../components/cards-grid/cards-grid.component';
+import { LoaderComponent } from '../../../components/loader/loader.component';
+import { PaginationComponent } from '../../../components/pagination/pagination.component';
+import { AnalyticsDashboardsResponse } from '../../../entities/analytics-dashboard/analytics-dashboard';
+import { AnalyticsDashboardService } from '../../../services/analytics-dashboard.service';
+import { BreadcrumbService } from '../../../services/breadcrumb.service';
+
+interface DashboardsListParams {
+  page: number;
+  pageSize: number;
+}
+
+export interface DashboardPaginatorVM {
+  data: Dashboard[];
+  page: number;
+  totalResults: number;
+}
 
 @Component({
   selector: 'app-analytics',
-  imports: [],
+  imports: [AnalyticsDashboardCardComponent, CardsGridComponent, PaginationComponent, LoaderComponent],
   templateUrl: './analytics.component.html',
   styleUrl: './analytics.component.scss',
 })
 export default class AnalyticsComponent {
-  readonly breadcrumbService = inject(BreadcrumbService);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly dashboardService = inject(AnalyticsDashboardService);
+  private readonly router = inject(Router);
+  private readonly breadcrumbService = inject(BreadcrumbService);
+
+  readonly pageSize = 20;
+  private readonly currentPage = signal(1);
+
+  protected readonly dashboardsResource = rxResource<AnalyticsDashboardsResponse | undefined, DashboardsListParams>({
+    params: () => ({ page: this.currentPage(), pageSize: this.pageSize }),
+    stream: ({ params }) => this.dashboardService.list(params.page, params.pageSize),
+  });
+
+  protected readonly dashboardPaginator = computed((): DashboardPaginatorVM => {
+    if (this.dashboardsResource.error()) {
+      return { data: [], page: 1, totalResults: 0 };
+    }
+    const resp = this.dashboardsResource.value();
+    const data = resp?.data ?? [];
+    const page = resp?.metadata?.pagination?.current_page ?? 1;
+    const totalResults = resp?.metadata?.pagination?.total ?? 0;
+    return { data, page, totalResults };
+  });
 
   constructor() {
     this.breadcrumbService.set([analyticsListBreadcrumb()]);
+  }
+
+  onPageChange(page: number): void {
+    this.currentPage.set(page);
+  }
+
+  navigateToDashboard(dashboardId: string): void {
+    this.router.navigate([dashboardId], { relativeTo: this.activatedRoute });
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.harness.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+import { AnalyticsDashboardCardHarness } from '../../../components/analytics-dashboard-card/analytics-dashboard-card.harness';
+import { LoaderHarness } from '../../../components/loader/loader.harness';
+
+export class AnalyticsComponentHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-analytics';
+
+  private readonly locateLoader = this.locatorForOptional(LoaderHarness);
+  private readonly locateError = this.locatorForOptional('[data-testid="analytics-list-error"]');
+  private readonly locateEmptyState = this.locatorForOptional('.cards-grid__empty-state');
+  private readonly locateCards = this.locatorForAll(AnalyticsDashboardCardHarness);
+  private readonly locateTitle = this.locatorForOptional('.next-gen-h3');
+
+  public async getLoader(): Promise<LoaderHarness | null> {
+    return this.locateLoader();
+  }
+
+  public async getErrorMessage(): Promise<string | null> {
+    const element = await this.locateError();
+    return element ? element.text() : null;
+  }
+
+  public async getCards(): Promise<AnalyticsDashboardCardHarness[]> {
+    return this.locateCards();
+  }
+
+  public async isEmptyStateDisplayed(): Promise<boolean> {
+    return !!(await this.locateEmptyState());
+  }
+
+  public async getTitle(): Promise<string | null> {
+    const element = await this.locateTitle();
+    return element ? element.text() : null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
@@ -33,14 +33,15 @@
       <span aria-hidden="true">·</span>
       <span data-testid="last-modified">{{ lastModified() | date: 'medium' }}</span>
     </div>
-    @if (labels() | keyvalue; as labelEntries) {
-      @if (labelEntries.length > 0) {
-        <div class="dashboard-card__labels">
-          @for (label of labelEntries; track label.key) {
-            <app-badge [label]="label.key + ':' + label.value" />
-          }
-        </div>
-      }
+    @if (visibleLabels().length > 0) {
+      <div class="dashboard-card__labels">
+        @for (label of visibleLabels(); track label) {
+          <app-badge [label]="label" />
+        }
+        @if (hiddenLabelsCount() > 0) {
+          <app-badge data-testid="hidden-labels-count" [matTooltip]="hiddenLabelsTooltip()" [label]="'+' + hiddenLabelsCount()" />
+        }
+      </div>
     }
   </mat-card-content>
 </mat-card>

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
@@ -1,0 +1,46 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card
+  class="dashboard-card"
+  appearance="outlined"
+  role="button"
+  tabindex="0"
+  [attr.aria-label]="ariaLabel()"
+  (click)="cardSelect.emit(dashboardId())"
+  (keydown.enter)="cardSelect.emit(dashboardId())"
+>
+  <mat-card-content class="dashboard-card__content">
+    <div class="dashboard-card__header">
+      <div class="dashboard-card__title next-gen-h5" [matTooltip]="name()">{{ name() }}</div>
+    </div>
+    <div class="dashboard-card__meta next-gen-body">
+      <span data-testid="widget-count" i18n="@@dashboardCardWidgets">{{ widgetCount() }} widgets</span>
+      <span aria-hidden="true">·</span>
+      <span data-testid="last-modified">{{ lastModified() | date: 'medium' }}</span>
+    </div>
+    @if (labels() | keyvalue; as labelEntries) {
+      @if (labelEntries.length > 0) {
+        <div class="dashboard-card__labels">
+          @for (label of labelEntries; track label.key) {
+            <app-badge [label]="label.key + ':' + label.value" />
+          }
+        </div>
+      }
+    }
+  </mat-card-content>
+</mat-card>

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
@@ -36,7 +36,7 @@
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
-    gap: 12px;
+    gap: 8px;
     overflow: hidden;
   }
 

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/theme' as app-theme;
+
+:host {
+  display: flex;
+  flex-flow: column;
+  width: 100%;
+  min-width: 0;
+}
+
+.dashboard-card {
+  height: 100%;
+  cursor: pointer;
+  overflow: hidden;
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 2px 8px app-theme.$shadow-color;
+  }
+
+  &__content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 12px;
+    overflow: hidden;
+  }
+
+  &__header {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  &__title {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  &__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px 8px;
+    color: app-theme.$paragraph-color;
+
+    > span {
+      white-space: nowrap;
+    }
+  }
+
+  &__labels {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { AnalyticsDashboardCardComponent } from './analytics-dashboard-card.component';
+import { AnalyticsDashboardCardHarness } from './analytics-dashboard-card.harness';
+import { fakeDashboard } from '../../entities/analytics-dashboard/analytics-dashboard.fixtures';
+
+describe('AnalyticsDashboardCardComponent', () => {
+  let fixture: ComponentFixture<AnalyticsDashboardCardComponent>;
+  let component: AnalyticsDashboardCardComponent;
+  let harness: AnalyticsDashboardCardHarness;
+
+  const dashboard = fakeDashboard({
+    id: 'dashboard-1',
+    name: 'HTTP Overview',
+    labels: { type: 'http', scope: 'proxy' },
+    widgets: [{} as never, {} as never],
+  });
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AnalyticsDashboardCardComponent],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AnalyticsDashboardCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('dashboard', dashboard);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AnalyticsDashboardCardHarness);
+  });
+
+  it('should_render_dashboard_name', async () => {
+    expect(await harness.getTitle()).toContain('HTTP Overview');
+  });
+
+  it('should_render_labels_as_badges', async () => {
+    expect(await harness.getLabelCount()).toBe(2);
+  });
+
+  it('should_render_widget_count', async () => {
+    expect(await harness.getWidgetCount()).toContain('2');
+  });
+
+  it('should_render_last_modified_date', async () => {
+    expect(await harness.getLastModified()).toBeTruthy();
+  });
+
+  it('should_not_render_labels_when_empty', async () => {
+    fixture.componentRef.setInput('dashboard', fakeDashboard({ labels: {} }));
+    fixture.detectChanges();
+    expect(await harness.getLabelCount()).toBe(0);
+  });
+
+  it('should_emit_card_select_on_click', async () => {
+    const emitSpy = jest.spyOn(component.cardSelect, 'emit');
+    await harness.click();
+    expect(emitSpy).toHaveBeenCalledWith('dashboard-1');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
@@ -50,8 +50,21 @@ describe('AnalyticsDashboardCardComponent', () => {
     expect(await harness.getTitle()).toContain('HTTP Overview');
   });
 
-  it('should_render_labels_as_badges', async () => {
+  it('should_render_all_labels_when_count_is_within_visible_limit', async () => {
     expect(await harness.getLabelCount()).toBe(2);
+    expect(await harness.getOverflowCounter()).toBeNull();
+  });
+
+  it('should_render_overflow_counter_when_labels_exceed_visible_limit', async () => {
+    fixture.componentRef.setInput(
+      'dashboard',
+      fakeDashboard({
+        labels: { type: 'http', scope: 'proxy', env: 'dev', team: 'core' },
+      }),
+    );
+    fixture.detectChanges();
+    expect(await harness.getLabelCount()).toBe(3);
+    expect(await harness.getOverflowCounter()).toContain('+2');
   });
 
   it('should_render_widget_count', async () => {

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DatePipe, KeyValuePipe } from '@angular/common';
+import { Component, computed, input, output } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatTooltip } from '@angular/material/tooltip';
+
+import { Dashboard } from '@gravitee/gravitee-dashboard';
+
+import { BadgeComponent } from '../badge/badge.component';
+
+@Component({
+  selector: 'app-analytics-dashboard-card',
+  imports: [MatCardModule, MatTooltip, KeyValuePipe, DatePipe, BadgeComponent],
+  templateUrl: './analytics-dashboard-card.component.html',
+  styleUrl: './analytics-dashboard-card.component.scss',
+})
+export class AnalyticsDashboardCardComponent {
+  readonly dashboard = input.required<Dashboard>();
+
+  readonly cardSelect = output<string>();
+
+  protected readonly name = computed(() => this.dashboard().name);
+  protected readonly dashboardId = computed(() => this.dashboard().id);
+  protected readonly labels = computed(() => this.dashboard().labels ?? {});
+  protected readonly widgetCount = computed(() => this.dashboard().widgets?.length ?? 0);
+  protected readonly lastModified = computed(() => this.dashboard().lastModified);
+  protected readonly ariaLabel = computed(() => $localize`:@@analyticsDashboardCardAriaLabel:Open dashboard ${this.name()}:name:`);
+}

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { DatePipe, KeyValuePipe } from '@angular/common';
+import { DatePipe } from '@angular/common';
 import { Component, computed, input, output } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -25,19 +25,39 @@ import { BadgeComponent } from '../badge/badge.component';
 
 @Component({
   selector: 'app-analytics-dashboard-card',
-  imports: [MatCardModule, MatTooltip, KeyValuePipe, DatePipe, BadgeComponent],
+  imports: [MatCardModule, MatTooltip, DatePipe, BadgeComponent],
   templateUrl: './analytics-dashboard-card.component.html',
   styleUrl: './analytics-dashboard-card.component.scss',
 })
 export class AnalyticsDashboardCardComponent {
+  private static readonly MAX_VISIBLE_LABELS = 2;
+
   readonly dashboard = input.required<Dashboard>();
 
   readonly cardSelect = output<string>();
 
   protected readonly name = computed(() => this.dashboard().name);
   protected readonly dashboardId = computed(() => this.dashboard().id);
-  protected readonly labels = computed(() => this.dashboard().labels ?? {});
   protected readonly widgetCount = computed(() => this.dashboard().widgets?.length ?? 0);
   protected readonly lastModified = computed(() => this.dashboard().lastModified);
   protected readonly ariaLabel = computed(() => $localize`:@@analyticsDashboardCardAriaLabel:Open dashboard ${this.name()}:name:`);
+
+  private readonly labelEntries = computed(() => Object.entries(this.dashboard().labels ?? {}));
+
+  protected readonly visibleLabels = computed(() =>
+    this.labelEntries()
+      .slice(0, AnalyticsDashboardCardComponent.MAX_VISIBLE_LABELS)
+      .map(([k, v]) => `${k}:${v}`),
+  );
+
+  protected readonly hiddenLabelsCount = computed(() =>
+    Math.max(0, this.labelEntries().length - AnalyticsDashboardCardComponent.MAX_VISIBLE_LABELS),
+  );
+
+  protected readonly hiddenLabelsTooltip = computed(() =>
+    this.labelEntries()
+      .slice(AnalyticsDashboardCardComponent.MAX_VISIBLE_LABELS)
+      .map(([k, v]) => `${k}:${v}`)
+      .join(', '),
+  );
 }

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.harness.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BaseHarnessFilters, ContentContainerComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+
+export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarness {
+  public static hostSelector = 'app-analytics-dashboard-card';
+
+  private readonly locateTitle = this.locatorFor('.dashboard-card__title');
+  private readonly locateWidgetCount = this.locatorForOptional('[data-testid="widget-count"]');
+  private readonly locateLastModified = this.locatorForOptional('[data-testid="last-modified"]');
+  private readonly locateLabels = this.locatorForAll('app-badge');
+
+  public static with(options: BaseHarnessFilters): HarnessPredicate<AnalyticsDashboardCardHarness> {
+    return new HarnessPredicate(AnalyticsDashboardCardHarness, options);
+  }
+
+  public async getTitle(): Promise<string> {
+    return (await this.locateTitle()).text();
+  }
+
+  public async getWidgetCount(): Promise<string | null> {
+    const element = await this.locateWidgetCount();
+    return element ? element.text() : null;
+  }
+
+  public async getLastModified(): Promise<string | null> {
+    const element = await this.locateLastModified();
+    return element ? element.text() : null;
+  }
+
+  public async getLabelCount(): Promise<number> {
+    return (await this.locateLabels()).length;
+  }
+
+  public async click(): Promise<void> {
+    const card = await this.locatorFor('.dashboard-card')();
+    return card.click();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.harness.ts
@@ -22,6 +22,7 @@ export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarn
   private readonly locateWidgetCount = this.locatorForOptional('[data-testid="widget-count"]');
   private readonly locateLastModified = this.locatorForOptional('[data-testid="last-modified"]');
   private readonly locateLabels = this.locatorForAll('app-badge');
+  private readonly locateOverflowCounter = this.locatorForOptional('[data-testid="hidden-labels-count"]');
 
   public static with(options: BaseHarnessFilters): HarnessPredicate<AnalyticsDashboardCardHarness> {
     return new HarnessPredicate(AnalyticsDashboardCardHarness, options);
@@ -43,6 +44,11 @@ export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarn
 
   public async getLabelCount(): Promise<number> {
     return (await this.locateLabels()).length;
+  }
+
+  public async getOverflowCounter(): Promise<string | null> {
+    const element = await this.locateOverflowCounter();
+    return element ? element.text() : null;
   }
 
   public async click(): Promise<void> {

--- a/gravitee-apim-portal-webui-next/src/entities/analytics-dashboard/analytics-dashboard.fixtures.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/analytics-dashboard/analytics-dashboard.fixtures.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Dashboard } from '@gravitee/gravitee-dashboard';
+
+import { AnalyticsDashboardsResponse } from './analytics-dashboard';
+
+export function fakeDashboard(modifier?: Partial<Dashboard>): Dashboard {
+  return {
+    id: 'dashboard-1',
+    name: 'HTTP Overview',
+    createdBy: 'admin',
+    createdAt: '2026-01-01T00:00:00Z',
+    lastModified: '2026-01-15T00:00:00Z',
+    labels: {},
+    widgets: [],
+    ...modifier,
+  };
+}
+
+export function fakeAnalyticsDashboardsResponse(modifier?: Partial<AnalyticsDashboardsResponse>): AnalyticsDashboardsResponse {
+  return {
+    data: [fakeDashboard(), fakeDashboard({ id: 'dashboard-2', name: 'API Performance' })],
+    metadata: {
+      pagination: {
+        current_page: 1,
+        total_pages: 1,
+        total: 2,
+        size: 10,
+      },
+    },
+    ...modifier,
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/entities/analytics-dashboard/analytics-dashboard.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/analytics-dashboard/analytics-dashboard.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Dashboard } from '@gravitee/gravitee-dashboard';
+
+import { Links } from '../pagination/links';
+
+export interface AnalyticsDashboardsResponse {
+  data?: Dashboard[];
+  metadata?: {
+    pagination?: {
+      current_page?: number;
+      first?: number;
+      last?: number;
+      size?: number;
+      total?: number;
+      total_pages?: number;
+    };
+  };
+  links?: Links;
+}

--- a/gravitee-apim-portal-webui-next/src/services/analytics-dashboard.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/analytics-dashboard.service.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { AnalyticsDashboardService } from './analytics-dashboard.service';
+import { fakeDashboard, fakeAnalyticsDashboardsResponse } from '../entities/analytics-dashboard/analytics-dashboard.fixtures';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
+
+describe('AnalyticsDashboardService', () => {
+  let service: AnalyticsDashboardService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(AnalyticsDashboardService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('list', () => {
+    it('should_return_dashboards_with_default_page_and_size', done => {
+      const response = fakeAnalyticsDashboardsResponse();
+
+      service.list().subscribe(result => {
+        expect(result).toMatchObject(response);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        r => r.url === `${TESTING_BASE_URL}/analytics/dashboards` && r.params.get('page') === '1' && r.params.get('size') === '10',
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(response);
+    });
+
+    it('should_return_dashboards_with_specified_page_and_size', done => {
+      const response = fakeAnalyticsDashboardsResponse();
+
+      service.list(2, 20).subscribe(result => {
+        expect(result).toMatchObject(response);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        r => r.url === `${TESTING_BASE_URL}/analytics/dashboards` && r.params.get('page') === '2' && r.params.get('size') === '20',
+      );
+      expect(req.request.method).toEqual('GET');
+      req.flush(response);
+    });
+  });
+
+  describe('getById', () => {
+    it('should_return_single_dashboard', done => {
+      const dashboard = fakeDashboard({ id: 'my-dashboard' });
+
+      service.getById('my-dashboard').subscribe(result => {
+        expect(result).toMatchObject(dashboard);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(r => r.url === `${TESTING_BASE_URL}/analytics/dashboards/my-dashboard`);
+      expect(req.request.method).toEqual('GET');
+      req.flush(dashboard);
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/analytics-dashboard.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/analytics-dashboard.service.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Dashboard } from '@gravitee/gravitee-dashboard';
+
+import { ConfigService } from './config.service';
+import { AnalyticsDashboardsResponse } from '../entities/analytics-dashboard/analytics-dashboard';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AnalyticsDashboardService {
+  private readonly http = inject(HttpClient);
+  private readonly configService = inject(ConfigService);
+
+  list(page: number = 1, size: number = 10): Observable<AnalyticsDashboardsResponse> {
+    return this.http.get<AnalyticsDashboardsResponse>(`${this.configService.baseURL}/analytics/dashboards`, {
+      params: {
+        page: page.toString(),
+        size: size.toString(),
+      },
+    });
+  }
+
+  getById(id: string): Observable<Dashboard> {
+    return this.http.get<Dashboard>(`${this.configService.baseURL}/analytics/dashboards/${id}`);
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/number-value-input.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/number-value-input.component.ts
@@ -32,8 +32,8 @@ import { FilterDefinition } from '../../filter.model';
         matInput
         type="number"
         placeholder="Enter a number"
-        [min]="rangeMin()"
-        [max]="rangeMax()"
+        [min]="rangeMin() ?? null"
+        [max]="rangeMax() ?? null"
         [ngModel]="numberValue()"
         (ngModelChange)="onInput($event)"
       />


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13614
https://gravitee.atlassian.net/browse/APIM-13646

## Description

Adds `/dashboard/analytics` with a paginated card grid of dashboards (name + labels) and a click-through to `/dashboard/analytics/:id`.

## Additional context

<img width="1491" height="830" alt="Capture d’écran 2026-04-29 à 09 00 29" src="https://github.com/user-attachments/assets/e647fbe2-7c2a-4ceb-b087-594519acc4e9" />

