### PR TITLE
fix: default api product role change of group member

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.html
@@ -20,7 +20,7 @@
   <form [formGroup]="addMemberForm" class="add-member__form">
     <mat-form-field aria-hidden="false" aria-label="Select default API role">
       <mat-label>Default API Role</mat-label>
-      <mat-select formControlName="defaultAPIRole" (selectionChange)="onAPIRoleChange()">
+      <mat-select formControlName="defaultAPIRole" (selectionChange)="onDefaultRoleChange()">
         @for (role of defaultAPIRoles; track role.id) {
           <mat-option [value]="role.name" [disabled]="disabledAPIRoles.has(role.id)">{{ role.name }}</mat-option>
         }
@@ -29,7 +29,7 @@
 
     <mat-form-field aria-hidden="false" aria-label="Select default API product role">
       <mat-label>Default API Product Role</mat-label>
-      <mat-select formControlName="defaultAPIProductRole">
+      <mat-select formControlName="defaultAPIProductRole" (selectionChange)="onDefaultRoleChange()">
         @for (role of defaultAPIProductRoles; track role.id) {
           <mat-option [value]="role.name" [disabled]="disabledAPIProductRoles.has(role.id)">{{ role.name }}</mat-option>
         }

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.spec.ts
@@ -13,36 +13,270 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { of } from 'rxjs';
 
 import { AddMembersDialogComponent } from './add-members-dialog.component';
 
 import { GioTestingModule } from '../../../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../../../shared/components/gio-permission/gio-permission.service';
+import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
+import { UsersService } from '../../../../../services-ngx/users.service';
+import { Group } from '../../../../../entities/group/group';
+import { Member } from '../membershipState';
+import { Role } from '../../../../../entities/role/role';
+import { SearchableUser } from '../../../../../entities/user/searchableUser';
+import { GroupMembership } from '../../../../../entities/group/groupMember';
+import { AddOrInviteMembersDialogData } from '../group.component';
 
 describe('AddMembersDialogComponent', () => {
-  TestBed.configureTestingModule({
-    imports: [AddMembersDialogComponent, MatDialogModule, GioTestingModule],
-    declarations: [],
-    providers: [
-      {
-        provide: MatDialogRef,
-        useValue: {
-          close: jest.fn(),
-        },
-      },
-      {
-        provide: MAT_DIALOG_DATA,
-        useValue: {
-          /* mock data */
-        },
-      },
-    ],
-  }).compileComponents();
+  const GROUP: Group = {
+    id: 'group-1',
+    name: 'Group 1',
+    manageable: true,
+    system_invitation: true,
+    email_invitation: false,
+    max_invitation: 10,
+    lock_api_role: false,
+    lock_api_product_role: false,
+    lock_application_role: false,
+    disable_membership_notifications: false,
+    event_rules: [],
+    roles: {},
+  };
 
-  it('should create', () => {
-    const fixture = TestBed.createComponent(AddMembersDialogComponent);
-    const component = fixture.componentInstance;
-    expect(component).toBeTruthy();
+  const ROLES_API: Role[] = [
+    { id: 'r-api-owner', name: 'OWNER', scope: 'API' },
+    { id: 'r-api-po', name: 'PRIMARY_OWNER', scope: 'API' },
+    { id: 'r-api-reviewer', name: 'REVIEWER', scope: 'API' },
+    { id: 'r-api-user', name: 'USER', scope: 'API' },
+  ];
+  const ROLES_API_PRODUCT: Role[] = [
+    { id: 'r-ap-owner', name: 'OWNER', scope: 'API_PRODUCT' },
+    { id: 'r-ap-po', name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+    { id: 'r-ap-user', name: 'USER', scope: 'API_PRODUCT' },
+  ];
+  const ROLES_APPLICATION: Role[] = [
+    { id: 'r-app-owner', name: 'OWNER', scope: 'APPLICATION' },
+    { id: 'r-app-user', name: 'USER', scope: 'APPLICATION' },
+  ];
+  const ROLES_INTEGRATION: Role[] = [{ id: 'r-int-user', name: 'USER', scope: 'INTEGRATION' }];
+  const ROLES_CLUSTER: Role[] = [{ id: 'r-cl-user', name: 'USER', scope: 'CLUSTER' }];
+
+  const HYBRID_SETTINGS = { api: { primaryOwnerMode: 'HYBRID' }, apiProduct: { primaryOwnerMode: 'HYBRID' } };
+
+  const ALICE: SearchableUser = { id: 'a', reference: 'ref-a', email: 'a@x.com', displayName: 'Alice' };
+  const BOB: SearchableUser = { id: 'b', reference: 'ref-b', email: 'b@x.com', displayName: 'Bob' };
+
+  const fakeSelection = (user: SearchableUser): MatAutocompleteSelectedEvent =>
+    ({ option: { value: user } }) as unknown as MatAutocompleteSelectedEvent;
+
+  let fixture: ComponentFixture<AddMembersDialogComponent>;
+  let component: AddMembersDialogComponent;
+  let dialogRefSpy: { close: jest.Mock };
+
+  const setup = (overrides: Partial<AddOrInviteMembersDialogData> = {}, settings = HYBRID_SETTINGS, members: Member[] = []) => {
+    dialogRefSpy = { close: jest.fn() };
+    const data: AddOrInviteMembersDialogData = {
+      group: GROUP,
+      members,
+      defaultAPIRoles: ROLES_API,
+      defaultAPIProductRoles: ROLES_API_PRODUCT,
+      defaultApplicationRoles: ROLES_APPLICATION,
+      defaultIntegrationRoles: ROLES_INTEGRATION,
+      defaultClusterRoles: ROLES_CLUSTER,
+      ...overrides,
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [AddMembersDialogComponent, MatDialogModule, GioTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRefSpy },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: EnvironmentSettingsService, useValue: { getSnapshot: () => settings } },
+        { provide: UsersService, useValue: { search: () => of([ALICE, BOB]) } },
+        { provide: GioTestingPermissionProvider, useValue: ['environment-group-u'] },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddMembersDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  describe('initial state', () => {
+    it('starts with empty selection and submit disabled', () => {
+      setup();
+
+      expect(component.selectedUsers).toEqual([]);
+      expect(component.disableSubmit).toBe(true);
+    });
+
+    it('seeds form values from the group default roles', () => {
+      setup({ group: { ...GROUP, roles: { API: 'REVIEWER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER' } } });
+
+      expect(component.addMemberForm.controls.defaultAPIRole.value).toBe('REVIEWER');
+      expect(component.addMemberForm.controls.defaultAPIProductRole.value).toBe('OWNER');
+      expect(component.addMemberForm.controls.defaultApplicationRole.value).toBe('OWNER');
+    });
+  });
+
+  describe('selectUser / deselectUser', () => {
+    it('adds a user to selectedUsers and enables submit', () => {
+      setup();
+
+      component.selectUser(fakeSelection(ALICE));
+
+      expect(component.selectedUsers).toEqual([ALICE]);
+      expect(component.disableSubmit).toBe(false);
+    });
+
+    it('does not add the same user twice', () => {
+      setup();
+
+      component.selectUser(fakeSelection(ALICE));
+      component.selectUser(fakeSelection(ALICE));
+
+      expect(component.selectedUsers).toEqual([ALICE]);
+    });
+
+    it('removes a user and disables submit when none remain', () => {
+      setup();
+
+      component.selectUser(fakeSelection(ALICE));
+      component.deselectUser(ALICE);
+
+      expect(component.selectedUsers).toEqual([]);
+      expect(component.disableSubmit).toBe(true);
+    });
+  });
+
+  describe('onDefaultRoleChange', () => {
+    it('clears all selected users on role change', () => {
+      setup();
+      component.selectUser(fakeSelection(ALICE));
+      component.selectUser(fakeSelection(BOB));
+
+      component.onDefaultRoleChange();
+
+      expect(component.selectedUsers).toEqual([]);
+      expect(component.disableSubmit).toBe(true);
+    });
+  });
+
+  describe('PRIMARY_OWNER single-user constraint', () => {
+    it('disables search when API role is PRIMARY_OWNER and a user is chipped', () => {
+      setup();
+      component.addMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.selectUser(fakeSelection(ALICE));
+
+      expect(component.addMemberForm.controls.searchTerm.disabled).toBe(true);
+    });
+
+    it('disables search when API_PRODUCT role is PRIMARY_OWNER and a user is chipped', () => {
+      setup();
+      component.addMemberForm.controls.defaultAPIProductRole.setValue('PRIMARY_OWNER');
+      component.selectUser(fakeSelection(ALICE));
+
+      expect(component.addMemberForm.controls.searchTerm.disabled).toBe(true);
+    });
+
+    it('keeps search enabled with required validator when PRIMARY_OWNER is selected and no user is chipped', () => {
+      setup();
+      component.addMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.onDefaultRoleChange();
+
+      expect(component.addMemberForm.controls.searchTerm.enabled).toBe(true);
+    });
+  });
+
+  describe('submit', () => {
+    it('builds a membership for each selected user using current form values', () => {
+      setup();
+      component.addMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.addMemberForm.controls.defaultAPIProductRole.setValue('OWNER');
+      component.addMemberForm.controls.defaultApplicationRole.setValue('OWNER');
+      component.addMemberForm.controls.defaultIntegrationRole.setValue('USER');
+      component.addMemberForm.controls.defaultClusterRole.setValue('USER');
+      component.selectUser(fakeSelection(ALICE));
+      component.selectUser(fakeSelection(BOB));
+
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      expect(memberships).toHaveLength(2);
+      expect(memberships.map(m => m.id).sort()).toEqual(['a', 'b']);
+      memberships.forEach(m => {
+        expect(m.roles).toContainEqual({ name: 'OWNER', scope: 'API' });
+        expect(m.roles).toContainEqual({ name: 'OWNER', scope: 'API_PRODUCT' });
+        expect(m.roles).toContainEqual({ name: 'OWNER', scope: 'APPLICATION' });
+        expect(m.roles).toContainEqual({ name: 'USER', scope: 'INTEGRATION' });
+        expect(m.roles).toContainEqual({ name: 'USER', scope: 'CLUSTER' });
+      });
+    });
+
+    it('reflects role changes that happen AFTER the user was selected (lazy form-value mapping)', () => {
+      // Reproduces the original APIM-13783 bug: role values must be read at submit time, not at selection time.
+      setup();
+      component.addMemberForm.controls.defaultAPIProductRole.setValue('USER');
+      component.selectUser(fakeSelection(ALICE));
+
+      // Bypassing onDefaultRoleChange() (which would clear the chip in real UI) to exercise the pure mapping logic.
+      component.addMemberForm.controls.defaultAPIProductRole.setValue('OWNER');
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      expect(memberships[0].roles).toContainEqual({ name: 'OWNER', scope: 'API_PRODUCT' });
+    });
+
+    it('closes with an empty memberships list when no users are selected', () => {
+      setup();
+
+      component.submit();
+
+      expect(dialogRefSpy.close).toHaveBeenCalledWith({ memberships: [] });
+    });
+  });
+
+  describe('disabling roles', () => {
+    it('disables PRIMARY_OWNER for API when another member already holds it', () => {
+      const existingPo: Member = {
+        id: 'm1',
+        displayName: 'Existing PO',
+        roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'USER', APPLICATION: 'USER', INTEGRATION: 'USER', CLUSTER: 'USER' },
+      };
+      setup({}, HYBRID_SETTINGS, [existingPo]);
+
+      expect(component.disabledAPIRoles.has('r-api-po')).toBe(true);
+    });
+
+    it('disables PRIMARY_OWNER for API_PRODUCT when another member already holds it', () => {
+      const existingPo: Member = {
+        id: 'm1',
+        displayName: 'Existing PO',
+        roles: { API: 'USER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'USER', INTEGRATION: 'USER', CLUSTER: 'USER' },
+      };
+      setup({}, HYBRID_SETTINGS, [existingPo]);
+
+      expect(component.disabledAPIProductRoles.has('r-ap-po')).toBe(true);
+    });
+
+    it('disables PRIMARY_OWNER for both scopes when primaryOwnerMode is USER', () => {
+      setup({}, { api: { primaryOwnerMode: 'USER' }, apiProduct: { primaryOwnerMode: 'USER' } });
+
+      expect(component.disabledAPIRoles.has('r-api-po')).toBe(true);
+      expect(component.disabledAPIProductRoles.has('r-ap-po')).toBe(true);
+    });
+
+    it('does not disable PRIMARY_OWNER when mode is HYBRID and no member holds it yet', () => {
+      setup();
+
+      expect(component.disabledAPIRoles.has('r-api-po')).toBe(false);
+      expect(component.disabledAPIProductRoles.has('r-ap-po')).toBe(false);
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/add-members-dialog/add-members-dialog.component.ts
@@ -80,7 +80,6 @@ export class AddMembersDialogComponent implements OnInit {
 
   private group: Group;
   private members: Member[] = [];
-  private memberships: GroupMembership[] = [];
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: AddOrInviteMembersDialogData,
@@ -228,7 +227,7 @@ export class AddMembersDialogComponent implements OnInit {
   }
 
   submit() {
-    this.matDialogRef.close({ memberships: this.memberships });
+    this.matDialogRef.close({ memberships: this.selectedUsers.map(user => this.mapGroupMembership(user)) });
   }
 
   mapGroupMembership(user: SearchableUser): GroupMembership {
@@ -278,7 +277,6 @@ export class AddMembersDialogComponent implements OnInit {
 
     if (!this.selectedUsers.includes(selectedUser)) {
       this.selectedUsers.push(selectedUser);
-      this.memberships.push(this.mapGroupMembership(selectedUser));
     }
     this.changeFormState();
   }
@@ -288,39 +286,35 @@ export class AddMembersDialogComponent implements OnInit {
 
     if (index >= 0) {
       this.selectedUsers.splice(index, 1);
-      const membershipIndex = this.memberships.findIndex(member => member.id === user.id);
-
-      if (membershipIndex >= 0) {
-        this.memberships.splice(index, 1);
-      }
     }
     this.changeFormState();
   }
 
   private changeFormState() {
-    const noOfPrimaryOwners = this.filterPrimaryOwners().length;
     this.addMemberForm.controls.searchTerm.setValue('');
     this.disableSearch();
 
-    if (this.addMemberForm.controls.defaultAPIRole.value === RoleName.PRIMARY_OWNER) {
-      if (noOfPrimaryOwners > 0) {
+    if (this.isPrimaryOwnerSelected()) {
+      if (this.selectedUsers.length > 0) {
         this.addMemberForm.controls.searchTerm.disable();
         this.addMemberForm.controls.searchTerm.removeValidators(Validators.required);
-      } else if (noOfPrimaryOwners < 1) {
+      } else {
         this.addMemberForm.controls.searchTerm.enable();
         this.addMemberForm.controls.searchTerm.addValidators(Validators.required);
       }
     }
-    this.disableSubmit = this.memberships.length === 0;
+    this.disableSubmit = this.selectedUsers.length === 0;
   }
 
-  private filterPrimaryOwners() {
-    return this.memberships.filter(membership => membership.roles.find(role => role.scope === 'API').name === RoleName.PRIMARY_OWNER);
+  private isPrimaryOwnerSelected(): boolean {
+    return (
+      this.addMemberForm.controls.defaultAPIRole.value === RoleName.PRIMARY_OWNER ||
+      this.addMemberForm.controls.defaultAPIProductRole.value === RoleName.PRIMARY_OWNER
+    );
   }
 
-  onAPIRoleChange() {
+  onDefaultRoleChange() {
     this.selectedUsers = [];
-    this.memberships = [];
     this.changeFormState();
   }
 }

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.html
@@ -78,7 +78,7 @@
       <mat-form-field appearance="outline">
         <mat-label>Search Members</mat-label>
         <input aria-label="Search members" matInput formControlName="searchTerm" [matAutocomplete]="auto" />
-        <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selectPrimaryOwner($event)">
+        <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayMember" (optionSelected)="selectPrimaryOwner($event)">
           @for (member of filteredMembers$ | async; track member.id) {
             <mat-option [value]="member">
               {{ member.displayName }}

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.spec.ts
@@ -13,36 +13,693 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of, throwError } from 'rxjs';
 
 import { EditMemberDialogComponent } from './edit-member-dialog.component';
 
 import { GioTestingModule } from '../../../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../../../shared/components/gio-permission/gio-permission.service';
+import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
+import { UsersService } from '../../../../../services-ngx/users.service';
+import { Group } from '../../../../../entities/group/group';
+import { Member } from '../membershipState';
+import { Role } from '../../../../../entities/role/role';
+import { SearchableUser } from '../../../../../entities/user/searchableUser';
+import { GroupMembership } from '../../../../../entities/group/groupMember';
+import { EditMemberDialogData } from '../group.component';
 
 describe('EditMemberDialogComponent', () => {
-  TestBed.configureTestingModule({
-    imports: [EditMemberDialogComponent, GioTestingModule],
-    declarations: [],
-    providers: [
-      {
-        provide: MatDialogRef,
-        useValue: {
-          close: jest.fn(),
-        },
-      },
-      {
-        provide: MAT_DIALOG_DATA,
-        useValue: {
-          /* mock data */
-        },
-      },
-    ],
-  }).compileComponents();
+  const GROUP: Group = {
+    id: 'group-1',
+    name: 'Group 1',
+    manageable: true,
+    system_invitation: true,
+    email_invitation: false,
+    max_invitation: 10,
+    lock_api_role: false,
+    lock_api_product_role: false,
+    lock_application_role: false,
+    disable_membership_notifications: false,
+    event_rules: [],
+    roles: {},
+  };
 
-  it('should create', () => {
-    const fixture = TestBed.createComponent(EditMemberDialogComponent);
-    const component = fixture.componentInstance;
-    expect(component).toBeTruthy();
+  const ROLES_API: Role[] = [
+    { id: 'r-api-owner', name: 'OWNER', scope: 'API' },
+    { id: 'r-api-po', name: 'PRIMARY_OWNER', scope: 'API' },
+    { id: 'r-api-reviewer', name: 'REVIEWER', scope: 'API' },
+    { id: 'r-api-user', name: 'USER', scope: 'API' },
+  ];
+  const ROLES_API_PRODUCT: Role[] = [
+    { id: 'r-ap-owner', name: 'OWNER', scope: 'API_PRODUCT' },
+    { id: 'r-ap-po', name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+    { id: 'r-ap-user', name: 'USER', scope: 'API_PRODUCT' },
+  ];
+  const ROLES_APPLICATION: Role[] = [
+    { id: 'r-app-owner', name: 'OWNER', scope: 'APPLICATION' },
+    { id: 'r-app-user', name: 'USER', scope: 'APPLICATION' },
+  ];
+  const ROLES_INTEGRATION: Role[] = [{ id: 'r-int-user', name: 'USER', scope: 'INTEGRATION' }];
+  const ROLES_CLUSTER: Role[] = [{ id: 'r-cl-user', name: 'USER', scope: 'CLUSTER' }];
+
+  const USERS: SearchableUser[] = [
+    { id: '1', reference: 'ref-1', email: '1@x.com', displayName: 'Member One' },
+    { id: '2', reference: 'ref-2', email: '2@x.com', displayName: 'Member Two' },
+    { id: '3', reference: 'ref-3', email: '3@x.com', displayName: 'Member Three' },
+  ];
+
+  const HYBRID_SETTINGS = { api: { primaryOwnerMode: 'HYBRID' }, apiProduct: { primaryOwnerMode: 'HYBRID' } };
+
+  const mkMember = (id: string, displayName: string, roles: Record<string, string> = {}): Member => ({
+    id,
+    displayName,
+    roles: {
+      API: roles.API ?? 'USER',
+      API_PRODUCT: roles.API_PRODUCT ?? 'USER',
+      APPLICATION: roles.APPLICATION ?? 'USER',
+      INTEGRATION: roles.INTEGRATION ?? 'USER',
+      CLUSTER: roles.CLUSTER ?? 'USER',
+      ...roles,
+    },
+  });
+
+  let fixture: ComponentFixture<EditMemberDialogComponent>;
+  let component: EditMemberDialogComponent;
+  let dialogRefSpy: { close: jest.Mock };
+  let snackBarSpy: { error: jest.Mock; success: jest.Mock };
+  let usersSearchSpy: jest.Mock;
+
+  const setup = (member: Member, members: Member[] = [member], settings = HYBRID_SETTINGS, users: SearchableUser[] = USERS) => {
+    dialogRefSpy = { close: jest.fn() };
+    snackBarSpy = { error: jest.fn(), success: jest.fn() };
+    usersSearchSpy = jest.fn(() => of(users));
+    const data: EditMemberDialogData = {
+      group: GROUP,
+      member,
+      members,
+      defaultAPIRoles: ROLES_API,
+      defaultAPIProductRoles: ROLES_API_PRODUCT,
+      defaultApplicationRoles: ROLES_APPLICATION,
+      defaultIntegrationRoles: ROLES_INTEGRATION,
+      defaultClusterRoles: ROLES_CLUSTER,
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [EditMemberDialogComponent, GioTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: MatDialogRef, useValue: dialogRefSpy },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: EnvironmentSettingsService, useValue: { getSnapshot: () => settings } },
+        { provide: UsersService, useValue: { search: usersSearchSpy } },
+        { provide: SnackBarService, useValue: snackBarSpy },
+        { provide: GioTestingPermissionProvider, useValue: ['environment-group-u'] },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EditMemberDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  describe('upgrade / downgrade detection', () => {
+    it('detects API role upgrade', () => {
+      setup(mkMember('1', 'Member One', { API: 'OWNER' }));
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+
+      expect(component['isRoleUpgrade']('API')).toBe(true);
+      expect(component['isRoleDowngrade']('API')).toBe(false);
+    });
+
+    it('detects API role downgrade', () => {
+      setup(mkMember('1', 'Member One', { API: 'PRIMARY_OWNER' }));
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+
+      expect(component['isRoleDowngrade']('API')).toBe(true);
+      expect(component['isRoleUpgrade']('API')).toBe(false);
+    });
+
+    it('detects API_PRODUCT role upgrade', () => {
+      setup(mkMember('1', 'Member One', { API_PRODUCT: 'USER' }));
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('PRIMARY_OWNER');
+
+      expect(component['isRoleUpgrade']('API_PRODUCT')).toBe(true);
+      expect(component['isRoleDowngrade']('API_PRODUCT')).toBe(false);
+    });
+
+    it('detects API_PRODUCT role downgrade', () => {
+      setup(mkMember('1', 'Member One', { API_PRODUCT: 'PRIMARY_OWNER' }));
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('USER');
+
+      expect(component['isRoleDowngrade']('API_PRODUCT')).toBe(true);
+      expect(component['isRoleUpgrade']('API_PRODUCT')).toBe(false);
+    });
+
+    it('reports neither upgrade nor downgrade for non-PO transitions', () => {
+      setup(mkMember('1', 'Member One', { API: 'USER', API_PRODUCT: 'USER' }));
+      component.editMemberForm.controls.defaultAPIRole.setValue('REVIEWER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('OWNER');
+
+      expect(component['isRoleUpgrade']('API')).toBe(false);
+      expect(component['isRoleDowngrade']('API')).toBe(false);
+      expect(component['isRoleUpgrade']('API_PRODUCT')).toBe(false);
+      expect(component['isRoleDowngrade']('API_PRODUCT')).toBe(false);
+    });
+  });
+
+  describe('existing PO lookups', () => {
+    it('finds another member holding API PRIMARY_OWNER', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'OWNER' });
+      const apiPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser, apiPo]);
+
+      expect(component['findExistingPrimaryOwner']('API')?.id).toBe('2');
+    });
+
+    it('returns null when the only API PRIMARY_OWNER is the edit user themselves', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser]);
+
+      expect(component['findExistingPrimaryOwner']('API')).toBeNull();
+    });
+
+    it('finds another member holding API_PRODUCT PRIMARY_OWNER', () => {
+      const editUser = mkMember('1', 'Member One');
+      const apiProductPo = mkMember('2', 'Member Two', { API_PRODUCT: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser, apiProductPo]);
+
+      expect(component['findExistingPrimaryOwner']('API_PRODUCT')?.id).toBe('2');
+    });
+  });
+
+  describe('upgrade banner', () => {
+    it('shows fresh-assignment phrasing when no existing PO holds the upgraded scope', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'OWNER' });
+      setup(editUser, [editUser]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+
+      expect(component.ownershipTransferMessage).toContain('Member One will become the API primary owner of this group.');
+      expect(component.ownershipTransferMessage).not.toContain('will be transferred');
+    });
+
+    it('shows transfer phrasing when an existing PO holds the upgraded scope', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'OWNER' });
+      const apiPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser, apiPo]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+
+      expect(component.ownershipTransferMessage).toContain('Member Two is the API primary owner');
+      expect(component.ownershipTransferMessage).toContain('transferred to Member One');
+    });
+
+    it('collapses to a single sentence when the same outgoing PO holds both scopes', () => {
+      const editUser = mkMember('1', 'Member One');
+      const dualPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser, dualPo]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+
+      expect(component.ownershipTransferMessage).toContain('Member Two is the API and API Product primary owner');
+      expect(component.ownershipTransferMessage).not.toContain('The API primary ownership will be transferred');
+      expect(component.ownershipTransferMessage).not.toContain('The API Product primary ownership will be transferred');
+    });
+
+    it('emits two sentences when API and API_PRODUCT POs are different members', () => {
+      const editUser = mkMember('1', 'Member One');
+      const apiPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER' });
+      const apiProductPo = mkMember('3', 'Member Three', { API_PRODUCT: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser, apiPo, apiProductPo]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+
+      expect(component.ownershipTransferMessage).toContain('Member Two is the API primary owner');
+      expect(component.ownershipTransferMessage).toContain('Member Three is the API Product primary owner');
+    });
+  });
+
+  describe('downgrade banner', () => {
+    it('mentions only the API scope when downgrading API alone', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER' });
+      const successor = mkMember('2', 'Member Two');
+      setup(editUser, [editUser, successor]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.onChange();
+      component.selectPrimaryOwner({ option: { value: successor } } as any);
+
+      expect(component.ownershipTransferMessage).toContain('Member One is the API primary owner');
+      expect(component.ownershipTransferMessage).toContain('transferred to Member Two');
+      expect(component.ownershipTransferMessage).not.toContain('API Product');
+    });
+
+    it('mentions only the API Product scope when downgrading API_PRODUCT alone', () => {
+      const editUser = mkMember('1', 'Member One', { API_PRODUCT: 'PRIMARY_OWNER' });
+      const successor = mkMember('2', 'Member Two');
+      setup(editUser, [editUser, successor]);
+
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('USER');
+      component.onChange();
+      component.selectPrimaryOwner({ option: { value: successor } } as any);
+
+      expect(component.ownershipTransferMessage).toContain('Member One is the API Product primary owner');
+      expect(component.ownershipTransferMessage).toContain('transferred to Member Two');
+    });
+
+    it('collapses into one sentence when downgrading both scopes', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER' });
+      const successor = mkMember('2', 'Member Two');
+      setup(editUser, [editUser, successor]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('USER');
+      component.onChange();
+      component.selectPrimaryOwner({ option: { value: successor } } as any);
+
+      expect(component.ownershipTransferMessage).toContain('Member One is the API and API Product primary owner');
+    });
+  });
+
+  describe('mixed downgrade + upgrade banner', () => {
+    it('mentions BOTH the downgrade transfer and the upgrade transfer when scopes move in opposite directions', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER', API_PRODUCT: 'OWNER' });
+      const apiProductPo = mkMember('2', 'Member Two', { API_PRODUCT: 'PRIMARY_OWNER' });
+      const successor = mkMember('3', 'Member Three');
+      setup(editUser, [editUser, apiProductPo, successor]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+      component.selectPrimaryOwner({ option: { value: successor } } as any);
+
+      expect(component.ownershipTransferMessage).toContain('Member One is the API primary owner');
+      expect(component.ownershipTransferMessage).toContain('transferred to Member Three');
+      expect(component.ownershipTransferMessage).toContain('Member Two is the API Product primary owner');
+      expect(component.ownershipTransferMessage).toContain('transferred to Member One');
+    });
+
+    it('shows only the upgrade message before a successor is picked, then adds the downgrade message afterwards', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER', API_PRODUCT: 'OWNER' });
+      const apiProductPo = mkMember('2', 'Member Two', { API_PRODUCT: 'PRIMARY_OWNER' });
+      const successor = mkMember('3', 'Member Three');
+      setup(editUser, [editUser, apiProductPo, successor]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+
+      // Before successor picked: only the upgrade-side message is visible.
+      expect(component.ownershipTransferMessage).toContain('Member Two is the API Product primary owner');
+      expect(component.ownershipTransferMessage).not.toContain('Member One is the API primary owner');
+
+      component.selectPrimaryOwner({ option: { value: successor } } as any);
+
+      // After successor picked: both messages present.
+      expect(component.ownershipTransferMessage).toContain('Member One is the API primary owner');
+      expect(component.ownershipTransferMessage).toContain('Member Two is the API Product primary owner');
+    });
+  });
+
+  describe('submit ordering and payload shape', () => {
+    it('sends a single membership with the edited form values and no PO transfer when only application/integration/cluster change', () => {
+      // Pure non-PO save: only APPLICATION/INTEGRATION/CLUSTER are touched, no API or API_PRODUCT
+      // role transition. The submit must not produce any demotion or successor membership and must
+      // forward the edit user's new values verbatim — guarding against regressions that would route
+      // simple edits through the transfer machinery.
+      const editUser = mkMember('1', 'Member One', { API: 'OWNER', API_PRODUCT: 'OWNER' });
+      setup(editUser, [editUser]);
+
+      component.editMemberForm.controls.defaultApplicationRole.setValue('USER');
+      component.editMemberForm.controls.defaultIntegrationRole.setValue('USER');
+      component.editMemberForm.controls.defaultClusterRole.setValue('USER');
+      component.onChange();
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      expect(memberships).toHaveLength(1);
+      expect(memberships[0].id).toBe('1');
+      expect(memberships[0].roles).toEqual(
+        expect.arrayContaining([
+          { name: 'OWNER', scope: 'API' },
+          { name: 'OWNER', scope: 'API_PRODUCT' },
+          { name: 'USER', scope: 'APPLICATION' },
+          { name: 'USER', scope: 'INTEGRATION' },
+          { name: 'USER', scope: 'CLUSTER' },
+        ]),
+      );
+    });
+
+    it('sends only the edit user when promoting to PO with no existing PO for that scope', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'OWNER' });
+      setup(editUser, [editUser]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+      component.submit();
+
+      const closeArg = dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] };
+      expect(closeArg.memberships).toHaveLength(1);
+      expect(closeArg.memberships[0].id).toBe('1');
+      expect(closeArg.memberships[0].roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API' });
+    });
+
+    it('demotes the previous API PO before promoting the edit user', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'OWNER' });
+      const apiPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser, apiPo]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      expect(memberships).toHaveLength(2);
+      expect(memberships[0].id).toBe('2');
+      expect(memberships[0].roles).toContainEqual({ name: 'OWNER', scope: 'API' });
+      expect(memberships[1].id).toBe('1');
+      expect(memberships[1].roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API' });
+    });
+
+    it('collapses the demotion into a single membership when one member holds both POs', () => {
+      const editUser = mkMember('1', 'Member One');
+      const dualPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'OWNER' });
+      setup(editUser, [editUser, dualPo]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      expect(memberships).toHaveLength(2);
+      expect(memberships[0].id).toBe('2');
+      expect(memberships[0].roles).toContainEqual({ name: 'OWNER', scope: 'API' });
+      expect(memberships[0].roles).toContainEqual({ name: 'OWNER', scope: 'API_PRODUCT' });
+      // Demoted member's other-scope roles must NOT be overwritten with the edit user's form values.
+      expect(memberships[0].roles).toContainEqual({ name: 'OWNER', scope: 'APPLICATION' });
+    });
+
+    it('produces two demotions when API and API_PRODUCT POs are different members', () => {
+      const editUser = mkMember('1', 'Member One');
+      const apiPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER', APPLICATION: 'OWNER' });
+      const apiProductPo = mkMember('3', 'Member Three', { API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'OWNER' });
+      setup(editUser, [editUser, apiPo, apiProductPo]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      expect(memberships).toHaveLength(3);
+      const m2 = memberships.find(m => m.id === '2');
+      const m3 = memberships.find(m => m.id === '3');
+      const m1 = memberships.find(m => m.id === '1');
+      expect(m2?.roles).toContainEqual({ name: 'OWNER', scope: 'API' });
+      expect(m3?.roles).toContainEqual({ name: 'OWNER', scope: 'API_PRODUCT' });
+      expect(m1?.roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API' });
+      expect(m1?.roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' });
+      // Promotion of the edit user must come last in the payload.
+      expect(memberships[memberships.length - 1].id).toBe('1');
+    });
+
+    it('promotes the chosen successor and demotes the edit user on downgrade', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER' });
+      const successor = mkMember('2', 'Member Two', { APPLICATION: 'OWNER' });
+      setup(editUser, [editUser, successor]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.onChange();
+      component.selectPrimaryOwner({ option: { value: successor } } as any);
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      expect(memberships).toHaveLength(2);
+      expect(memberships[0].id).toBe('1');
+      expect(memberships[0].roles).toContainEqual({ name: 'OWNER', scope: 'API' });
+      expect(memberships[1].id).toBe('2');
+      expect(memberships[1].roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API' });
+      // Successor's APPLICATION role must be preserved at OWNER, not overwritten with the edit user's form value.
+      expect(memberships[1].roles).toContainEqual({ name: 'OWNER', scope: 'APPLICATION' });
+    });
+
+    it('promotes the successor for both scopes when downgrading both', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER' });
+      const successor = mkMember('2', 'Member Two');
+      setup(editUser, [editUser, successor]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('USER');
+      component.onChange();
+      component.selectPrimaryOwner({ option: { value: successor } } as any);
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      const successorMembership = memberships.find(m => m.id === '2');
+      expect(successorMembership?.roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API' });
+      expect(successorMembership?.roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' });
+    });
+
+    it('handles api downgrade + api product upgrade in a single save (mixed case)', () => {
+      // The case the reviewer flagged: edit user is API PO and changes API to OWNER (downgrade) while
+      // simultaneously promoting their API_PRODUCT role from OWNER to PRIMARY_OWNER (upgrade). Another
+      // member currently holds API_PRODUCT=PRIMARY_OWNER and must be demoted; the operator picks a
+      // successor for the API role. The submit must produce three memberships ordered as
+      // [demote-existing-API_PRODUCT-PO, edit-user, promote-successor-as-new-API-PO].
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER', API_PRODUCT: 'OWNER' });
+      const apiProductPo = mkMember('2', 'Member Two', {
+        API_PRODUCT: 'PRIMARY_OWNER',
+        APPLICATION: 'OWNER',
+        INTEGRATION: 'USER',
+        CLUSTER: 'USER',
+      });
+      const successor = mkMember('3', 'Member Three');
+      setup(editUser, [editUser, apiProductPo, successor]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+      component.selectPrimaryOwner({ option: { value: successor } } as any);
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      expect(memberships).toHaveLength(3);
+      // 1. The previous API_PRODUCT PO is demoted FIRST so the edit user's API_PRODUCT promotion doesn't
+      //    trip the server's PRIMARY_OWNER uniqueness check.
+      expect(memberships[0].id).toBe('2');
+      expect(memberships[0].roles).toContainEqual({ name: 'OWNER', scope: 'API_PRODUCT' });
+      // The demoted member's other-scope roles must stay intact.
+      expect(memberships[0].roles).toContainEqual({ name: 'OWNER', scope: 'APPLICATION' });
+      expect(memberships[0].roles).toContainEqual({ name: 'USER', scope: 'INTEGRATION' });
+      expect(memberships[0].roles).toContainEqual({ name: 'USER', scope: 'CLUSTER' });
+      // 2. The edit user's combined demotion + promotion comes next.
+      expect(memberships[1].id).toBe('1');
+      expect(memberships[1].roles).toContainEqual({ name: 'OWNER', scope: 'API' });
+      expect(memberships[1].roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' });
+      // 3. The successor is promoted to the new API PO last.
+      expect(memberships[2].id).toBe('3');
+      expect(memberships[2].roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API' });
+    });
+
+    it('handles api upgrade + api product downgrade in a single save (mixed case, inverse)', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'OWNER', API_PRODUCT: 'PRIMARY_OWNER' });
+      const apiPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER', APPLICATION: 'OWNER' });
+      const successor = mkMember('3', 'Member Three');
+      setup(editUser, [editUser, apiPo, successor]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.editMemberForm.controls.defaultAPIProductRole.setValue('USER');
+      component.onChange();
+      component.selectPrimaryOwner({ option: { value: successor } } as any);
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      expect(memberships).toHaveLength(3);
+      expect(memberships[0].id).toBe('2');
+      expect(memberships[0].roles).toContainEqual({ name: 'OWNER', scope: 'API' });
+      expect(memberships[0].roles).toContainEqual({ name: 'OWNER', scope: 'APPLICATION' });
+      expect(memberships[1].id).toBe('1');
+      expect(memberships[1].roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API' });
+      expect(memberships[1].roles).toContainEqual({ name: 'USER', scope: 'API_PRODUCT' });
+      expect(memberships[2].id).toBe('3');
+      expect(memberships[2].roles).toContainEqual({ name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' });
+    });
+  });
+
+  describe('successor search filter', () => {
+    it('returns no candidates when the term is empty (autocomplete only filters on typed input)', () => {
+      const editUser = mkMember('1', 'Member One');
+      const m2 = mkMember('2', 'Member Two');
+      const m3 = mkMember('3', 'Member Three');
+      setup(editUser, [editUser, m2, m3]);
+
+      expect(component['filterMembers']('')).toEqual([]);
+      expect(component['filterMembers']('   ')).toEqual([]);
+    });
+
+    it('filters by display name case-insensitively', () => {
+      const editUser = mkMember('1', 'Member One');
+      const m2 = mkMember('2', 'Member Two');
+      const m3 = mkMember('3', 'Other Person');
+      setup(editUser, [editUser, m2, m3]);
+
+      const result = component['filterMembers']('member');
+
+      expect(result.map(m => m.id)).toEqual(['2']);
+    });
+
+    it('coerces a Member object value into a search string instead of throwing', () => {
+      const editUser = mkMember('1', 'Member One');
+      const m2 = mkMember('2', 'Member Two');
+      setup(editUser, [editUser, m2]);
+
+      // mat-autocomplete may transiently write the picked Member object into the form control.
+      const result = component['filterMembers'](m2 as unknown as string);
+
+      expect(result.map(m => m.id)).toEqual(['2']);
+    });
+  });
+
+  describe('displayMember', () => {
+    it('returns the displayName for a Member', () => {
+      const editUser = mkMember('1', 'Member One');
+      setup(editUser);
+
+      expect(component.displayMember(mkMember('2', 'Member Two'))).toBe('Member Two');
+    });
+
+    it('returns the string verbatim for a string value', () => {
+      const editUser = mkMember('1', 'Member One');
+      setup(editUser);
+
+      expect(component.displayMember('typed text')).toBe('typed text');
+    });
+
+    it('returns an empty string for null/undefined', () => {
+      const editUser = mkMember('1', 'Member One');
+      setup(editUser);
+
+      expect(component.displayMember(null)).toBe('');
+    });
+  });
+
+  describe('downgradedMember reset (review #1)', () => {
+    it('clears downgradedMember when the role transitions back to PRIMARY_OWNER', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser, mkMember('2', 'Member Two')]);
+
+      // Trigger downgrade — downgradedMember = edit user, search rendered.
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.onChange();
+      expect(component.downgradedMember?.id).toBe('1');
+
+      // Revert to PRIMARY_OWNER — must reset, otherwise the search field stays rendered.
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+
+      expect(component.downgradedMember).toBeNull();
+    });
+
+    it('clears downgradedMember on any non-transfer role change', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser, mkMember('2', 'Member Two')]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.onChange();
+      expect(component.downgradedMember?.id).toBe('1');
+
+      // No transfer happening — reset back to the seed value, downgradedMember should clear.
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+      expect(component.downgradedMember).toBeNull();
+    });
+  });
+
+  describe('error handling on submit (review #2 and #3)', () => {
+    it('surfaces a snackbar error and keeps the dialog open if the successor lookup returns no matching user', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'PRIMARY_OWNER' });
+      const successor = mkMember('2', 'Member Two');
+      // Mock returns a list that does NOT contain the successor — find() will yield undefined.
+      setup(editUser, [editUser, successor], HYBRID_SETTINGS, [USERS[0]]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('OWNER');
+      component.onChange();
+      component.selectPrimaryOwner({ option: { value: successor } } as any);
+      component.submit();
+
+      expect(snackBarSpy.error).toHaveBeenCalledTimes(1);
+      expect(dialogRefSpy.close).not.toHaveBeenCalled();
+      expect(component.disableSubmit).toBe(false);
+    });
+
+    it('surfaces a snackbar error and keeps the dialog open if the demotion lookup returns no matching user', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'OWNER' });
+      const apiPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser, apiPo], HYBRID_SETTINGS, [USERS[0]]); // USERS[0] has id '1' only
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+      component.submit();
+
+      expect(snackBarSpy.error).toHaveBeenCalledTimes(1);
+      expect(dialogRefSpy.close).not.toHaveBeenCalled();
+      expect(component.disableSubmit).toBe(false);
+    });
+
+    it('surfaces a snackbar error if the user search itself fails', () => {
+      const editUser = mkMember('1', 'Member One', { API: 'OWNER' });
+      const apiPo = mkMember('2', 'Member Two', { API: 'PRIMARY_OWNER' });
+      setup(editUser, [editUser, apiPo]);
+      // Replace the search after init so getUserDetails has already populated this.user.
+      usersSearchSpy.mockReturnValueOnce(throwError(() => new Error('network down')));
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+      component.submit();
+
+      expect(snackBarSpy.error).toHaveBeenCalledTimes(1);
+      expect(dialogRefSpy.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('demoted membership shape (review #4)', () => {
+    it('emits exactly the demoted member roles regardless of source object key order', () => {
+      const editUser = mkMember('1', 'Member One');
+      const apiPo: Member = {
+        id: '2',
+        displayName: 'Member Two',
+        // Source roles intentionally inserted in a non-canonical order — assertion is order-insensitive.
+        roles: { CLUSTER: 'USER', INTEGRATION: 'USER', APPLICATION: 'OWNER', API_PRODUCT: 'OWNER', API: 'PRIMARY_OWNER' },
+      };
+      setup(editUser, [editUser, apiPo]);
+
+      component.editMemberForm.controls.defaultAPIRole.setValue('PRIMARY_OWNER');
+      component.onChange();
+      component.submit();
+
+      const memberships = (dialogRefSpy.close.mock.calls[0][0] as { memberships: GroupMembership[] }).memberships;
+      const demoted = memberships.find(m => m.id === '2');
+      expect(demoted?.roles).toHaveLength(5);
+      expect(demoted?.roles).toEqual(
+        expect.arrayContaining([
+          { name: 'OWNER', scope: 'API' },
+          { name: 'OWNER', scope: 'API_PRODUCT' },
+          { name: 'OWNER', scope: 'APPLICATION' },
+          { name: 'USER', scope: 'INTEGRATION' },
+          { name: 'USER', scope: 'CLUSTER' },
+        ]),
+      );
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/edit-member-dialog/edit-member-dialog.component.ts
@@ -25,7 +25,7 @@ import { CommonModule } from '@angular/common';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatAutocomplete, MatAutocompleteSelectedEvent, MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { MatInput } from '@angular/material/input';
-import { Observable, of, startWith } from 'rxjs';
+import { catchError, EMPTY, forkJoin, Observable, of, startWith } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
 import { MatChip, MatChipRemove, MatChipSet } from '@angular/material/chips';
 import { GioBannerModule, GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
@@ -37,9 +37,10 @@ import { GioPermissionService } from '../../../../../shared/components/gio-permi
 import { ApiPrimaryOwnerMode } from '../../../../../services/apiPrimaryOwnerMode.service';
 import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
 import { Role } from '../../../../../entities/role/role';
-import { GroupMembership } from '../../../../../entities/group/groupMember';
+import { GroupMembership, GroupMembershipMemberRoleEntity } from '../../../../../entities/group/groupMember';
 import { SearchableUser } from '../../../../../entities/user/searchableUser';
 import { UsersService } from '../../../../../services-ngx/users.service';
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { EditMemberDialogData } from '../group.component';
 import { Group } from '../../../../../entities/group/group';
 
@@ -107,6 +108,7 @@ export class EditMemberDialogComponent implements OnInit {
     private matDialogRef: MatDialogRef<EditMemberDialogComponent>,
     private permissionService: GioPermissionService,
     private settingsService: EnvironmentSettingsService,
+    private snackBarService: SnackBarService,
   ) {}
 
   ngOnInit(): void {
@@ -243,43 +245,91 @@ export class EditMemberDialogComponent implements OnInit {
   }
 
   submit() {
-    if (this.isUpgradeRole() && this.ifPrimaryOwnerPresent()) {
-      this.usersService
-        .search(this.downgradedMember.displayName)
-        .pipe(
-          map(users => {
-            const ownerId = this.downgradedMember.id;
-            const reference = users.find(u => u.id === ownerId).reference;
-            const ownerMembership = this.mapGroupMembership(ownerId, reference, RoleName.OWNER);
-            const primaryOwnerMembership = this.mapGroupMembership(this.user.id, this.user.reference, RoleName.PRIMARY_OWNER);
-            this.setGroupAdminRole(primaryOwnerMembership);
-            this.memberships = [ownerMembership, primaryOwnerMembership];
-            this.matDialogRef.close({ memberships: this.memberships });
-          }),
-          takeUntilDestroyed(this.destroyRef),
-        )
-        .subscribe();
-    } else if (this.isDowngradeRole()) {
-      const ownerMembership = this.mapGroupMembership(this.user.id, this.user.reference, this.editMemberForm.controls.defaultAPIRole.value);
-      this.setGroupAdminRole(ownerMembership);
-      this.usersService
-        .search(this.selectedPrimaryOwner.displayName)
-        .pipe(
-          map(users => {
-            const reference = users.find(user => user.id === this.selectedPrimaryOwner.id).reference;
-            const primaryOwnerMembership = this.mapGroupMembership(this.selectedPrimaryOwner.id, reference, RoleName.PRIMARY_OWNER);
-            this.memberships = [ownerMembership, primaryOwnerMembership];
-            this.matDialogRef.close({ memberships: this.memberships });
-          }),
-          takeUntilDestroyed(this.destroyRef),
-        )
-        .subscribe();
-    } else {
-      const groupMembership = this.mapGroupMembership(this.user.id, this.user.reference, this.editMemberForm.controls.defaultAPIRole.value);
-      this.setGroupAdminRole(groupMembership);
-      this.memberships = [groupMembership];
-      this.matDialogRef.close({ memberships: this.memberships });
+    const apiUpgrade = this.isRoleUpgrade('API');
+    const apiProductUpgrade = this.isRoleUpgrade('API_PRODUCT');
+    const apiDowngrade = this.isRoleDowngrade('API');
+    const apiProductDowngrade = this.isRoleDowngrade('API_PRODUCT');
+
+    const editMembership = this.mapEditUserMembership();
+    this.setGroupAdminRole(editMembership);
+
+    const apiPo = apiUpgrade ? this.findExistingPrimaryOwner('API') : null;
+    const apiProductPo = apiProductUpgrade ? this.findExistingPrimaryOwner('API_PRODUCT') : null;
+    const sameOutgoing = !!(apiPo && apiProductPo && apiPo.id === apiProductPo.id);
+
+    const demotionLookups: Observable<GroupMembership>[] = [];
+    if (apiPo) {
+      const scopes: ('API' | 'API_PRODUCT')[] = sameOutgoing ? ['API', 'API_PRODUCT'] : ['API'];
+      demotionLookups.push(this.demote(apiPo, scopes));
     }
+    if (apiProductPo && !sameOutgoing) {
+      demotionLookups.push(this.demote(apiProductPo, ['API_PRODUCT']));
+    }
+
+    const successorLookup: Observable<GroupMembership> | null =
+      apiDowngrade || apiProductDowngrade ? this.promoteSuccessor(this.selectedPrimaryOwner, apiDowngrade, apiProductDowngrade) : null;
+
+    if (demotionLookups.length === 0 && !successorLookup) {
+      this.memberships = [editMembership];
+      this.matDialogRef.close({ memberships: this.memberships });
+      return;
+    }
+
+    const allLookups = successorLookup ? [...demotionLookups, successorLookup] : demotionLookups;
+
+    forkJoin(allLookups)
+      .pipe(
+        catchError(() => {
+          this.handleTransferLookupFailure();
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(resolved => {
+        // Order: previous-PO demotion(s) → edit user → successor promotion.
+        const demoted = resolved.slice(0, demotionLookups.length);
+        const successor = successorLookup ? resolved[resolved.length - 1] : null;
+        this.memberships = successor ? [...demoted, editMembership, successor] : [...demoted, editMembership];
+        this.matDialogRef.close({ memberships: this.memberships });
+      });
+  }
+
+  private promoteSuccessor(successor: Member, apiDowngrade: boolean, apiProductDowngrade: boolean): Observable<GroupMembership> {
+    return this.usersService.search(successor.displayName).pipe(
+      map(users => {
+        const successorUser = users.find(u => u.id === successor.id);
+        if (!successorUser) {
+          throw new Error(`Could not resolve user reference for member ${successor.id}`);
+        }
+        const successorMembership = this.buildMembershipFromMember(successor, successorUser.reference);
+        if (apiDowngrade) {
+          this.setRole(successorMembership, 'API', RoleName.PRIMARY_OWNER);
+        }
+        if (apiProductDowngrade) {
+          this.setRole(successorMembership, 'API_PRODUCT', RoleName.PRIMARY_OWNER);
+        }
+        return successorMembership;
+      }),
+    );
+  }
+
+  private demote(member: Member, scopes: ('API' | 'API_PRODUCT')[]): Observable<GroupMembership> {
+    return this.usersService.search(member.displayName).pipe(
+      map(users => {
+        const memberUser = users.find(u => u.id === member.id);
+        if (!memberUser) {
+          throw new Error(`Could not resolve user reference for member ${member.id}`);
+        }
+        const membership = this.buildMembershipFromMember(member, memberUser.reference);
+        scopes.forEach(scope => this.setRole(membership, scope, RoleName.OWNER));
+        return membership;
+      }),
+    );
+  }
+
+  private handleTransferLookupFailure(): void {
+    this.snackBarService.error('Could not resolve member references for the ownership transfer. Please try again.');
+    this.disableSubmit = false;
   }
 
   private setGroupAdminRole(groupMembership: GroupMembership) {
@@ -288,39 +338,43 @@ export class EditMemberDialogComponent implements OnInit {
     }
   }
 
-  mapGroupMembership(id: string, reference: string, defaultAPIRole: string): GroupMembership {
+  private mapEditUserMembership(): GroupMembership {
     return {
-      id: id,
-      reference: reference,
+      id: this.user.id,
+      reference: this.user.reference,
       roles: [
-        {
-          name: defaultAPIRole,
-          scope: 'API',
-        },
-        {
-          name: this.editMemberForm.controls.defaultAPIProductRole.value,
-          scope: 'API_PRODUCT',
-        },
-        {
-          name: this.editMemberForm.controls.defaultApplicationRole.value,
-          scope: 'APPLICATION',
-        },
-        {
-          name: this.editMemberForm.controls.defaultIntegrationRole.value,
-          scope: 'INTEGRATION',
-        },
-        {
-          name: this.editMemberForm.controls.defaultClusterRole.value,
-          scope: 'CLUSTER',
-        },
+        { name: this.editMemberForm.controls.defaultAPIRole.value, scope: 'API' },
+        { name: this.editMemberForm.controls.defaultAPIProductRole.value, scope: 'API_PRODUCT' },
+        { name: this.editMemberForm.controls.defaultApplicationRole.value, scope: 'APPLICATION' },
+        { name: this.editMemberForm.controls.defaultIntegrationRole.value, scope: 'INTEGRATION' },
+        { name: this.editMemberForm.controls.defaultClusterRole.value, scope: 'CLUSTER' },
       ],
     };
   }
 
+  private buildMembershipFromMember(member: Member, reference: string): GroupMembership {
+    const roles: GroupMembershipMemberRoleEntity[] = [];
+    Object.entries(member.roles).forEach(([scope, name]) => {
+      if (name) {
+        roles.push({ name, scope: scope as GroupMembershipMemberRoleEntity['scope'] });
+      }
+    });
+    return { id: member.id, reference, roles };
+  }
+
+  private setRole(membership: GroupMembership, scope: GroupMembershipMemberRoleEntity['scope'], name: string) {
+    const existing = membership.roles.find(role => role.scope === scope);
+    if (existing) {
+      existing.name = name;
+    } else {
+      membership.roles.push({ name, scope });
+    }
+  }
+
   selectPrimaryOwner($event: MatAutocompleteSelectedEvent) {
-    if (this.isDowngradeRole()) {
+    if (this.isAnyRoleDowngrade()) {
       this.selectedPrimaryOwner = $event.option.value;
-      this.ownershipTransferMessage = `${this.member.displayName} is the API primary owner. The primary ownership will be transferred to ${this.selectedPrimaryOwner.displayName} and ${this.member.displayName} will be updated as owner.`;
+      this.ownershipTransferMessage = this.buildOwnershipTransferMessage(this.selectedPrimaryOwner);
       this.editMemberForm.controls.searchTerm.disable();
       this.editMemberForm.controls.searchTerm.setValue('');
       this.editMemberForm.controls.searchTerm.removeValidators(Validators.required);
@@ -329,63 +383,153 @@ export class EditMemberDialogComponent implements OnInit {
   }
 
   deselectPrimaryOwner() {
-    if (this.isDowngradeRole()) {
+    if (this.isAnyRoleDowngrade()) {
       this.selectedPrimaryOwner = null;
-      this.ownershipTransferMessage = null;
+      this.ownershipTransferMessage = this.buildOwnershipTransferMessage(null);
       this.editMemberForm.controls.searchTerm.enable();
       this.editMemberForm.controls.searchTerm.addValidators(Validators.required);
       this.disableSubmit = true;
     }
   }
 
-  private filterMembers(searchTerm: string) {
-    if (!searchTerm.trim()) {
+  private filterMembers(searchTerm: string | Member | null | undefined) {
+    const term = typeof searchTerm === 'string' ? searchTerm : (searchTerm?.displayName ?? '');
+    if (!term.trim()) {
       return [];
     }
-
-    const filterValue = searchTerm.toLowerCase();
+    const filterValue = term.toLowerCase();
     return this.members.filter(member => member.displayName.toLowerCase().includes(filterValue) && member.id !== this.member.id);
   }
+
+  displayMember = (member: Member | string | null): string => {
+    if (!member) {
+      return '';
+    }
+    return typeof member === 'string' ? member : member.displayName;
+  };
 
   onChange() {
     this.selectedPrimaryOwner = null;
     this.ownershipTransferMessage = null;
+    this.downgradedMember = null;
     this.memberships = [];
 
-    if (this.isUpgradeRole() && this.ifPrimaryOwnerPresent()) {
-      this.editMemberForm.controls.searchTerm.disable();
-      this.editMemberForm.controls.searchTerm.removeValidators(Validators.required);
-      this.downgradedMember = this.members.find(member => member.roles['API'] === RoleName.PRIMARY_OWNER);
-      this.selectedPrimaryOwner = this.member;
-      this.ownershipTransferMessage = `${this.downgradedMember.displayName} is the API primary owner. The primary ownership will be transferred to ${this.member.displayName} and ${this.downgradedMember.displayName} will be updated as owner.`;
-      this.disableSubmit = false;
-    } else if (this.isDowngradeRole()) {
+    const apiUpgrade = this.isRoleUpgrade('API');
+    const apiProductUpgrade = this.isRoleUpgrade('API_PRODUCT');
+    const apiDowngrade = this.isRoleDowngrade('API');
+    const apiProductDowngrade = this.isRoleDowngrade('API_PRODUCT');
+    const apiPo = apiUpgrade ? this.findExistingPrimaryOwner('API') : null;
+    const apiProductPo = apiProductUpgrade ? this.findExistingPrimaryOwner('API_PRODUCT') : null;
+
+    if (apiDowngrade || apiProductDowngrade) {
+      // A downgrade requires the operator to pick a successor; the upgrade-side message (if any) is
+      // composed alongside it so the banner reflects ALL transfers happening in this save, including
+      // mixed downgrade-on-one-scope + upgrade-on-the-other cases.
       this.editMemberForm.controls.searchTerm.enable();
       this.editMemberForm.controls.searchTerm.addValidators(Validators.required);
       this.downgradedMember = this.member;
       this.disableSubmit = !this.selectedPrimaryOwner;
-    } else {
+      this.ownershipTransferMessage = this.buildOwnershipTransferMessage(this.selectedPrimaryOwner);
+      return;
+    }
+
+    if (apiUpgrade || apiProductUpgrade) {
       this.editMemberForm.controls.searchTerm.disable();
       this.editMemberForm.controls.searchTerm.removeValidators(Validators.required);
+      this.downgradedMember = apiPo ?? apiProductPo;
+      this.selectedPrimaryOwner = this.member;
+      this.ownershipTransferMessage = this.buildUpgradeMessage(apiUpgrade, apiProductUpgrade, apiPo, apiProductPo);
       this.disableSubmit = false;
+      return;
     }
+
+    this.editMemberForm.controls.searchTerm.disable();
+    this.editMemberForm.controls.searchTerm.removeValidators(Validators.required);
+    this.disableSubmit = false;
   }
 
-  private ifPrimaryOwnerPresent() {
-    return this.members.some(member => member.roles['API'] === RoleName.PRIMARY_OWNER);
+  private buildOwnershipTransferMessage(successor: Member | null): string | null {
+    const apiUpgrade = this.isRoleUpgrade('API');
+    const apiProductUpgrade = this.isRoleUpgrade('API_PRODUCT');
+    const apiDowngrade = this.isRoleDowngrade('API');
+    const apiProductDowngrade = this.isRoleDowngrade('API_PRODUCT');
+    const apiPo = apiUpgrade ? this.findExistingPrimaryOwner('API') : null;
+    const apiProductPo = apiProductUpgrade ? this.findExistingPrimaryOwner('API_PRODUCT') : null;
+
+    const parts: string[] = [];
+
+    // Downgrade message(s) — only when a successor is actually picked.
+    if (successor) {
+      if (apiDowngrade && apiProductDowngrade) {
+        parts.push(
+          `${this.member.displayName} is the API and API Product primary owner. Primary ownership will be transferred to ${successor.displayName} and ${this.member.displayName} will be updated as owner.`,
+        );
+      } else if (apiDowngrade) {
+        parts.push(
+          `${this.member.displayName} is the API primary owner. The API primary ownership will be transferred to ${successor.displayName} and ${this.member.displayName} will be updated as owner.`,
+        );
+      } else if (apiProductDowngrade) {
+        parts.push(
+          `${this.member.displayName} is the API Product primary owner. The API Product primary ownership will be transferred to ${successor.displayName} and ${this.member.displayName} will be updated as owner.`,
+        );
+      }
+    }
+
+    // Upgrade message(s) — independent of successor selection.
+    parts.push(this.buildUpgradeMessage(apiUpgrade, apiProductUpgrade, apiPo, apiProductPo));
+
+    const message = parts.filter(Boolean).join(' ').trim();
+    return message.length > 0 ? message : null;
   }
 
-  private isDowngradeRole() {
+  private buildUpgradeMessage(apiUpgrade: boolean, apiProductUpgrade: boolean, apiPo: Member | null, apiProductPo: Member | null): string {
+    if (apiUpgrade && apiProductUpgrade && apiPo && apiProductPo && apiPo.id === apiProductPo.id) {
+      return `${apiPo.displayName} is the API and API Product primary owner. Primary ownership will be transferred to ${this.member.displayName} and ${apiPo.displayName} will be updated as owner.`;
+    }
+
+    const parts: string[] = [];
+    if (apiUpgrade) {
+      if (apiPo) {
+        parts.push(
+          `${apiPo.displayName} is the API primary owner. The API primary ownership will be transferred to ${this.member.displayName} and ${apiPo.displayName} will be updated as owner.`,
+        );
+      } else {
+        parts.push(`${this.member.displayName} will become the API primary owner of this group.`);
+      }
+    }
+    if (apiProductUpgrade) {
+      if (apiProductPo) {
+        parts.push(
+          `${apiProductPo.displayName} is the API Product primary owner. The API Product primary ownership will be transferred to ${this.member.displayName} and ${apiProductPo.displayName} will be updated as owner.`,
+        );
+      } else {
+        parts.push(`${this.member.displayName} will become the API Product primary owner of this group.`);
+      }
+    }
+    return parts.join(' ');
+  }
+
+  private findExistingPrimaryOwner(scope: 'API' | 'API_PRODUCT'): Member | null {
+    return this.members.find(member => member.roles[scope] === RoleName.PRIMARY_OWNER && member.id !== this.member.id) ?? null;
+  }
+
+  private isAnyRoleDowngrade() {
+    return this.isRoleDowngrade('API') || this.isRoleDowngrade('API_PRODUCT');
+  }
+
+  private isRoleUpgrade(scope: 'API' | 'API_PRODUCT'): boolean {
+    const controlName = scope === 'API' ? 'defaultAPIRole' : 'defaultAPIProductRole';
     return (
-      this.initialValues.defaultAPIRole === RoleName.PRIMARY_OWNER &&
-      this.editMemberForm.controls.defaultAPIRole.value !== RoleName.PRIMARY_OWNER
+      this.editMemberForm.controls[controlName].value === RoleName.PRIMARY_OWNER &&
+      this.initialValues[controlName] !== RoleName.PRIMARY_OWNER
     );
   }
 
-  private isUpgradeRole() {
+  private isRoleDowngrade(scope: 'API' | 'API_PRODUCT'): boolean {
+    const controlName = scope === 'API' ? 'defaultAPIRole' : 'defaultAPIProductRole';
     return (
-      this.editMemberForm.controls.defaultAPIRole.value === RoleName.PRIMARY_OWNER &&
-      this.initialValues.defaultAPIRole !== RoleName.PRIMARY_OWNER
+      this.initialValues[controlName] === RoleName.PRIMARY_OWNER &&
+      this.editMemberForm.controls[controlName].value !== RoleName.PRIMARY_OWNER
     );
   }
 }

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
@@ -63,6 +63,15 @@ describe('GroupComponent', () => {
     },
   };
 
+  const HYBRID_SETTINGS_SNAPSHOT = {
+    api: {
+      primaryOwnerMode: 'HYBRID',
+    },
+    apiProduct: {
+      primaryOwnerMode: 'HYBRID',
+    },
+  };
+
   const GROUP: Group = {
     disable_membership_notifications: false,
     manageable: true,
@@ -128,7 +137,8 @@ describe('GroupComponent', () => {
 
   const ROLES_API_PRODUCT: Role[] = [
     { id: 'ap1', name: 'OWNER', scope: 'API_PRODUCT' },
-    { id: 'ap2', name: 'USER', scope: 'API_PRODUCT' },
+    { id: 'ap2', name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+    { id: 'ap3', name: 'USER', scope: 'API_PRODUCT' },
   ];
 
   const INVITATIONS: Invitation[] = [
@@ -448,6 +458,689 @@ describe('GroupComponent', () => {
     });
   });
 
+  describe('Transfer of Primary Ownership via Edit Member dialog', () => {
+    it('should transfer API primary ownership when promoting a member to PRIMARY_OWNER', async () => {
+      await init(GROUP.id, HYBRID_SETTINGS_SNAPSHOT);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const editButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Modify member settings"]' }));
+      await editButton.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const apiRoleSelect = await dialogHarness.getHarness(MatSelectHarness.with({ selector: '[formControlName="defaultAPIRole"]' }));
+      await apiRoleSelect.open();
+      const apiOptions = await apiRoleSelect.getOptions({ text: 'PRIMARY_OWNER' });
+      await apiOptions[0].click();
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await confirmButtonHarness.click();
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      // Demoted PO sent first; otherwise the server rejects the promotion of the new PO.
+      expect(req.request.body).toEqual([
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+        {
+          id: '1',
+          reference: 'testmember1',
+          roles: [
+            { name: 'PRIMARY_OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      req.flush({});
+    });
+
+    it('should transfer API Product primary ownership when promoting a member', async () => {
+      await init(GROUP.id, HYBRID_SETTINGS_SNAPSHOT);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: { API: 'OWNER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const editButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Modify member settings"]' }));
+      await editButton.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const apiProductRoleSelect = await dialogHarness.getHarness(
+        MatSelectHarness.with({ selector: '[formControlName="defaultAPIProductRole"]' }),
+      );
+      await apiProductRoleSelect.open();
+      const options = await apiProductRoleSelect.getOptions({ text: 'PRIMARY_OWNER' });
+      await options[0].click();
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await confirmButtonHarness.click();
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual([
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+        {
+          id: '1',
+          reference: 'testmember1',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      req.flush({});
+    });
+
+    it('should transfer both API and API Product primary ownership in a single demotion when same outgoing PO', async () => {
+      await init(GROUP.id, HYBRID_SETTINGS_SNAPSHOT);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const editButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Modify member settings"]' }));
+      await editButton.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const apiRoleSelect = await dialogHarness.getHarness(MatSelectHarness.with({ selector: '[formControlName="defaultAPIRole"]' }));
+      await apiRoleSelect.open();
+      const apiOptions = await apiRoleSelect.getOptions({ text: 'PRIMARY_OWNER' });
+      await apiOptions[0].click();
+      const apiProductRoleSelect = await dialogHarness.getHarness(
+        MatSelectHarness.with({ selector: '[formControlName="defaultAPIProductRole"]' }),
+      );
+      await apiProductRoleSelect.open();
+      const apiProductOptions = await apiProductRoleSelect.getOptions({ text: 'PRIMARY_OWNER' });
+      await apiProductOptions[0].click();
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await confirmButtonHarness.click();
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual([
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+        {
+          id: '1',
+          reference: 'testmember1',
+          roles: [
+            { name: 'PRIMARY_OWNER', scope: 'API' },
+            { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      req.flush({});
+    });
+
+    it('should transfer both primary ownerships to a chosen successor when downgrading both scopes', async () => {
+      await init(GROUP.id, HYBRID_SETTINGS_SNAPSHOT);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const editButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Modify member settings"]' }));
+      await editButton.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const apiRoleSelect = await dialogHarness.getHarness(MatSelectHarness.with({ selector: '[formControlName="defaultAPIRole"]' }));
+      await apiRoleSelect.open();
+      const apiOptions = await apiRoleSelect.getOptions({ text: 'OWNER' });
+      await apiOptions[0].click();
+      const apiProductRoleSelect = await dialogHarness.getHarness(
+        MatSelectHarness.with({ selector: '[formControlName="defaultAPIProductRole"]' }),
+      );
+      await apiProductRoleSelect.open();
+      const apiProductOptions = await apiProductRoleSelect.getOptions({ text: 'OWNER' });
+      await apiProductOptions[0].click();
+      const autoCompleteHarness = await rootLoader.getHarness(MatAutocompleteHarness);
+      await autoCompleteHarness.enterText('Test Member 2');
+      const successors = await autoCompleteHarness.getOptions();
+      await successors[0].click();
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await confirmButtonHarness.click();
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual([
+        {
+          id: '1',
+          reference: 'testmember1',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'PRIMARY_OWNER', scope: 'API' },
+            { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      req.flush({});
+    });
+
+    it('should successfully transfer api product ownership and freshly assign api primary owner in one save', async () => {
+      await init(GROUP.id, HYBRID_SETTINGS_SNAPSHOT);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: { API: 'USER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'USER', INTEGRATION: 'USER', CLUSTER: 'USER' },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const editButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Modify member settings"]' }));
+      await editButton.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const apiRoleSelect = await dialogHarness.getHarness(MatSelectHarness.with({ selector: '[formControlName="defaultAPIRole"]' }));
+      await apiRoleSelect.open();
+      const apiPoOption = (await apiRoleSelect.getOptions({ text: 'PRIMARY_OWNER' }))[0];
+      await apiPoOption.click();
+      const apiProductRoleSelect = await dialogHarness.getHarness(
+        MatSelectHarness.with({ selector: '[formControlName="defaultAPIProductRole"]' }),
+      );
+      await apiProductRoleSelect.open();
+      const apiProductPoOption = (await apiProductRoleSelect.getOptions({ text: 'PRIMARY_OWNER' }))[0];
+      await apiProductPoOption.click();
+      await fixture.whenStable();
+
+      // Scoped to the dialog to avoid matching banners rendered by the parent component.
+      const bannerText = document.querySelector('#editMemberDialog gio-banner-info')?.textContent ?? '';
+      expect(bannerText).toContain('Test Member 1 will become the API primary owner of this group.');
+      expect(bannerText).toContain('Test Member 2 is the API Product primary owner');
+      expect(bannerText).toContain('transferred to Test Member 1');
+
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await confirmButtonHarness.click();
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      // Demotion of the previous API_PRODUCT PO must come before the new PO is promoted.
+      expect(req.request.body).toEqual([
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'USER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'USER', scope: 'APPLICATION' },
+            { name: 'USER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+        {
+          id: '1',
+          reference: 'testmember1',
+          roles: [
+            { name: 'PRIMARY_OWNER', scope: 'API' },
+            { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      req.flush({});
+    });
+
+    it('should send only the edit user when promoting to PRIMARY_OWNER with no existing primary owner for that scope', async () => {
+      await init(GROUP.id, HYBRID_SETTINGS_SNAPSHOT);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const editButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Modify member settings"]' }));
+      await editButton.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const apiRoleSelect = await dialogHarness.getHarness(MatSelectHarness.with({ selector: '[formControlName="defaultAPIRole"]' }));
+      await apiRoleSelect.open();
+      (await apiRoleSelect.getOptions({ text: 'PRIMARY_OWNER' }))[0].click();
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await confirmButtonHarness.click();
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual([
+        {
+          id: '1',
+          reference: 'testmember1',
+          roles: [
+            { name: 'PRIMARY_OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      req.flush({});
+    });
+
+    it('should produce two distinct demotions when API and API Product primary owners are different members', async () => {
+      await init(GROUP.id, HYBRID_SETTINGS_SNAPSHOT, [
+        ...USERS,
+        { id: '3', reference: 'testmember3', email: 'testmember3@xxx.com', displayName: 'Test Member 3' },
+      ]);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: { API: 'OWNER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+        {
+          id: '3',
+          displayName: 'Test Member 3',
+          roles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[2].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const editButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Modify member settings"]' }));
+      await editButton.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const apiRoleSelect = await dialogHarness.getHarness(MatSelectHarness.with({ selector: '[formControlName="defaultAPIRole"]' }));
+      await apiRoleSelect.open();
+      (await apiRoleSelect.getOptions({ text: 'PRIMARY_OWNER' }))[0].click();
+      const apiProductRoleSelect = await dialogHarness.getHarness(
+        MatSelectHarness.with({ selector: '[formControlName="defaultAPIProductRole"]' }),
+      );
+      await apiProductRoleSelect.open();
+      (await apiProductRoleSelect.getOptions({ text: 'PRIMARY_OWNER' }))[0].click();
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await confirmButtonHarness.click();
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      // Each demotion only touches the relevant scope; the demoted member's other scopes stay at their existing values.
+      expect(req.request.body).toEqual([
+        {
+          id: '1',
+          reference: 'testmember1',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+        {
+          id: '3',
+          reference: 'testmember3',
+          roles: [
+            { name: 'PRIMARY_OWNER', scope: 'API' },
+            { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      req.flush({});
+    });
+
+    it('should transfer API primary ownership only when downgrading API role alone', async () => {
+      await init(GROUP.id, HYBRID_SETTINGS_SNAPSHOT);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const editButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Modify member settings"]' }));
+      await editButton.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const apiRoleSelect = await dialogHarness.getHarness(MatSelectHarness.with({ selector: '[formControlName="defaultAPIRole"]' }));
+      await apiRoleSelect.open();
+      (await apiRoleSelect.getOptions({ text: 'OWNER' }))[0].click();
+      const autoCompleteHarness = await rootLoader.getHarness(MatAutocompleteHarness);
+      await autoCompleteHarness.enterText('Test Member 2');
+      const successors = await autoCompleteHarness.getOptions();
+      await successors[0].click();
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await confirmButtonHarness.click();
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual([
+        {
+          id: '1',
+          reference: 'testmember1',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'PRIMARY_OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      req.flush({});
+    });
+
+    it('should transfer API Product primary ownership only when downgrading API Product role alone', async () => {
+      await init(GROUP.id, HYBRID_SETTINGS_SNAPSHOT);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: { API: 'OWNER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const editButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Modify member settings"]' }));
+      await editButton.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const apiProductRoleSelect = await dialogHarness.getHarness(
+        MatSelectHarness.with({ selector: '[formControlName="defaultAPIProductRole"]' }),
+      );
+      await apiProductRoleSelect.open();
+      (await apiProductRoleSelect.getOptions({ text: 'OWNER' }))[0].click();
+      const autoCompleteHarness = await rootLoader.getHarness(MatAutocompleteHarness);
+      await autoCompleteHarness.enterText('Test Member 2');
+      const successors = await autoCompleteHarness.getOptions();
+      await successors[0].click();
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Save' }));
+      await confirmButtonHarness.click();
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual([
+        {
+          id: '1',
+          reference: 'testmember1',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      req.flush({});
+    });
+
+    it('should display a single combined banner when the same member is PO of both scopes during upgrade', async () => {
+      await init(GROUP.id, HYBRID_SETTINGS_SNAPSHOT);
+      expectGetGroup();
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: { API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const editButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Modify member settings"]' }));
+      await editButton.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const apiRoleSelect = await dialogHarness.getHarness(MatSelectHarness.with({ selector: '[formControlName="defaultAPIRole"]' }));
+      await apiRoleSelect.open();
+      const apiPoOption = (await apiRoleSelect.getOptions({ text: 'PRIMARY_OWNER' }))[0];
+      await apiPoOption.click();
+      const apiProductRoleSelect = await dialogHarness.getHarness(
+        MatSelectHarness.with({ selector: '[formControlName="defaultAPIProductRole"]' }),
+      );
+      await apiProductRoleSelect.open();
+      const apiProductPoOption = (await apiProductRoleSelect.getOptions({ text: 'PRIMARY_OWNER' }))[0];
+      await apiProductPoOption.click();
+      await fixture.whenStable();
+
+      const bannerText = document.querySelector('#editMemberDialog gio-banner-info')?.textContent ?? '';
+      expect(bannerText).toContain('Test Member 2 is the API and API Product primary owner');
+      expect(bannerText).toContain('transferred to Test Member 1');
+      expect(bannerText).not.toContain('The API primary ownership will be transferred');
+      expect(bannerText).not.toContain('The API Product primary ownership will be transferred');
+    });
+  });
+
   describe('Invitations', () => {
     beforeEach(async () => {
       await init(GROUP.id);
@@ -590,9 +1283,10 @@ describe('GroupComponent', () => {
       expect(apiProductRoleSelect).toBeTruthy();
       await apiProductRoleSelect.open();
       const options = await apiProductRoleSelect.getOptions();
-      expect(options.length).toEqual(2);
+      expect(options.length).toEqual(3);
       expect(await options[0].getText()).toEqual('OWNER');
-      expect(await options[1].getText()).toEqual('USER');
+      expect(await options[1].getText()).toEqual('PRIMARY_OWNER');
+      expect(await options[2].getText()).toEqual('USER');
     });
 
     it('should show API Product role dropdown in Edit Member dialog', async () => {
@@ -909,6 +1603,117 @@ describe('GroupComponent', () => {
         { name: 'USER', scope: 'API_PRODUCT' },
         { name: 'OWNER', scope: 'APPLICATION' },
         { name: 'OWNER', scope: 'INTEGRATION' },
+        { name: 'USER', scope: 'CLUSTER' },
+      ]);
+    });
+
+    it('should clear selected user when api product role changes', async () => {
+      await init(GROUP.id);
+      expectGetGroup({
+        disable_membership_notifications: false,
+        email_invitation: false,
+        event_rules: [],
+        lock_api_role: false,
+        lock_application_role: false,
+        max_invitation: 10,
+        manageable: true,
+        name: 'Group 1',
+        roles: {},
+        system_invitation: true,
+        id: '1',
+      });
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers();
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
+      await buttonHarness.click();
+      const menuHarness = await harnessLoader.getHarness(MatMenuHarness);
+      const userSearchMenuItem = await menuHarness.getHarness(
+        MatMenuItemHarness.with({ selector: '[aria-label="Click to invite user via search"]' }),
+      );
+      await userSearchMenuItem.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const autoCompleteHarness = await rootLoader.getHarness(MatAutocompleteHarness);
+      await autoCompleteHarness.enterText('test');
+      const searchResults = await autoCompleteHarness.getOptions();
+      await searchResults[0].click();
+      const apiProductRoleSelect = await dialogHarness.getHarness(
+        MatSelectHarness.with({ selector: '[formControlName="defaultAPIProductRole"]' }),
+      );
+      await apiProductRoleSelect.open();
+      const apiProductOptions = await apiProductRoleSelect.getOptions({ text: 'OWNER' });
+      await apiProductOptions[0].click();
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Add Users' }));
+      expect(await confirmButtonHarness.isDisabled()).toEqual(true);
+      await autoCompleteHarness.enterText('test');
+      const searchResultsAgain = await autoCompleteHarness.getOptions();
+      await searchResultsAgain[0].click();
+      expect(await confirmButtonHarness.isDisabled()).toEqual(false);
+      await confirmButtonHarness.click();
+      expectAddOrUpdateMembership('2', 'testmember2', [
+        { name: 'USER', scope: 'API' },
+        { name: 'OWNER', scope: 'API_PRODUCT' },
+        { name: 'USER', scope: 'APPLICATION' },
+        { name: 'USER', scope: 'INTEGRATION' },
+        { name: 'USER', scope: 'CLUSTER' },
+      ]);
+    });
+
+    it('should clear selected user when api role changes after the user is selected', async () => {
+      await init(GROUP.id);
+      expectGetGroup({
+        disable_membership_notifications: false,
+        email_invitation: false,
+        event_rules: [],
+        lock_api_role: false,
+        lock_application_role: false,
+        max_invitation: 10,
+        manageable: true,
+        name: 'Group 1',
+        roles: {},
+        system_invitation: true,
+        id: '1',
+      });
+      expect(component.mode).toEqual('edit');
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers();
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      const buttonHarness = await getButtonByTooltipText('Search and invite users to the group');
+      await buttonHarness.click();
+      const menuHarness = await harnessLoader.getHarness(MatMenuHarness);
+      const userSearchMenuItem = await menuHarness.getHarness(
+        MatMenuItemHarness.with({ selector: '[aria-label="Click to invite user via search"]' }),
+      );
+      await userSearchMenuItem.click();
+      const dialogHarness = await rootLoader.getHarness(MatDialogHarness);
+      const autoCompleteHarness = await rootLoader.getHarness(MatAutocompleteHarness);
+      await autoCompleteHarness.enterText('test');
+      const searchResults = await autoCompleteHarness.getOptions();
+      await searchResults[0].click();
+      const apiRoleSelect = await dialogHarness.getHarness(MatSelectHarness.with({ selector: '[formControlName="defaultAPIRole"]' }));
+      await apiRoleSelect.open();
+      const apiOptions = await apiRoleSelect.getOptions({ text: 'REVIEWER' });
+      await apiOptions[0].click();
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Add Users' }));
+      expect(await confirmButtonHarness.isDisabled()).toEqual(true);
+      await autoCompleteHarness.enterText('test');
+      const searchResultsAgain = await autoCompleteHarness.getOptions();
+      await searchResultsAgain[0].click();
+      await confirmButtonHarness.click();
+      expectAddOrUpdateMembership('2', 'testmember2', [
+        { name: 'REVIEWER', scope: 'API' },
+        { name: 'USER', scope: 'API_PRODUCT' },
+        { name: 'USER', scope: 'APPLICATION' },
+        { name: 'USER', scope: 'INTEGRATION' },
         { name: 'USER', scope: 'CLUSTER' },
       ]);
     });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13783

## Description


Add-members: derive memberships from selection + react to API Product PRIMARY_OWNER toggles like API; Edit-member: full API & API Product primary-owner transfer/demotion with correct membership order for the API; autocomplete display helper; specs for transfers and chip clears.

Area | File(s) | What changed | Why
-- | -- | -- | --
Add members – default roles | add-members-dialog.component.html | defaultAPIRole → (selectionChange)="onPrimaryOwnerCandidateRoleChange()" (was onAPIRoleChange) | Same reset/clear behaviour when PO-related default changes.
  |   | defaultAPIProductRole → add (selectionChange)="onPrimaryOwnerCandidateRoleChange()" | Fix: Changing API Product default (e.g. away from PRIMARY_OWNER) now clears selections / re-enables search like API role changes.
Add members – state / submit | add-members-dialog.component.ts | Removed cached memberships[]; submit uses selectedUsers.map(mapGroupMembership) | Membership payload always reflects current form defaults + picked users (no stale rows).
  |   | Replaced API-only PRIMARY_OWNER detection with isPrimaryOwnerSelected() (API or API Product PRIMARY_OWNER) | Search/disable rules respect either PO default.
  |   | Renamed handler to onPrimaryOwnerCandidateRoleChange(); clears selectedUsers (and old parallel memberships sync) | Consistent UX when switching PO defaults on either dropdown.
Edit member – autocomplete | edit-member-dialog.component.html | mat-autocomplete + [displayWith]="displayMember" | Input shows readable label when value is odd-shaped after select/clear (Material autocomplete).
Edit member – API + API Product PO | edit-member-dialog.component.ts | Replaced narrow API-only transfer with explicit upgrade / downgrade paths for API and API_PRODUCT | Matches product model: separate PO slots per scope.
  |   | submit(): build editMembership from all form scopes; downgrade → submitWithSuccessor; upgrade → resolve existingApiPrimaryOwner / existingApiProductPrimaryOwner; forkJoin demotions then append edited membership | Backend rejects new PRIMARY_OWNER while another row still holds it → demote outgoing first, then promote.
  |   | demote(member, scopes) / buildMembershipFromMember / setRole helpers | Builds PATCH rows without duplicating fragile mapGroupMembership variants.
  |   | onChange(): banners via buildUpgradeBanner / buildDowngradeBanner | Clear copy for transfer vs “will become PO” when no incumbent.
  |   | filterMembers + displayMember | Wider filtering + stable display helper for autocomplete.
Specs | group.component.spec.ts | HYBRID_SETTINGS_SNAPSHOT, PRIMARY_OWNER in default API Product roles (+ option count assertions) | PO options & hybrid settings available in UI tests.
  |   | New “Transfer of Primary Ownership via Edit Member dialog” block | Covers API/API Product promote, dual-PO same member, downgrade + successor, combined promote, demotion ordering, banners, lone member promote, distinct dual demotions, single-scope downgrade, combined banner dup check.
  |   | Add-members: clear selected user when api product role changes (+ parallel test for API role) | Guards regression on chip + submit state when defaults change after user pick.
Formatting | edit-member-dialog.component.ts | Prettier-only tweak (may show as tiny diff) | Lint/format hygiene after edits.



https://github.com/user-attachments/assets/4618a629-3eb8-462b-8387-db4446062cea
