### PR TITLE
fix(helm): null-safe $hzActive expression for helm 3.9 lint

### DIFF
--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,7 +1,7 @@
 1. Watch all containers come up.
   $ kubectl get pods --namespace={{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} -w
 
-{{- $hzActive := or (eq .Values.ratelimit.type "hazelcast") (and .Values.gateway.cluster (eq (.Values.gateway.cluster.type | default "") "hazelcast")) }}
+{{- $hzActive := or (eq .Values.ratelimit.type "hazelcast") (eq (dig "cluster" "type" "" .Values.gateway) "hazelcast") }}
 {{- if and $hzActive (not .Values.apim.managedServiceAccount) }}
 
 WARNING: Hazelcast is enabled (ratelimit.type=hazelcast or gateway.cluster.type=hazelcast)

--- a/helm/templates/gateway/gateway-hz-service.yaml
+++ b/helm/templates/gateway/gateway-hz-service.yaml
@@ -1,4 +1,4 @@
-{{- $hzActive := or (eq .Values.ratelimit.type "hazelcast") (and .Values.gateway.cluster (eq (.Values.gateway.cluster.type | default "") "hazelcast")) -}}
+{{- $hzActive := or (eq .Values.ratelimit.type "hazelcast") (eq (dig "cluster" "type" "" .Values.gateway) "hazelcast") -}}
 {{- $hzCfg := dict }}
 {{- if and .Values.gateway.ratelimit (kindIs "map" .Values.gateway.ratelimit) }}{{ $hzCfg = (.Values.gateway.ratelimit.hazelcast | default dict) }}{{ end }}
 {{- $hzRateLimitPort := $hzCfg.port | default 5901 }}
@@ -34,7 +34,7 @@ spec:
       protocol: TCP
       name: {{ printf "%s-%s" (.Values.gateway.name | trunc 56 | trimSuffix "-") "hz-rl" }}
     {{- end }}
-    {{- if and .Values.gateway.cluster (eq (.Values.gateway.cluster.type | default "") "hazelcast") }}
+    {{- if eq (dig "cluster" "type" "" .Values.gateway) "hazelcast" }}
     - port: 5701
       targetPort: 5701
       protocol: TCP

--- a/helm/templates/gateway/gateway-rbac.yaml
+++ b/helm/templates/gateway/gateway-rbac.yaml
@@ -1,4 +1,4 @@
-{{- $hzActive := or (eq .Values.ratelimit.type "hazelcast") (and .Values.gateway.cluster (eq (.Values.gateway.cluster.type | default "") "hazelcast")) -}}
+{{- $hzActive := or (eq .Values.ratelimit.type "hazelcast") (eq (dig "cluster" "type" "" .Values.gateway) "hazelcast") -}}
 {{ if and $hzActive .Values.apim.managedServiceAccount }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
## Summary

Follow-up fix to #16606 (already merged). CI helm-lint matrix runs `v3.9.4 v3.10.3 v3.11.3 v3.12.3 v3.13.3 v3.14.4 v3.15.1`. The `$hzActive` expression introduced by #16606 trips a nil-pointer error on helm v3.9.4:

```
[ERROR] templates/: template: apim/templates/gateway/gateway-rbac.yaml:1:101: executing "apim/templates/gateway/gateway-rbac.yaml" at <.Values.gateway.cluster.type>: nil pointer evaluating interface {}.type
```

The Go `text/template` engine bundled with helm 3.9 evaluates the inner pipeline `eq (.Values.gateway.cluster.type | default "")` regardless of the outer `and` short-circuit, and `.Values.gateway.cluster` is nil under the chart's default `values.yaml`. Helm 3.10+ short-circuits and the other 6 versions in the matrix pass.

The fix swaps the unsafe `(and X.cluster (eq X.cluster.type ...))` pattern for `(eq (dig "cluster" "type" "" .Values.gateway) "hazelcast")` — Sprig's `dig` walks the path and returns the default when any step is nil, so it's null-safe regardless of helm/Go version.

Refs: APIM-13746

## Test plan

- [x] Reproduced exact CI error locally with helm v3.9.4
- [x] Lint passes on all 7 matrix versions (v3.9.4 → v3.15.1) after fix
- [x] `helm unittest` 627/627 still pass
- [x] `helm template` rendered output is byte-identical before/after (semantics preserved)