### PR TITLE
fix: remove lag on manage groups button for api-product

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.html
@@ -26,43 +26,45 @@
               Manage who can interact with your API Product through the API Management console
             </p>
           </div>
-          <div class="card__header__actions">
-            @if (canTransferOwnership) {
+          @if (!state.isLoading) {
+            <div class="card__header__actions">
+              @if (canTransferOwnership) {
+                <button
+                  class="card__header__actions__button"
+                  mat-raised-button
+                  type="button"
+                  (click)="transferOwnership()"
+                  data-testid="api_product_members_transfer_ownership_button"
+                >
+                  Transfer ownership
+                </button>
+              }
               <button
+                *gioPermission="{ anyOf: ['api_product-member-u'] }"
                 class="card__header__actions__button"
                 mat-raised-button
                 type="button"
-                (click)="transferOwnership()"
-                data-testid="api_product_members_transfer_ownership_button"
+                aria-label="Manage groups"
+                data-testid="api_product_members_manage_groups_button"
+                [disabled]="state.groups.length === 0"
+                (click)="openManageGroups()"
               >
-                Transfer ownership
+                Manage groups
               </button>
-            }
-            <button
-              *gioPermission="{ anyOf: ['api_product-member-u'] }"
-              class="card__header__actions__button"
-              mat-raised-button
-              type="button"
-              aria-label="Manage groups"
-              data-testid="api_product_members_manage_groups_button"
-              [disabled]="(state.groups?.length ?? 0) === 0"
-              (click)="openManageGroups()"
-            >
-              Manage groups
-            </button>
-            <button
-              *gioPermission="{ anyOf: ['api_product-member-c'] }"
-              class="card__header__actions__button"
-              mat-raised-button
-              color="primary"
-              type="button"
-              data-testid="api_product_members_add_button"
-              [disabled]="isReadOnly"
-              (click)="openAddMemberDialog()"
-            >
-              <mat-icon svgIcon="gio:plus"></mat-icon> Add members
-            </button>
-          </div>
+              <button
+                *gioPermission="{ anyOf: ['api_product-member-c'] }"
+                class="card__header__actions__button"
+                mat-raised-button
+                color="primary"
+                type="button"
+                data-testid="api_product_members_add_button"
+                [disabled]="isReadOnly"
+                (click)="openAddMemberDialog()"
+              >
+                <mat-icon svgIcon="gio:plus"></mat-icon> Add members
+              </button>
+            </div>
+          }
         </div>
 
         <gio-form-slide-toggle class="card__enable-notification-toggle">


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13831

## Description

The action buttons (Transfer ownership, Manage groups, Add members) were rendered immediately in a disabled state while the page forkJoin was in flight, because LOADING_STATE initialised groups as []. This made "Manage groups" appear blocked until all three requests completed.

Wrapped card__header__actions in @if (!state.isLoading) so buttons only render after data is ready, matching the *ngIf="form" guard used in api-general-members. Simplified [disabled] binding to state.groups.length === 0 now that the expression is only evaluated post-load.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

