### PR TITLE
feat(gamma): scope module routes to environment

### DIFF
--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaModulesResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaModulesResource.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Path("/organizations/{orgId}/modules")
+@Path("/organizations/{orgId}/environments/{envId}/modules")
 public class GammaModulesResource {
 
     @Inject


### PR DESCRIPTION
Add `/environments/{envId}` to the gamma module path so `GraviteeContext.getCurrentEnvironment()` is populated for module resources (via existing `GraviteeContextFilter`).

Path: `/gamma/organizations/{orgId}/modules/...` → `/gamma/organizations/{orgId}/environments/{envId}/modules/...`

Draft for workshop discussion.