### PR TITLE
fix(http-proxy): use HC target host in setServer instead of endpoint defaultHost

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -134,7 +134,7 @@ public class HttpConnector implements ProxyConnector {
             // setServer() so the custom value only affects the HTTP Host header, not the connection address.
             final String customHost = options.getHeaders() != null ? options.getHeaders().get(io.vertx.core.http.HttpHeaders.HOST) : null;
             if (customHost != null && !customHost.isBlank()) {
-                options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(options.getPort(), defaultHost));
+                options.setServer(io.vertx.core.net.SocketAddress.inetSocketAddress(options.getPort(), options.getHost()));
                 options.setHost(customHost);
             }
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
@@ -542,6 +542,28 @@ class HttpConnectorTest {
     }
 
     @Test
+    void should_connect_to_hc_absolute_target_not_to_endpoint_default_host_when_custom_host_header_is_configured()
+        throws InterruptedException {
+        // Regression: setServer() must use options.getHost() (actual HC target) not defaultHost (endpoint config).
+        // Using defaultHost when the two differ causes the TCP connection to go to the wrong server.
+        configuration.setTarget("http://endpoint-host.invalid/");
+        sharedConfiguration.setHeaders(List.of(new HttpHeader("Host", "custom-backend.example.com")));
+        cut = new HttpConnector(configuration, sharedConfiguration, new HttpClientFactory());
+
+        when(request.method()).thenReturn(HttpMethod.GET);
+        when(ctx.getAttribute(ATTR_REQUEST_ENDPOINT)).thenReturn("http://127.0.0.1:" + wiremock.port() + "/health");
+
+        wiremock.stubFor(get("/health").willReturn(ok(BACKEND_RESPONSE_BODY)));
+
+        final TestObserver<Void> obs = cut.connect(ctx).test();
+
+        assertNoTimeout(obs);
+        obs.assertComplete();
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/health")).withHeader(HOST, equalTo("custom-backend.example.com")));
+    }
+
+    @Test
     void should_propagate_request_vertx_http_header_without_temporary_copy() throws InterruptedException {
         requestHeaders = new VertxHttpHeaders(new HeadersMultiMap());
         when(request.headers()).thenReturn(requestHeaders);


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-13512

## Description
- Fixed `HttpConnector.connect()` using `defaultHost` (endpoint config host) instead of `options.getHost()` (actual HC target host) in `setServer()` when a custom `Host` header is configured
- The bug caused TCP connections to go to the endpoint's configured host instead of the absolute HC target host, so health checks always hit the wrong server
- Added a regression test: endpoint target set to an unresolvable host (`endpoint-host.invalid`), HC target set to `127.0.0.1` (WireMock) — with the bug the test fails with `NXDOMAIN`, with the fix it passes
- V2 and the apiservice-healthcheck-http `RequestOptionsBuilder` both use `target.getHost()` correctly — the bug is isolated to `HttpConnector`

## Additional context
Root cause: after `setAbsoluteURI()` resolves the HC target, `options.getHost()` reflects the HC target IP, but the `setServer()` call one line below still used the stale `defaultHost` field from the constructor.

Reproduction: v4 HTTP-proxy endpoint with endpoint target `http://api.gravitee.io/`, health check target `http://178.63.67.153/` and a configured `Host: api.gravitee.io` header — the TCP connection goes to `api.gravitee.io` instead of `178.63.67.153`.
