### PR TITLE
Feat/ext122 openapi viewer frontend

### DIFF
--- a/gravitee-apim-console-webui/project.json
+++ b/gravitee-apim-console-webui/project.json
@@ -97,6 +97,11 @@
             "glob": "**/*",
             "input": "gravitee-apim-webui-libs/gravitee-markdown/src/lib/assets/homepage",
             "output": "assets/homepage"
+          },
+          {
+            "glob": "redoc.standalone.js",
+            "input": "node_modules/redoc/bundles",
+            "output": "assets/redoc"
           }
         ],
         "styles": [

--- a/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.component.html
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div #redoc class="revert-all-gravitee-styles"></div>

--- a/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.component.scss
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.component.scss
@@ -1,11 +1,11 @@
 /*
- * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,17 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.model;
 
-import jakarta.validation.constraints.NotNull;
-
-public record RedocConfiguration(@NotNull String tryItUrl) implements OpenApiConfiguration {
-    public RedocConfiguration() {
-        this("");
-    }
-
-    @Override
-    public Viewer viewer() {
-        return Viewer.REDOC;
-    }
+:host {
+  display: block;
+  height: 100%;
 }

--- a/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.component.spec.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, fakeAsync, flushMicrotasks, TestBed, tick } from '@angular/core/testing';
+
+import { GioRedocComponent } from './gio-redoc.component';
+import { GioRedocService, type RedocApi } from './gio-redoc.service';
+
+type RedocWindow = Window &
+  typeof globalThis & {
+    Redoc?: RedocApi;
+  };
+
+@Component({
+  template: `<gio-redoc [spec]="spec" [tryItURL]="tryItURL" />`,
+  standalone: true,
+  imports: [GioRedocComponent],
+})
+class TestHostComponent {
+  spec = JSON.stringify({
+    openapi: '3.0.0',
+    info: {
+      title: 'Test API',
+      version: '1.0.0',
+    },
+    paths: {},
+  });
+  tryItURL = '';
+}
+
+describe('GioRedocComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let redocApi: RedocApi;
+  let redocService: jest.Mocked<Pick<GioRedocService, 'load'>>;
+
+  beforeEach(async () => {
+    redocApi = { init: jest.fn() };
+    redocService = { load: jest.fn() };
+    redocService.load.mockResolvedValue(redocApi);
+    delete (window as RedocWindow).Redoc;
+
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [{ provide: GioRedocService, useValue: redocService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fixture.destroy();
+  });
+
+  it('should initialize Redoc with the API returned by the loader', fakeAsync(() => {
+    host.tryItURL = 'https://api.example.com';
+
+    fixture.detectChanges();
+    tick(300);
+    flushMicrotasks();
+
+    expect(redocService.load).toHaveBeenCalledTimes(1);
+    expect(redocApi.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        openapi: '3.0.0',
+        servers: [{ url: 'https://api.example.com' }],
+      }),
+      expect.objectContaining({
+        hideDownloadButton: true,
+        hideLoading: true,
+        disableSearch: true,
+      }),
+      expect.any(HTMLElement),
+      expect.any(Function),
+    );
+  }));
+
+  it('should not initialize Redoc when the loader fails', fakeAsync(() => {
+    const error = new Error('Failed to load Redoc');
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    redocService.load.mockRejectedValue(error);
+
+    fixture.detectChanges();
+    tick(300);
+    flushMicrotasks();
+
+    expect(redocApi.init).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[gio-redoc] Failed to load Redoc script:', error);
+  }));
+});

--- a/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.component.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, ElementRef, OnDestroy, effect, inject, input, viewChild } from '@angular/core';
+import * as yaml from 'js-yaml';
+
+import { GioRedocService, type RedocApi } from './gio-redoc.service';
+
+const yamlSchema = yaml.DEFAULT_SCHEMA.extend([]);
+
+const parseSpec = (spec: string): object | null => {
+  try {
+    const result: unknown = JSON.parse(spec);
+    return result instanceof Object ? result : null;
+  } catch {
+    const result: unknown = yaml.load(spec, { schema: yamlSchema });
+    return result instanceof Object ? result : null;
+  }
+};
+
+@Component({
+  selector: 'gio-redoc',
+  templateUrl: './gio-redoc.component.html',
+  styleUrls: ['./gio-redoc.component.scss'],
+  standalone: true,
+})
+export class GioRedocComponent implements OnDestroy {
+  private readonly gioRedocService = inject(GioRedocService);
+
+  spec = input('');
+  tryItURL = input('');
+
+  private readonly redocNode = viewChild<ElementRef<HTMLElement>>('redoc');
+
+  private pendingTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private initCallId = 0;
+
+  private readonly initEffect = effect(() => {
+    this.spec();
+    this.tryItURL();
+    const redocNode = this.redocNode();
+    if (redocNode) {
+      this.scheduleInit();
+    }
+  });
+
+  ngOnDestroy(): void {
+    if (this.pendingTimeoutId !== null) {
+      clearTimeout(this.pendingTimeoutId);
+      this.pendingTimeoutId = null;
+    }
+  }
+
+  private scheduleInit(): void {
+    if (this.pendingTimeoutId !== null) {
+      clearTimeout(this.pendingTimeoutId);
+    }
+    this.pendingTimeoutId = setTimeout(() => {
+      this.pendingTimeoutId = null;
+      this.initRedoc();
+    }, 300);
+  }
+
+  private async initRedoc(): Promise<void> {
+    const callId = ++this.initCallId;
+    const specValue = this.spec();
+    const redocNode = this.redocNode();
+    if (!specValue || !redocNode) return;
+
+    let redoc: RedocApi;
+    try {
+      redoc = await this.gioRedocService.load();
+    } catch (err) {
+      // eslint-disable-next-line angular/log
+      console.error('[gio-redoc] Failed to load Redoc script:', err);
+      return;
+    }
+
+    if (callId !== this.initCallId) return;
+
+    const tryItURL = this.tryItURL();
+    const parsedSpec = parseSpec(specValue);
+    if (parsedSpec === null) return;
+    const spec = tryItURL ? { ...parsedSpec, servers: [{ url: tryItURL }] } : parsedSpec;
+    redocNode.nativeElement.innerHTML = '';
+    redoc.init(
+      spec,
+      {
+        hideDownloadButton: true,
+        hideLoading: true,
+        disableSearch: true,
+        onlyRequiredInSamples: true,
+        nativeScrollbars: true,
+        theme: {
+          sidebar: { width: '150px' },
+          breakpoints: { medium: '599rem', large: '600rem' },
+        },
+      },
+      redocNode.nativeElement,
+      err => {
+        // eslint-disable-next-line angular/log
+        if (err) console.error('[gio-redoc] Redoc.init failed:', err);
+      },
+    );
+  }
+}

--- a/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.service.spec.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.service.spec.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+
+import { GioRedocService, type RedocApi } from './gio-redoc.service';
+
+const REDOC_SCRIPT_SRC = 'assets/redoc/redoc.standalone.js';
+
+type RedocWindow = Window & {
+  Redoc?: RedocApi;
+  define?: unknown;
+  require?: unknown;
+};
+
+describe('GioRedocService', () => {
+  let service: GioRedocService;
+  let redocApi: RedocApi;
+  let redocWindow: RedocWindow;
+  let originalDefine: unknown;
+  let originalRequire: unknown;
+
+  beforeEach(() => {
+    redocApi = { init: jest.fn() };
+    redocWindow = window as RedocWindow;
+    originalDefine = redocWindow.define;
+    originalRequire = redocWindow.require;
+    delete redocWindow.Redoc;
+    redocWindow.define = undefined;
+    redocWindow.require = undefined;
+
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GioRedocService);
+  });
+
+  afterEach(() => {
+    document.head.querySelectorAll(`script[src="${REDOC_SCRIPT_SRC}"]`).forEach(el => el.remove());
+    delete redocWindow.Redoc;
+    redocWindow.define = originalDefine;
+    redocWindow.require = originalRequire;
+  });
+
+  it('should append a script element with the correct src to document.head', () => {
+    service.load();
+
+    const script = document.head.querySelector(`script[src="${REDOC_SCRIPT_SRC}"]`);
+    expect(script).toBeTruthy();
+  });
+
+  it('should return the same Promise on repeated calls (singleton)', () => {
+    const firstPromise = service.load();
+    const secondPromise = service.load();
+
+    expect(firstPromise).toBe(secondPromise);
+  });
+
+  it('should append only one script element on repeated calls', () => {
+    service.load();
+    service.load();
+
+    const scripts = document.head.querySelectorAll(`script[src="${REDOC_SCRIPT_SRC}"]`);
+    expect(scripts.length).toBe(1);
+  });
+
+  it('should return the already available Redoc API without loading the script again', async () => {
+    redocWindow.Redoc = redocApi;
+
+    await expect(service.load()).resolves.toBe(redocApi);
+
+    const scripts = document.head.querySelectorAll(`script[src="${REDOC_SCRIPT_SRC}"]`);
+    expect(scripts.length).toBe(0);
+  });
+
+  it('should resolve when the script onload fires', async () => {
+    const loadPromise = service.load();
+    const script = document.head.querySelector(`script[src="${REDOC_SCRIPT_SRC}"]`) as HTMLScriptElement;
+
+    redocWindow.Redoc = redocApi;
+    script.onload!(new Event('load'));
+
+    await expect(loadPromise).resolves.toBe(redocApi);
+  });
+
+  it('should load Redoc with AMD require when Monaco AMD loader is available', async () => {
+    const amdDefine = Object.assign(jest.fn(), { amd: {} });
+    const amdRequire = jest.fn((dependencies: string[] | string, onLoad?: (redocModule: unknown) => void) => {
+      if (typeof dependencies === 'string') {
+        throw new Error(`Module ${dependencies} is not available`);
+      }
+
+      expect(dependencies).toEqual(['assets/redoc/redoc.standalone']);
+      if (!onLoad) {
+        throw new Error('Missing Redoc AMD onLoad callback');
+      }
+      onLoad(redocApi);
+    });
+    redocWindow.define = amdDefine;
+    redocWindow.require = amdRequire;
+
+    const loadPromise = service.load();
+
+    await expect(loadPromise).resolves.toBe(redocApi);
+    expect(amdDefine).toHaveBeenCalledWith('null', [], expect.any(Function));
+    expect((amdDefine.mock.calls[0][2] as () => unknown)()).toBeNull();
+    expect(amdRequire).toHaveBeenCalledTimes(2);
+    expect(amdRequire).toHaveBeenCalledWith('null');
+    expect(redocWindow.define).toBe(amdDefine);
+
+    const script = document.head.querySelector(`script[src="${REDOC_SCRIPT_SRC}"]`);
+    expect(script).toBeNull();
+  });
+
+  it('should not redefine the Redoc standalone AMD dependency when it is already available', async () => {
+    const amdDefine = Object.assign(jest.fn(), { amd: {} });
+    const amdRequire = jest.fn((dependencies: string[] | string, onLoad?: (redocModule: unknown) => void) => {
+      if (typeof dependencies === 'string') {
+        return null;
+      }
+
+      onLoad?.(redocApi);
+      return undefined;
+    });
+    redocWindow.define = amdDefine;
+    redocWindow.require = amdRequire;
+
+    await expect(service.load()).resolves.toBe(redocApi);
+
+    expect(amdDefine).not.toHaveBeenCalled();
+    expect(amdRequire).toHaveBeenCalledWith('null');
+    expect(amdRequire).toHaveBeenCalledWith(['assets/redoc/redoc.standalone'], expect.any(Function), expect.any(Function));
+  });
+
+  it('should reject when the script loads without exposing the Redoc API', async () => {
+    const loadPromise = service.load();
+    const script = document.head.querySelector(`script[src="${REDOC_SCRIPT_SRC}"]`) as HTMLScriptElement;
+
+    script.onload!(new Event('load'));
+
+    await expect(loadPromise).rejects.toThrow('Redoc script loaded but window.Redoc.init is unavailable.');
+  });
+
+  it('should reject when the script onerror fires', async () => {
+    const loadPromise = service.load();
+    const script = document.head.querySelector(`script[src="${REDOC_SCRIPT_SRC}"]`) as HTMLScriptElement;
+
+    script.onerror!(new ErrorEvent('error'));
+
+    await expect(loadPromise).rejects.toBeDefined();
+  });
+
+  it('should allow retry after loading failed', async () => {
+    const firstLoadPromise = service.load();
+    const firstScript = document.head.querySelector(`script[src="${REDOC_SCRIPT_SRC}"]`) as HTMLScriptElement;
+
+    firstScript.onerror!(new ErrorEvent('error'));
+
+    await expect(firstLoadPromise).rejects.toBeDefined();
+
+    const secondLoadPromise = service.load();
+    const secondScript = document.head.querySelector(`script[src="${REDOC_SCRIPT_SRC}"]`) as HTMLScriptElement;
+
+    redocWindow.Redoc = redocApi;
+    secondScript.onload!(new Event('load'));
+
+    await expect(secondLoadPromise).resolves.toBe(redocApi);
+  });
+});

--- a/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.service.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-redoc/gio-redoc.service.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DOCUMENT } from '@angular/common';
+import { inject, Injectable } from '@angular/core';
+
+export type RedocApi = {
+  init: (spec: unknown, options: Record<string, unknown>, element: HTMLElement, callback?: (err?: unknown) => void) => void;
+};
+
+type AmdDefine = {
+  (moduleName: string, dependencies: string[], factory: () => unknown): void;
+  amd?: unknown;
+};
+
+type AmdRequire = {
+  (dependencies: string[], onLoad: (redocModule: unknown) => void, onError?: (err: unknown) => void): void;
+  (moduleName: string): unknown;
+};
+
+type RedocWindow = Window & {
+  Redoc?: RedocApi;
+  define?: unknown;
+  require?: unknown;
+};
+
+const REDOC_SCRIPT_SRC = 'assets/redoc/redoc.standalone.js';
+const REDOC_AMD_MODULE = 'assets/redoc/redoc.standalone';
+const REDOC_STANDALONE_AMD_DEPENDENCY = 'null';
+
+@Injectable({ providedIn: 'root' })
+export class GioRedocService {
+  private readonly document = inject(DOCUMENT);
+  private loadPromise: Promise<RedocApi> | null = null;
+
+  load(): Promise<RedocApi> {
+    const loadedRedoc = this.getRedocApi();
+    if (loadedRedoc) {
+      return Promise.resolve(loadedRedoc);
+    }
+
+    if (this.loadPromise !== null) {
+      return this.loadPromise;
+    }
+
+    const loadPromise = this.loadRedoc().catch(err => {
+      this.loadPromise = null;
+      throw err;
+    });
+    this.loadPromise = loadPromise;
+    return loadPromise;
+  }
+
+  private loadRedoc(): Promise<RedocApi> {
+    const amdRequire = this.getAmdRequire();
+    if (amdRequire) {
+      this.ensureRedocStandaloneAmdDependency(amdRequire);
+      return this.loadWithAmd(amdRequire);
+    }
+
+    return this.loadWithScript();
+  }
+
+  private loadWithAmd(amdRequire: AmdRequire): Promise<RedocApi> {
+    return new Promise<RedocApi>((resolve, reject) => {
+      amdRequire(
+        [REDOC_AMD_MODULE],
+        redocModule => {
+          const redoc = this.extractRedocApi(redocModule);
+          if (redoc) {
+            resolve(redoc);
+            return;
+          }
+          reject(new Error('Redoc AMD module loaded but Redoc.init is unavailable.'));
+        },
+        err => reject(err),
+      );
+    });
+  }
+
+  private loadWithScript(): Promise<RedocApi> {
+    return new Promise<RedocApi>((resolve, reject) => {
+      const script = this.document.createElement('script');
+      script.src = REDOC_SCRIPT_SRC;
+      script.onload = () => {
+        const redoc = this.getRedocApi();
+        if (redoc) {
+          resolve(redoc);
+          return;
+        }
+        script.remove();
+        reject(new Error('Redoc script loaded but window.Redoc.init is unavailable.'));
+      };
+      script.onerror = err => {
+        script.remove();
+        reject(err);
+      };
+      this.document.head.appendChild(script);
+    });
+  }
+
+  private getRedocApi(): RedocApi | null {
+    const redoc = (this.document.defaultView as RedocWindow | null)?.Redoc;
+    return typeof redoc?.init === 'function' ? redoc : null;
+  }
+
+  private extractRedocApi(redocModule: unknown): RedocApi | null {
+    if (this.isRedocApi(redocModule)) {
+      return redocModule;
+    }
+
+    if (this.isRedocApi((redocModule as { default?: unknown })?.default)) {
+      return (redocModule as { default: RedocApi }).default;
+    }
+
+    return this.getRedocApi();
+  }
+
+  private isRedocApi(value: unknown): value is RedocApi {
+    return typeof (value as RedocApi | null)?.init === 'function';
+  }
+
+  private ensureRedocStandaloneAmdDependency(amdRequire: AmdRequire): void {
+    const amdDefine = this.getAmdDefine();
+    if (!amdDefine || this.isAmdModuleAvailable(amdRequire, REDOC_STANDALONE_AMD_DEPENDENCY)) {
+      return;
+    }
+
+    // Redoc standalone declares this unused AMD dependency.
+    amdDefine(REDOC_STANDALONE_AMD_DEPENDENCY, [], () => null);
+  }
+
+  private isAmdModuleAvailable(amdRequire: AmdRequire, moduleName: string): boolean {
+    try {
+      amdRequire(moduleName);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private getAmdRequire(): AmdRequire | null {
+    const redocWindow = this.document.defaultView as RedocWindow | null;
+    return redocWindow && this.hasAmdDefine(redocWindow.define) && typeof redocWindow.require === 'function'
+      ? (redocWindow.require as AmdRequire)
+      : null;
+  }
+
+  private getAmdDefine(): AmdDefine | null {
+    const define = (this.document.defaultView as RedocWindow | null)?.define;
+    return this.hasAmdDefine(define) ? define : null;
+  }
+
+  private hasAmdDefine(define: unknown): define is AmdDefine {
+    return typeof define === 'function' && Boolean((define as { amd?: unknown }).amd);
+  }
+}

--- a/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.scss
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.scss
@@ -11,5 +11,9 @@
         padding: 10px 20px;
       }
     }
+
+    .swagger-ui .opblock-summary-operation-id {
+      word-break: keep-all;
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.ts
@@ -47,8 +47,8 @@ const normalizeTypeArrays = (obj: unknown): unknown => {
   return result;
 };
 
-const loadContent = (spec: string) => {
-  let contentAsJson = {};
+const loadContent = (spec: string): Record<string, unknown> => {
+  let contentAsJson: Record<string, unknown> = {};
   if (spec) {
     try {
       contentAsJson = normalizeTypeArrays(angular.fromJson(spec)) as Record<string, unknown>;
@@ -76,7 +76,7 @@ const loadOauth2RedirectUrl = () => {
 })
 export class GioSwaggerUiComponent implements AfterViewInit, OnChanges {
   @Input()
-  spec: string;
+  spec: string = '';
 
   @Input()
   docExpansion: 'none' | 'list' | 'full' = 'none';
@@ -94,10 +94,13 @@ export class GioSwaggerUiComponent implements AfterViewInit, OnChanges {
   showCommonExtensions = true;
 
   @Input()
-  maxDisplayedTags: number;
+  maxDisplayedTags?: number;
+
+  @Input()
+  tryItURL: string = '';
 
   @ViewChild('swagger')
-  swaggerNode: ElementRef;
+  swaggerNode!: ElementRef;
 
   ngOnChanges(): void {
     if (this.swaggerNode) {
@@ -110,9 +113,13 @@ export class GioSwaggerUiComponent implements AfterViewInit, OnChanges {
   }
 
   private initSwaggerUI() {
+    const parsedSpec = loadContent(this.spec);
+    const tryItURL = this.tryItURL;
+    const spec = tryItURL ? { ...parsedSpec, servers: [{ url: tryItURL }] } : parsedSpec;
+
     SwaggerUI({
       domNode: this.swaggerNode.nativeElement,
-      spec: loadContent(this.spec),
+      spec,
       docExpansion: this.docExpansion,
       displayOperationId: this.displayOperationId,
       filter: this.filter,

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalPageContent/openApiViewerConfiguration.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalPageContent/openApiViewerConfiguration.ts
@@ -13,6 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './portalPageContent';
-export * from './portalPageContent.fixture';
-export * from './openApiViewerConfiguration';
+export enum OpenApiViewer {
+  Swagger = 'SWAGGER',
+  Redoc = 'REDOC',
+}
+
+export enum OpenApiDocExpansion {
+  List = 'list',
+  Full = 'full',
+  None = 'none',
+}
+
+export interface OpenApiViewerConfiguration {
+  viewer: OpenApiViewer;
+  tryItURL: string;
+  tryIt: boolean;
+  disableSyntaxHighlight: boolean;
+  tryItAnonymous: boolean;
+  showURL: boolean;
+  displayOperationId: boolean;
+  usePkce: boolean;
+  docExpansion: OpenApiDocExpansion;
+  enableFiltering: boolean;
+  showExtensions: boolean;
+  showCommonExtensions: boolean;
+  maxDisplayedTags: number;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/portalPageContent/portalPageContent.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/portalPageContent/portalPageContent.ts
@@ -13,12 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { OpenApiViewerConfiguration } from './openApiViewerConfiguration';
+
 export type PortalPageContentType = 'GRAVITEE_MARKDOWN' | 'OPENAPI' | 'ASYNCAPI';
 
 export interface PortalPageContent {
   id: string;
   type: PortalPageContentType;
   content: string;
+  configuration?: Partial<OpenApiViewerConfiguration>;
 }
 
 export interface NewPortalPageContent {
@@ -28,4 +31,5 @@ export interface NewPortalPageContent {
 
 export interface UpdatePortalPageContent {
   content: string;
+  configuration?: OpenApiViewerConfiguration;
 }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
@@ -213,6 +213,7 @@ export class DocumentationEditPageComponent implements OnInit {
       .pipe(distinctUntilChanged(isEqual), takeUntilDestroyed(this.destroyRef))
       .subscribe(enabled => {
         if (enabled) {
+          this.form.controls.openApiConfiguration.controls.tryItURL.setValue('');
           this.form.controls.openApiConfiguration.controls.tryItURL.disable();
         } else {
           this.form.controls.openApiConfiguration.controls.tryItURL.enable();

--- a/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.html
@@ -26,6 +26,19 @@
     ></gio-monaco-editor>
   </div>
   <div class="content__editor__cell">
-    <gio-swagger-ui [spec]="_value"></gio-swagger-ui>
+    @if (isRedocViewer()) {
+      <gio-redoc [spec]="_value" [tryItURL]="swaggerTryItURL()"></gio-redoc>
+    } @else {
+      <gio-swagger-ui
+        [spec]="_value"
+        [tryItURL]="swaggerTryItURL()"
+        [docExpansion]="swaggerDocExpansion()"
+        [displayOperationId]="swaggerDisplayOperationId()"
+        [filter]="swaggerFilter()"
+        [showExtensions]="swaggerShowExtensions()"
+        [showCommonExtensions]="swaggerShowCommonExtensions()"
+        [maxDisplayedTags]="swaggerMaxDisplayedTags()"
+      ></gio-swagger-ui>
+    }
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.spec.ts
@@ -15,7 +15,7 @@
  */
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component } from '@angular/core';
+import { Component, viewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -23,23 +23,36 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { OpenApiEditorComponent } from './openapi-editor.component';
 import { OpenApiEditorHarness } from './openapi-editor.harness';
 
+import { GioRedocService, type RedocApi } from '../../../components/documentation/gio-redoc/gio-redoc.service';
+import {
+  OpenApiDocExpansion,
+  OpenApiViewer,
+  OpenApiViewerConfiguration,
+} from '../../../entities/management-api-v2/portalPageContent/openApiViewerConfiguration';
+
 @Component({
-  template: ` <openapi-editor [formControl]="contentControl" /> `,
+  template: ` <openapi-editor [formControl]="contentControl" [configuration]="configuration" /> `,
   standalone: true,
   imports: [OpenApiEditorComponent, ReactiveFormsModule],
 })
 class TestHostComponent {
+  readonly editor = viewChild.required(OpenApiEditorComponent);
   contentControl = new FormControl('openapi: 3.0.0\ninfo:\n  title: Test');
+  configuration: Partial<OpenApiViewerConfiguration> | null = null;
 }
 
 describe('OpenApiEditorComponent', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let host: TestHostComponent;
   let loader: HarnessLoader;
+  let redocApi: RedocApi;
 
   beforeEach(async () => {
+    redocApi = { init: jest.fn() };
+
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, TestHostComponent],
+      providers: [{ provide: GioRedocService, useValue: { load: () => Promise.resolve(redocApi) } }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);
@@ -64,5 +77,30 @@ describe('OpenApiEditorComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
     expect(host.contentControl.value).toBe('openapi: 3.0.0\ninfo:\n  title: Updated');
+  });
+
+  it('should read OpenAPI viewer settings from camelCase configuration', () => {
+    host.configuration = {
+      viewer: OpenApiViewer.Redoc,
+      tryItURL: 'https://try-it.example.com',
+      docExpansion: OpenApiDocExpansion.Full,
+      displayOperationId: true,
+      enableFiltering: true,
+      showExtensions: true,
+      showCommonExtensions: true,
+      maxDisplayedTags: 5,
+    };
+    fixture.detectChanges();
+
+    const editor = host.editor();
+
+    expect(editor.isRedocViewer()).toBe(true);
+    expect(editor.swaggerTryItURL()).toBe('https://try-it.example.com');
+    expect(editor.swaggerDocExpansion()).toBe(OpenApiDocExpansion.Full);
+    expect(editor.swaggerDisplayOperationId()).toBe(true);
+    expect(editor.swaggerFilter()).toBe(true);
+    expect(editor.swaggerShowExtensions()).toBe(true);
+    expect(editor.swaggerShowCommonExtensions()).toBe(true);
+    expect(editor.swaggerMaxDisplayedTags()).toBe(5);
   });
 });

--- a/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.ts
@@ -13,11 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { GioMonacoEditorModule } from '@gravitee/ui-particles-angular';
 
 import { GioSwaggerUiModule } from '../../../components/documentation/gio-swagger-ui/gio-swagger-ui.module';
+import { GioRedocComponent } from '../../../components/documentation/gio-redoc/gio-redoc.component';
+import {
+  OpenApiDocExpansion,
+  OpenApiViewer,
+  OpenApiViewerConfiguration,
+} from '../../../entities/management-api-v2/portalPageContent/openApiViewerConfiguration';
 
 @Component({
   selector: 'openapi-editor',
@@ -30,15 +36,32 @@ import { GioSwaggerUiModule } from '../../../components/documentation/gio-swagge
       multi: true,
     },
   ],
-  imports: [FormsModule, GioMonacoEditorModule, GioSwaggerUiModule],
+  imports: [FormsModule, GioMonacoEditorModule, GioSwaggerUiModule, GioRedocComponent],
 })
 export class OpenApiEditorComponent implements ControlValueAccessor {
+  configuration = input<Partial<OpenApiViewerConfiguration> | null>(null);
+
   _value = '';
   private _disabled = false;
 
   _onChange: (value: string) => void = () => ({});
 
   _onTouched: () => void = () => ({});
+
+  isRedocViewer = computed(() => this.configuration()?.viewer === OpenApiViewer.Redoc);
+
+  swaggerTryItURL = computed(() => this.configuration()?.tryItURL ?? '');
+  swaggerDocExpansion = computed(() => this.configuration()?.docExpansion ?? OpenApiDocExpansion.None);
+  swaggerDisplayOperationId = computed(() => this.configuration()?.displayOperationId ?? false);
+  swaggerFilter = computed(() => this.configuration()?.enableFiltering ?? false);
+  swaggerShowExtensions = computed(() => this.configuration()?.showExtensions ?? false);
+  swaggerShowCommonExtensions = computed(() => this.configuration()?.showCommonExtensions ?? false);
+  swaggerMaxDisplayedTags = computed(() => {
+    const raw = this.configuration()?.maxDisplayedTags;
+    if (raw == null) return undefined;
+    const v = Number(raw);
+    return Number.isFinite(v) && v >= 0 ? v : undefined;
+  });
 
   registerOnChange(fn: (value: string) => void): void {
     this._onChange = fn;

--- a/gravitee-apim-console-webui/src/portal/navigation-items/openapi-config-dialog/openapi-config-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/openapi-config-dialog/openapi-config-dialog.component.html
@@ -1,0 +1,152 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div mat-dialog-title>Configure OpenAPI Viewer</div>
+
+<form [formGroup]="form" (ngSubmit)="onSave()">
+  <mat-dialog-content>
+    <div class="open-api-configuration">
+      <mat-form-field>
+        <mat-label>Base URL</mat-label>
+        <input id="openapi-try-it-url" matInput type="text" aria-label="Base URL" formControlName="tryItURL" />
+        <mat-hint
+          >Custom base URL to use as server URL. If empty and not using API entrypoints as a base URL, the server URL from the specification
+          will be used.</mat-hint
+        >
+        @if (form.controls.tryItURL.hasError('pattern')) {
+          <mat-error>Must be a valid URL starting with http:// or https://</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>OpenAPI Documentation Viewer</mat-label>
+        <mat-select formControlName="viewer">
+          <mat-option [value]="viewerEnum.Swagger">SwaggerUI</mat-option>
+          <mat-option [value]="viewerEnum.Redoc">Redoc</mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      @if (isSwaggerViewer()) {
+        <gio-form-slide-toggle>
+          <mat-slide-toggle gioFormSlideToggle formControlName="tryIt" />
+          <gio-form-label>
+            <div>Enable "Try It!" mode</div>
+            <div class="mat-body-2">
+              Allows trying the API from the Developer Portal for authenticated users. You may have to configure CORS in the entrypoint
+              section.
+            </div>
+          </gio-form-label>
+        </gio-form-slide-toggle>
+
+        <gio-form-slide-toggle>
+          <mat-slide-toggle gioFormSlideToggle formControlName="disableSyntaxHighlight" />
+          <gio-form-label>
+            <div>Disable response body styling for large JSON payloads</div>
+            <div class="mat-body-2">
+              Displays API responses without Swagger UI styling to optimize performance when handling large payloads.
+            </div>
+          </gio-form-label>
+        </gio-form-slide-toggle>
+
+        <gio-form-slide-toggle>
+          <mat-slide-toggle gioFormSlideToggle formControlName="tryItAnonymous" />
+          <gio-form-label>
+            <div>Enable "Try It!" mode for anonymous users</div>
+            <div class="mat-body-2">
+              Allows users not logged into the Developer Portal to try the API from the OpenAPI spec when the page and API are public.
+            </div>
+          </gio-form-label>
+        </gio-form-slide-toggle>
+
+        <gio-form-slide-toggle>
+          <mat-slide-toggle gioFormSlideToggle formControlName="showURL" />
+          <gio-form-label>
+            <div>Show URL to download content</div>
+          </gio-form-label>
+        </gio-form-slide-toggle>
+
+        <gio-form-slide-toggle>
+          <mat-slide-toggle gioFormSlideToggle formControlName="displayOperationId" />
+          <gio-form-label>
+            <div>Display the <code>operationId</code> in the operation list</div>
+          </gio-form-label>
+        </gio-form-slide-toggle>
+
+        <gio-form-slide-toggle>
+          <mat-slide-toggle gioFormSlideToggle formControlName="usePkce" />
+          <gio-form-label>
+            <div>Use PKCE with OAuth</div>
+            <div class="mat-body-2">Uses PKCE when authenticating with OAuth authorization code flow.</div>
+          </gio-form-label>
+        </gio-form-slide-toggle>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Expand content on the page</mat-label>
+          <mat-select formControlName="docExpansion">
+            <mat-option [value]="docExpansionEnum.List">Only tags</mat-option>
+            <mat-option [value]="docExpansionEnum.Full">Tags and operations</mat-option>
+            <mat-option [value]="docExpansionEnum.None">Default</mat-option>
+          </mat-select>
+          <mat-hint>Determines whether to expand operations, tags, or nothing by default when the page is opened.</mat-hint>
+        </mat-form-field>
+
+        <gio-form-slide-toggle>
+          <mat-slide-toggle gioFormSlideToggle formControlName="enableFiltering" />
+          <gio-form-label>
+            <div>Add top bar to filter content</div>
+          </gio-form-label>
+        </gio-form-slide-toggle>
+
+        <gio-form-slide-toggle>
+          <mat-slide-toggle gioFormSlideToggle formControlName="showExtensions" />
+          <gio-form-label>
+            <div>Display vendor extensions</div>
+            <div class="mat-body-2">
+              Determines whether vendor extension (X-) fields and values for operations, parameters, and schemas should be displayed.
+            </div>
+          </gio-form-label>
+        </gio-form-slide-toggle>
+
+        <gio-form-slide-toggle>
+          <mat-slide-toggle gioFormSlideToggle formControlName="showCommonExtensions" />
+          <gio-form-label>
+            <div>Display extension fields for Parameters</div>
+            <div class="mat-body-2">Determines whether pattern, maxLength, minLength, maximum, and minimum extensions should be shown.</div>
+          </gio-form-label>
+        </gio-form-slide-toggle>
+
+        <mat-form-field>
+          <mat-label>Max number of tagged operations displayed</mat-label>
+          <input
+            id="openapi-max-displayed-tags"
+            matInput
+            type="number"
+            min="-1"
+            aria-label="Max number of tagged operations displayed"
+            formControlName="maxDisplayedTags"
+          />
+          <mat-hint>Limits the number of tagged operations displayed to the specific value. -1 means to show all operations.</mat-hint>
+        </mat-form-field>
+      }
+    </div>
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button mat-button type="button" (click)="onCancel()">Cancel</button>
+    <button mat-flat-button color="primary" type="submit" [disabled]="form.invalid">Save</button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/openapi-config-dialog/openapi-config-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/openapi-config-dialog/openapi-config-dialog.component.scss
@@ -1,0 +1,6 @@
+.open-api-configuration {
+  display: flex;
+  flex-flow: column;
+  gap: 16px;
+  padding-top: 8px;
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/openapi-config-dialog/openapi-config-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/openapi-config-dialog/openapi-config-dialog.component.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { OpenApiConfigDialogComponent } from './openapi-config-dialog.component';
+
+import { OpenApiDocExpansion, OpenApiViewer } from '../../../entities/management-api-v2/portalPageContent/openApiViewerConfiguration';
+
+describe('OpenApiConfigDialogComponent', () => {
+  let fixture: ComponentFixture<OpenApiConfigDialogComponent>;
+  let component: OpenApiConfigDialogComponent;
+  let dialogRefClose: jest.Mock;
+
+  beforeEach(async () => {
+    dialogRefClose = jest.fn();
+
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, OpenApiConfigDialogComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: dialogRefClose } },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            configuration: {
+              viewer: OpenApiViewer.Swagger,
+              tryItURL: 'https://api.example.com',
+              displayOperationId: true,
+              docExpansion: OpenApiDocExpansion.Full,
+              enableFiltering: true,
+              maxDisplayedTags: 10,
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OpenApiConfigDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should emit camelCase configuration keys on save', () => {
+    component.form.patchValue({
+      viewer: OpenApiViewer.Redoc,
+      tryItURL: 'https://try-it.example.com',
+      tryIt: true,
+      disableSyntaxHighlight: true,
+      tryItAnonymous: true,
+      showURL: true,
+      displayOperationId: true,
+      usePkce: true,
+      docExpansion: OpenApiDocExpansion.List,
+      enableFiltering: true,
+      showExtensions: true,
+      showCommonExtensions: true,
+      maxDisplayedTags: 12,
+    });
+
+    component.onSave();
+
+    expect(dialogRefClose).toHaveBeenCalledWith({
+      viewer: OpenApiViewer.Redoc,
+      tryItURL: 'https://try-it.example.com',
+      tryIt: true,
+      disableSyntaxHighlight: true,
+      tryItAnonymous: true,
+      showURL: true,
+      displayOperationId: true,
+      usePkce: true,
+      docExpansion: OpenApiDocExpansion.List,
+      enableFiltering: true,
+      showExtensions: true,
+      showCommonExtensions: true,
+      maxDisplayedTags: 12,
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/portal/navigation-items/openapi-config-dialog/openapi-config-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/openapi-config-dialog/openapi-config-dialog.component.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
+
+import {
+  OpenApiDocExpansion,
+  OpenApiViewer,
+  OpenApiViewerConfiguration,
+} from '../../../entities/management-api-v2/portalPageContent/openApiViewerConfiguration';
+
+export interface OpenApiConfigDialogData {
+  configuration: Partial<OpenApiViewerConfiguration>;
+}
+
+interface OpenApiFormControls {
+  viewer: FormControl<OpenApiViewer>;
+  tryItURL: FormControl<string>;
+  tryIt: FormControl<boolean>;
+  disableSyntaxHighlight: FormControl<boolean>;
+  tryItAnonymous: FormControl<boolean>;
+  showURL: FormControl<boolean>;
+  displayOperationId: FormControl<boolean>;
+  usePkce: FormControl<boolean>;
+  docExpansion: FormControl<OpenApiDocExpansion>;
+  enableFiltering: FormControl<boolean>;
+  showExtensions: FormControl<boolean>;
+  showCommonExtensions: FormControl<boolean>;
+  maxDisplayedTags: FormControl<number | null>;
+}
+
+function parseBoolean(value: string | boolean | undefined): boolean {
+  return value === 'true' || value === true;
+}
+
+function parseNumber(value: string | number | undefined): number | null {
+  if (value === undefined || value === '' || value === null) return null;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+@Component({
+  selector: 'openapi-config-dialog',
+  standalone: true,
+  imports: [
+    MatDialogModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatSlideToggleModule,
+    GioFormSlideToggleModule,
+  ],
+  templateUrl: './openapi-config-dialog.component.html',
+  styleUrls: ['./openapi-config-dialog.component.scss'],
+})
+export class OpenApiConfigDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<OpenApiConfigDialogComponent, OpenApiViewerConfiguration>);
+  private readonly data: OpenApiConfigDialogData = inject(MAT_DIALOG_DATA);
+
+  private readonly configuration = this.data.configuration ?? {};
+
+  readonly form = new FormGroup<OpenApiFormControls>({
+    viewer: new FormControl(this.configuration.viewer ?? OpenApiViewer.Swagger, { nonNullable: true }),
+    tryItURL: new FormControl(this.configuration.tryItURL ?? '', {
+      nonNullable: true,
+      validators: [Validators.pattern(/^$|^https?:\/\/\S+/)],
+    }),
+    tryIt: new FormControl(parseBoolean(this.configuration.tryIt), { nonNullable: true }),
+    disableSyntaxHighlight: new FormControl(parseBoolean(this.configuration.disableSyntaxHighlight), { nonNullable: true }),
+    tryItAnonymous: new FormControl(parseBoolean(this.configuration.tryItAnonymous), { nonNullable: true }),
+    showURL: new FormControl(parseBoolean(this.configuration.showURL), { nonNullable: true }),
+    displayOperationId: new FormControl(parseBoolean(this.configuration.displayOperationId), { nonNullable: true }),
+    usePkce: new FormControl(parseBoolean(this.configuration.usePkce), { nonNullable: true }),
+    docExpansion: new FormControl(this.configuration.docExpansion ?? OpenApiDocExpansion.None, { nonNullable: true }),
+    enableFiltering: new FormControl(parseBoolean(this.configuration.enableFiltering), { nonNullable: true }),
+    showExtensions: new FormControl(parseBoolean(this.configuration.showExtensions), { nonNullable: true }),
+    showCommonExtensions: new FormControl(parseBoolean(this.configuration.showCommonExtensions), { nonNullable: true }),
+    maxDisplayedTags: new FormControl<number | null>(parseNumber(this.configuration.maxDisplayedTags)),
+  });
+  readonly viewerEnum = OpenApiViewer;
+  readonly docExpansionEnum = OpenApiDocExpansion;
+
+  private readonly viewer = toSignal(this.form.controls.viewer.valueChanges, { initialValue: this.form.controls.viewer.value });
+
+  readonly isSwaggerViewer = computed(() => this.viewer() === OpenApiViewer.Swagger);
+
+  onSave(): void {
+    const formValue = this.form.getRawValue();
+    this.dialogRef.close({
+      viewer: formValue.viewer,
+      tryItURL: formValue.tryItURL,
+      tryIt: formValue.tryIt,
+      disableSyntaxHighlight: formValue.disableSyntaxHighlight,
+      tryItAnonymous: formValue.tryItAnonymous,
+      showURL: formValue.showURL,
+      displayOperationId: formValue.displayOperationId,
+      usePkce: formValue.usePkce,
+      docExpansion: formValue.docExpansion,
+      enableFiltering: formValue.enableFiltering,
+      showExtensions: formValue.showExtensions,
+      showCommonExtensions: formValue.showCommonExtensions,
+      maxDisplayedTags: formValue.maxDisplayedTags,
+    });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/openapi-config-dialog/openapi-config-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/openapi-config-dialog/openapi-config-dialog.harness.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class OpenApiConfigDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'openapi-config-dialog';
+
+  private readonly locateSaveButton = this.locatorFor(MatButtonHarness.with({ text: /^Save$/ }));
+  private readonly locateCancelButton = this.locatorFor(MatButtonHarness.with({ text: /^Cancel$/ }));
+
+  async clickSaveButton(): Promise<void> {
+    return (await this.locateSaveButton()).click();
+  }
+
+  async clickCancelButton(): Promise<void> {
+    return (await this.locateCancelButton()).click();
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -85,6 +85,9 @@
         </div>
       }
       <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-documentation-u'] }">
+        @if (currentPageContentType() === 'OPENAPI') {
+          <button [disabled]="actionsDisabled()" mat-stroked-button (click)="onConfigure()">Configure</button>
+        }
         <button [disabled]="actionsDisabled()" mat-stroked-button (click)="onEdit()">Edit</button>
         <span [matTooltip]="publishDisabledTooltip()" [matTooltipDisabled]="!publishDisabled()">
           <button [disabled]="publishActionDisabled()" mat-stroked-button (click)="onPublishToggle()">
@@ -113,7 +116,7 @@
           } @else {
             @switch (currentPageContentType()) {
               @case ('OPENAPI') {
-                <openapi-editor [formControl]="contentControl" />
+                <openapi-editor [formControl]="contentControl" [configuration]="currentPageConfiguration()" />
               }
               @case ('ASYNCAPI') {
                 <asyncapi-editor [formControl]="contentControl" />

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -25,6 +25,7 @@ import { Router } from '@angular/router';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { GioConfirmAndValidateDialogHarness, GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+import { of } from 'rxjs';
 
 import SpyInstance = jest.SpyInstance;
 
@@ -32,6 +33,7 @@ import { findFirstAvailablePage, PortalNavigationItemsComponent } from './portal
 import { PortalNavigationItemsHarness } from './portal-navigation-items.harness';
 import { SectionEditorDialogHarness } from './section-editor-dialog/section-editor-dialog.harness';
 import { ApiSectionEditorDialogHarness } from './api-section-editor-dialog/api-section-editor-dialog.harness';
+import { OpenApiConfigDialogHarness } from './openapi-config-dialog/openapi-config-dialog.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../shared/testing';
 import { GioTestingPermissionProvider } from '../../shared/components/gio-permission/gio-permission.service';
@@ -39,6 +41,7 @@ import {
   fakeNewFolderPortalNavigationItem,
   fakeNewLinkPortalNavigationItem,
   fakeNewPagePortalNavigationItem,
+  fakePortalPageContent,
   fakePortalNavigationApi,
   fakePortalNavigationFolder,
   fakePortalNavigationItemsResponse,
@@ -54,8 +57,14 @@ import {
   UpdateLinkPortalNavigationItem,
   UpdatePortalNavigationItem,
 } from '../../entities/management-api-v2';
+import {
+  OpenApiDocExpansion,
+  OpenApiViewer,
+  OpenApiViewerConfiguration,
+} from '../../entities/management-api-v2/portalPageContent/openApiViewerConfiguration';
 import { SectionNode } from '../components/flat-tree/flat-tree.component';
 import { SnackBarService } from '../../services-ngx/snack-bar.service';
+import { PortalPageContentService } from '../../services-ngx/portal-page-content.service';
 
 type PortalNavigationItemsComponentPrivateMethods = {
   validateAsyncApiSpec: () => boolean;
@@ -2521,10 +2530,15 @@ describe('PortalNavigationItemsComponent', () => {
     fixture.detectChanges();
   }
 
-  function expectGetPageContent(contentId: string, content: string, type: PortalPageContentType = 'GRAVITEE_MARKDOWN') {
+  function expectGetPageContent(
+    contentId: string,
+    content: string,
+    type: PortalPageContentType = 'GRAVITEE_MARKDOWN',
+    configuration?: Partial<OpenApiViewerConfiguration>,
+  ) {
     httpTestingController
       .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/${contentId}` })
-      .flush({ id: contentId, content, type });
+      .flush({ id: contentId, content, type, configuration });
 
     fixture.detectChanges();
   }
@@ -2622,6 +2636,136 @@ describe('PortalNavigationItemsComponent', () => {
 
     component.contentControl.setValue('Initial content');
     expect(component.hasUnsavedChanges()).toBeFalsy();
+  });
+
+  describe('Configure button for OPENAPI page', () => {
+    const openApiNavItem = fakePortalNavigationPage({
+      id: 'openapi-page-1',
+      title: 'OpenAPI Page',
+      portalPageContentId: 'openapi-content-1',
+    });
+    const initialConfig: OpenApiViewerConfiguration = {
+      viewer: OpenApiViewer.Redoc,
+      tryItURL: '',
+      tryIt: false,
+      disableSyntaxHighlight: false,
+      tryItAnonymous: false,
+      showURL: false,
+      displayOperationId: false,
+      usePkce: false,
+      docExpansion: OpenApiDocExpansion.None,
+      enableFiltering: false,
+      showExtensions: false,
+      showCommonExtensions: false,
+      maxDisplayedTags: 0,
+    };
+
+    beforeEach(async () => {
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [openApiNavItem] }));
+      expectGetPageContent('openapi-content-1', 'openapi: 3.0.0', 'OPENAPI', initialConfig);
+    });
+
+    it('should show Configure button when an OPENAPI page is selected', async () => {
+      expect(await harness.isConfigureButtonVisible()).toBe(true);
+    });
+
+    it('should open the Configure dialog when Configure button is clicked', async () => {
+      await harness.clickConfigureButton();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(OpenApiConfigDialogHarness);
+      expect(dialog).not.toBeNull();
+    });
+
+    it('should call PATCH and update configuration when dialog is saved', async () => {
+      await harness.clickConfigureButton();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarness(OpenApiConfigDialogHarness);
+      await dialog.clickSaveButton();
+
+      const req = httpTestingController.expectOne({
+        method: 'PATCH',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/openapi-content-1/configuration`,
+      });
+      expect(req.request.body).toEqual(expect.objectContaining({ viewer: OpenApiViewer.Redoc }));
+      req.flush(fakePortalPageContent({ id: 'openapi-content-1', type: 'OPENAPI', configuration: initialConfig }));
+      fixture.detectChanges();
+
+      expect(component.currentPageConfiguration()).toEqual(expect.objectContaining({ viewer: OpenApiViewer.Redoc }));
+    });
+
+    it('should not call PATCH when dialog is cancelled', async () => {
+      await harness.clickConfigureButton();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarness(OpenApiConfigDialogHarness);
+      await dialog.clickCancelButton();
+      fixture.detectChanges();
+
+      httpTestingController.expectNone({
+        method: 'PATCH',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/openapi-content-1/configuration`,
+      });
+    });
+  });
+
+  it('should save OpenAPI viewer configuration without persisting dirty content', async () => {
+    const initialConfiguration: OpenApiViewerConfiguration = {
+      viewer: OpenApiViewer.Redoc,
+      tryItURL: '',
+      tryIt: false,
+      disableSyntaxHighlight: false,
+      tryItAnonymous: false,
+      showURL: false,
+      displayOperationId: false,
+      usePkce: false,
+      docExpansion: OpenApiDocExpansion.None,
+      enableFiltering: false,
+      showExtensions: false,
+      showCommonExtensions: false,
+      maxDisplayedTags: 0,
+    };
+    const updatedConfiguration: OpenApiViewerConfiguration = {
+      ...initialConfiguration,
+      viewer: OpenApiViewer.Swagger,
+      tryIt: true,
+      showURL: true,
+      docExpansion: OpenApiDocExpansion.Full,
+      maxDisplayedTags: 12,
+    };
+
+    await expectGetNavigationItems({
+      items: [fakePortalNavigationPage({ id: 'page-1', title: 'Page 1', portalPageContentId: 'content-1' })],
+    });
+    expectGetPageContent('content-1', 'Initial content', 'OPENAPI', initialConfiguration);
+
+    const portalPageContentService = TestBed.inject(PortalPageContentService);
+    const updatePageContentSpy = jest.spyOn(portalPageContentService, 'updatePageContent');
+    const updatePageContentConfigurationSpy = jest.spyOn(portalPageContentService, 'updatePageContentConfiguration').mockReturnValue(
+      of(
+        fakePortalPageContent({
+          id: 'content-1',
+          content: 'Initial content',
+          type: 'OPENAPI',
+          configuration: updatedConfiguration,
+        }),
+      ),
+    );
+    jest.spyOn(TestBed.inject(MatDialog), 'open').mockReturnValue({
+      afterClosed: () => of(updatedConfiguration),
+    } as ReturnType<MatDialog['open']>);
+
+    component.contentControl.setValue('Dirty draft content');
+    component.contentControl.markAsDirty();
+
+    component.onConfigure();
+
+    expect(updatePageContentConfigurationSpy).toHaveBeenCalledWith('content-1', updatedConfiguration);
+    expect(updatePageContentSpy).not.toHaveBeenCalled();
+    expect(component.contentControl.value).toBe('Dirty draft content');
+    expect(component.hasUnsavedChanges()).toBeTruthy();
+    expect(component.currentPageConfiguration()).toEqual(updatedConfiguration);
   });
 
   it('should not have unsaved changes after opening and closing the edit dialog without changes', async () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -50,6 +50,7 @@ import {
   ApiSectionEditorDialogComponent,
   ApiSectionEditorDialogData,
 } from './api-section-editor-dialog/api-section-editor-dialog.component';
+import { OpenApiConfigDialogComponent, OpenApiConfigDialogData } from './openapi-config-dialog/openapi-config-dialog.component';
 
 import { PortalHeaderComponent } from '../components/header/portal-header.component';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
@@ -66,6 +67,7 @@ import {
   PortalVisibility,
   UpdatePortalNavigationItem,
 } from '../../entities/management-api-v2';
+import { OpenApiViewerConfiguration } from '../../entities/management-api-v2/portalPageContent/openApiViewerConfiguration';
 import { SnackBarService } from '../../services-ngx/snack-bar.service';
 import { GioPermissionModule } from '../../shared/components/gio-permission/gio-permission.module';
 import { PortalNavigationItemService } from '../../services-ngx/portal-navigation-item.service';
@@ -196,6 +198,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   initialContent = signal('');
 
   readonly currentPageContentType = signal<PortalPageContentType | null>(null);
+  readonly currentPageConfiguration = signal<Partial<OpenApiViewerConfiguration>>({});
   readonly contentLoadError = signal(false);
   private readonly asyncApiSpecValidator: ValidatorFn = (control: AbstractControl): ValidationErrors | null => {
     const validationError = this.getAsyncApiSpecValidationError(control.value);
@@ -374,6 +377,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
 
         if (result.success) {
           this.currentPageContentType.set(result.type);
+          this.currentPageConfiguration.set(result.configuration ?? {});
           this.contentControl.reset(result.content);
           this.contentControl.updateValueAndValidity();
           this.initialContent.set(result.content);
@@ -381,9 +385,11 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       });
   }
 
-  private loadPageContent(contentId: string): Observable<{ success: boolean; content: string; type?: PortalPageContentType }> {
+  private loadPageContent(
+    contentId: string,
+  ): Observable<{ success: boolean; content: string; type?: PortalPageContentType; configuration?: Partial<OpenApiViewerConfiguration> }> {
     return this.portalPageContentService.getPageContent(contentId).pipe(
-      map(({ content, type }) => ({ success: true, content, type })),
+      map(({ content, type, configuration }) => ({ success: true, content, type, configuration })),
       catchError(() => {
         this.contentLoadError.set(true);
         this.isLoadingPageContent.set(false);
@@ -613,6 +619,32 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
       return { message: `Invalid AsyncAPI spec: ${yamlError.message}` };
     }
     return null;
+  }
+
+  onConfigure() {
+    const navItem = this.selectedNavigationItem()?.data as PortalNavigationPage | undefined;
+    if (!navItem) return;
+
+    this.matDialog
+      .open<OpenApiConfigDialogComponent, OpenApiConfigDialogData, OpenApiViewerConfiguration>(OpenApiConfigDialogComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        data: { configuration: this.currentPageConfiguration() },
+      })
+      .afterClosed()
+      .pipe(
+        filter(result => !!result),
+        switchMap(result => {
+          return this.portalPageContentService.updatePageContentConfiguration(navItem.portalPageContentId, result).pipe(map(() => result));
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: configuration => {
+          this.currentPageConfiguration.set(configuration);
+          this.snackBarService.success('OpenAPI viewer configuration saved.');
+        },
+        error: () => this.snackBarService.error('Failed to save configuration.'),
+      });
   }
 
   onEdit() {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -30,6 +30,7 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   private getAddButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Add new section"]' }));
   private getEditButton = this.locatorFor(MatButtonHarness.with({ text: /Edit/i }));
   private getSaveButton = this.locatorFor(MatButtonHarness.with({ text: /Save/i }));
+  private readonly getConfigureButtonOptional = this.locatorForOptional(MatButtonHarness.with({ text: /^Configure$/ }));
   private getPublishButton = this.locatorForOptional(MatButtonHarness.with({ text: /^Publish$/ }));
   private getUnpublishButton = this.locatorForOptional(MatButtonHarness.with({ text: /^Unpublish$/ }));
   private getMenu = this.locatorFor(MatMenuHarness);
@@ -63,6 +64,15 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   async clickEditButton(): Promise<void> {
     const button = await this.getEditButton();
     return button.click();
+  }
+
+  async isConfigureButtonVisible(): Promise<boolean> {
+    return (await this.getConfigureButtonOptional()) !== null;
+  }
+
+  async clickConfigureButton(): Promise<void> {
+    const button = await this.getConfigureButtonOptional();
+    return button?.click();
   }
 
   async getPageMenuItem(): Promise<MatMenuItemHarness> {

--- a/gravitee-apim-console-webui/src/services-ngx/portal-page-content.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-page-content.service.spec.ts
@@ -20,6 +20,7 @@ import { PortalPageContentService } from './portal-page-content.service';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
 import { fakePortalPageContent, fakeNewPortalPageContent } from '../entities/management-api-v2';
+import { OpenApiDocExpansion, OpenApiViewer } from '../entities/management-api-v2/portalPageContent/openApiViewerConfiguration';
 
 describe('PortalPageContentService', () => {
   let httpTestingController: HttpTestingController;
@@ -88,6 +89,40 @@ describe('PortalPageContentService', () => {
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/${contentId}`,
       });
       expect(req.request.body).toEqual(updateContent);
+      req.flush(fakeUpdatedContent);
+    });
+  });
+
+  describe('updatePageContentConfiguration', () => {
+    it('should call the API', done => {
+      const contentId = 'content-1';
+      const configuration = {
+        viewer: OpenApiViewer.Swagger,
+        tryItURL: 'https://example.com',
+        tryIt: true,
+        disableSyntaxHighlight: true,
+        tryItAnonymous: true,
+        showURL: true,
+        displayOperationId: true,
+        usePkce: true,
+        docExpansion: OpenApiDocExpansion.Full,
+        enableFiltering: true,
+        showExtensions: true,
+        showCommonExtensions: true,
+        maxDisplayedTags: 10,
+      };
+      const fakeUpdatedContent = fakePortalPageContent({ id: contentId, configuration });
+
+      service.updatePageContentConfiguration(contentId, configuration).subscribe(response => {
+        expect(response).toMatchObject(fakeUpdatedContent);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'PATCH',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/${contentId}/configuration`,
+      });
+      expect(req.request.body).toEqual(configuration);
       req.flush(fakeUpdatedContent);
     });
   });

--- a/gravitee-apim-console-webui/src/services-ngx/portal-page-content.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-page-content.service.ts
@@ -19,6 +19,7 @@ import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
 import { NewPortalPageContent, PortalPageContent, UpdatePortalPageContent } from '../entities/management-api-v2';
+import { OpenApiViewerConfiguration } from '../entities/management-api-v2/portalPageContent/openApiViewerConfiguration';
 
 @Injectable({
   providedIn: 'root',
@@ -39,5 +40,12 @@ export class PortalPageContentService {
 
   public updatePageContent(contentId: string, content: UpdatePortalPageContent): Observable<PortalPageContent> {
     return this.http.put<PortalPageContent>(`${this.constants.env.v2BaseURL}/portal-page-contents/${contentId}`, content);
+  }
+
+  public updatePageContentConfiguration(contentId: string, configuration: OpenApiViewerConfiguration): Observable<PortalPageContent> {
+    return this.http.patch<PortalPageContent>(
+      `${this.constants.env.v2BaseURL}/portal-page-contents/${contentId}/configuration`,
+      configuration,
+    );
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.html
@@ -22,7 +22,13 @@
       <gmd-viewer [content]="pageContentVM.content" appInnerLink />
     }
     @case ('OPENAPI') {
-      <app-redoc-content-viewer [content]="pageContentVM.content" />
+      @if (pageContentVM.configuration?.viewer === viewerEnum.Redoc) {
+        <app-redoc-content-viewer [content]="pageContentVM.content" [tryItUrl]="tryItUrl()" />
+      } @else {
+        @if (swaggerPage(); as swaggerPageVM) {
+          <app-page-swagger [page]="swaggerPageVM" />
+        }
+      }
     }
     @case ('ASYNCAPI') {
       <app-page-async-api [content]="pageContentVM.content" />

--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.spec.ts
@@ -15,11 +15,14 @@
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import SwaggerUI from 'swagger-ui';
 
 import { NavigationItemContentViewerComponent } from './navigation-item-content-viewer.component';
 import { NavigationItemContentViewerHarness } from './navigation-item-content-viewer.harness';
+import { ViewerEnum } from '../../entities/page/page-configuration';
 import { PortalPageContent } from '../../entities/portal-navigation/portal-page-content';
 import { RedocService } from '../../services/redoc.service';
+import { AppTestingModule } from '../../testing/app-testing.module';
 
 interface initData {
   pageContent: PortalPageContent | null;
@@ -61,6 +64,7 @@ describe('NavigationItemContentViewerComponent', () => {
     const pageContent: PortalPageContent = {
       type: 'OPENAPI',
       content: 'openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0',
+      configuration: { viewer: ViewerEnum.Redoc, try_it_url: 'https://try-it.example.com' },
     };
     beforeEach(async () => {
       await TestBed.configureTestingModule({
@@ -84,6 +88,9 @@ describe('NavigationItemContentViewerComponent', () => {
       expect(redocViewer).not.toBeNull();
       expect(await harness.isShowingRedocContent()).toBe(true);
     });
+    it('should read Redoc try it URL from snake_case configuration', () => {
+      expect(fixture.componentInstance.tryItUrl()).toBe('https://try-it.example.com');
+    });
     it('should not render markdown viewer', async () => {
       const markdownViewer = await harness.getGMDViewer();
       expect(markdownViewer).toBeNull();
@@ -106,6 +113,76 @@ describe('NavigationItemContentViewerComponent', () => {
       const markdownViewer = await harness.getGMDViewer();
       expect(markdownViewer).toBeNull();
     });
+    it('should not render redoc viewer', async () => {
+      expect(await harness.isShowingRedocContent()).toBe(false);
+    });
+  });
+
+  describe('if page content is OPENAPI with Swagger', () => {
+    const pageContent: PortalPageContent = {
+      type: 'OPENAPI',
+      content: 'openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0',
+      configuration: { viewer: ViewerEnum.Swagger },
+    };
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [NavigationItemContentViewerComponent, AppTestingModule],
+      }).compileComponents();
+
+      jest.mocked(SwaggerUI).mockClear();
+
+      fixture = TestBed.createComponent(NavigationItemContentViewerComponent);
+      fixture.componentRef.setInput('pageContent', pageContent);
+
+      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, NavigationItemContentViewerHarness);
+      fixture.detectChanges();
+    });
+
+    it('should not reinitialize Swagger UI on unchanged change detection cycles', () => {
+      expect(SwaggerUI).toHaveBeenCalledTimes(1);
+
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      expect(SwaggerUI).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render swagger viewer', async () => {
+      const swaggerViewer = await harness.getSwaggerViewer();
+      expect(swaggerViewer).not.toBeNull();
+    });
+
+    it('should not render redoc viewer', async () => {
+      expect(await harness.isShowingRedocContent()).toBe(false);
+    });
+  });
+
+  describe('if page content is OPENAPI with no viewer set', () => {
+    const pageContent: PortalPageContent = {
+      type: 'OPENAPI',
+      content: 'openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0.0',
+    };
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [NavigationItemContentViewerComponent, AppTestingModule],
+      }).compileComponents();
+
+      jest.mocked(SwaggerUI).mockClear();
+
+      fixture = TestBed.createComponent(NavigationItemContentViewerComponent);
+      fixture.componentRef.setInput('pageContent', pageContent);
+
+      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, NavigationItemContentViewerHarness);
+      fixture.detectChanges();
+    });
+
+    it('should render swagger viewer', async () => {
+      const swaggerViewer = await harness.getSwaggerViewer();
+      expect(swaggerViewer).not.toBeNull();
+    });
+
     it('should not render redoc viewer', async () => {
       expect(await harness.isShowingRedocContent()).toBe(false);
     });

--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.component.ts
@@ -13,21 +13,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 
 import { GraviteeMarkdownViewerModule } from '@gravitee/gravitee-markdown';
 
 import { InnerLinkDirective } from '../../directives/inner-link.directive';
+import { Page } from '../../entities/page/page';
+import { ViewerEnum } from '../../entities/page/page-configuration';
 import { PortalPageContent } from '../../entities/portal-navigation/portal-page-content';
 import { PageAsyncApiComponent } from '../page/page-async-api/page-async-api.component';
+import { PageSwaggerComponent } from '../page/page-swagger/page-swagger.component';
 import { RedocContentViewerComponent } from '../redoc-content-viewer/redoc-content-viewer.component';
 
 @Component({
   selector: 'app-navigation-item-content-viewer',
-  imports: [GraviteeMarkdownViewerModule, InnerLinkDirective, PageAsyncApiComponent, RedocContentViewerComponent],
+  imports: [GraviteeMarkdownViewerModule, InnerLinkDirective, PageAsyncApiComponent, RedocContentViewerComponent, PageSwaggerComponent],
   templateUrl: './navigation-item-content-viewer.component.html',
   styleUrl: './navigation-item-content-viewer.component.scss',
 })
 export class NavigationItemContentViewerComponent {
   pageContent = input.required<PortalPageContent | null>();
+  protected readonly viewerEnum = ViewerEnum;
+
+  tryItUrl = computed(() => this.pageContent()?.configuration?.try_it_url);
+
+  swaggerPage = computed<Page | null>(() => {
+    const pageContent = this.pageContent();
+    if (pageContent?.type !== 'OPENAPI') {
+      return null;
+    }
+
+    return {
+      id: '',
+      name: '',
+      type: 'SWAGGER',
+      order: 0,
+      content: pageContent.content,
+      configuration: pageContent.configuration,
+    };
+  });
 }

--- a/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/navigation-item-content-viewer/navigation-item-content-viewer.harness.ts
@@ -19,6 +19,7 @@ import { GraviteeMarkdownViewerHarness } from '@gravitee/gravitee-markdown';
 
 import { DivHarness } from '../../testing/div.harness';
 import { PageAsyncApiHarness } from '../page/page-async-api/page-async-api.harness';
+import { PageSwaggerHarness } from '../page/page-swagger/page-swagger.harness';
 import { RedocContentViewerHarness } from '../redoc-content-viewer/redoc-content-viewer.harness';
 
 export class NavigationItemContentViewerHarness extends ComponentHarness {
@@ -27,6 +28,7 @@ export class NavigationItemContentViewerHarness extends ComponentHarness {
   private locateGMDViewer = this.locatorForOptional(GraviteeMarkdownViewerHarness);
   private locateAsyncApiViewer = this.locatorForOptional(PageAsyncApiHarness);
   private locateRedocViewer = this.locatorForOptional(RedocContentViewerHarness);
+  private readonly locateSwaggerViewer = this.locatorForOptional(PageSwaggerHarness);
   private locateEmptyState = this.locatorForOptional(DivHarness.with({ selector: '.empty-state' }));
 
   public async isShowingMarkdownContent(): Promise<boolean> {
@@ -49,6 +51,14 @@ export class NavigationItemContentViewerHarness extends ComponentHarness {
 
   public async getRedocViewer(): Promise<RedocContentViewerHarness | null> {
     return this.locateRedocViewer();
+  }
+
+  public async getSwaggerViewer(): Promise<PageSwaggerHarness | null> {
+    return this.locateSwaggerViewer();
+  }
+
+  public async isShowingSwaggerContent(): Promise<boolean> {
+    return (await this.locateSwaggerViewer()) !== null;
   }
 
   public async getEmptyState(): Promise<DivHarness | null> {

--- a/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.spec.ts
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import SwaggerUI from 'swagger-ui';
 
 import { PageSwaggerComponent } from './page-swagger.component';
+import { DocExpansionEnum } from '../../../entities/page/page-configuration';
 import { fakePage } from '../../../entities/page/page.fixtures';
 import { AppTestingModule } from '../../../testing/app-testing.module';
 
@@ -25,13 +27,26 @@ const SwaggerUIMock = jest.mocked(SwaggerUI);
 
 type WithNormalizeTypeArrays = { normalizeTypeArrays: (obj: unknown) => unknown };
 
+@Component({
+  standalone: true,
+  imports: [PageSwaggerComponent],
+  template: `
+    <app-page-swagger [page]="firstPage" />
+    <app-page-swagger [page]="secondPage" />
+  `,
+})
+class PageSwaggerHostComponent {
+  firstPage = fakePage({ id: 'first-page', type: 'SWAGGER', content: '{"openapi":"3.0.0"}' });
+  secondPage = fakePage({ id: 'second-page', type: 'SWAGGER', content: '{"openapi":"3.0.0"}' });
+}
+
 describe('PageSwaggerComponent', () => {
   let component: PageSwaggerComponent;
   let fixture: ComponentFixture<PageSwaggerComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PageSwaggerComponent, AppTestingModule],
+      imports: [PageSwaggerComponent, PageSwaggerHostComponent, AppTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PageSwaggerComponent);
@@ -191,5 +206,73 @@ describe('PageSwaggerComponent', () => {
       expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays('string')).toBe('string');
       expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays(42)).toBe(42);
     });
+  });
+
+  it('should map snake_case page configuration to Swagger UI options', () => {
+    const initOAuth = jest.fn();
+    jest.mocked(SwaggerUI).mockClear();
+    jest.mocked(SwaggerUI).mockReturnValue({ initOAuth } as never);
+    component.page = fakePage({
+      type: 'SWAGGER',
+      content: '{"openapi":"3.0.0","info":{"title":"Test","version":"1.0.0"}}',
+      configuration: {
+        try_it_url: 'https://try-it.example.com',
+        disable_syntax_highlight: true,
+        doc_expansion: DocExpansionEnum.Full,
+        display_operation_id: true,
+        enable_filtering: true,
+        show_extensions: true,
+        show_common_extensions: true,
+        max_displayed_tags: 7,
+        use_pkce: true,
+      },
+    });
+
+    component.ngOnChanges();
+
+    expect(SwaggerUI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: expect.objectContaining({ servers: [{ url: 'https://try-it.example.com' }] }),
+        syntaxHighlight: false,
+        docExpansion: DocExpansionEnum.Full,
+        displayOperationId: true,
+        filter: true,
+        showExtensions: true,
+        showCommonExtensions: true,
+        maxDisplayedTags: 7,
+      }),
+    );
+    expect(initOAuth).toHaveBeenCalledWith({
+      usePkceWithAuthorizationCodeGrant: true,
+    });
+  });
+
+  it('should mount Swagger UI on its local element without using a global id lookup', () => {
+    const getElementByIdSpy = jest.spyOn(document, 'getElementById');
+    jest.mocked(SwaggerUI).mockClear();
+
+    component.ngOnChanges();
+
+    expect(getElementByIdSpy).not.toHaveBeenCalled();
+    expect(SwaggerUI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domNode: expect.any(HTMLDivElement),
+      }),
+    );
+
+    getElementByIdSpy.mockRestore();
+  });
+
+  it('should mount multiple instances on separate local elements', () => {
+    jest.mocked(SwaggerUI).mockClear();
+
+    const hostFixture = TestBed.createComponent(PageSwaggerHostComponent);
+    hostFixture.detectChanges();
+
+    const [firstOptions, secondOptions] = jest.mocked(SwaggerUI).mock.calls.map(([options]) => options);
+
+    expect(firstOptions.domNode).toEqual(expect.any(HTMLDivElement));
+    expect(secondOptions.domNode).toEqual(expect.any(HTMLDivElement));
+    expect(firstOptions.domNode).not.toBe(secondOptions.domNode);
   });
 });

--- a/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { PlatformLocation } from '@angular/common';
-import { Component, inject, Input, OnChanges } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, inject, Input, OnChanges, viewChild } from '@angular/core';
 import SwaggerUI, { SwaggerUIOptions, SwaggerUIPlugin } from 'swagger-ui';
 
 import { readYaml } from '../../../app/helpers/yaml-parser';
@@ -28,17 +28,30 @@ const OAS_TYPE_PRIORITY = ['string', 'number', 'integer', 'boolean', 'array', 'o
 @Component({
   selector: 'app-page-swagger',
   standalone: true,
-  template: `<div id="swagger"></div>`,
+  template: `<div #swagger data-testid="swagger"></div>`,
 })
-export class PageSwaggerComponent implements OnChanges {
-  @Input() page!: Page;
-  private platformLocation: PlatformLocation = inject(PlatformLocation);
+export class PageSwaggerComponent implements AfterViewInit, OnChanges {
+  private readonly platformLocation = inject(PlatformLocation);
+  private readonly currentUser = inject(CurrentUserService);
 
-  constructor(private currentUser: CurrentUserService) {}
+  @Input() page!: Page;
+  private readonly swaggerNode = viewChild.required<ElementRef<HTMLDivElement>>('swagger');
+  private isViewInitialized = false;
 
   ngOnChanges() {
+    if (this.isViewInitialized) {
+      this.initializeSwagger();
+    }
+  }
+
+  ngAfterViewInit() {
+    this.isViewInitialized = true;
+    this.initializeSwagger();
+  }
+
+  private initializeSwagger() {
     SwaggerUI({
-      domNode: document.getElementById('swagger'),
+      domNode: this.swaggerNode().nativeElement,
       spec: this.readSpec() ?? '',
       ...this.buildConfig(),
     }).initOAuth({ usePkceWithAuthorizationCodeGrant: this.page.configuration?.use_pkce });
@@ -61,24 +74,25 @@ export class PageSwaggerComponent implements OnChanges {
     };
 
     if (this.page.configuration) {
-      const pageConfiguration = this.page.configuration;
-      if (pageConfiguration.show_url) {
-        config.url = this.page._links?.content;
+      const cfg = this.page.configuration;
+      if (cfg.show_url && this.page._links?.content) {
+        config.url = this.page._links.content;
         config.spec = undefined;
         plugins.push(this.normalizeSpecPlugin());
+      } else if (cfg.try_it_url) {
+        const parsedSpec = this.readSpec() as Record<string, unknown>;
+        config.spec = { ...parsedSpec, servers: [{ url: cfg.try_it_url }] };
       }
-      if (this.page.configuration?.disable_syntax_highlight) {
+      if (cfg.disable_syntax_highlight) {
         config.syntaxHighlight = false;
       }
-      config.docExpansion = this.page.configuration?.doc_expansion ?? 'none';
-      config.displayOperationId = pageConfiguration.display_operation_id || false;
-      config.filter = pageConfiguration.enable_filtering || false;
-      config.showExtensions = pageConfiguration.show_extensions || false;
-      config.showCommonExtensions = pageConfiguration.show_common_extensions || false;
-      config.maxDisplayedTags =
-        pageConfiguration.max_displayed_tags && pageConfiguration.max_displayed_tags >= 0
-          ? pageConfiguration.max_displayed_tags
-          : undefined;
+      config.docExpansion = cfg.doc_expansion ?? 'none';
+      config.displayOperationId = Boolean(cfg.display_operation_id);
+      config.filter = Boolean(cfg.enable_filtering);
+      config.showExtensions = Boolean(cfg.show_extensions);
+      config.showCommonExtensions = Boolean(cfg.show_common_extensions);
+      const maxTags = Number(cfg.max_displayed_tags);
+      config.maxDisplayedTags = !Number.isNaN(maxTags) && maxTags >= 0 ? maxTags : undefined;
     }
 
     return config;
@@ -192,10 +206,10 @@ export class PageSwaggerComponent implements OnChanges {
   }
 
   private isTryItEnabled() {
-    return this.page.configuration?.try_it && this.isTryItAllowed();
+    return Boolean(this.page.configuration?.try_it) && this.isTryItAllowed();
   }
 
   private isTryItAllowed() {
-    return this.currentUser.isAuthenticated() || this.page.configuration?.try_it_anonymous;
+    return this.currentUser.isAuthenticated() || Boolean(this.page.configuration?.try_it_anonymous);
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.harness.ts
@@ -17,7 +17,7 @@ import { ComponentHarness, TestElement } from '@angular/cdk/testing';
 
 export class PageSwaggerHarness extends ComponentHarness {
   public static hostSelector = 'app-page-swagger';
-  protected locateSwagger = this.locatorFor('#swagger');
+  protected locateSwagger = this.locatorFor('[data-testid="swagger"]');
 
   public async getSwagger(): Promise<TestElement> {
     return await this.locateSwagger();

--- a/gravitee-apim-portal-webui-next/src/components/page/page.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/page/page.component.html
@@ -17,7 +17,7 @@
 -->
 @switch (page.type) {
   @case ('SWAGGER') {
-    @if (effectiveViewer.toLowerCase() === 'redoc') {
+    @if (effectiveViewer === viewerEnum.Redoc) {
       <app-page-redoc [page]="page" />
     } @else {
       <app-page-swagger [page]="page" />

--- a/gravitee-apim-portal-webui-next/src/components/page/page.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page.component.spec.ts
@@ -23,6 +23,7 @@ import { PageMarkdownHarness } from './page-markdown/page-markdown.harness';
 import { PageRedocHarness } from './page-redoc/page-redoc.harness';
 import { PageSwaggerHarness } from './page-swagger/page-swagger.harness';
 import { PageComponent } from './page.component';
+import { ViewerEnum } from '../../entities/page/page-configuration';
 import { fakePage } from '../../entities/page/page.fixtures';
 import { ConfigService } from '../../services/config.service';
 import { RedocService } from '../../services/redoc.service';
@@ -66,7 +67,7 @@ describe('PageComponent', () => {
 
   describe('redoc', () => {
     beforeEach(() => {
-      component.page = fakePage({ type: 'SWAGGER', configuration: { viewer: 'Redoc' } });
+      component.page = fakePage({ type: 'SWAGGER', configuration: { viewer: ViewerEnum.Redoc } });
       fixture.detectChanges();
     });
 
@@ -80,12 +81,12 @@ describe('PageComponent', () => {
   describe('redoc via env default', () => {
     beforeEach(() => {
       const configService = TestBed.inject(ConfigService) as unknown as ConfigServiceStub;
-      configService.configuration = { openAPIDocViewer: { openAPIDocType: { defaultType: 'Redoc' } } };
+      configService.configuration = { openAPIDocViewer: { openAPIDocType: { defaultType: 'redoc' } } };
       component.page = fakePage({ type: 'SWAGGER' });
       fixture.detectChanges();
     });
 
-    it('should show redoc content when env default is Redoc and page has no explicit viewer', async () => {
+    it('should show redoc content when env default is lowercase redoc and page has no explicit viewer', async () => {
       const redoc = await harnessLoader.getHarnessOrNull(PageRedocHarness);
       expect(redoc).toBeTruthy();
       expect(await redoc?.getRedoc()).toBeTruthy();

--- a/gravitee-apim-portal-webui-next/src/components/page/page.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page.component.ts
@@ -21,6 +21,7 @@ import { PageMarkdownComponent } from './page-markdown/page-markdown.component';
 import { PageRedocComponent } from './page-redoc/page-redoc.component';
 import { PageSwaggerComponent } from './page-swagger/page-swagger.component';
 import { Page } from '../../entities/page/page';
+import { ViewerEnum } from '../../entities/page/page-configuration';
 import { ConfigService } from '../../services/config.service';
 
 @Component({
@@ -39,7 +40,12 @@ export class PageComponent {
 
   private configService = inject(ConfigService);
 
-  get effectiveViewer(): string {
-    return this.page.configuration?.viewer ?? this.configService.configuration.openAPIDocViewer?.openAPIDocType?.defaultType ?? 'Swagger';
+  protected readonly viewerEnum = ViewerEnum;
+
+  get effectiveViewer(): ViewerEnum {
+    const configuredViewer =
+      this.page.configuration?.viewer ?? this.configService.configuration.openAPIDocViewer?.openAPIDocType?.defaultType;
+
+    return configuredViewer?.toLowerCase() === ViewerEnum.Redoc.toLowerCase() ? ViewerEnum.Redoc : ViewerEnum.Swagger;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/redoc-content-viewer/redoc-content-viewer.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/redoc-content-viewer/redoc-content-viewer.component.spec.ts
@@ -56,6 +56,7 @@ describe('RedocContentViewerComponent', () => {
         theme: { breakpoints: { medium: REDOC_BREAKPOINT_MEDIUM, large: REDOC_BREAKPOINT_LARGE } },
       }),
       expect.anything(),
+      undefined,
     );
   });
 

--- a/gravitee-apim-portal-webui-next/src/components/redoc-content-viewer/redoc-content-viewer.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/redoc-content-viewer/redoc-content-viewer.component.ts
@@ -33,15 +33,16 @@ const RENDER_DELAY_MS = 0;
 })
 export class RedocContentViewerComponent {
   content = input.required<string>();
+  tryItUrl = input<string | undefined>(undefined);
 
   private readonly destroyRef = inject(DestroyRef);
   private readonly element = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly redocService = inject(RedocService);
-  private pendingTimeoutId: number | null = null;
+  private pendingTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     effect(onCleanup => {
-      this.scheduleRedocInit(this.content());
+      this.scheduleRedocInit(this.content(), this.tryItUrl());
       onCleanup(() => {
         if (this.pendingTimeoutId !== null) {
           clearTimeout(this.pendingTimeoutId);
@@ -58,26 +59,18 @@ export class RedocContentViewerComponent {
     });
   }
 
-  /**
-   * Schedules Redoc initialization after the next tick so the #redoc container is in the DOM.
-   * The innerHTML is cleared before initialization to ensure a clean render state.
-   */
-  private scheduleRedocInit(spec: string): void {
-    this.pendingTimeoutId = window.setTimeout(() => this.initializeRedoc(spec), RENDER_DELAY_MS);
+  private scheduleRedocInit(spec: string, serverUrl?: string): void {
+    this.pendingTimeoutId = setTimeout(() => this.initializeRedoc(spec, serverUrl), RENDER_DELAY_MS);
   }
 
-  /**
-   * Initializes Redoc in the #redoc container: clears pending timeout, queries the container,
-   * clears its content, and calls RedocService.init with options (breakpoints from host CSS vars).
-   */
-  private initializeRedoc(spec: string): void {
+  private initializeRedoc(spec: string, serverUrl?: string): void {
     this.pendingTimeoutId = null;
     const redocElement = this.element.nativeElement?.querySelector('#redoc') as HTMLElement | null;
     if (!redocElement || !spec) {
       return;
     }
     redocElement.innerHTML = '';
-    this.redocService.init(spec, this.getRedocOptions(), redocElement);
+    this.redocService.init(spec, this.getRedocOptions(), redocElement, serverUrl);
   }
 
   /**
@@ -85,7 +78,7 @@ export class RedocContentViewerComponent {
    * (--redoc-breakpoint-medium, --redoc-breakpoint-large), with fallbacks.
    */
   private getRedocOptions(): Record<string, unknown> {
-    const style = this.element.nativeElement && window.getComputedStyle(this.element.nativeElement);
+    const style = this.element.nativeElement && getComputedStyle(this.element.nativeElement);
     const medium = style?.getPropertyValue('--redoc-breakpoint-medium')?.trim() || REDOC_BREAKPOINT_MEDIUM;
     const large = style?.getPropertyValue('--redoc-breakpoint-large')?.trim() || REDOC_BREAKPOINT_LARGE;
     return {

--- a/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-page-content.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/portal-navigation/portal-page-content.ts
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { PageConfiguration } from '../page/page-configuration';
+
 export type PortalPageContentType = 'GRAVITEE_MARKDOWN' | 'OPENAPI' | 'ASYNCAPI';
 
 export interface PortalPageContent {
   type: PortalPageContentType;
   content: string;
+  configuration?: PageConfiguration;
 }

--- a/gravitee-apim-portal-webui-next/src/services/redoc.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/redoc.service.ts
@@ -59,11 +59,12 @@ interface RedocOptions {
 export class RedocService {
   private readonly document = inject(DOCUMENT);
 
-  init(content: string | undefined, options: RedocOptions, element: HTMLElement): void {
+  init(content: string | undefined, options: RedocOptions, element: HTMLElement, serverUrl?: string): void {
     if (content) {
-      const swaggerSpec = this.parseContent(content);
+      const parsedSpec = this.parseContent(content) as Record<string, unknown>;
+      const spec = serverUrl ? { ...parsedSpec, servers: [{ url: serverUrl }] } : parsedSpec;
       const mergedOptions = this.mergeThemeWithPrimary(options);
-      Redoc.init(swaggerSpec, mergedOptions, element);
+      Redoc.init(spec, mergedOptions, element);
     }
   }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapper.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.management.v2.rest.model.PortalPageOpenApiConfigurat
 import io.gravitee.rest.api.management.v2.rest.model.PortalPageRedocConfiguration;
 import io.gravitee.rest.api.management.v2.rest.model.PortalPageSwaggerConfiguration;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -72,7 +73,7 @@ public interface PortalPageContentMapper {
         }
         return switch (configuration) {
             case SwaggerUiConfiguration cfg -> new PortalPageOpenApiConfiguration(mapToDto(cfg));
-            case RedocConfiguration ignored -> new PortalPageOpenApiConfiguration(mapRedocToDto());
+            case RedocConfiguration cfg -> new PortalPageOpenApiConfiguration(mapRedocToDto(cfg));
         };
     }
 
@@ -81,22 +82,22 @@ public interface PortalPageContentMapper {
             return null;
         }
         return switch (configuration.getActualInstance()) {
-            case PortalPageRedocConfiguration ignored -> new RedocConfiguration();
+            case PortalPageRedocConfiguration redoc -> new RedocConfiguration(Objects.requireNonNullElse(redoc.getTryItURL(), ""));
             case PortalPageSwaggerConfiguration swagger -> new SwaggerUiConfiguration(
-                swagger.getDisplayOperationId(),
+                Objects.requireNonNullElse(swagger.getDisplayOperationId(), false),
                 mapDocExpansion(swagger.getDocExpansion()),
-                swagger.getEnableFiltering(),
-                swagger.getMaxDisplayedTags(),
-                swagger.getShowCommonExtensions(),
-                swagger.getShowExtensions(),
-                swagger.getShowURL(),
-                swagger.getTryIt(),
-                swagger.getDisableSyntaxHighlight(),
-                swagger.getTryItAnonymous(),
-                swagger.getTryItURL(),
-                swagger.getUsePkce(),
-                swagger.getEntrypointsAsServers(),
-                swagger.getEntrypointAsBasePath()
+                Objects.requireNonNullElse(swagger.getEnableFiltering(), false),
+                Objects.requireNonNullElse(swagger.getMaxDisplayedTags(), -1),
+                Objects.requireNonNullElse(swagger.getShowCommonExtensions(), false),
+                Objects.requireNonNullElse(swagger.getShowExtensions(), false),
+                Objects.requireNonNullElse(swagger.getShowURL(), false),
+                Objects.requireNonNullElse(swagger.getTryIt(), false),
+                Objects.requireNonNullElse(swagger.getDisableSyntaxHighlight(), false),
+                Objects.requireNonNullElse(swagger.getTryItAnonymous(), false),
+                Objects.requireNonNullElse(swagger.getTryItURL(), ""),
+                Objects.requireNonNullElse(swagger.getUsePkce(), false),
+                Objects.requireNonNullElse(swagger.getEntrypointsAsServers(), false),
+                Objects.requireNonNullElse(swagger.getEntrypointAsBasePath(), false)
             );
             default -> throw new IllegalStateException("Cannot map configuration to OpenApi configuration");
         };
@@ -130,9 +131,10 @@ public interface PortalPageContentMapper {
         return configuration;
     }
 
-    private static PortalPageRedocConfiguration mapRedocToDto() {
+    private static PortalPageRedocConfiguration mapRedocToDto(RedocConfiguration cfg) {
         var configuration = new PortalPageRedocConfiguration();
         configuration.setViewer(BasePortalPageOpenApiConfiguration.ViewerEnum.REDOC);
+        configuration.setTryItURL(cfg.tryItUrl());
         return configuration;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -2526,6 +2526,11 @@ components:
       description: Redoc viewer configuration for a portal page content
       allOf:
         - $ref: "#/components/schemas/BasePortalPageOpenApiConfiguration"
+        - properties:
+            tryItURL:
+              type: string
+              description: Base URL used as OpenAPI server URL for Redoc.
+              default: ""
 
     PortalPageContent:
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
@@ -163,7 +163,7 @@ class PortalPageContentMapperTest {
             "ORG",
             "ENV",
             OpenApi.of("openapi: 3.0.0"),
-            new RedocConfiguration()
+            new RedocConfiguration("https://redoc.example.com")
         );
 
         // When
@@ -173,7 +173,10 @@ class PortalPageContentMapperTest {
         assertThat(result.getConfiguration()).isNotNull();
         assertThat(result.getConfiguration().getActualInstance()).isInstanceOfSatisfying(
             PortalPageRedocConfiguration.class,
-            configuration -> assertThat(configuration.getViewer()).isEqualTo(BasePortalPageOpenApiConfiguration.ViewerEnum.REDOC)
+            configuration -> {
+                assertThat(configuration.getViewer()).isEqualTo(BasePortalPageOpenApiConfiguration.ViewerEnum.REDOC);
+                assertThat(configuration.getTryItURL()).isEqualTo("https://redoc.example.com");
+            }
         );
     }
 
@@ -264,7 +267,9 @@ class PortalPageContentMapperTest {
         var result = mapper.map(content);
 
         // Then
-        assertThat(result.getConfiguration()).isInstanceOf(RedocConfiguration.class);
+        assertThat(result.getConfiguration()).isInstanceOfSatisfying(RedocConfiguration.class, configuration ->
+            assertThat(configuration.tryItUrl()).isEqualTo("https://redoc.example.com")
+        );
     }
 
     private static PortalPageSwaggerConfiguration newSwaggerConfiguration() {
@@ -276,6 +281,7 @@ class PortalPageContentMapperTest {
     private static PortalPageRedocConfiguration newRedocConfiguration() {
         var configuration = new PortalPageRedocConfiguration();
         configuration.setViewer(BasePortalPageOpenApiConfiguration.ViewerEnum.REDOC);
+        configuration.setTryItURL("https://redoc.example.com");
         return configuration;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResourceTest.java
@@ -369,6 +369,43 @@ class PortalPageContentsResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_update_redoc_configuration_with_try_it_url() {
+            // Given
+            when(
+                permissionService.hasPermission(
+                    GraviteeContext.getExecutionContext(),
+                    RolePermission.ENVIRONMENT_DOCUMENTATION,
+                    ENVIRONMENT,
+                    RolePermissionAction.UPDATE
+                )
+            ).thenReturn(true);
+
+            var configuration = Map.of("viewer", "REDOC", "tryItURL", "https://redoc.example.com");
+
+            // When
+            Response response = target.path(CONTENT_ID).path("configuration").request().method("PATCH", Entity.json(configuration));
+
+            // Then
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(io.gravitee.rest.api.management.v2.rest.model.PortalPageContent.class)
+                .satisfies(result -> {
+                    assertThat(result.getId()).isEqualTo(CONTENT_ID);
+                    assertThat(result.getContent()).isEqualTo(OPENAPI_CONTENT);
+                    assertThat(result.getConfiguration().getActualInstance()).isInstanceOfSatisfying(
+                        io.gravitee.rest.api.management.v2.rest.model.PortalPageRedocConfiguration.class,
+                        redocConfiguration -> assertThat(redocConfiguration.getTryItURL()).isEqualTo("https://redoc.example.com")
+                    );
+                });
+
+            var storedContent = (OpenApiPageContent) portalPageContentCrudService.storage().getFirst();
+            assertThat(storedContent.getContent().value()).isEqualTo(OPENAPI_CONTENT);
+            assertThat(storedContent.getViewerSettings()).isInstanceOfSatisfying(RedocConfiguration.class, redocConfiguration ->
+                assertThat(redocConfiguration.tryItUrl()).isEqualTo("https://redoc.example.com")
+            );
+        }
+
+        @Test
         void should_return_403_when_insufficient_permissions() {
             // Given
             when(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.portal.rest.mapper;
 
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiConfiguration;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
@@ -27,7 +28,9 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
 import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
 import io.gravitee.rest.api.portal.rest.model.PageConfiguration;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
@@ -75,10 +78,45 @@ public interface PortalNavigationItemMapper {
     }
 
     @Mapping(target = "content", expression = "java(content.value())")
-    @Mapping(target = "configuration", ignore = true)
     @Mapping(target = "_configuration", ignore = true)
     @Mapping(source = "type", target = "type")
     io.gravitee.rest.api.portal.rest.model.PortalPageContent map(RenderedPageContent content);
+
+    default PageConfiguration map(OpenApiConfiguration configuration) {
+        if (configuration == null) {
+            return null;
+        }
+
+        return switch (configuration) {
+            case SwaggerUiConfiguration cfg -> map(cfg);
+            case RedocConfiguration cfg -> mapRedocConfiguration(cfg);
+        };
+    }
+
+    private static PageConfiguration map(SwaggerUiConfiguration cfg) {
+        var configuration = new PageConfiguration();
+        configuration.setDisplayOperationId(cfg.displayOperationId());
+        configuration.setDocExpansion(PageConfiguration.DocExpansionEnum.fromValue(cfg.docExpansion()));
+        configuration.setEnableFiltering(cfg.enableFiltering());
+        configuration.setMaxDisplayedTags(cfg.maxDisplayedTags());
+        configuration.setShowCommonExtensions(cfg.showCommonExtensions());
+        configuration.setShowExtensions(cfg.showExtensions());
+        configuration.setShowUrl(cfg.showUrl());
+        configuration.setTryIt(cfg.tryIt());
+        configuration.setDisableSyntaxHighlight(cfg.disableSyntaxHighlight());
+        configuration.setTryItAnonymous(cfg.tryItAnonymous());
+        configuration.setTryItUrl(cfg.tryItUrl());
+        configuration.setUsePkce(cfg.usePkce());
+        configuration.setViewer(PageConfiguration.ViewerEnum.SWAGGER);
+        return configuration;
+    }
+
+    private static PageConfiguration mapRedocConfiguration(RedocConfiguration cfg) {
+        var configuration = new PageConfiguration();
+        configuration.setViewer(PageConfiguration.ViewerEnum.REDOC);
+        configuration.setTryItUrl(cfg.tryItUrl());
+        return configuration;
+    }
 
     default String map(@Nullable PortalNavigationItemId portalNavigationItemId) {
         if (portalNavigationItemId == null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
@@ -27,9 +27,12 @@ import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
 import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
+import io.gravitee.rest.api.portal.rest.model.PageConfiguration;
 import io.gravitee.rest.api.portal.rest.model.PortalPageContent;
 import io.gravitee.rest.api.portal.rest.model.PortalPageContentType;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -202,6 +205,103 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
             var content = response.readEntity(PortalPageContent.class);
             assertThat(content.getContent()).isEqualTo("Page content text");
             assertThat(content.getType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
+        }
+
+        @Test
+        void should_return_openapi_content_configuration_when_page_found_and_published() {
+            // Given
+            var itemId = PortalNavigationFixtures.randomNavigationId();
+            var contentId = PortalNavigationFixtures.randomPageId();
+            var configuration = new SwaggerUiConfiguration(
+                true,
+                "list",
+                true,
+                12,
+                true,
+                true,
+                true,
+                true,
+                true,
+                true,
+                "https://sandbox.example.com",
+                true,
+                false,
+                false
+            );
+            var pageContent = PortalPageContentFixtures.anOpenApiPageContent(
+                contentId,
+                ORGANIZATION_ID,
+                ENV_ID,
+                "openapi: 3.0.3\ninfo:\n  title: Test",
+                configuration
+            );
+
+            var publishedPage = PortalNavigationFixtures.page(itemId, "Published Page", PortalArea.TOP_NAVBAR, contentId);
+            publishedPage.setPublished(true);
+            publishedPage.setEnvironmentId(ENV_ID);
+
+            portalNavigationItemsQueryService.initWith(List.of(publishedPage));
+            portalPageContentQueryService.initWith(List.of(pageContent));
+
+            // When
+            Response response = target(itemId.toString()).path("content").request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(200);
+            var content = response.readEntity(PortalPageContent.class);
+            assertThat(content.getContent()).isEqualTo("openapi: 3.0.3\ninfo:\n  title: Test");
+            assertThat(content.getType()).isEqualTo(PortalPageContentType.OPENAPI);
+
+            PageConfiguration pageConfiguration = content.getConfiguration();
+            assertThat(pageConfiguration).isNotNull();
+            assertThat(pageConfiguration.getViewer()).isEqualTo(PageConfiguration.ViewerEnum.SWAGGER);
+            assertThat(pageConfiguration.getDisplayOperationId()).isTrue();
+            assertThat(pageConfiguration.getDocExpansion()).isEqualTo(PageConfiguration.DocExpansionEnum.LIST);
+            assertThat(pageConfiguration.getEnableFiltering()).isTrue();
+            assertThat(pageConfiguration.getMaxDisplayedTags()).isEqualTo(12);
+            assertThat(pageConfiguration.getShowCommonExtensions()).isTrue();
+            assertThat(pageConfiguration.getShowExtensions()).isTrue();
+            assertThat(pageConfiguration.getShowUrl()).isTrue();
+            assertThat(pageConfiguration.getTryIt()).isTrue();
+            assertThat(pageConfiguration.getDisableSyntaxHighlight()).isTrue();
+            assertThat(pageConfiguration.getTryItAnonymous()).isTrue();
+            assertThat(pageConfiguration.getTryItUrl()).isEqualTo("https://sandbox.example.com");
+            assertThat(pageConfiguration.getUsePkce()).isTrue();
+        }
+
+        @Test
+        void should_return_redoc_openapi_content_configuration_when_page_found_and_published() {
+            // Given
+            var itemId = PortalNavigationFixtures.randomNavigationId();
+            var contentId = PortalNavigationFixtures.randomPageId();
+            var pageContent = PortalPageContentFixtures.anOpenApiPageContent(
+                contentId,
+                ORGANIZATION_ID,
+                ENV_ID,
+                "openapi: 3.0.3\ninfo:\n  title: Test",
+                new RedocConfiguration("https://redoc.example.com")
+            );
+
+            var publishedPage = PortalNavigationFixtures.page(itemId, "Published Page", PortalArea.TOP_NAVBAR, contentId);
+            publishedPage.setPublished(true);
+            publishedPage.setEnvironmentId(ENV_ID);
+
+            portalNavigationItemsQueryService.initWith(List.of(publishedPage));
+            portalPageContentQueryService.initWith(List.of(pageContent));
+
+            // When
+            Response response = target(itemId.toString()).path("content").request().get();
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(200);
+            var content = response.readEntity(PortalPageContent.class);
+            assertThat(content.getContent()).isEqualTo("openapi: 3.0.3\ninfo:\n  title: Test");
+            assertThat(content.getType()).isEqualTo(PortalPageContentType.OPENAPI);
+
+            PageConfiguration pageConfiguration = content.getConfiguration();
+            assertThat(pageConfiguration).isNotNull();
+            assertThat(pageConfiguration.getViewer()).isEqualTo(PageConfiguration.ViewerEnum.REDOC);
+            assertThat(pageConfiguration.getTryItUrl()).isEqualTo("https://redoc.example.com");
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/DefaultContentRenderer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/DefaultContentRenderer.java
@@ -36,7 +36,11 @@ public class DefaultContentRenderer implements ContentRenderer {
     @Override
     public RenderedPageContent render(PortalNavigationItem item, PortalPageContent<?> content) {
         return switch (content) {
-            case OpenApiPageContent oapi -> RenderedPageContent.of(oapi.getContent().value(), PortalPageContentType.OPENAPI);
+            case OpenApiPageContent oapi -> RenderedPageContent.of(
+                oapi.getContent().value(),
+                PortalPageContentType.OPENAPI,
+                oapi.getViewerSettings()
+            );
             case AsyncApiPageContent aapi -> RenderedPageContent.of(aapi.getContent().value(), PortalPageContentType.ASYNCAPI);
             default -> throw new RendererException("Content type not supported: " + content.getType());
         };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/OpenApiPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/OpenApiPageContent.java
@@ -77,9 +77,9 @@ public final class OpenApiPageContent extends PortalPageContent<OpenApi> {
     @Override
     public void update(@Nonnull UpdatePortalPageContent updatePortalPageContent) {
         this.content = OpenApi.of(updatePortalPageContent.getContent());
-        this.viewerSettings = updatePortalPageContent.getConfiguration() != null
-            ? updatePortalPageContent.getConfiguration()
-            : new RedocConfiguration();
+        if (updatePortalPageContent.getConfiguration() != null) {
+            this.viewerSettings = updatePortalPageContent.getConfiguration();
+        }
     }
 
     public void updateViewerSettings(@Nonnull OpenApiConfiguration viewerSettings) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/RenderedPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/RenderedPageContent.java
@@ -15,8 +15,12 @@
  */
 package io.gravitee.apim.core.portal_page.model;
 
-public record RenderedPageContent(String value, PortalPageContentType type) {
+public record RenderedPageContent(String value, PortalPageContentType type, OpenApiConfiguration configuration) {
     public static RenderedPageContent of(String value, PortalPageContentType type) {
-        return new RenderedPageContent(value, type);
+        return new RenderedPageContent(value, type, null);
+    }
+
+    public static RenderedPageContent of(String value, PortalPageContentType type, OpenApiConfiguration configuration) {
+        return new RenderedPageContent(value, type, configuration);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapter.java
@@ -173,7 +173,7 @@ public interface PortalPageContentAdapter {
                 OpenApiConfiguration.Viewer.valueOf(viewerNode.asText())
             );
             return switch (viewer.orElse(OpenApiConfiguration.Viewer.REDOC)) {
-                case REDOC -> new RedocConfiguration();
+                case REDOC -> new RedocConfiguration(optionalText(node, "tryItUrl", optionalText(node, "tryItURL", "")));
                 case SWAGGER -> new SwaggerUiConfiguration(
                     optionalBoolean(node, "displayOperationId", false),
                     optionalText(node, "docExpansion", "none"),
@@ -200,7 +200,10 @@ public interface PortalPageContentAdapter {
         throws com.fasterxml.jackson.core.JsonProcessingException {
         var values = new LinkedHashMap<String, Object>();
         switch (configuration) {
-            case RedocConfiguration ignored -> values.put("viewer", OpenApiConfiguration.Viewer.REDOC);
+            case RedocConfiguration redoc -> {
+                values.put("viewer", OpenApiConfiguration.Viewer.REDOC);
+                values.put("tryItUrl", redoc.tryItUrl());
+            }
             case SwaggerUiConfiguration swagger -> {
                 values.put("viewer", OpenApiConfiguration.Viewer.SWAGGER);
                 values.put("displayOperationId", swagger.displayOperationId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
@@ -52,6 +52,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import java.util.List;
 import java.util.Map;
@@ -185,6 +186,55 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
         assertThat(output.renderedContent()).isNotNull();
         assertThat(output.renderedContent().type()).isEqualTo(PortalPageContentType.ASYNCAPI);
         assertThat(output.renderedContent().value()).isEqualTo(content);
+    }
+
+    @Test
+    void should_return_openapi_page_content_with_viewer_configuration_when_navigation_page_found() {
+        var contentId = PortalPageContentId.random();
+        var pageId = "00000000-0000-0000-0000-000000000096";
+        var content = "openapi: 3.0.3\ninfo:\n  title: Test";
+        var configuration = new SwaggerUiConfiguration(
+            true,
+            "list",
+            true,
+            12,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            "https://sandbox.example.com",
+            true,
+            false,
+            false
+        );
+        var page = PortalNavigationItemFixtures.aPage(pageId, "OpenAPI page", null, contentId);
+        page.markAsRoot();
+        var openApiContent = PortalPageContentFixtures.anOpenApiPageContent(
+            contentId,
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            content,
+            configuration
+        );
+
+        pageContentQueryService.initWith(List.of(openApiContent));
+        navigationItemsQueryService.initWith(List.of(page));
+
+        var output = useCase.execute(
+            new GetPortalPageContentByNavigationIdUseCase.Input(
+                pageId,
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                PortalNavigationItemViewerContext.forConsole()
+            )
+        );
+
+        assertThat(output.renderedContent()).isNotNull();
+        assertThat(output.renderedContent().type()).isEqualTo(PortalPageContentType.OPENAPI);
+        assertThat(output.renderedContent().value()).isEqualTo(content);
+        assertThat(output.renderedContent().configuration()).isEqualTo(configuration);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.portal_page.use_case;
 import static fixtures.core.model.PortalPageContentFixtures.CONTENT_ID;
 import static fixtures.core.model.PortalPageContentFixtures.ENVIRONMENT_ID;
 import static fixtures.core.model.PortalPageContentFixtures.ORGANIZATION_ID;
+import static fixtures.core.model.SwaggerUiConfigurationFixtures.aSwaggerUiConfiguration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,10 +37,13 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosin
 import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -49,11 +53,13 @@ import org.junit.jupiter.api.Test;
 class UpdatePortalPageContentUseCaseTest {
 
     private UpdatePortalPageContentUseCase useCase;
+    private PortalPageContentQueryServiceInMemory queryService;
+    private PortalPageContentCrudServiceInMemory crudService;
 
     @BeforeEach
     void setUp() {
-        PortalPageContentQueryServiceInMemory queryService = new PortalPageContentQueryServiceInMemory();
-        PortalPageContentCrudServiceInMemory crudService = new PortalPageContentCrudServiceInMemory();
+        queryService = new PortalPageContentQueryServiceInMemory();
+        crudService = new PortalPageContentCrudServiceInMemory();
 
         GraviteeMarkdownValidator gmdValidator = new GraviteeMarkdownValidator();
         PortalNavigationItemsQueryService portalNavigationItemsQueryService = mock(PortalNavigationItemsQueryService.class);
@@ -93,6 +99,38 @@ class UpdatePortalPageContentUseCaseTest {
         final var updatedContent = (GraviteeMarkdownPageContent) output.portalPageContent();
         assertThat(updatedContent.getContent().value()).isEqualTo("Updated content");
         assertThat(updatedContent.getId()).isEqualTo(PortalPageContentId.of(CONTENT_ID));
+    }
+
+    @Test
+    void should_preserve_openapi_viewer_configuration_when_updating_content_only() {
+        // Given
+        final var contentId = PortalPageContentId.of("00000000-0000-0000-0000-000000000003");
+        final var openApiContent = PortalPageContentFixtures.anOpenApiPageContent(
+            contentId,
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            "openapi: 3.0.3\ninfo:\n  title: Initial",
+            aSwaggerUiConfiguration()
+        );
+        queryService.initWith(List.of(openApiContent));
+        crudService.initWith(List.of(openApiContent));
+
+        final var updateContent = UpdatePortalPageContent.builder().content("openapi: 3.0.3\ninfo:\n  title: Updated").build();
+        final var input = UpdatePortalPageContentUseCase.Input.builder()
+            .organizationId(ORGANIZATION_ID)
+            .environmentId(ENVIRONMENT_ID)
+            .portalPageContentId(contentId.toString())
+            .updatePortalPageContent(updateContent)
+            .build();
+
+        // When
+        final var output = useCase.execute(input);
+
+        // Then
+        assertThat(output.portalPageContent()).isInstanceOf(OpenApiPageContent.class);
+        final var updatedContent = (OpenApiPageContent) output.portalPageContent();
+        assertThat(updatedContent.getContent().value()).contains("title: Updated");
+        assertThat(updatedContent.getViewerSettings()).isInstanceOf(SwaggerUiConfiguration.class);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapterTest.java
@@ -119,7 +119,29 @@ class PortalPageContentAdapterTest {
             // Then
             assertThat(entity).isInstanceOf(OpenApiPageContent.class);
             var openApiContent = (OpenApiPageContent) entity;
-            assertThat(openApiContent.getViewerSettings()).isInstanceOf(RedocConfiguration.class);
+            assertThat(openApiContent.getViewerSettings()).isInstanceOfSatisfying(RedocConfiguration.class, configuration ->
+                assertThat(configuration.tryItUrl()).isEmpty()
+            );
+        }
+
+        @Test
+        void should_map_openapi_content_with_redoc_try_it_url_configuration_to_entity() {
+            // Given
+            var repositoryContent = anOpenApiPageContent(
+                "550e8400-e29b-41d4-a716-446655440006",
+                "openapi: 3.0.0",
+                "{\"viewer\":\"REDOC\",\"tryItUrl\":\"https://redoc.example.com\"}"
+            );
+
+            // When
+            var entity = adapter.toEntity(repositoryContent);
+
+            // Then
+            assertThat(entity).isInstanceOf(OpenApiPageContent.class);
+            var openApiContent = (OpenApiPageContent) entity;
+            assertThat(openApiContent.getViewerSettings()).isInstanceOfSatisfying(RedocConfiguration.class, configuration ->
+                assertThat(configuration.tryItUrl()).isEqualTo("https://redoc.example.com")
+            );
         }
 
         @Test
@@ -236,6 +258,26 @@ class PortalPageContentAdapterTest {
             assertThat(repositoryContent.getConfiguration()).contains("\"viewer\":\"SWAGGER\"");
             assertThat(repositoryContent.getConfiguration()).contains("\"docExpansion\":\"full\"");
             assertThat(repositoryContent.getConfiguration()).contains("\"tryItUrl\":\"https://try-it.example.com\"");
+        }
+
+        @Test
+        void should_map_openapi_content_with_redoc_try_it_url_configuration_to_repository() {
+            // Given
+            final var entityContent = PortalPageContentFixtures.anOpenApiPageContent(
+                PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440006"),
+                "DEFAULT_ORG",
+                "DEFAULT_ENV",
+                "openapi: 3.0.0",
+                new RedocConfiguration("https://redoc.example.com")
+            );
+
+            // When
+            var repositoryContent = adapter.toRepository(entityContent);
+
+            // Then
+            assertThat(repositoryContent.getType()).isEqualTo(PortalPageContent.Type.OPENAPI);
+            assertThat(repositoryContent.getConfiguration()).contains("\"viewer\":\"REDOC\"");
+            assertThat(repositoryContent.getConfiguration()).contains("\"tryItUrl\":\"https://redoc.example.com\"");
         }
     }
 }


### PR DESCRIPTION
Link to jira ticket: https://gravitee.atlassian.net/browse/EXT-122

Summary
Implements the OpenAPI viewer configuration UI for the console navigation items editor, and wires all configuration options through to both the console preview and the portal-next rendering pipeline.

Console (gravitee-apim-console-webui)
New configuration dialog (openapi-config-dialog) — allows configuring the OpenAPI viewer with all available options: viewer selection (SwaggerUI / Redoc), base URL override, and SwaggerUI-specific options (Try It Out, doc expansion, operation ID display, filtering, extensions, max displayed tags, OAuth/PKCE settings)
Redoc viewer added as a new gio-redoc Angular component, used in the split-pane OpenAPI editor preview alongside the existing gio-swagger-ui
Config options wired to preview — all SwaggerUI configuration values (tryItURL, docExpansion, displayOperationId, enableFiltering, showExtensions, showCommonExtensions, maxDisplayedTags) are now passed from the config dialog to the viewer components in real time

Configuration modal:
<img width="1716" height="914" alt="image" src="https://github.com/user-attachments/assets/491c1f88-1c39-43ce-853d-953b2d1a090f" />

Swagger preview:
<img width="1724" height="876" alt="image" src="https://github.com/user-attachments/assets/94adbd49-93fb-41b4-abb6-623c83dc8f89" />

Redoc preview:
<img width="1712" height="886" alt="image" src="https://github.com/user-attachments/assets/e0a8eb5b-1f26-4e48-bb69-590dde700054" />

Swagger portal:
<img width="1726" height="930" alt="image" src="https://github.com/user-attachments/assets/5716260b-1295-4687-bff8-25892f5bd9c6" />

Redoc portal:
<img width="1719" height="947" alt="image" src="https://github.com/user-attachments/assets/a91fd2b5-9fdb-4f28-821c-fdc81c8ee240" />


