### PR TITLE
feat(cluster): expose DELEGATE_TO_BROKER SASL mechanism in cluster connection form

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json
@@ -41,7 +41,7 @@
           "properties": {
             "type": {
               "title": "Select SASL mechanism",
-              "enum": ["NONE", "AWS_MSK_IAM", "GSSAPI", "OAUTHBEARER", "OAUTHBEARER_TOKEN", "PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512"],
+              "enum": ["NONE", "AWS_MSK_IAM", "GSSAPI", "OAUTHBEARER", "OAUTHBEARER_TOKEN", "PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512", "DELEGATE_TO_BROKER"],
               "default": "NONE"
             }
           },
@@ -246,6 +246,15 @@
                   },
                   "additionalProperties": false,
                   "required": ["saslJaasConfig"]
+                },
+                {
+                  "description": "Delegate the SASL handshake to the backend broker. The gateway forwards the client's SASL exchange as-is.",
+                  "properties": {
+                    "type": {
+                      "enum": ["DELEGATE_TO_BROKER"]
+                    }
+                  },
+                  "additionalProperties": false
                 }
               ]
             }

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
         <gravitee-resource-schema-registry-embedded.version>1.0.0-alpha.1</gravitee-resource-schema-registry-embedded.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0-alpha.2</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>7.0.0-alpha.6</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>7.0.0-alpha.9</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.2</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>2.8.1</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13755

## Description
Adds DELEGATE_TO_BROKER to the SASL mechanism enum and the matching dependency block (no credential fields — the gateway forwards the client's SASL exchange as-is) in the kafka-cluster connection schema-form. Bumps the native-kafka reactor to 7.0.0-alpha.9 to pull in the cross-cluster SASL replay support that backs this mode in MESH virtual clusters.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

