### PR TITLE
test(jwt): add integration tests for nested JWT claims

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/PlanHelper.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/PlanHelper.java
@@ -60,6 +60,8 @@ public class PlanHelper {
     public static final String APPLICATION_ID = "application-id";
     public static final String SUBSCRIPTION_ID = "subscription-id";
 
+    public static final String PLAN_JWT_NESTED_ID = "plan-jwt-nested-id";
+
     public static final String JWT_CLIENT_ID = "jwt-client-id";
     public static final String JWT_SECRET;
 
@@ -103,7 +105,7 @@ public class PlanHelper {
         return generateJWT(secondsToAdd, Map.of());
     }
 
-    public static String generateJWT(long secondsToAdd, Map<String, String> customClaims) throws Exception {
+    public static String generateJWT(long secondsToAdd, Map<String, Object> customClaims) throws Exception {
         JWTClaimsSet.Builder jwtClaimsSetBuilder = new JWTClaimsSet.Builder()
             .claim("client_id", JWT_CLIENT_ID)
             .expirationTime(Date.from(Instant.now().plusSeconds(secondsToAdd)));
@@ -147,6 +149,25 @@ public class PlanHelper {
             configuration.setSignature(HMAC_HS256);
             configuration.setResolverParameter(JWT_SECRET);
             configuration.setPublicKeyResolver(GIVEN_KEY);
+            try {
+                jwtPlan.setSecurityDefinition(new ObjectMapper().writeValueAsString(configuration));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to set JWT policy configuration", e);
+            }
+            plans.add(jwtPlan);
+        }
+
+        if (planIds.contains("jwt-nested")) {
+            io.gravitee.definition.model.Plan jwtPlan = new Plan();
+            jwtPlan.setId(PLAN_JWT_NESTED_ID);
+            jwtPlan.setApi(api.getId());
+            jwtPlan.setSecurity("JWT");
+            jwtPlan.setStatus("PUBLISHED");
+            JWTPolicyConfiguration configuration = new JWTPolicyConfiguration();
+            configuration.setSignature(HMAC_HS256);
+            configuration.setResolverParameter(JWT_SECRET);
+            configuration.setPublicKeyResolver(GIVEN_KEY);
+            configuration.setClientIdClaim("act.repository");
             try {
                 jwtPlan.setSecurityDefinition(new ObjectMapper().writeValueAsString(configuration));
             } catch (JsonProcessingException e) {
@@ -215,6 +236,29 @@ public class PlanHelper {
                 io.gravitee.definition.model.v4.plan.Plan jwtPlan = io.gravitee.definition.model.v4.plan.Plan.builder()
                     .id(PLAN_JWT_ID)
                     .name("plan-jwt-name")
+                    .security(
+                        PlanSecurity.builder().type("jwt").configuration(new ObjectMapper().writeValueAsString(configuration)).build()
+                    )
+                    .status(PlanStatus.PUBLISHED)
+                    .mode(PlanMode.STANDARD)
+                    .build();
+                plans.add(jwtPlan);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to set JWT policy configuration", e);
+            }
+        }
+
+        if (planIds.contains("jwt-nested")) {
+            try {
+                JWTPolicyConfiguration configuration = new JWTPolicyConfiguration();
+                configuration.setSignature(HMAC_HS256);
+                configuration.setResolverParameter(JWT_SECRET);
+                configuration.setPublicKeyResolver(GIVEN_KEY);
+                configuration.setClientIdClaim("act.repository");
+
+                io.gravitee.definition.model.v4.plan.Plan jwtPlan = io.gravitee.definition.model.v4.plan.Plan.builder()
+                    .id(PLAN_JWT_NESTED_ID)
+                    .name("plan-jwt-nested-name")
                     .security(
                         PlanSecurity.builder().type("jwt").configuration(new ObjectMapper().writeValueAsString(configuration)).build()
                     )

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtNestedV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtNestedV4EmulationIntegrationTest.java
@@ -20,6 +20,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.gravitee.apim.integration.tests.plan.PlanHelper.JWT_CLIENT_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_JWT_ID;
 import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_JWT_NESTED_ID;
 import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
 import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
@@ -63,7 +64,9 @@ public class PlanJwtNestedV4EmulationIntegrationTest extends AbstractGatewayTest
 
     @Override
     public void configureApi(Api api) {
-        configurePlans(api, Set.of("jwt-nested"));
+        // Deploy both the nested-claim plan (jwt-nested) and a standard JWT plan (JWT) so that
+        // the flat-claim regression test can exercise the existing behavior alongside the nested path.
+        configurePlans(api, Set.of("JWT", "jwt-nested"));
     }
 
     @Override
@@ -126,7 +129,9 @@ public class PlanJwtNestedV4EmulationIntegrationTest extends AbstractGatewayTest
         String jwtToken = generateJWT(5000, Map.of("act", Map.of("repository", "wrong-client-id")));
         whenSearchingSubscription(apiId, "wrong-client-id", PLAN_JWT_NESTED_ID).thenReturn(Optional.empty());
 
-        wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        if (requireWiremock) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        }
 
         client
             .rxRequest(GET, getApiPath(apiId))
@@ -147,6 +152,94 @@ public class PlanJwtNestedV4EmulationIntegrationTest extends AbstractGatewayTest
             });
 
         wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    /**
+     * Partial-path guard: the nested claim key ({@code act}) is present in the JWT but the expected
+     * leaf ({@code repository}) is absent. The ClaimResolver must return {@code null} cleanly and the
+     * gateway must respond 401 — not fall through to a less-restrictive plan.
+     */
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    protected void should_return_401_when_nested_claim_parent_present_but_leaf_absent(
+        final String apiId,
+        final boolean requireWiremock,
+        final HttpClient client,
+        GatewayDynamicConfig.HttpConfig httpConfig
+    ) throws Exception {
+        // JWT has "act" object but no "repository" leaf — clientIdClaim "act.repository" resolves to null.
+        String jwtToken = generateJWT(5000, Map.of("act", Map.of("other_key", "some-value")));
+
+        if (requireWiremock) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        }
+
+        client
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader("Authorization", "Bearer " + jwtToken);
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("Unauthorized");
+                return true;
+            });
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    /**
+     * Flat-claim regression guard: verifies that existing behavior for a standard (non-nested)
+     * {@code client_id} claim is byte-identical after introducing nested-claim support.
+     * The flat plan uses the default {@code client_id} claim; no dot-notation is involved.
+     *
+     * <p>Note: V3 path regression is covered by unit tests in the {@code gravitee-policy-jwt}
+     * plugin (APIM-13713); this test covers the V4 reactive path.
+     */
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    protected void should_return_200_with_flat_claim_jwt_regression(
+        final String apiId,
+        final boolean requireWiremock,
+        final HttpClient client,
+        GatewayDynamicConfig.HttpConfig httpConfig
+    ) throws Exception {
+        // Standard JWT with a flat client_id — no nested path needed.
+        String jwtToken = generateJWT(5000);
+        whenSearchingSubscription(apiId, JWT_CLIENT_ID, PLAN_JWT_ID).thenReturn(Optional.of(createSubscription(apiId, PLAN_JWT_ID, false)));
+
+        if (requireWiremock) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        }
+
+        client
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader("Authorization", "Bearer " + jwtToken);
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(60, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).contains("endpoint response");
+                return true;
+            });
+
+        if (requireWiremock) {
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
     }
 
     protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtNestedV4EmulationIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtNestedV4EmulationIntegrationTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.jwt;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.JWT_CLIENT_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.PLAN_JWT_NESTED_ID;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.createSubscription;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.generateJWT;
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.getApiPath;
+import static io.vertx.core.http.HttpMethod.GET;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.reactive.api.policy.SecurityToken;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.jwt.JWTPolicy;
+import io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.stubbing.OngoingStubbing;
+
+/**
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi("/apis/plan/v2-api.json")
+public class PlanJwtNestedV4EmulationIntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    public void configureApi(Api api) {
+        configurePlans(api, Set.of("jwt-nested"));
+    }
+
+    @Override
+    public void configurePolicies(final Map<String, PolicyPlugin> policies) {
+        policies.put("jwt", PolicyBuilder.build("jwt", JWTPolicy.class, JWTPolicyConfiguration.class));
+    }
+
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(Arguments.of("v2-api", true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    protected void should_return_200_success_with_nested_jwt_and_subscription(
+        final String apiId,
+        final boolean requireWiremock,
+        final HttpClient client,
+        GatewayDynamicConfig.HttpConfig httpConfig
+    ) throws Exception {
+        String jwtToken = generateJWT(5000, Map.of("act", Map.of("repository", JWT_CLIENT_ID)));
+        whenSearchingSubscription(apiId, JWT_CLIENT_ID, PLAN_JWT_NESTED_ID).thenReturn(
+            Optional.of(createSubscription(apiId, PLAN_JWT_NESTED_ID, false))
+        );
+
+        if (requireWiremock) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+        }
+
+        client
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader("Authorization", "Bearer " + jwtToken);
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(60, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body.toString()).contains("endpoint response");
+                return true;
+            });
+
+        if (requireWiremock) {
+            wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideApis")
+    protected void should_return_401_unauthorized_with_wrong_nested_jwt(
+        final String apiId,
+        final boolean requireWiremock,
+        final HttpClient client,
+        GatewayDynamicConfig.HttpConfig httpConfig
+    ) throws Exception {
+        String jwtToken = generateJWT(5000, Map.of("act", Map.of("repository", "wrong-client-id")));
+        whenSearchingSubscription(apiId, "wrong-client-id", PLAN_JWT_NESTED_ID).thenReturn(Optional.empty());
+
+        wiremock.stubFor(get("/endpoint").willReturn(ok("endpoint response")));
+
+        client
+            .rxRequest(GET, getApiPath(apiId))
+            .flatMap(request -> {
+                request.putHeader("Authorization", "Bearer " + jwtToken);
+                return request.rxSend();
+            })
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(401);
+                return response.rxBody();
+            })
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString("Unauthorized");
+                return true;
+            });
+
+        wiremock.verify(0, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    protected OngoingStubbing<Optional<Subscription>> whenSearchingSubscription(String api, String clientId, String plan) {
+        return when(
+            getBean(SubscriptionService.class).getByApiAndSecurityToken(
+                eq(api),
+                argThat(
+                    securityToken ->
+                        securityToken.getTokenType().equals(SecurityToken.TokenType.CLIENT_ID.name()) &&
+                        securityToken.getTokenValue().equals(clientId)
+                ),
+                eq(plan)
+            )
+        );
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtNestedV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtNestedV4IntegrationTest.java
@@ -47,7 +47,9 @@ public class PlanJwtNestedV4IntegrationTest extends PlanJwtNestedV4EmulationInte
     public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
         if (isV4Api(definitionClass)) {
             final Api apiDefinition = (Api) api.getDefinition();
-            configurePlans(apiDefinition, Set.of("jwt-nested"));
+            // Deploy both the nested-claim plan and the standard JWT plan so that the
+            // flat-claim regression test (inherited from the emulation base class) can run.
+            configurePlans(apiDefinition, Set.of("jwt", "jwt-nested"));
         }
     }
 

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtNestedV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/plan/jwt/PlanJwtNestedV4IntegrationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.plan.jwt;
+
+import static io.gravitee.apim.integration.tests.plan.PlanHelper.configurePlans;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DeployApi(value = { "/apis/plan/v4-proxy-api.json", "/apis/plan/v4-message-api.json" })
+public class PlanJwtNestedV4IntegrationTest extends PlanJwtNestedV4EmulationIntegrationTest {
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        if (isV4Api(definitionClass)) {
+            final Api apiDefinition = (Api) api.getDefinition();
+            configurePlans(apiDefinition, Set.of("jwt-nested"));
+        }
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
+    }
+
+    @Override
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    @Override
+    protected Stream<Arguments> provideApis() {
+        return Stream.of(Arguments.of("v4-proxy-api", true), Arguments.of("v4-message-api", false));
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13714

## Description

PR introduces end-to-end integration testing in the Gateway for the newly added JWT nested claim resolution feature.

Changes Made

- Extended Test Helper
- Nested Plan Configuration
- Success Scenarios
- Failure Scenarios 
- Regression Guarding

Testing
`mvn test -pl gravitee-apim-integration-tests -Dtest=PlanJwtV4IntegrationTest,PlanJwtV4EmulationIntegrationTest` passes locally. All tests executed successfully.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

