### PR TITLE
fix: prevent deserializing V4 definition in V2 model in GroupService

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
@@ -217,15 +217,6 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
     }
 
     private static DefinitionVersion foundDefinitionVersion(JsonNode node) {
-        if (node.hasNonNull("definitionVersion")) {
-            JsonNode definitionVersion = node.get("definitionVersion");
-            try {
-                return DefinitionVersion.valueOf(definitionVersion.asText());
-            } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Unsupported API definition version: " + definitionVersion.asText());
-            }
-        }
-
         if (node.hasNonNull("gravitee")) {
             JsonNode gravitee = node.get("gravitee");
             DefinitionVersion version = DefinitionVersion.valueOfLabel(gravitee.asText());

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -610,12 +610,4 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals(1, api.getPlans().size());
         assertEquals("my-api-id", api.getPlans().get(0).getApi());
     }
-
-    @Test
-    public void definition_federated() throws IOException {
-        Api api = load("/io/gravitee/definition/jackson/api-federated.json", Api.class);
-
-        assertThat(api.getProxy()).isNull();
-        assertThat(api.getName()).isEqualTo("IrishUsagePlanAPI100");
-    }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-federated.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-federated.json
@@ -1,9 +1,0 @@
-{
-  "id": "0068af5c-b68c-3f33-a4b9-9e7ff435badb",
-  "providerId": "9fdee45mq6",
-  "name": "IrishUsagePlanAPI100",
-  "definitionVersion": "FEDERATED",
-  "server": {
-    "url": "https://9fdee45mq6.execute-api.eu-west-1.amazonaws.com/Test"
-  }
-}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiModel.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiModel.java
@@ -36,6 +36,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -47,10 +49,12 @@ import lombok.ToString;
  * @author GraviteeSource Team
  */
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
 @Setter
 @ToString
 @EqualsAndHashCode
+@Builder
 public class ApiModel implements GenericApiModel {
 
     private String id;
@@ -62,12 +66,22 @@ public class ApiModel implements GenericApiModel {
     private Date createdAt;
     private Date updatedAt;
     private String description;
+
+    @Builder.Default
     private Set<String> tags = new HashSet<>();
+
     private List<Listener> listeners;
     private List<EndpointGroup> endpointGroups;
+
+    @Builder.Default
     private List<Property> properties = new ArrayList<>();
+
+    @Builder.Default
     private List<Resource> resources = new ArrayList<>();
+
+    @Builder.Default
     private Map<String, Map<String, ResponseTemplate>> responseTemplates = new LinkedHashMap<>();
+
     private ApiServices services;
     private Set<String> groups;
     private Visibility visibility;
@@ -75,7 +89,10 @@ public class ApiModel implements GenericApiModel {
     private PrimaryOwnerEntity primaryOwner;
     private String picture;
     private Set<String> categories;
+
+    @Builder.Default
     private Map<String, String> metadata = new HashMap<>();
+
     private ApiLifecycleState lifecycleState;
     private boolean disableMembershipNotifications;
     private Failover failover;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -96,6 +96,7 @@ import io.gravitee.rest.api.service.notification.ApiProductTemplateModel;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
+import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import io.reactivex.rxjava3.functions.Action;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -197,6 +198,9 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     @Lazy
     @Autowired
     private SearchEngineService searchEngineService;
+
+    @Autowired
+    private ApiTemplateService apiTemplateService;
 
     @Override
     public List<GroupEntity> findAll(ExecutionContext executionContext) {
@@ -1358,12 +1362,12 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     private void triggerUpdateNotification(ExecutionContext executionContext, Api api) {
-        ApiEntity apiEntity = apiConverter.toApiEntity(api, null, false);
+        var apiModel = apiTemplateService.findByIdForTemplates(executionContext, api.getId(), true);
         notifierService.trigger(
             executionContext,
             ApiHook.API_UPDATED,
             api.getId(),
-            new NotificationParamsBuilder().api(apiEntity).user(userService.findById(executionContext, getAuthenticatedUsername())).build()
+            new NotificationParamsBuilder().api(apiModel).user(userService.findById(executionContext, getAuthenticatedUsername())).build()
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
@@ -51,6 +51,7 @@ import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
 import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import io.gravitee.rest.api.service.impl.GroupServiceImpl;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import java.util.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -117,6 +118,9 @@ public class GroupService_DeleteTest {
 
     @Mock
     private ApiProductsRepository apiProductsRepository;
+
+    @Mock
+    private ApiTemplateService apiTemplateService;
 
     @Test(expected = GroupNotFoundException.class)
     public void throwGroupNotFoundException() throws Exception {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_AssociateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_AssociateTest.java
@@ -33,12 +33,15 @@ import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.alert.ApplicationAlertEventType;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.v4.api.ApiModel;
+import io.gravitee.rest.api.model.v4.api.GenericApiModel;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -84,6 +87,9 @@ public class GroupService_AssociateTest extends TestCase {
     @Mock
     private MembershipService membershipService;
 
+    @Mock
+    private ApiTemplateService apiTemplateService;
+
     @Test(expected = GroupNotFoundException.class)
     public void shouldThrowGroupNotFoundException() throws TechnicalException {
         when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.empty());
@@ -107,9 +113,8 @@ public class GroupService_AssociateTest extends TestCase {
                 ApiFieldFilter.allFields()
             )
         ).thenReturn(Stream.of(api1, api2));
-        ApiEntity apiEntity1 = new ApiEntity();
-        apiEntity1.setId("api1");
-        when(apiConverter.toApiEntity(api1, null, false)).thenReturn(apiEntity1);
+        GenericApiModel apiModel = ApiModel.builder().id("api1").build();
+        when(apiTemplateService.findByIdForTemplates(executionContext, api1.getId(), true)).thenReturn(apiModel);
 
         UserEntity fakeUserEntity = new UserEntity();
         fakeUserEntity.setFirstname("firstName");


### PR DESCRIPTION
## Description

ApiDeserializer is used only to deserialize a V2 definition (io.gravitee.definition.model).Api. In this model, the `definitionVersion` attribute does not exist (its name is `gravitee`). Therefore, we should only rely on the `gravitee` attribute to deserialize definitionVersion.

In GroupService, we were converting all APIs to V2. However, we can trigger a notification for V4. ApiTemplateService exists to build a model specifically for Notification

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

