### PR TITLE
chore(deps): bump gravitee-endpoint-solace to 3.0.3 (APIM-13274)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
         <gravitee-endpoint-kafka.version>4.0.10</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>4.0.1</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>3.0.2</gravitee-endpoint-rabbitmq.version>
-        <gravitee-endpoint-solace.version>3.0.2</gravitee-endpoint-solace.version>
+        <gravitee-endpoint-solace.version>3.0.3</gravitee-endpoint-solace.version>
         <gravitee-endpoint-azure-service-bus.version>1.0.2</gravitee-endpoint-azure-service-bus.version>
         <gravitee-endpoint-agent-to-agent.version>1.0.1</gravitee-endpoint-agent-to-agent.version>
         <gravitee-policy-graphql-rate-limit.version>1.0.2</gravitee-policy-graphql-rate-limit.version>


### PR DESCRIPTION
Bumps `gravitee-endpoint-solace` from 3.0.2 to 3.0.3 on 4.8.x.

Picks up the EL-on-topics fix from [APIM-13274](https://gravitee.atlassian.net/browse/APIM-13274) (gravitee-endpoint-solace#85).

Solace endpoint topics now evaluate EL expressions properly (e.g. `dyn/{#request.path}`). Previously the literal string was published to the broker.

3.0.3 changes:
- `SolaceEndpointConnector.buildFinalConfiguration` runs producer + consumer topic Sets through `resolveTopics(ctx, set)` which delegates to `resolveConfig` (null/empty-safe).
- WARN log per dropped topic if EL resolves to null/empty.
- Skips resolution when consumer/producer is disabled.

[APIM-13274]: https://gravitee.atlassian.net/browse/APIM-13274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ