### PR TITLE
Fix/exposed entrypoints duplicates with override vhost

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImpl.java
@@ -166,7 +166,31 @@ public class ApiEntrypointServiceImpl implements ApiEntrypointService {
             );
         }
 
-        return apiEntrypoints;
+        return deduplicateByTarget(apiEntrypoints);
+    }
+
+    /**
+     * Removes duplicate entrypoints sharing the same target URL.
+     * Duplicates appear whenever the resolved {@code target} does not depend on the matched
+     * organization entrypoint mapping, so iterating over multiple matching mappings produces
+     * identical entries. This is the case for:
+     * <ul>
+     *   <li>V4 HTTP listener paths with {@code overrideAccess=true} (target is built from the virtual host)</li>
+     *   <li>V2 {@code VirtualHost} with {@code overrideEntrypoint=true} (same as above for legacy APIs)</li>
+     *   <li>V4 TCP listeners (target is always {@code tcpHost:tcpPort}, where the port is the env-level
+     *       {@code PORTAL_TCP_PORT} parameter, independent of the matched mapping)</li>
+     * </ul>
+     * Insertion order is preserved so the UI keeps a deterministic display.
+     * <p>
+     * The dedupe key is the raw {@code target} string; we assume host casing has been normalized
+     * upstream (paths are intentionally not lower-cased because they are case-sensitive).
+     */
+    private List<ApiEntrypointEntity> deduplicateByTarget(final List<ApiEntrypointEntity> apiEntrypoints) {
+        Map<String, ApiEntrypointEntity> deduplicated = new LinkedHashMap<>();
+        for (ApiEntrypointEntity entrypoint : apiEntrypoints) {
+            deduplicated.putIfAbsent(entrypoint.getTarget(), entrypoint);
+        }
+        return new ArrayList<>(deduplicated.values());
     }
 
     private List<ApiEntrypointEntity> getEntrypoints(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiEntrypointServiceImplTest.java
@@ -153,6 +153,101 @@ class ApiEntrypointServiceImplTest {
     }
 
     @Test
+    void should_not_duplicate_api_v4_entrypoints_when_multiple_mappings_match_and_virtual_host_overrides_access() {
+        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("4082");
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_DOMAIN), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn(
+            "kafka.domain"
+        );
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
+
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setTags(Set.of("multi-entrypoint-tag"));
+        HttpListener httpListener = HttpListener.builder()
+            .paths(List.of(Path.builder().host("some_host").path("/test").overrideAccess(true).build()))
+            .build();
+        apiEntity.setListeners(List.of(httpListener));
+
+        EntrypointEntity entrypointOne = new EntrypointEntity();
+        entrypointOne.setTags(Arrays.array("multi-entrypoint-tag"));
+        entrypointOne.setValue("https://entrypoint-one.com");
+        entrypointOne.setTarget(EntrypointEntity.Target.HTTP);
+        EntrypointEntity entrypointTwo = new EntrypointEntity();
+        entrypointTwo.setTags(Arrays.array("multi-entrypoint-tag"));
+        entrypointTwo.setValue("https://entrypoint-two.com");
+        entrypointTwo.setTarget(EntrypointEntity.Target.HTTP);
+        when(entrypointService.findAll(any())).thenReturn(List.of(entrypointOne, entrypointTwo));
+
+        List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(apiEntrypoints).hasSize(1);
+        assertThat(apiEntrypoints.getFirst().getHost()).isEqualTo("some_host");
+        assertThat(apiEntrypoints.getFirst().getTarget()).isEqualTo("https://some_host/test");
+    }
+
+    @Test
+    void should_return_distinct_api_v4_entrypoints_when_multiple_mappings_match_and_virtual_host_does_not_override_access() {
+        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("4082");
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_DOMAIN), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn(
+            "kafka.domain"
+        );
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
+
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setTags(Set.of("multi-entrypoint-tag"));
+        HttpListener httpListener = HttpListener.builder()
+            .paths(List.of(Path.builder().host("some_host").path("/test").overrideAccess(false).build()))
+            .build();
+        apiEntity.setListeners(List.of(httpListener));
+
+        EntrypointEntity entrypointOne = new EntrypointEntity();
+        entrypointOne.setTags(Arrays.array("multi-entrypoint-tag"));
+        entrypointOne.setValue("https://entrypoint-one.com");
+        entrypointOne.setTarget(EntrypointEntity.Target.HTTP);
+        EntrypointEntity entrypointTwo = new EntrypointEntity();
+        entrypointTwo.setTags(Arrays.array("multi-entrypoint-tag"));
+        entrypointTwo.setValue("https://entrypoint-two.com");
+        entrypointTwo.setTarget(EntrypointEntity.Target.HTTP);
+        when(entrypointService.findAll(any())).thenReturn(List.of(entrypointOne, entrypointTwo));
+
+        List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(apiEntrypoints).hasSize(2);
+        assertThat(apiEntrypoints.getFirst().getTarget()).isEqualTo("https://entrypoint-one.com/test");
+        assertThat(apiEntrypoints.get(1).getTarget()).isEqualTo("https://entrypoint-two.com/test");
+    }
+
+    @Test
+    void should_not_duplicate_api_v2_entrypoints_when_multiple_mappings_match_and_virtual_host_overrides_entrypoint() {
+        io.gravitee.rest.api.model.api.ApiEntity apiEntity = new io.gravitee.rest.api.model.api.ApiEntity();
+        apiEntity.setTags(Set.of("multi-entrypoint-tag"));
+        Proxy proxy = new Proxy();
+        VirtualHost virtualHost = new VirtualHost();
+        virtualHost.setHost("some_host");
+        virtualHost.setPath("/test");
+        virtualHost.setOverrideEntrypoint(true);
+        proxy.setVirtualHosts(List.of(virtualHost));
+        apiEntity.setProxy(proxy);
+
+        EntrypointEntity entrypointOne = new EntrypointEntity();
+        entrypointOne.setTags(Arrays.array("multi-entrypoint-tag"));
+        entrypointOne.setValue("https://entrypoint-one.com");
+        entrypointOne.setTarget(EntrypointEntity.Target.HTTP);
+        EntrypointEntity entrypointTwo = new EntrypointEntity();
+        entrypointTwo.setTags(Arrays.array("multi-entrypoint-tag"));
+        entrypointTwo.setValue("https://entrypoint-two.com");
+        entrypointTwo.setTarget(EntrypointEntity.Target.HTTP);
+        when(entrypointService.findAll(any())).thenReturn(List.of(entrypointOne, entrypointTwo));
+
+        List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(apiEntrypoints).hasSize(1);
+        assertThat(apiEntrypoints.getFirst().getHost()).isEqualTo("some_host");
+        assertThat(apiEntrypoints.getFirst().getTarget()).isEqualTo("https://some_host/test");
+    }
+
+    @Test
     void shouldReturnDefaultTcpPortAndEntrypointWithoutApiV4Tags() {
         ApiEntity apiEntity = new ApiEntity();
         apiEntity.setDefinitionVersion(DefinitionVersion.V4);
@@ -172,6 +267,36 @@ class ApiEntrypointServiceImplTest {
 
         assertThat(apiEntrypoints).hasSize(1);
         assertThat(apiEntrypoints.getFirst().getHost()).isEqualTo("https://default-entrypoint");
+        assertThat(apiEntrypoints.getFirst().getTarget()).isEqualTo("some_tcp_host:4082");
+    }
+
+    @Test
+    void should_not_duplicate_api_v4_tcp_entrypoints_when_multiple_mappings_match_same_listener() {
+        when(parameterService.find(any(), eq(Key.PORTAL_TCP_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("4082");
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_DOMAIN), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn(
+            "kafka.domain"
+        );
+        when(parameterService.find(any(), eq(Key.PORTAL_KAFKA_PORT), any(), eq(ParameterReferenceType.ENVIRONMENT))).thenReturn("9092");
+
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setTags(Set.of("multi-entrypoint-tag"));
+        TcpListener tcpListener = TcpListener.builder().hosts(List.of("some_tcp_host")).build();
+        apiEntity.setListeners(List.of(tcpListener));
+
+        EntrypointEntity entrypointOne = new EntrypointEntity();
+        entrypointOne.setTags(Arrays.array("multi-entrypoint-tag"));
+        entrypointOne.setValue("https://tcp-entrypoint-one.com");
+        entrypointOne.setTarget(EntrypointEntity.Target.TCP);
+        EntrypointEntity entrypointTwo = new EntrypointEntity();
+        entrypointTwo.setTags(Arrays.array("multi-entrypoint-tag"));
+        entrypointTwo.setValue("https://tcp-entrypoint-two.com");
+        entrypointTwo.setTarget(EntrypointEntity.Target.TCP);
+        when(entrypointService.findAll(any())).thenReturn(List.of(entrypointOne, entrypointTwo));
+
+        List<ApiEntrypointEntity> apiEntrypoints = apiEntrypointService.getApiEntrypoints(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(apiEntrypoints).hasSize(1);
         assertThat(apiEntrypoints.getFirst().getTarget()).isEqualTo("some_tcp_host:4082");
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13933

## Description

When an API uses a sharding tag with multiple matching organization entrypoint mappings and a virtual host with override access, the Exposed Entrypoints panel shows the same URL once per matching mapping.

### Fix
Deduplicate the result list by target URL using a LinkedHashMap (preserves insertion order). Applied at the source, so it also fixes incidental duplicates surfaced through SubscriptionServiceImpl, PageServiceImpl, ApiServiceImpl, and the portal ApiMapper.

### Behavior change

- HTTP / V2 vhost with override + multi-mapping: N -> 1 entry (the bug being fixed).
- TCP with multi-mapping: N -> 1 entry. TCP target was always identical (tcpHost:tcpPort is independent of the mapping); duplicates were never useful and not visible separately in the UI. Test case added for this.
- Non-override HTTP, native Kafka, default fallback: unchanged — targets already differ per mapping, so dedupe is a no-op.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

