### PR TITLE
fix: jwt clientIdClaim

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/security/JwtPlanBasedAuthenticationHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/security/JwtPlanBasedAuthenticationHandler.java
@@ -110,7 +110,7 @@ public class JwtPlanBasedAuthenticationHandler extends PlanBasedAuthenticationHa
     protected String getClientId(Map<String, Object> claims) {
         final String customClientIdClaimName = getCustomClientIdClaimName();
         if (customClientIdClaimName != null) {
-            Object clientIdClaim = claims.get(customClientIdClaimName);
+            Object clientIdClaim = resolveNestedClaim(claims, customClientIdClaimName);
             return extractClientId(clientIdClaim);
         }
 
@@ -154,6 +154,41 @@ public class JwtPlanBasedAuthenticationHandler extends PlanBasedAuthenticationHa
             }
         }
         return null;
+    }
+
+    /**
+     * Resolves a claim value from a raw JWT claims map, supporting dot-notation nested paths.
+     *
+     * Tries a flat lookup first (preserves backward compat for claim names that literally
+     * contain a dot). If that misses and the name contains a dot, splits on '.' and walks
+     * successive Map values. Returns null if any segment is missing or not a Map.
+     */
+    private static Object resolveNestedClaim(Map<String, Object> claims, String name) {
+        // 1. Flat lookup — covers common case and preserves backward compatibility.
+        Object flatValue = claims.get(name);
+        if (flatValue != null) {
+            return flatValue;
+        }
+
+        // 2. Nested walk — only when the name contains a dot.
+        if (!name.contains(".")) {
+            return null;
+        }
+
+        String[] segments = name.split("\\.", -1);
+        Object current = claims.get(segments[0]);
+
+        for (int i = 1; i < segments.length; i++) {
+            if (!(current instanceof Map<?, ?> map)) {
+                return null;
+            }
+            current = map.get(segments[i]);
+            if (current == null) {
+                return null;
+            }
+        }
+
+        return current;
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/security/JwtPlanBasedAuthenticationHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/security/JwtPlanBasedAuthenticationHandlerTest.java
@@ -29,6 +29,7 @@ import io.gravitee.reporter.api.http.Metrics;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import net.minidev.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -119,6 +120,66 @@ public class JwtPlanBasedAuthenticationHandlerTest {
     @Test
     public void getClientId_should_return_null_cause_no_clientId_found() {
         Map<String, Object> claims = Map.of("another", "value1", "my-custom-claim", "value2", "anotheragain", "value3");
+
+        assertNull(authenticationHandler.getClientId(claims));
+    }
+
+    @Test
+    public void getClientId_should_resolve_nested_claim_via_dot_notation() {
+        when(plan.getSecurityDefinition()).thenReturn("{\"clientIdClaim\": \"act.repository\"}");
+
+        JSONObject act = new JSONObject();
+        act.put("repository", "my-nested-client-id");
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("act", act);
+
+        assertEquals("my-nested-client-id", authenticationHandler.getClientId(claims));
+    }
+
+    @Test
+    public void getClientId_should_prefer_flat_claim_over_nested_walk_for_backward_compat() {
+        // A claim whose key literally contains a dot must be found by flat lookup
+        // even when a matching nested structure also exists.
+        when(plan.getSecurityDefinition()).thenReturn("{\"clientIdClaim\": \"act.repository\"}");
+
+        JSONObject act = new JSONObject();
+        act.put("repository", "nested-value");
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("act.repository", "flat-literal-value"); // flat key with dot
+        claims.put("act", act);
+
+        // Flat key wins
+        assertEquals("flat-literal-value", authenticationHandler.getClientId(claims));
+    }
+
+    @Test
+    public void getClientId_should_return_null_when_nested_segment_is_missing() {
+        when(plan.getSecurityDefinition()).thenReturn("{\"clientIdClaim\": \"act.missing\"}");
+
+        JSONObject act = new JSONObject();
+        act.put("repository", "my-nested-client-id");
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("act", act);
+
+        assertNull(authenticationHandler.getClientId(claims));
+    }
+
+    @Test
+    public void getClientId_should_return_null_when_intermediate_is_not_a_map() {
+        when(plan.getSecurityDefinition()).thenReturn("{\"clientIdClaim\": \"sub.nested\"}");
+
+        // "sub" is a String, not a nested object — walk must abort gracefully
+        Map<String, Object> claims = Map.of("sub", "plain-string-value");
+
+        assertNull(authenticationHandler.getClientId(claims));
+    }
+
+    @Test
+    public void getClientId_should_return_null_when_clientIdClaim_is_empty_string() {
+        // empty string is non-null so it enters the custom-claim branch;
+        // resolveNestedClaim returns null and the azp/aud/client_id fallback is bypassed
+        when(plan.getSecurityDefinition()).thenReturn("{\"clientIdClaim\": \"\"}");
+        Map<String, Object> claims = Map.of("azp", "should-not-be-returned", "client_id", "also-not-returned");
 
         assertNull(authenticationHandler.getClientId(claims));
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13867
## Description

PROBLEM

When a V3 API has multiple JWT plans and `clientIdClaim` is configured as a dot-notation path (e.g. act.repository), plan routing silently fails.

`JwtPlanBasedAuthenticationHandler.getClientId()` was using a plain `Map.get(name)` — a flat lookup that looks for a key literally named "act.repository". When the JWT payload is:

  `{ "act": { "repository": "my-org/my-repo" } }`

the flat lookup returns `null`, `preCheckSubscription` returns `false,` and the gateway cannot route the request to the correct plan.

Single-plan V3 APIs and all V4 APIs are unaffected — single-plan V3 bypasses the pre-check entirely, and V4 uses a different code path.


FIX

Replace the flat `claims.get()` call with a `resolveNestedClaim()` private helper using the same flat-first / nested-walk algorithm introduced in the JWT policy (ClaimPathResolver) as part of APIM-13714:

  1. Flat lookup first — if a key with that exact name exists, return it.
     Preserves backward compatibility for claim names that literally contain a dot.
  2. Nested walk — if the flat lookup misses and the name contains a dot,
     split on '.' and traverse successive Map values.

No other code paths are changed. The azp / aud / client_id fallback chain is untouched.


TESTS

4 new unit tests added to `JwtPlanBasedAuthenticationHandlerTest`

NOTES

The class already contains two "FIXME: This is duplicated from JWT policy" comments.
Extracting this logic to a shared gateway-api module is the right long-term fix and is tracked separately — it is out of scope here.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

