### PR TITLE
chore(deps): bump gravitee-endpoint-solace to 4.0.1 (APIM-13274)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <gravitee-endpoint-kafka.version>6.0.2</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>4.0.0</gravitee-endpoint-rabbitmq.version>
-        <gravitee-endpoint-solace.version>4.0.0</gravitee-endpoint-solace.version>
+        <gravitee-endpoint-solace.version>4.0.1</gravitee-endpoint-solace.version>
         <gravitee-endpoint-azure-service-bus.version>2.0.0</gravitee-endpoint-azure-service-bus.version>
         <gravitee-endpoint-agent-to-agent.version>2.0.0</gravitee-endpoint-agent-to-agent.version>
         <gravitee-policy-graphql-rate-limit.version>1.0.2</gravitee-policy-graphql-rate-limit.version>


### PR DESCRIPTION
Bumps `gravitee-endpoint-solace` from 4.0.0 to 4.0.1 on 4.11.x.

Picks up the EL-on-topics fix from [APIM-13274](https://gravitee.atlassian.net/browse/APIM-13274) (gravitee-endpoint-solace#86, forward-port to main).

Solace endpoint topics now evaluate EL expressions properly (e.g. `dyn/{#request.path}`). Previously the literal string was published to the broker.

4.0.1 changes:
- `SolaceEndpointConnector.buildFinalConfiguration` runs producer + consumer topic Sets through `resolveTopics(ctx, set)` which delegates to `resolveConfig` (null/empty-safe).
- WARN log per dropped topic if EL resolves to null/empty (uses `ctx.withLogger(log)` per arch rule).
- Skips resolution when consumer/producer is disabled.

[APIM-13274]: https://gravitee.atlassian.net/browse/APIM-13274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ