### PR TITLE
fix(console): correct controller name for dictionary add-property dialog

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.controller.ts
+++ b/gravitee-apim-console-webui/src/management/settings/dictionaries/dictionary.controller.ts
@@ -212,7 +212,7 @@ class DictionaryController {
   addProperty() {
     this.$mdDialog
       .show({
-        controller: 'DialogAddPropertyController',
+        controller: 'DialogDictionaryAddPropertyController',
         controllerAs: 'dialogDictionaryAddPropertyCtrl',
         template: require('html-loader!./add-property.dialog.html').default, // eslint-disable-line @typescript-eslint/no-var-requires
         clickOutsideToClose: true,


### PR DESCRIPTION
## Summary
The "Add property" dialog on a dictionary's detail page was broken with `[$controller:ctrlreg] The controller with the name 'DialogAddPropertyController' is not registered`.

The controller of that name was removed by the V1 properties cleanup (commit `634cfe941a`), but the dictionary screen — not part of that V1 area — still referenced it.

## Fix
Point `dictionary.controller.ts` to `DialogDictionaryAddPropertyController`, which is the local controller already living next to the dialog template and already registered in `app.module.ajs.ts`. The existing `controllerAs: 'dialogDictionaryAddPropertyCtrl'` alias confirms this was the intended target.

https://gravitee.atlassian.net/browse/APIM-13935


<img width="1999" height="1133" alt="image" src="https://github.com/user-attachments/assets/b5fea22c-debd-4e93-b06c-86143d6e46f3" />
