### PR TITLE
chore(4.11.x): bump gravitee-policy-groovy from 4.3.1 to 4.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <gravitee-policy-generate-http-signature.version>1.3.0</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.8.0</gravitee-policy-generate-jwt.version>
         <gravitee-policy-geoip-filtering.version>2.2.2</gravitee-policy-geoip-filtering.version>
-        <gravitee-policy-groovy.version>4.3.1</gravitee-policy-groovy.version>
+        <gravitee-policy-groovy.version>4.3.2</gravitee-policy-groovy.version>
         <gravitee-policy-html-json.version>1.6.3</gravitee-policy-html-json.version>
         <gravitee-policy-http-signature.version>1.7.0</gravitee-policy-http-signature.version>
         <gravitee-policy-interrupt.version>2.1.0</gravitee-policy-interrupt.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-policy-groovy](https://github.com/gravitee-io/gravitee-policy-groovy)** from `4.3.1` to `4.3.2` on branch `4.11.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-policy-groovy/releases) page for details.