### PR TITLE
Error 500 when trying to filter logs in the developer portal

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
@@ -251,27 +251,47 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
         return tabularResponse;
     }
 
-    /**
-     * Escapes backslashes and forward slashes so they survive both JSON
-     * and Lucene parsing levels (fix APIM-12955).
-     *
-     * Parentheses are intentionally left unescaped to preserve Lucene
-     * grouping syntax (e.g., {@code status:(200 OR 400)}).
-     */
     private String createSafeElasticsearchJsonQuery(final TabularQuery query) {
         String json = this.createElasticsearchJsonQuery(query);
 
-        if (query != null && query.query() != null && query.query().filter() != null) {
-            String filter = query.query().filter();
-
-            if (!filter.isEmpty()) {
-                String escaped = escapeForJsonLucene(filter);
-
-                // Targeted replacement within quotes to protect JSON structure
-                json = json.replace("\"" + filter + "\"", "\"" + escaped + "\"");
-            }
+        if (query != null && query.query() != null) {
+            return safeEscapeReplacement(json, query.query().filter());
         }
+
         return json;
+    }
+
+    /**
+     * Replaces the filter value inside the rendered JSON with its escaped form
+     * so backslashes and forward slashes survive both JSON and Lucene parsing.
+     *
+     * <p>Parentheses are intentionally left unescaped to preserve Lucene grouping
+     * syntax (e.g., {@code status:(200 OR 400)}).
+     *
+     * <p>The replacement is skipped entirely when the filter contains a double-quote
+     * character. The filter reaches the rendered JSON verbatim:
+     * {@code FreeMarkerComponent} in {@code gravitee-common-elasticsearch} pins the
+     * FreeMarker {@code Configuration} to incompatible-improvements 2.3.23 — which
+     * predates output-format auto-escaping (added in 2.3.24) — and registers no
+     * {@code JSON} output format, so {@code <#ftl output_format="JSON">} in
+     * {@code log.ftl} is a no-op. A literal {@code \"} pair in the filter therefore
+     * lands in the rendered JSON as a valid escape sequence for {@code "}. Applying
+     * the backslash-quadrupling on top of that would turn each pair into four
+     * backslashes plus an unescaped {@code "}, prematurely terminating the JSON
+     * string and producing a 400 from Elasticsearch.
+     *
+     * <p><b>Caller contract:</b> any caller that emits a literal {@code "} inside
+     * {@code filter} must pre-escape {@code \} and {@code /} inside the quoted span
+     * itself. The legacy portal does so in {@code analytics.service.ts}; without that
+     * pre-escaping a filter mixing {@code "} with raw {@code /} would lose the
+     * regex-delimiter protection added for APIM-12955.
+     */
+    static String safeEscapeReplacement(String json, String filter) {
+        if (filter == null || filter.isEmpty() || filter.contains("\"")) {
+            return json;
+        }
+        String escaped = escapeForJsonLucene(filter);
+        return json.replace("\"" + filter + "\"", "\"" + escaped + "\"");
     }
 
     /**

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/LuceneEscapeTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/LuceneEscapeTest.java
@@ -63,10 +63,14 @@ class LuceneEscapeTest {
 
         String result = ElasticLogRepository.escapeForJsonLucene(input);
 
-        assertThat(result).doesNotContain("RMel/1.0.0");
+        // forward slash is escaped so Lucene treats it as literal, not a regex delimiter
+        assertThat(result).contains("RMel\\\\/1.0.0");
         assertThat(result).contains("status:200");
         assertThat(result).contains("custom.userAgent:");
+
+        // parentheses are intentionally left unescaped to preserve Lucene grouping syntax
         assertThat(result).contains("(Ubuntu)");
+        assertThat(result).doesNotContain("\\\\(");
     }
 
     @Test
@@ -75,5 +79,58 @@ class LuceneEscapeTest {
 
         assertThat(result).startsWith("status:(200 OR 400)");
         assertThat(result).doesNotContain("uri:/");
+    }
+
+    // --- safeEscapeReplacement ---
+
+    @Test
+    void should_replace_filter_with_escaped_form_when_filter_has_no_double_quote() {
+        String filter = "uri:/api/test";
+        String json = "{\"query\":\"" + filter + "\"}";
+
+        String result = ElasticLogRepository.safeEscapeReplacement(json, filter);
+
+        assertThat(result).isEqualTo("{\"query\":\"uri:\\\\/api\\\\/test\"}");
+    }
+
+    @Test
+    void should_skip_replacement_when_filter_contains_double_quote() {
+        // legacy portal wraps API UUIDs in backslash-escaped quotes: api:(\"uuid\")
+        String filter = "api:(\\\"bad3b39c-7d97-4ab4-93b3-9c7d970ab4ca\\\")";
+        String json = "{\"query\":\"" + filter + "\"}";
+
+        String result = ElasticLogRepository.safeEscapeReplacement(json, filter);
+
+        // bypass — backslash quadrupling would corrupt the \" JSON escape sequences (APIM-13402)
+        assertThat(result).isEqualTo(json);
+    }
+
+    @Test
+    void should_skip_replacement_when_filter_with_double_quote_also_has_forward_slash() {
+        // caller contract: when filter contains ", caller must pre-escape / and \ in the quoted span
+        String filter = "uri:(\\\"/api/v1\\\")";
+        String json = "{\"query\":\"" + filter + "\"}";
+
+        String result = ElasticLogRepository.safeEscapeReplacement(json, filter);
+
+        assertThat(result).isEqualTo(json);
+    }
+
+    @Test
+    void should_no_op_when_filter_is_empty() {
+        String json = "{\"query\":\"\"}";
+
+        String result = ElasticLogRepository.safeEscapeReplacement(json, "");
+
+        assertThat(result).isEqualTo(json);
+    }
+
+    @Test
+    void should_no_op_when_filter_is_null() {
+        String json = "{\"query\":\"\"}";
+
+        String result = ElasticLogRepository.safeEscapeReplacement(json, null);
+
+        assertThat(result).isEqualTo(json);
     }
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-13998

# Steps to reproduce

- create a v2 API
- remove its keyless plan
- add an api key plan
- subscribe to it with an existing application
- send 2-3 requests so there is logs
- go to the dev portal
- Applications > your app > Logs
- click on search it should work
- click on Show advanced filters
- select an API
- before the change, you receive a 500 error