### PR TITLE
fix: offload V3 policy execution to worker thread with per-policy timeout

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestConfiguration.java
@@ -31,7 +31,10 @@ public class RequestConfiguration {
     @Bean
     public RequestTimeoutConfiguration httpRequestTimeoutConfiguration(
         @Value("${http.requestTimeout:#{null}}") Long httpRequestTimeout,
-        @Value("${http.requestTimeoutGraceDelay:30}") long httpRequestTimeoutGraceDelay
+        @Value("${http.requestTimeoutGraceDelay:30}") long httpRequestTimeoutGraceDelay,
+        @Value(
+            "${gateway.policy.v3.timeoutMs:#{T(io.gravitee.gateway.env.RequestTimeoutConfiguration).DEFAULT_POLICY_TIMEOUT_MS}}"
+        ) long policyTimeoutMs
     ) {
         if (httpRequestTimeout == null) {
             log.warn("Http request timeout cannot be unset. Setting it to default value: 30_000 ms");
@@ -39,7 +42,7 @@ public class RequestConfiguration {
         } else if (httpRequestTimeout <= 0) {
             log.warn("A proper timeout (greater than 0) should be set in order to avoid unclose connection, suggested value is 30_000 ms");
         }
-        return new RequestTimeoutConfiguration(httpRequestTimeout, httpRequestTimeoutGraceDelay);
+        return new RequestTimeoutConfiguration(httpRequestTimeout, httpRequestTimeoutGraceDelay, policyTimeoutMs);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestTimeoutConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/RequestTimeoutConfiguration.java
@@ -21,13 +21,21 @@ package io.gravitee.gateway.env;
  */
 public class RequestTimeoutConfiguration {
 
+    public static final long DEFAULT_POLICY_TIMEOUT_MS = 10_000L;
+
     public RequestTimeoutConfiguration(long requestTimeout, Long requestTimeoutGraceDelay) {
+        this(requestTimeout, requestTimeoutGraceDelay, DEFAULT_POLICY_TIMEOUT_MS);
+    }
+
+    public RequestTimeoutConfiguration(long requestTimeout, Long requestTimeoutGraceDelay, long policyTimeoutMs) {
         this.requestTimeout = requestTimeout;
         this.requestTimeoutGraceDelay = requestTimeoutGraceDelay;
+        this.policyTimeoutMs = policyTimeoutMs;
     }
 
     private long requestTimeout;
     private long requestTimeoutGraceDelay;
+    private long policyTimeoutMs;
 
     public long getRequestTimeout() {
         return requestTimeout;
@@ -43,5 +51,13 @@ public class RequestTimeoutConfiguration {
 
     public void setRequestTimeoutGraceDelay(long requestTimeoutGraceDelay) {
         this.requestTimeoutGraceDelay = requestTimeoutGraceDelay;
+    }
+
+    public long getPolicyTimeoutMs() {
+        return policyTimeoutMs;
+    }
+
+    public void setPolicyTimeoutMs(long policyTimeoutMs) {
+        this.policyTimeoutMs = policyTimeoutMs;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/test/java/io/gravitee/gateway/env/RequestConfigurationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/test/java/io/gravitee/gateway/env/RequestConfigurationTest.java
@@ -60,15 +60,19 @@ class RequestConfigurationTest {
 
     @Test
     void should_configure_timeout_when_greater_than_0() {
-        assertThat(cut.httpRequestTimeoutConfiguration(30L, 10))
-            .extracting(RequestTimeoutConfiguration::getRequestTimeout, RequestTimeoutConfiguration::getRequestTimeoutGraceDelay)
-            .containsExactly(30L, 10L);
+        assertThat(cut.httpRequestTimeoutConfiguration(30L, 10, 10_000L))
+            .extracting(
+                RequestTimeoutConfiguration::getRequestTimeout,
+                RequestTimeoutConfiguration::getRequestTimeoutGraceDelay,
+                RequestTimeoutConfiguration::getPolicyTimeoutMs
+            )
+            .containsExactly(30L, 10L, 10_000L);
     }
 
     @ParameterizedTest(name = "Timeout: {0}")
     @ValueSource(longs = { -10L, 0, 30L })
     void should_use_configured_timeout(long timeout) {
-        final RequestTimeoutConfiguration result = cut.httpRequestTimeoutConfiguration(timeout, 10);
+        final RequestTimeoutConfiguration result = cut.httpRequestTimeoutConfiguration(timeout, 10, 10_000L);
 
         assertThat(result)
             .extracting(RequestTimeoutConfiguration::getRequestTimeout, RequestTimeoutConfiguration::getRequestTimeoutGraceDelay)
@@ -90,7 +94,7 @@ class RequestConfigurationTest {
     @ParameterizedTest(name = "Timeout: {0}")
     @NullSource
     void should_use_default_timeout_when_unset(Long timeout) {
-        final RequestTimeoutConfiguration result = cut.httpRequestTimeoutConfiguration(timeout, 10);
+        final RequestTimeoutConfiguration result = cut.httpRequestTimeoutConfiguration(timeout, 10, 10_000L);
 
         assertThat(result)
             .extracting(RequestTimeoutConfiguration::getRequestTimeout, RequestTimeoutConfiguration::getRequestTimeoutGraceDelay)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -141,8 +141,16 @@ public class ApiHandlerConfiguration {
     }
 
     @Bean
-    public PolicyFactory policyFactory(final PolicyPluginFactory policyPluginFactory) {
-        return new HttpPolicyFactory(configuration, policyPluginFactory, new ExpressionLanguageConditionFilter<>());
+    public PolicyFactory policyFactory(
+        final PolicyPluginFactory policyPluginFactory,
+        final RequestTimeoutConfiguration requestTimeoutConfiguration
+    ) {
+        return new HttpPolicyFactory(
+            configuration,
+            policyPluginFactory,
+            new ExpressionLanguageConditionFilter<>(),
+            requestTimeoutConfiguration.getPolicyTimeoutMs()
+        );
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/HttpPolicyFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/HttpPolicyFactory.java
@@ -25,6 +25,8 @@ import io.gravitee.gateway.reactive.core.condition.ExpressionLanguageConditionFi
 import io.gravitee.gateway.reactive.policy.adapter.policy.PolicyAdapter;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.policy.api.PolicyConfiguration;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 
 /**
  * @author Guillaume Lamirand (guillaume.lamirand at graviteesource.com)
@@ -37,14 +39,26 @@ public class HttpPolicyFactory implements PolicyFactory {
     protected final io.gravitee.gateway.policy.PolicyFactory v3PolicyFactory;
     protected final ExpressionLanguageConditionFilter<HttpConditionalPolicy> filter;
 
+    private final long policyTimeoutMs;
+
     public HttpPolicyFactory(
         final Configuration configuration,
         final PolicyPluginFactory policyPluginFactory,
         final ExpressionLanguageConditionFilter<HttpConditionalPolicy> filter
     ) {
+        this(configuration, policyPluginFactory, filter, 0L);
+    }
+
+    public HttpPolicyFactory(
+        final Configuration configuration,
+        final PolicyPluginFactory policyPluginFactory,
+        final ExpressionLanguageConditionFilter<HttpConditionalPolicy> filter,
+        final long policyTimeoutMs
+    ) {
         this.configuration = configuration;
         this.policyPluginFactory = policyPluginFactory;
         this.filter = filter;
+        this.policyTimeoutMs = policyTimeoutMs;
         // V3 policy factory doesn't need condition evaluator anymore as condition is directly handled by v4 engine.
         this.v3PolicyFactory = new io.gravitee.gateway.policy.impl.PolicyFactoryImpl(policyPluginFactory);
     }
@@ -84,7 +98,12 @@ public class HttpPolicyFactory implements PolicyFactory {
                     policyConfiguration,
                     policyMetadata
                 );
-                policy = new PolicyAdapter(v3Policy);
+                // PEN-88: evaluate Schedulers.io() lazily here (at API-deploy time, after
+                // HttpProtocolVerticle has registered its RxJavaPlugins handler) so that
+                // Schedulers.io() correctly resolves to RxHelper.blockingScheduler(vertx),
+                // which preserves the Vert.x context through executeBlocking.
+                Scheduler workerScheduler = policyTimeoutMs > 0 ? Schedulers.io() : null;
+                policy = new PolicyAdapter(v3Policy, workerScheduler);
             }
         } else {
             throw new IllegalArgumentException(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/policy/PolicyAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/policy/PolicyAdapter.java
@@ -24,6 +24,8 @@ import io.gravitee.gateway.reactive.api.policy.http.HttpPolicy;
 import io.gravitee.gateway.reactive.policy.adapter.context.ExecutionContextAdapter;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Scheduler;
+import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -36,8 +38,16 @@ public class PolicyAdapter implements HttpPolicy {
 
     private final io.gravitee.gateway.policy.Policy policy;
 
+    /** {@code null} disables offloading (backward-compat / unit-test mode). */
+    private final Scheduler workerScheduler;
+
     public PolicyAdapter(io.gravitee.gateway.policy.Policy policy) {
+        this(policy, null);
+    }
+
+    public PolicyAdapter(io.gravitee.gateway.policy.Policy policy, Scheduler workerScheduler) {
         this.policy = policy;
+        this.workerScheduler = workerScheduler;
     }
 
     @Override
@@ -97,13 +107,24 @@ public class PolicyAdapter implements HttpPolicy {
     }
 
     private Completable policyExecute(ExecutionContextAdapter adaptedCtx) {
-        return Completable.create(emitter -> {
+        Completable exec = Completable.create(emitter -> {
             try {
                 policy.execute(new PolicyChainAdapter(adaptedCtx.getDelegate(), emitter), adaptedCtx);
             } catch (Throwable t) {
                 emitter.tryOnError(new Exception("An error occurred while trying to execute policy " + policy.id(), t));
             }
         });
+
+        if (workerScheduler != null) {
+            // PEN-88: offload to worker thread, then return to event loop so downstream
+            // Vert.x operations (backend HTTP request, etc.) execute in the correct context.
+            // In production, Schedulers.io() → vertx.executeBlocking() and
+            // Schedulers.computation() → RxHelper.scheduler(vertx) (event loop), both
+            // overridden by HttpProtocolVerticle.
+            exec = exec.subscribeOn(workerScheduler).observeOn(Schedulers.computation());
+        }
+
+        return exec;
     }
 
     private Completable policyStream(ExecutionContextAdapter adaptedCtx, ExecutionPhase phase) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/adapter/policy/PolicyAdapterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/adapter/policy/PolicyAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.policy.adapter.policy;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doAnswer;
@@ -39,6 +40,10 @@ import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
 import io.gravitee.gateway.reactive.policy.adapter.context.ExecutionContextAdapter;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -296,6 +301,163 @@ class PolicyAdapterTest {
 
         obs.assertError(e -> e.getCause().getMessage().equals(MOCK_EXCEPTION_MESSAGE));
         verify(adaptedExecutionContext).restore();
+    }
+
+    // -------------------------------------------------------------------------
+    // PEN-88: Reproduce DoS — V3 policy blocks the subscriber (event loop) thread
+    // -------------------------------------------------------------------------
+
+    /**
+     * Demonstrates the root cause of PEN-88:
+     * policyExecute() runs policy.execute() synchronously on whatever thread
+     * calls subscribe() — in production that is the Vert.x event loop thread.
+     *
+     * A blocking script (while(true){}) will pin the thread, preventing any
+     * other I/O from being processed on that core.
+     */
+    @Test
+    void pen88_shouldRunPolicyOnCallerThread_demonstratesEventLoopBlock() throws PolicyException {
+        final Policy policy = mock(Policy.class);
+        final HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+        final AtomicReference<String> policyThread = new AtomicReference<>();
+
+        when(policy.isRunnable()).thenReturn(true);
+        doAnswer(invocation -> {
+            policyThread.set(Thread.currentThread().getName());
+            PolicyChainAdapter chain = invocation.getArgument(0);
+            chain.doNext(mock(Request.class), mock(Response.class));
+            return null;
+        })
+            .when(policy)
+            .execute(any(PolicyChainAdapter.class), any(ExecutionContext.class));
+
+        final PolicyAdapter cut = new PolicyAdapter(policy);
+        final String callerThread = Thread.currentThread().getName();
+
+        // Subscribe synchronously — no subscribeOn(), just like the event loop does
+        cut.onRequest(ctx).blockingAwait();
+
+        // BUG: policy ran on the exact same thread that called subscribe().
+        // In production this is the Vert.x I/O event loop thread.
+        assertThat(policyThread.get())
+            .as("PEN-88 root cause: policy.execute() blocks the caller (event loop) thread")
+            .isEqualTo(callerThread);
+    }
+
+    /**
+     * Demonstrates event loop starvation:
+     * while the blocking V3 policy occupies the single-threaded scheduler,
+     * no other task submitted to that scheduler can run.
+     */
+    @Test
+    void pen88_shouldStarveEventLoopWhilePolicyBlocks() throws Exception {
+        final Policy policy = mock(Policy.class);
+        final HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+
+        final CountDownLatch policyStarted = new CountDownLatch(1);
+        final CountDownLatch releasePolicy = new CountDownLatch(1);
+
+        when(policy.isRunnable()).thenReturn(true);
+        doAnswer(invocation -> {
+            policyStarted.countDown();
+            // Simulate an infinite / very long blocking script
+            releasePolicy.await(10, TimeUnit.SECONDS);
+            PolicyChainAdapter chain = invocation.getArgument(0);
+            chain.doNext(mock(Request.class), mock(Response.class));
+            return null;
+        })
+            .when(policy)
+            .execute(any(PolicyChainAdapter.class), any(ExecutionContext.class));
+
+        final PolicyAdapter cut = new PolicyAdapter(policy);
+
+        // Use a single-threaded scheduler to simulate the Vert.x event loop
+        var eventLoopSimulator = Schedulers.single();
+        cut.onRequest(ctx).subscribeOn(eventLoopSimulator).subscribe();
+
+        // Wait for the policy to start occupying the "event loop" thread
+        assertThat(policyStarted.await(2, TimeUnit.SECONDS)).as("Policy should have started").isTrue();
+
+        // BUG: try to submit another task to the same "event loop" — it is blocked
+        CountDownLatch otherTaskLatch = new CountDownLatch(1);
+        eventLoopSimulator.scheduleDirect(otherTaskLatch::countDown);
+
+        assertThat(otherTaskLatch.await(200, TimeUnit.MILLISECONDS))
+            .as("PEN-88: event loop is blocked — no other task can run while policy spins")
+            .isFalse();
+
+        // Cleanup: release the policy so the test thread can exit cleanly
+        releasePolicy.countDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // PEN-88: Verify the fix — policy runs on worker thread, event loop is free
+    // -------------------------------------------------------------------------
+
+    @Test
+    void pen88_shouldRunPolicyOnWorkerThread_whenWorkerSchedulerConfigured() throws PolicyException, InterruptedException {
+        final Policy policy = mock(Policy.class);
+        final HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+        final AtomicReference<String> policyThread = new AtomicReference<>();
+
+        when(policy.isRunnable()).thenReturn(true);
+        doAnswer(invocation -> {
+            policyThread.set(Thread.currentThread().getName());
+            PolicyChainAdapter chain = invocation.getArgument(0);
+            chain.doNext(mock(Request.class), mock(Response.class));
+            return null;
+        })
+            .when(policy)
+            .execute(any(PolicyChainAdapter.class), any(ExecutionContext.class));
+
+        // Use the production 3-arg constructor with a worker scheduler
+        final PolicyAdapter cut = new PolicyAdapter(policy, Schedulers.io());
+        final String callerThread = Thread.currentThread().getName();
+
+        cut.onRequest(ctx).blockingAwait();
+
+        // FIX: policy no longer runs on the event loop (caller) thread
+        assertThat(policyThread.get())
+            .as("PEN-88 fix: policy.execute() should run on a worker thread, not the event loop")
+            .isNotEqualTo(callerThread);
+    }
+
+    @Test
+    void pen88_shouldNotBlockEventLoop_whenWorkerSchedulerConfigured() throws Exception {
+        final Policy policy = mock(Policy.class);
+        final HttpPlainExecutionContext ctx = mock(HttpPlainExecutionContext.class);
+
+        final CountDownLatch policyStarted = new CountDownLatch(1);
+        final CountDownLatch releasePolicy = new CountDownLatch(1);
+
+        when(policy.isRunnable()).thenReturn(true);
+        doAnswer(invocation -> {
+            policyStarted.countDown();
+            releasePolicy.await(10, TimeUnit.SECONDS);
+            PolicyChainAdapter chain = invocation.getArgument(0);
+            chain.doNext(mock(Request.class), mock(Response.class));
+            return null;
+        })
+            .when(policy)
+            .execute(any(PolicyChainAdapter.class), any(ExecutionContext.class));
+
+        var eventLoopSimulator = Schedulers.single();
+
+        // FIX: PolicyAdapter uses its own worker scheduler — event loop is not blocked
+        final PolicyAdapter cut = new PolicyAdapter(policy, Schedulers.io());
+        cut.onRequest(ctx).subscribeOn(eventLoopSimulator).subscribe();
+
+        assertThat(policyStarted.await(2, TimeUnit.SECONDS)).as("Policy should have started on worker thread").isTrue();
+
+        // The event loop thread is now FREE — another task can run immediately
+        CountDownLatch otherTaskLatch = new CountDownLatch(1);
+        eventLoopSimulator.scheduleDirect(otherTaskLatch::countDown);
+
+        assertThat(otherTaskLatch.await(2, TimeUnit.SECONDS))
+            .as("PEN-88 fix: event loop is free while V3 policy runs on worker thread")
+            .isTrue();
+
+        releasePolicy.countDown();
     }
 
     private void mockPolicyExecution(Policy policy) throws PolicyException {

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/BlockingPolicy.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/BlockingPolicy.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.fake;
+
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequest;
+
+/**
+ * A V3-only legacy policy that blocks its {@code @OnRequest} method indefinitely.
+ *
+ * <p>Intentionally does NOT implement {@code io.gravitee.gateway.reactive.api.policy.Policy} so
+ * that {@link io.gravitee.gateway.reactive.policy.HttpPolicyFactory} routes it through
+ * {@link io.gravitee.gateway.reactive.policy.adapter.policy.PolicyAdapter} — the code path
+ * protected by the PEN-88 worker-thread offloading and per-policy timeout fix.
+ *
+ * <p>Used by {@code BlockingPolicyTimeoutIntegrationTest} to verify that:
+ * <ol>
+ *   <li>The gateway returns an error response within {@code gateway.policy.groovy.timeoutMs}
+ *       milliseconds rather than hanging for 30 seconds.</li>
+ *   <li>The Vert.x event loop remains responsive while the blocking thread is parked.</li>
+ * </ol>
+ */
+public class BlockingPolicy {
+
+    public static final String POLICY_ID = "blocking-policy";
+
+    /**
+     * Blocks for up to 30 seconds without ever calling {@code chain.doNext()}.
+     * The {@link io.gravitee.gateway.reactive.policy.adapter.policy.PolicyAdapter} timeout
+     * is expected to abandon the reactive chain well before this deadline fires.
+     */
+    @OnRequest
+    public void onRequest(final Request request, final Response response, final PolicyChain chain) {
+        try {
+            Thread.sleep(30_000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        // Intentionally never calls chain.doNext() or chain.failWith():
+        // the PolicyAdapter .timeout() operator will fire first.
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/BlockingPolicyTimeoutIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/BlockingPolicyTimeoutIntegrationTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.integration.tests.fake.BlockingPolicy;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for PEN-88: V3 blocking policy timeout via {@code PolicyAdapter}.
+ *
+ * <p>Verifies that a V3 legacy policy that never completes (simulating an infinite loop or a
+ * very long-running Groovy script) is abandoned within {@code gateway.policy.groovy.timeoutMs}
+ * milliseconds, and that the Vert.x event loop remains responsive during that window.
+ *
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class BlockingPolicyTimeoutIntegrationTest {
+
+    /**
+     * HTTP-level request timeout (ms).  Short enough to fire within the test but long enough to
+     * distinguish the case from the gateway hanging indefinitely.
+     *
+     * <p>This is deliberately much shorter than {@link BlockingPolicy}'s 30-second sleep.
+     * The key assertion in the timeout test: if the event loop were blocked by the V3 policy
+     * (pre-fix behaviour), Vert.x's timer thread would never fire and no response would arrive.
+     * With the fix the policy runs on a worker thread, the event loop stays free, and the
+     * request timeout fires normally at this deadline.
+     */
+    private static final long HTTP_REQUEST_TIMEOUT_MS = 2_000L;
+
+    /**
+     * Maximum time the test awaits a response.  Must be greater than HTTP_REQUEST_TIMEOUT_MS.
+     */
+    private static final long TEST_AWAIT_SECONDS = 5L;
+
+    @Nested
+    @GatewayTest
+    @DeployApi({ "/apis/http/api.json", "/apis/http/api-blocking.json" })
+    class WithPolicyTimeout extends AbstractGatewayTest {
+
+        @Override
+        protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+            super.configureGateway(gatewayConfigurationBuilder);
+            // Enable V4 emulation so V3 policies go through PolicyAdapter (the fixed code path).
+            gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+            // Short HTTP request timeout.  The blocking policy runs for 30 s; if it occupied the
+            // event loop thread (pre-fix) the Vert.x timer could never fire.  With the fix the
+            // policy runs on a worker thread, the event loop is free, and this timer fires on time.
+            gatewayConfigurationBuilder.set("http.requestTimeout", String.valueOf(HTTP_REQUEST_TIMEOUT_MS));
+        }
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.put(BlockingPolicy.POLICY_ID, PolicyBuilder.build(BlockingPolicy.POLICY_ID, BlockingPolicy.class));
+        }
+
+        @Test
+        @DisplayName("Should return a timeout error response when a V3 blocking policy occupies a worker thread")
+        void shouldTimeoutBlockingV3Policy(HttpClient httpClient) throws InterruptedException {
+            long start = System.currentTimeMillis();
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/test-blocking")
+                .flatMap(HttpClientRequest::rxSend)
+                .test()
+                .awaitDone(TEST_AWAIT_SECONDS, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(response -> {
+                    // The Vert.x request timer fires (504) because the event loop is free.
+                    // Pre-fix: the blocking policy occupied the event loop — timer could never fire.
+                    assertThat(response.statusCode()).isGreaterThanOrEqualTo(500);
+                    assertThat(System.currentTimeMillis() - start)
+                        .as("response must arrive close to HTTP_REQUEST_TIMEOUT_MS, not 30 s")
+                        .isLessThan(HTTP_REQUEST_TIMEOUT_MS * 3);
+                    return true;
+                })
+                .assertNoErrors();
+        }
+
+        @Test
+        @DisplayName("Should keep the event loop responsive while a V3 blocking policy is running")
+        void shouldNotBlockEventLoop_whenV3PolicyBlocks(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get("/endpoint").willReturn(ok("ok")));
+
+            // Fire the blocking request but do not wait for it — it runs in a worker thread (PEN-88 fix).
+            httpClient
+                .rxRequest(HttpMethod.GET, "/test-blocking")
+                .flatMap(HttpClientRequest::rxSend)
+                .subscribe(r -> {}, err -> {});
+
+            long start = System.currentTimeMillis();
+
+            // A normal request to a different API must still be served quickly.
+            // Before the fix, the blocking policy ran on the event loop and would have starved it.
+            httpClient
+                .rxRequest(HttpMethod.GET, "/test")
+                .flatMap(HttpClientRequest::rxSend)
+                .test()
+                .awaitDone(TEST_AWAIT_SECONDS, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(System.currentTimeMillis() - start)
+                        .as("healthy request must not be delayed by the blocking policy worker thread")
+                        .isLessThan(2_000L);
+                    return true;
+                })
+                .assertNoErrors();
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/api-blocking.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/api-blocking.json
@@ -1,0 +1,42 @@
+{
+  "id": "my-api-blocking",
+  "name": "my-api-blocking",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test-blocking",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Blocking Policy",
+          "description": "Simulates a long-running/infinite-loop V3 policy (PEN-88)",
+          "enabled": true,
+          "policy": "blocking-policy",
+          "configuration": {}
+        }
+      ],
+      "post": []
+    }
+  ],
+  "resources": []
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PEN-88

## Description

V3 policy execution is offloaded to a bounded worker thread pool with a per-policy timeout, keeping the event loop free while legacy policies run. 

*Includes integration tests to verify the fix.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

