### PR TITLE
feat: api product in filter picker

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -302,6 +302,11 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public io.gravitee.apim.core.api_product.query_service.ApiProductQueryService apiProductQueryService() {
+        return mock(io.gravitee.apim.core.api_product.query_service.ApiProductQueryService.class);
+    }
+
+    @Bean
     public CustomDashboardRepository customDashboardRepository() {
         return mock(CustomDashboardRepository.class);
     }
@@ -1332,7 +1337,8 @@ public class ResourceContextConfiguration {
         FilterValueNameResolver filterValueNameResolver,
         AnalyticsQueryContextLoader analyticsQueryContextLoader,
         io.gravitee.apim.core.application.query_service.ApplicationQueryService applicationQueryService,
-        io.gravitee.apim.core.plan.query_service.PlanQueryService planQueryService
+        io.gravitee.apim.core.plan.query_service.PlanQueryService planQueryService,
+        io.gravitee.apim.core.api_product.query_service.ApiProductQueryService apiProductQueryService
     ) {
         return new GetFilterValuesUseCase(
             analyticsDefinitionQueryService,
@@ -1340,7 +1346,8 @@ public class ResourceContextConfiguration {
             filterValueNameResolver,
             analyticsQueryContextLoader,
             applicationQueryService,
-            planQueryService
+            planQueryService,
+            apiProductQueryService
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCase.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.analytics_engine.model.FilterValue;
 import io.gravitee.apim.core.analytics_engine.model.FilterValuesPage;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.query_service.ApplicationQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
@@ -51,7 +52,8 @@ public class GetFilterValuesUseCase {
     private static final Set<FilterSpec.Name> ID_BASED_FILTERS = Set.of(
         FilterSpec.Name.API,
         FilterSpec.Name.APPLICATION,
-        FilterSpec.Name.PLAN
+        FilterSpec.Name.PLAN,
+        FilterSpec.Name.API_PRODUCT
     );
 
     private final AnalyticsDefinitionQueryService definitionQueryService;
@@ -60,6 +62,7 @@ public class GetFilterValuesUseCase {
     private final AnalyticsQueryContextLoader contextLoader;
     private final ApplicationQueryService applicationQueryService;
     private final PlanQueryService planQueryService;
+    private final ApiProductQueryService apiProductQueryService;
 
     public record Input(AuditInfo auditInfo, String filterName, Instant from, Instant to, int page, int perPage, String query) {}
 
@@ -137,6 +140,9 @@ public class GetFilterValuesUseCase {
         if (filterSpecName == FilterSpec.Name.PLAN) {
             return searchPlansByNameFromAuthorizedApis(input, analyticsContext);
         }
+        if (filterSpecName == FilterSpec.Name.API_PRODUCT) {
+            return searchApiProductsByNameFromEnvironment(input);
+        }
         return new Output(new FilterValuesPage(Collections.emptyList(), null, 0L));
     }
 
@@ -188,6 +194,33 @@ public class GetFilterValuesUseCase {
         var values = pageApps
             .stream()
             .map(app -> new FilterValue(app.getName(), app.getId()))
+            .toList();
+
+        return new Output(new FilterValuesPage(values, null, totalFiltered));
+    }
+
+    private Output searchApiProductsByNameFromEnvironment(Input input) {
+        var environmentId = input.auditInfo().environmentId();
+        var lowerQuery = input.query().toLowerCase();
+        var matching = apiProductQueryService
+            .findByEnvironmentId(environmentId)
+            .stream()
+            .filter(ap -> ap.getName() != null && ap.getName().toLowerCase().contains(lowerQuery))
+            .sorted(
+                Comparator.comparing(
+                    io.gravitee.apim.core.api_product.model.ApiProduct::getName,
+                    String.CASE_INSENSITIVE_ORDER
+                ).thenComparing(io.gravitee.apim.core.api_product.model.ApiProduct::getId)
+            )
+            .toList();
+
+        var totalFiltered = (long) matching.size();
+        var fromIndex = Math.min((input.page() - 1) * input.perPage(), matching.size());
+        var toIndex = Math.min(fromIndex + input.perPage(), matching.size());
+        var pageProducts = matching.subList(fromIndex, toIndex);
+        var values = pageProducts
+            .stream()
+            .map(ap -> new FilterValue(ap.getName(), ap.getId()))
             .toList();
 
         return new Output(new FilterValuesPage(values, null, totalFiltered));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/FilterValueNameResolverImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/FilterValueNameResolverImpl.java
@@ -22,10 +22,13 @@ import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.model.ApiFieldFilter;
 import io.gravitee.apim.core.api.model.ApiSearchCriteria;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -43,6 +46,7 @@ public class FilterValueNameResolverImpl implements FilterValueNameResolver {
     private final ApiQueryService apiQueryService;
     private final ApplicationCrudService applicationCrudService;
     private final PlanCrudService planCrudService;
+    private final ApiProductQueryService apiProductQueryService;
 
     @Override
     public Map<String, String> resolveNames(String environmentId, FilterSpec.Name filterName, List<String> ids) {
@@ -63,6 +67,10 @@ public class FilterValueNameResolverImpl implements FilterValueNameResolver {
                 yield names;
             }
             case PLAN -> planCrudService.findByIds(ids).stream().collect(Collectors.toMap(plan -> plan.getId(), plan -> plan.getName()));
+            case API_PRODUCT -> apiProductQueryService
+                .findByEnvironmentIdAndIdIn(environmentId, new HashSet<>(ids))
+                .stream()
+                .collect(Collectors.toMap(ApiProduct::getId, ApiProduct::getName));
             default -> Collections.emptyMap();
         };
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImpl.java
@@ -111,6 +111,7 @@ public class FilterValuesQueryServiceImpl implements FilterValuesQueryService {
             case MCP_PROXY_TOOL -> "additional-metrics.keyword_mcp-proxy_tools/call";
             case MCP_PROXY_RESOURCE -> "additional-metrics.keyword_mcp-proxy_resources/read";
             case MCP_PROXY_PROMPT -> "additional-metrics.keyword_mcp-proxy_prompts/get";
+            case API_PRODUCT -> "api-product-id";
             default -> throw new UnsupportedOperationException("No ES field mapping for filter: " + filterName);
         };
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCaseTest.java
@@ -33,6 +33,7 @@ import io.gravitee.apim.core.analytics_engine.model.FilterValue;
 import io.gravitee.apim.core.analytics_engine.model.FilterValuesPage;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.application.query_service.ApplicationQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
@@ -89,6 +90,9 @@ class GetFilterValuesUseCaseTest {
     @Mock
     private PlanQueryService planQueryService;
 
+    @Mock
+    private io.gravitee.apim.core.api_product.query_service.ApiProductQueryService apiProductQueryService;
+
     private GetFilterValuesUseCase useCase;
     private AutoCloseable closeable;
 
@@ -102,7 +106,8 @@ class GetFilterValuesUseCaseTest {
             filterValueNameResolver,
             contextLoader,
             applicationQueryService,
-            planQueryService
+            planQueryService,
+            apiProductQueryService
         );
     }
 
@@ -1115,6 +1120,98 @@ class GetFilterValuesUseCaseTest {
                 eq(null),
                 eq(Set.of("plan-scope-a", "plan-scope-b"))
             );
+        }
+    }
+
+    @Nested
+    class ApiProductIdBasedFilters {
+
+        @BeforeEach
+        void setUp() {
+            when(definitionQueryService.getAllFilters()).thenReturn(
+                List.of(
+                    new FilterSpec(
+                        FilterSpec.Name.API_PRODUCT,
+                        "API Product",
+                        FilterType.KEYWORD,
+                        null,
+                        null,
+                        List.of(FilterOperator.EQ, FilterOperator.IN),
+                        null
+                    )
+                )
+            );
+        }
+
+        @Test
+        void should_resolve_names_for_api_product_filter() {
+            var esPage = new FilterValuesPage(List.of(new FilterValue("prod-id-1")), null);
+            when(
+                filterValuesQueryService.searchFilterValues(
+                    any(),
+                    any(),
+                    eq(FilterSpec.Name.API_PRODUCT),
+                    any(),
+                    any(),
+                    anyInt(),
+                    eq(10),
+                    any(),
+                    any(),
+                    any()
+                )
+            ).thenReturn(esPage);
+            when(filterValueNameResolver.resolveNames(any(), eq(FilterSpec.Name.API_PRODUCT), any())).thenReturn(
+                Map.of("prod-id-1", "My API Product")
+            );
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API_PRODUCT", null, null, 1, 10, null));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("My API Product");
+                    assertThat(v.id()).isEqualTo("prod-id-1");
+                });
+        }
+
+        @Test
+        void should_search_api_product_by_name_when_query_provided() {
+            var prod1 = ApiProduct.builder().id("prod-id-1").name("My Product 1").build();
+            when(apiProductQueryService.findByEnvironmentId("env-id")).thenReturn(Set.of(prod1));
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API_PRODUCT", null, null, 1, 10, "My Prod"));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("My Product 1");
+                    assertThat(v.id()).isEqualTo("prod-id-1");
+                });
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(1L);
+            verifyNoInteractions(filterValuesQueryService);
+            verifyNoInteractions(filterValueNameResolver);
+            verify(apiProductQueryService).findByEnvironmentId("env-id");
+        }
+
+        @Test
+        void should_paginate_api_product_search_by_name() {
+            var prod1 = ApiProduct.builder().id("p-1").name("My Product A").build();
+            var prod2 = ApiProduct.builder().id("p-2").name("My Product B").build();
+            var prod3 = ApiProduct.builder().id("p-3").name("My Product C").build();
+            when(apiProductQueryService.findByEnvironmentId("env-id")).thenReturn(Set.of(prod1, prod2, prod3));
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API_PRODUCT", null, null, 2, 2, "My Prod"));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("My Product C");
+                    assertThat(v.id()).isEqualTo("p-3");
+                });
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(3L);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/FilterValueNameResolverImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/FilterValueNameResolverImplTest.java
@@ -27,12 +27,14 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.ApiFieldFilter;
 import io.gravitee.apim.core.api.model.ApiSearchCriteria;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,13 +62,22 @@ class FilterValueNameResolverImplTest {
     @Mock
     private PlanCrudService planCrudService;
 
+    @Mock
+    private io.gravitee.apim.core.api_product.query_service.ApiProductQueryService apiProductQueryService;
+
     private FilterValueNameResolverImpl resolver;
     private AutoCloseable closeable;
 
     @BeforeEach
     void setUp() {
         closeable = MockitoAnnotations.openMocks(this);
-        resolver = new FilterValueNameResolverImpl(apiCrudService, apiQueryService, applicationCrudService, planCrudService);
+        resolver = new FilterValueNameResolverImpl(
+            apiCrudService,
+            apiQueryService,
+            applicationCrudService,
+            planCrudService,
+            apiProductQueryService
+        );
     }
 
     @AfterEach
@@ -134,6 +145,21 @@ class FilterValueNameResolverImplTest {
             var result = resolver.resolveNames(ENVIRONMENT_ID, FilterSpec.Name.PLAN, ids);
 
             assertThat(result).containsEntry("plan-1", "Gold Plan").containsEntry("plan-2", "Silver Plan").hasSize(2);
+        }
+
+        @Test
+        void should_resolve_api_product_names() {
+            var ids = List.of("prod-1", "prod-2");
+            when(apiProductQueryService.findByEnvironmentIdAndIdIn(ENVIRONMENT_ID, Set.copyOf(ids))).thenReturn(
+                Set.of(
+                    ApiProduct.builder().id("prod-1").name("Product 1").build(),
+                    ApiProduct.builder().id("prod-2").name("Product 2").build()
+                )
+            );
+
+            var result = resolver.resolveNames(ENVIRONMENT_ID, FilterSpec.Name.API_PRODUCT, ids);
+
+            assertThat(result).containsEntry("prod-1", "Product 1").containsEntry("prod-2", "Product 2").hasSize(2);
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImplTest.java
@@ -176,6 +176,16 @@ class FilterValuesQueryServiceImplTest {
     }
 
     @Test
+    void should_resolve_es_field_name_for_api_product_filter() {
+        when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(new FilterValuesResult(List.of("product-1"), null, 1));
+
+        service.searchFilterValues(ORG_ID, ENV_ID, FilterSpec.Name.API_PRODUCT, null, null, 1, 10, null, null, null);
+
+        verify(analyticsRepository).searchFilterValues(any(), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().esFieldName()).isEqualTo("api-product-id");
+    }
+
+    @Test
     void should_pass_authorized_api_ids_to_es_query() {
         when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(new FilterValuesResult(List.of("gw-1"), null, 1));
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13865

**Summary:**
This PR enables `API_PRODUCT` filtering in the Analytics dashboard by implementing the required backend resolution and search capabilities.

Since the Elasticsearch index stores API Product IDs, but the dashboard UI requires human-readable names and search-by-name functionality, we extended the core filter use cases to resolve these IDs via the `ApiProductQueryService`. Follows existing APPLICATION / API architectural patterns for analytics filtering.

Note: there is a separate bug with the frontend component where the first letter of the search term doesn't disappear from the input box after selecting. That is not in scope for this issue. 
<img width="3000" height="1430" alt="2026-04-30 10 55 43" src="https://github.com/user-attachments/assets/9228d051-203e-4756-8a23-8b2d9bc5bb3b" />
<img width="1216" height="120" alt="Screenshot 2026-04-30 at 10 56 12 AM" src="https://github.com/user-attachments/assets/22c22e59-f104-49ae-bdb3-2c2dafd5d68d" />


