### PR TITLE
ci: trigger gravitee-apim-api-docs ingestion at end of full release

### DIFF
--- a/.circleci/ci/src/jobs/index.ts
+++ b/.circleci/ci/src/jobs/index.ts
@@ -29,4 +29,5 @@ export * from './job-release-notes-apim';
 export * from './job-setup';
 export * from './job-slack-announcement';
 export * from './job-sonarcloud-analysis';
+export * from './job-trigger-apim-api-docs-pipeline';
 export * from './job-trigger-saas-docker-images';

--- a/.circleci/ci/src/jobs/job-trigger-apim-api-docs-pipeline.ts
+++ b/.circleci/ci/src/jobs/job-trigger-apim-api-docs-pipeline.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { commands, Job } from '@circleci/circleci-config-sdk';
+import { CircleCIEnvironment } from '../pipelines';
+import { Command } from '@circleci/circleci-config-sdk/dist/src/lib/Components/Commands/exports/Command';
+import { BaseExecutor } from '../executors';
+
+/**
+ * Notifies the gravitee-apim-api-docs repository of a new APIM release so it
+ * regenerates its OpenAPI documentation site. Fire-and-forget: the docs
+ * pipeline absorbs Sonatype → Maven Central propagation delay on its side, so
+ * we do not wait for completion here.
+ */
+export class TriggerApimApiDocsPipelineJob {
+  private static jobName: string = 'job-trigger-apim-api-docs-pipeline';
+  public static create(environment: CircleCIEnvironment): Job {
+    const steps: Command[] = [
+      new commands.Run({
+        name: 'Trigger gravitee-apim-api-docs ingestion pipeline',
+        command: `curl --fail --request POST \
+--url https://circleci.com/api/v2/project/github/gravitee-io/gravitee-apim-api-docs/pipeline \
+--header "Circle-Token: \${CIRCLE_TOKEN}" \
+--header 'content-type: application/json' \
+--data '{"parameters":{"version":"${environment.graviteeioVersion}", "dry_run":${environment.isDryRun}}}'
+echo "Docs ingestion pipeline triggered for APIM ${environment.graviteeioVersion}."`,
+      }),
+    ];
+    return new Job(TriggerApimApiDocsPipelineJob.jobName, BaseExecutor.create(), steps);
+  }
+}

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -739,6 +739,16 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-apim-api-docs-pipeline:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger gravitee-apim-api-docs ingestion pipeline
+          command: |-
+            curl --fail --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/gravitee-apim-api-docs/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"version":"4.2.0-alpha.1", "dry_run":false}}'
+            echo "Docs ingestion pipeline triggered for APIM 4.2.0-alpha.1."
 workflows:
   full_release:
     jobs:
@@ -841,6 +851,13 @@ workflows:
           name: Nexus staging
           requires:
             - Trigger SaaS Docker images creation
+      - job-trigger-apim-api-docs-pipeline:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger APIM API docs ingestion
+          requires:
+            - Nexus staging
       - job-release-helm:
           context:
             - cicd-orchestrator
@@ -862,6 +879,7 @@ workflows:
           requires:
             - Nexus staging
             - Release Helm Chart
+            - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0-alpha.1
 orbs:
   keeper: gravitee-io/keeper@0.7.0

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -773,6 +773,16 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-apim-api-docs-pipeline:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger gravitee-apim-api-docs ingestion pipeline
+          command: |-
+            curl --fail --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/gravitee-apim-api-docs/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"version":"4.2.0", "dry_run":true}}'
+            echo "Docs ingestion pipeline triggered for APIM 4.2.0."
 workflows:
   full_release:
     jobs:
@@ -875,6 +885,13 @@ workflows:
           name: Nexus staging
           requires:
             - Trigger SaaS Docker images creation
+      - job-trigger-apim-api-docs-pipeline:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger APIM API docs ingestion
+          requires:
+            - Nexus staging
       - job-release-helm:
           context:
             - cicd-orchestrator
@@ -896,6 +913,7 @@ workflows:
           requires:
             - Nexus staging
             - Release Helm Chart
+            - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0 - Dry Run
 orbs:
   keeper: gravitee-io/keeper@0.7.0

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -785,6 +785,16 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-apim-api-docs-pipeline:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger gravitee-apim-api-docs ingestion pipeline
+          command: |-
+            curl --fail --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/gravitee-apim-api-docs/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"version":"4.2.0", "dry_run":false}}'
+            echo "Docs ingestion pipeline triggered for APIM 4.2.0."
 workflows:
   full_release:
     jobs:
@@ -887,6 +897,13 @@ workflows:
           name: Nexus staging
           requires:
             - Trigger SaaS Docker images creation
+      - job-trigger-apim-api-docs-pipeline:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger APIM API docs ingestion
+          requires:
+            - Nexus staging
       - job-release-helm:
           context:
             - cicd-orchestrator
@@ -908,6 +925,7 @@ workflows:
           requires:
             - Nexus staging
             - Release Helm Chart
+            - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0
 orbs:
   keeper: gravitee-io/keeper@0.7.0

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -785,6 +785,16 @@ jobs:
                 done
             }  
             waitForPipelineCompletion
+  job-trigger-apim-api-docs-pipeline:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+    steps:
+      - run:
+          name: Trigger gravitee-apim-api-docs ingestion pipeline
+          command: |-
+            curl --fail --request POST --url https://circleci.com/api/v2/project/github/gravitee-io/gravitee-apim-api-docs/pipeline --header "Circle-Token: ${CIRCLE_TOKEN}" --header 'content-type: application/json' --data '{"parameters":{"version":"4.2.0", "dry_run":false}}'
+            echo "Docs ingestion pipeline triggered for APIM 4.2.0."
 workflows:
   full_release:
     jobs:
@@ -887,6 +897,13 @@ workflows:
           name: Nexus staging
           requires:
             - Trigger SaaS Docker images creation
+      - job-trigger-apim-api-docs-pipeline:
+          context:
+            - cicd-orchestrator
+            - keeper-orb-publishing
+          name: Trigger APIM API docs ingestion
+          requires:
+            - Nexus staging
       - job-release-helm:
           context:
             - cicd-orchestrator
@@ -908,6 +925,7 @@ workflows:
           requires:
             - Nexus staging
             - Release Helm Chart
+            - Trigger APIM API docs ingestion
             - Build and push RPM packages for APIM 4.2.0
 orbs:
   keeper: gravitee-io/keeper@0.7.0

--- a/.circleci/ci/src/workflows/workflow-full-release.ts
+++ b/.circleci/ci/src/workflows/workflow-full-release.ts
@@ -28,6 +28,7 @@ import {
   ReleaseNotesApimJob,
   SetupJob,
   SlackAnnouncementJob,
+  TriggerApimApiDocsPipelineJob,
   TriggerSaasDockerImagesJob,
 } from '../jobs';
 import { CircleCIEnvironment } from '../pipelines';
@@ -77,6 +78,9 @@ export class FullReleaseWorkflow {
 
     const runTriggerSaasDockerImagesJob = TriggerSaasDockerImagesJob.create(environment, 'prod');
     dynamicConfig.addJob(runTriggerSaasDockerImagesJob);
+
+    const triggerApimApiDocsPipelineJob = TriggerApimApiDocsPipelineJob.create(environment);
+    dynamicConfig.addJob(triggerApimApiDocsPipelineJob);
 
     return new Workflow(FullReleaseWorkflow.workflowName, [
       // PREPARE
@@ -180,6 +184,14 @@ export class FullReleaseWorkflow {
         requires: ['Trigger SaaS Docker images creation'],
       }),
 
+      // Trigger gravitee-apim-api-docs ingestion (fire-and-forget; the docs
+      // pipeline absorbs the Sonatype → Maven Central propagation delay).
+      new workflow.WorkflowJob(triggerApimApiDocsPipelineJob, {
+        context: [...config.jobContext, 'keeper-orb-publishing'],
+        name: 'Trigger APIM API docs ingestion',
+        requires: ['Nexus staging'],
+      }),
+
       // Release Helm chart
       new workflow.WorkflowJob(releaseHelmJob, {
         context: config.jobContext,
@@ -205,6 +217,7 @@ export class FullReleaseWorkflow {
         requires: [
           'Nexus staging',
           'Release Helm Chart',
+          'Trigger APIM API docs ingestion',
           `Build and push RPM packages for APIM ${environment.graviteeioVersion}${environment.isDryRun ? ' - Dry Run' : ''}`,
         ],
       }),


### PR DESCRIPTION
## Summary

After Nexus staging, dispatch a pipeline on the [`gravitee-apim-api-docs`](https://github.com/gravitee-io/gravitee-apim-api-docs) CircleCI project so it regenerates the OpenAPI documentation site for the released APIM version.

The docs site aggregates the four APIM REST APIs (Automation, Portal, Management v1, Management v2) and is published via GitHub Pages from the `gh-pages` branch of the docs repo.

## What changes

- **New job** \`TriggerApimApiDocsPipelineJob\` — POSTs to the CircleCI API of the docs project with the released \`version\` and \`dry_run\` flag.
- **Workflow change** in \`workflow-full-release.ts\` — the new job runs after \`Nexus staging\` and gates the final \`Announce release is completed\` Slack notification, so the announce only fires once the docs ingestion has been dispatched.
- **Fire-and-forget** — the docs pipeline polls Maven Central on its side to absorb the Sonatype → Maven Central propagation delay (typically 10-30 min), so we do not wait for completion here.
- **Reuses** the \`keeper-orb-publishing\` context, which already exposes \`CIRCLE_TOKEN\` (same context used by \`TriggerSaasDockerImagesJob\`).

## Test plan

- [x] \`npm run lint\` in \`.circleci/ci/\` passes
- [x] \`npm test\` in \`.circleci/ci/\` passes (94/94)
- [x] Test fixtures regenerated (\`release-4-2-0-{dry-run,no-dry-run,latest,alpha}.yml\`)
- [ ] On merge: a real APIM release should trigger an ingestion run on https://app.circleci.com/pipelines/github/gravitee-io/gravitee-apim-api-docs and update the docs site at https://gravitee-io.github.io/gravitee-apim-api-docs/

## Forward-port

This PR targets \`4.8.x\`. Once merged, cherry-pick to \`4.9.x\`, \`4.10.x\`, \`4.11.x\`, \`master\`.