### PR TITLE
feat(portal): APIM-13764 implement application invitation creation - …

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -108,6 +108,7 @@ import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.group.use_case.ValidateGroupCRDUseCase;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
@@ -358,6 +359,11 @@ public class ResourceContextConfiguration {
     @Bean
     public InvitationQueryService invitationQueryService() {
         return mock(InvitationQueryService.class);
+    }
+
+    @Bean
+    public InvitationCrudService invitationCrudService() {
+        return mock(InvitationCrudService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -134,6 +134,7 @@ import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
@@ -470,6 +471,11 @@ public class ResourceContextConfiguration {
     @Bean
     public InvitationQueryService invitationQueryService() {
         return mock(InvitationQueryService.class);
+    }
+
+    @Bean
+    public InvitationCrudService invitationCrudService() {
+        return mock(InvitationCrudService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -103,6 +103,7 @@ import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainService;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
@@ -323,6 +324,11 @@ public class ResourceContextConfiguration {
     @Bean
     public InvitationQueryService invitationQueryService() {
         return mock(InvitationQueryService.class);
+    }
+
+    @Bean
+    public InvitationCrudService invitationCrudService() {
+        return mock(InvitationCrudService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapper.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.rest.api.portal.rest.mapper;
 
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
 import io.gravitee.rest.api.portal.rest.model.Invitation;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
@@ -30,9 +30,9 @@ public interface ApplicationInvitationMapper {
     ApplicationInvitationMapper INSTANCE = Mappers.getMapper(ApplicationInvitationMapper.class);
 
     @Mapping(target = "role", source = "roleName")
-    Invitation toInvitation(ApplicationInvitationItem invitation);
+    Invitation toInvitation(ApplicationInvitation invitation);
 
-    List<Invitation> toInvitation(List<ApplicationInvitationItem> invitations);
+    List<Invitation> toInvitation(List<ApplicationInvitation> invitations);
 
     default String map(ApplicationInvitationId id) {
         return id.toString();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapperTest.java
@@ -17,8 +17,8 @@ package io.gravitee.rest.api.portal.rest.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
@@ -30,8 +30,9 @@ class ApplicationInvitationMapperTest {
     @Test
     void should_map_application_invitation_item() {
         var invitationId = "00000000-0000-0000-0000-000000000001";
-        var invitationItem = new ApplicationInvitationItem(
+        var invitationItem = new ApplicationInvitation(
             ApplicationInvitationId.of(invitationId),
+            "application-id",
             "alice@example.com",
             "USER",
             ZonedDateTime.parse("2026-04-23T09:30:00Z"),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
@@ -25,8 +25,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import inmemory.ApplicationCrudServiceInMemory;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
 import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.common.data.domain.Page;
@@ -152,9 +152,10 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
         verify(invitationQueryService, never()).findByApplicationId(anyString(), any(), any());
     }
 
-    private ApplicationInvitationItem anInvitation(String id, String email) {
-        return new ApplicationInvitationItem(
+    private ApplicationInvitation anInvitation(String id, String email) {
+        return new ApplicationInvitation(
             ApplicationInvitationId.of(id),
+            APPLICATION,
             email,
             "USER",
             ZonedDateTime.parse("2026-04-23T09:30:00Z"),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -107,6 +107,7 @@ import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainService;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
@@ -462,6 +463,11 @@ public class ResourceContextConfiguration {
     @Bean
     public InvitationQueryService invitationQueryService() {
         return mock(InvitationQueryService.class);
+    }
+
+    @Bean
+    public InvitationCrudService invitationCrudService() {
+        return mock(InvitationCrudService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/crud_service/InvitationCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/crud_service/InvitationCrudService.java
@@ -13,22 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.query_service;
+package io.gravitee.apim.core.invitation.crud_service;
 
 import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
-import io.gravitee.apim.core.invitation.model.InvitationReferenceType;
-import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
-import io.gravitee.common.data.domain.Page;
-import io.gravitee.rest.api.model.common.Pageable;
-import jakarta.annotation.Nonnull;
 import java.util.List;
 
-public interface InvitationQueryService {
-    List<ApplicationInvitationItem> findByReference(InvitationReferenceType referenceType, String referenceId);
-
-    Page<ApplicationInvitationItem> findByApplicationId(
-        String applicationId,
-        @Nonnull SearchApplicationInvitationsCriteria criteria,
-        @Nonnull Pageable pageable
-    );
+public interface InvitationCrudService {
+    List<ApplicationInvitationItem> createApplicationInvitations(String applicationId, String role, List<String> emails);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/crud_service/InvitationCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/crud_service/InvitationCrudService.java
@@ -15,9 +15,8 @@
  */
 package io.gravitee.apim.core.invitation.crud_service;
 
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
-import java.util.List;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 
 public interface InvitationCrudService {
-    List<ApplicationInvitationItem> createApplicationInvitations(String applicationId, String role, List<String> emails);
+    ApplicationInvitation create(ApplicationInvitation invitation);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
@@ -21,17 +21,16 @@ import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.exception.ConflictDomainException;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
-import io.gravitee.apim.core.invitation.model.InvitationReferenceType;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationReference;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
 import io.gravitee.apim.core.membership.query_service.RoleQueryService;
 import io.gravitee.rest.api.service.common.ReferenceContext;
+import jakarta.annotation.Nonnull;
 import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 
@@ -43,53 +42,54 @@ public class CreateApplicationInvitationsDomainService {
     private final InvitationCrudService invitationCrudService;
     private final RoleQueryService roleQueryService;
 
-    public List<ApplicationInvitationItem> create(
-        String organizationId,
-        String applicationId,
-        Set<String> recipientEmails,
-        String role,
+    public List<ApplicationInvitation> create(
+        @Nonnull String organizationId,
+        @Nonnull String applicationId,
+        @Nonnull Set<String> recipientEmails,
+        @Nonnull String roleName,
         boolean notifyUsers
     ) {
         if (notifyUsers) {
             throw new UnsupportedOperationException("Application invitation notifications are not implemented yet.");
         }
 
-        var sanitizedRole = validateAndSanitizeRole(organizationId, role);
-        var emails = validateAndSanitizeRecipients(recipientEmails);
+        validateRoleName(organizationId, roleName);
+        var emails = validateRecipients(recipientEmails);
 
         validateNoPendingInvitation(applicationId, emails);
-        return invitationCrudService.createApplicationInvitations(applicationId, sanitizedRole, emails);
+        return emails
+            .stream()
+            .map(email -> ApplicationInvitation.create(applicationId, email, roleName))
+            .map(invitationCrudService::create)
+            .toList();
     }
 
-    private String validateAndSanitizeRole(String organizationId, String role) {
-        if (role == null || role.isBlank()) {
+    private void validateRoleName(String organizationId, String roleName) {
+        if (roleName == null || roleName.isBlank()) {
             throw new ValidationDomainException("Application invitation role must not be blank.");
         }
 
-        var sanitizedRole = role.trim();
         var referenceContext = new ReferenceContext(ORGANIZATION, organizationId);
         roleQueryService
-            .findApplicationRole(sanitizedRole, referenceContext)
-            .orElseThrow(() -> new RoleNotFoundException(sanitizedRole, referenceContext));
-
-        return sanitizedRole;
+            .findApplicationRole(roleName, referenceContext)
+            .orElseThrow(() -> new RoleNotFoundException(roleName, referenceContext));
     }
 
-    private List<String> validateAndSanitizeRecipients(Set<String> recipients) {
+    private Set<String> validateRecipients(Set<String> recipients) {
         if (recipients == null || recipients.isEmpty()) {
             throw new ValidationDomainException("At least one application invitation recipient is required.");
         }
 
-        var sanitizedEmails = new ArrayList<String>();
-        for (var recipient : recipients) {
-            var email = sanitizeEmail(recipient);
+        for (var email : recipients) {
+            if (email == null || email.isBlank()) {
+                throw new ValidationDomainException("Application invitation email must not be blank.");
+            }
             if (!isValidEmail(email)) {
                 throw new ValidationDomainException("Application invitation email is invalid: " + email);
             }
-            sanitizedEmails.add(email);
         }
 
-        return sanitizedEmails;
+        return recipients;
     }
 
     private boolean isValidEmail(String email) {
@@ -102,21 +102,15 @@ public class CreateApplicationInvitationsDomainService {
         }
     }
 
-    private void validateNoPendingInvitation(String applicationId, List<String> emails) {
-        var requestedEmails = Set.copyOf(emails);
+    private void validateNoPendingInvitation(String applicationId, Set<String> emails) {
         invitationQueryService
-            .findByReference(InvitationReferenceType.APPLICATION, applicationId)
+            .findByReference(InvitationReference.application(applicationId))
             .stream()
-            .map(ApplicationInvitationItem::email)
-            .map(this::sanitizeEmail)
-            .filter(requestedEmails::contains)
+            .map(ApplicationInvitation::email)
+            .filter(emails::contains)
             .findFirst()
             .ifPresent(email -> {
                 throw new ConflictDomainException("A pending application invitation already exists for email [" + email + "].", email);
             });
-    }
-
-    private String sanitizeEmail(String email) {
-        return email == null ? "" : email.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.domain_service;
+
+import static io.gravitee.rest.api.service.common.ReferenceContext.Type.ORGANIZATION;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.exception.ConflictDomainException;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.core.invitation.model.InvitationReferenceType;
+import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
+import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
+import io.gravitee.apim.core.membership.query_service.RoleQueryService;
+import io.gravitee.rest.api.service.common.ReferenceContext;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class CreateApplicationInvitationsDomainService {
+
+    private final InvitationQueryService invitationQueryService;
+    private final InvitationCrudService invitationCrudService;
+    private final RoleQueryService roleQueryService;
+
+    public List<ApplicationInvitationItem> create(
+        String organizationId,
+        String applicationId,
+        Set<String> recipientEmails,
+        String role,
+        boolean notifyUsers
+    ) {
+        if (notifyUsers) {
+            throw new UnsupportedOperationException("Application invitation notifications are not implemented yet.");
+        }
+
+        var sanitizedRole = validateAndSanitizeRole(organizationId, role);
+        var emails = validateAndSanitizeRecipients(recipientEmails);
+
+        validateNoPendingInvitation(applicationId, emails);
+        return invitationCrudService.createApplicationInvitations(applicationId, sanitizedRole, emails);
+    }
+
+    private String validateAndSanitizeRole(String organizationId, String role) {
+        if (role == null || role.isBlank()) {
+            throw new ValidationDomainException("Application invitation role must not be blank.");
+        }
+
+        var sanitizedRole = role.trim();
+        var referenceContext = new ReferenceContext(ORGANIZATION, organizationId);
+        roleQueryService
+            .findApplicationRole(sanitizedRole, referenceContext)
+            .orElseThrow(() -> new RoleNotFoundException(sanitizedRole, referenceContext));
+
+        return sanitizedRole;
+    }
+
+    private List<String> validateAndSanitizeRecipients(Set<String> recipients) {
+        if (recipients == null || recipients.isEmpty()) {
+            throw new ValidationDomainException("At least one application invitation recipient is required.");
+        }
+
+        var sanitizedEmails = new ArrayList<String>();
+        for (var recipient : recipients) {
+            var email = sanitizeEmail(recipient);
+            if (!isValidEmail(email)) {
+                throw new ValidationDomainException("Application invitation email is invalid: " + email);
+            }
+            sanitizedEmails.add(email);
+        }
+
+        return sanitizedEmails;
+    }
+
+    private boolean isValidEmail(String email) {
+        try {
+            var internetAddress = new InternetAddress(email);
+            internetAddress.validate();
+            return email.equals(internetAddress.getAddress());
+        } catch (AddressException e) {
+            return false;
+        }
+    }
+
+    private void validateNoPendingInvitation(String applicationId, List<String> emails) {
+        var requestedEmails = Set.copyOf(emails);
+        invitationQueryService
+            .findByReference(InvitationReferenceType.APPLICATION, applicationId)
+            .stream()
+            .map(ApplicationInvitationItem::email)
+            .map(this::sanitizeEmail)
+            .filter(requestedEmails::contains)
+            .findFirst()
+            .ifPresent(email -> {
+                throw new ConflictDomainException("A pending application invitation already exists for email [" + email + "].", email);
+            });
+    }
+
+    private String sanitizeEmail(String email) {
+        return email == null ? "" : email.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/ApplicationInvitation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/ApplicationInvitation.java
@@ -18,15 +18,16 @@ package io.gravitee.apim.core.invitation.model;
 import io.gravitee.common.utils.TimeProvider;
 import java.time.ZonedDateTime;
 
-public record ApplicationInvitationItem(
+public record ApplicationInvitation(
     ApplicationInvitationId id,
+    String applicationId,
     String email,
     String roleName,
     ZonedDateTime createdAt,
     ZonedDateTime updatedAt
 ) {
-    public static ApplicationInvitationItem create(String email, String roleName) {
+    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
         var now = TimeProvider.now();
-        return new ApplicationInvitationItem(ApplicationInvitationId.random(), email, roleName, now, now);
+        return new ApplicationInvitation(ApplicationInvitationId.random(), applicationId, email, roleName, now, now);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/InvitationReference.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/InvitationReference.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.model;
+
+import jakarta.annotation.Nonnull;
+import java.util.Objects;
+
+public record InvitationReference(@Nonnull InvitationReferenceType type, @Nonnull String id) {
+    public InvitationReference {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(id, "id");
+    }
+
+    public static InvitationReference application(String applicationId) {
+        return new InvitationReference(InvitationReferenceType.APPLICATION, applicationId);
+    }
+
+    public static InvitationReference api(String apiId) {
+        return new InvitationReference(InvitationReferenceType.API, apiId);
+    }
+
+    public static InvitationReference group(String groupId) {
+        return new InvitationReference(InvitationReferenceType.GROUP, groupId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/InvitationReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/InvitationReferenceType.java
@@ -17,5 +17,6 @@ package io.gravitee.apim.core.invitation.model;
 
 public enum InvitationReferenceType {
     APPLICATION,
+    API,
     GROUP,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/InvitationReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/InvitationReferenceType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.model;
+
+public enum InvitationReferenceType {
+    APPLICATION,
+    GROUP,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/query_service/InvitationQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/query_service/InvitationQueryService.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.apim.core.invitation.query_service;
 
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
-import io.gravitee.apim.core.invitation.model.InvitationReferenceType;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationReference;
 import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -24,9 +24,9 @@ import jakarta.annotation.Nonnull;
 import java.util.List;
 
 public interface InvitationQueryService {
-    List<ApplicationInvitationItem> findByReference(InvitationReferenceType referenceType, String referenceId);
+    List<ApplicationInvitation> findByReference(@Nonnull InvitationReference reference);
 
-    Page<ApplicationInvitationItem> findByApplicationId(
+    Page<ApplicationInvitation> findByApplicationId(
         String applicationId,
         @Nonnull SearchApplicationInvitationsCriteria criteria,
         @Nonnull Pageable pageable

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/SearchApplicationInvitationsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/SearchApplicationInvitationsUseCase.java
@@ -17,7 +17,7 @@ package io.gravitee.apim.core.invitation.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.common.data.domain.Page;
@@ -51,5 +51,5 @@ public class SearchApplicationInvitationsUseCase {
         Pageable pageable
     ) {}
 
-    public record Output(Page<ApplicationInvitationItem> invitations) {}
+    public record Output(Page<ApplicationInvitation> invitations) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApplicationInvitationAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApplicationInvitationAdapter.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.infra.query_service.invitation;
+package io.gravitee.apim.infra.adapter;
 
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.repository.management.model.Invitation;
 import java.time.ZonedDateTime;
@@ -26,17 +26,32 @@ import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
-public interface ApplicationInvitationItemMapper {
-    ApplicationInvitationItemMapper INSTANCE = Mappers.getMapper(ApplicationInvitationItemMapper.class);
+public interface ApplicationInvitationAdapter {
+    ApplicationInvitationAdapter INSTANCE = Mappers.getMapper(ApplicationInvitationAdapter.class);
 
     @Mapping(target = "roleName", source = "applicationRole")
-    ApplicationInvitationItem toApplicationInvitationItem(Invitation invitation);
+    @Mapping(target = "applicationId", source = "referenceId")
+    ApplicationInvitation toEntity(Invitation invitation);
+
+    @Mapping(target = "applicationRole", source = "roleName")
+    @Mapping(target = "referenceId", source = "applicationId")
+    @Mapping(target = "referenceType", constant = "APPLICATION")
+    @Mapping(target = "apiRole", ignore = true)
+    Invitation toRepository(ApplicationInvitation invitation);
 
     default ApplicationInvitationId map(String id) {
         return ApplicationInvitationId.of(id);
     }
 
+    default String map(ApplicationInvitationId id) {
+        return id.toString();
+    }
+
     default ZonedDateTime map(Date date) {
         return date == null ? null : date.toInstant().atZone(TimeProvider.clock().getZone());
+    }
+
+    default Date map(ZonedDateTime date) {
+        return date == null ? null : Date.from(date.toInstant());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.invitation;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.infra.query_service.invitation.ApplicationInvitationItemMapper;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.InvitationRepository;
+import io.gravitee.repository.management.model.Invitation;
+import io.gravitee.repository.management.model.InvitationReferenceType;
+import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.impl.TransactionalService;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class InvitationCrudServiceImpl extends TransactionalService implements InvitationCrudService {
+
+    private final InvitationRepository invitationRepository;
+
+    public InvitationCrudServiceImpl(@Lazy InvitationRepository invitationRepository) {
+        this.invitationRepository = invitationRepository;
+    }
+
+    @Override
+    public List<ApplicationInvitationItem> createApplicationInvitations(String applicationId, String role, List<String> emails) {
+        try {
+            var createdInvitations = new ArrayList<ApplicationInvitationItem>();
+            for (var email : emails) {
+                createdInvitations.add(createApplicationInvitation(applicationId, role, email));
+            }
+            return createdInvitations;
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurs while trying to create application invitations", e);
+        }
+    }
+
+    private ApplicationInvitationItem createApplicationInvitation(String applicationId, String role, String email)
+        throws TechnicalException {
+        var invitation = new Invitation();
+        invitation.setId(UuidString.generateRandom());
+        invitation.setReferenceType(InvitationReferenceType.APPLICATION.name());
+        invitation.setReferenceId(applicationId);
+        invitation.setEmail(email);
+        invitation.setApiRole(null);
+        invitation.setApplicationRole(role);
+        invitation.setCreatedAt(new Date());
+
+        return ApplicationInvitationItemMapper.INSTANCE.toApplicationInvitationItem(invitationRepository.create(invitation));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImpl.java
@@ -17,17 +17,11 @@ package io.gravitee.apim.infra.crud_service.invitation;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
-import io.gravitee.apim.infra.query_service.invitation.ApplicationInvitationItemMapper;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.infra.adapter.ApplicationInvitationAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.InvitationRepository;
-import io.gravitee.repository.management.model.Invitation;
-import io.gravitee.repository.management.model.InvitationReferenceType;
-import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.impl.TransactionalService;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
@@ -41,29 +35,13 @@ public class InvitationCrudServiceImpl extends TransactionalService implements I
     }
 
     @Override
-    public List<ApplicationInvitationItem> createApplicationInvitations(String applicationId, String role, List<String> emails) {
+    public ApplicationInvitation create(ApplicationInvitation invitation) {
         try {
-            var createdInvitations = new ArrayList<ApplicationInvitationItem>();
-            for (var email : emails) {
-                createdInvitations.add(createApplicationInvitation(applicationId, role, email));
-            }
-            return createdInvitations;
+            return ApplicationInvitationAdapter.INSTANCE.toEntity(
+                invitationRepository.create(ApplicationInvitationAdapter.INSTANCE.toRepository(invitation))
+            );
         } catch (TechnicalException e) {
-            throw new TechnicalDomainException("An error occurs while trying to create application invitations", e);
+            throw new TechnicalDomainException("An error occurs while trying to create application invitation", e);
         }
-    }
-
-    private ApplicationInvitationItem createApplicationInvitation(String applicationId, String role, String email)
-        throws TechnicalException {
-        var invitation = new Invitation();
-        invitation.setId(UuidString.generateRandom());
-        invitation.setReferenceType(InvitationReferenceType.APPLICATION.name());
-        invitation.setReferenceId(applicationId);
-        invitation.setEmail(email);
-        invitation.setApiRole(null);
-        invitation.setApplicationRole(role);
-        invitation.setCreatedAt(new Date());
-
-        return ApplicationInvitationItemMapper.INSTANCE.toApplicationInvitationItem(invitationRepository.create(invitation));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImpl.java
@@ -30,6 +30,7 @@ import io.gravitee.repository.management.model.InvitationReferenceType;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import jakarta.annotation.Nonnull;
+import java.util.List;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
@@ -40,6 +41,22 @@ public class InvitationQueryServiceImpl implements InvitationQueryService {
 
     public InvitationQueryServiceImpl(@Lazy InvitationRepository invitationRepository) {
         this.invitationRepository = invitationRepository;
+    }
+
+    @Override
+    public List<ApplicationInvitationItem> findByReference(
+        io.gravitee.apim.core.invitation.model.InvitationReferenceType referenceType,
+        String referenceId
+    ) {
+        try {
+            return invitationRepository
+                .findByReferenceIdAndReferenceType(referenceId, InvitationReferenceType.valueOf(referenceType.name()))
+                .stream()
+                .map(ApplicationInvitationItemMapper.INSTANCE::toApplicationInvitationItem)
+                .toList();
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurs while trying to find invitations by reference", e);
+        }
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImpl.java
@@ -16,9 +16,11 @@
 package io.gravitee.apim.infra.query_service.invitation;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationReference;
 import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
+import io.gravitee.apim.infra.adapter.ApplicationInvitationAdapter;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.InvitationRepository;
@@ -44,15 +46,12 @@ public class InvitationQueryServiceImpl implements InvitationQueryService {
     }
 
     @Override
-    public List<ApplicationInvitationItem> findByReference(
-        io.gravitee.apim.core.invitation.model.InvitationReferenceType referenceType,
-        String referenceId
-    ) {
+    public List<ApplicationInvitation> findByReference(@Nonnull InvitationReference reference) {
         try {
             return invitationRepository
-                .findByReferenceIdAndReferenceType(referenceId, InvitationReferenceType.valueOf(referenceType.name()))
+                .findByReferenceIdAndReferenceType(reference.id(), InvitationReferenceType.valueOf(reference.type().name()))
                 .stream()
-                .map(ApplicationInvitationItemMapper.INSTANCE::toApplicationInvitationItem)
+                .map(ApplicationInvitationAdapter.INSTANCE::toEntity)
                 .toList();
         } catch (TechnicalException e) {
             throw new TechnicalDomainException("An error occurs while trying to find invitations by reference", e);
@@ -60,7 +59,7 @@ public class InvitationQueryServiceImpl implements InvitationQueryService {
     }
 
     @Override
-    public Page<ApplicationInvitationItem> findByApplicationId(
+    public Page<ApplicationInvitation> findByApplicationId(
         String applicationId,
         @Nonnull SearchApplicationInvitationsCriteria criteria,
         @Nonnull Pageable pageable
@@ -77,11 +76,7 @@ public class InvitationQueryServiceImpl implements InvitationQueryService {
                 new PageableBuilder().pageNumber(resolvedPageable.getPageNumber() - 1).pageSize(resolvedPageable.getPageSize()).build()
             );
 
-            var content = repositoryPage
-                .getContent()
-                .stream()
-                .map(ApplicationInvitationItemMapper.INSTANCE::toApplicationInvitationItem)
-                .toList();
+            var content = repositoryPage.getContent().stream().map(ApplicationInvitationAdapter.INSTANCE::toEntity).toList();
 
             return new Page<>(content, resolvedPageable.getPageNumber(), content.size(), repositoryPage.getTotalElements());
         } catch (TechnicalException e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApplicationInvitationFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApplicationInvitationFixtures.java
@@ -15,24 +15,29 @@
  */
 package fixtures.core.model;
 
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-public class ApplicationInvitationItemFixtures {
+public class ApplicationInvitationFixtures {
 
     private static final Instant INSTANT_NOW = Instant.parse("2020-02-01T20:22:02.00Z");
+    private static final String APPLICATION_ID = "application-id";
 
-    private ApplicationInvitationItemFixtures() {}
+    private ApplicationInvitationFixtures() {}
 
-    public static ApplicationInvitationItem anApplicationInvitationItem(String id, String email) {
-        return anApplicationInvitationItem(id, email, "USER");
+    public static ApplicationInvitation anApplicationInvitation(String id, String email) {
+        return anApplicationInvitation(id, email, "USER");
     }
 
-    public static ApplicationInvitationItem anApplicationInvitationItem(String id, String email, String role) {
-        return new ApplicationInvitationItem(ApplicationInvitationId.of(id), email, role, date(), date());
+    public static ApplicationInvitation anApplicationInvitation(String id, String email, String role) {
+        return anApplicationInvitation(id, APPLICATION_ID, email, role);
+    }
+
+    public static ApplicationInvitation anApplicationInvitation(String id, String applicationId, String email, String role) {
+        return new ApplicationInvitation(ApplicationInvitationId.of(id), applicationId, email, role, date(), date());
     }
 
     private static ZonedDateTime date() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApplicationInvitationItemFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApplicationInvitationItemFixtures.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public class ApplicationInvitationItemFixtures {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2020-02-01T20:22:02.00Z");
+
+    private ApplicationInvitationItemFixtures() {}
+
+    public static ApplicationInvitationItem anApplicationInvitationItem(String id, String email) {
+        return anApplicationInvitationItem(id, email, "USER");
+    }
+
+    public static ApplicationInvitationItem anApplicationInvitationItem(String id, String email, String role) {
+        return new ApplicationInvitationItem(ApplicationInvitationId.of(id), email, role, date(), date());
+    }
+
+    private static ZonedDateTime date() {
+        return INSTANT_NOW.atZone(ZoneOffset.UTC);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.domain_service;
+
+import static fixtures.core.model.ApplicationInvitationItemFixtures.anApplicationInvitationItem;
+import static fixtures.core.model.RoleFixtures.anApplicationRole;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.ConflictDomainException;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.core.invitation.model.InvitationReferenceType;
+import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
+import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
+import io.gravitee.apim.core.membership.query_service.RoleQueryService;
+import io.gravitee.rest.api.service.common.ReferenceContext;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CreateApplicationInvitationsDomainServiceTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String APPLICATION_ID = "application-id";
+    private static final String ROLE = "USER";
+    private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
+    private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
+    private static final String EXISTING_INVITATION_ID = "00000000-0000-0000-0000-000000000003";
+
+    @Mock
+    private InvitationQueryService invitationQueryService;
+
+    @Mock
+    private InvitationCrudService invitationCrudService;
+
+    @Mock
+    private RoleQueryService roleQueryService;
+
+    private CreateApplicationInvitationsDomainService cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new CreateApplicationInvitationsDomainService(invitationQueryService, invitationCrudService, roleQueryService);
+    }
+
+    @Test
+    void should_create_invitations_with_sanitized_input_when_notify_is_false() {
+        givenExistingRole();
+        when(invitationQueryService.findByReference(InvitationReferenceType.APPLICATION, APPLICATION_ID)).thenReturn(List.of());
+        when(
+            invitationCrudService.createApplicationInvitations(APPLICATION_ID, ROLE, List.of("alice@example.com", "bob@example.com"))
+        ).thenReturn(
+            List.of(
+                anApplicationInvitationItem(INVITATION_ID_1, "alice@example.com"),
+                anApplicationInvitationItem(INVITATION_ID_2, "bob@example.com")
+            )
+        );
+
+        var result = cut.create(ORGANIZATION_ID, APPLICATION_ID, recipients(" Alice@Example.com ", "BOB@example.com"), " USER ", false);
+
+        assertThat(result).extracting(ApplicationInvitationItem::email).containsExactly("alice@example.com", "bob@example.com");
+        verify(invitationCrudService).createApplicationInvitations(APPLICATION_ID, ROLE, List.of("alice@example.com", "bob@example.com"));
+    }
+
+    @Test
+    void should_reject_invalid_email_before_creating_any_invitation() {
+        givenExistingRole();
+
+        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("not-an-email"), ROLE, false));
+
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class).hasMessageContaining("email is invalid");
+        verifyNoInteractions(invitationCrudService);
+        verify(invitationQueryService, never()).findByReference(any(), any());
+    }
+
+    @Test
+    void should_reject_notify_true_before_creating_any_invitation() {
+        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE, true));
+
+        assertThat(throwable).isInstanceOf(UnsupportedOperationException.class).hasMessageContaining("not implemented yet");
+        verifyNoInteractions(roleQueryService, invitationQueryService, invitationCrudService);
+    }
+
+    @Test
+    void should_reject_pending_invitation_conflict_before_creating_any_invitation() {
+        givenExistingRole();
+        when(invitationQueryService.findByReference(InvitationReferenceType.APPLICATION, APPLICATION_ID)).thenReturn(
+            List.of(anApplicationInvitationItem(EXISTING_INVITATION_ID, "alice@example.com"))
+        );
+
+        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("ALICE@example.com"), ROLE, false));
+
+        assertThat(throwable).isInstanceOf(ConflictDomainException.class).hasMessageContaining("pending application invitation");
+        verifyNoInteractions(invitationCrudService);
+    }
+
+    @Test
+    void should_reject_unknown_application_role() {
+        when(roleQueryService.findApplicationRole(eq(ROLE), any(ReferenceContext.class))).thenReturn(Optional.empty());
+
+        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE, false));
+
+        assertThat(throwable).isInstanceOf(RoleNotFoundException.class);
+        verifyNoInteractions(invitationQueryService, invitationCrudService);
+    }
+
+    private void givenExistingRole() {
+        when(roleQueryService.findApplicationRole(eq(ROLE), any(ReferenceContext.class))).thenReturn(
+            Optional.of(anApplicationRole("role-id", ROLE))
+        );
+    }
+
+    private Set<String> recipients(String... emails) {
+        return new LinkedHashSet<>(List.of(emails));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
@@ -15,13 +15,14 @@
  */
 package io.gravitee.apim.core.invitation.domain_service;
 
-import static fixtures.core.model.ApplicationInvitationItemFixtures.anApplicationInvitationItem;
+import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
 import static fixtures.core.model.RoleFixtures.anApplicationRole;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -29,8 +30,8 @@ import static org.mockito.Mockito.when;
 import io.gravitee.apim.core.exception.ConflictDomainException;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
-import io.gravitee.apim.core.invitation.model.InvitationReferenceType;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationReference;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
 import io.gravitee.apim.core.membership.query_service.RoleQueryService;
@@ -42,6 +43,7 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -50,7 +52,7 @@ class CreateApplicationInvitationsDomainServiceTest {
 
     private static final String ORGANIZATION_ID = "organization-id";
     private static final String APPLICATION_ID = "application-id";
-    private static final String ROLE = "USER";
+    private static final String ROLE_NAME = "USER";
     private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
     private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
     private static final String EXISTING_INVITATION_ID = "00000000-0000-0000-0000-000000000003";
@@ -72,38 +74,41 @@ class CreateApplicationInvitationsDomainServiceTest {
     }
 
     @Test
-    void should_create_invitations_with_sanitized_input_when_notify_is_false() {
+    void should_create_invitations_with_normalized_input_when_notify_is_false() {
         givenExistingRole();
-        when(invitationQueryService.findByReference(InvitationReferenceType.APPLICATION, APPLICATION_ID)).thenReturn(List.of());
-        when(
-            invitationCrudService.createApplicationInvitations(APPLICATION_ID, ROLE, List.of("alice@example.com", "bob@example.com"))
-        ).thenReturn(
-            List.of(
-                anApplicationInvitationItem(INVITATION_ID_1, "alice@example.com"),
-                anApplicationInvitationItem(INVITATION_ID_2, "bob@example.com")
-            )
+        when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
+        when(invitationCrudService.create(any(ApplicationInvitation.class))).thenReturn(
+            anApplicationInvitation(INVITATION_ID_1, "alice@example.com"),
+            anApplicationInvitation(INVITATION_ID_2, "bob@example.com")
         );
 
-        var result = cut.create(ORGANIZATION_ID, APPLICATION_ID, recipients(" Alice@Example.com ", "BOB@example.com"), " USER ", false);
+        var result = cut.create(ORGANIZATION_ID, APPLICATION_ID, recipients("alice@example.com", "bob@example.com"), ROLE_NAME, false);
 
-        assertThat(result).extracting(ApplicationInvitationItem::email).containsExactly("alice@example.com", "bob@example.com");
-        verify(invitationCrudService).createApplicationInvitations(APPLICATION_ID, ROLE, List.of("alice@example.com", "bob@example.com"));
+        assertThat(result).extracting(ApplicationInvitation::email).containsExactly("alice@example.com", "bob@example.com");
+
+        var invitationCaptor = ArgumentCaptor.forClass(ApplicationInvitation.class);
+        verify(invitationCrudService, times(2)).create(invitationCaptor.capture());
+        assertThat(invitationCaptor.getAllValues()).extracting(ApplicationInvitation::applicationId).containsOnly(APPLICATION_ID);
+        assertThat(invitationCaptor.getAllValues())
+            .extracting(ApplicationInvitation::email)
+            .containsExactly("alice@example.com", "bob@example.com");
+        assertThat(invitationCaptor.getAllValues()).extracting(ApplicationInvitation::roleName).containsOnly(ROLE_NAME);
     }
 
     @Test
     void should_reject_invalid_email_before_creating_any_invitation() {
         givenExistingRole();
 
-        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("not-an-email"), ROLE, false));
+        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("not-an-email"), ROLE_NAME, false));
 
         assertThat(throwable).isInstanceOf(ValidationDomainException.class).hasMessageContaining("email is invalid");
         verifyNoInteractions(invitationCrudService);
-        verify(invitationQueryService, never()).findByReference(any(), any());
+        verify(invitationQueryService, never()).findByReference(any());
     }
 
     @Test
     void should_reject_notify_true_before_creating_any_invitation() {
-        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE, true));
+        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE_NAME, true));
 
         assertThat(throwable).isInstanceOf(UnsupportedOperationException.class).hasMessageContaining("not implemented yet");
         verifyNoInteractions(roleQueryService, invitationQueryService, invitationCrudService);
@@ -112,11 +117,11 @@ class CreateApplicationInvitationsDomainServiceTest {
     @Test
     void should_reject_pending_invitation_conflict_before_creating_any_invitation() {
         givenExistingRole();
-        when(invitationQueryService.findByReference(InvitationReferenceType.APPLICATION, APPLICATION_ID)).thenReturn(
-            List.of(anApplicationInvitationItem(EXISTING_INVITATION_ID, "alice@example.com"))
+        when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(
+            List.of(anApplicationInvitation(EXISTING_INVITATION_ID, "alice@example.com"))
         );
 
-        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("ALICE@example.com"), ROLE, false));
+        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE_NAME, false));
 
         assertThat(throwable).isInstanceOf(ConflictDomainException.class).hasMessageContaining("pending application invitation");
         verifyNoInteractions(invitationCrudService);
@@ -124,17 +129,17 @@ class CreateApplicationInvitationsDomainServiceTest {
 
     @Test
     void should_reject_unknown_application_role() {
-        when(roleQueryService.findApplicationRole(eq(ROLE), any(ReferenceContext.class))).thenReturn(Optional.empty());
+        when(roleQueryService.findApplicationRole(eq(ROLE_NAME), any(ReferenceContext.class))).thenReturn(Optional.empty());
 
-        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE, false));
+        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE_NAME, false));
 
         assertThat(throwable).isInstanceOf(RoleNotFoundException.class);
         verifyNoInteractions(invitationQueryService, invitationCrudService);
     }
 
     private void givenExistingRole() {
-        when(roleQueryService.findApplicationRole(eq(ROLE), any(ReferenceContext.class))).thenReturn(
-            Optional.of(anApplicationRole("role-id", ROLE))
+        when(roleQueryService.findApplicationRole(eq(ROLE_NAME), any(ReferenceContext.class))).thenReturn(
+            Optional.of(anApplicationRole("role-id", ROLE_NAME))
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/SearchApplicationInvitationsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/SearchApplicationInvitationsUseCaseTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationItem;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.common.data.domain.Page;
@@ -94,9 +94,7 @@ class SearchApplicationInvitationsUseCaseTest {
 
         assertThat(result.invitations().getTotalElements()).isEqualTo(1);
         assertThat(result.invitations().getPageElements()).isEqualTo(1);
-        assertThat(result.invitations().getContent())
-            .extracting(ApplicationInvitationItem::email)
-            .containsExactly("john.alpha@example.com");
+        assertThat(result.invitations().getContent()).extracting(ApplicationInvitation::email).containsExactly("john.alpha@example.com");
         verify(invitationQueryService).findByApplicationId(APPLICATION_ID, criteria, pageable);
     }
 
@@ -132,7 +130,7 @@ class SearchApplicationInvitationsUseCaseTest {
         assertThat(throwable).isInstanceOf(PaginationInvalidException.class);
     }
 
-    private ApplicationInvitationItem anInvitation(String email) {
-        return ApplicationInvitationItem.create(email, "USER");
+    private ApplicationInvitation anInvitation(String email) {
+        return ApplicationInvitation.create(APPLICATION_ID, email, "USER");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImplTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.crud_service.invitation;
 
+import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,11 +26,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.InvitationRepository;
 import io.gravitee.repository.management.model.Invitation;
 import io.gravitee.repository.management.model.InvitationReferenceType;
-import io.gravitee.rest.api.service.common.UuidString;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,7 +40,6 @@ class InvitationCrudServiceImplTest {
     private static final String APPLICATION_ID = "application-id";
     private static final String ROLE = "USER";
     private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
-    private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
 
     @Mock
     private InvitationRepository invitationRepository;
@@ -52,37 +48,32 @@ class InvitationCrudServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        var index = new AtomicInteger(0);
-        UuidString.overrideGenerator(() -> List.of(INVITATION_ID_1, INVITATION_ID_2).get(index.getAndIncrement()));
         cut = new InvitationCrudServiceImpl(invitationRepository);
     }
 
-    @AfterEach
-    void tearDown() {
-        UuidString.reset();
-    }
-
     @Test
-    void should_create_application_invitations() throws TechnicalException {
+    void should_create_application_invitation() throws TechnicalException {
         when(invitationRepository.create(any(Invitation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        var invitationToCreate = anApplicationInvitation(INVITATION_ID_1, APPLICATION_ID, "alice@example.com", ROLE);
 
-        var result = cut.createApplicationInvitations(APPLICATION_ID, ROLE, List.of("alice@example.com", "bob@example.com"));
+        var result = cut.create(invitationToCreate);
 
-        assertThat(result).extracting(invitation -> invitation.id().toString()).containsExactly(INVITATION_ID_1, INVITATION_ID_2);
-        assertThat(result).extracting("email").containsExactly("alice@example.com", "bob@example.com");
+        assertThat(result.id().toString()).isEqualTo(INVITATION_ID_1);
+        assertThat(result.applicationId()).isEqualTo(APPLICATION_ID);
+        assertThat(result.email()).isEqualTo("alice@example.com");
 
         var captor = ArgumentCaptor.forClass(Invitation.class);
-        org.mockito.Mockito.verify(invitationRepository, org.mockito.Mockito.times(2)).create(captor.capture());
+        org.mockito.Mockito.verify(invitationRepository).create(captor.capture());
         SoftAssertions.assertSoftly(soft -> {
-            var firstInvitation = captor.getAllValues().get(0);
-            soft.assertThat(firstInvitation.getId()).isEqualTo(INVITATION_ID_1);
-            soft.assertThat(firstInvitation.getReferenceType()).isEqualTo(InvitationReferenceType.APPLICATION.name());
-            soft.assertThat(firstInvitation.getReferenceId()).isEqualTo(APPLICATION_ID);
-            soft.assertThat(firstInvitation.getEmail()).isEqualTo("alice@example.com");
-            soft.assertThat(firstInvitation.getApplicationRole()).isEqualTo(ROLE);
-            soft.assertThat(firstInvitation.getApiRole()).isNull();
-            soft.assertThat(firstInvitation.getCreatedAt()).isNotNull();
-            soft.assertThat(firstInvitation.getUpdatedAt()).isNull();
+            var repositoryInvitation = captor.getValue();
+            soft.assertThat(repositoryInvitation.getId()).isEqualTo(INVITATION_ID_1);
+            soft.assertThat(repositoryInvitation.getReferenceType()).isEqualTo(InvitationReferenceType.APPLICATION.name());
+            soft.assertThat(repositoryInvitation.getReferenceId()).isEqualTo(APPLICATION_ID);
+            soft.assertThat(repositoryInvitation.getEmail()).isEqualTo("alice@example.com");
+            soft.assertThat(repositoryInvitation.getApplicationRole()).isEqualTo(ROLE);
+            soft.assertThat(repositoryInvitation.getApiRole()).isNull();
+            soft.assertThat(repositoryInvitation.getCreatedAt()).isNotNull();
+            soft.assertThat(repositoryInvitation.getUpdatedAt()).isNotNull();
         });
     }
 
@@ -90,8 +81,10 @@ class InvitationCrudServiceImplTest {
     void should_throw_technical_domain_exception_when_repository_fails() throws TechnicalException {
         when(invitationRepository.create(any(Invitation.class))).thenThrow(new TechnicalException("error"));
 
-        var throwable = catchThrowable(() -> cut.createApplicationInvitations(APPLICATION_ID, ROLE, List.of("alice@example.com")));
+        var throwable = catchThrowable(() ->
+            cut.create(anApplicationInvitation(INVITATION_ID_1, APPLICATION_ID, "alice@example.com", ROLE))
+        );
 
-        assertThat(throwable).isInstanceOf(TechnicalDomainException.class).hasMessageContaining("create application invitations");
+        assertThat(throwable).isInstanceOf(TechnicalDomainException.class).hasMessageContaining("create application invitation");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImplTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.invitation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.InvitationRepository;
+import io.gravitee.repository.management.model.Invitation;
+import io.gravitee.repository.management.model.InvitationReferenceType;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InvitationCrudServiceImplTest {
+
+    private static final String APPLICATION_ID = "application-id";
+    private static final String ROLE = "USER";
+    private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
+    private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
+
+    @Mock
+    private InvitationRepository invitationRepository;
+
+    private InvitationCrudServiceImpl cut;
+
+    @BeforeEach
+    void setUp() {
+        var index = new AtomicInteger(0);
+        UuidString.overrideGenerator(() -> List.of(INVITATION_ID_1, INVITATION_ID_2).get(index.getAndIncrement()));
+        cut = new InvitationCrudServiceImpl(invitationRepository);
+    }
+
+    @AfterEach
+    void tearDown() {
+        UuidString.reset();
+    }
+
+    @Test
+    void should_create_application_invitations() throws TechnicalException {
+        when(invitationRepository.create(any(Invitation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var result = cut.createApplicationInvitations(APPLICATION_ID, ROLE, List.of("alice@example.com", "bob@example.com"));
+
+        assertThat(result).extracting(invitation -> invitation.id().toString()).containsExactly(INVITATION_ID_1, INVITATION_ID_2);
+        assertThat(result).extracting("email").containsExactly("alice@example.com", "bob@example.com");
+
+        var captor = ArgumentCaptor.forClass(Invitation.class);
+        org.mockito.Mockito.verify(invitationRepository, org.mockito.Mockito.times(2)).create(captor.capture());
+        SoftAssertions.assertSoftly(soft -> {
+            var firstInvitation = captor.getAllValues().get(0);
+            soft.assertThat(firstInvitation.getId()).isEqualTo(INVITATION_ID_1);
+            soft.assertThat(firstInvitation.getReferenceType()).isEqualTo(InvitationReferenceType.APPLICATION.name());
+            soft.assertThat(firstInvitation.getReferenceId()).isEqualTo(APPLICATION_ID);
+            soft.assertThat(firstInvitation.getEmail()).isEqualTo("alice@example.com");
+            soft.assertThat(firstInvitation.getApplicationRole()).isEqualTo(ROLE);
+            soft.assertThat(firstInvitation.getApiRole()).isNull();
+            soft.assertThat(firstInvitation.getCreatedAt()).isNotNull();
+            soft.assertThat(firstInvitation.getUpdatedAt()).isNull();
+        });
+    }
+
+    @Test
+    void should_throw_technical_domain_exception_when_repository_fails() throws TechnicalException {
+        when(invitationRepository.create(any(Invitation.class))).thenThrow(new TechnicalException("error"));
+
+        var throwable = catchThrowable(() -> cut.createApplicationInvitations(APPLICATION_ID, ROLE, List.of("alice@example.com")));
+
+        assertThat(throwable).isInstanceOf(TechnicalDomainException.class).hasMessageContaining("create application invitations");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImplTest.java
@@ -97,6 +97,27 @@ class InvitationQueryServiceImplTest {
     }
 
     @Test
+    void should_find_invitations_by_reference() throws Exception {
+        var createdAt = OffsetDateTime.parse("2026-04-23T09:30:00Z");
+        var invitation = anInvitation(INVITATION_ID_1, "john@example.com", "USER", createdAt, createdAt);
+        when(invitationRepository.findByReferenceIdAndReferenceType(APPLICATION_ID, InvitationReferenceType.APPLICATION)).thenReturn(
+            List.of(invitation)
+        );
+
+        var result = cut.findByReference(
+            io.gravitee.apim.core.invitation.model.InvitationReferenceType.APPLICATION,
+            APPLICATION_ID
+        );
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().id()).isEqualTo(ApplicationInvitationId.of(INVITATION_ID_1));
+        assertThat(result.getFirst().email()).isEqualTo("john@example.com");
+        assertThat(result.getFirst().roleName()).isEqualTo("USER");
+        assertThat(result.getFirst().createdAt()).isEqualTo(createdAt.toInstant().atZone(TimeProvider.clock().getZone()));
+        verify(invitationRepository).findByReferenceIdAndReferenceType(APPLICATION_ID, InvitationReferenceType.APPLICATION);
+    }
+
+    @Test
     void should_wrap_technical_exception() throws Exception {
         var repositoryCriteria = new InvitationCriteria(APPLICATION_ID, InvitationReferenceType.APPLICATION, null);
         var sortable = new SortableBuilder().field("email").order(Order.ASC).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.InvitationReference;
 import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.utils.TimeProvider;
@@ -86,10 +87,12 @@ class InvitationQueryServiceImplTest {
         assertThat(result.getTotalElements()).isEqualTo(3);
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getContent().get(0).id()).isEqualTo(ApplicationInvitationId.of(INVITATION_ID_2));
+        assertThat(result.getContent().get(0).applicationId()).isEqualTo(APPLICATION_ID);
         assertThat(result.getContent().get(0).roleName()).isNull();
         assertThat(result.getContent().get(0).createdAt()).isEqualTo(expectedCreatedAt);
         assertThat(result.getContent().get(0).updatedAt()).isEqualTo(expectedUpdatedAt);
         assertThat(result.getContent().get(1).id()).isEqualTo(ApplicationInvitationId.of(INVITATION_ID_1));
+        assertThat(result.getContent().get(1).applicationId()).isEqualTo(APPLICATION_ID);
         assertThat(result.getContent().get(1).roleName()).isEqualTo("USER");
         assertThat(result.getContent().get(1).createdAt()).isEqualTo(expectedCreatedAt);
         assertThat(result.getContent().get(1).updatedAt()).isEqualTo(expectedUpdatedAt);
@@ -104,17 +107,26 @@ class InvitationQueryServiceImplTest {
             List.of(invitation)
         );
 
-        var result = cut.findByReference(
-            io.gravitee.apim.core.invitation.model.InvitationReferenceType.APPLICATION,
-            APPLICATION_ID
-        );
+        var result = cut.findByReference(InvitationReference.application(APPLICATION_ID));
 
         assertThat(result).hasSize(1);
         assertThat(result.getFirst().id()).isEqualTo(ApplicationInvitationId.of(INVITATION_ID_1));
+        assertThat(result.getFirst().applicationId()).isEqualTo(APPLICATION_ID);
         assertThat(result.getFirst().email()).isEqualTo("john@example.com");
         assertThat(result.getFirst().roleName()).isEqualTo("USER");
         assertThat(result.getFirst().createdAt()).isEqualTo(createdAt.toInstant().atZone(TimeProvider.clock().getZone()));
         verify(invitationRepository).findByReferenceIdAndReferenceType(APPLICATION_ID, InvitationReferenceType.APPLICATION);
+    }
+
+    @Test
+    void should_find_invitations_by_api_reference() throws Exception {
+        var apiId = "api-id";
+        when(invitationRepository.findByReferenceIdAndReferenceType(apiId, InvitationReferenceType.API)).thenReturn(List.of());
+
+        var result = cut.findByReference(InvitationReference.api(apiId));
+
+        assertThat(result).isEmpty();
+        verify(invitationRepository).findByReferenceIdAndReferenceType(apiId, InvitationReferenceType.API);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13764

## Summary

This PR introduces the first backend increment for application invitation creation.

The scope is intentionally limited to the domain and persistence layer. It allows creating pending application invitations in the repository, while leaving the REST endpoint, use case orchestration, and notification flow for follow-up PRs.


## Out of Scope

- REST resource integration is not included in this PR.
- Use case wiring is not included in this PR.
- Notification sending is not included in this PR.
- When `notifyUsers = true`, the domain service currently throws `UnsupportedOperationException`, as notifications will be implemented in a later PR.
