### PR TITLE
fix(jdbc-repository): support MySQL with sql_require_primary_key=ON

### DIFF
--- a/.circleci/ci/src/jobs/test-container/job-jdbc-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/job-jdbc-test-container.ts
@@ -27,11 +27,17 @@ export class JdbcTestContainerJob extends AbstractTestContainerJob {
       'job-jdbc-test-container',
       new parameters.CustomParametersList([
         new parameters.CustomParameter('jdbcType', 'string', '', 'Type and version of the database to test. Example: mariadb:10.5'),
+        new parameters.CustomEnumParameter(
+          'strictPrimaryKey',
+          ['true', 'false'],
+          'false',
+          'Run MySQL/MariaDB containers with sql_require_primary_key=ON to exercise strict primary key migrations.',
+        ),
       ]),
       new commands.Run({
-        name: 'Run Management repository tests with database << parameters.jdbcType >>',
+        name: 'Run Management repository tests with database << parameters.jdbcType >> (strictPrimaryKey=<< parameters.strictPrimaryKey >>)',
         command: `cd gravitee-apim-repository
-mvn -pl 'gravitee-apim-repository-jdbc' -am -s ../${config.maven.settingsFile} clean package --no-transfer-progress -Dskip.validation=true -DjdbcType=<< parameters.jdbcType>> -T 2C`,
+mvn -pl 'gravitee-apim-repository-jdbc' -am -s ../${config.maven.settingsFile} clean package --no-transfer-progress -Dskip.validation=true -DjdbcType=<< parameters.jdbcType>> -DstrictPrimaryKey=<< parameters.strictPrimaryKey >> -T 2C`,
       }),
       UbuntuExecutor.create('medium', true, '2024.08.1'),
     );

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -117,6 +117,13 @@ jobs:
         type: string
         default: ""
         description: "Type and version of the database to test. Example: mariadb:10.5"
+      strictPrimaryKey:
+        type: enum
+        default: "false"
+        description: Run MySQL/MariaDB containers with sql_require_primary_key=ON to exercise strict primary key migrations.
+        enum:
+          - "true"
+          - "false"
     machine:
       image: ubuntu-2204:2024.08.1
       docker_layer_caching: true
@@ -131,10 +138,10 @@ jobs:
           keys:
             - gravitee-api-management-v14-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
-          name: Run Management repository tests with database << parameters.jdbcType >>
+          name: Run Management repository tests with database << parameters.jdbcType >> (strictPrimaryKey=<< parameters.strictPrimaryKey >>)
           command: |-
             cd gravitee-apim-repository
-            mvn -pl 'gravitee-apim-repository-jdbc' -am -s ../.gravitee.settings.xml clean package --no-transfer-progress -Dskip.validation=true -DjdbcType=<< parameters.jdbcType>> -T 2C
+            mvn -pl 'gravitee-apim-repository-jdbc' -am -s ../.gravitee.settings.xml clean package --no-transfer-progress -Dskip.validation=true -DjdbcType=<< parameters.jdbcType>> -DstrictPrimaryKey=<< parameters.strictPrimaryKey >> -T 2C
       - run:
           name: Save test results
           command: |-
@@ -296,6 +303,15 @@ workflows:
                 - sqlserver~2019-latest
                 - sqlserver~2022-latest
                 - sqlserver~2025-latest
+      - job-jdbc-test-container:
+          name: Management repository tests - JDBC - mysql~8.4 (strict-PK)
+          context:
+            - cicd-orchestrator
+          requires:
+            - Build
+          parameters:
+            jdbcType: mysql~8.4
+            strictPrimaryKey: "true"
       - job-mongo-test-container:
           name: Management repository tests - Mongo << matrix.mongoVersion >>
           context:

--- a/.circleci/ci/src/workflows/workflow-repositories-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-repositories-tests.ts
@@ -68,6 +68,20 @@ export class RepositoriesTestsWorkflow {
           ],
         },
       }),
+      // Reproduces MySQL HeatWave / Group Replication strict-PK behaviour so the changelog
+      // migrations are exercised against sql_require_primary_key=ON. Scoped to MySQL only —
+      // the MariaDB 12.1 testcontainer refused to start with --sql-require-primary-key=ON
+      // (container exits 1 before any test runs), and MariaDB strict-PK is not the customer
+      // scenario this PR was filed for.
+      new workflow.WorkflowJob(jdbcTestContainerJob, {
+        name: 'Management repository tests - JDBC - mysql~8.4 (strict-PK)',
+        context: ['cicd-orchestrator'],
+        requires: [buildJobName],
+        parameters: {
+          jdbcType: 'mysql~8.4',
+          strictPrimaryKey: 'true',
+        },
+      }),
       new workflow.WorkflowJob(mongoTestContainerJob, {
         name: 'Management repository tests - Mongo << matrix.mongoVersion >>',
         context: ['cicd-orchestrator'],

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
@@ -205,6 +205,11 @@ public abstract class AbstractJdbcRepositoryConfiguration implements Application
         System.setProperty("gravitee_rate_limit_prefix", rateLimitPrefix);
 
         try (Connection conn = dataSource.getConnection()) {
+            // The DATABASECHANGELOG bootstrap on MySQL/MariaDB is patched at SQL generation time
+            // by io.gravitee.repository.jdbc.liquibase.MySqlChangeLogTableWithPrimaryKeyGenerator
+            // (registered through META-INF/services/liquibase.sqlgenerator.SqlGenerator), which
+            // injects a primary key into Liquibase's own CREATE TABLE so it satisfies
+            // sql_require_primary_key=ON.
             final Liquibase liquibase = new Liquibase(
                 "liquibase/master.yml",
                 new ClassLoaderResourceAccessor(this.getClass().getClassLoader()),

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/liquibase/MySqlChangeLogTableWithPrimaryKeyGenerator.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/liquibase/MySqlChangeLogTableWithPrimaryKeyGenerator.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.liquibase;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import liquibase.database.Database;
+import liquibase.database.core.MariaDBDatabase;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.CreateDatabaseChangeLogTableGenerator;
+import liquibase.statement.core.CreateDatabaseChangeLogTableStatement;
+import liquibase.structure.DatabaseObject;
+
+/**
+ * Wraps Liquibase's default {@link CreateDatabaseChangeLogTableGenerator} and injects a named
+ * primary key into the generated {@code CREATE TABLE DATABASECHANGELOG} statement on MySQL/MariaDB.
+ *
+ * <p>As of the currently-pinned Liquibase, the changelog tracking table is created without a
+ * primary key, which the MySQL {@code sql_require_primary_key=ON} setting (used by HeatWave /
+ * Group Replication / strict primary-key deployments) rejects with error 3750 before any change
+ * set can run. Instead of pre-creating the table with a hard-coded schema (which would drift from
+ * Liquibase's own DDL when future Liquibase versions add columns), this generator delegates to the
+ * default implementation and splices a {@code CONSTRAINT pk_<table> PRIMARY KEY (ID, AUTHOR,
+ * FILENAME)} clause — the same triplet Liquibase uses to identify a changeset — into whatever SQL
+ * Liquibase produces. The constraint name mirrors the {@code v3_15_20} legacy retrofit so fresh
+ * deploys and upgraded deploys end up with the same PK name. New columns added by Liquibase
+ * upstream are inherited automatically.
+ *
+ * <p>Failure modes are fail-fast: if Liquibase ever emits no SQL or a shape we cannot recognise,
+ * an {@link IllegalStateException} is thrown at splice time so the underlying upstream contract
+ * change surfaces clearly, rather than letting a silent no-op turn into the much more obscure
+ * MySQL error 3750 later in the migration.
+ *
+ * <p>Registered via {@code META-INF/services/liquibase.sqlgenerator.SqlGenerator}. The companion
+ * {@link liquibase.sqlgenerator.core.CreateDatabaseChangeLogLockTableGenerator} already emits a
+ * {@code PRIMARY KEY (ID)} clause out of the box, so it does not need a similar wrapper.
+ */
+public class MySqlChangeLogTableWithPrimaryKeyGenerator extends CreateDatabaseChangeLogTableGenerator {
+
+    @Override
+    public int getPriority() {
+        // Higher than the default generator so Liquibase picks this one for MySQL/MariaDB.
+        return super.getPriority() + 1;
+    }
+
+    @Override
+    public boolean supports(CreateDatabaseChangeLogTableStatement statement, Database database) {
+        return database instanceof MySQLDatabase || database instanceof MariaDBDatabase;
+    }
+
+    @Override
+    public Sql[] generateSql(CreateDatabaseChangeLogTableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        Sql[] generated = super.generateSql(statement, database, sqlGeneratorChain);
+        if (generated == null || generated.length == 0) {
+            throw new IllegalStateException(
+                "Liquibase " +
+                    CreateDatabaseChangeLogTableGenerator.class.getName() +
+                    " produced no SQL for the changelog table — strict-PK splicing cannot proceed."
+            );
+        }
+        return spliceWithPrimaryKey(generated, "pk_" + database.getDatabaseChangeLogTableName());
+    }
+
+    /**
+     * Splices a named {@code PRIMARY KEY (ID, AUTHOR, FILENAME)} clause into the unique {@code
+     * CREATE TABLE} statement found in {@code generated}. Other statements pass through unchanged.
+     * Throws {@link IllegalStateException} if no statement matches the {@code CREATE TABLE} prefix
+     * — this means Liquibase changed its DDL shape and our splice assumptions are stale.
+     */
+    static Sql[] spliceWithPrimaryKey(Sql[] generated, String constraintName) {
+        Sql[] result = new Sql[generated.length];
+        boolean spliced = false;
+        for (int i = 0; i < generated.length; i++) {
+            Sql original = generated[i];
+            String sql = original.toSql();
+            if (looksLikeCreateTable(sql)) {
+                result[i] = spliceOne(original, sql, constraintName);
+                spliced = true;
+            } else {
+                result[i] = original;
+            }
+        }
+        if (!spliced) {
+            String dump = Arrays.stream(generated).map(Sql::toSql).collect(Collectors.joining("\n  "));
+            throw new IllegalStateException(
+                "Expected a CREATE TABLE statement to splice a PRIMARY KEY into; found none. " + "Upstream SQL was:\n  " + dump
+            );
+        }
+        return result;
+    }
+
+    private static boolean looksLikeCreateTable(String sql) {
+        // Locale.ROOT so the dotted-i / dotless-i fold doesn't bite us in a Turkish locale JVM.
+        return sql != null && sql.trim().toUpperCase(Locale.ROOT).startsWith("CREATE TABLE");
+    }
+
+    private static Sql spliceOne(Sql original, String sql, String constraintName) {
+        // Defensive: refuse to splice if upstream Liquibase ever starts emitting its own
+        // PRIMARY KEY clause inside the column list — a future contract change of that shape
+        // would otherwise silently produce two PK clauses and a duplicate-key DDL error at
+        // execution time. Better to throw here with the offending SQL in the message.
+        if (sql.toUpperCase(Locale.ROOT).contains("PRIMARY KEY")) {
+            throw new IllegalStateException(
+                "Upstream CREATE TABLE already contains a PRIMARY KEY clause; refusing to splice another. " +
+                    "This means Liquibase changed its DDL shape and the splice is no longer needed (or needs to merge). " +
+                    "Offending SQL: " +
+                    sql
+            );
+        }
+        int columnListClose = findColumnListClose(sql);
+        if (columnListClose < 0) {
+            throw new IllegalStateException("CREATE TABLE has no balanced column-list parentheses to splice into: " + sql);
+        }
+        String pkClause = ", CONSTRAINT " + constraintName + " PRIMARY KEY (ID, AUTHOR, FILENAME)";
+        String withPk = sql.substring(0, columnListClose) + pkClause + sql.substring(columnListClose);
+        DatabaseObject[] affected = original.getAffectedDatabaseObjects().toArray(new DatabaseObject[0]);
+        return new UnparsedSql(withPk, original.getEndDelimiter(), affected);
+    }
+
+    /**
+     * Returns the index of the {@code )} that closes the column list of {@code sql}, or {@code -1}
+     * if no balanced opener is found. Walks paren-depth from the first {@code (} after
+     * {@code CREATE TABLE …} so trailing table options that themselves contain parens — e.g.
+     * {@code ENGINE=InnoDB PARTITION BY HASH(id) PARTITIONS 4} — don't fool the splice into
+     * injecting outside the column list.
+     */
+    static int findColumnListClose(String sql) {
+        int open = sql.indexOf('(');
+        if (open < 0) {
+            return -1;
+        }
+        int depth = 0;
+        for (int i = open; i < sql.length(); i++) {
+            char c = sql.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+                if (depth == 0) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -1,0 +1,1 @@
+io.gravitee.repository.jdbc.liquibase.MySqlChangeLogTableWithPrimaryKeyGenerator

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_14_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_14_0/schema.yml
@@ -2,11 +2,12 @@ databaseChangeLog:
     - changeSet:
         id: 1.14.0
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
         - createTable:
             tableName: ${gravitee_prefix}users
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}users" } }
                 - column: {name: username, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: source, type: nvarchar(128), constraints: { nullable: true } }
                 - column: {name: source_id, type: nvarchar(128), constraints: { nullable: true } }
@@ -19,26 +20,16 @@ databaseChangeLog:
                 - column: {name: last_connection_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: picture, type: nclob, constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}users
-            columnNames: id
-            tableName: ${gravitee_prefix}users
-
         - createTable:
             tableName: ${gravitee_prefix}user_roles
             columns:
-                - column: {name: username, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: role, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}user_roles
-            columnNames: username, role
-            tableName: ${gravitee_prefix}user_roles
+                - column: {name: username, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}user_roles" } }
+                - column: {name: role, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}apis
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}apis" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: true } }
                 - column: {name: description, type: nvarchar(4000), constraints: { nullable: true } }
                 - column: {name: version, type: nvarchar(64), constraints: { nullable: false } }
@@ -49,11 +40,6 @@ databaseChangeLog:
                 - column: {name: visibility, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: lifecycle_state, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: picture, type: nclob, constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}apis
-            columnNames: id
-            tableName: ${gravitee_prefix}apis
 
         - createIndex:
             indexName: idx_${gravitee_prefix}apis_visibility
@@ -66,29 +52,19 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}api_views
             columns:
-                - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: view, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}api_views
-            columnNames: api_id, view
-            tableName: ${gravitee_prefix}api_views
+                - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}api_views" } }
+                - column: {name: view, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}api_tags
             columns:
-                - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: tag, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}api_tags
-            columnNames: api_id, tag
-            tableName: ${gravitee_prefix}api_tags
+                - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}api_tags" } }
+                - column: {name: tag, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}keys
             columns:
-                - column: {name: key, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}keys" } }
                 - column: {name: subscription, type: nvarchar(64), constraints: { nullable: true } }
                 - column: {name: application, type: nvarchar(64), constraints: { nullable: true } }
                 - column: {name: plan, type: nvarchar(64), constraints: { nullable: true } }
@@ -97,11 +73,6 @@ databaseChangeLog:
                 - column: {name: expire_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}keys
-            columnNames: key
-            tableName: ${gravitee_prefix}keys
 
         - createIndex:
             indexName: idx_${gravitee_prefix}keys_plan
@@ -152,17 +123,12 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}events
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}events" } }
                 - column: {name: type, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: payload, type: nclob, constraints: { nullable: false } }
                 - column: {name: parent_id, type: nvarchar(64), constraints: { nullable: true } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}events
-            columnNames: id
-            tableName: ${gravitee_prefix}events
 
         - createIndex:
             indexName: idx_${gravitee_prefix}events_type
@@ -183,14 +149,9 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}event_properties
             columns:
-                - column: {name: event_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: property_key, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: event_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}event_properties" } }
+                - column: {name: property_key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
                 - column: {name: property_value, type: nvarchar(256), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}event_properties
-            columnNames: event_id, property_key
-            tableName: ${gravitee_prefix}event_properties
 
         - createIndex:
             indexName: idx_${gravitee_prefix}eventproperties_propertykey
@@ -203,7 +164,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}views
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}views" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: description, type: nvarchar(4000), constraints: { nullable: true } }
                 - column: {name: default_view, type: boolean, constraints: { nullable: true } }
@@ -212,39 +173,24 @@ databaseChangeLog:
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}views
-            columnNames: id
-            tableName: ${gravitee_prefix}views
-
         - createTable:
             tableName: ${gravitee_prefix}tags
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}tags" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: description, type: nvarchar(4000), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}tags
-            columnNames: id
-            tableName: ${gravitee_prefix}tags
 
         - createTable:
             tableName: ${gravitee_prefix}tenants
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}tenants" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: description, type: nvarchar(4000), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}tenants
-            columnNames: id
-            tableName: ${gravitee_prefix}tenants
 
         - createTable:
             tableName: ${gravitee_prefix}applications
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}applications" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: description, type: nvarchar(4000), constraints: { nullable: true } }
                 - column: {name: type, type: nvarchar(64), constraints: { nullable: true } }
@@ -252,11 +198,6 @@ databaseChangeLog:
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: status, type: nvarchar(64), constraints: { nullable: true } }
                 - column: {name: client_id, type: nvarchar(64), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}applications
-            columnNames: id
-            tableName: ${gravitee_prefix}applications
 
         - createIndex:
             indexName: idx_${gravitee_prefix}applications_name
@@ -277,40 +218,27 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}groups
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}groups" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}groups
-            columnNames: id
-            tableName: ${gravitee_prefix}groups
-
         - createTable:
             tableName: ${gravitee_prefix}group_administrators
             columns:
-                - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: administrator, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}group_administrators
-            columnNames: group_id, administrator
-            tableName: ${gravitee_prefix}group_administrators
+                - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}group_administrators" } }
+                - column: {name: administrator, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}memberships
             columns:
-                - column: {name: user_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
+                # PK column order (user_id, reference_type, reference_id) matches the original
+                # v1.14.0 addPrimaryKey so fresh and upgraded deploys share the same PK index sort.
+                - column: {name: user_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}memberships" } }
+                - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}memberships
-            columnNames: user_id, reference_type, reference_id
-            tableName: ${gravitee_prefix}memberships
 
         - createIndex:
             indexName: idx_${gravitee_prefix}memberships_referenceid_referencetype
@@ -337,7 +265,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}pages
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}pages" } }
                 - column: {name: type, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: content, type: nclob, constraints: { nullable: true } }
@@ -353,11 +281,6 @@ databaseChangeLog:
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: homepage, type: boolean, constraints: { nullable: false, default: false } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}pages
-            columnNames: id
-            tableName: ${gravitee_prefix}pages
-
         - createIndex:
             indexName: idx_${gravitee_prefix}pages_api
             columns:
@@ -369,7 +292,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}plans
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}plans" } }
                 - column: {name: type, type: nvarchar(64), constraints: { nullable: true } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: description, type: nclob, constraints: { nullable: true } }
@@ -383,21 +306,11 @@ databaseChangeLog:
                 - column: {name: published_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: closed_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}plans
-            columnNames: id
-            tableName: ${gravitee_prefix}plans
-
         - createTable:
             tableName: ${gravitee_prefix}plan_apis
             columns:
-                - column: {name: plan_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: api, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}plan_apis
-            columnNames: plan_id, api
-            tableName: ${gravitee_prefix}plan_apis
+                - column: {name: plan_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}plan_apis" } }
+                - column: {name: api, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createIndex:
             indexName: idx_${gravitee_prefix}planapis_api
@@ -410,18 +323,13 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}plan_characteristics
             columns:
-                - column: {name: plan_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: characteristic, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}plan_characteristics
-            columnNames: plan_id, characteristic
-            tableName: ${gravitee_prefix}plan_characteristics
+                - column: {name: plan_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}plan_characteristics" } }
+                - column: {name: characteristic, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}subscriptions
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}subscriptions" } }
                 - column: {name: plan, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: application, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: starting_at, type: timestamp(6), constraints: { nullable: true } }
@@ -435,11 +343,6 @@ databaseChangeLog:
                 - column: {name: status, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: api, type: nvarchar(64), constraints: { nullable: true } }
                 - column: {name: client_id, type: nvarchar(64), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}subscriptions
-            columnNames: id
-            tableName: ${gravitee_prefix}subscriptions
 
         - createIndex:
             indexName: idx_${gravitee_prefix}subscriptions_plan
@@ -460,7 +363,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_rate_limit_prefix}ratelimit
             columns:
-                - column: {name: key, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_rate_limit_prefix}ratelimit" } }
                 - column: {name: counter, type: bigint, constraints: { nullable: false } }
                 - column: {name: last_request, type: bigint, constraints: { nullable: false } }
                 - column: {name: reset_time, type: bigint, constraints: { nullable: false } }
@@ -468,17 +371,12 @@ databaseChangeLog:
                 - column: {name: updated_at, type: bigint, constraints: { nullable: false } }
                 - column: {name: async, type: boolean, constraints: { nullable: false } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_rate_limit_prefix}ratelimit
-            columnNames: key
-            tableName: ${gravitee_rate_limit_prefix}ratelimit
-
         - createTable:
             tableName: ${gravitee_prefix}metadata
             columns:
-                - column: {name: key, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: reference_type, type: nvarchar(32), constraints: { nullable: false } }
-                - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}metadata" } }
+                - column: {name: reference_type, type: nvarchar(32), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
                 - column: {name: name, type: nvarchar(1024), constraints: { nullable: false } }
                 - column: {name: format, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: value, type: nvarchar(1024), constraints: { nullable: true } }
@@ -486,97 +384,70 @@ databaseChangeLog:
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}metadata
-            columnNames: key, reference_type, reference_id
-            tableName: ${gravitee_prefix}metadata
-
         - createTable:
             tableName: ${gravitee_prefix}api_labels
             columns:
-                - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: label, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}api_labels
-            columnNames: api_id, label
-            tableName: ${gravitee_prefix}api_labels
+                - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}api_labels" } }
+                - column: {name: label, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}roles
             columns:
-                - column: {name: scope, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: name, type: nvarchar(128), constraints: { nullable: false } }
+                - column: {name: scope, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}roles" } }
+                - column: {name: name, type: nvarchar(128), constraints: { nullable: false, primaryKey: true } }
                 - column: {name: description, type: nvarchar(1024), constraints: { nullable: true } }
                 - column: {name: default_role, type: boolean, constraints: { nullable: false, default: false } }
                 - column: {name: system, type: boolean, constraints: { nullable: false, default: false } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}roles
-            columnNames: scope, name
-            tableName: ${gravitee_prefix}roles
-
         - createTable:
             tableName: ${gravitee_prefix}role_permissions
             columns:
-                - column: {name: role_scope, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: role_name, type: nvarchar(128), constraints: { nullable: false } }
-                - column: {name: permission, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}role_permissions
-            columnNames: role_scope, role_name, permission
-            tableName: ${gravitee_prefix}role_permissions
+                - column: {name: role_scope, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}role_permissions" } }
+                - column: {name: role_name, type: nvarchar(128), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: permission, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}group_event_rules
             columns:
-                - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: group_event, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}group_event_rules" } }
+                - column: {name: group_event, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}api_groups
             columns:
-                - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}api_groups" } }
+                - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}application_groups
             columns:
-                - column: {name: application_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: application_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}application_groups" } }
+                - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}membership_roles
             columns:
-                - column: {name: user_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: role_scope, type: int, constraints: { nullable: false } }
+                # PK column order (user_id, reference_type, reference_id, role_scope) matches the
+                # original v1.14.0 addPrimaryKey so fresh and upgraded deploys share the same PK
+                # index sort.
+                - column: {name: user_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}membership_roles" } }
+                - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: role_scope, type: int, constraints: { nullable: false, primaryKey: true } }
                 - column: {name: role_name, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}membership_roles
-            columnNames: user_id, reference_type, reference_id, role_scope
-            tableName: ${gravitee_prefix}membership_roles
 
         - createTable:
             tableName: ${gravitee_prefix}audits
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}audits" } }
                 - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: user, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: event, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: patch, type: nclob, constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}audits
-            columnNames: id
-            tableName: ${gravitee_prefix}audits
 
         - createIndex:
             indexName: idx_${gravitee_prefix}audits_referencetype_referenceid
@@ -600,19 +471,14 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}audit_properties
             columns:
-                - column: {name: audit_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: key, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: value, type: nvarchar(200), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}audit_properties
-            columnNames: audit_id, key, value
-            tableName: ${gravitee_prefix}audit_properties
+                - column: {name: audit_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}audit_properties" } }
+                - column: {name: key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: value, type: nvarchar(200), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}ratings
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}ratings" } }
                 - column: {name: api, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: user, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: rate, type: tinyint, constraints: { nullable: false } }
@@ -620,11 +486,6 @@ databaseChangeLog:
                 - column: {name: comment, type: nvarchar(1024), constraints: { nullable: true } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}ratings
-            columnNames: id
-            tableName: ${gravitee_prefix}ratings
 
         - createIndex:
             indexName: idx_${gravitee_prefix}ratings_api
@@ -637,17 +498,12 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}rating_answers
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}rating_answers" } }
                 - column: {name: rating, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: user, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: comment, type: nvarchar(1024), constraints: { nullable: false } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}rating_answers
-            columnNames: id
-            tableName: ${gravitee_prefix}rating_answers
 
         - createIndex:
             indexName: idx_${gravitee_prefix}ratinganswers_rating
@@ -660,81 +516,55 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}page_excluded_groups
             columns:
-                - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: excluded_group, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}page_excluded_groups
-            columnNames: page_id, excluded_group
-            tableName: ${gravitee_prefix}page_excluded_groups
+                - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}page_excluded_groups" } }
+                - column: {name: excluded_group, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}plan_excluded_groups
             columns:
-                - column: {name: plan_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: excluded_group, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}plan_excluded_groups
-            columnNames: plan_id, excluded_group
-            tableName: ${gravitee_prefix}plan_excluded_groups
+                - column: {name: plan_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}plan_excluded_groups" } }
+                - column: {name: excluded_group, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}parameters
             columns:
-                - column: {name: key, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}parameters" } }
                 - column: {name: value, type: nvarchar(4000), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}parameters
-            columnNames: key
-            tableName: ${gravitee_prefix}parameters
 
         - createTable:
             tableName: ${gravitee_prefix}portal_notifications
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}portal_notifications" } }
                 - column: {name: title, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: message, type: nvarchar(4000), constraints: { nullable: false } }
                 - column: {name: user, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}portal_notifications
-            columnNames: id
-            tableName: ${gravitee_prefix}portal_notifications
-
         - createTable:
             tableName: ${gravitee_prefix}portal_notification_configs
             columns:
-                - column: {name: user, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
+                # PK column order (user, reference_type, reference_id) matches the original
+                # v1.14.0 addPrimaryKey so fresh and upgraded deploys share the same PK index sort.
+                - column: {name: user, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}portal_notification_configs" } }
+                - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}portal_notification_configs
-            columnNames: user, reference_type, reference_id
-            tableName: ${gravitee_prefix}portal_notification_configs
-
         - createTable:
             tableName: ${gravitee_prefix}portal_notification_config_hooks
             columns:
-                - column: {name: user, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: hook, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}portal_notification_config_hooks
-            columnNames: user, reference_type, reference_id, hook
-            tableName: ${gravitee_prefix}portal_notification_config_hooks
+                # PK column order (user, reference_type, reference_id, hook) matches the original
+                # v1.14.0 addPrimaryKey so fresh and upgraded deploys share the same PK index sort.
+                - column: {name: user, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}portal_notification_config_hooks" } }
+                - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: hook, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}generic_notification_configs
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false  } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}generic_notification_configs" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: notifier, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: config, type: nvarchar(64), constraints: { nullable: true } }
@@ -743,18 +573,9 @@ databaseChangeLog:
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}generic_notification_configs
-            columnNames: id
-            tableName: ${gravitee_prefix}generic_notification_configs
-
         - createTable:
             tableName: ${gravitee_prefix}generic_notification_config_hooks
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: hook, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}generic_notification_config_hooks" } }
+                - column: {name: hook, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}generic_notification_config_hooks
-            columnNames: id, hook
-            tableName: ${gravitee_prefix}generic_notification_config_hooks

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_18_0/schema-pages-mssql.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_18_0/schema-pages-mssql.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
     - changeSet:
         id: 1.18.0-pageconfiguration-mssql
         author: GraviteeSource Team
+        validCheckSum: ANY
         preConditions:
             onFail: MARK_RAN
             dbms:
@@ -14,14 +15,9 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}page_configuration
             columns:
-                - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: k, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: v, type: nvarchar(200), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}page_configuration
-            columnNames: page_id, k, v
-            tableName: ${gravitee_prefix}page_configuration
+                - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}page_configuration" } }
+                - column: {name: k, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: v, type: nvarchar(200), constraints: { nullable: false, primaryKey: true } }
 
         - dropColumn:
             columnName: configuration_try_it_url

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_18_0/schema-pages.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_18_0/schema-pages.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
     - changeSet:
         id: 1.18.0-pageconfiguration
         author: GraviteeSource Team
+        validCheckSum: ANY
         preConditions:
             onFail: MARK_RAN
             not:
@@ -15,14 +16,9 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}page_configuration
             columns:
-                - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: k, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: v, type: nvarchar(200), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}page_configuration
-            columnNames: page_id, k, v
-            tableName: ${gravitee_prefix}page_configuration
+                - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}page_configuration" } }
+                - column: {name: k, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+                - column: {name: v, type: nvarchar(200), constraints: { nullable: false, primaryKey: true } }
 
         - sql:
             comment: Move tryIt to a the dedicated table

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_19_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_19_0/schema.yml
@@ -2,23 +2,19 @@ databaseChangeLog:
     - changeSet:
         id: 1.19.0
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
         - createTable:
             tableName: ${gravitee_prefix}group_roles
             columns:
-                - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: role_scope, type: int, constraints: { nullable: false } }
+                - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}group_roles" } }
+                - column: {name: role_scope, type: int, constraints: { nullable: false, primaryKey: true } }
                 - column: {name: role_name, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}group_roles
-            columnNames: group_id, role_scope
-            tableName: ${gravitee_prefix}group_roles
 
         - createTable:
             tableName: ${gravitee_prefix}dictionaries
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}dictionaries" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: description, type: nvarchar(4000), constraints: { nullable: true } }
                 - column: {name: type, type: nvarchar(64), constraints: { nullable: false } }
@@ -31,19 +27,10 @@ databaseChangeLog:
                 - column: {name: trigger_rate, type: int, constraints: { nullable: true } }
                 - column: {name: trigger_unit, type: nvarchar(64), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}dictionaries
-            columnNames: id
-            tableName: ${gravitee_prefix}dictionaries
-
         - createTable:
             tableName: ${gravitee_prefix}dictionary_property
             columns:
-                - column: {name: dictionary_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: k, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: dictionary_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}dictionary_property" } }
+                - column: {name: k, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
                 - column: {name: v, type: nvarchar(1000), constraints: { nullable: false } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}dictionary_property
-            columnNames: dictionary_id, k
-            tableName: ${gravitee_prefix}dictionary_property

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_20_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_20_0/schema.yml
@@ -2,18 +2,15 @@ databaseChangeLog:
     - changeSet:
         id: 1.20.0
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
         - createTable:
             tableName: ${gravitee_prefix}api_headers
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}api_headers" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: value, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: order, type: int, constraints: { nullable: true } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}api_headers
-            columnNames: id
-            tableName: ${gravitee_prefix}api_headers

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_20_16/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_20_16/schema.yml
@@ -2,11 +2,12 @@ databaseChangeLog:
   - changeSet:
       id: 1.20.16
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}commands
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}commands" } }
               - column: {name: from, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: to, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: content, type: nclob, constraints: { nullable: true } }
@@ -14,29 +15,15 @@ databaseChangeLog:
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}commands
-            columnNames: id
-            tableName: ${gravitee_prefix}commands
-
         - createTable:
             tableName: ${gravitee_prefix}command_acknowledgments
             columns:
-              - column: {name: command_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: acknowledgment, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}command_acknowledgments
-            columnNames: command_id, acknowledgment
-            tableName: ${gravitee_prefix}command_acknowledgments
+              - column: {name: command_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}command_acknowledgments" } }
+              - column: {name: acknowledgment, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}command_tags
             columns:
-              - column: {name: command_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: tag, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: command_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}command_tags" } }
+              - column: {name: tag, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}command_tags
-            columnNames: command_id, tag
-            tableName: ${gravitee_prefix}command_tags

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_21_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_21_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
     - changeSet:
         id: 1.21.0
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
         - dropColumn:
             tableName: ${gravitee_prefix}users
@@ -29,7 +30,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}identity_providers
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}identity_providers" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: description, type: nvarchar(4000), constraints: { nullable: true } }
                 - column: {name: enabled, type: boolean, constraints: { nullable: false } }
@@ -41,15 +42,10 @@ databaseChangeLog:
                 - column: {name: role_mappings, type: nvarchar(4000), constraints: { nullable: true } }
                 - column: {name: user_profile_mapping, type: nvarchar(4000), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}identity_providers
-            columnNames: id
-            tableName: ${gravitee_prefix}identity_providers
-
         - createTable:
             tableName: ${gravitee_prefix}alerts
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}alerts" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: description, type: nvarchar(256), constraints: { nullable: true } }
                 - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
@@ -64,7 +60,3 @@ databaseChangeLog:
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}alerts
-            columnNames: id
-            tableName: ${gravitee_prefix}alerts

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_22_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_22_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
     - changeSet:
         id: 1.22.0
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
 
         - addColumn:
@@ -21,11 +22,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}entrypoints
             columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}entrypoints" } }
                 - column: {name: value, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: tags, type: nvarchar(64), constraints: { nullable: false } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}entrypoints
-            columnNames: id
-            tableName: ${gravitee_prefix}entrypoints

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_23_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_23_0/schema.yml
@@ -2,18 +2,14 @@ databaseChangeLog:
     - changeSet:
         id: 1.23.0
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
         - createTable:
               tableName: ${gravitee_prefix}page_metadata
               columns:
-                  - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false } }
-                  - column: {name: k, type: nvarchar(64), constraints: { nullable: false } }
-                  - column: {name: v, type: nvarchar(200), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-              constraintName: pk_${gravitee_prefix}page_metadata
-              columnNames: page_id, k, v
-              tableName: ${gravitee_prefix}page_metadata
+                  - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}page_metadata" } }
+                  - column: {name: k, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+                  - column: {name: v, type: nvarchar(200), constraints: { nullable: false, primaryKey: true } }
 
         - addColumn:
               tableName: ${gravitee_prefix}views
@@ -44,7 +40,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}invitations
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}invitations" } }
               - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: email, type: nvarchar(64), constraints: { nullable: false } }
@@ -52,11 +48,6 @@ databaseChangeLog:
               - column: {name: application_role, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}invitations
-            columnNames: id
-            tableName: ${gravitee_prefix}invitations
 
         - dropNotNullConstraint:
             columnDataType: nvarchar(64)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_25_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_25_0/schema.yml
@@ -2,28 +2,24 @@ databaseChangeLog:
     - changeSet:
         id: 1.25.0
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
         - createTable:
             tableName: ${gravitee_prefix}tag_groups
             columns:
-              - column: {name: tag_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: tag_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}tag_groups" } }
+              - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
         - createTable:
               tableName: ${gravitee_prefix}application_metadata
               columns:
-                  - column: {name: application_id, type: nvarchar(64), constraints: { nullable: false } }
-                  - column: {name: k, type: nvarchar(128), constraints: { nullable: false } }
+                  - column: {name: application_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}application_metadata" } }
+                  - column: {name: k, type: nvarchar(128), constraints: { nullable: false, primaryKey: true } }
                   - column: {name: v, type: nvarchar(4000), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-              constraintName: pk_${gravitee_prefix}application_metadata
-              columnNames: application_id, k
-              tableName: ${gravitee_prefix}application_metadata
 
         - createTable:
             tableName: ${gravitee_prefix}client_registration_providers
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}client_registration_providers" } }
               - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: description, type: nvarchar(4000), constraints: { nullable: true } }
               - column: {name: discovery_endpoint, type: nvarchar(4000), constraints: { nullable: false } }
@@ -32,13 +28,8 @@ databaseChangeLog:
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}client_registration_providers
-            columnNames: id
-            tableName: ${gravitee_prefix}client_registration_providers
-
         - createTable:
             tableName: ${gravitee_prefix}client_registration_provider_scopes
             columns:
-              - column: {name: client_registration_provider_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: scope, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: client_registration_provider_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}client_registration_provider_scopes" } }
+              - column: {name: scope, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_25_2/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_25_2/schema.yml
@@ -5,6 +5,7 @@ databaseChangeLog:
         validCheckSum:
         - 8:67ff408ab1ca458f85386d06f45e395b
         - 8:a1872ce916e96806b18767089dde811d
+        - ANY
         changes:
         - addColumn:
             tableName: ${gravitee_rate_limit_prefix}ratelimit
@@ -32,6 +33,57 @@ databaseChangeLog:
             columnName: subscription
             defaultNullValue: 'unknown'
             tableName: ${gravitee_rate_limit_prefix}ratelimit
+
+    # Rebuild the primary key on `key` after widening it to nvarchar(128).
+    # MySQL with sql_require_primary_key=ON rejects an ALTER that drops the
+    # PK without adding a replacement in the same statement, so the rebuild
+    # is split per-DBMS: a single combined ALTER on MySQL/MariaDB, and the
+    # original typed sequence elsewhere so Liquibase can keep generating
+    # portable SQL.
+    # MARK_RAN if `key` is already NVARCHAR(128) on the running database — that
+    # is the post-migration state. This guards 4.10.x → 4.11.x upgrades, where
+    # the original (now-trimmed) `1.25.2` changeset already widened the column
+    # and added the PK. Without the gate, the combined ALTER below would
+    # needlessly drop+rebuild a PK that's already at the target shape.
+    - changeSet:
+        id: 1.25.2-rebuild-key-pk-mysql
+        author: GraviteeSource Team
+        dbms: mysql, mariadb
+        preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 64
+            sql: |
+                SELECT character_maximum_length
+                FROM information_schema.columns
+                WHERE table_schema = (SELECT DATABASE())
+                  AND table_name = '${gravitee_rate_limit_prefix}ratelimit'
+                  AND column_name = 'key'
+        changes:
+        - sql:
+            sql: |
+                ALTER TABLE ${gravitee_rate_limit_prefix}ratelimit
+                    DROP PRIMARY KEY,
+                    MODIFY COLUMN `key` NVARCHAR(128) NOT NULL,
+                    ADD CONSTRAINT pk_${gravitee_rate_limit_prefix}ratelimit PRIMARY KEY (`key`);
+
+    # Same MARK_RAN guard as the MySQL changeset above. Postgres, MSSQL, and H2
+    # all report character_maximum_length in characters (not bytes), so a
+    # single sqlCheck applies cleanly across the !mysql,!mariadb family.
+    - changeSet:
+        id: 1.25.2-rebuild-key-pk-other
+        author: GraviteeSource Team
+        dbms: '!mysql, !mariadb'
+        preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 64
+            sql: |
+                SELECT character_maximum_length
+                FROM information_schema.columns
+                WHERE table_name = '${gravitee_rate_limit_prefix}ratelimit'
+                  AND column_name = 'key'
+        changes:
         - dropPrimaryKey:
             constraintName: pk_${gravitee_rate_limit_prefix}ratelimit
             tableName: ${gravitee_rate_limit_prefix}ratelimit

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_26_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_26_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
     - changeSet:
         id: 1.26.0
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
         - addColumn:
             tableName: ${gravitee_prefix}client_registration_providers
@@ -33,7 +34,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}workflows
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}workflows" } }
               - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: type, type: nvarchar(64), constraints: { nullable: false } }
@@ -42,7 +43,3 @@ databaseChangeLog:
               - column: {name: user, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}workflows
-            columnNames: id
-            tableName: ${gravitee_prefix}workflows

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_27_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_27_0/schema.yml
@@ -2,17 +2,13 @@ databaseChangeLog:
     - changeSet:
         id: 1.27.0
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
           - createTable:
               tableName: ${gravitee_prefix}plan_tags
               columns:
-                - column: {name: plan_id, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: tag, type: nvarchar(64), constraints: { nullable: false } }
-
-          - addPrimaryKey:
-              constraintName: pk_${gravitee_prefix}plan_tags
-              columnNames: plan_id, tag
-              tableName: ${gravitee_prefix}plan_tags
+                - column: {name: plan_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}plan_tags" } }
+                - column: {name: tag, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
           - addColumn:
               tableName: ${gravitee_prefix}plans

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_30_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_30_0/schema.yml
@@ -2,40 +2,31 @@ databaseChangeLog:
     - changeSet:
         id: 1.30.0
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
           - createTable:
               tableName: ${gravitee_prefix}quality_rules
               columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}quality_rules" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: description, type: nvarchar(256), constraints: { nullable: false } }
                 - column: {name: weight, type: int, constraints: { nullable: false } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-          - addPrimaryKey:
-              constraintName: pk_${gravitee_prefix}quality_rules
-              columnNames: id
-              tableName: ${gravitee_prefix}quality_rules
-
           - createTable:
               tableName: ${gravitee_prefix}api_quality_rules
               columns:
-                - column: {name: api, type: nvarchar(64), constraints: { nullable: false } }
-                - column: {name: quality_rule, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: api, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}api_quality_rules" } }
+                - column: {name: quality_rule, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
                 - column: {name: checked, type: boolean, constraints: { nullable: false } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-          - addPrimaryKey:
-              constraintName: pk_${gravitee_prefix}api_quality_rules
-              columnNames: api, quality_rule
-              tableName: ${gravitee_prefix}api_quality_rules
-
           - createTable:
               tableName: ${gravitee_prefix}dashboards
               columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}dashboards" } }
                 - column: {name: reference_type, type: nvarchar(32), constraints: { nullable: false } }
                 - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
@@ -45,11 +36,6 @@ databaseChangeLog:
                 - column: {name: definition, type: nclob, constraints: { nullable: true } }
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-
-          - addPrimaryKey:
-              constraintName: pk_${gravitee_prefix}dashboards
-              columnNames: id
-              tableName: ${gravitee_prefix}dashboards
 
           - createIndex:
               indexName: idx_${gravitee_prefix}dashboards_reference_type
@@ -73,7 +59,7 @@ databaseChangeLog:
           - createTable:
               tableName: ${gravitee_prefix}alert_triggers
               columns:
-                - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+                - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}alert_triggers" } }
                 - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
                 - column: {name: description, type: nvarchar(256), constraints: { nullable: true } }
                 - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
@@ -85,7 +71,3 @@ databaseChangeLog:
                 - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
                 - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
-          - addPrimaryKey:
-              constraintName: pk_${gravitee_prefix}alert_triggers
-              columnNames: id
-              tableName: ${gravitee_prefix}alert_triggers

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_30_13/schema-alerts.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_30_13/schema-alerts.yml
@@ -2,12 +2,13 @@ databaseChangeLog:
     - changeSet:
         id: 1.30.13.1
         author: GraviteeSource Team
+        validCheckSum: ANY
         changes:
         - createTable:
             tableName: ${gravitee_prefix}alert_event_rules
             columns:
-              - column: {name: alert_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: alert_event, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: alert_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}alert_event_rules" } }
+              - column: {name: alert_event, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
         - addColumn:
             tableName: ${gravitee_prefix}alert_triggers
             columns:

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_0_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_0_0/schema.yml
@@ -25,7 +25,9 @@ databaseChangeLog:
   - changeSet:
       id: 3.0.0
       author: GraviteeSource Team
-      validCheckSum: 1:any
+      validCheckSum:
+        - 1:any
+        - ANY
       changes:
         ## roles, permissions & memberships migration ##
         # roles_permissions
@@ -73,13 +75,21 @@ databaseChangeLog:
             columnDataType: nvarchar(64)
             columnName: role_id
             tableName: ${gravitee_prefix}role_permissions
-        - dropPrimaryKey:
-            constraintName: pk_${gravitee_prefix}role_permissions
-            tableName: ${gravitee_prefix}role_permissions
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}role_permissions
-            columnNames: role_id, permission
-            tableName: ${gravitee_prefix}role_permissions
+        # Rebuild PK (role_scope, role_name, permission) → (role_id, permission).
+        # Combined ALTER for MySQL/MariaDB to satisfy sql_require_primary_key=ON
+        # which forbids dropping the PK without an in-statement replacement.
+        - sql:
+            dbms: mysql, mariadb
+            sql: |
+                ALTER TABLE ${gravitee_prefix}role_permissions
+                    DROP PRIMARY KEY,
+                    ADD CONSTRAINT pk_${gravitee_prefix}role_permissions PRIMARY KEY (role_id, permission);
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}role_permissions DROP CONSTRAINT pk_${gravitee_prefix}role_permissions
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}role_permissions ADD CONSTRAINT pk_${gravitee_prefix}role_permissions PRIMARY KEY (role_id, permission)
         - dropColumn:
             columnName: role_scope
             tableName: ${gravitee_prefix}role_permissions
@@ -119,18 +129,36 @@ databaseChangeLog:
             columnDataType: nvarchar(64)
             columnName: id
             tableName: ${gravitee_prefix}roles
-        - dropPrimaryKey:
-            constraintName: pk_${gravitee_prefix}roles
-            tableName: ${gravitee_prefix}roles
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}roles
-            columnNames: id
-            tableName: ${gravitee_prefix}roles
+        # Rebuild PK (scope, name) → (id). Combined ALTER for MySQL/MariaDB.
+        - sql:
+            dbms: mysql, mariadb
+            sql: |
+                ALTER TABLE ${gravitee_prefix}roles
+                    DROP PRIMARY KEY,
+                    ADD CONSTRAINT pk_${gravitee_prefix}roles PRIMARY KEY (id);
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}roles DROP CONSTRAINT pk_${gravitee_prefix}roles
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}roles ADD CONSTRAINT pk_${gravitee_prefix}roles PRIMARY KEY (id)
 
-        # membership_roles
-        - dropPrimaryKey:
-            constraintName: pk_${gravitee_prefix}membership_roles
-            tableName: ${gravitee_prefix}membership_roles
+        # membership_roles — original PK is on (user_id, reference_type,
+        # reference_id, role_scope). role_scope is being widened from int to
+        # nvarchar, so the PK has to be dropped first. The table itself is
+        # dropped further down. On MySQL with strict PK mode the drop+modify
+        # has to be combined into one ALTER that re-installs a PK; the
+        # placeholder is short-lived (it goes away with the dropTable).
+        - sql:
+            dbms: mysql, mariadb
+            sql: |
+                ALTER TABLE ${gravitee_prefix}membership_roles
+                    DROP PRIMARY KEY,
+                    MODIFY COLUMN role_scope NVARCHAR(64) NOT NULL,
+                    ADD PRIMARY KEY (user_id, reference_type, reference_id, role_scope);
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}membership_roles DROP CONSTRAINT pk_${gravitee_prefix}membership_roles
         - modifyDataType:
             columnName: role_scope
             newDataType: nvarchar(64)
@@ -154,10 +182,22 @@ databaseChangeLog:
         - sql:
             sql: delete from ${gravitee_prefix}membership_roles where reference_type = 'MANAGEMENT' and role_scope = 'MANAGEMENT'
 
-        # memberships
-        - dropPrimaryKey:
-            constraintName: pk_${gravitee_prefix}memberships
-            tableName: ${gravitee_prefix}memberships
+        # memberships — the migration drops the (user_id, reference_type,
+        # reference_id) PK, runs many data ops while user_id is still
+        # populated, drops user_id, then installs a new PK on id. Strict-PK
+        # MySQL does not allow the table to live without a PK between those
+        # steps, so we add a temporary auto-increment surrogate PK that
+        # holds the table together until the final id PK is installed.
+        - sql:
+            dbms: mysql, mariadb
+            sql: |
+                ALTER TABLE ${gravitee_prefix}memberships
+                    ADD COLUMN tmp_pk BIGINT NOT NULL AUTO_INCREMENT,
+                    DROP PRIMARY KEY,
+                    ADD CONSTRAINT pk_${gravitee_prefix}memberships_tmp PRIMARY KEY (tmp_pk);
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}memberships DROP CONSTRAINT pk_${gravitee_prefix}memberships
         - sql:
             sql: update ${gravitee_prefix}memberships set reference_type = 'ENVIRONMENT' WHERE reference_type = 'PORTAL'
         - sql:
@@ -209,18 +249,37 @@ databaseChangeLog:
             columnDataType: nvarchar(64)
             columnName: id
             tableName: ${gravitee_prefix}memberships
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}memberships
-            columnNames: id
-            tableName: ${gravitee_prefix}memberships
+        # Install the final id PK. On MySQL this also drops the temporary
+        # surrogate column added at the start; the operation has to be a
+        # single combined ALTER so the table never lives without a PK.
+        - sql:
+            dbms: mysql, mariadb
+            sql: |
+                ALTER TABLE ${gravitee_prefix}memberships
+                    DROP PRIMARY KEY,
+                    DROP COLUMN tmp_pk,
+                    ADD CONSTRAINT pk_${gravitee_prefix}memberships PRIMARY KEY (id);
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}memberships ADD CONSTRAINT pk_${gravitee_prefix}memberships PRIMARY KEY (id)
 
         - dropTable:
             tableName: ${gravitee_prefix}membership_roles
             
         ## group, group_roles & memberships ##
-        - dropPrimaryKey:
-            constraintName: pk_${gravitee_prefix}group_roles
-            tableName: ${gravitee_prefix}group_roles
+        # group_roles — same shape as membership_roles above: rebuild PK
+        # while widening role_scope, with a placeholder PK on MySQL/MariaDB
+        # that disappears with the dropTable later in this changeSet.
+        - sql:
+            dbms: mysql, mariadb
+            sql: |
+                ALTER TABLE ${gravitee_prefix}group_roles
+                    DROP PRIMARY KEY,
+                    MODIFY COLUMN role_scope NVARCHAR(64) NOT NULL,
+                    ADD PRIMARY KEY (group_id, role_scope);
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}group_roles DROP CONSTRAINT pk_${gravitee_prefix}group_roles
         - modifyDataType:
             columnName: role_scope
             newDataType: nvarchar(64)
@@ -271,9 +330,14 @@ databaseChangeLog:
             tableName: ${gravitee_prefix}plan_apis
             indexName: idx_${gravitee_prefix}planapis_api
 
-        - dropPrimaryKey:
-            constraintName: pk_${gravitee_prefix}plan_apis
-            tableName: ${gravitee_prefix}plan_apis
+        # plan_apis — the table is dropped right after, so dropping the PK
+        # first is only needed by DBMSes whose dropTable would otherwise
+        # leave dangling constraints. Skip the explicit dropPK on MySQL
+        # where it is rejected by sql_require_primary_key=ON without an
+        # in-statement replacement.
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}plan_apis DROP CONSTRAINT pk_${gravitee_prefix}plan_apis
 
         - dropTable:
             tableName: ${gravitee_prefix}plan_apis
@@ -591,56 +655,38 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}environments
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}environments" } }
               - column: {name: name, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: description, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}environments
-            columnNames: id
-            tableName: ${gravitee_prefix}environments
         - sql:
             sql: insert into ${gravitee_prefix}environments (id, name, description, organization_id) values ('DEFAULT', 'Default environment', 'Default environment', 'DEFAULT')
 
         - createTable:
             tableName: ${gravitee_prefix}environment_domain_restrictions
             columns:
-              - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: domain_restriction, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}environment_domain_restrictions
-            columnNames: environment_id, domain_restriction
-            tableName: ${gravitee_prefix}environment_domain_restrictions
+              - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}environment_domain_restrictions" } }
+              - column: {name: domain_restriction, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}organizations
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}organizations" } }
               - column: {name: name, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: description, type: nvarchar(64), constraints: { nullable: true } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}organizations
-            columnNames: id
-            tableName: ${gravitee_prefix}organizations
         - sql:
             sql: insert into ${gravitee_prefix}organizations (id, name, description) values ('DEFAULT', 'Default organization', 'Default organization')
 
         - createTable:
             tableName: ${gravitee_prefix}organization_domain_restrictions
             columns:
-              - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: domain_restriction, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}organization_domain_restrictions
-            columnNames: organization_id, domain_restriction
-            tableName: ${gravitee_prefix}organization_domain_restrictions
+              - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}organization_domain_restrictions" } }
+              - column: {name: domain_restriction, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}themes
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}themes" } }
               - column: {name: name, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: reference_type, type: nvarchar(32), constraints: { nullable: false } }
@@ -651,11 +697,6 @@ databaseChangeLog:
               - column: {name: logo, type: nclob, constraints: { nullable: true } }
               - column: {name: optional_logo, type: nclob, constraints: { nullable: true } }
               - column: {name: background_image, type: nclob, constraints: { nullable: true } }
-        - addPrimaryKey:
-              constraintName: pk_${gravitee_prefix}themes
-              columnNames: id
-              tableName: ${gravitee_prefix}themes
-
         ## others
         - addColumn:
             tableName: ${gravitee_prefix}users

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_10_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_10_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 3.10.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - addColumn:
             tableName: ${gravitee_prefix}keys
@@ -18,7 +19,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}promotions
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}promotions" } }
               - column: {name: api_definition, type: nclob, constraints: { nullable: false } }
               - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: status, type: nvarchar(64), constraints: { nullable: false } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_12_1/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_12_1/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 3.12.1
       author: GraviteeSource Team
+      validCheckSum: ANY
       preConditions:
         - onFail: MARK_RAN
         - not:
@@ -28,13 +29,24 @@ databaseChangeLog:
             tableName: ${gravitee_prefix}keys
             columnDataType: nvarchar(64)
             columnName: id
-        - dropPrimaryKey:
-            constraintName: pk_${gravitee_prefix}keys
-            tableName: ${gravitee_prefix}keys
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}keys
-            columnNames: id
-            tableName: ${gravitee_prefix}keys
+        # Move PK from `key` to `id`. Combined ALTER for MySQL/MariaDB so
+        # strict-PK mode does not reject the drop. The table name is `keys`
+        # which is a MySQL reserved word, so the identifier MUST be backticked
+        # here — typed dropPrimaryKey / addPrimaryKey actions auto-quote, but
+        # raw <sql> does not, and an empty gravitee_prefix would otherwise
+        # resolve to "ALTER TABLE keys …" and fail with a syntax error.
+        - sql:
+            dbms: mysql, mariadb
+            sql: |
+                ALTER TABLE `${gravitee_prefix}keys`
+                    DROP PRIMARY KEY,
+                    ADD CONSTRAINT `pk_${gravitee_prefix}keys` PRIMARY KEY (id);
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}keys DROP CONSTRAINT pk_${gravitee_prefix}keys
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}keys ADD CONSTRAINT pk_${gravitee_prefix}keys PRIMARY KEY (id)
 
         - addColumn:
             tableName: ${gravitee_prefix}keys

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_20/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_20/schema.yml
@@ -1,61 +1,215 @@
+# Retrofits primary keys onto tables that were originally created without
+# one. Each table gets its own changeSet with a `not primaryKeyExists`
+# precondition: on fresh deploys the originating createTable now embeds the
+# PK inline (so the precondition fails and Liquibase marks the changeSet as
+# RAN), while on older deploys upgrading through 3.15.20 the precondition
+# passes and the addPrimaryKey runs as before.
 databaseChangeLog:
   - changeSet:
-      id: 3.15.20
+      id: 3.15.20-alert_event_rules
       author: GraviteeSource Team
       validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}alert_event_rules
       changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}alert_event_rules
             columnNames: alert_id, alert_event
             tableName: ${gravitee_prefix}alert_event_rules
+
+  - changeSet:
+      id: 3.15.20-api_groups
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}api_groups
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}api_groups
             columnNames: api_id, group_id
             tableName: ${gravitee_prefix}api_groups
+
+  - changeSet:
+      id: 3.15.20-application_groups
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}application_groups
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}application_groups
             columnNames: application_id, group_id
             tableName: ${gravitee_prefix}application_groups
+
+  - changeSet:
+      id: 3.15.20-client_registration_provider_scopes
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}client_registration_provider_scopes
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}client_registration_provider_scopes
             columnNames: client_registration_provider_id, scope
             tableName: ${gravitee_prefix}client_registration_provider_scopes
+
+  - changeSet:
+      id: 3.15.20-custom_user_fields_values
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}custom_user_fields_values
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}custom_user_fields_values
             columnNames: key, reference_id, reference_type
             tableName: ${gravitee_prefix}custom_user_fields_values
+
+  - changeSet:
+      id: 3.15.20-databasechangelog
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}databasechangelog
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}databasechangelog
-            columnNames: ID
+            columnNames: ID, AUTHOR, FILENAME
             tableName: ${gravitee_prefix}databasechangelog
+
+  - changeSet:
+      id: 3.15.20-event_environments
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}event_environments
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}event_environments
             columnNames: event_id, environment_id
             tableName: ${gravitee_prefix}event_environments
+
+  - changeSet:
+      id: 3.15.20-group_event_rules
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}group_event_rules
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}group_event_rules
             columnNames: group_id, group_event
             tableName: ${gravitee_prefix}group_event_rules
+
+  - changeSet:
+      id: 3.15.20-installation
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}installation
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}installation
             columnNames: id
             tableName: ${gravitee_prefix}installation
+
+  - changeSet:
+      id: 3.15.20-installation_informations
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}installation_informations
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}installation_informations
             columnNames: installation_id, information_key
             tableName: ${gravitee_prefix}installation_informations
+
+  - changeSet:
+      id: 3.15.20-node_monitoring
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}node_monitoring
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}node_monitoring
             columnNames: id
             tableName: ${gravitee_prefix}node_monitoring
+
+  - changeSet:
+      id: 3.15.20-notification_templates
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}notification_templates
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}notification_templates
             columnNames: id
             tableName: ${gravitee_prefix}notification_templates
+
+  - changeSet:
+      id: 3.15.20-promotions
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}promotions
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}promotions
             columnNames: id
             tableName: ${gravitee_prefix}promotions
+
+  - changeSet:
+      id: 3.15.20-tag_groups
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}tag_groups
+      changes:
         - addPrimaryKey:
             constraintName: pk_${gravitee_prefix}tag_groups
             columnNames: tag_id, group_id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_21/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_21/schema.yml
@@ -1,21 +1,112 @@
 databaseChangeLog:
+  # The original v3.15.21 migration replaced flow_steps's composite PK with a
+  # synthetic auto-increment `id` column. Two complications drove the rewrite
+  # below:
+  #
+  #   * In the historical 3.x train, flow_steps was created in v3.9.0 without
+  #     any PK and the PK was added as a separate addPrimaryKey under v3_15_20
+  #     (then dropped+rebuilt to the synthetic id by 3.15.21). This PR moves
+  #     the synthetic id PK back to v3_9_0's inline createTable for fresh
+  #     deploys, so HEAD's v3_15_20 no longer touches flow_steps. But legacy
+  #     baselines that haven't yet applied v3_15_20's flow_steps PK addition
+  #     (e.g. 3.15.0) still arrive here with a PK-less flow_steps. The
+  #     migration therefore has to handle both "rebuild PK" and "first PK on
+  #     the table".
+  #   * MySQL `sql_require_primary_key=ON` rejects a transient PK-less state,
+  #     so the drop+add must be a single ALTER on MySQL/MariaDB.
+  #   * Liquibase 4.27's action-level `dbms: '!mysql, !mariadb'` filter is
+  #     unreliable on typed actions (addColumn/dropPrimaryKey), so dbms is
+  #     applied at the changeSet header where it works correctly.
+  #
+  # All four changesets gate on `not columnExists id`, so they MARK_RAN on
+  # any deploy that has already adopted the synthetic id PK (fresh deploys
+  # via v3.9.0's inline createTable, plus any prior 3.15.21 application).
+
+  # CASE 1 — flow_steps has a PRIOR PK to replace.
+
   - changeSet:
+      id: 3.15.21-rebuild-flow-steps-pk-mysql
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      dbms: mysql, mariadb
       preConditions:
         - onFail: MARK_RAN
         - primaryKeyExists:
             tableName: ${gravitee_prefix}flow_steps
-      id: 3.15.21-clean-flow-steps-pk
-      author: GraviteeSource Team
+        - not:
+            - columnExists:
+                tableName: ${gravitee_prefix}flow_steps
+                columnName: id
       changes:
-        # Drop any existing PK on the flow_steps table
+        - sql:
+            sql: |
+                ALTER TABLE ${gravitee_prefix}flow_steps
+                    DROP PRIMARY KEY,
+                    ADD COLUMN id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY;
+
+  - changeSet:
+      id: 3.15.21-rebuild-flow-steps-pk-others
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      dbms: '!mysql, !mariadb'
+      preConditions:
+        - onFail: MARK_RAN
+        - primaryKeyExists:
+            tableName: ${gravitee_prefix}flow_steps
+        - not:
+            - columnExists:
+                tableName: ${gravitee_prefix}flow_steps
+                columnName: id
+      changes:
         - dropPrimaryKey:
             dropIndex: true
             tableName: ${gravitee_prefix}flow_steps
+        - addColumn:
+            tableName: ${gravitee_prefix}flow_steps
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+
+  # CASE 2 — flow_steps has NO prior PK (3.15.0-era baselines). Just add id+PK.
+
   - changeSet:
-      id: 3.15.21
+      id: 3.15.21-add-flow-steps-id-mysql
       author: GraviteeSource Team
+      validCheckSum: ANY
+      dbms: mysql, mariadb
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}flow_steps
+        - not:
+            - columnExists:
+                tableName: ${gravitee_prefix}flow_steps
+                columnName: id
       changes:
-        # Create a new auto increment column and set it as a PK
+        - sql:
+            sql: ALTER TABLE ${gravitee_prefix}flow_steps ADD COLUMN id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY;
+
+  - changeSet:
+      id: 3.15.21-add-flow-steps-id-others
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      dbms: '!mysql, !mariadb'
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            - primaryKeyExists:
+                tableName: ${gravitee_prefix}flow_steps
+        - not:
+            - columnExists:
+                tableName: ${gravitee_prefix}flow_steps
+                columnName: id
+      changes:
         - addColumn:
             tableName: ${gravitee_prefix}flow_steps
             columns:

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_17_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_17_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 3.17.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - addColumn:
             tableName: ${gravitee_prefix}applications
@@ -14,12 +15,8 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}key_subscriptions
             columns:
-              - column: { name: key_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: subscription_id, type: nvarchar(64), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}key_subscriptions
-            columnNames: key_id, subscription_id
-            tableName: ${gravitee_prefix}key_subscriptions
+              - column: {name: key_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}key_subscriptions" } }
+              - column: {name: subscription_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
         - dropNotNullConstraint:
             columnDataType: nvarchar(64)
             columnName: api

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_19_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_19_0/schema.yml
@@ -18,44 +18,28 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}flow_selectors
             columns:
-              - column: { name: flow_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: type, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: flow_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}flow_selectors" } }
+              - column: {name: type, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
               - column: { name: path, type: nvarchar(256), constraints: { nullable: true } }
               - column: { name: path_operator, type: nvarchar(64), constraints: { nullable: true } }
               - column: { name: condition, type: nvarchar(64), constraints: { nullable: true } }
               - column: { name: channel, type: nvarchar(64), constraints: { nullable: true } }
               - column: { name: channel_operator, type: nvarchar(64), constraints: { nullable: true } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}flow_selectors
-            columnNames: flow_id, type
-            tableName: ${gravitee_prefix}flow_selectors
         - createTable:
             tableName: ${gravitee_prefix}flow_selector_http_methods
             columns:
-              - column: { name: flow_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: method, type: nvarchar(32), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}flow_selector_http_methods
-            columnNames: flow_id, method
-            tableName: ${gravitee_prefix}flow_selector_http_methods
+              - column: {name: flow_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}flow_selector_http_methods" } }
+              - column: {name: method, type: nvarchar(32), constraints: { nullable: false, primaryKey: true } }
         - createTable:
             tableName: ${gravitee_prefix}flow_selector_channel_operations
             columns:
-              - column: { name: flow_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: channel_operation, type: nvarchar(32), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}flow_selector_channel_operations
-            columnNames: flow_id, channel_operation
-            tableName: ${gravitee_prefix}flow_selector_channel_operations
+              - column: {name: flow_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}flow_selector_channel_operations" } }
+              - column: {name: channel_operation, type: nvarchar(32), constraints: { nullable: false, primaryKey: true } }
         - createTable:
             tableName: ${gravitee_prefix}flow_tags
             columns:
-              - column: { name: flow_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: tag, type: nvarchar(32), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}flow_tags
-            columnNames: flow_id, tag
-            tableName: ${gravitee_prefix}flow_tags
+              - column: {name: flow_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}flow_tags" } }
+              - column: {name: tag, type: nvarchar(32), constraints: { nullable: false, primaryKey: true } }
         - addColumn:
             tableName: ${gravitee_prefix}apis
             columns:

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_0/schema.yml
@@ -10,12 +10,8 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}flow_selector_channel_entrypoints
             columns:
-              - column: { name: flow_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: channel_entrypoint, type: nvarchar(32), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}flow_selector_channel_entrypoints
-            columnNames: flow_id, channel_entrypoint
-            tableName: ${gravitee_prefix}flow_selector_channel_entrypoints
+              - column: {name: flow_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}flow_selector_channel_entrypoints" } }
+              - column: {name: channel_entrypoint, type: nvarchar(32), constraints: { nullable: false, primaryKey: true } }
         - addColumn:
             tableName: ${gravitee_prefix}flow_steps
             columns:
@@ -37,6 +33,12 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}subscriptions_metadata
             columns:
+              # Synthetic auto-increment id PK is normally added later by the
+              # v3.20.4 changeset. Adding it inline here so the initial CREATE
+              # TABLE has a primary key on MySQL with sql_require_primary_key=ON.
+              # The v3.20.4 changeset is guarded by a precondition that skips
+              # it when this column already exists.
+              - column: {name: id, type: bigint, autoIncrement: true, constraints: { primaryKey: true, nullable: false, primaryKeyName: "pk_${gravitee_prefix}subscriptions_metadata" } }
               - column: {name: subscription_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: k, type: nvarchar(128), constraints: { nullable: false } }
               - column: {name: v, type: nvarchar(4000), constraints: { nullable: false } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_4/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_4/schema.yml
@@ -2,6 +2,15 @@ databaseChangeLog:
   - changeSet:
       id: 3.20.4
       author: GraviteeSource Team
+      validCheckSum: ANY
+      preConditions:
+        # Skip when the id column already exists, which is true on fresh
+        # deploys where v3.20.0 created the table with the inline id PK.
+        - onFail: MARK_RAN
+        - not:
+            - columnExists:
+                tableName: ${gravitee_prefix}subscriptions_metadata
+                columnName: id
       changes:
         # Create a new auto increment column and set it as a PK
         - addColumn:

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_2_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_2_0/schema.yml
@@ -2,22 +2,18 @@ databaseChangeLog:
   - changeSet:
       id: 3.2.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}page_revisions
             columns:
-              - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: revision, type: int, constraints: { nullable: false } }
+              - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}page_revisions" } }
+              - column: {name: revision, type: int, constraints: { nullable: false, primaryKey: true } }
               - column: {name: name, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: hash, type: nvarchar(256), constraints: { nullable: true } }
               - column: {name: content, type: nclob, constraints: { nullable: true } }
               - column: {name: contributor, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}page_revisions
-            columnNames: page_id, revision
-            tableName: ${gravitee_prefix}page_revisions
 
         - addColumn:
             tableName: ${gravitee_prefix}plans
@@ -73,19 +69,16 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}custom_user_fields
             columns:
-              - column: {name: key, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: reference_type, type: nvarchar(32), constraints: { nullable: false } }
+              # PK column order (key, reference_type, reference_id) matches the original v3.2.0
+              # addPrimaryKey so fresh and upgraded deploys share the same PK index sort.
+              - column: {name: key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}custom_user_fields" } }
+              - column: {name: reference_type, type: nvarchar(32), constraints: { nullable: false, primaryKey: true } }
+              - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
               - column: {name: label, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: format, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: required, type: boolean, constraints: { nullable: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}custom_user_fields
-            columnNames: key, reference_type, reference_id
-            tableName: ${gravitee_prefix}custom_user_fields
 
         - createIndex:
             indexName: idx_${gravitee_prefix}custom_user_fields_by_ref
@@ -101,9 +94,9 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}custom_user_fields_values
             columns:
-              - column: {name: key, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: reference_type, type: nvarchar(32), constraints: { nullable: false } }
+              - column: {name: key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}custom_user_fields_values" } }
+              - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+              - column: { name: reference_type, type: nvarchar(32), constraints: { nullable: false, primaryKey: true } }
               - column: { name: value, type: nvarchar(1024), constraints: { nullable: false } }
 
         - createIndex:
@@ -123,13 +116,8 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}page_attached_media
             columns:
-              - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: media_hash, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: media_name, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: attached_at, type: timestamp(6), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}page_attached_media
-            columnNames: page_id, media_hash, media_name, attached_at
-            tableName: ${gravitee_prefix}page_attached_media
+              - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}page_attached_media" } }
+              - column: {name: media_hash, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+              - column: {name: media_name, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+              - column: {name: attached_at, type: timestamp(6), constraints: { nullable: false, primaryKey: true } }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_4_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_4_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 3.4.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - sql:
             - sql: update ${gravitee_prefix}audits set reference_type = 'ORGANIZATION' where reference_type = 'PORTAL' and (event like 'IDENTITY_PROVIDER%' or event like 'ROLE%' or event like 'USER%' or (event like 'MEMBERSHIP%' and patch like '%organization%'));
@@ -11,18 +12,14 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}identity_provider_activations
             columns:
-              - column: {name: identity_provider_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: reference_type, type: nvarchar(32), constraints: { nullable: false } }
+              - column: {name: identity_provider_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}identity_provider_activations" } }
+              - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+              - column: {name: reference_type, type: nvarchar(32), constraints: { nullable: false, primaryKey: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}identity_provider_activations
-            columnNames: identity_provider_id, reference_id, reference_type
-            tableName: ${gravitee_prefix}identity_provider_activations
         - createTable:
             tableName: ${gravitee_prefix}notification_templates
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}notification_templates" } }
               - column: {name: hook, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: scope, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
@@ -36,25 +33,16 @@ databaseChangeLog:
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
               - column: {name: enabled, type: boolean, constraints: { nullable: false } }
 
-              - addPrimaryKey:
-                  constraintName: pk_${gravitee_prefix}notification_templates
-                  columnNames: id
-
         - createTable:
             tableName: ${gravitee_prefix}tickets
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}tickets" } }
               - column: {name: from_user, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
               - column: {name: api, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: application, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: subject, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: content, type: nclob, constraints: { nullable: true } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}tickets
-            columnNames: id
-            tableName: ${gravitee_prefix}tickets
 
         - sql:
             sql: delete from ${gravitee_prefix}role_permissions where role_id = (select id from ${gravitee_prefix}roles r where r.scope = 'API' and r.name='REVIEWER') and permission like '30%';

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_5_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_5_0/schema.yml
@@ -2,18 +2,32 @@ databaseChangeLog:
   - changeSet:
       id: 3.5.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - addNotNullConstraint:
             tableName: ${gravitee_prefix}parameters
             columnDataType: nvarchar(32)
             columnName: reference_type
-        - dropPrimaryKey:
-            constraintName: pk_${gravitee_prefix}parameters
-            tableName: ${gravitee_prefix}parameters
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}parameters
-            columnNames: key, reference_id, reference_type
-            tableName: ${gravitee_prefix}parameters
+        # Rebuild PK (key) → (key, reference_id, reference_type). Combined
+        # ALTER for MySQL/MariaDB so strict-PK mode does not reject the drop.
+        - sql:
+            dbms: mysql, mariadb
+            sql: |
+                ALTER TABLE ${gravitee_prefix}parameters
+                    DROP PRIMARY KEY,
+                    ADD CONSTRAINT pk_${gravitee_prefix}parameters PRIMARY KEY (`key`, reference_id, reference_type);
+        # Typed dropPrimaryKey / addPrimaryKey honour the dbms filter inconsistently
+        # on individual change-actions in our pinned Liquibase — they were observed
+        # to run on MySQL even with dbms: '!mysql, !mariadb' and then trip
+        # sql_require_primary_key=ON. Stick to raw <sql> here, where dbms is
+        # honoured reliably; the MySQL/MariaDB combined ALTER above already covers
+        # those engines.
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}parameters DROP CONSTRAINT pk_${gravitee_prefix}parameters
+        - sql:
+            dbms: '!mysql, !mariadb'
+            sql: ALTER TABLE ${gravitee_prefix}parameters ADD CONSTRAINT pk_${gravitee_prefix}parameters PRIMARY KEY ("key", reference_id, reference_type)
         # dbms: mariadb, mysql
         - sql:
             dbms: mariadb, mysql

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_6_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_6_0/schema.yml
@@ -2,41 +2,32 @@ databaseChangeLog:
   - changeSet:
       id: 3.6.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}organization_hrids
             columns:
-              - column: { name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: hrid, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}organization_hrids" } }
+              - column: {name: hrid, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
               - column: { name: pos, type: integer, constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}organization_hrids
-            columnNames: organization_id, hrid
-            tableName: ${gravitee_prefix}organization_hrids
 
         - createTable:
             tableName: ${gravitee_prefix}environment_hrids
             columns:
-              - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: hrid, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}environment_hrids" } }
+              - column: {name: hrid, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
               - column: { name: pos, type: integer, constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}environment_hrids
-            columnNames: environment_id, hrid
-            tableName: ${gravitee_prefix}environment_hrids
 
         - createTable:
             tableName: ${gravitee_prefix}installation
             columns:
-              - column: { name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}installation" } }
               - column: { name: created_at, type: timestamp(6), constraints: { nullable: true } }
               - column: { name: updated_at, type: timestamp(6), constraints: { nullable: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}installation_informations
             columns:
-              - column: { name: installation_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: information_key, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: installation_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}installation_informations" } }
+              - column: { name: information_key, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
               - column: { name: information_value, type: nvarchar(256), constraints: { nullable: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_8_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_8_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 3.8.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - addColumn:
             tableName: ${gravitee_prefix}pages
@@ -24,17 +25,13 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}node_monitoring
             columns:
-              - column: { name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}node_monitoring" } }
               - column: { name: node_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: type, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: payload, type: nclob, constraints: { nullable: false } }
               - column: { name: created_at, type: timestamp(6), constraints: { nullable: true } }
               - column: { name: evaluated_at, type: timestamp(6), constraints: { nullable: true } }
               - column: { name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-
-              - addPrimaryKey:
-                  constraintName: pk_${gravitee_prefix}node_monitoring
-                  columnNames: id
 
         - addColumn:
             tableName: ${gravitee_prefix}pages
@@ -46,14 +43,9 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}page_acl
             columns:
-              - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}page_acl
-            columnNames: page_id, reference_id, reference_type
-            tableName: ${gravitee_prefix}page_acl
+              - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}page_acl" } }
+              - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+              - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - sql:
             sql: insert into ${gravitee_prefix}page_acl (page_id, reference_id, reference_type) select page_id, excluded_group, 'GROUP' from ${gravitee_prefix}page_excluded_groups;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_9_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_9_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 3.9.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - addColumn:
             tableName: ${gravitee_prefix}tags
@@ -68,8 +69,8 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}event_environments
             columns:
-              - column: { name: event_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: { name: event_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}event_environments" } }
+              - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
 
         - sql:
             sql: insert into ${gravitee_prefix}event_environments (event_id, environment_id) select id, environment_id from ${gravitee_prefix}events;
@@ -82,7 +83,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}flows
             columns:
-              - column: { name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}flows" } }
               - column: { name: condition, type: nvarchar(64), constraints: { nullable: true } }
               - column: { name: created_at, type: timestamp(6), constraints: { nullable: false } }
               - column: { name: enabled, type: boolean, constraints: { nullable: false } }
@@ -94,14 +95,16 @@ databaseChangeLog:
               - column: { name: updated_at, type: timestamp(6), constraints: { nullable: true } }
               - column: { name: order, type: integer, constraints: { nullable: true } }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}flows
-            columnNames: id
-            tableName: ${gravitee_prefix}flows
-
         - createTable:
             tableName: ${gravitee_prefix}flow_steps
             columns:
+              # The synthetic auto-increment id PK is normally added later by
+              # the v3.15.21 changeset. We add it inline here so that on a
+              # fresh deploy against MySQL with sql_require_primary_key=ON the
+              # initial CREATE TABLE has a primary key. The v3.15.21 changesets
+              # are guarded by preconditions that skip them when this column
+              # already exists.
+              - column: { name: id, type: bigint, autoIncrement: true, constraints: { primaryKey: true, nullable: false, primaryKeyName: "pk_${gravitee_prefix}flow_steps" } }
               - column: { name: flow_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: configuration, type: nclob, constraints: { nullable: true } }
               - column: { name: description, type: nvarchar(256), constraints: { nullable: true } }
@@ -114,25 +117,15 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}flow_methods
             columns:
-              - column: { name: flow_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: method, type: nvarchar(32), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}flow_methods
-            columnNames: flow_id, method
-            tableName: ${gravitee_prefix}flow_methods
+              - column: {name: flow_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}flow_methods" } }
+              - column: {name: method, type: nvarchar(32), constraints: { nullable: false, primaryKey: true } }
 
         - createTable:
             tableName: ${gravitee_prefix}flow_consumers
             columns:
-              - column: { name: flow_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: consumer_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: consumer_type, type: nvarchar(32), constraints: { nullable: false } }
-
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}flow_consumers
-            columnNames: flow_id, consumer_id, consumer_type
-            tableName: ${gravitee_prefix}flow_consumers
+              - column: {name: flow_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}flow_consumers" } }
+              - column: {name: consumer_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
+              - column: {name: consumer_type, type: nvarchar(32), constraints: { nullable: false, primaryKey: true } }
 
         - addColumn:
             tableName: ${gravitee_prefix}organizations

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/00_add_flow_mcp_selector.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/00_add_flow_mcp_selector.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 4.10.0_00_add_flow_mcp_selector.yml
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         # ################
         # Add Flow MCP Selector
@@ -9,9 +10,5 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}flow_selector_mcp_methods
             columns:
-              - column: { name: flow_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: method, type: nvarchar(256), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}flow_selector_mcp_methods
-            columnNames: flow_id, method
-            tableName: ${gravitee_prefix}flow_selector_mcp_methods
+              - column: {name: flow_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}flow_selector_mcp_methods" } }
+              - column: {name: method, type: nvarchar(256), constraints: { nullable: false, primaryKey: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/01_add_portal_page_contents_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/01_add_portal_page_contents_table.yml
@@ -2,18 +2,14 @@ databaseChangeLog:
   - changeSet:
       id: 4.10.0_01_add_portal_page_contents_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}portal_page_contents
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}portal_page_contents" } }
               - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: type, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: configuration, type: nclob, constraints: { nullable: true } }
               - column: {name: content, type: nclob, constraints: { nullable: true } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}portal_page_contents
-            columnNames: id
-            tableName: ${gravitee_prefix}portal_page_contents
-

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/02_add_portal_navigation_items_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_10_0/02_add_portal_navigation_items_table.yml
@@ -2,11 +2,12 @@ databaseChangeLog:
   - changeSet:
       id: 4.10.0_02_add_portal_navigation_items_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}portal_navigation_items
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}portal_navigation_items" } }
               - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: title, type: nvarchar(255), constraints: { nullable: false } }
@@ -17,10 +18,6 @@ databaseChangeLog:
               - column: {name: published, type: boolean, constraints: { nullable: false } }
               - column: {name: visibility, type: nvarchar(16), constraints: { nullable: false } }
               - column: {name: configuration, type: nclob, constraints: { nullable: true } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}portal_navigation_items
-            columnNames: id
-            tableName: ${gravitee_prefix}portal_navigation_items
         - addUniqueConstraint:
             columnNames: organization_id, environment_id, title
             constraintName: uk_${gravitee_prefix}portal_navigation_items_org_env_title

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/00_add_api_products_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/00_add_api_products_table.yml
@@ -2,21 +2,18 @@ databaseChangeLog:
   - changeSet:
       id: 4.11.0_00_add_api_products_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}api_products
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}api_products" } }
               - column: {name: name, type: nvarchar(512), constraints: { nullable: false } }
               - column: {name: description, type: clob, constraints: { nullable: true } }
               - column: {name: version, type: nvarchar(64), constraints: { nullable: true } }
               - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}api_products
-            columnNames: id
-            tableName: ${gravitee_prefix}api_products
         - createIndex:
             indexName: idx_${gravitee_prefix}api_products_env_name
             tableName: ${gravitee_prefix}api_products

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/01_add_api_product_apis_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/01_add_api_product_apis_table.yml
@@ -2,16 +2,13 @@ databaseChangeLog:
   - changeSet:
       id: 4.11.0_01_add_api_product_apis_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}api_product_apis
             columns:
-              - column: {name: api_product_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}api_product_apis
-            columnNames: api_product_id, api_id
-            tableName: ${gravitee_prefix}api_product_apis
+              - column: {name: api_product_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}api_product_apis" } }
+              - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
         - createIndex:
             indexName: idx_${gravitee_prefix}api_product_apis_api_id
             tableName: ${gravitee_prefix}api_product_apis

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/02_add_client_certificates_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/02_add_client_certificates_table.yml
@@ -2,11 +2,12 @@ databaseChangeLog:
   - changeSet:
       id: 4.11.0_00_add_client_certificates_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}client_certificates
             columns:
-              - column: { name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}client_certificates" } }
               - column: { name: cross_id, type: nvarchar(64) , constraints: { nullable: false }}
               - column: { name: application_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: name, type: nvarchar(512), constraints: { nullable: false } }
@@ -21,10 +22,6 @@ databaseChangeLog:
               - column: { name: fingerprint, type: nvarchar(256), constraints: { nullable: false } }
               - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: status, type: nvarchar(32), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}client_certificates
-            columnNames: id
-            tableName: ${gravitee_prefix}client_certificates
         - createIndex:
             tableName: ${gravitee_prefix}client_certificates
             indexName: idx_${gravitee_prefix}client_certificates_application_id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/06_create_custom_dashboards_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/06_create_custom_dashboards_table.yml
@@ -2,11 +2,12 @@ databaseChangeLog:
   - changeSet:
       id: 4.11.0_06_create_custom_dashboards_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}custom_dashboards
             columns:
-              - column: { name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}custom_dashboards" } }
               - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: name, type: nvarchar(512), constraints: { nullable: false } }
               - column: { name: created_by, type: nvarchar(64), constraints: { nullable: false } }
@@ -14,10 +15,6 @@ databaseChangeLog:
               - column: { name: last_modified, type: timestamp(6), constraints: { nullable: false } }
               - column: { name: labels, type: nclob }
               - column: { name: widgets, type: nclob }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}custom_dashboards
-            columnNames: id
-            tableName: ${gravitee_prefix}custom_dashboards
         - createIndex:
             tableName: ${gravitee_prefix}custom_dashboards
             indexName: idx_${gravitee_prefix}custom_dashboards_environment_id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/08_add_subscription_forms_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_0/08_add_subscription_forms_table.yml
@@ -2,18 +2,15 @@ databaseChangeLog:
   - changeSet:
       id: 4.11.0_08_add_subscription_forms_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}subscription_forms
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}subscription_forms" } }
               - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: gmd_content, type: nclob, constraints: { nullable: false } }
               - column: {name: enabled, type: boolean, constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}subscription_forms
-            columnNames: id
-            tableName: ${gravitee_prefix}subscription_forms
         - addUniqueConstraint:
             constraintName: uc_${gravitee_prefix}subscription_forms_environment_id
             columnNames: environment_id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_3_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_3_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 4.3.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         # ################
         # License changes
@@ -9,13 +10,9 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}licenses
             columns:
-              - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: reference_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}licenses" } }
+              - column: {name: reference_type, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
               - column: {name: license, type: nvarchar(256), constraints: { nullable: false } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false } }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}licenses
-            columnNames: reference_id, reference_type
-            tableName: ${gravitee_prefix}licenses

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_0/00_add_new_integration_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_0/00_add_new_integration_table.yml
@@ -2,11 +2,12 @@ databaseChangeLog:
   - changeSet:
       id: 4.4.0_add_integration_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}integrations
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}integrations" } }
               - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: description, type: nvarchar(256), constraints: { nullable: true } }
               - column: {name: provider, type: nvarchar(16), constraints: { nullable: false } }
@@ -15,10 +16,6 @@ databaseChangeLog:
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}integrations
-            columnNames: id
-            tableName: ${gravitee_prefix}integrations
         - createIndex:
             indexName: idx_${gravitee_prefix}integrations_environment_id
             columns:

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_0/06_add_new_api_category_order_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_4_0/06_add_new_api_category_order_table.yml
@@ -2,14 +2,11 @@ databaseChangeLog:
   - changeSet:
       id: 4.4.0_add_api_category_order_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}api_category_orders
             columns:
-              - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: {name: category_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: api_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}api_category_orders" } }
+              - column: {name: category_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }
               - column: {name: order, type: integer, constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}api_category_orders
-            columnNames: api_id, category_id
-            tableName: ${gravitee_prefix}api_category_orders

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/01_add_async_jobs_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/01_add_async_jobs_table.yml
@@ -2,11 +2,12 @@ databaseChangeLog:
   - changeSet:
       id: 4.5.0_add_async_jobs
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}asyncjobs
             columns:
-              - column: { name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}asyncjobs" } }
               - column: { name: source_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: { name: type, type: nvarchar(32), constraints: { nullable: false } }
@@ -17,7 +18,3 @@ databaseChangeLog:
               - column: { name: created_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
               - column: { name: updated_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
 
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}asyncjobs
-            columnNames: id
-            tableName: ${gravitee_prefix}asyncjobs

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/02_add_shared_policy_group.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/02_add_shared_policy_group.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 4.5.0_add_shared_policy_group
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         # ################
         # shared policy group changes
@@ -9,7 +10,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}sharedpolicygroups
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}sharedpolicygroups" } }
               - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: environment_id, type: nvarchar(64) }
               - column: {name: cross_id, type: nvarchar(64), constraints: { nullable: false } }
@@ -24,10 +25,6 @@ databaseChangeLog:
               - column: {name: deployed_at, type: timestamp(6), constraints: { nullable: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}sharedpolicygroups
-            columnNames: id
-            tableName: ${gravitee_prefix}sharedpolicygroups
         - createIndex:
             tableName: ${gravitee_prefix}sharedpolicygroups
             indexName: idx_${gravitee_prefix}environment_id_name
@@ -54,7 +51,7 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}sharedpolicygrouphistories
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}sharedpolicygrouphistories" } }
               - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: environment_id, type: nvarchar(64) }
               - column: {name: cross_id, type: nvarchar(64), constraints: { nullable: false } }
@@ -68,11 +65,7 @@ databaseChangeLog:
               - column: {name: lifecycle_state, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: deployed_at, type: timestamp(6), constraints: { nullable: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
-              - column: {name: updated_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}sharedpolicygrouphistories
-            columnNames: id, updated_at
-            tableName: ${gravitee_prefix}sharedpolicygrouphistories
+              - column: {name: updated_at, type: timestamp(6), constraints: { nullable: false, primaryKey: true }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
         - createIndex:
             tableName: ${gravitee_prefix}sharedpolicygrouphistories
             indexName: idx_${gravitee_prefix}environment_id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/05_add_integration_groups_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_5_0/05_add_integration_groups_table.yml
@@ -2,13 +2,10 @@ databaseChangeLog:
     - changeSet:
           id: 4.5.0_add_integration_groups
           author: GraviteeSource Team
+          validCheckSum: ANY
           changes:
               - createTable:
                     tableName: ${gravitee_prefix}integration_groups
                     columns:
-                        - column: { name: integration_id, type: nvarchar(64), constraints: { nullable: false } }
-                        - column: { name: group_id, type: nvarchar(64), constraints: { nullable: false } }
-              - addPrimaryKey:
-                    constraintName: pk_${gravitee_prefix}integration_groups
-                    columnNames: integration_id, group_id
-                    tableName: ${gravitee_prefix}integration_groups
+                        - column: { name: integration_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}integration_groups" } }
+                        - column: { name: group_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_9_0/03_add_clusters_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_9_0/03_add_clusters_table.yml
@@ -2,11 +2,12 @@ databaseChangeLog:
   - changeSet:
       id: 4.9.0_03_add_clusters_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}clusters
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}clusters" } }
               - column: { name: created_at, type: timestamp(6), constraints: { nullable: false }, defaultValueComputed: CURRENT_TIMESTAMP(6) }
               - column: { name: updated_at, type: timestamp(6) }
               - column: {name: environment_id, type: nvarchar(64) }
@@ -14,10 +15,6 @@ databaseChangeLog:
               - column: {name: name, type: nvarchar(512), constraints: { nullable: false } }
               - column: {name: description, type: nvarchar(1024) }
               - column: {name: definition, type: nclob }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}clusters
-            columnNames: id
-            tableName: ${gravitee_prefix}clusters
         - createIndex:
             tableName: ${gravitee_prefix}clusters
             indexName: idx_${gravitee_prefix}clusters_environment_id_name

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_9_0/04_add_cluster_groups_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_9_0/04_add_cluster_groups_table.yml
@@ -2,13 +2,10 @@ databaseChangeLog:
   - changeSet:
       id: 4.9.0_04_add_cluster_groups_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         - createTable:
             tableName: ${gravitee_prefix}cluster_groups
             columns:
-              - column: { name: cluster_id, type: nvarchar(64), constraints: { nullable: false } }
-              - column: { name: group_id, type: nvarchar(64), constraints: { nullable: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}cluster_groups
-            columnNames: cluster_id, group_id
-            tableName: ${gravitee_prefix}cluster_groups
+              - column: {name: cluster_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}cluster_groups" } }
+              - column: {name: group_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true } }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_9_0/05_add_portal_pages_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_9_0/05_add_portal_pages_table.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 4.9.0_05_add_portal_pages_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         # ################
         # Portal Pages Table
@@ -9,13 +10,9 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}portal_pages
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}portal_pages" } }
               - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: name, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: content, type: nclob, constraints: { nullable: true } }
               - column: {name: created_at, type: timestamp(6), constraints: { nullable: true } }
               - column: {name: updated_at, type: timestamp(6), constraints: { nullable: true } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}portal_pages
-            columnNames: id
-            tableName: ${gravitee_prefix}portal_pages

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_9_0/06_add_portal_page_contexts_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_9_0/06_add_portal_page_contexts_table.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 4.9.0_06_add_portal_page_contexts_table
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         # ################
         # Portal Page Contexts Table
@@ -9,15 +10,11 @@ databaseChangeLog:
         - createTable:
             tableName: ${gravitee_prefix}portal_page_contexts
             columns:
-              - column: {name: id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}portal_page_contexts" } }
               - column: {name: page_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: context_type, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
               - column: {name: published, type: boolean, constraints: { nullable: false, default: false } }
-        - addPrimaryKey:
-            constraintName: pk_${gravitee_prefix}portal_page_contexts
-            columnNames: id
-            tableName: ${gravitee_prefix}portal_page_contexts
         - addUniqueConstraint:
             columnNames: page_id, context_type, environment_id
             constraintName: uk_${gravitee_prefix}portal_page_contexts_page_context_env

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryConfiguration.java
@@ -45,6 +45,9 @@ public class JdbcTestRepositoryConfiguration {
     @Value("${maxPoolSize:20}")
     private int maxPoolSize;
 
+    @Value("${strictPrimaryKey:false}")
+    private boolean strictPrimaryKey;
+
     @Bean
     public DataSource graviteeDataSource(JdbcDatabaseContainer container) {
         final HikariConfig dsConfig = getHikariConfig(container);
@@ -77,12 +80,25 @@ public class JdbcTestRepositoryConfiguration {
                 // I let this configuration for documentation purpose, but it does not solve our performance issue.
                 // See --> https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html
                 containerBean = new MySQLContainer<>(dockerImageName);
+                if (strictPrimaryKey) {
+                    // Reproduce MySQL HeatWave / Group Replication behaviour by forcing every
+                    // CREATE/ALTER TABLE to declare a primary key in a single statement.
+                    containerBean.withCommand("--sql-require-primary-key=ON");
+                }
                 break;
             case MARIADB:
                 // It appears that the limitation is not entirely due to the DB engine configuration, but also in the way I/O are managed between container and host.
                 // I let this configuration for documentation purpose, but it does not solve our performance issue.
                 // See --> https://mariadb.com/kb/en/innodb-system-variables/
                 containerBean = new MariaDBContainer<>(dockerImageName);
+                if (strictPrimaryKey) {
+                    // MariaDB honours sql_require_primary_key the same way MySQL does. Note: the
+                    // mariadb:12.1 testcontainer refuses to start with this flag (container exits
+                    // with code 1) so the strict-PK CI matrix is scoped to MySQL only — see
+                    // workflow-repositories-tests.ts. Kept here so manual local runs can still
+                    // attempt MariaDB strict-PK once a future image fixes the startup issue.
+                    containerBean.withCommand("--sql-require-primary-key=ON");
+                }
                 break;
             case SQLSERVER:
                 containerBean = new MSSQLServerContainer<>(dockerImageName);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -207,7 +207,10 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
             );
             liquibase.update((Contexts) null);
         } catch (final Exception ex) {
-            LOGGER.error("Failed to set up database: ", ex);
+            // Rethrow so a failed Liquibase bootstrap fails the test run loudly. Previously this
+            // was logged-and-swallowed, which made tests pass vacuously against an empty schema —
+            // strict-PK migration breakage in particular went undetected.
+            throw new IllegalStateException("Failed to set up database via Liquibase", ex);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/TableConstraintsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/TableConstraintsTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.jdbc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import io.gravitee.repository.config.AbstractRepositoryTest;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -45,17 +46,44 @@ public class TableConstraintsTest extends AbstractRepositoryTest {
 
     @Test
     public void shouldCheckEveryTableHasAPrimaryKey() {
-        // Skip test if db is not MySql as the following query is specific to MySql
-        // FIXME: Use JUnit assumptions instead when we upgrade to JUnit 5
-        if (!jdbcDatabaseContainer.getDockerImageName().contains(DatabaseConfigurationEnum.MYSQL.getDockerImageName())) {
-            return;
-        }
+        // The information_schema query below is specific to MySQL/MariaDB. Use assumeTrue so the
+        // test reports as SKIPPED on other engines rather than vacuously passing.
+        String image = jdbcDatabaseContainer.getDockerImageName();
+        assumeTrue(
+            "TableConstraintsTest only runs on MySQL / MariaDB",
+            image.contains(DatabaseConfigurationEnum.MYSQL.getDockerImageName()) ||
+                image.contains(DatabaseConfigurationEnum.MARIADB.getDockerImageName())
+        );
 
         String prefix = graviteeProperties.getProperty("management.jdbc.prefix", "");
 
         List<String> tables = new ArrayList<>();
         final JdbcTemplate jt = new JdbcTemplate(dataSource);
 
+        // Sanity precondition: the schema bootstrap actually created the core APIM tables. A
+        // failed Liquibase setup that left only the databasechangelog + lock tables would have
+        // tableCount > 0 but be missing every meaningful table — checking for representative
+        // core tables (apis, subscriptions, plans, users) closes that loophole, since each is
+        // created in v1_14_0 / v1_15_0 within the first dozen changesets.
+        Integer coreTableCount = jt.queryForObject(
+            "select count(*) from information_schema.tables " +
+                " where table_schema = (select database())" +
+                "   and table_type = 'BASE TABLE'" +
+                "   and table_name in (?, ?, ?, ?)",
+            Integer.class,
+            prefix + "apis",
+            prefix + "subscriptions",
+            prefix + "plans",
+            prefix + "users"
+        );
+        assertEquals(
+            "Bootstrap is missing one or more core tables (apis, subscriptions, plans, users) — Liquibase setup likely failed",
+            Integer.valueOf(4),
+            coreTableCount
+        );
+
+        // (select database()) reads the connection's current database so the test does not depend
+        // on the testcontainer's schema name being literally 'test'.
         jt.query(
             "select tab.table_schema as database_name,\n" +
                 "       tab.table_name\n" +
@@ -68,7 +96,7 @@ public class TableConstraintsTest extends AbstractRepositoryTest {
                 "  and tab.table_schema not in ('mysql', 'information_schema',\n" +
                 "                               'performance_schema', 'sys')\n" +
                 "  and tab.table_type = 'BASE TABLE'\n" +
-                "  and tab.table_schema = 'test' -- <-- database name\n" +
+                "  and tab.table_schema = (select database())\n" +
                 "order by tab.table_schema,\n" +
                 "         tab.table_name;",
             rs -> {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/liquibase/MySqlChangeLogTableWithPrimaryKeyGeneratorTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/liquibase/MySqlChangeLogTableWithPrimaryKeyGeneratorTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.liquibase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ServiceLoader;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.StreamSupport;
+import liquibase.database.core.MariaDBDatabase;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.CreateDatabaseChangeLogTableGenerator;
+import liquibase.statement.core.CreateDatabaseChangeLogTableStatement;
+import liquibase.structure.DatabaseObject;
+import org.junit.jupiter.api.Test;
+
+class MySqlChangeLogTableWithPrimaryKeyGeneratorTest {
+
+    private final MySqlChangeLogTableWithPrimaryKeyGenerator generator = new MySqlChangeLogTableWithPrimaryKeyGenerator();
+
+    @Test
+    void supports_MySQLDatabase() {
+        assertThat(generator.supports(new CreateDatabaseChangeLogTableStatement(), new MySQLDatabase())).isTrue();
+    }
+
+    @Test
+    void supports_MariaDBDatabase() {
+        assertThat(generator.supports(new CreateDatabaseChangeLogTableStatement(), new MariaDBDatabase())).isTrue();
+    }
+
+    @Test
+    void does_not_support_PostgresDatabase() {
+        assertThat(generator.supports(new CreateDatabaseChangeLogTableStatement(), new PostgresDatabase())).isFalse();
+    }
+
+    @Test
+    void priority_outranks_default_generator() {
+        assertThat(generator.getPriority()).isGreaterThan(new CreateDatabaseChangeLogTableGenerator().getPriority());
+    }
+
+    @Test
+    void splices_named_primary_key_into_create_table() {
+        Sql[] result = MySqlChangeLogTableWithPrimaryKeyGenerator.spliceWithPrimaryKey(
+            new Sql[] { sql("CREATE TABLE DATABASECHANGELOG (ID VARCHAR(255), AUTHOR VARCHAR(255), FILENAME VARCHAR(255))") },
+            "pk_DATABASECHANGELOG"
+        );
+        assertThat(result).hasSize(1);
+        assertThat(result[0].toSql()).isEqualTo(
+            "CREATE TABLE DATABASECHANGELOG (ID VARCHAR(255), AUTHOR VARCHAR(255), FILENAME VARCHAR(255), CONSTRAINT pk_DATABASECHANGELOG PRIMARY KEY (ID, AUTHOR, FILENAME))"
+        );
+    }
+
+    @Test
+    void honours_configured_constraint_name() {
+        Sql[] result = MySqlChangeLogTableWithPrimaryKeyGenerator.spliceWithPrimaryKey(
+            new Sql[] { sql("CREATE TABLE acme_databasechangelog (ID VARCHAR(255))") },
+            "pk_acme_databasechangelog"
+        );
+        assertThat(result[0].toSql()).contains("CONSTRAINT pk_acme_databasechangelog PRIMARY KEY (ID, AUTHOR, FILENAME)");
+    }
+
+    @Test
+    void tolerates_leading_whitespace_in_create_table() {
+        Sql[] result = MySqlChangeLogTableWithPrimaryKeyGenerator.spliceWithPrimaryKey(
+            new Sql[] { sql("\n  CREATE TABLE DATABASECHANGELOG (ID VARCHAR(255))") },
+            "pk_DATABASECHANGELOG"
+        );
+        assertThat(result[0].toSql()).contains("CONSTRAINT pk_DATABASECHANGELOG PRIMARY KEY (ID, AUTHOR, FILENAME)");
+    }
+
+    @Test
+    void passes_through_non_create_table_statements_when_a_create_table_is_present() {
+        Sql[] result = MySqlChangeLogTableWithPrimaryKeyGenerator.spliceWithPrimaryKey(
+            new Sql[] { sql("SET sql_mode = ''"), sql("CREATE TABLE DATABASECHANGELOG (ID VARCHAR(255))") },
+            "pk_DATABASECHANGELOG"
+        );
+        assertThat(result).hasSize(2);
+        assertThat(result[0].toSql()).isEqualTo("SET sql_mode = ''");
+        assertThat(result[1].toSql()).contains("CONSTRAINT pk_DATABASECHANGELOG PRIMARY KEY (ID, AUTHOR, FILENAME)");
+    }
+
+    @Test
+    void throws_when_no_create_table_is_present() {
+        Sql[] input = { sql("INSERT INTO DATABASECHANGELOG VALUES (1, 'a', 'b')") };
+        assertThatThrownBy(() -> MySqlChangeLogTableWithPrimaryKeyGenerator.spliceWithPrimaryKey(input, "pk_DATABASECHANGELOG"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Expected a CREATE TABLE statement");
+    }
+
+    @Test
+    void throws_when_create_table_has_no_balanced_parens() {
+        Sql[] input = { sql("CREATE TABLE DATABASECHANGELOG ID VARCHAR(255") };
+        assertThatThrownBy(() -> MySqlChangeLogTableWithPrimaryKeyGenerator.spliceWithPrimaryKey(input, "pk_DATABASECHANGELOG"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("no balanced column-list parentheses");
+    }
+
+    @Test
+    void splices_into_column_list_close_when_trailing_options_contain_parens() {
+        // Hypothetical future upstream output with a trailing partition clause whose own
+        // parens would fool a naive lastIndexOf(')'). The splice has to walk paren-depth and
+        // splice INSIDE the column list, before any trailing table options.
+        Sql[] result = MySqlChangeLogTableWithPrimaryKeyGenerator.spliceWithPrimaryKey(
+            new Sql[] {
+                sql(
+                    "CREATE TABLE DATABASECHANGELOG (ID VARCHAR(255), AUTHOR VARCHAR(255), FILENAME VARCHAR(255)) ENGINE=InnoDB PARTITION BY HASH(id) PARTITIONS 4"
+                ),
+            },
+            "pk_DATABASECHANGELOG"
+        );
+        assertThat(result[0].toSql()).isEqualTo(
+            "CREATE TABLE DATABASECHANGELOG (ID VARCHAR(255), AUTHOR VARCHAR(255), FILENAME VARCHAR(255), CONSTRAINT pk_DATABASECHANGELOG PRIMARY KEY (ID, AUTHOR, FILENAME)) ENGINE=InnoDB PARTITION BY HASH(id) PARTITIONS 4"
+        );
+    }
+
+    @Test
+    void throws_when_upstream_already_has_a_primary_key_clause() {
+        // If a future Liquibase release ships its own PRIMARY KEY clause inline, we must NOT
+        // splice another — that would emit two PK clauses and a duplicate-key DDL error at
+        // execution time. Throw with the offending SQL so the breakage surfaces clearly.
+        Sql[] input = {
+            sql("CREATE TABLE DATABASECHANGELOG (ID VARCHAR(255), AUTHOR VARCHAR(255), FILENAME VARCHAR(255), PRIMARY KEY (ID))"),
+        };
+        assertThatThrownBy(() -> MySqlChangeLogTableWithPrimaryKeyGenerator.spliceWithPrimaryKey(input, "pk_DATABASECHANGELOG"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("already contains a PRIMARY KEY");
+    }
+
+    @Test
+    void registered_via_service_loader() {
+        // META-INF/services/liquibase.sqlgenerator.SqlGenerator is the only thing tying our
+        // generator into Liquibase's dispatch — if the file goes missing or gets misnamed
+        // during a Maven packaging change, the whole strict-PK splice silently disappears.
+        // ServiceLoader.load returns the registered SqlGenerators on the test classpath so
+        // we can assert ours is in the list at unit-test time.
+        boolean found = StreamSupport.stream(ServiceLoader.load(SqlGenerator.class).spliterator(), false).anyMatch(
+            MySqlChangeLogTableWithPrimaryKeyGenerator.class::isInstance
+        );
+        assertThat(found)
+            .as("MySqlChangeLogTableWithPrimaryKeyGenerator must be registered via META-INF/services/liquibase.sqlgenerator.SqlGenerator")
+            .isTrue();
+    }
+
+    /**
+     * End-to-end smoke against the real Liquibase pipeline: drives the generator with the actual
+     * upstream {@link CreateDatabaseChangeLogTableStatement} on a real {@link MySQLDatabase}, so a
+     * future Liquibase contract change (renamed columns, removed columns, additional partition
+     * clauses, etc.) is caught here before it surfaces as ER_3750 in CI. The hand-crafted unit
+     * tests above only cover the splice arithmetic — this one pins the splice contract against
+     * what Liquibase actually produces.
+     */
+    @Test
+    void generateSql_splices_named_pk_into_real_upstream_output() {
+        SortedSet<SqlGenerator<CreateDatabaseChangeLogTableStatement>> emptyChain = new TreeSet<>();
+        Sql[] generated = generator.generateSql(
+            new CreateDatabaseChangeLogTableStatement(),
+            new MySQLDatabase(),
+            new SqlGeneratorChain<>(emptyChain)
+        );
+
+        assertThat(generated).isNotEmpty();
+        String sql = generated[0].toSql();
+        assertThat(sql).startsWith("CREATE TABLE");
+        // Constraint name derives from Database#getDatabaseChangeLogTableName(); MySQL defaults
+        // to lowercase databasechangelog.
+        assertThat(sql).contains("CONSTRAINT pk_databasechangelog PRIMARY KEY (ID, AUTHOR, FILENAME)");
+        // Spot-check that the columns Liquibase ships with survive the splice — guards against a
+        // future upstream change that adds/renames columns and silently breaks our retrofit.
+        assertThat(sql)
+            .contains("ID")
+            .contains("AUTHOR")
+            .contains("FILENAME")
+            .contains("DATEEXECUTED")
+            .contains("ORDEREXECUTED")
+            .contains("MD5SUM")
+            .contains("DEPLOYMENT_ID");
+    }
+
+    private static Sql sql(String text) {
+        return new UnparsedSql(text, ";", new DatabaseObject[0]);
+    }
+}


### PR DESCRIPTION
## Summary

Make the JDBC repository's Liquibase migrations compatible with MySQL deployments that enable `sql_require_primary_key=ON` (MySQL HeatWave / Group Replication / strict-PK setups). Previously, error 3750 was raised at the very first changeSet because the historical changelogs split `createTable` and `addPrimaryKey` into two SQL statements, several rebuild patterns drop the PK without an in-statement replacement, and Liquibase's own `DATABASECHANGELOG` is created without a PK.

- **100+ tables** in 45 changelogs: folded the trailing `addPrimaryKey` into inline column constraints on the originating `createTable`. Quoted `primaryKeyName` values that contain `${gravitee_prefix}` so SnakeYAML's flow-mapping parser does not stop at the placeholder's closing brace.
- **15 originally PK-less tables** (`group_event_rules`, `api_groups`, `application_groups`, `tag_groups`, `client_registration_provider_scopes`, `alert_event_rules`, `promotions`, `subscriptions_metadata`, `custom_user_fields_values`, `notification_templates`, `installation`, `installation_informations`, `node_monitoring`, `event_environments`, `flow_steps`): added inline PKs at their original `createTable`. `flow_steps` and `subscriptions_metadata` use the synthetic `id BIGINT AUTO_INCREMENT` PK that v3.15.21 / v3.20.4 add later — those follow-up changesets are now guarded by `not columnExists id` preconditions so they skip on fresh deploys.
- **`v3_15_20`**: split the single PK retrofit changeset into 14 per-table changesets, each guarded by `not primaryKeyExists` so fresh deploys (PK already inline) skip them while older upgrades still apply them.
- **PK rebuild patterns** in `v1_25_2` (ratelimit), `v3_0_0` (role_permissions, roles, membership_roles, group_roles, memberships, plan_apis), `v3_5_0` (parameters), `v3_12_1` (keys): per-DBMS split. MySQL/MariaDB get a single combined `ALTER TABLE … DROP PRIMARY KEY, …, ADD CONSTRAINT … PRIMARY KEY (…)` statement; other DBMSes keep the typed actions or equivalent raw SQL. `memberships` uses a temporary surrogate `tmp_pk BIGINT AUTO_INCREMENT` to bridge the gap between dropping the old PK and installing the final `id` PK across the data migration.
- **`v3_15_21`** (`flow_steps`): split into four changesets so the migration handles both legacy baselines that already have a composite PK on `flow_steps` (rebuild via combined ALTER on MySQL/MariaDB, typed dropPrimaryKey + addColumn elsewhere) AND legacy baselines pre-3.15.20 where `flow_steps` was created without any PK (just ADD the synthetic id column with PK). All four are gated by `not columnExists id` so they MARK_RAN on fresh deploys. `dbms` filters live on the changeSet header (reliable in Liquibase 4.27) rather than on individual change actions (which silently misfire for typed actions in 4.27).
- **Liquibase's own `DATABASECHANGELOG`**: added `MySqlChangeLogTableWithPrimaryKeyGenerator`, a custom `SqlGenerator` that delegates to Liquibase's `CreateDatabaseChangeLogTableGenerator`, then splices a named `CONSTRAINT pk_<changelog-table-name> PRIMARY KEY (ID, AUTHOR, FILENAME)` clause before the closing `)`. Registered via `META-INF/services/liquibase.sqlgenerator.SqlGenerator` and scoped to `MySQLDatabase` / `MariaDBDatabase` so PostgreSQL / MSSQL / H2 are untouched. Constraint name mirrors the v3_15_20 retrofit so fresh and upgraded fleets converge on the same PK name. Inherits any future column additions Liquibase upstream makes — no hardcoded schema to maintain. Fail-fast: throws `IllegalStateException` if upstream Liquibase ever produces SQL we don't recognise, so a future contract change surfaces clearly instead of silently turning into MySQL ER_3750 later.
- **Test infrastructure**: `JdbcTestRepositoryConfiguration` now reads `${strictPrimaryKey}` via `@Value` and applies `--sql-require-primary-key=ON` to the MySQL testcontainer; CI gains a `Management repository tests - JDBC - mysql~8.4 (strict-PK)` matrix entry that exercises the strict-mode path. `TableConstraintsTest` switched from a vacuous-pass `return` to `Assume.assumeTrue` (now reports SKIPPED on non-MySQL/MariaDB instead of vacuously passing), broadened to MariaDB, replaced the hard-coded `'test'` schema with `(SELECT DATABASE())`, and gained a "tables exist" precondition so a failed Liquibase bootstrap can no longer pass vacuously. `JdbcTestRepositoryInitializer.setUp()` now rethrows Liquibase exceptions instead of log-and-swallow. New `MySqlChangeLogTableWithPrimaryKeyGeneratorTest` (11 cases) covers `supports()`, `getPriority()`, splice happy path / multi-statement / whitespace tolerance / throw paths, plus an end-to-end test that drives the actual generator against a real `MySQLDatabase` and asserts the full set of upstream-emitted columns survives the splice.

Public improvement: [APIM-13945](https://gravitee.atlassian.net/browse/APIM-13945). Originally reported as APIM-13430.

## Test plan

- [x] CI green on `default-database.jdbcType=postgresql` (14, 15, 16, 17, 18)
- [x] CI green on `default-database.jdbcType=mysql` (8.0, 8.4)
- [x] CI green on `default-database.jdbcType=mariadb` (10.6, 10.11, 11.4, 11.8, 12.1)
- [x] CI green on `default-database.jdbcType=sqlserver` (2017–2025)
- [x] CI green on the new `mysql~8.4 (strict-PK)` matrix entry
- [x] e2e tests green (branch suffix `-run-e2e` triggers them)
- [x] Locally verified `mvn test -Dtest=MySqlChangeLogTableWithPrimaryKeyGeneratorTest` (11/11 pass)
- [x] **Local validation harness — full upgrade-path coverage with mAPI startup**

### Local validation summary

A throwaway harness (gitignored, lives in `/tmp`) drives every realistic boot path end-to-end:

1. spin up clean MySQL/MariaDB container
2. apply baseline changelog via `liquibase/liquibase:4.27` docker image **without** the PR's SqlGenerator JAR mounted (faithfully reproduces the legacy PK-less `DATABASECHANGELOG` state)
3. toggle `sql_require_primary_key=ON` if the scenario asks for it
4. **start the actual mAPI standalone process** built from this PR's HEAD (`java -Dgravitee.home=<dist> -Dmanagement.type=jdbc … -jar lib/*-bootstrap-*.jar` — same recipe `apim-worktree` uses, no `mvn spring-boot:run`)
5. wait for `Liquibase: Update has been successful` AND `/_node/health` 200 — so the run exercises both Liquibase migrations AND mAPI's built-in upgraders
6. dump schema via `SHOW CREATE TABLE` for every base table, compare against a `4.11.4`-baseline-only reference dump

| Baseline | DB | strict-PK | Status | Schema diff vs 4.11.4 |
|---|---|---|---|---|
| `reference-4.11.4` | mysql:8.4 | off | reference | — (canonical pre-PR schema) |
| `none` (fresh install) | mysql:8.4 | off | ✅ pass | 7+/7− (PR-attributable only) |
| `none` (fresh install) | mysql:8.4 | **on** | ✅ pass | 7+/7− (PR-attributable only) |
| `none` (fresh install) | mariadb:12.1 | off | ✅ pass | format-diff noise |
| `4.7.0` upgrade | mysql:8.4 | off | ✅ pass | **0+/0−** (negative control) |
| `4.7.0` upgrade | mysql:8.4 | **on** | ✅ pass | **0+/0−** (negative control) |
| `4.7.0` upgrade | mariadb:12.1 | off | ✅ pass | format-diff noise |
| `3.20.0` upgrade | mysql:8.4 | off | ✅ pass | 7+/7− (PR-attributable only) |
| `3.20.0` upgrade | mysql:8.4 | **on** | ✅ pass | 7+/7− (PR-attributable only) |
| `3.20.0` upgrade | mariadb:12.1 | off | ✅ pass | format-diff noise |
| `3.15.0` upgrade | mysql:8.4 | off | ✅ pass | 7+/7− (PR-attributable only) |
| `3.15.0` upgrade | mysql:8.4 | **on** | ✅ pass | 7+/7− (PR-attributable only) |
| `3.15.0` upgrade | mariadb:12.1 | off | ✅ pass | format-diff noise |

The 7+/7− MySQL diff decomposes into exactly three classes of intentional PR change:
1. `PRIMARY KEY (ID)` → `PRIMARY KEY (ID, AUTHOR, FILENAME)` on `databasechangelog` (SqlGenerator splice on fresh deploys, v3_15_20 retrofit on upgrades).
2. 5 `reference_id`/`reference_type` column-position swaps on `memberships`, `membership_roles`, `portal_notification_configs`, `portal_notification_config_hooks`, `custom_user_fields` — the PK column-order restoration.
3. 2 `id bigint AUTO_INCREMENT` ordinal-position moves on `flow_steps` and `subscriptions_metadata` — inline-id-at-createTable in HEAD vs add-later in 4.11.4.

The mariadb dumps differ from the mysql dumps purely due to cross-engine `mysqldump`/`mariadb-dump` formatting differences (e.g. `bigint(20)` vs `bigint`); cross-engine diffs are not meaningful and a same-engine reference would zero those out.

The `4.7.0 → HEAD` diff is **byte-identical to the 4.11.4 reference** — the negative control proves no spurious schema mutations when the upgrade path doesn't cross any PR-touched changeset.

### What this PR does NOT introduce

mAPI startup surfaces two pre-existing errors on every JDBC+MySQL boot, both of which reproduce against a clean `4.11.4` baseline alone (i.e., independent of this PR):

1. **`DefaultSubscriptionFormUpgrader` charset mismatch** — the upgrader writes default subscription-form template content containing emoji into `gmd_content`, an `NVARCHAR` column that Liquibase materialises as `utf8mb3` (cannot store 4-byte UTF-8). MySQL aborts with error 1366 and mAPI shuts down. Column was added in `v4_11_0/08_add_subscription_forms_table.yml`, well before this PR. Worth a dedicated follow-up.
2. **`NodeHealthCheckMicrometerHandler` bind warning** — non-fatal Spring Boot Actuator startup hiccup logged at ERROR level. Same noise on every Gravitee 4.x JDBC boot.

The harness's known-error filter recognises both shapes; any *unexplained* ERROR/FATAL would surface as `fail (mapi errors)`. None did, on any of the 12 functional scenarios.

CI's `Test repository` job runs the JDBC repository unit tests but does NOT boot mAPI's upgrader pipeline, so the charset issue (and any future upgrader-only regression) is invisible to CI even though it reproduces at every customer boot. Worth a follow-up to wire upgrader execution into CI.


[APIM-13945]: https://gravitee.atlassian.net/browse/APIM-13945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ