### PR TITLE
Feat/v4 wsdl import

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/importWsdlDescriptor.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/importWsdlDescriptor.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ImportWsdlDescriptor {
+  /** The raw WSDL content (INLINE) or the URL to fetch it from (URL). */
+  payload: string;
+  /** Whether the payload is an inline WSDL string or a remote URL. Defaults to INLINE. */
+  type?: 'INLINE' | 'URL';
+  /** Generate a Swagger documentation page from the converted OpenAPI spec. */
+  withDocumentation?: boolean;
+  /** Add an OAS Validation policy to every flow. */
+  withOASValidationPolicy?: boolean;
+  /** Policy visitor IDs to apply (e.g. 'rest-to-soap', 'json-validation'). */
+  withPolicies?: string[];
+}

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
@@ -79,11 +79,7 @@
             <h3>API format</h3>
             <gio-form-selection-inline formControlName="format">
               @for (format of formats; track format.value) {
-                <gio-form-selection-inline-card
-                  [value]="format.value"
-                  [disabled]="format.value === 'wsdl'"
-                  [matTooltip]="format.value === 'wsdl' ? 'Coming soon' : null"
-                >
+                <gio-form-selection-inline-card [value]="format.value">
                   <gio-form-selection-inline-card-content [icon]="format.icon">
                     <gio-card-content-title>{{ format.label }}</gio-card-content-title>
                   </gio-form-selection-inline-card-content>

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
@@ -321,6 +321,59 @@ describe('ApiImportV4FormComponent', () => {
     httpMock.verify();
   });
 
+  it('should show the options step for WSDL', async () => {
+    fixture.componentInstance.selectApiFormatForm.patchValue({ format: 'wsdl' });
+    fixture.detectChanges();
+    const showOptions = (fixture.componentInstance as unknown as { showImportOptionsStep: () => boolean }).showImportOptionsStep;
+    expect(showOptions()).toBe(true);
+  });
+
+  it('should POST WSDL from a local file', async () => {
+    const httpMock = TestBed.inject(HttpTestingController);
+    const wsdlContent = '<definitions name="CalculatorService"/>';
+
+    await harness.selectFormat('wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.pickFiles([new File([wsdlContent], 'calculator.wsdl', { type: 'text/xml' })]);
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.clickNext();
+    await harness.clickImport();
+
+    const req = httpMock.expectOne(r => r.method === 'POST' && r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_import/wsdl`);
+    expect(req.request.body).toEqual(
+      expect.objectContaining({
+        payload: wsdlContent,
+        type: 'INLINE',
+      }),
+    );
+    req.flush(fakeApiV4({ id: 'imported-wsdl' }));
+    httpMock.verify();
+  });
+
+  it('should call importWsdlApi with remote URL for WSDL', async () => {
+    const apiV2 = TestBed.inject(ApiV2Service);
+    jest.spyOn(apiV2, 'importWsdlApi').mockReturnValue(of({ id: 'new-api' } as ApiV4));
+
+    await harness.selectFormat('wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.selectSource('remote');
+    await harness.setRemoteUrl('https://example.com/calculator.wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.clickNext();
+    await harness.clickImport();
+
+    expect(apiV2.importWsdlApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: 'https://example.com/calculator.wsdl',
+        type: 'URL',
+      }),
+    );
+  });
+
   it('should show actionable message when remote fetch fails with status 0', async () => {
     const snackBarService = TestBed.inject(SnackBarService);
     const snackBarErrorSpy = jest.spyOn(snackBarService, 'error');
@@ -423,6 +476,22 @@ describe('ApiImportV4FormComponent (oas-validation policy installed)', () => {
 
     expect(await harness.isConfigureSourceNextDisabled()).toBe(false);
     expect(await harness.getPickedFilesCount()).toBe(1);
+  });
+
+  it('should expose documentation and OAS validation toggles for WSDL when oas-validation policy is installed', async () => {
+    await harness.selectFormat('wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.pickFiles([new File(['<definitions/>'], 'service.wsdl', { type: 'text/xml' })]);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await harness.clickNext();
+
+    expect(await harness.isDocumentationImportSelected()).toBe(true);
+    expect(await harness.isDocumentationImportDisabled()).toBe(false);
+    expect(await harness.isOasValidationPolicyImportPresent()).toBe(true);
+    expect(await harness.isOasValidationPolicyImportSelected()).toBe(true);
+    expect(await harness.isOasValidationPolicyImportDisabled()).toBe(false);
   });
 
   it('should still skip the options step for Gravitee definition when policy is installed', async () => {

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
@@ -34,6 +34,7 @@ import { catchError, distinctUntilChanged, finalize, map, startWith, switchMap, 
 import { ApiImportFilePickerComponent } from '../../component/api-import-file-picker/api-import-file-picker.component';
 import { ApiV4, PolicyPlugin } from '../../../../entities/management-api-v2';
 import { ImportSwaggerDescriptor } from '../../../../entities/management-api-v2/api/v4/importSwaggerDescriptor';
+import { ImportWsdlDescriptor } from '../../../../entities/management-api-v2/api/v4/importWsdlDescriptor';
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 import { PolicyV2Service } from '../../../../services-ngx/policy-v2.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
@@ -422,7 +423,7 @@ export class ApiImportV4FormComponent {
       if (!url || this.configureFileSourceForm.controls.remoteUrl.invalid) {
         return false;
       }
-      return format === 'gravitee' || format === 'openapi';
+      return format === 'gravitee' || format === 'openapi' || format === 'wsdl';
     }
 
     const type = this.importType();
@@ -431,7 +432,11 @@ export class ApiImportV4FormComponent {
       return false;
     }
 
-    return (format === 'gravitee' && type === 'MAPI_V2') || (format === 'openapi' && type === 'SWAGGER');
+    return (
+      (format === 'gravitee' && type === 'MAPI_V2') ||
+      (format === 'openapi' && type === 'SWAGGER') ||
+      (format === 'wsdl' && type === 'WSDL')
+    );
   }
 
   private resolveImportRequest$(): Observable<ApiV4> | null {
@@ -447,6 +452,9 @@ export class ApiImportV4FormComponent {
       const url = this.configureFileSourceForm.controls.remoteUrl.value?.trim() as string;
       if (format === 'gravitee') {
         return this.importGraviteeDefinitionFromRemoteUrl$(url, updateId);
+      }
+      if (format === 'wsdl') {
+        return this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(url, 'URL'));
       }
       return updateId
         ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(url))
@@ -470,6 +478,9 @@ export class ApiImportV4FormComponent {
         ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(fileContent as string))
         : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(fileContent as string));
     }
+    if (format === 'wsdl' && pickedType === 'WSDL') {
+      return this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(fileContent as string, 'INLINE'));
+    }
     return null;
   }
 
@@ -478,6 +489,17 @@ export class ApiImportV4FormComponent {
     const rawOptions = this.optionsForm.getRawValue();
     return {
       payload,
+      withDocumentation: rawOptions.withDocumentation,
+      withOASValidationPolicy: rawOptions.withOASValidationPolicy,
+    };
+  }
+
+  /** Builds the WSDL import descriptor sent to the Management API. */
+  private buildImportWsdlDescriptor(payload: string, type: 'INLINE' | 'URL'): ImportWsdlDescriptor {
+    const rawOptions = this.optionsForm.getRawValue();
+    return {
+      payload,
+      type,
       withDocumentation: rawOptions.withDocumentation,
       withOASValidationPolicy: rawOptions.withOASValidationPolicy,
     };

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
@@ -454,7 +454,9 @@ export class ApiImportV4FormComponent {
         return this.importGraviteeDefinitionFromRemoteUrl$(url, updateId);
       }
       if (format === 'wsdl') {
-        return this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(url, 'URL'));
+        return updateId
+          ? this.apiV2Service.updateApiFromWsdl(updateId, this.buildImportWsdlDescriptor(url, 'URL'))
+          : this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(url, 'URL'));
       }
       return updateId
         ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(url))
@@ -479,7 +481,9 @@ export class ApiImportV4FormComponent {
         : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(fileContent as string));
     }
     if (format === 'wsdl' && pickedType === 'WSDL') {
-      return this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(fileContent as string, 'INLINE'));
+      return updateId
+        ? this.apiV2Service.updateApiFromWsdl(updateId, this.buildImportWsdlDescriptor(fileContent as string, 'INLINE'))
+        : this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(fileContent as string, 'INLINE'));
     }
     return null;
   }

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -38,6 +38,7 @@ import {
 import { PathToVerify, VerifyApiPathResponse } from '../entities/management-api-v2/api/verifyApiPath';
 import { VerifyApiHostsResponse } from '../entities/management-api-v2/api/verifyApiHosts';
 import { ImportSwaggerDescriptor } from '../entities/management-api-v2/api/v4/importSwaggerDescriptor';
+import { ImportWsdlDescriptor } from '../entities/management-api-v2/api/v4/importWsdlDescriptor';
 import { MigrateToV4Response } from '../entities/management-api-v2/api/v2/migrateToV4Response';
 import { ApiProductInfo } from '../entities/management-api-v2/api-product/apiProductInfo';
 
@@ -154,6 +155,14 @@ export class ApiV2Service {
 
   importSwaggerApi(descriptor: ImportSwaggerDescriptor) {
     return this.http.post<ApiV4>(`${this.constants.env.v2BaseURL}/apis/_import/swagger`, descriptor, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  importWsdlApi(descriptor: ImportWsdlDescriptor): Observable<ApiV4> {
+    return this.http.post<ApiV4>(`${this.constants.env.v2BaseURL}/apis/_import/wsdl`, descriptor, {
       headers: {
         'Content-Type': 'application/json',
       },

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -169,6 +169,14 @@ export class ApiV2Service {
     });
   }
 
+  updateApiFromWsdl(apiId: string, descriptor: ImportWsdlDescriptor): Observable<ApiV4> {
+    return this.http.put<ApiV4>(`${this.constants.env.v2BaseURL}/apis/${apiId}/_import/wsdl`, descriptor, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
   /**
    * Updates an existing v4 API from a Gravitee export document (same shape as {@link export}).
    */

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -63,6 +63,7 @@ import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiCRDDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.use_case.ExportApiCRDUseCase;
@@ -71,6 +72,7 @@ import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
@@ -602,6 +604,17 @@ public class ResourceContextConfiguration {
     @Bean
     public OAIDomainService oaiDomainService() {
         return mock(OAIDomainService.class);
+    }
+
+    @Bean
+    public WsdlParserDomainService wsdlParserDomainService() {
+        return mock(WsdlParserDomainService.class);
+    }
+
+    @Bean
+    @Primary
+    public WsdlToImportApiUseCase wsdlToImportApiUseCase() {
+        return mock(WsdlToImportApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -38,6 +38,7 @@ import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateFederatedApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateNativeApiUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToUpdateApiUseCase;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.Excludable;
@@ -67,6 +68,7 @@ import io.gravitee.rest.api.management.v2.rest.model.DuplicateApiOptions;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.ImportSwaggerDescriptor;
+import io.gravitee.rest.api.management.v2.rest.model.ImportWsdlDescriptor;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationReportResponses;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationReportResponsesIssuesInner;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationStateType;
@@ -267,6 +269,9 @@ public class ApiResource extends AbstractResource {
     private OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
 
     @Inject
+    private WsdlToUpdateApiUseCase wsdlToUpdateApiUseCase;
+
+    @Inject
     private UpdateApiGroupsUseCase updateApiGroupsUseCase;
 
     @Context
@@ -390,6 +395,31 @@ public class ApiResource extends AbstractResource {
                 .withPolicyPaths(Boolean.TRUE.equals(descriptor.getWithPolicyPaths()))
                 .auditInfo(audit)
                 .build()
+        );
+
+        boolean isSynchronized = apiStateService.isSynchronized(
+            GraviteeContext.getExecutionContext(),
+            getGenericApiEntityById(apiId, false)
+        );
+        return Response.ok().entity(ApiMapper.INSTANCE.map(output.apiWithFlows(), uriInfo, isSynchronized)).build();
+    }
+
+    @PUT
+    @Path("/_import/wsdl")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response updateApiFromWsdl(@PathParam("apiId") String apiId, @Valid @NotNull ImportWsdlDescriptor descriptor) {
+        var audit = getAuditInfo();
+        var output = wsdlToUpdateApiUseCase.execute(
+            WsdlToUpdateApiUseCase.Input.of(
+                apiId,
+                descriptor.getPayload(),
+                ImportWsdlDescriptor.TypeEnum.URL.equals(descriptor.getType()),
+                Boolean.TRUE.equals(descriptor.getWithDocumentation()),
+                Boolean.TRUE.equals(descriptor.getWithOASValidationPolicy()),
+                audit
+            )
         );
 
         boolean isSynchronized = apiStateService.isSynchronized(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -39,6 +39,7 @@ import io.gravitee.apim.core.api.use_case.OAIToImportApiUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.VerifyApiHostsUseCase;
 import io.gravitee.apim.core.api.use_case.VerifyApiPathsUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.common.data.domain.Page;
@@ -56,6 +57,7 @@ import io.gravitee.rest.api.management.v2.rest.model.CreateApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.GenericApi;
 import io.gravitee.rest.api.management.v2.rest.model.ImportSwaggerDescriptor;
+import io.gravitee.rest.api.management.v2.rest.model.ImportWsdlDescriptor;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiHosts;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiHostsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiPaths;
@@ -151,6 +153,9 @@ public class ApisResource extends AbstractResource {
     @Inject
     private OAIToImportApiUseCase oaiToImportApiUseCase;
 
+    @Inject
+    private WsdlToImportApiUseCase wsdlToImportApiUseCase;
+
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
@@ -242,6 +247,34 @@ public class ApisResource extends AbstractResource {
 
             return Response.created(this.getLocationHeader(importOutput.apiWithFlows().getId()))
                 .entity(ApiMapper.INSTANCE.map(importOutput.apiWithFlows(), uriInfo, isSynchronized))
+                .build();
+        } catch (InvalidPathsException e) {
+            throw new InvalidPathException("Cannot import API with invalid paths", e);
+        }
+    }
+
+    @POST
+    @Path("/_import/wsdl")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.CREATE) })
+    public Response createApiFromWsdl(@Valid @NotNull ImportWsdlDescriptor descriptor) {
+        try {
+            var audit = getAuditInfo();
+            var output = wsdlToImportApiUseCase.execute(
+                WsdlToImportApiUseCase.Input.of(
+                    descriptor.getPayload(),
+                    ImportWsdlDescriptor.TypeEnum.URL.equals(descriptor.getType()),
+                    Boolean.TRUE.equals(descriptor.getWithDocumentation()),
+                    Boolean.TRUE.equals(descriptor.getWithOASValidationPolicy()),
+                    audit
+                )
+            );
+
+            boolean isSynchronized = apiStateDomainService.isSynchronized(output.apiWithFlows(), audit);
+
+            return Response.created(this.getLocationHeader(output.apiWithFlows().getId()))
+                .entity(ApiMapper.INSTANCE.map(output.apiWithFlows(), uriInfo, isSynchronized))
                 .build();
         } catch (InvalidPathsException e) {
             throw new InvalidPathException("Cannot import API with invalid paths", e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -133,6 +133,36 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
+    /environments/{envId}/apis/_import/wsdl:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+        post:
+            tags:
+                - APIs
+            summary: Create API from WSDL
+            description: |-
+                Create a v4 HTTP Proxy API from a WSDL descriptor. The WSDL is converted to OpenAPI
+                and processed through the v4 OAI import pipeline. Payload can be inline WSDL (type: INLINE)
+                or a remote URL (type: URL).
+
+                User must have the ENVIRONMENT_API[CREATE] permission.
+            operationId: createApiFromWsdl
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ImportWsdlDescriptor"
+                required: true
+            responses:
+                "201":
+                    description: API successfully created
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiV4"
+                default:
+                    $ref: "#/components/responses/Error"
+
     /environments/{envId}/apis/_import/definition:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -3849,6 +3879,34 @@ components:
                     description: The list of API's media used in pages.
                     items:
                         $ref: "#/components/schemas/Media"
+
+        ImportWsdlDescriptor:
+            type: object
+            required:
+                - payload
+            properties:
+                payload:
+                    type: string
+                    description: Inline WSDL content (when type is INLINE) or a remote URL (when type is URL).
+                type:
+                    type: string
+                    description: Whether the payload is inline WSDL or a remote URL.
+                    enum:
+                        - INLINE
+                        - URL
+                    default: INLINE
+                withDocumentation:
+                    type: boolean
+                    description: Generate a Swagger documentation page from the converted OpenAPI spec.
+                withOASValidationPolicy:
+                    type: boolean
+                    description: Add an OAS Validation policy to every flow.
+                withPolicies:
+                    type: array
+                    description: Policy visitor IDs to apply (e.g. rest-to-soap, json-validation, mock, validate-request, xml-validation).
+                    items:
+                        type: string
+                    uniqueItems: true
 
         ImportSwaggerDescriptor:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -665,6 +665,36 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
+    /environments/{envId}/apis/{apiId}/_import/wsdl:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        put:
+            tags:
+                - APIs
+            summary: Update API from WSDL descriptor
+            description: |-
+                Update an existing API by importing a WSDL descriptor.<br>
+                The descriptor payload must be a valid WSDL 1.1 document, either as inline content or a remote URL.
+
+                User must have the API_DEFINITION[UPDATE] permission.
+            operationId: updateApiFromWsdl
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ImportWsdlDescriptor"
+                required: true
+            responses:
+                "200":
+                    description: API successfully updated
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiV4"
+                default:
+                    $ref: "#/components/responses/Error"
+
     /environments/{envId}/apis/{apiId}/_import/swagger:
         parameters:
             - $ref: "#/components/parameters/envIdParam"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -45,6 +45,7 @@ import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToUpdateApiUseCase;
 import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.specgen.use_case.SpecGenRequestUseCase;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
@@ -138,6 +139,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
+
+    @Autowired
+    protected WsdlToUpdateApiUseCase wsdlToUpdateApiUseCase;
 
     @Autowired
     protected PermissionService permissionService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
@@ -55,7 +55,8 @@ public abstract class ApiResourceTest extends AbstractResourceTest {
             apiDuplicatorService,
             apiDuplicateService,
             updateApiDefinitionUseCase,
-            oaiToUpdateApiUseCase
+            oaiToUpdateApiUseCase,
+            wsdlToUpdateApiUseCase
         );
         GraviteeContext.cleanContext();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromWsdlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromWsdlTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.exception.InvalidApiDefinitionException;
+import io.gravitee.apim.core.api.exception.InvalidPathsException;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.use_case.WsdlToUpdateApiUseCase;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.ImportWsdlDescriptor;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+class ApiResource_UpdateApiFromWsdlTest extends ApiResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/_import/wsdl";
+    }
+
+    @Test
+    void should_return_403_when_no_definition_update_permission() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_DEFINITION,
+                API,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(false);
+
+        Response response = rootTarget().request().put(Entity.json(new ImportWsdlDescriptor()));
+
+        assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
+    }
+
+    @Test
+    void should_return_404_when_api_not_found() {
+        when(wsdlToUpdateApiUseCase.execute(any())).thenThrow(new ApiNotFoundException(API));
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("<definitions/>"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(NOT_FOUND_404);
+    }
+
+    @Test
+    void should_return_200_and_updated_api_on_success() {
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API).environmentId(ENVIRONMENT).build();
+        var apiWithFlows = new ApiWithFlows(existingApi, java.util.List.of());
+
+        when(wsdlToUpdateApiUseCase.execute(any())).thenReturn(new WsdlToUpdateApiUseCase.Output(apiWithFlows));
+        when(apiSearchServiceV4.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(
+            io.gravitee.rest.api.model.v4.api.ApiEntity.builder().id(API).name("CalculatorService").apiVersion("1.0").build()
+        );
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("<definitions/>"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        var body = response.readEntity(ApiV4.class);
+        assertThat(body).isNotNull();
+        assertThat(body.getId()).isEqualTo(API);
+    }
+
+    @Test
+    void should_return_400_when_wsdl_cannot_be_converted() {
+        when(wsdlToUpdateApiUseCase.execute(any())).thenThrow(
+            new InvalidApiDefinitionException("Unable to read the swagger specification")
+        );
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("<definitions/>"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_400_when_invalid_paths() {
+        when(wsdlToUpdateApiUseCase.execute(any())).thenThrow(new InvalidPathsException("Path [/foo] already exists"));
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("<definitions/>"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    private ImportWsdlDescriptor buildDescriptor(String payload) {
+        return new ImportWsdlDescriptor().payload(payload).withDocumentation(false).withOASValidationPolicy(false);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromWsdlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromWsdlTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.api.exception.InvalidPathsException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.ImportWsdlDescriptor;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ApisResource_CreateApiFromWsdlTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT_ID = "my-env";
+
+    @Autowired
+    private WsdlToImportApiUseCase wsdlToImportApiUseCase;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT_ID + "/apis/_import/wsdl";
+    }
+
+    @BeforeEach
+    public void init() throws TechnicalException {
+        reset(wsdlToImportApiUseCase);
+        GraviteeContext.cleanContext();
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+
+        EnvironmentEntity environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENVIRONMENT_ID);
+        environmentEntity.setOrganizationId(ORGANIZATION);
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT_ID)).thenReturn(environmentEntity);
+    }
+
+    @Test
+    public void should_return_403_when_no_permission() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_API,
+                ENVIRONMENT_ID,
+                RolePermissionAction.CREATE
+            )
+        ).thenReturn(false);
+
+        var response = rootTarget().request().post(null);
+
+        assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
+    }
+
+    @Test
+    public void should_return_201_with_created_api() {
+        var createdApi = Api.builder()
+            .id("wsdl-api-id")
+            .name("CalculatorService")
+            .environmentId(ENVIRONMENT_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .type(ApiType.PROXY)
+            .build();
+        when(wsdlToImportApiUseCase.execute(any())).thenReturn(new WsdlToImportApiUseCase.Output(new ApiWithFlows(createdApi, List.of())));
+
+        var descriptor = new ImportWsdlDescriptor().payload("<definitions/>").withDocumentation(false).withOASValidationPolicy(false);
+
+        var response = rootTarget().request().post(Entity.json(descriptor));
+
+        assertThat(response.getStatus()).isEqualTo(CREATED_201);
+        var api = response.readEntity(ApiV4.class);
+        assertThat(api.getId()).isEqualTo("wsdl-api-id");
+        assertThat(api.getName()).isEqualTo("CalculatorService");
+    }
+
+    @Test
+    public void should_return_400_when_invalid_paths() {
+        when(wsdlToImportApiUseCase.execute(any())).thenThrow(new InvalidPathsException("Invalid paths"));
+
+        var descriptor = new ImportWsdlDescriptor().payload("<definitions/>");
+
+        var response = rootTarget().request().post(Entity.json(descriptor));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        var error = response.readEntity(Error.class);
+        assertThat(error.getHttpStatus()).isEqualTo(BAD_REQUEST_400);
+        assertThat(error.getMessage()).isEqualTo("Cannot import API with invalid paths (Invalid paths)");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -83,6 +83,7 @@ import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToUpdateApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
@@ -666,6 +667,12 @@ public class ResourceContextConfiguration {
     @Primary
     public WsdlToImportApiUseCase wsdlToImportApiUseCase() {
         return mock(WsdlToImportApiUseCase.class);
+    }
+
+    @Bean
+    @Primary
+    public WsdlToUpdateApiUseCase wsdlToUpdateApiUseCase() {
+        return mock(WsdlToUpdateApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -72,6 +72,7 @@ import io.gravitee.apim.core.api.domain_service.ValidateApiCRDDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
@@ -81,6 +82,7 @@ import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
@@ -653,6 +655,17 @@ public class ResourceContextConfiguration {
     @Primary
     public OAIToUpdateApiUseCase oaiToUpdateApiUseCase() {
         return mock(OAIToUpdateApiUseCase.class);
+    }
+
+    @Bean
+    public WsdlParserDomainService wsdlParserDomainService() {
+        return mock(WsdlParserDomainService.class);
+    }
+
+    @Bean
+    @Primary
+    public WsdlToImportApiUseCase wsdlToImportApiUseCase() {
+        return mock(WsdlToImportApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -59,11 +59,13 @@ import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
@@ -867,6 +869,17 @@ public class ResourceContextConfiguration {
     @Bean
     public OAIDomainService oaiDomainService() {
         return mock(OAIDomainService.class);
+    }
+
+    @Bean
+    public WsdlParserDomainService wsdlParserDomainService() {
+        return mock(WsdlParserDomainService.class);
+    }
+
+    @Bean
+    @Primary
+    public WsdlToImportApiUseCase wsdlToImportApiUseCase() {
+        return mock(WsdlToImportApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -62,11 +62,13 @@ import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
@@ -266,6 +268,7 @@ import io.vertx.rxjava3.core.Vertx;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -798,6 +801,17 @@ public class ResourceContextConfiguration {
     @Bean
     public OAIDomainService oaiDomainService() {
         return mock(OAIDomainService.class);
+    }
+
+    @Bean
+    public WsdlParserDomainService wsdlParserDomainService() {
+        return mock(WsdlParserDomainService.class);
+    }
+
+    @Bean
+    @Primary
+    public WsdlToImportApiUseCase wsdlToImportApiUseCase() {
+        return mock(WsdlToImportApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/WsdlParserDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/WsdlParserDomainService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+/**
+ * Converts a WSDL descriptor into an OpenAPI YAML string
+ * that can be fed into the standard v4 OAI import pipeline.
+ */
+public interface WsdlParserDomainService {
+    /**
+     * @param content inline WSDL XML content or a remote URL
+     * @return OpenAPI 3.x YAML string, or {@code null} if parsing failed
+     */
+    String toOpenApiYaml(String content);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCase.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.OAIDomainService;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
+import io.gravitee.apim.core.api.domain_service.import_definition.ImportDefinitionCreateDomainService;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+
+@UseCase
+public class WsdlToImportApiUseCase {
+
+    public sealed interface Input permits Input.Inline, Input.Url {
+        boolean withDocumentation();
+        boolean withOASValidationPolicy();
+        AuditInfo auditInfo();
+
+        record Inline(String payload, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) implements Input {}
+
+        record Url(String url, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) implements Input {}
+
+        static Input of(String payload, boolean isUrl, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) {
+            return isUrl
+                ? new Url(payload, withDocumentation, withOASValidationPolicy, auditInfo)
+                : new Inline(payload, withDocumentation, withOASValidationPolicy, auditInfo);
+        }
+    }
+
+    public record Output(ApiWithFlows apiWithFlows) {}
+
+    private final WsdlParserDomainService wsdlParserDomainService;
+    private final OAIDomainService oaiDomainService;
+    private final ImportDefinitionCreateDomainService importDefinitionCreateDomainService;
+
+    public WsdlToImportApiUseCase(
+        WsdlParserDomainService wsdlParserDomainService,
+        OAIDomainService oaiDomainService,
+        ImportDefinitionCreateDomainService importDefinitionCreateDomainService
+    ) {
+        this.wsdlParserDomainService = wsdlParserDomainService;
+        this.oaiDomainService = oaiDomainService;
+        this.importDefinitionCreateDomainService = importDefinitionCreateDomainService;
+    }
+
+    public Output execute(Input input) {
+        String content = switch (input) {
+            case Input.Url u -> u.url();
+            case Input.Inline i -> i.payload();
+        };
+        String openApiYaml = wsdlParserDomainService.toOpenApiYaml(content);
+
+        if (openApiYaml == null) {
+            throw new SwaggerDescriptorException("Failed to convert WSDL to OpenAPI specification");
+        }
+
+        var importSwaggerDescriptor = ImportSwaggerDescriptorEntity.builder()
+            .payload(openApiYaml)
+            .withDocumentation(input.withDocumentation())
+            .build();
+
+        var importDefinition = oaiDomainService.convert(
+            input.auditInfo().organizationId(),
+            input.auditInfo().environmentId(),
+            importSwaggerDescriptor,
+            input.withDocumentation(),
+            input.withOASValidationPolicy()
+        );
+
+        if (importDefinition == null) {
+            throw new SwaggerDescriptorException("Failed to convert OpenAPI specification to API definition");
+        }
+
+        ApiWithFlows apiWithFlows = importDefinitionCreateDomainService.create(input.auditInfo(), importDefinition);
+        return new Output(apiWithFlows);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+
+@UseCase
+public class WsdlToUpdateApiUseCase {
+
+    public sealed interface Input permits Input.Inline, Input.Url {
+        String apiId();
+        boolean withDocumentation();
+        boolean withOASValidationPolicy();
+        AuditInfo auditInfo();
+
+        record Inline(
+            String apiId,
+            String payload,
+            boolean withDocumentation,
+            boolean withOASValidationPolicy,
+            AuditInfo auditInfo
+        ) implements Input {}
+
+        record Url(String apiId, String url, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) implements
+            Input {}
+
+        static Input of(
+            String apiId,
+            String payload,
+            boolean isUrl,
+            boolean withDocumentation,
+            boolean withOASValidationPolicy,
+            AuditInfo auditInfo
+        ) {
+            return isUrl
+                ? new Url(apiId, payload, withDocumentation, withOASValidationPolicy, auditInfo)
+                : new Inline(apiId, payload, withDocumentation, withOASValidationPolicy, auditInfo);
+        }
+    }
+
+    public record Output(ApiWithFlows apiWithFlows) {}
+
+    private final WsdlParserDomainService wsdlParserDomainService;
+    private final OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
+
+    public WsdlToUpdateApiUseCase(WsdlParserDomainService wsdlParserDomainService, OAIToUpdateApiUseCase oaiToUpdateApiUseCase) {
+        this.wsdlParserDomainService = wsdlParserDomainService;
+        this.oaiToUpdateApiUseCase = oaiToUpdateApiUseCase;
+    }
+
+    public Output execute(Input input) {
+        String content = switch (input) {
+            case Input.Url u -> u.url();
+            case Input.Inline i -> i.payload();
+        };
+        String openApiYaml = wsdlParserDomainService.toOpenApiYaml(content);
+
+        if (openApiYaml == null) {
+            throw new SwaggerDescriptorException("Failed to convert WSDL to OpenAPI specification");
+        }
+
+        var importSwaggerDescriptor = ImportSwaggerDescriptorEntity.builder()
+            .payload(openApiYaml)
+            .withDocumentation(input.withDocumentation())
+            .build();
+
+        var output = oaiToUpdateApiUseCase.execute(
+            OAIToUpdateApiUseCase.Input.builder()
+                .apiId(input.apiId())
+                .importSwaggerDescriptor(importSwaggerDescriptor)
+                .withDocumentation(input.withDocumentation())
+                .withOASValidationPolicy(input.withOASValidationPolicy())
+                .withPolicyPaths(false)
+                .auditInfo(input.auditInfo())
+                .build()
+        );
+
+        return new Output(output.apiWithFlows());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
+import io.gravitee.rest.api.service.impl.swagger.parser.WsdlParser;
+import io.gravitee.rest.api.service.sanitizer.UrlSanitizerUtils;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.oas.models.OpenAPI;
+import lombok.CustomLog;
+import org.springframework.stereotype.Service;
+
+@Service
+@CustomLog
+public class WsdlParserDomainServiceImpl implements WsdlParserDomainService {
+
+    private final ImportConfiguration importConfiguration;
+
+    public WsdlParserDomainServiceImpl(ImportConfiguration importConfiguration) {
+        this.importConfiguration = importConfiguration;
+    }
+
+    @Override
+    public String toOpenApiYaml(String content) {
+        if (UrlSanitizerUtils.isUrl(content)) {
+            UrlSanitizerUtils.checkAllowed(
+                content,
+                importConfiguration.getImportWhitelist(),
+                importConfiguration.isAllowImportFromPrivate()
+            );
+        }
+        OpenAPI openAPI = new WsdlParser().parse(content);
+        if (openAPI == null) {
+            return null;
+        }
+        return Yaml.pretty(openAPI);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtils.java
@@ -30,6 +30,15 @@ import java.util.List;
  */
 public class UrlSanitizerUtils {
 
+    public static boolean isUrl(String content) {
+        try {
+            new URL(content);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     public static void checkAllowed(String url, List<String> whitelist, boolean allowPrivate) {
         checkUrlForbiddenCharacters(url);
         checkUriSyntax(url);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCaseTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import fixtures.core.model.AuditInfoFixtures;
+import initializers.ImportDefinitionCreateDomainServiceTestInitializer;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.PolicyPluginCrudServiceInMemory;
+import inmemory.TagQueryServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.infra.domain_service.api.OAIDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.api.WsdlParserDomainServiceImpl;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.repository.management.model.Parameter;
+import io.gravitee.repository.management.model.ParameterReferenceType;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class WsdlToImportApiUseCaseTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final String SHARED_CONFIGURATION = """
+            { "description": "shared config" }
+        """;
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    private final EndpointConnectorPluginDomainService endpointConnectorPluginService = mock(EndpointConnectorPluginDomainService.class);
+    private final PolicyPluginCrudServiceInMemory policyPluginCrudService = new PolicyPluginCrudServiceInMemory();
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+
+    private WsdlToImportApiUseCase useCase;
+    private ImportDefinitionCreateDomainServiceTestInitializer importDefinitionCreateDomainServiceTestInitializer;
+
+    @BeforeEach
+    void setUp() {
+        importDefinitionCreateDomainServiceTestInitializer = new ImportDefinitionCreateDomainServiceTestInitializer(apiCrudService);
+
+        when(endpointConnectorPluginService.getDefaultSharedConfiguration(anyString())).thenReturn(SHARED_CONFIGURATION);
+
+        importDefinitionCreateDomainServiceTestInitializer.parametersQueryService.initWith(
+            List.of(
+                new Parameter(
+                    Key.API_PRIMARY_OWNER_MODE.key(),
+                    ENVIRONMENT_ID,
+                    ParameterReferenceType.ENVIRONMENT,
+                    ApiPrimaryOwnerMode.USER.name()
+                ),
+                new Parameter(Key.PLAN_SECURITY_KEYLESS_ENABLED.key(), ENVIRONMENT_ID, ParameterReferenceType.ENVIRONMENT, "true")
+            )
+        );
+        importDefinitionCreateDomainServiceTestInitializer.userCrudService.initWith(
+            List.of(BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane@gravitee.io").build())
+        );
+        when(
+            importDefinitionCreateDomainServiceTestInitializer.validateApiDomainService.validateAndSanitizeForCreation(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        ).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ImportConfiguration importConfiguration = mock(ImportConfiguration.class);
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(true);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+
+        useCase = new WsdlToImportApiUseCase(
+            new WsdlParserDomainServiceImpl(importConfiguration),
+            new OAIDomainServiceImpl(
+                new PolicyOperationVisitorManagerImpl(),
+                new GroupQueryServiceInMemory(),
+                new TagQueryServiceInMemory(),
+                endpointConnectorPluginService,
+                policyPluginCrudService
+            ),
+            importDefinitionCreateDomainServiceTestInitializer.initialize()
+        );
+    }
+
+    @Test
+    void should_create_api_with_name_from_wsdl_service_element() {
+        var output = useCase.execute(buildInput(loadWsdl(), false, false));
+
+        assertThat(output).isNotNull();
+        assertThat(output.apiWithFlows().getName()).isEqualTo("CalculatorService");
+    }
+
+    @Test
+    void should_create_api_with_endpoint_url_from_wsdl_soap_address() {
+        var output = useCase.execute(buildInput(loadWsdl(), false, false));
+        var apiDefinition = (Api) output.apiWithFlows().getApiDefinitionValue();
+
+        assertThat(output).isNotNull();
+        assertThat(apiDefinition.getEndpointGroups())
+            .isNotEmpty()
+            .first()
+            .satisfies(endpointGroup ->
+                assertThat(endpointGroup.getEndpoints())
+                    .isNotEmpty()
+                    .first()
+                    .satisfies(endpoint -> assertThat(endpoint.getConfiguration()).contains("http://localhost:8080/calculator"))
+            );
+    }
+
+    @Test
+    void should_create_flows_for_each_wsdl_operation() {
+        var output = useCase.execute(buildInput(loadWsdl(), false, false));
+        var apiDefinition = (Api) output.apiWithFlows().getApiDefinitionValue();
+
+        assertThat(output).isNotNull();
+        // calculator.wsdl has 4 operations × 2 bindings (SOAP 1.1 + SOAP 1.2) = 8 flows
+        assertThat(apiDefinition.getFlows()).hasSize(8);
+    }
+
+    @Test
+    void should_throw_when_wsdl_payload_is_invalid() {
+        var throwable = catchThrowable(() -> useCase.execute(buildInput("not valid wsdl content", false, false)));
+
+        assertThat(throwable).isInstanceOf(SwaggerDescriptorException.class);
+    }
+
+    @Nested
+    class WithDocumentation {
+
+        @Test
+        void should_add_documentation_page_with_openapi_yaml_content() {
+            var output = useCase.execute(buildInput(loadWsdl(), true, false));
+
+            assertThat(output).isNotNull();
+            assertThat(importDefinitionCreateDomainServiceTestInitializer.pageCrudService.storage())
+                .hasSize(1)
+                .first()
+                .satisfies(page -> {
+                    assertThat(page.getReferenceId()).isEqualTo(output.apiWithFlows().getId());
+                    assertThat(page.getName()).isEqualTo("Swagger");
+                    // Content must be the converted OpenAPI YAML, not the raw WSDL XML
+                    assertThat(page.getContent()).startsWith("openapi:");
+                    assertThat(page.getContent()).doesNotStartWith("<");
+                });
+        }
+
+        @Test
+        void should_not_add_documentation_page_when_disabled() {
+            useCase.execute(buildInput(loadWsdl(), false, false));
+
+            assertThat(importDefinitionCreateDomainServiceTestInitializer.pageCrudService.storage()).isEmpty();
+        }
+    }
+
+    @Nested
+    @WireMockTest
+    class WithUrlImport {
+
+        @Test
+        void should_create_api_from_remote_wsdl_url(WireMockRuntimeInfo wm) {
+            var wsdlContent = loadWsdl();
+            wm.getWireMock().register(get(urlEqualTo("/calculator.wsdl")).willReturn(aResponse().withStatus(200).withBody(wsdlContent)));
+
+            var input = new WsdlToImportApiUseCase.Input.Url(
+                "http://localhost:" + wm.getHttpPort() + "/calculator.wsdl",
+                false,
+                false,
+                AUDIT_INFO
+            );
+            var output = useCase.execute(input);
+
+            assertThat(output).isNotNull();
+            assertThat(output.apiWithFlows().getName()).isEqualTo("CalculatorService");
+            assertThat(((Api) output.apiWithFlows().getApiDefinitionValue()).getFlows()).hasSize(8);
+        }
+
+        @Test
+        void should_throw_when_remote_url_is_unreachable() {
+            var input = new WsdlToImportApiUseCase.Input.Url("http://localhost:1/nonexistent.wsdl", false, false, AUDIT_INFO);
+
+            var throwable = catchThrowable(() -> useCase.execute(input));
+
+            assertThat(throwable).isInstanceOf(SwaggerDescriptorException.class);
+        }
+
+        @Test
+        void should_throw_when_remote_url_returns_invalid_wsdl(WireMockRuntimeInfo wm) {
+            wm.getWireMock().register(get(urlEqualTo("/bad.wsdl")).willReturn(aResponse().withStatus(200).withBody("not valid wsdl")));
+
+            var input = new WsdlToImportApiUseCase.Input.Url(
+                "http://localhost:" + wm.getHttpPort() + "/bad.wsdl",
+                false,
+                false,
+                AUDIT_INFO
+            );
+            var throwable = catchThrowable(() -> useCase.execute(input));
+
+            assertThat(throwable).isInstanceOf(SwaggerDescriptorException.class);
+        }
+    }
+
+    @SneakyThrows
+    private String loadWsdl() {
+        return Resources.toString(Resources.getResource("wsdl/calculator.wsdl"), Charsets.UTF_8);
+    }
+
+    private WsdlToImportApiUseCase.Input buildInput(String payload, boolean withDocumentation, boolean withOASValidationPolicy) {
+        return new WsdlToImportApiUseCase.Input.Inline(payload, withDocumentation, withOASValidationPolicy, AUDIT_INFO);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseIntegrationTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static fixtures.core.model.ApiFixtures.aProxyApiV4;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import fixtures.core.model.AuditInfoFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.PolicyPluginCrudServiceInMemory;
+import inmemory.TagQueryServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.import_definition.ImportDefinitionUpdateDomainServiceTestInitializer;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
+import io.gravitee.apim.infra.domain_service.api.OAIDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.api.WsdlParserDomainServiceImpl;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class WsdlToUpdateApiUseCaseIntegrationTest {
+
+    private static final String API_ID = "existing-api-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final String SHARED_CONFIGURATION = """
+            { "description": "shared config" }
+        """;
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    private final EndpointConnectorPluginDomainService endpointConnectorPluginService = mock(EndpointConnectorPluginDomainService.class);
+    private final PolicyPluginCrudServiceInMemory policyPluginCrudService = new PolicyPluginCrudServiceInMemory();
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    private final FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
+
+    private WsdlToUpdateApiUseCase useCase;
+    private ImportDefinitionUpdateDomainServiceTestInitializer updateInitializer;
+
+    @BeforeEach
+    void setUp() {
+        updateInitializer = new ImportDefinitionUpdateDomainServiceTestInitializer(apiCrudService);
+
+        when(endpointConnectorPluginService.getDefaultSharedConfiguration(anyString())).thenReturn(SHARED_CONFIGURATION);
+
+        when(updateInitializer.validateApiDomainService.validateAndSanitizeForUpdate(any(), any(), any(), any(), any())).thenAnswer(inv ->
+            inv.getArgument(1)
+        );
+
+        when(updateInitializer.apiService.update(any(), any(), any(), anyBoolean(), any())).thenAnswer(inv -> {
+            io.gravitee.rest.api.model.v4.api.UpdateApiEntity updateApi = inv.getArgument(2);
+            return ApiEntity.builder().id(API_ID).name(updateApi.getName()).apiVersion(updateApi.getApiVersion()).build();
+        });
+
+        ImportConfiguration importConfiguration = mock(ImportConfiguration.class);
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(true);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+
+        var oaiDomainService = new OAIDomainServiceImpl(
+            new PolicyOperationVisitorManagerImpl(),
+            new GroupQueryServiceInMemory(),
+            new TagQueryServiceInMemory(),
+            endpointConnectorPluginService,
+            policyPluginCrudService
+        );
+
+        var updateApiDefinitionUseCase = new UpdateApiDefinitionFromImportUseCase(
+            apiCrudService,
+            updateInitializer.initialize(ENVIRONMENT_ID),
+            flowCrudService
+        );
+
+        var oaiToUpdateApiUseCase = new OAIToUpdateApiUseCase(oaiDomainService, flowCrudService, updateApiDefinitionUseCase);
+
+        useCase = new WsdlToUpdateApiUseCase(new WsdlParserDomainServiceImpl(importConfiguration), oaiToUpdateApiUseCase);
+    }
+
+    @AfterEach
+    void tearDown() {
+        updateInitializer.tearDown();
+        Stream.of(apiCrudService, flowCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_preserve_api_id_when_updating_from_wsdl() {
+        givenExistingApi(API_ID);
+
+        var output = useCase.execute(buildInput(loadWsdl(), false, false));
+
+        assertThat(output).isNotNull();
+        assertThat(output.apiWithFlows().getId()).isEqualTo(API_ID);
+    }
+
+    @Test
+    void should_update_api_name_from_wsdl_service_element() {
+        givenExistingApi(API_ID);
+
+        useCase.execute(buildInput(loadWsdl(), false, false));
+
+        var captor = ArgumentCaptor.forClass(io.gravitee.rest.api.model.v4.api.UpdateApiEntity.class);
+        verify(updateInitializer.apiService).update(any(), any(), captor.capture(), anyBoolean(), any());
+        assertThat(captor.getValue().getName()).isEqualTo("CalculatorService");
+    }
+
+    @Test
+    void should_replace_flows_with_wsdl_operations() {
+        givenExistingApi(API_ID);
+
+        useCase.execute(buildInput(loadWsdl(), false, false));
+
+        var captor = ArgumentCaptor.forClass(io.gravitee.rest.api.model.v4.api.UpdateApiEntity.class);
+        verify(updateInitializer.apiService).update(any(), any(), captor.capture(), anyBoolean(), any());
+        // calculator.wsdl has 4 operations × 2 bindings (SOAP 1.1 + SOAP 1.2) = 8 flows
+        assertThat(captor.getValue().getFlows()).hasSize(8);
+    }
+
+    @Test
+    void should_update_endpoint_url_from_wsdl_soap_address() {
+        givenExistingApi(API_ID);
+
+        useCase.execute(buildInput(loadWsdl(), false, false));
+
+        var captor = ArgumentCaptor.forClass(io.gravitee.rest.api.model.v4.api.UpdateApiEntity.class);
+        verify(updateInitializer.apiService).update(any(), any(), captor.capture(), anyBoolean(), any());
+        assertThat(captor.getValue().getEndpointGroups())
+            .isNotEmpty()
+            .first()
+            .satisfies(endpointGroup ->
+                assertThat(endpointGroup.getEndpoints())
+                    .isNotEmpty()
+                    .first()
+                    .satisfies(endpoint -> assertThat(endpoint.getConfiguration()).contains("http://localhost:8080/calculator"))
+            );
+    }
+
+    @Test
+    void should_throw_when_wsdl_payload_is_invalid() {
+        givenExistingApi(API_ID);
+
+        var throwable = catchThrowable(() -> useCase.execute(buildInput("not valid wsdl content", false, false)));
+
+        assertThat(throwable).isInstanceOf(SwaggerDescriptorException.class);
+    }
+
+    private void givenExistingApi(String apiId) {
+        var existingApi = aProxyApiV4().toBuilder().id(apiId).environmentId(ENVIRONMENT_ID).build();
+        apiCrudService.initWith(List.of(existingApi));
+    }
+
+    @SneakyThrows
+    private String loadWsdl() {
+        return Resources.toString(Resources.getResource("wsdl/calculator.wsdl"), Charsets.UTF_8);
+    }
+
+    private WsdlToUpdateApiUseCase.Input buildInput(String payload, boolean withDocumentation, boolean withOASValidationPolicy) {
+        return new WsdlToUpdateApiUseCase.Input.Inline(API_ID, payload, withDocumentation, withOASValidationPolicy, AUDIT_INFO);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.AuditInfoFixtures;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class WsdlToUpdateApiUseCaseTest {
+
+    private static final String API_ID = "my-api-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+    private static final String OPENAPI_YAML = "openapi: 3.0.0\ninfo:\n  title: CalculatorService\n";
+
+    private WsdlParserDomainService wsdlParserDomainService;
+    private OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
+    private WsdlToUpdateApiUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        wsdlParserDomainService = mock(WsdlParserDomainService.class);
+        oaiToUpdateApiUseCase = mock(OAIToUpdateApiUseCase.class);
+        useCase = new WsdlToUpdateApiUseCase(wsdlParserDomainService, oaiToUpdateApiUseCase);
+    }
+
+    @Test
+    void should_throw_when_wsdl_conversion_returns_null() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(null);
+
+        assertThatThrownBy(() ->
+            useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, AUDIT_INFO))
+        )
+            .isInstanceOf(SwaggerDescriptorException.class)
+            .hasMessage("Failed to convert WSDL to OpenAPI specification");
+    }
+
+    @Test
+    void should_pass_openapi_yaml_to_oai_update_use_case() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of())));
+
+        useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, AUDIT_INFO));
+
+        var captor = ArgumentCaptor.forClass(OAIToUpdateApiUseCase.Input.class);
+        verify(oaiToUpdateApiUseCase).execute(captor.capture());
+        assertThat(captor.getValue().apiId()).isEqualTo(API_ID);
+        assertThat(captor.getValue().importSwaggerDescriptor().getPayload()).isEqualTo(OPENAPI_YAML);
+        assertThat(captor.getValue().withPolicyPaths()).isFalse();
+    }
+
+    @Test
+    void should_forward_withDocumentation_flag_to_oai_use_case() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of())));
+
+        useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", true, false, AUDIT_INFO));
+
+        var captor = ArgumentCaptor.forClass(OAIToUpdateApiUseCase.Input.class);
+        verify(oaiToUpdateApiUseCase).execute(captor.capture());
+        assertThat(captor.getValue().withDocumentation()).isTrue();
+    }
+
+    @Test
+    void should_return_api_from_oai_use_case_output() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        var apiWithFlows = new ApiWithFlows(existingApi, List.of());
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(apiWithFlows));
+
+        var output = useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, AUDIT_INFO));
+
+        assertThat(output.apiWithFlows().getId()).isEqualTo(API_ID);
+    }
+
+    @Nested
+    class WithUrlInput {
+
+        @Test
+        void should_pass_url_string_to_parser() {
+            when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+            var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+            when(oaiToUpdateApiUseCase.execute(any())).thenReturn(
+                new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of()))
+            );
+
+            useCase.execute(new WsdlToUpdateApiUseCase.Input.Url(API_ID, "http://example.com/service.wsdl", false, false, AUDIT_INFO));
+
+            verify(wsdlParserDomainService).toOpenApiYaml(eq("http://example.com/service.wsdl"));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImplTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import io.gravitee.rest.api.service.exceptions.UrlForbiddenException;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class WsdlParserDomainServiceImplTest {
+
+    private final ImportConfiguration importConfiguration = mock(ImportConfiguration.class);
+    private final WsdlParserDomainServiceImpl service = new WsdlParserDomainServiceImpl(importConfiguration);
+
+    @Test
+    void should_parse_inline_wsdl_content() {
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+
+        var result = service.toOpenApiYaml(loadWsdl());
+
+        assertThat(result).isNotNull().startsWith("openapi:");
+    }
+
+    @Test
+    void should_throw_when_url_points_to_private_address() {
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+
+        var throwable = catchThrowable(() -> service.toOpenApiYaml("http://192.168.1.1/spec.wsdl"));
+
+        assertThat(throwable).isInstanceOf(UrlForbiddenException.class);
+    }
+
+    @SneakyThrows
+    private String loadWsdl() {
+        return Resources.toString(Resources.getResource("wsdl/calculator.wsdl"), Charsets.UTF_8);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtilsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtilsTest.java
@@ -34,6 +34,16 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class UrlSanitizerUtilsTest {
 
     @Test
+    public void isUrl_returnsTrue_forHttpUrl() {
+        assertTrue(UrlSanitizerUtils.isUrl("https://www.gravitee.io/spec.wsdl"));
+    }
+
+    @Test
+    public void isUrl_returnsFalse_forInlineContent() {
+        assertFalse(UrlSanitizerUtils.isUrl("<definitions xmlns=\"http://schemas.xmlsoap.org/wsdl/\"/>"));
+    }
+
+    @Test
     public void checkAllowed_allowPrivate() {
         UrlSanitizerUtils.checkAllowed("http://localhost:8080", Collections.emptyList(), true);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/wsdl/calculator.wsdl
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/wsdl/calculator.wsdl
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+    xmlns:tns="http://gravitee.io/wsdl/calculator"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://gravitee.io/wsdl/calculator"
+    name="CalculatorService">
+
+    <types>
+        <xsd:schema targetNamespace="http://gravitee.io/wsdl/calculator">
+
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="a" type="xsd:double"/>
+                        <xsd:element name="b" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="SubtractRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="a" type="xsd:double"/>
+                        <xsd:element name="b" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SubtractResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="MultiplyRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="a" type="xsd:double"/>
+                        <xsd:element name="b" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="MultiplyResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="DivideRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="a" type="xsd:double"/>
+                        <xsd:element name="b" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DivideResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+        </xsd:schema>
+    </types>
+
+    <!-- Messages -->
+    <message name="AddRequest">
+        <part name="parameters" element="tns:AddRequest"/>
+    </message>
+    <message name="AddResponse">
+        <part name="parameters" element="tns:AddResponse"/>
+    </message>
+    <message name="SubtractRequest">
+        <part name="parameters" element="tns:SubtractRequest"/>
+    </message>
+    <message name="SubtractResponse">
+        <part name="parameters" element="tns:SubtractResponse"/>
+    </message>
+    <message name="MultiplyRequest">
+        <part name="parameters" element="tns:MultiplyRequest"/>
+    </message>
+    <message name="MultiplyResponse">
+        <part name="parameters" element="tns:MultiplyResponse"/>
+    </message>
+    <message name="DivideRequest">
+        <part name="parameters" element="tns:DivideRequest"/>
+    </message>
+    <message name="DivideResponse">
+        <part name="parameters" element="tns:DivideResponse"/>
+    </message>
+
+    <!-- Port Type -->
+    <portType name="CalculatorPortType">
+        <operation name="Add">
+            <input message="tns:AddRequest"/>
+            <output message="tns:AddResponse"/>
+        </operation>
+        <operation name="Subtract">
+            <input message="tns:SubtractRequest"/>
+            <output message="tns:SubtractResponse"/>
+        </operation>
+        <operation name="Multiply">
+            <input message="tns:MultiplyRequest"/>
+            <output message="tns:MultiplyResponse"/>
+        </operation>
+        <operation name="Divide">
+            <input message="tns:DivideRequest"/>
+            <output message="tns:DivideResponse"/>
+        </operation>
+    </portType>
+
+    <!-- SOAP 1.1 Binding -->
+    <binding name="CalculatorSoap11Binding" type="tns:CalculatorPortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="Add">
+            <soap:operation soapAction="http://gravitee.io/wsdl/calculator/Add"/>
+            <input><soap:body use="literal"/></input>
+            <output><soap:body use="literal"/></output>
+        </operation>
+        <operation name="Subtract">
+            <soap:operation soapAction="http://gravitee.io/wsdl/calculator/Subtract"/>
+            <input><soap:body use="literal"/></input>
+            <output><soap:body use="literal"/></output>
+        </operation>
+        <operation name="Multiply">
+            <soap:operation soapAction="http://gravitee.io/wsdl/calculator/Multiply"/>
+            <input><soap:body use="literal"/></input>
+            <output><soap:body use="literal"/></output>
+        </operation>
+        <operation name="Divide">
+            <soap:operation soapAction="http://gravitee.io/wsdl/calculator/Divide"/>
+            <input><soap:body use="literal"/></input>
+            <output><soap:body use="literal"/></output>
+        </operation>
+    </binding>
+
+    <!-- SOAP 1.2 Binding -->
+    <binding name="CalculatorSoap12Binding" type="tns:CalculatorPortType">
+        <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="Add">
+            <soap12:operation soapAction="http://gravitee.io/wsdl/calculator/Add"/>
+            <input><soap12:body use="literal"/></input>
+            <output><soap12:body use="literal"/></output>
+        </operation>
+        <operation name="Subtract">
+            <soap12:operation soapAction="http://gravitee.io/wsdl/calculator/Subtract"/>
+            <input><soap12:body use="literal"/></input>
+            <output><soap12:body use="literal"/></output>
+        </operation>
+        <operation name="Multiply">
+            <soap12:operation soapAction="http://gravitee.io/wsdl/calculator/Multiply"/>
+            <input><soap12:body use="literal"/></input>
+            <output><soap12:body use="literal"/></output>
+        </operation>
+        <operation name="Divide">
+            <soap12:operation soapAction="http://gravitee.io/wsdl/calculator/Divide"/>
+            <input><soap12:body use="literal"/></input>
+            <output><soap12:body use="literal"/></output>
+        </operation>
+    </binding>
+
+    <!-- Service -->
+    <service name="CalculatorService">
+        <port name="CalculatorSoap11Port" binding="tns:CalculatorSoap11Binding">
+            <soap:address location="http://localhost:8080/calculator"/>
+        </port>
+        <port name="CalculatorSoap12Port" binding="tns:CalculatorSoap12Binding">
+            <soap12:address location="http://localhost:8080/calculator"/>
+        </port>
+    </service>
+
+</definitions>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-103

## Description

Adds WSDL as an additional import format for v4 APIs (create and update).

  **Backend**
  - New POST /v4/apis/_import/wsdl endpoint (ApisResource) + WsdlToImportApiUseCase: converts WSDL → OpenAPI, then delegates to the existing v4 OAI pipeline
  - New PUT /v4/apis/{apiId}/_import/wsdl endpoint + WsdlToUpdateApiUseCase: same pre-processing, delegates to the existing v4 update pipeline
  - No changes to the core OAI/flow converters
  - Remote URL import uses UrlSanitizerUtils.checkAllowed() + ImportConfiguration whitelist (same as v2)

  **Frontend**
  - WSDL format option added to the v4 import wizard with local file and remote URL support
  - 2 pre-existing import options exposed: Create documentation and OAS validation

## Recording

https://github.com/user-attachments/assets/50b799ea-6d3e-4611-90f9-b73e1ff525c9

## To be confirmed

- [ ] Import options (to confirm): v4 WSDL import exposes 2 options (documentation + OAS validation) per PO decision. v2 exposes 7 (adds json-validation, mock, rest-to-soap, validate-request, xml-validation). Confirm this is the agreed final scope before merging.
- [ ] URL sanitization consistency (to confirm): Remote URL sanitization (UrlSanitizerUtils) is applied for WSDL import but is currently absent for OpenAPI remote URL import in the v4 wizard. Should be made consistent across all formats — tracked separately or addressed here?
