### PR TITLE
fix(rest-api): drop emoji from default subscription form template

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/default-subscription-form.md
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/default-subscription-form.md
@@ -1,19 +1,19 @@
 <gmd-grid columns="1" class="hero-grid">
   <gmd-card class="boilerplate-hero">
-    <gmd-card-title>🎨 Subscription Form Builder</gmd-card-title>
+    <gmd-card-title>Subscription Form Builder</gmd-card-title>
     <gmd-md>
       Welcome to your subscription form workspace! This is where you can design and customize the form that API consumers will see when subscribing to your APIs.
 
       **How to use this space:**
 
-      - **✏️ Edit freely** - Modify the examples below or start from scratch
-      - **👀 Live preview** - See your changes instantly on the right side
-      - **🧪 Test validation** - Try filling out the form to test required fields and validation rules
-      - **💾 Save & publish** - When ready, save your form and publish it to make it available in the portal
+      - **Edit freely** - Modify the examples below or start from scratch
+      - **Live preview** - See your changes instantly on the right side
+      - **Test validation** - Try filling out the form to test required fields and validation rules
+      - **Save & publish** - When ready, save your form and publish it to make it available in the portal
 
       ---
 
-      **💡 Pro tip:** Start by editing the example form below, then delete what you don't need and build your own!
+      **Pro tip:** Start by editing the example form below, then delete what you don't need and build your own!
     </gmd-md>
   </gmd-card>
 </gmd-grid>


### PR DESCRIPTION
## Summary

Strip emoji (🎨 ✏️ 👀 🧪 💾 💡) from the hero card of `default-subscription-form.md` so the `DefaultSubscriptionFormUpgrader` insert succeeds against MySQL/MariaDB on JDBC deployments.

## Why

`gmd_content` is declared `nvarchar` in the Liquibase changelog; on MySQL `nvarchar` maps to `utf8mb3`, which cannot store 4-byte UTF-8 (emoji). Every fresh boot of mAPI on JDBC + MySQL/MariaDB aborts during the upgrader phase with:

```
SQLException: HY000 / 1366 — Incorrect string value: '\xF0\x9F\x8E\xA8 S...' for column 'gmd_content' at row 1
ERROR UpgraderServiceImpl - Upgrade failed for DefaultSubscriptionFormUpgrader.
ERROR UpgraderServiceImpl - Stopping because one of the upgrades could not be performed
```

Removing the emoji from the boilerplate template is the minimal, low-risk fix to unblock JDBC + MySQL/MariaDB tenants. Migrating the column charset to `utf8mb4` is a longer-term followup tracked separately on APIM-13944.

Fixes [APIM-13944](https://gravitee.atlassian.net/browse/APIM-13944).

## Test plan

- [x] Existing unit test (`DefaultSubscriptionFormUpgraderTest`) passes — the test reads the template via `ClassPathResource` so the emoji-strip is automatically reflected.
- [x] End-to-end on `mysql:8.4` with `sql_require_primary_key=ON`: built rest-api dist, started mAPI standalone, confirmed
  - Liquibase: 159 EXECUTED + 19 MARK_RAN changesets
  - `DefaultSubscriptionFormUpgrader` created 1 form for the DEFAULT environment (5636-byte body)
  - 0× error 1366 (`Incorrect string value`)
  - 0× `Stopping because one of the upgrades could not be performed`
  - mAPI: `started in 6316 ms`

[APIM-13944]: https://gravitee.atlassian.net/browse/APIM-13944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ