### PR TITLE
feat: add tracing REST API to gamma APIM module

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/pom.xml
+++ b/gravitee-gamma/gravitee-gamma-module-apim/pom.xml
@@ -62,6 +62,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
             <scope>provided</scope>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/domain_service/TracingGraphBuilder.java
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/domain_service/TracingGraphBuilder.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.apim.core.tracing.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.gamma.module.apim.core.tracing.model.EdgeSpan;
+import io.gravitee.gamma.module.apim.core.tracing.model.TracingEdge;
+import io.gravitee.gamma.module.apim.core.tracing.model.TracingGraph;
+import io.gravitee.gamma.module.apim.core.tracing.model.TracingNode;
+import io.gravitee.node.api.opentelemetry.query.model.Trace;
+import io.gravitee.node.api.opentelemetry.query.model.TraceSpan;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Pure-function builder: takes a {@link Trace} and produces a {@link TracingGraph} by classifying spans as agent/LLM/MCP nodes from
+ * OTel attributes. No I/O, no Spring.
+ */
+@DomainService
+public class TracingGraphBuilder {
+
+    private static final Set<String> LLM_OPERATION_NAMES = Set.of("chat", "generate_content", "text_completion", "stream_generate_content");
+
+    public TracingGraph buildTracingGraph(Trace trace) {
+        Map<String, TracingNode> nodes = new LinkedHashMap<>();
+        Map<String, List<EdgeSpan>> edgesMap = new LinkedHashMap<>();
+        Map<String, Set<String>> mcpToolsPerServer = new HashMap<>();
+        Map<String, long[]> llmTokenTotals = new HashMap<>();
+
+        String agentNodeId = "agent";
+        String agentLabel = "Agent";
+        String agentSubtitle = null;
+        boolean foundAgentSpan = false;
+
+        for (TraceSpan span : trace.spans()) {
+            Map<String, String> attrs = span.attributes();
+            if (isAgentSpan(span.operationName(), attrs)) {
+                String name = attrs.get("gen_ai.agent.name");
+                if (name == null) name = attrs.get("agent.name");
+                String id = attrs.get("gen_ai.agent.id");
+                if (id == null) id = attrs.get("agent.id");
+
+                if (name != null) agentLabel = name;
+                if (id != null) agentNodeId = id;
+
+                String provider = attrs.get("gen_ai.provider.name");
+                String model = attrs.get("gen_ai.request.model");
+                if (provider != null && model != null) {
+                    agentSubtitle = capitalize(provider) + " · " + model;
+                } else if (provider != null) {
+                    agentSubtitle = capitalize(provider);
+                }
+                foundAgentSpan = true;
+                break;
+            }
+        }
+
+        if (!foundAgentSpan) {
+            for (TraceSpan span : trace.spans()) {
+                String serviceName = span.serviceName();
+                if (serviceName != null && serviceName.contains("langchain4j")) {
+                    agentLabel = serviceName;
+                    agentSubtitle = "Langchain4j · Java";
+                    break;
+                }
+                if (serviceName != null && serviceName.contains("agent")) {
+                    agentLabel = serviceName;
+                    agentSubtitle = serviceName;
+                    break;
+                }
+            }
+        }
+
+        nodes.put(agentNodeId, new TracingNode(agentNodeId, "agent", agentLabel, agentSubtitle));
+
+        boolean hasErrors = false;
+
+        for (TraceSpan span : trace.spans()) {
+            String serviceName = span.serviceName();
+            String operation = span.operationName();
+            Map<String, String> attrs = span.attributes();
+
+            if (isAgentSpan(operation, attrs)) {
+                continue;
+            } else if (isMcpSpan(attrs)) {
+                String mcpId = getMcpNodeId(attrs, serviceName);
+                String serverName = attrs.get("mcp.server.name");
+                if (serverName == null) serverName = serviceName != null ? serviceName : "MCP Server";
+                String transport = attrs.get("network.transport");
+                if (transport == null) transport = attrs.get("mcp.transport");
+                String toolName = attrs.get("gen_ai.tool.name");
+                if (toolName == null) toolName = attrs.get("mcp.tool.name");
+
+                if (toolName != null) {
+                    mcpToolsPerServer.computeIfAbsent(mcpId, k -> new LinkedHashSet<>()).add(toolName);
+                }
+
+                if (!nodes.containsKey(mcpId)) {
+                    String subtitle = transport != null ? capitalize(transport) : null;
+                    Map<String, String> metadata = new LinkedHashMap<>();
+                    if (transport != null) metadata.put("transport", transport);
+                    nodes.put(mcpId, new TracingNode(mcpId, "mcp_server", serverName, subtitle, null, metadata));
+                }
+
+                String spanStatus = getStatus(attrs);
+                if ("error".equals(spanStatus)) hasErrors = true;
+
+                String edgeKey = agentNodeId + "->" + mcpId;
+                edgesMap
+                    .computeIfAbsent(edgeKey, k -> new ArrayList<>())
+                    .add(new EdgeSpan(operation, span.durationNanos(), spanStatus, toolName, null));
+            } else if (isLlmSpan(attrs)) {
+                String llmId = getLlmNodeId(attrs);
+                String model = attrs.get("gen_ai.request.model");
+                if (model == null) model = attrs.getOrDefault("llm.model", "LLM");
+                String provider = attrs.get("gen_ai.provider.name");
+                if (provider == null) provider = attrs.get("llm.provider");
+
+                if (!nodes.containsKey(llmId)) {
+                    String subtitle = buildLlmSubtitle(provider, model);
+                    Map<String, String> metadata = new LinkedHashMap<>();
+                    if (provider != null) metadata.put("provider", provider);
+                    metadata.put("model", model);
+                    nodes.put(llmId, new TracingNode(llmId, "llm", model, subtitle, null, metadata));
+                }
+
+                Integer tokens = parseTokens(attrs);
+                if (tokens != null) {
+                    llmTokenTotals.computeIfAbsent(llmId, k -> new long[] { 0 })[0] += tokens;
+                }
+
+                String spanStatus = getStatus(attrs);
+                if ("error".equals(spanStatus)) hasErrors = true;
+
+                String edgeKey = agentNodeId + "->" + llmId;
+                edgesMap
+                    .computeIfAbsent(edgeKey, k -> new ArrayList<>())
+                    .add(new EdgeSpan(operation, span.durationNanos(), spanStatus, null, tokens));
+            }
+        }
+
+        for (Map.Entry<String, Set<String>> entry : mcpToolsPerServer.entrySet()) {
+            String mcpId = entry.getKey();
+            TracingNode existing = nodes.get(mcpId);
+            if (existing != null) {
+                int toolCount = entry.getValue().size();
+                String transport = existing.metadata().get("transport");
+                String subtitle =
+                    (transport != null ? capitalize(transport) : "") + " · " + toolCount + " tool" + (toolCount > 1 ? "s" : "");
+                nodes.put(
+                    mcpId,
+                    new TracingNode(mcpId, existing.type(), existing.label(), subtitle.trim(), existing.status(), existing.metadata())
+                );
+            }
+        }
+
+        for (Map.Entry<String, long[]> entry : llmTokenTotals.entrySet()) {
+            String llmId = entry.getKey();
+            TracingNode existing = nodes.get(llmId);
+            if (existing != null && entry.getValue()[0] > 0) {
+                String base = existing.subtitle() != null ? existing.subtitle() : existing.label();
+                String subtitle = base + " · " + entry.getValue()[0] + " tokens";
+                nodes.put(
+                    llmId,
+                    new TracingNode(llmId, existing.type(), existing.label(), subtitle, existing.status(), existing.metadata())
+                );
+            }
+        }
+
+        TracingNode agentNode = nodes.get(agentNodeId);
+        String agentStatus = hasErrors ? "error" : "healthy";
+        nodes.put(
+            agentNodeId,
+            new TracingNode(agentNodeId, agentNode.type(), agentNode.label(), agentNode.subtitle(), agentStatus, agentNode.metadata())
+        );
+
+        List<TracingEdge> edges = new ArrayList<>();
+        for (Map.Entry<String, List<EdgeSpan>> entry : edgesMap.entrySet()) {
+            String[] parts = entry.getKey().split("->");
+            edges.add(new TracingEdge(parts[0], parts[1], entry.getValue()));
+        }
+
+        return new TracingGraph(trace.traceId(), trace.durationNanos(), new ArrayList<>(nodes.values()), edges);
+    }
+
+    private boolean isAgentSpan(String operation, Map<String, String> attrs) {
+        String opName = attrs.get("gen_ai.operation.name");
+        if ("invoke_agent".equals(opName)) return true;
+        return operation != null && operation.startsWith("invoke_agent ");
+    }
+
+    private boolean isMcpSpan(Map<String, String> attrs) {
+        if (attrs.containsKey("mcp.method.name")) return true;
+        return attrs.containsKey("gen_ai.tool.name") && "execute_tool".equals(attrs.get("gen_ai.operation.name"));
+    }
+
+    private boolean isLlmSpan(Map<String, String> attrs) {
+        String opName = attrs.get("gen_ai.operation.name");
+        return opName != null && LLM_OPERATION_NAMES.contains(opName);
+    }
+
+    private String getMcpNodeId(Map<String, String> attrs, String serviceName) {
+        String serverName = attrs.get("mcp.server.name");
+        if (serverName != null) return "mcp-" + serverName;
+        if (serviceName != null) return "mcp-" + serviceName;
+        return "mcp-server";
+    }
+
+    private String getLlmNodeId(Map<String, String> attrs) {
+        String model = attrs.get("gen_ai.request.model");
+        if (model == null) model = attrs.getOrDefault("llm.model", "unknown");
+        return "llm-" + model.replaceAll("[^a-zA-Z0-9-]", "-");
+    }
+
+    private String getStatus(Map<String, String> attrs) {
+        String status = attrs.get("otel.status_code");
+        return status != null ? status.toLowerCase() : "ok";
+    }
+
+    private Integer parseTokens(Map<String, String> attrs) {
+        String inputTokens = attrs.get("gen_ai.usage.input_tokens");
+        String outputTokens = attrs.get("gen_ai.usage.output_tokens");
+        if (inputTokens == null) inputTokens = attrs.get("gen_ai.usage.prompt_tokens");
+        if (outputTokens == null) outputTokens = attrs.get("gen_ai.usage.completion_tokens");
+
+        if (inputTokens != null || outputTokens != null) {
+            try {
+                int total = 0;
+                if (inputTokens != null) total += Integer.parseInt(inputTokens);
+                if (outputTokens != null) total += Integer.parseInt(outputTokens);
+                return total;
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private String buildLlmSubtitle(String provider, String model) {
+        if (provider != null) {
+            return formatProvider(provider) + " · " + model;
+        }
+        return model;
+    }
+
+    private String formatProvider(String provider) {
+        if (provider == null) return "";
+        return Arrays.stream(provider.split("[-_]"))
+            .map(this::capitalize)
+            .reduce((a, b) -> a + " " + b)
+            .orElse(provider);
+    }
+
+    private String capitalize(String s) {
+        if (s == null || s.isEmpty()) return s;
+        return s.substring(0, 1).toUpperCase() + s.substring(1).toLowerCase();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/model/EdgeSpan.java
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/model/EdgeSpan.java
@@ -13,15 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gamma.module.apim;
+package io.gravitee.gamma.module.apim.core.tracing.model;
 
-import io.gravitee.apim.plugin.gamma.api.GammaModule;
-import io.gravitee.gamma.module.apim.rest.resource.HttpApiManagementResource;
-
-public class HttpApiManagementModule implements GammaModule {
-
-    @Override
-    public Class<?> restResource() {
-        return HttpApiManagementResource.class;
-    }
-}
+public record EdgeSpan(String operation, long durationNanos, String status, String tool, Integer tokens) {}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/model/TracingEdge.java
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/model/TracingEdge.java
@@ -13,15 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gamma.module.apim;
+package io.gravitee.gamma.module.apim.core.tracing.model;
 
-import io.gravitee.apim.plugin.gamma.api.GammaModule;
-import io.gravitee.gamma.module.apim.rest.resource.HttpApiManagementResource;
+import java.util.List;
 
-public class HttpApiManagementModule implements GammaModule {
-
-    @Override
-    public Class<?> restResource() {
-        return HttpApiManagementResource.class;
-    }
-}
+public record TracingEdge(String from, String to, List<EdgeSpan> spans) {}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/model/TracingGraph.java
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/model/TracingGraph.java
@@ -13,15 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gamma.module.apim;
+package io.gravitee.gamma.module.apim.core.tracing.model;
 
-import io.gravitee.apim.plugin.gamma.api.GammaModule;
-import io.gravitee.gamma.module.apim.rest.resource.HttpApiManagementResource;
+import java.util.List;
 
-public class HttpApiManagementModule implements GammaModule {
-
-    @Override
-    public Class<?> restResource() {
-        return HttpApiManagementResource.class;
-    }
-}
+public record TracingGraph(String traceId, long durationNanos, List<TracingNode> nodes, List<TracingEdge> edges) {}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/model/TracingNode.java
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/model/TracingNode.java
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gamma.module.apim;
+package io.gravitee.gamma.module.apim.core.tracing.model;
 
-import io.gravitee.apim.plugin.gamma.api.GammaModule;
-import io.gravitee.gamma.module.apim.rest.resource.HttpApiManagementResource;
+import java.util.Map;
 
-public class HttpApiManagementModule implements GammaModule {
+public record TracingNode(String id, String type, String label, String subtitle, String status, Map<String, String> metadata) {
+    public TracingNode(String id, String type, String label) {
+        this(id, type, label, null, null, Map.of());
+    }
 
-    @Override
-    public Class<?> restResource() {
-        return HttpApiManagementResource.class;
+    public TracingNode(String id, String type, String label, String subtitle) {
+        this(id, type, label, subtitle, null, Map.of());
     }
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/use_case/GetTraceUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/use_case/GetTraceUseCase.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.apim.core.tracing.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+import io.gravitee.node.api.opentelemetry.query.TracingQueryService;
+import io.gravitee.node.api.opentelemetry.query.model.Trace;
+
+@UseCase
+public class GetTraceUseCase {
+
+    private final TracingQueryService tracingQueryService;
+
+    public GetTraceUseCase(TracingQueryService tracingQueryService) {
+        this.tracingQueryService = tracingQueryService;
+    }
+
+    public record Input(String traceId) {}
+
+    public record Output(Trace trace) {}
+
+    public Output execute(Input input) {
+        // TODO multi-tenancy: add environmentId to Input and assert trace belongs to it once backend supports it.
+        Trace trace = tracingQueryService.getTrace(input.traceId()).blockingGet();
+        if (trace == null) {
+            throw new NotFoundDomainException("Trace [" + input.traceId() + "] not found");
+        }
+        return new Output(trace);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/use_case/GetTracingGraphUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/use_case/GetTracingGraphUseCase.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.apim.core.tracing.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+import io.gravitee.gamma.module.apim.core.tracing.domain_service.TracingGraphBuilder;
+import io.gravitee.gamma.module.apim.core.tracing.model.TracingGraph;
+import io.gravitee.node.api.opentelemetry.query.TracingQueryService;
+import io.gravitee.node.api.opentelemetry.query.model.Trace;
+
+@UseCase
+public class GetTracingGraphUseCase {
+
+    private final TracingQueryService tracingQueryService;
+    private final TracingGraphBuilder tracingGraphBuilder;
+
+    public GetTracingGraphUseCase(TracingQueryService tracingQueryService, TracingGraphBuilder tracingGraphBuilder) {
+        this.tracingQueryService = tracingQueryService;
+        this.tracingGraphBuilder = tracingGraphBuilder;
+    }
+
+    public record Input(String traceId) {}
+
+    public record Output(TracingGraph graph) {}
+
+    public Output execute(Input input) {
+        Trace trace = tracingQueryService.getTrace(input.traceId()).blockingGet();
+        if (trace == null) {
+            throw new NotFoundDomainException("Trace [" + input.traceId() + "] not found");
+        }
+        return new Output(tracingGraphBuilder.buildTracingGraph(trace));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/use_case/SearchTracesUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/core/tracing/use_case/SearchTracesUseCase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.apim.core.tracing.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.node.api.opentelemetry.query.TracingQueryService;
+import io.gravitee.node.api.opentelemetry.query.model.Trace;
+import io.gravitee.node.api.opentelemetry.query.model.TraceSearchCriteria;
+import java.util.List;
+
+@UseCase
+public class SearchTracesUseCase {
+
+    private final TracingQueryService tracingQueryService;
+
+    public SearchTracesUseCase(TracingQueryService tracingQueryService) {
+        this.tracingQueryService = tracingQueryService;
+    }
+
+    public record Input(TraceSearchCriteria criteria) {}
+
+    public record Output(List<Trace> traces) {}
+
+    public Output execute(Input input) {
+        // TODO multi-tenancy: add environmentId to Input and scope via TraceQL once backend supports it.
+        return new Output(tracingQueryService.searchTraces(input.criteria()).blockingGet());
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/rest/resource/HttpApiManagementResource.java
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/rest/resource/HttpApiManagementResource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.apim.rest.resource;
+
+import io.gravitee.gamma.module.apim.rest.resource.tracing.TracingResource;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+
+/**
+ * Root resource for the APIM gamma module. Mounted by the gamma plugin loader at
+ * {@code /organizations/{orgId}/modules/{pluginId}}. Sub-resources hang off this class.
+ */
+public class HttpApiManagementResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Path("tracing")
+    public TracingResource getTracingResource() {
+        return resourceContext.getResource(TracingResource.class);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/rest/resource/tracing/TracingResource.java
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/java/io/gravitee/gamma/module/apim/rest/resource/tracing/TracingResource.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.module.apim.rest.resource.tracing;
+
+import io.gravitee.gamma.module.apim.core.tracing.model.TracingGraph;
+import io.gravitee.gamma.module.apim.core.tracing.use_case.GetTraceUseCase;
+import io.gravitee.gamma.module.apim.core.tracing.use_case.GetTracingGraphUseCase;
+import io.gravitee.gamma.module.apim.core.tracing.use_case.SearchTracesUseCase;
+import io.gravitee.node.api.opentelemetry.query.model.Trace;
+import io.gravitee.node.api.opentelemetry.query.model.TraceSearchCriteria;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tracing resource — exposes Tempo-backed tracing data under {@code /tracing}. Returns domain records as JSON directly; a DTO/OpenAPI
+ * layer can be introduced later.
+ */
+@Produces(MediaType.APPLICATION_JSON)
+public class TracingResource {
+
+    @Inject
+    private SearchTracesUseCase searchTracesUseCase;
+
+    @Inject
+    private GetTraceUseCase getTraceUseCase;
+
+    @Inject
+    private GetTracingGraphUseCase getTracingGraphUseCase;
+
+    @GET
+    @Path("/traces")
+    public List<Trace> listTraces(
+        @QueryParam("tags") String tags,
+        @QueryParam("limit") @DefaultValue("20") int limit,
+        @QueryParam("start") Long start,
+        @QueryParam("end") Long end
+    ) {
+        var criteria = new TraceSearchCriteria(parseTags(tags), limit, toInstant(start), toInstant(end));
+        return searchTracesUseCase.execute(new SearchTracesUseCase.Input(criteria)).traces();
+    }
+
+    @GET
+    @Path("/traces/{traceId}")
+    public Trace getTrace(@PathParam("traceId") String traceId) {
+        return getTraceUseCase.execute(new GetTraceUseCase.Input(traceId)).trace();
+    }
+
+    @GET
+    @Path("/traces/{traceId}/graph")
+    public TracingGraph getTracingGraph(@PathParam("traceId") String traceId) {
+        return getTracingGraphUseCase.execute(new GetTracingGraphUseCase.Input(traceId)).graph();
+    }
+
+    private static Map<String, String> parseTags(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return Map.of();
+        }
+        Map<String, String> result = new LinkedHashMap<>();
+        for (String pair : raw.split("\\s+")) {
+            int eq = pair.indexOf('=');
+            if (eq > 0 && eq < pair.length() - 1) {
+                result.put(pair.substring(0, eq), pair.substring(eq + 1));
+            }
+        }
+        return result;
+    }
+
+    private static Instant toInstant(Long epochSeconds) {
+        return epochSeconds == null ? null : Instant.ofEpochSecond(epochSeconds);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-alpha.4</gravitee-node.version>
+        <gravitee-node.version>9.0.0-feat-add-tracing-tempo-query-service-SNAPSHOT</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.1</gravitee-plugin.version>


### PR DESCRIPTION
Moves the tracing REST API from the `poc-apim-ui-tracing` POC into the gamma APIM module. UI is not included.

3 endpoints exposed under `/gamma/organizations/{orgId}/modules/apim/tracing/...`. Env scoping will be added later, where it is actually consumed.

Tracing port + models come from gravitee-node (https://github.com/gravitee-io/gravitee-node/pull/554). Use cases bridge the reactive port (`Single`/`Maybe`) with `blockingGet()` so the JAX-RS layer stays sync.

`TracingGraph`, `TracingNode`, `TracingEdge`, `EdgeSpan` and `TracingGraphBuilder` are APIM-specific (output of the graph use case) and stay in the gamma module.

## ⚠️ Blocked by gravitee-node PR 554

The root pom pins `gravitee-node.version` to `9.0.0-feat-add-tracing-tempo-query-service-SNAPSHOT` so that `gravitee-node-opentelemetry` (loaded transitively by `gravitee-node-container`) ships the `TempoTracingQueryService` impl at runtime.

This PR cannot merge until gravitee-node releases a stable version including PR 554. At that point:

- Bump `gravitee-node.version` in the root pom to that stable version.
- No change needed in this gamma module.

No tests and no DTO/OpenAPI layer in this first cut.