### PR TITLE
Improve referenceType upgraders performances

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/plan/PlanReferenceTypeUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/plan/PlanReferenceTypeUpgrader.java
@@ -16,11 +16,9 @@
 package io.gravitee.repository.mongodb.management.upgrade.upgrader.plan;
 
 import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateManyModel;
-import com.mongodb.client.model.Updates;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
-import java.util.ArrayList;
+import java.util.List;
 import lombok.CustomLog;
 import org.bson.Document;
 import org.springframework.stereotype.Component;
@@ -37,47 +35,23 @@ public class PlanReferenceTypeUpgrader extends MongoUpgrader {
     }
 
     @Override
-    public boolean upgrade() {
-        try {
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
             log.debug("Starting plan reference type upgrader");
-            var query = Filters.and(
+
+            var filter = Filters.and(
                 Filters.exists("api", true),
                 Filters.ne("api", null),
+                Filters.ne("api", ""),
                 Filters.or(Filters.exists("referenceType", false), Filters.eq("referenceType", null))
             );
 
-            var projection = Projections.fields(Projections.include("_id", "api"));
+            var pipeline = List.of(new Document("$set", new Document("referenceType", "API").append("referenceId", "$api")));
 
-            var bulkActions = new ArrayList<UpdateManyModel<Document>>();
-
-            this.getCollection("plans")
-                .find(query)
-                .projection(projection)
-                .forEach(plan -> {
-                    String apiId = plan.getString("api");
-                    if (apiId != null && !apiId.isEmpty()) {
-                        bulkActions.add(
-                            new UpdateManyModel<>(
-                                Filters.eq("_id", plan.getString("_id")),
-                                Updates.combine(Updates.set("referenceType", "API"), Updates.set("referenceId", apiId))
-                            )
-                        );
-                    }
-                });
-
-            if (bulkActions.isEmpty()) {
-                log.debug("No plans found requiring reference type update");
-                return true;
-            }
-
-            log.debug("Updating {} plan(s) with reference type and reference id", bulkActions.size());
-            boolean acknowledged = this.getCollection("plans").bulkWrite(bulkActions).wasAcknowledged();
-            log.debug("Plan reference type upgrade completed successfully");
-            return acknowledged;
-        } catch (Exception ex) {
-            log.error("An error occurred while running the plan reference type upgrader, skipping it", ex);
-            return true;
-        }
+            var result = this.getCollection("plans").updateMany(filter, pipeline);
+            log.debug("Upgraded {} plan(s) with reference type and reference id", result.getModifiedCount());
+            return result.wasAcknowledged();
+        });
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/subscription/SubscriptionReferenceTypeUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/subscription/SubscriptionReferenceTypeUpgrader.java
@@ -16,11 +16,8 @@
 package io.gravitee.repository.mongodb.management.upgrade.upgrader.subscription;
 
 import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.Projections;
-import com.mongodb.client.model.UpdateManyModel;
-import com.mongodb.client.model.Updates;
+import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.mongodb.management.upgrade.upgrader.common.MongoUpgrader;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.CustomLog;
 import org.bson.Document;
@@ -34,48 +31,23 @@ public class SubscriptionReferenceTypeUpgrader extends MongoUpgrader {
         SubscriptionApplicationNameUpgrader.SUBSCRIPTION_APPLICATION_NAME_UPGRADER_ORDER + 1;
 
     @Override
-    public boolean upgrade() {
-        try {
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
             log.debug("Starting subscription reference type upgrader");
 
-            var query = Filters.and(
+            var filter = Filters.and(
                 Filters.exists("api", true),
                 Filters.ne("api", null),
+                Filters.ne("api", ""),
                 Filters.or(Filters.exists("referenceType", false), Filters.eq("referenceType", null))
             );
 
-            var projection = Projections.fields(Projections.include("_id", "api"));
+            var pipeline = List.of(new Document("$set", new Document("referenceType", "API").append("referenceId", "$api")));
 
-            List<UpdateManyModel<Document>> bulkActions = new ArrayList<>();
-
-            this.getCollection("subscriptions")
-                .find(query)
-                .projection(projection)
-                .forEach(subscription -> {
-                    String apiId = subscription.getString("api");
-                    if (apiId != null && !apiId.isEmpty()) {
-                        bulkActions.add(
-                            new UpdateManyModel<>(
-                                Filters.eq("_id", subscription.getString("_id")),
-                                Updates.combine(Updates.set("referenceType", "API"), Updates.set("referenceId", apiId))
-                            )
-                        );
-                    }
-                });
-
-            if (bulkActions.isEmpty()) {
-                log.debug("No subscriptions found requiring reference type update");
-                return true;
-            }
-
-            log.debug("Updating {} subscription(s) with reference type and reference id", bulkActions.size());
-            boolean acknowledged = this.getCollection("subscriptions").bulkWrite(bulkActions).wasAcknowledged();
-            log.debug("Subscription reference type upgrade completed successfully");
-            return acknowledged;
-        } catch (Exception ex) {
-            log.error("An error occurred while running the subscription reference type upgrader, skipping it", ex);
-            return true;
-        }
+            var result = this.getCollection("subscriptions").updateMany(filter, pipeline);
+            log.debug("Upgraded {} subscription(s) with reference type and reference id", result.getModifiedCount());
+            return result.wasAcknowledged();
+        });
     }
 
     @Override


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13985

## Description

Refactor `SubscriptionReferenceTypeUpgrader` and `PlanReferenceTypeUpgrader` to fix two issues:

  - **Performance / memory**: the previous implementation loaded every matching document into JVM heap (`find().forEach()` building an `UpdateManyModel` list) before issuing a single `bulkWrite`. On large tenants this risks OOM and adds N round-trips for what is a pure server-side field copy. Replaced with a single `updateMany` + aggregation pipeline (`$set referenceType: "API"`, `referenceId: "$api"`) — no documents transit through the JVM.

  - **Silent failures**: both upgraders caught `Exception` and returned `true`, marking the upgrade as successfully applied even on crash. Migrated to the `wrapException(...)` / `throws UpgraderException` pattern recommended by `Upgrader#upgrade()`, so failures now propagate to the framework.

The filter is unchanged (still skips already-migrated documents), so the upgraders remain idempotent and safe to re-run.

