### PR TITLE
fix: stale security chain, orphan subscription for api-product

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImpl.java
@@ -141,10 +141,9 @@ public class ApiProductManagerImpl implements ApiProductManager {
         if (currentApiProduct != null) {
             log.debug("Undeploying API Product [{}] from environment [{}]", apiProductId, currentApiProduct.getEnvironmentId());
 
-            // Emit UNDEPLOY event before removal from registry
-            emitApiProductChangedEvent(ApiProductEventType.UNDEPLOY, currentApiProduct);
-
             apiProductRegistry.remove(apiProductId, currentApiProduct.getEnvironmentId());
+
+            emitApiProductChangedEvent(ApiProductEventType.UNDEPLOY, currentApiProduct);
 
             log.info("API Product [{}] has been undeployed", apiProductId);
         } else {
@@ -165,8 +164,12 @@ public class ApiProductManagerImpl implements ApiProductManager {
             eventManager.publishEvent(eventType, event);
             log.debug("Emitted {} event for API Product [{}]", eventType, apiProduct.getId());
         } catch (Exception e) {
-            log.warn("Failed to emit {} event for API Product [{}]", eventType, apiProduct.getId(), e);
-            // Don't fail the operation if event emission fails
+            log.error(
+                "Failed to emit {} event for API Product [{}] — security chain may be stale until next sync cycle",
+                eventType,
+                apiProduct.getId(),
+                e
+            );
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheService.java
@@ -123,30 +123,46 @@ public class SubscriptionCacheService implements SubscriptionService {
 
     @Override
     public void unregister(final Subscription candidate) {
-        // only once per synchronization window
-        // take all fields (including "updatedAt" in metadata) into account
-        cacheBySubscriptionId.computeIfPresent(candidate.getId(), (h, existing) -> {
-            // Remove from exploded subscriptions cache
-            Set<Subscription> allSubscriptions = cacheBySubscriptionIdAll.get(existing.getId());
-            if (allSubscriptions != null) {
-                allSubscriptions.removeIf(s -> Objects.equals(existing.getApi(), s.getApi()));
-                if (allSubscriptions.isEmpty()) {
-                    cacheBySubscriptionIdAll.remove(existing.getId());
+        // Use compute() so that the isEmpty-check-then-remove is atomic with respect to
+        // concurrent register() calls on the same subscription ID. Without this, a register()
+        // interleaved between isEmpty()=true and remove() would add a new entry to the set
+        // and then have that set orphaned by the remove().
+        cacheBySubscriptionIdAll.compute(candidate.getId(), (id, allSubscriptions) -> {
+            if (allSubscriptions == null) return null;
+
+            var toEvict = allSubscriptions
+                .stream()
+                .filter(s -> Objects.equals(candidate.getApi(), s.getApi()))
+                .toList();
+
+            toEvict.forEach(existing -> {
+                allSubscriptions.remove(existing);
+                unregisterFromClientId(existing);
+                unregisterFromClientCertificate(existing);
+            });
+
+            if (!toEvict.isEmpty()) {
+                evictKeyForApi(candidate.getApi(), candidate.getId());
+                // Handle the case where the candidate carries a different clientId/cert than
+                // what was cached (e.g. a status-change event arriving after a credential update).
+                if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientId(), candidate.getClientId()))) {
+                    unregisterFromClientId(candidate);
+                }
+                if (toEvict.stream().noneMatch(s -> Objects.equals(s.getClientCertificate(), candidate.getClientCertificate()))) {
+                    unregisterFromClientCertificate(candidate);
                 }
             }
-            evictKeyForApi(existing.getApi(), existing.getId());
-            unregisterFromClientId(existing);
-            unregisterFromClientCertificate(existing);
 
-            // In case new ones have different client id than the one in cache
-            if (!Objects.equals(candidate.getClientId(), existing.getClientId())) {
-                unregisterFromClientId(candidate);
-            }
-            if (!Objects.equals(candidate.getClientCertificate(), existing.getClientCertificate())) {
-                unregisterFromClientCertificate(candidate);
-            }
+            return allSubscriptions.isEmpty() ? null : allSubscriptions;
+        });
 
-            return null;
+        // Only evict cacheBySubscriptionId when it points to this specific API. If sibling legs
+        // remain (exploded API-Product subscriptions), rehydrate from the authoritative set so
+        // getById() stays consistent with getAllById() regardless of unregistration order.
+        cacheBySubscriptionId.computeIfPresent(candidate.getId(), (k, existing) -> {
+            if (!Objects.equals(existing.getApi(), candidate.getApi())) return existing;
+            Set<Subscription> remaining = cacheBySubscriptionIdAll.get(candidate.getId());
+            return (remaining == null || remaining.isEmpty()) ? null : remaining.iterator().next();
         });
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImplTest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.handlers.api.manager.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -166,6 +168,18 @@ class ApiProductManagerImplTest {
 
             assertThat(manager.get("product-1")).isNull();
             verify(apiProductRegistry).remove("product-1", "env-1");
+        }
+
+        @Test
+        void should_remove_from_registry_before_emitting_undeploy_event() {
+            ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date());
+            manager.register(apiProduct);
+
+            InOrder inOrder = inOrder(apiProductRegistry, eventManager);
+            manager.unregister("product-1");
+
+            inOrder.verify(apiProductRegistry).remove("product-1", "env-1");
+            inOrder.verify(eventManager).publishEvent(eq(ApiProductEventType.UNDEPLOY), any(ApiProductChangedEvent.class));
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionCacheServiceTest.java
@@ -485,6 +485,40 @@ class SubscriptionCacheServiceTest {
         }
 
         @Test
+        void should_unregister_all_exploded_subscriptions_sharing_same_subscription_id() {
+            // Same subscription ID and plan (the API Product plan) exploded across two APIs
+            Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID_2, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subApi1);
+            subscriptionService.register(subApi2);
+
+            subscriptionService.unregister(subApi1);
+            subscriptionService.unregister(subApi2);
+
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getAllById(SUB_ID)).isEmpty();
+        }
+
+        @Test
+        void should_unregister_all_exploded_subscriptions_regardless_of_unregister_order() {
+            // Unregistering in the opposite order must produce the same result
+            Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID_2, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subApi1);
+            subscriptionService.register(subApi2);
+
+            subscriptionService.unregister(subApi2);
+            subscriptionService.unregister(subApi1);
+
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getAllById(SUB_ID)).isEmpty();
+        }
+
+        @Test
         void should_evict_subscription_when_re_registered_as_closed() {
             Subscription accepted = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
             subscriptionService.register(accepted);
@@ -497,6 +531,67 @@ class SubscriptionCacheServiceTest {
             assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
             assertThat(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).isEmpty();
             assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+        }
+
+        @Test
+        void should_evict_stale_client_id_when_unregister_candidate_has_different_client_id() {
+            // Register with current clientId
+            Subscription registered = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, "clientId-current", PLAN_ID);
+            subscriptionService.register(registered);
+
+            // An unregister event arrives carrying the old clientId (credential was rotated before this event)
+            Subscription staleCandidate = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, "clientId-old", PLAN_ID);
+            subscriptionService.unregister(staleCandidate);
+
+            // The API leg is removed
+            assertThat(subscriptionService.getById(SUB_ID)).isEmpty();
+            assertThat(subscriptionService.getAllById(SUB_ID)).isEmpty();
+            // Both the current and the stale client-id keys are gone
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "clientId-current", PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "clientId-old", PLAN_ID)).isEmpty();
+        }
+
+        @Test
+        void should_keep_sibling_subscription_accessible_after_one_leg_unregistered() {
+            // Same subscription ID exploded across two APIs (API Product scenario)
+            Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID_2, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subApi1);
+            subscriptionService.register(subApi2);
+
+            // Unregister only the first leg (subApi2 is the last-registered and sits in cacheBySubscriptionId)
+            subscriptionService.unregister(subApi1);
+
+            // API_ID leg is gone
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID)).isEmpty();
+
+            // API_ID_2 leg is still alive — getById must agree with getAllById
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isPresent().contains(subApi2);
+            assertThat(subscriptionService.getAllById(SUB_ID)).containsExactly(subApi2);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent();
+        }
+
+        @Test
+        void should_keep_getById_consistent_when_last_registered_leg_is_unregistered_first() {
+            // Same subscription ID exploded across two APIs (API Product scenario).
+            // subApi2 is registered last, so it wins the cacheBySubscriptionId single slot.
+            Subscription subApi1 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
+            Subscription subApi2 = buildAcceptedSubscriptionWithClientId(SUB_ID, API_ID_2, CLIENT_ID, PLAN_ID);
+            subscriptionService.register(subApi1);
+            subscriptionService.register(subApi2);
+
+            // Unregister the leg that currently occupies cacheBySubscriptionId
+            subscriptionService.unregister(subApi2);
+
+            // API_ID_2 leg is gone
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID_2, CLIENT_ID, PLAN_ID)).isEmpty();
+            assertThat(subscriptionService.getByApiId(API_ID_2)).isEmpty();
+
+            // API_ID leg is still alive — getById must agree with getAllById
+            assertThat(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).isPresent().contains(subApi1);
+            assertThat(subscriptionService.getAllById(SUB_ID)).containsExactly(subApi1);
+            assertThat(subscriptionService.getById(SUB_ID)).isPresent();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCase.java
@@ -34,13 +34,19 @@ import io.gravitee.apim.core.audit.model.event.ApiProductAuditEvent;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.event.model.Event;
+import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
+import io.gravitee.apim.core.subscription.domain_service.DeleteSubscriptionDomainService;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.model.EventType;
 import java.util.Map;
 import java.util.Set;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
+@CustomLog
 @RequiredArgsConstructor
 public class DeleteApiProductUseCase {
 
@@ -52,6 +58,9 @@ public class DeleteApiProductUseCase {
     private final EventCrudService eventCrudService;
     private final EventLatestCrudService eventLatestCrudService;
     private final ApiProductIndexerDomainService apiProductIndexerDomainService;
+    private final SubscriptionQueryService subscriptionQueryService;
+    private final CloseSubscriptionDomainService closeSubscriptionDomainService;
+    private final DeleteSubscriptionDomainService deleteSubscriptionDomainService;
 
     public void execute(Input input) {
         ApiProduct apiProduct = apiProductQueryService
@@ -67,11 +76,31 @@ public class DeleteApiProductUseCase {
             }
         }
 
+        closeAndDeleteSubscriptions(input.apiProductId(), input.auditInfo());
+
         publishUndeployEvent(input.auditInfo(), apiProduct);
 
         apiProductCrudService.delete(input.apiProductId());
         apiProductIndexerDomainService.delete(oneShotIndexation(input.auditInfo()), apiProduct);
         createAuditLog(input.apiProductId, input.auditInfo());
+    }
+
+    private void closeAndDeleteSubscriptions(String apiProductId, AuditInfo auditInfo) {
+        subscriptionQueryService
+            .findAllByReferenceIdAndReferenceType(apiProductId, SubscriptionReferenceType.API_PRODUCT)
+            .forEach(subscription -> {
+                try {
+                    closeSubscriptionDomainService.closeSubscription(subscription, auditInfo);
+                    deleteSubscriptionDomainService.delete(subscription, auditInfo);
+                } catch (Exception e) {
+                    log.error(
+                        "Failed to close/delete subscription [{}] for API Product [{}] — subscription may remain authorized on the gateway",
+                        subscription.getId(),
+                        apiProductId,
+                        e
+                    );
+                }
+            });
     }
 
     private void publishUndeployEvent(AuditInfo auditInfo, ApiProduct apiProduct) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeleteApiProductUseCaseTest.java
@@ -16,10 +16,13 @@
 package io.gravitee.apim.core.api_product.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -27,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.SubscriptionFixtures;
 import inmemory.AbstractUseCaseTest;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApiProductCrudServiceInMemory;
@@ -34,6 +38,8 @@ import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.IndexerInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import inmemory.SubscriptionCrudServiceInMemory;
+import inmemory.SubscriptionQueryServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
@@ -44,6 +50,10 @@ import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.search.model.IndexableApiProduct;
+import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomainService;
+import io.gravitee.apim.core.subscription.domain_service.DeleteSubscriptionDomainService;
+import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
+import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -58,10 +68,14 @@ class DeleteApiProductUseCaseTest extends AbstractUseCaseTest {
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory(apiCrudService);
     private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
+    private final SubscriptionCrudServiceInMemory subscriptionCrudService = new SubscriptionCrudServiceInMemory();
+    private final SubscriptionQueryServiceInMemory subscriptionQueryService = new SubscriptionQueryServiceInMemory(subscriptionCrudService);
     private final EventCrudService eventCrudService = mock(EventCrudService.class);
     private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
     private final ApiStateDomainService apiStateDomainService = mock(ApiStateDomainService.class);
     private final ApiProductIndexerDomainService apiProductIndexerDomainService = mock(ApiProductIndexerDomainService.class);
+    private final CloseSubscriptionDomainService closeSubscriptionDomainService = mock(CloseSubscriptionDomainService.class);
+    private final DeleteSubscriptionDomainService deleteSubscriptionDomainService = mock(DeleteSubscriptionDomainService.class);
     private DeleteApiProductUseCase deleteApiProductUseCase;
 
     @BeforeEach
@@ -81,7 +95,10 @@ class DeleteApiProductUseCaseTest extends AbstractUseCaseTest {
             apiStateDomainService,
             eventCrudService,
             eventLatestCrudService,
-            apiProductIndexerDomainService
+            apiProductIndexerDomainService,
+            subscriptionQueryService,
+            closeSubscriptionDomainService,
+            deleteSubscriptionDomainService
         );
     }
 
@@ -130,7 +147,10 @@ class DeleteApiProductUseCaseTest extends AbstractUseCaseTest {
             apiStateDomainService,
             eventCrudService,
             eventLatestCrudService,
-            realIndexerDomainService
+            realIndexerDomainService,
+            subscriptionQueryService,
+            closeSubscriptionDomainService,
+            deleteSubscriptionDomainService
         );
 
         useCaseWithRealIndexer.execute(new DeleteApiProductUseCase.Input(productId, AUDIT_INFO));
@@ -235,5 +255,87 @@ class DeleteApiProductUseCaseTest extends AbstractUseCaseTest {
         verify(apiStateDomainService).stop(argThat(api -> "api-2".equals(api.getId())), eq(AUDIT_INFO));
         verify(apiProductIndexerDomainService).delete(any(), argThat(apiProduct -> productId.equals(apiProduct.getId())));
         verify(apiProductIndexerDomainService, never()).index(any(), any(), any());
+    }
+
+    @Test
+    void should_close_and_delete_subscriptions_when_deleting_api_product() {
+        var productId = "api-product-id";
+        ApiProduct product = ApiProduct.builder().id(productId).name("Product").environmentId(ENV_ID).build();
+        apiProductCrudService.create(product);
+        apiProductQueryService.initWith(List.of(product));
+
+        SubscriptionEntity subscription1 = SubscriptionFixtures.aSubscription()
+            .toBuilder()
+            .id("sub-1")
+            .referenceId(productId)
+            .referenceType(SubscriptionReferenceType.API_PRODUCT)
+            .build();
+        SubscriptionEntity subscription2 = SubscriptionFixtures.aSubscription()
+            .toBuilder()
+            .id("sub-2")
+            .referenceId(productId)
+            .referenceType(SubscriptionReferenceType.API_PRODUCT)
+            .build();
+        subscriptionCrudService.initWith(List.of(subscription1, subscription2));
+
+        deleteApiProductUseCase.execute(new DeleteApiProductUseCase.Input(productId, AUDIT_INFO));
+
+        var inOrder = inOrder(closeSubscriptionDomainService, deleteSubscriptionDomainService);
+        inOrder.verify(closeSubscriptionDomainService).closeSubscription(subscription1, AUDIT_INFO);
+        inOrder.verify(deleteSubscriptionDomainService).delete(subscription1, AUDIT_INFO);
+        inOrder.verify(closeSubscriptionDomainService).closeSubscription(subscription2, AUDIT_INFO);
+        inOrder.verify(deleteSubscriptionDomainService).delete(subscription2, AUDIT_INFO);
+        assertThat(apiProductCrudService.findById(productId)).isEmpty();
+    }
+
+    @Test
+    void should_not_call_close_or_delete_when_no_subscriptions_exist_for_api_product() {
+        var productId = "api-product-id";
+        ApiProduct product = ApiProduct.builder().id(productId).name("Product").environmentId(ENV_ID).build();
+        apiProductCrudService.create(product);
+        apiProductQueryService.initWith(List.of(product));
+
+        deleteApiProductUseCase.execute(new DeleteApiProductUseCase.Input(productId, AUDIT_INFO));
+
+        verify(closeSubscriptionDomainService, never()).closeSubscription(any(SubscriptionEntity.class), any());
+        verify(deleteSubscriptionDomainService, never()).delete(any(), any());
+        assertThat(apiProductCrudService.findById(productId)).isEmpty();
+    }
+
+    @Test
+    void should_continue_closing_remaining_subscriptions_when_one_close_throws() {
+        var productId = "api-product-id";
+        ApiProduct product = ApiProduct.builder().id(productId).name("Product").environmentId(ENV_ID).build();
+        apiProductCrudService.create(product);
+        apiProductQueryService.initWith(List.of(product));
+
+        SubscriptionEntity subscription1 = SubscriptionFixtures.aSubscription()
+            .toBuilder()
+            .id("sub-1")
+            .referenceId(productId)
+            .referenceType(SubscriptionReferenceType.API_PRODUCT)
+            .build();
+        SubscriptionEntity subscription2 = SubscriptionFixtures.aSubscription()
+            .toBuilder()
+            .id("sub-2")
+            .referenceId(productId)
+            .referenceType(SubscriptionReferenceType.API_PRODUCT)
+            .build();
+        subscriptionCrudService.initWith(List.of(subscription1, subscription2));
+
+        doThrow(new RuntimeException("close failed")).when(closeSubscriptionDomainService).closeSubscription(eq(subscription1), any());
+
+        // The product deletion must complete even though closing subscription1 throws:
+        // any subscription skipped here will never receive another close event once the product is gone.
+        assertThatCode(() ->
+            deleteApiProductUseCase.execute(new DeleteApiProductUseCase.Input(productId, AUDIT_INFO))
+        ).doesNotThrowAnyException();
+
+        // subscription2 must still be processed despite subscription1 failing
+        verify(closeSubscriptionDomainService).closeSubscription(eq(subscription2), any());
+        verify(deleteSubscriptionDomainService).delete(eq(subscription2), any());
+        // subscription1 delete is never called because its close threw
+        verify(deleteSubscriptionDomainService, never()).delete(eq(subscription1), any());
+        assertThat(apiProductCrudService.findById(productId)).isEmpty();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14025

## Description

Three separate bugs in the API Product feature, all reproducible after deleting an API Product with active subscriptions:

Bug 1 — Stale security chain (gateway)
After undeploying an API Product, member APIs continued serving 401 for Security (jwt/api-key,etc) requests. Root cause: `ApiProductManagerImpl#undeploy` emitted the `UNDEPLOY` event (which triggers a synchronous security chain refresh).

Fixed by swapping the two statements — registry removal first, event second.

Bug 2 — Orphan subscription cache entries (gateway)
After deletion, one of the member APIs would still resolve requests (false 200) because its per-API subscription entry was never evicted from`SubscriptionCacheService`. API Product subscriptions are *exploded* into one entry per member API in `cacheBySubscriptionIdAll`, but `unregister` was reading from `cacheBySubscriptionId` (single-slot, last-write-wins), so only the last-registered API's entry was cleaned up.

Fixed to use`cacheBySubscriptionIdAll` as the authoritative eviction source.

Bug 3 — Orphan subscription records in the database (rest-api)
Deleting an API Product did not cascade to its subscriptions. Those subscriptions remained in `ACCEPTED` state on the Application's  Subscriptions tab — orphan records with no corresponding API Product.

Fix: `DeleteApiProductUseCase` now does the same as API via the existing`CloseSubscriptionDomainService` and `DeleteSubscriptionDomainService`.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

