### PR TITLE
fix: enable dynamic API metadata in GMD pages.

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalPageContentTemplateException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/InvalidPortalPageContentTemplateException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+/** Thrown when portal page markdown contains invalid FreeMarker for its navigation placement(s). */
+public class InvalidPortalPageContentTemplateException extends ValidationDomainException {
+
+    public InvalidPortalPageContentTemplateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/PortalPageContentTemplateException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/PortalPageContentTemplateException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.exception;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+
+/** Thrown when portal navigation page markdown fails FreeMarker evaluation (invalid syntax or missing model data). */
+public class PortalPageContentTemplateException extends TechnicalDomainException {
+
+    public PortalPageContentTemplateException(String message) {
+        super(message);
+    }
+
+    public PortalPageContentTemplateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/PortalNavigationTemplatingService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/PortalNavigationTemplatingService.java
@@ -15,22 +15,24 @@
  */
 package io.gravitee.apim.core.portal_page.service_provider;
 
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.rest.api.model.v4.api.GenericApiModel;
 import java.util.Optional;
 
 public interface PortalNavigationTemplatingService {
     /**
      * Renders Gravitee Markdown documentation using the same FreeMarker model as legacy API pages:
-     * {@code api} when {@code enclosingApiId} is present, otherwise environment {@code metadata} only.
+     * {@code api} when {@code apiModel} is present, otherwise environment {@code metadata} only.
      *
      * @throws io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException on invalid template or missing properties (navigation has no page "messages")
      */
-    String renderGraviteeMarkdown(RenderPortalNavigationMarkdownInput input);
+    RenderedPageContent renderGraviteeMarkdown(RenderPortalNavigationMarkdownInput input);
 
     record RenderPortalNavigationMarkdownInput(
-        String rawMarkdown,
+        GraviteeMarkdown rawMarkdown,
         String templateKey,
         String organizationId,
         String environmentId,
-        Optional<String> enclosingApiId
+        Optional<GenericApiModel> apiModel
     ) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/PortalNavigationTemplatingService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/PortalNavigationTemplatingService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.service_provider;
+
+import java.util.Optional;
+
+public interface PortalNavigationTemplatingService {
+    /**
+     * Renders Gravitee Markdown documentation using the same FreeMarker model as legacy API pages:
+     * {@code api} when {@code enclosingApiId} is present, otherwise environment {@code metadata} only.
+     *
+     * @throws io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException on invalid template or missing properties (navigation has no page "messages")
+     */
+    String renderGraviteeMarkdown(RenderPortalNavigationMarkdownInput input);
+
+    record RenderPortalNavigationMarkdownInput(
+        String rawMarkdown,
+        String templateKey,
+        String organizationId,
+        String environmentId,
+        Optional<String> enclosingApiId
+    ) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/PortalNavigationTemplatingService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/PortalNavigationTemplatingService.java
@@ -16,23 +16,15 @@
 package io.gravitee.apim.core.portal_page.service_provider;
 
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
-import io.gravitee.rest.api.model.v4.api.GenericApiModel;
-import java.util.Optional;
+import java.util.Map;
 
 public interface PortalNavigationTemplatingService {
     /**
-     * Renders Gravitee Markdown documentation using the same FreeMarker model as legacy API pages:
-     * {@code api} when {@code apiModel} is present, otherwise environment {@code metadata} only.
+     * Renders Gravitee Markdown documentation using the provided FreeMarker {@code model}.
      *
      * @throws io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException on invalid template or missing properties (navigation has no page "messages")
      */
     RenderedPageContent renderGraviteeMarkdown(RenderPortalNavigationMarkdownInput input);
 
-    record RenderPortalNavigationMarkdownInput(
-        GraviteeMarkdown rawMarkdown,
-        String templateKey,
-        String organizationId,
-        String environmentId,
-        Optional<GenericApiModel> apiModel
-    ) {}
+    record RenderPortalNavigationMarkdownInput(GraviteeMarkdown rawMarkdown, Map<String, Object> model) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/RenderedPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/RenderedPageContent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.service_provider;
+
+/**
+ * Rendered page content after FreeMarker template processing.
+ */
+public record RenderedPageContent(String value) {
+    public static RenderedPageContent of(String value) {
+        return new RenderedPageContent(value);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/template/TemplateProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/template/TemplateProcessor.java
@@ -21,5 +21,17 @@ import java.util.Map;
  * Interface of component handling Templates.
  */
 public interface TemplateProcessor {
+    /**
+     * Render an inline template with no specific name. Equivalent to
+     * {@link #processInlineTemplate(String, String, Map)} with an empty name.
+     */
     String processInlineTemplate(String template, Map<String, Object> params) throws TemplateProcessorException;
+
+    /**
+     * Render an inline template. The {@code name} is surfaced in error messages and engine diagnostics
+     * (typically the id of the entity owning the template, e.g. a portal page id).
+     */
+    default String processInlineTemplate(String name, String template, Map<String, Object> params) throws TemplateProcessorException {
+        return processInlineTemplate(template, params);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImpl.java
@@ -18,13 +18,12 @@ package io.gravitee.apim.infra.portal_page;
 import freemarker.template.TemplateException;
 import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import io.gravitee.apim.core.portal_page.service_provider.RenderedPageContent;
 import io.gravitee.apim.core.template.TemplateProcessor;
 import io.gravitee.apim.core.template.TemplateProcessorException;
 import io.gravitee.repository.management.model.MetadataReferenceType;
 import io.gravitee.rest.api.model.MetadataEntity;
 import io.gravitee.rest.api.service.MetadataService;
-import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,21 +35,16 @@ import org.springframework.stereotype.Service;
 public class PortalNavigationTemplatingServiceImpl implements PortalNavigationTemplatingService {
 
     private final TemplateProcessor templateProcessor;
-    private final ApiTemplateService apiTemplateService;
     private final MetadataService metadataService;
 
     @Override
-    public String renderGraviteeMarkdown(RenderPortalNavigationMarkdownInput input) {
-        final var executionContext = new ExecutionContext(input.organizationId(), input.environmentId());
+    public RenderedPageContent renderGraviteeMarkdown(RenderPortalNavigationMarkdownInput input) {
         final Map<String, Object> templateParams = new HashMap<>();
 
         input
-            .enclosingApiId()
+            .apiModel()
             .ifPresentOrElse(
-                apiId -> {
-                    final var genericApiModel = apiTemplateService.findByIdForTemplates(executionContext, apiId, true);
-                    templateParams.put("api", genericApiModel);
-                },
+                apiModel -> templateParams.put("api", apiModel),
                 () -> {
                     final List<MetadataEntity> metadataList = metadataService.findByReferenceTypeAndReferenceId(
                         MetadataReferenceType.ENVIRONMENT,
@@ -65,7 +59,9 @@ public class PortalNavigationTemplatingServiceImpl implements PortalNavigationTe
             );
 
         try {
-            return templateProcessor.processInlineTemplate(input.templateKey(), input.rawMarkdown(), templateParams);
+            return RenderedPageContent.of(
+                templateProcessor.processInlineTemplate(input.templateKey(), input.rawMarkdown().value(), templateParams)
+            );
         } catch (TemplateProcessorException e) {
             // Evaluation failures wrap a freemarker.template.TemplateException; parse failures wrap an IOException
             // (FreeMarker's ParseException extends IOException, not TemplateException).

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.portal_page;
+
+import freemarker.template.TemplateException;
+import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import io.gravitee.apim.core.template.TemplateProcessor;
+import io.gravitee.apim.core.template.TemplateProcessorException;
+import io.gravitee.repository.management.model.MetadataReferenceType;
+import io.gravitee.rest.api.model.MetadataEntity;
+import io.gravitee.rest.api.service.MetadataService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.ApiTemplateService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PortalNavigationTemplatingServiceImpl implements PortalNavigationTemplatingService {
+
+    private final TemplateProcessor templateProcessor;
+    private final ApiTemplateService apiTemplateService;
+    private final MetadataService metadataService;
+
+    @Override
+    public String renderGraviteeMarkdown(RenderPortalNavigationMarkdownInput input) {
+        final var executionContext = new ExecutionContext(input.organizationId(), input.environmentId());
+        final Map<String, Object> templateParams = new HashMap<>();
+
+        input
+            .enclosingApiId()
+            .ifPresentOrElse(
+                apiId -> {
+                    final var genericApiModel = apiTemplateService.findByIdForTemplates(executionContext, apiId, true);
+                    templateParams.put("api", genericApiModel);
+                },
+                () -> {
+                    final List<MetadataEntity> metadataList = metadataService.findByReferenceTypeAndReferenceId(
+                        MetadataReferenceType.ENVIRONMENT,
+                        input.environmentId()
+                    );
+                    if (metadataList != null) {
+                        final Map<String, String> mapMetadata = new HashMap<>(metadataList.size());
+                        metadataList.forEach(metadata -> mapMetadata.put(metadata.getKey(), metadata.getValue()));
+                        templateParams.put("metadata", mapMetadata);
+                    }
+                }
+            );
+
+        try {
+            return templateProcessor.processInlineTemplate(input.templateKey(), input.rawMarkdown(), templateParams);
+        } catch (TemplateProcessorException e) {
+            // Evaluation failures wrap a freemarker.template.TemplateException; parse failures wrap an IOException
+            // (FreeMarker's ParseException extends IOException, not TemplateException).
+            if (e.getCause() instanceof TemplateException te) {
+                throw new PortalPageContentTemplateException(
+                    "Invalid expression or value is missing for " + te.getBlamedExpressionString(),
+                    e
+                );
+            }
+            final var message = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+            throw new PortalPageContentTemplateException("Invalid template: " + message, e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImpl.java
@@ -21,12 +21,6 @@ import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTempla
 import io.gravitee.apim.core.portal_page.service_provider.RenderedPageContent;
 import io.gravitee.apim.core.template.TemplateProcessor;
 import io.gravitee.apim.core.template.TemplateProcessorException;
-import io.gravitee.repository.management.model.MetadataReferenceType;
-import io.gravitee.rest.api.model.MetadataEntity;
-import io.gravitee.rest.api.service.MetadataService;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -35,33 +29,11 @@ import org.springframework.stereotype.Service;
 public class PortalNavigationTemplatingServiceImpl implements PortalNavigationTemplatingService {
 
     private final TemplateProcessor templateProcessor;
-    private final MetadataService metadataService;
 
     @Override
     public RenderedPageContent renderGraviteeMarkdown(RenderPortalNavigationMarkdownInput input) {
-        final Map<String, Object> templateParams = new HashMap<>();
-
-        input
-            .apiModel()
-            .ifPresentOrElse(
-                apiModel -> templateParams.put("api", apiModel),
-                () -> {
-                    final List<MetadataEntity> metadataList = metadataService.findByReferenceTypeAndReferenceId(
-                        MetadataReferenceType.ENVIRONMENT,
-                        input.environmentId()
-                    );
-                    if (metadataList != null) {
-                        final Map<String, String> mapMetadata = new HashMap<>(metadataList.size());
-                        metadataList.forEach(metadata -> mapMetadata.put(metadata.getKey(), metadata.getValue()));
-                        templateParams.put("metadata", mapMetadata);
-                    }
-                }
-            );
-
         try {
-            return RenderedPageContent.of(
-                templateProcessor.processInlineTemplate(input.templateKey(), input.rawMarkdown().value(), templateParams)
-            );
+            return RenderedPageContent.of(templateProcessor.processInlineTemplate(input.rawMarkdown().value(), input.model()));
         } catch (TemplateProcessorException e) {
             // Evaluation failures wrap a freemarker.template.TemplateException; parse failures wrap an IOException
             // (FreeMarker's ParseException extends IOException, not TemplateException).

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/template/FreemarkerTemplateProcessor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/template/FreemarkerTemplateProcessor.java
@@ -40,8 +40,13 @@ public class FreemarkerTemplateProcessor implements TemplateProcessor {
 
     @Override
     public String processInlineTemplate(String template, Map<String, Object> params) throws TemplateProcessorException {
+        return processInlineTemplate("", template, params);
+    }
+
+    @Override
+    public String processInlineTemplate(String name, String template, Map<String, Object> params) throws TemplateProcessorException {
         try {
-            Template freemarkerTemplate = new Template("", new StringReader(template), configuration);
+            Template freemarkerTemplate = new Template(name, new StringReader(template), configuration);
             return FreeMarkerTemplateUtils.processTemplateIntoString(freemarkerTemplate, params);
         } catch (TemplateException | IOException e) {
             throw new TemplateProcessorException(template, e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImplTest.java
@@ -18,7 +18,6 @@ package io.gravitee.apim.infra.portal_page;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -26,8 +25,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import io.gravitee.apim.core.portal_page.service_provider.RenderedPageContent;
 import io.gravitee.apim.core.template.TemplateProcessor;
 import io.gravitee.apim.core.template.TemplateProcessorException;
 import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
@@ -35,8 +36,6 @@ import io.gravitee.repository.management.model.MetadataReferenceType;
 import io.gravitee.rest.api.model.MetadataEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiModel;
 import io.gravitee.rest.api.service.MetadataService;
-import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -60,40 +59,36 @@ class PortalNavigationTemplatingServiceImplTest {
     private TemplateProcessor templateProcessor;
 
     @Mock
-    private ApiTemplateService apiTemplateService;
-
-    @Mock
     private MetadataService metadataService;
 
     private PortalNavigationTemplatingServiceImpl cut;
 
     @BeforeEach
     void setUp() {
-        cut = new PortalNavigationTemplatingServiceImpl(templateProcessor, apiTemplateService, metadataService);
+        cut = new PortalNavigationTemplatingServiceImpl(templateProcessor, metadataService);
     }
 
     @Test
-    void should_put_api_in_model_when_enclosing_api_id_is_present() throws TemplateProcessorException {
+    void should_put_api_in_model_when_api_model_is_present() throws TemplateProcessorException {
         var apiModel = org.mockito.Mockito.mock(GenericApiModel.class);
-        when(apiTemplateService.findByIdForTemplates(any(ExecutionContext.class), eq("api-1"), eq(true))).thenReturn(apiModel);
         when(templateProcessor.processInlineTemplate(eq("page-key"), eq("${api}"), argThat(m -> m.get("api") == apiModel))).thenReturn(
             "ok"
         );
 
         var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
-            "${api}",
+            GraviteeMarkdown.of("${api}"),
             "page-key",
             ORG,
             ENV,
-            Optional.of("api-1")
+            Optional.of(apiModel)
         );
 
-        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo("ok");
+        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo(RenderedPageContent.of("ok"));
         verify(metadataService, never()).findByReferenceTypeAndReferenceId(any(), anyString());
     }
 
     @Test
-    void should_put_environment_metadata_in_model_when_no_enclosing_api() throws TemplateProcessorException {
+    void should_put_environment_metadata_in_model_when_no_api_model() throws TemplateProcessorException {
         var m = new MetadataEntity();
         m.setKey("k");
         m.setName("n");
@@ -108,25 +103,29 @@ class PortalNavigationTemplatingServiceImplTest {
         ).thenReturn("rendered");
 
         var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
-            "${metadata.k}",
+            GraviteeMarkdown.of("${metadata.k}"),
             "page-key",
             ORG,
             ENV,
             Optional.empty()
         );
 
-        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo("rendered");
-        verify(apiTemplateService, never()).findByIdForTemplates(any(), anyString(), anyBoolean());
+        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo(RenderedPageContent.of("rendered"));
     }
 
     @Test
-    void should_not_query_metadata_when_enclosing_api_is_present() throws TemplateProcessorException {
+    void should_not_query_metadata_when_api_model_is_present() throws TemplateProcessorException {
         var apiModel = org.mockito.Mockito.mock(GenericApiModel.class);
-        when(apiTemplateService.findByIdForTemplates(any(ExecutionContext.class), eq("api-x"), eq(true))).thenReturn(apiModel);
         when(templateProcessor.processInlineTemplate(anyString(), anyString(), any())).thenReturn("x");
 
         cut.renderGraviteeMarkdown(
-            new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput("md", "key", ORG, ENV, Optional.of("api-x"))
+            new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
+                GraviteeMarkdown.of("md"),
+                "key",
+                ORG,
+                ENV,
+                Optional.of(apiModel)
+            )
         );
 
         verify(metadataService, never()).findByReferenceTypeAndReferenceId(any(), anyString());
@@ -139,19 +138,25 @@ class PortalNavigationTemplatingServiceImplTest {
 
         assertThat(
             cut.renderGraviteeMarkdown(
-                new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput("plain", "key", ORG, ENV, Optional.empty())
+                new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
+                    GraviteeMarkdown.of("plain"),
+                    "key",
+                    ORG,
+                    ENV,
+                    Optional.empty()
+                )
             )
-        ).isEqualTo("plain");
+        ).isEqualTo(RenderedPageContent.of("plain"));
     }
 
     @Test
     void should_wrap_freemarker_template_exception_with_blamed_expression_message() {
         var freemarkerProcessor = new FreemarkerTemplateProcessor();
-        var impl = new PortalNavigationTemplatingServiceImpl(freemarkerProcessor, apiTemplateService, metadataService);
+        var impl = new PortalNavigationTemplatingServiceImpl(freemarkerProcessor, metadataService);
         when(metadataService.findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, ENV)).thenReturn(null);
 
         var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
-            "${thisVariableIsMissing}",
+            GraviteeMarkdown.of("${thisVariableIsMissing}"),
             "key",
             ORG,
             ENV,
@@ -170,7 +175,7 @@ class PortalNavigationTemplatingServiceImplTest {
         );
 
         var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
-            "${broken!",
+            GraviteeMarkdown.of("${broken!"),
             "key",
             ORG,
             ENV,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImplTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.portal_page;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import io.gravitee.apim.core.template.TemplateProcessor;
+import io.gravitee.apim.core.template.TemplateProcessorException;
+import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
+import io.gravitee.repository.management.model.MetadataReferenceType;
+import io.gravitee.rest.api.model.MetadataEntity;
+import io.gravitee.rest.api.model.v4.api.GenericApiModel;
+import io.gravitee.rest.api.service.MetadataService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.ApiTemplateService;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationTemplatingServiceImplTest {
+
+    private static final String ORG = "org-id";
+    private static final String ENV = "env-id";
+
+    @Mock
+    private TemplateProcessor templateProcessor;
+
+    @Mock
+    private ApiTemplateService apiTemplateService;
+
+    @Mock
+    private MetadataService metadataService;
+
+    private PortalNavigationTemplatingServiceImpl cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new PortalNavigationTemplatingServiceImpl(templateProcessor, apiTemplateService, metadataService);
+    }
+
+    @Test
+    void should_put_api_in_model_when_enclosing_api_id_is_present() throws TemplateProcessorException {
+        var apiModel = org.mockito.Mockito.mock(GenericApiModel.class);
+        when(apiTemplateService.findByIdForTemplates(any(ExecutionContext.class), eq("api-1"), eq(true))).thenReturn(apiModel);
+        when(templateProcessor.processInlineTemplate(eq("page-key"), eq("${api}"), argThat(m -> m.get("api") == apiModel))).thenReturn(
+            "ok"
+        );
+
+        var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
+            "${api}",
+            "page-key",
+            ORG,
+            ENV,
+            Optional.of("api-1")
+        );
+
+        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo("ok");
+        verify(metadataService, never()).findByReferenceTypeAndReferenceId(any(), anyString());
+    }
+
+    @Test
+    void should_put_environment_metadata_in_model_when_no_enclosing_api() throws TemplateProcessorException {
+        var m = new MetadataEntity();
+        m.setKey("k");
+        m.setName("n");
+        m.setValue("v");
+        when(metadataService.findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, ENV)).thenReturn(List.of(m));
+        when(
+            templateProcessor.processInlineTemplate(
+                eq("page-key"),
+                eq("${metadata.k}"),
+                argThat(model -> "v".equals(((Map<?, ?>) model.get("metadata")).get("k")))
+            )
+        ).thenReturn("rendered");
+
+        var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
+            "${metadata.k}",
+            "page-key",
+            ORG,
+            ENV,
+            Optional.empty()
+        );
+
+        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo("rendered");
+        verify(apiTemplateService, never()).findByIdForTemplates(any(), anyString(), anyBoolean());
+    }
+
+    @Test
+    void should_not_query_metadata_when_enclosing_api_is_present() throws TemplateProcessorException {
+        var apiModel = org.mockito.Mockito.mock(GenericApiModel.class);
+        when(apiTemplateService.findByIdForTemplates(any(ExecutionContext.class), eq("api-x"), eq(true))).thenReturn(apiModel);
+        when(templateProcessor.processInlineTemplate(anyString(), anyString(), any())).thenReturn("x");
+
+        cut.renderGraviteeMarkdown(
+            new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput("md", "key", ORG, ENV, Optional.of("api-x"))
+        );
+
+        verify(metadataService, never()).findByReferenceTypeAndReferenceId(any(), anyString());
+    }
+
+    @Test
+    void should_omit_metadata_when_metadata_list_is_null() throws TemplateProcessorException {
+        when(metadataService.findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, ENV)).thenReturn(null);
+        when(templateProcessor.processInlineTemplate(eq("key"), eq("plain"), argThat(Map::isEmpty))).thenReturn("plain");
+
+        assertThat(
+            cut.renderGraviteeMarkdown(
+                new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput("plain", "key", ORG, ENV, Optional.empty())
+            )
+        ).isEqualTo("plain");
+    }
+
+    @Test
+    void should_wrap_freemarker_template_exception_with_blamed_expression_message() {
+        var freemarkerProcessor = new FreemarkerTemplateProcessor();
+        var impl = new PortalNavigationTemplatingServiceImpl(freemarkerProcessor, apiTemplateService, metadataService);
+        when(metadataService.findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, ENV)).thenReturn(null);
+
+        var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
+            "${thisVariableIsMissing}",
+            "key",
+            ORG,
+            ENV,
+            Optional.empty()
+        );
+
+        assertThatThrownBy(() -> impl.renderGraviteeMarkdown(input))
+            .isInstanceOf(PortalPageContentTemplateException.class)
+            .hasMessageContaining("Invalid expression or value is missing for thisVariableIsMissing");
+    }
+
+    @Test
+    void should_wrap_non_template_exception_failure_as_invalid_template() throws TemplateProcessorException {
+        when(templateProcessor.processInlineTemplate(anyString(), anyString(), any())).thenThrow(
+            new TemplateProcessorException("tmpl", new IOException("parse failure"))
+        );
+
+        var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
+            "${broken!",
+            "key",
+            ORG,
+            ENV,
+            Optional.empty()
+        );
+
+        assertThatThrownBy(() -> cut.renderGraviteeMarkdown(input))
+            .isInstanceOf(PortalPageContentTemplateException.class)
+            .hasMessageContaining("Invalid template:")
+            .hasMessageContaining("parse failure");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImplTest.java
@@ -21,8 +21,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
@@ -32,14 +30,8 @@ import io.gravitee.apim.core.portal_page.service_provider.RenderedPageContent;
 import io.gravitee.apim.core.template.TemplateProcessor;
 import io.gravitee.apim.core.template.TemplateProcessorException;
 import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
-import io.gravitee.repository.management.model.MetadataReferenceType;
-import io.gravitee.rest.api.model.MetadataEntity;
-import io.gravitee.rest.api.model.v4.api.GenericApiModel;
-import io.gravitee.rest.api.service.MetadataService;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -52,115 +44,42 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class PortalNavigationTemplatingServiceImplTest {
 
-    private static final String ORG = "org-id";
-    private static final String ENV = "env-id";
-
     @Mock
     private TemplateProcessor templateProcessor;
-
-    @Mock
-    private MetadataService metadataService;
 
     private PortalNavigationTemplatingServiceImpl cut;
 
     @BeforeEach
     void setUp() {
-        cut = new PortalNavigationTemplatingServiceImpl(templateProcessor, metadataService);
+        cut = new PortalNavigationTemplatingServiceImpl(templateProcessor);
     }
 
     @Test
-    void should_put_api_in_model_when_api_model_is_present() throws TemplateProcessorException {
-        var apiModel = org.mockito.Mockito.mock(GenericApiModel.class);
-        when(templateProcessor.processInlineTemplate(eq("page-key"), eq("${api}"), argThat(m -> m.get("api") == apiModel))).thenReturn(
-            "ok"
-        );
+    void should_render_template_with_provided_model() throws TemplateProcessorException {
+        var model = Map.<String, Object>of("api", "my-api");
+        when(templateProcessor.processInlineTemplate(eq("${api}"), argThat(m -> "my-api".equals(m.get("api"))))).thenReturn("my-api");
 
-        var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
-            GraviteeMarkdown.of("${api}"),
-            "page-key",
-            ORG,
-            ENV,
-            Optional.of(apiModel)
-        );
+        var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(GraviteeMarkdown.of("${api}"), model);
 
-        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo(RenderedPageContent.of("ok"));
-        verify(metadataService, never()).findByReferenceTypeAndReferenceId(any(), anyString());
+        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo(RenderedPageContent.of("my-api"));
     }
 
     @Test
-    void should_put_environment_metadata_in_model_when_no_api_model() throws TemplateProcessorException {
-        var m = new MetadataEntity();
-        m.setKey("k");
-        m.setName("n");
-        m.setValue("v");
-        when(metadataService.findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, ENV)).thenReturn(List.of(m));
-        when(
-            templateProcessor.processInlineTemplate(
-                eq("page-key"),
-                eq("${metadata.k}"),
-                argThat(model -> "v".equals(((Map<?, ?>) model.get("metadata")).get("k")))
-            )
-        ).thenReturn("rendered");
+    void should_render_template_with_empty_model() throws TemplateProcessorException {
+        when(templateProcessor.processInlineTemplate(eq("plain"), argThat(Map::isEmpty))).thenReturn("plain");
 
-        var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
-            GraviteeMarkdown.of("${metadata.k}"),
-            "page-key",
-            ORG,
-            ENV,
-            Optional.empty()
-        );
+        var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(GraviteeMarkdown.of("plain"), Map.of());
 
-        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo(RenderedPageContent.of("rendered"));
-    }
-
-    @Test
-    void should_not_query_metadata_when_api_model_is_present() throws TemplateProcessorException {
-        var apiModel = org.mockito.Mockito.mock(GenericApiModel.class);
-        when(templateProcessor.processInlineTemplate(anyString(), anyString(), any())).thenReturn("x");
-
-        cut.renderGraviteeMarkdown(
-            new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
-                GraviteeMarkdown.of("md"),
-                "key",
-                ORG,
-                ENV,
-                Optional.of(apiModel)
-            )
-        );
-
-        verify(metadataService, never()).findByReferenceTypeAndReferenceId(any(), anyString());
-    }
-
-    @Test
-    void should_omit_metadata_when_metadata_list_is_null() throws TemplateProcessorException {
-        when(metadataService.findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, ENV)).thenReturn(null);
-        when(templateProcessor.processInlineTemplate(eq("key"), eq("plain"), argThat(Map::isEmpty))).thenReturn("plain");
-
-        assertThat(
-            cut.renderGraviteeMarkdown(
-                new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
-                    GraviteeMarkdown.of("plain"),
-                    "key",
-                    ORG,
-                    ENV,
-                    Optional.empty()
-                )
-            )
-        ).isEqualTo(RenderedPageContent.of("plain"));
+        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo(RenderedPageContent.of("plain"));
     }
 
     @Test
     void should_wrap_freemarker_template_exception_with_blamed_expression_message() {
-        var freemarkerProcessor = new FreemarkerTemplateProcessor();
-        var impl = new PortalNavigationTemplatingServiceImpl(freemarkerProcessor, metadataService);
-        when(metadataService.findByReferenceTypeAndReferenceId(MetadataReferenceType.ENVIRONMENT, ENV)).thenReturn(null);
+        var impl = new PortalNavigationTemplatingServiceImpl(new FreemarkerTemplateProcessor());
 
         var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
             GraviteeMarkdown.of("${thisVariableIsMissing}"),
-            "key",
-            ORG,
-            ENV,
-            Optional.empty()
+            Map.of()
         );
 
         assertThatThrownBy(() -> impl.renderGraviteeMarkdown(input))
@@ -170,17 +89,11 @@ class PortalNavigationTemplatingServiceImplTest {
 
     @Test
     void should_wrap_non_template_exception_failure_as_invalid_template() throws TemplateProcessorException {
-        when(templateProcessor.processInlineTemplate(anyString(), anyString(), any())).thenThrow(
+        when(templateProcessor.processInlineTemplate(anyString(), any())).thenThrow(
             new TemplateProcessorException("tmpl", new IOException("parse failure"))
         );
 
-        var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
-            GraviteeMarkdown.of("${broken!"),
-            "key",
-            ORG,
-            ENV,
-            Optional.empty()
-        );
+        var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(GraviteeMarkdown.of("${broken!"), Map.of());
 
         assertThatThrownBy(() -> cut.renderGraviteeMarkdown(input))
             .isInstanceOf(PortalPageContentTemplateException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/template/FreemarkerTemplateProcessorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/template/FreemarkerTemplateProcessorTest.java
@@ -50,6 +50,12 @@ class FreemarkerTemplateProcessorTest {
     }
 
     @Test
+    void should_process_named_inline_template() throws TemplateProcessorException {
+        var result = cut.processInlineTemplate("owner-entity-id", "Hello ${name}!", Map.of("name", "Gravitee"));
+        assertThat(result).isEqualTo("Hello Gravitee!");
+    }
+
+    @Test
     void should_throw_a_TemplateProcessorException_for_an_invalid_template() {
         assertThatExceptionOfType(TemplateProcessorException.class)
             .isThrownBy(() -> cut.processInlineTemplate("Hello ${name!", Map.of()))


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14001

### Stacked PRs
- **master**
  - https://github.com/gravitee-io/gravitee-api-management/pull/16696 👈
    - https://github.com/gravitee-io/gravitee-api-management/pull/16779
      - https://github.com/gravitee-io/gravitee-api-management/pull/16780
        - https://github.com/gravitee-io/gravitee-api-management/pull/16781


### Portal navigation FreeMarker templating service

Introduces `PortalNavigationTemplatingService` and infra to render inline Gravitee Markdown with the same FreeMarker model pattern as legacy API docs: **`api`** when an enclosing API id is supplied, otherwise environment **`metadata`**.

### Scope

- Core port + Spring impl (`TemplateProcessor`, `ApiTemplateService`, `MetadataService`).
- Named inline template overload on `TemplateProcessor` / `FreemarkerTemplateProcessor` for clearer diagnostics.
- Exceptions: `PortalPageContentTemplateException`, `InvalidPortalPageContentTemplateException` (used by follow-up PRs).

No change yet to validators, GET flow, or console; later PRs wire this in.
