### PR TITLE
fix(tracing): report correct trigger.executed flag for policies in OTEL

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/HttpConditionalPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/HttpConditionalPolicy.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactive.policy;
 
 import static io.gravitee.gateway.reactive.policy.tracing.TracingPolicyHook.ATTR_POLICY_TRIGGER_CONDITION_PREFIX;
+import static io.gravitee.gateway.reactive.policy.tracing.TracingPolicyHook.ATTR_POLICY_TRIGGER_EXECUTED_PREFIX;
 
 import io.gravitee.definition.model.ConditionSupplier;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
@@ -59,8 +60,13 @@ public class HttpConditionalPolicy implements HttpPolicy, ConditionSupplier {
         if (!conditionDefined) {
             return policy.onRequest(ctx);
         }
-        storeTriggerCondition(ctx);
-        return conditionFilter.filter(ctx, this).flatMapCompletable(conditionalPolicy -> Completable.defer(() -> policy.onRequest(ctx)));
+        String policyId = policy.id();
+        storeTriggerCondition(ctx, policyId);
+        return conditionFilter
+            .filter(ctx, this)
+            .doOnSuccess(ignored -> ctx.setInternalAttribute(ATTR_POLICY_TRIGGER_EXECUTED_PREFIX + policyId, true))
+            .doOnComplete(() -> ctx.setInternalAttribute(ATTR_POLICY_TRIGGER_EXECUTED_PREFIX + policyId, false))
+            .flatMapCompletable(conditionalPolicy -> Completable.defer(() -> policy.onRequest(ctx)));
     }
 
     @Override
@@ -68,19 +74,34 @@ public class HttpConditionalPolicy implements HttpPolicy, ConditionSupplier {
         if (!conditionDefined) {
             return policy.onResponse(ctx);
         }
-        storeTriggerCondition(ctx);
-        return conditionFilter.filter(ctx, this).flatMapCompletable(conditionalPolicy -> policy.onResponse(ctx));
+        String policyId = policy.id();
+        storeTriggerCondition(ctx, policyId);
+        return conditionFilter
+            .filter(ctx, this)
+            .doOnSuccess(ignored -> ctx.setInternalAttribute(ATTR_POLICY_TRIGGER_EXECUTED_PREFIX + policyId, true))
+            .doOnComplete(() -> ctx.setInternalAttribute(ATTR_POLICY_TRIGGER_EXECUTED_PREFIX + policyId, false))
+            .flatMapCompletable(conditionalPolicy -> policy.onResponse(ctx));
     }
 
     @Override
     public Completable onMessageRequest(final HttpMessageExecutionContext ctx) {
-        storeTriggerCondition(ctx);
+        if (!conditionDefined) {
+            return policy.onMessageRequest(ctx);
+        }
+        String policyId = policy.id();
+        storeTriggerCondition(ctx, policyId);
+        ctx.setInternalAttribute(ATTR_POLICY_TRIGGER_EXECUTED_PREFIX + policyId, false);
         return Completable.complete();
     }
 
     @Override
     public Completable onMessageResponse(final HttpMessageExecutionContext ctx) {
-        storeTriggerCondition(ctx);
+        if (!conditionDefined) {
+            return policy.onMessageResponse(ctx);
+        }
+        String policyId = policy.id();
+        storeTriggerCondition(ctx, policyId);
+        ctx.setInternalAttribute(ATTR_POLICY_TRIGGER_EXECUTED_PREFIX + policyId, false);
         return Completable.complete();
     }
 
@@ -89,9 +110,9 @@ public class HttpConditionalPolicy implements HttpPolicy, ConditionSupplier {
         return condition;
     }
 
-    private void storeTriggerCondition(final BaseExecutionContext ctx) {
+    private void storeTriggerCondition(final BaseExecutionContext ctx, final String policyId) {
         if (conditionDefined) {
-            ctx.setInternalAttribute(ATTR_POLICY_TRIGGER_CONDITION_PREFIX + policy.id(), condition);
+            ctx.setInternalAttribute(ATTR_POLICY_TRIGGER_CONDITION_PREFIX + policyId, condition);
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHook.java
@@ -40,6 +40,7 @@ public class TracingPolicyHook extends AbstractTracingHook implements PolicyHook
     private static final String ATTR_SPAN_POLICY_TRIGGER_EXECUTED = "gravitee.policy.trigger.executed";
     private static final String ATTR_SPAN_POLICY_TRIGGER_CONDITION = "gravitee.policy.trigger.condition";
     public static final String ATTR_POLICY_TRIGGER_CONDITION_PREFIX = "gravitee.policy.trigger.condition.";
+    public static final String ATTR_POLICY_TRIGGER_EXECUTED_PREFIX = "gravitee.policy.trigger.executed.";
     private static final String EVENT_POLICY_PRE = "gravitee.policy.pre";
     private static final String EVENT_POLICY_POST = "gravitee.policy.post";
     private static final String ATTR_HTTP_REQUEST_HEADER_PREFIX = "http.request.header.";
@@ -73,11 +74,6 @@ public class TracingPolicyHook extends AbstractTracingHook implements PolicyHook
         });
     }
 
-    /**
-     * Add policy.trigger.condition and policy.trigger.executed attributes to the span.
-     * These must be added in post() because HttpConditionalPolicy stores the condition
-     * in the context during policy execution, after the span is created.
-     */
     private void addTriggerAttributes(final String id, final HttpExecutionContext ctx) {
         Span span = getSpan(ctx, id);
         if (span != null) {
@@ -85,7 +81,8 @@ public class TracingPolicyHook extends AbstractTracingHook implements PolicyHook
             if (triggerCondition != null && !triggerCondition.isBlank()) {
                 span.withAttribute(ATTR_SPAN_POLICY_TRIGGER_CONDITION, triggerCondition);
             }
-            span.withAttribute(ATTR_SPAN_POLICY_TRIGGER_EXECUTED, "true");
+            Boolean executed = ctx.getInternalAttribute(ATTR_POLICY_TRIGGER_EXECUTED_PREFIX + id);
+            span.withAttribute(ATTR_SPAN_POLICY_TRIGGER_EXECUTED, executed != null ? String.valueOf(executed) : "true");
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/HttpConditionalPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/HttpConditionalPolicyTest.java
@@ -113,24 +113,26 @@ class HttpConditionalPolicyTest {
 
     @ParameterizedTest
     @NullAndEmptySource
-    void shouldExecuteConditionOnMessageRequestWhenNoCondition(String condition) {
+    void shouldDelegateToUnderlyingPolicyOnMessageRequestWhenNoCondition(String condition) {
         final HttpConditionalPolicy cut = new HttpConditionalPolicy(policy, condition, conditionFilter);
 
         cut.onMessageRequest(ctx).test().assertComplete();
 
-        verify(policy, never()).onMessageRequest(ctx);
+        verify(policy).onMessageRequest(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
         verifyNoMoreInteractions(policy);
         verifyNoInteractions(conditionFilter);
     }
 
     @ParameterizedTest
     @NullAndEmptySource
-    void shouldExecuteConditionOnMessageResponseWhenNoCondition(String condition) {
+    void shouldDelegateToUnderlyingPolicyOnMessageResponseWhenNoCondition(String condition) {
         final HttpConditionalPolicy cut = new HttpConditionalPolicy(policy, condition, conditionFilter);
 
         cut.onMessageResponse(ctx).test().assertComplete();
 
-        verify(policy, never()).onMessageResponse(ctx);
+        verify(policy).onMessageResponse(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
         verifyNoMoreInteractions(policy);
         verifyNoInteractions(conditionFilter);
     }
@@ -259,5 +261,71 @@ class HttpConditionalPolicyTest {
             eq("gravitee.policy.trigger.condition." + POLICY_ID),
             any()
         );
+    }
+
+    @Test
+    void shouldStoreExecutedTrueWhenConditionMetOnRequest() {
+        final HttpConditionalPolicy cut = new HttpConditionalPolicy(policy, CONDITION, conditionFilter);
+        when(policy.id()).thenReturn(POLICY_ID);
+        when(conditionFilter.filter(ctx, cut)).thenReturn(Maybe.just(cut));
+
+        cut.onRequest(ctx).test().assertComplete();
+
+        verify((HttpExecutionContextInternal) ctx).setInternalAttribute("gravitee.policy.trigger.executed." + POLICY_ID, true);
+    }
+
+    @Test
+    void shouldStoreExecutedFalseWhenConditionNotMetOnRequest() {
+        final HttpConditionalPolicy cut = new HttpConditionalPolicy(policy, CONDITION, conditionFilter);
+        when(policy.id()).thenReturn(POLICY_ID);
+        when(conditionFilter.filter(ctx, cut)).thenReturn(Maybe.empty());
+
+        cut.onRequest(ctx).test().assertComplete();
+
+        verify((HttpExecutionContextInternal) ctx).setInternalAttribute("gravitee.policy.trigger.executed." + POLICY_ID, false);
+    }
+
+    @Test
+    void shouldStoreExecutedTrueWhenConditionMetOnResponse() {
+        final HttpConditionalPolicy cut = new HttpConditionalPolicy(policy, CONDITION, conditionFilter);
+        when(policy.id()).thenReturn(POLICY_ID);
+        when(conditionFilter.filter(ctx, cut)).thenReturn(Maybe.just(cut));
+
+        cut.onResponse(ctx).test().assertComplete();
+
+        verify((HttpExecutionContextInternal) ctx).setInternalAttribute("gravitee.policy.trigger.executed." + POLICY_ID, true);
+    }
+
+    @Test
+    void shouldStoreExecutedFalseWhenConditionNotMetOnResponse() {
+        final HttpConditionalPolicy cut = new HttpConditionalPolicy(policy, CONDITION, conditionFilter);
+        when(policy.id()).thenReturn(POLICY_ID);
+        when(conditionFilter.filter(ctx, cut)).thenReturn(Maybe.empty());
+
+        cut.onResponse(ctx).test().assertComplete();
+
+        verify((HttpExecutionContextInternal) ctx).setInternalAttribute("gravitee.policy.trigger.executed." + POLICY_ID, false);
+    }
+
+    @Test
+    void shouldStoreExecutedFalseWhenConditionDefinedOnMessageRequest() {
+        final HttpConditionalPolicy cut = new HttpConditionalPolicy(policy, CONDITION, conditionFilter);
+        when(policy.id()).thenReturn(POLICY_ID);
+
+        cut.onMessageRequest(ctx).test().assertComplete();
+
+        verify((HttpExecutionContextInternal) ctx).setInternalAttribute("gravitee.policy.trigger.executed." + POLICY_ID, false);
+        verify(policy, never()).onMessageRequest(ctx);
+    }
+
+    @Test
+    void shouldStoreExecutedFalseWhenConditionDefinedOnMessageResponse() {
+        final HttpConditionalPolicy cut = new HttpConditionalPolicy(policy, CONDITION, conditionFilter);
+        when(policy.id()).thenReturn(POLICY_ID);
+
+        cut.onMessageResponse(ctx).test().assertComplete();
+
+        verify((HttpExecutionContextInternal) ctx).setInternalAttribute("gravitee.policy.trigger.executed." + POLICY_ID, false);
+        verify(policy, never()).onMessageResponse(ctx);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHookTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/tracing/TracingPolicyHookTest.java
@@ -104,6 +104,7 @@ class TracingPolicyHookTest {
 
         when(ctx.getInternalAttribute("tracing-span-test-policy")).thenReturn(span);
         when(ctx.getInternalAttribute("gravitee.policy.trigger.condition." + policyId)).thenReturn(condition);
+        when(ctx.getInternalAttribute("gravitee.policy.trigger.executed." + policyId)).thenReturn(true);
         lenient().when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(false);
         when(ctx.getTracer()).thenReturn(tracer);
 
@@ -114,12 +115,44 @@ class TracingPolicyHookTest {
     }
 
     @Test
+    void shouldSetTriggerExecutedFalseWhenConditionDefinedButPolicyNotExecuted() {
+        String policyId = "test-policy";
+        String condition = "{1 == 2}";
+
+        when(ctx.getInternalAttribute("tracing-span-test-policy")).thenReturn(span);
+        when(ctx.getInternalAttribute("gravitee.policy.trigger.condition." + policyId)).thenReturn(condition);
+        when(ctx.getInternalAttribute("gravitee.policy.trigger.executed." + policyId)).thenReturn(false);
+        lenient().when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(false);
+        when(ctx.getTracer()).thenReturn(tracer);
+
+        hook.post(policyId, ctx, ExecutionPhase.REQUEST).test().assertResult();
+        verify(span).withAttribute("gravitee.policy.trigger.condition", condition);
+        verify(span).withAttribute("gravitee.policy.trigger.executed", "false");
+        verify(tracer).end(span);
+    }
+
+    @Test
+    void shouldSetTriggerExecutedTrueWhenNoPolicyConditionDefined() {
+        String policyId = "test-policy";
+
+        when(ctx.getInternalAttribute("tracing-span-test-policy")).thenReturn(span);
+        when(ctx.getInternalAttribute("gravitee.policy.trigger.condition." + policyId)).thenReturn(null);
+        lenient().when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(false);
+        when(ctx.getTracer()).thenReturn(tracer);
+
+        hook.post(policyId, ctx, ExecutionPhase.REQUEST).test().assertResult();
+        verify(span).withAttribute("gravitee.policy.trigger.executed", "true");
+        verify(span, never()).withAttribute(eq("gravitee.policy.trigger.condition"), anyString());
+        verify(tracer).end(span);
+    }
+
+    @Test
     void shouldExecutePostHookWithVerbose() {
         String policyId = "test-policy";
         Map<String, String> headers = Map.of("header1", "value1", "header2", "value2");
 
         when(ctx.getInternalAttribute("tracing-span-test-policy")).thenReturn(span);
-        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(true);
+        lenient().when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_VERBOSE_ENABLED)).thenReturn(true);
         lenient().when(ctx.getInternalAttribute("gravitee.policy.trigger.condition." + policyId)).thenReturn(null);
         when(ctx.request()).thenReturn(request);
         when(request.headers()).thenReturn(httpHeaders);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13830

## Description

Issue:

Always TRUE


<img width="1714" height="858" alt="Screenshot 2026-05-02 at 7 31 33 PM" src="https://github.com/user-attachments/assets/8d358bef-5046-40e1-990d-1837791c0369" />


Now, trigger.executed is calculated:


<img width="862" height="858" alt="Screenshot 2026-05-02 at 8 06 15 PM" src="https://github.com/user-attachments/assets/0b18d53a-7766-4a88-851c-e367c63522dd" />
<img width="862" height="858" alt="Screenshot 2026-05-02 at 8 13 57 PM" src="https://github.com/user-attachments/assets/7eec92a8-036c-46a1-adef-49d267488615" />
<img width="862" height="858" alt="Screenshot 2026-05-02 at 8 30 54 PM" src="https://github.com/user-attachments/assets/13634f0a-51fe-42b3-a2ad-0fb9adffa44c" />



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

