### PR TITLE
fix: bump gravitee-resource-oauth2-provider-keycloak for vertx5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
         <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
         <gravitee-resource-auth-provider-ldap.version>2.0.1</gravitee-resource-auth-provider-ldap.version>
         <gravitee-resource-cache-redis.version>4.0.4</gravitee-resource-cache-redis.version>
-        <gravitee-resource-oauth2-provider-keycloak.version>3.0.1</gravitee-resource-oauth2-provider-keycloak.version>
+        <gravitee-resource-oauth2-provider-keycloak.version>4.0.0-alpha.1</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-resource-ai-model-text-classification.version>2.2.1</gravitee-resource-ai-model-text-classification.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>
         <gravitee-inference-service.version>2.0.0-alpha.1</gravitee-inference-service.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

bump gravitee-resource-oauth2-provider-keycloak for vertx5

