### PR TITLE
Fix/apim cockpit org command preserve flows

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandler.java
@@ -26,6 +26,7 @@ import io.gravitee.exchange.api.command.CommandHandler;
 import io.gravitee.rest.api.model.OrganizationEntity;
 import io.gravitee.rest.api.model.UpdateOrganizationEntity;
 import io.gravitee.rest.api.service.OrganizationService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.OrganizationNotFoundException;
 import io.reactivex.rxjava3.core.Single;
 import java.util.ArrayList;
@@ -58,13 +59,29 @@ public class OrganizationCommandHandler implements CommandHandler<OrganizationCo
         OrganizationCommandPayload organizationPayload = command.getPayload();
 
         try {
-            final OrganizationEntity organization = createOrUpdateOrganization(organizationPayload);
+            final String organizationId = getOrganizationId(organizationPayload);
 
-            handleLicense(organization, command.getPayload().license());
+            // This handler runs outside any user-bound execution context, so the calling thread
+            // carries the platform default GraviteeContext on entry. Bind currentOrganization to
+            // the organization being modified so audit log entries written along the call chain
+            // (organization update, flow update, access point update, license update) are
+            // attributed to the real organization, and restore the previous value in finally so
+            // we don't wipe state any other caller on the dispatcher thread might rely on.
+            // currentEnvironment is intentionally left untouched: this is an organization-level
+            // command and downstream consumers expect the previously-bound environment scope.
+            final String previousOrganization = GraviteeContext.getCurrentOrganization();
+            GraviteeContext.setCurrentOrganization(organizationId);
+            try {
+                final OrganizationEntity organization = createOrUpdateOrganization(organizationId, organizationPayload);
 
-            handleAccessPoints(organizationPayload, organization);
-            log.info("Organization [{}] handled with id [{}].", organization.getName(), organization.getId());
-            return Single.just(new OrganizationReply(command.getId()));
+                handleLicense(organization, command.getPayload().license());
+
+                handleAccessPoints(organizationPayload, organization);
+                log.info("Organization [{}] handled with id [{}].", organization.getName(), organization.getId());
+                return Single.just(new OrganizationReply(command.getId()));
+            } finally {
+                GraviteeContext.setCurrentOrganization(previousOrganization);
+            }
         } catch (Exception e) {
             String errorDetails = "Error occurred when handling organization [%s] with id [%s].".formatted(
                 organizationPayload.name(),
@@ -106,9 +123,7 @@ public class OrganizationCommandHandler implements CommandHandler<OrganizationCo
         organizationLicenseService.createOrUpdateOrganizationLicense(organization.getId(), license);
     }
 
-    private OrganizationEntity createOrUpdateOrganization(OrganizationCommandPayload organizationPayload) {
-        String organizationId = this.getOrganizationId(organizationPayload);
-
+    private OrganizationEntity createOrUpdateOrganization(String organizationId, OrganizationCommandPayload organizationPayload) {
         UpdateOrganizationEntity newOrganization = new UpdateOrganizationEntity();
         newOrganization.setCockpitId(organizationPayload.cockpitId());
         newOrganization.setHrids(organizationPayload.hrids());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
@@ -110,15 +110,24 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
         }
     }
 
+    /**
+     * Create the organization with the given id when it does not exist yet, or update its metadata
+     * when it does. This method is intentionally flow-agnostic: it never reads, writes, or deletes
+     * the organization's platform flows, and any {@code flows} value carried on the supplied
+     * {@link UpdateOrganizationEntity} is ignored. Callers that need to persist organization flows
+     * alongside the organization metadata must use
+     * {@link #updateOrganizationAndFlows(String, UpdateOrganizationEntity)} instead — it is the only
+     * path on this service that touches organization flows, and treats a missing flow list as
+     * "delete all flows for this reference".
+     */
     @Override
     public OrganizationEntity createOrUpdate(String organizationId, final UpdateOrganizationEntity organizationEntity) {
         try {
             try {
-                return this.updateOrganizationAndFlows(organizationId, organizationEntity);
+                return this.updateOrganization(organizationId, organizationEntity);
             } catch (OrganizationNotFoundException e) {
                 Organization organization = convert(organizationEntity);
                 organization.setId(organizationId);
-                flowService.save(FlowReferenceType.ORGANIZATION, organizationId, organizationEntity.getFlows());
                 OrganizationEntity createdOrganization = convert(organizationRepository.create(organization));
 
                 //create Default role for organization

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandlerTest.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.rest.api.service.cockpit.command.handler;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,10 +34,12 @@ import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.rest.api.model.OrganizationEntity;
 import io.gravitee.rest.api.model.UpdateOrganizationEntity;
 import io.gravitee.rest.api.service.OrganizationService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.OrganizationNotFoundException;
 import io.reactivex.rxjava3.observers.TestObserver;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -172,5 +176,65 @@ public class OrganizationCommandHandlerTest {
 
         obs.await();
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+    }
+
+    @Test
+    public void handle_must_set_organization_context_during_processing() throws InterruptedException {
+        OrganizationCommandPayload payload = OrganizationCommandPayload.builder()
+            .id("orga#1")
+            .cockpitId("org#cockpit-1")
+            .hrids(Collections.singletonList("orga-1"))
+            .description("Organization description")
+            .name("Organization name")
+            .build();
+
+        OrganizationEntity existing = mock(OrganizationEntity.class);
+        when(existing.getId()).thenReturn("ACME");
+        when(organizationService.findByCockpitId("org#cockpit-1")).thenReturn(existing);
+
+        AtomicReference<String> orgIdSeenInsideService = new AtomicReference<>();
+        when(organizationService.createOrUpdate(eq("ACME"), any(UpdateOrganizationEntity.class))).thenAnswer(invocation -> {
+            orgIdSeenInsideService.set(GraviteeContext.getCurrentOrganization());
+            return new OrganizationEntity();
+        });
+
+        cut
+            .handle(new OrganizationCommand(payload))
+            .test()
+            .await()
+            .assertValue(reply -> reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        assertThat(orgIdSeenInsideService.get())
+            .as("createOrUpdate must run with GraviteeContext bound to the resolved organization")
+            .isEqualTo("ACME");
+        assertThat(GraviteeContext.getCurrentOrganization())
+            .as("GraviteeContext must be cleaned up after handle()")
+            .isEqualTo(GraviteeContext.getDefaultOrganization());
+    }
+
+    @Test
+    public void handle_must_clean_organization_context_when_service_throws() throws InterruptedException {
+        OrganizationCommandPayload payload = OrganizationCommandPayload.builder()
+            .id("orga#1")
+            .cockpitId("org#cockpit-1")
+            .hrids(Collections.singletonList("orga-1"))
+            .description("Organization description")
+            .name("Organization name")
+            .build();
+
+        OrganizationEntity existing = mock(OrganizationEntity.class);
+        when(existing.getId()).thenReturn("ACME");
+        when(organizationService.findByCockpitId("org#cockpit-1")).thenReturn(existing);
+        when(organizationService.createOrUpdate(eq("ACME"), any(UpdateOrganizationEntity.class))).thenThrow(new RuntimeException("boom"));
+
+        cut
+            .handle(new OrganizationCommand(payload))
+            .test()
+            .await()
+            .assertValue(reply -> reply.getCommandStatus().equals(CommandStatus.ERROR));
+
+        assertThat(GraviteeContext.getCurrentOrganization())
+            .as("GraviteeContext must be cleaned up even when the downstream service fails")
+            .isEqualTo(GraviteeContext.getDefaultOrganization());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/OrganizationService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/OrganizationService_CreateTest.java
@@ -15,10 +15,16 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.flow.Flow;
@@ -35,7 +41,10 @@ import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -84,7 +93,7 @@ public class OrganizationService_CreateTest {
     }
 
     @Test
-    public void shouldCreateOrganization() throws Exception {
+    public void create_or_update_should_create_organization_without_touching_flows() throws Exception {
         when(mockOrganizationRepository.findById(any())).thenReturn(Optional.empty());
 
         UpdateOrganizationEntity org1 = new UpdateOrganizationEntity();
@@ -115,7 +124,7 @@ public class OrganizationService_CreateTest {
         verify(mockOrganizationRepository, never()).update(any());
         verify(mockRoleService, times(1)).initialize(GraviteeContext.getExecutionContext(), "org_id");
         verify(mockRoleService, times(1)).createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), "org_id");
-        verify(mockFlowService, times(1)).save(FlowReferenceType.ORGANIZATION, "org_id", List.of());
+        verify(mockFlowService, never()).save(any(), any(), any());
         verify(eventService, times(1)).createOrganizationEvent(
             eq(new ExecutionContext("org_id")),
             eq(Set.of("env_1", "env_2")),
@@ -126,7 +135,7 @@ public class OrganizationService_CreateTest {
     }
 
     @Test
-    public void shouldUpdateOrganization() throws Exception {
+    public void create_or_update_should_update_existing_organization_without_touching_flows() throws Exception {
         when(mockOrganizationRepository.findById(any())).thenReturn(Optional.of(new Organization()));
 
         UpdateOrganizationEntity org1 = new UpdateOrganizationEntity();
@@ -157,7 +166,7 @@ public class OrganizationService_CreateTest {
         verify(mockOrganizationRepository, never()).create(any());
         verify(mockRoleService, never()).initialize(GraviteeContext.getExecutionContext(), "org_id");
         verify(mockRoleService, never()).createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), "org_id");
-        verify(mockFlowService, times(1)).save(FlowReferenceType.ORGANIZATION, "org_id", org1.getFlows());
+        verify(mockFlowService, never()).save(any(), any(), any());
         verify(eventService, times(1)).createOrganizationEvent(
             eq(new ExecutionContext("org_id")),
             eq(Set.of("env_1", "env_2")),
@@ -165,5 +174,32 @@ public class OrganizationService_CreateTest {
             eq(EventType.PUBLISH_ORGANIZATION),
             any()
         );
+    }
+
+    @Test
+    public void create_or_update_should_preserve_existing_flows_when_payload_has_null_flows() throws Exception {
+        when(mockOrganizationRepository.findById(any())).thenReturn(Optional.of(new Organization()));
+
+        UpdateOrganizationEntity payloadWithoutFlows = new UpdateOrganizationEntity();
+        payloadWithoutFlows.setHrids(List.of("orgid"));
+        payloadWithoutFlows.setName("org_name");
+        payloadWithoutFlows.setDescription("org_desc");
+
+        Organization updatedOrganization = new Organization();
+        updatedOrganization.setId("org_id");
+        when(mockOrganizationRepository.update(any())).thenReturn(updatedOrganization);
+
+        Flow existingFlow = mock(Flow.class);
+        when(mockFlowService.findByReference(FlowReferenceType.ORGANIZATION, "org_id")).thenReturn(List.of(existingFlow));
+
+        EnvironmentEntity env1 = new EnvironmentEntity();
+        env1.setId("env_1");
+        when(environmentService.findByOrganization("org_id")).thenReturn(List.of(env1));
+
+        OrganizationEntity organization = organizationService.createOrUpdate("org_id", payloadWithoutFlows);
+
+        assertNotNull(organization);
+        assertEquals(List.of(existingFlow), organization.getFlows());
+        verify(mockFlowService, never()).save(any(), any(), any());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13855

## Description

- **`OrganizationServiceImpl.createOrUpdate`** is now flow-agnostic: ignores `flows` on the supplied `UpdateOrganizationEntity` and routes the update branch through `updateOrganization`. The destructive flow semantic (`null`/empty == delete-all) is now reachable only via `updateOrganizationAndFlows`, used solely by the management-UI endpoint that explicitly carries flows. Documented on the method.
- **`OrganizationCommandHandler.handle`** binds `GraviteeContext` to the resolved organization id for the duration of the command and cleans it in `finally`, so audits, events, and any thread-local-org consumer see the real org id.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

