### PR TITLE
feat: Resolve enclosing API for portal navigation pages.

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationEnclosingApiDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationEnclosingApiDomainService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Resolves the API that scopes documentation templates for a navigation item by walking {@link PortalNavigationItem#getParentId()}.
+ */
+@DomainService
+@RequiredArgsConstructor
+public class PortalNavigationEnclosingApiDomainService {
+
+    private final PortalNavigationItemsQueryService queryService;
+
+    public Optional<String> findEnclosingApiId(String environmentId, PortalNavigationItem item) {
+        PortalNavigationItem current = item;
+        while (current != null && current.getParentId() != null) {
+            current = queryService.findByIdAndEnvironmentId(environmentId, current.getParentId());
+            if (current instanceof PortalNavigationApi api) {
+                return Optional.of(api.getApiId());
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/query_service/PortalNavigationItemsQueryService.java
@@ -19,7 +19,11 @@ import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import java.util.List;
+import java.util.Optional;
 
 public interface PortalNavigationItemsQueryService {
     PortalNavigationItem findByIdAndEnvironmentId(String environmentId, PortalNavigationItemId id);
@@ -29,4 +33,17 @@ public interface PortalNavigationItemsQueryService {
     List<PortalNavigationItem> search(PortalNavigationItemQueryCriteria criteria);
 
     List<PortalNavigationItem> findTopLevelItemsByEnvironmentIdAndPortalArea(String environmentId, PortalArea portalArea);
+
+    default Optional<PortalNavigationPage> findNavigationPageByPortalPageContentId(String environmentId, PortalPageContentId contentId) {
+        final var criteria = PortalNavigationItemQueryCriteria.builder()
+            .environmentId(environmentId)
+            .type(PortalNavigationItemType.PAGE)
+            .build();
+        return search(criteria)
+            .stream()
+            .filter(PortalNavigationPage.class::isInstance)
+            .map(PortalNavigationPage.class::cast)
+            .filter(page -> page.getPortalPageContentId().equals(contentId))
+            .findFirst();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationEnclosingApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationEnclosingApiDomainServiceTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static fixtures.core.model.PortalNavigationItemFixtures.ENV_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PortalNavigationEnclosingApiDomainServiceTest {
+
+    private static final String ROOT_PAGE_ID = "00000000-0000-0000-0000-00000000a001";
+    private static final String FOLDER_UNDER_API_ID = "00000000-0000-0000-0000-00000000a002";
+    private static final String DOC_PAGE_ID = "00000000-0000-0000-0000-00000000a003";
+
+    private PortalNavigationItemsQueryServiceInMemory itemsQueryService;
+    private PortalNavigationEnclosingApiDomainService enclosingApiDomainService;
+
+    @BeforeEach
+    void setUp() {
+        itemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+        enclosingApiDomainService = new PortalNavigationEnclosingApiDomainService(itemsQueryService);
+    }
+
+    @Test
+    void should_find_no_api_when_root_page_without_api_ancestor() {
+        var page = PortalNavigationItemFixtures.aPage(ROOT_PAGE_ID, "P", null);
+        page.markAsRoot();
+        itemsQueryService.initWith(List.of(page));
+
+        assertThat(enclosingApiDomainService.findEnclosingApiId(ENV_ID, page)).isEmpty();
+    }
+
+    @Test
+    void should_find_api_ancestor_through_folder_chain() {
+        var api = PortalNavigationItemFixtures.anApi(PortalNavigationItemFixtures.API1_ID, "A", null, "api-x");
+        api.markAsRoot();
+        var folder = PortalNavigationItemFixtures.aFolder(FOLDER_UNDER_API_ID, "F", api.getId());
+        folder.updateParent(api);
+        var contentId = PortalPageContentId.random();
+        var page = PortalNavigationItemFixtures.aPage(DOC_PAGE_ID, "Doc", folder.getId(), contentId);
+        page.updateParent(folder);
+        itemsQueryService.initWith(List.of(api, folder, page));
+
+        assertThat(enclosingApiDomainService.findEnclosingApiId(ENV_ID, page)).contains("api-x");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_page/PortalNavigationItemsQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/portal_page/PortalNavigationItemsQueryServiceImplTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.infra.query_service.portal_page;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
@@ -26,6 +27,7 @@ import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.infra.adapter.PortalNavigationItemAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -272,6 +274,73 @@ class PortalNavigationItemsQueryServiceImplTest {
                 .hasCauseInstanceOf(TechnicalException.class);
             var capturedCriteria = criteriaCaptor.getValue();
             assertThat(capturedCriteria.getEnvironmentId()).isEqualTo(environmentId);
+        }
+    }
+
+    @Nested
+    class FindNavigationPageByPortalPageContentId {
+
+        @Test
+        void should_return_first_matching_portal_navigation_page() throws TechnicalException {
+            var contentIdStr = "00000000-0000-0000-0000-0000000000aa";
+            var contentId = PortalPageContentId.of(contentIdStr);
+            var other = PortalNavigationItemsRepositoryFixtures.aPage(
+                "00000000-0000-0000-0000-0000000000cc",
+                "Other",
+                "00000000-0000-0000-0000-0000000000dd",
+                null
+            );
+            var matching = PortalNavigationItemsRepositoryFixtures.aPage(
+                "00000000-0000-0000-0000-0000000000bb",
+                "Match",
+                contentIdStr,
+                null
+            );
+            when(repository.searchByCriteria(any())).thenReturn(List.of(other, matching));
+
+            var result = service.findNavigationPageByPortalPageContentId(PortalNavigationItemsRepositoryFixtures.ENV_ID, contentId);
+
+            assertThat(result).isPresent();
+            assertThat(result.orElseThrow().getTitle()).isEqualTo("Match");
+        }
+
+        @Test
+        void should_return_empty_when_no_page_has_the_content_id() throws TechnicalException {
+            var wanted = PortalPageContentId.of("00000000-0000-0000-0000-0000000099");
+            var page = PortalNavigationItemsRepositoryFixtures.aPage(
+                "00000000-0000-0000-0000-000000000001",
+                "X",
+                "00000000-0000-0000-0000-0000000098",
+                null
+            );
+            when(repository.searchByCriteria(any())).thenReturn(List.of(page));
+
+            assertThat(service.findNavigationPageByPortalPageContentId(PortalNavigationItemsRepositoryFixtures.ENV_ID, wanted)).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_when_results_contain_no_pages() throws TechnicalException {
+            var contentId = PortalPageContentId.random();
+            var folder = PortalNavigationItemsRepositoryFixtures.aFolder("00000000-0000-0000-0000-0000000000ee", "Folder");
+            when(repository.searchByCriteria(any())).thenReturn(List.of(folder));
+
+            assertThat(
+                service.findNavigationPageByPortalPageContentId(PortalNavigationItemsRepositoryFixtures.ENV_ID, contentId)
+            ).isEmpty();
+        }
+
+        @Test
+        void should_propagate_failure_from_search() throws TechnicalException {
+            when(repository.searchByCriteria(any())).thenThrow(new TechnicalException("Database error"));
+
+            assertThatThrownBy(() ->
+                service.findNavigationPageByPortalPageContentId(
+                    PortalNavigationItemsRepositoryFixtures.ENV_ID,
+                    PortalPageContentId.random()
+                )
+            )
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasCauseInstanceOf(TechnicalException.class);
         }
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14001

### Stacked PRs
- **master**
  - https://github.com/gravitee-io/gravitee-api-management/pull/16696 
    - https://github.com/gravitee-io/gravitee-api-management/pull/16779 👈
      - https://github.com/gravitee-io/gravitee-api-management/pull/16780
        - https://github.com/gravitee-io/gravitee-api-management/pull/16781

###  Enclosing API resolution for portal navigation pages

Adds navigation helpers so templating can tell whether a portal page lives under an API (for `api` in FreeMarker) vs environment-only context (for `metadata`).

### Scope

- `PortalNavigationEnclosingApiDomainService`: walks ancestors to find enclosing API id.
- `PortalNavigationItemsQueryService`: default `findNavigationPageByPortalPageContentId`.
- Unit tests for domain service and query implementation.
