### PR TITLE
feat: Validate and render GMD using navigation template context.

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -139,6 +139,7 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDoma
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
@@ -1115,6 +1116,11 @@ public class ResourceContextConfiguration {
     @Bean
     public GetPortalPageContentUseCase getPortalPageContentUseCase() {
         return mock(GetPortalPageContentUseCase.class);
+    }
+
+    @Bean
+    public PortalNavigationTemplatingService portalNavigationTemplatingService() {
+        return mock(PortalNavigationTemplatingService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -63,6 +63,7 @@ import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.ExportApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
@@ -103,6 +104,7 @@ import io.gravitee.apim.core.dictionary.use_case.DeleteDictionaryUseCase;
 import io.gravitee.apim.core.documentation.crud_service.PageCrudService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageAccessControlsDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDomainService;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
@@ -1121,6 +1123,16 @@ public class ResourceContextConfiguration {
     @Bean
     public PortalNavigationTemplatingService portalNavigationTemplatingService() {
         return mock(PortalNavigationTemplatingService.class);
+    }
+
+    @Bean
+    public ApiTemplateModelProvider apiTemplateModelProvider() {
+        return mock(ApiTemplateModelProvider.class);
+    }
+
+    @Bean
+    public EnvironmentTemplateModelProvider environmentTemplateModelProvider() {
+        return mock(EnvironmentTemplateModelProvider.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -1322,6 +1322,16 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public ApiTemplateModelProvider apiTemplateModelProvider() {
+        return mock(ApiTemplateModelProvider.class);
+    }
+
+    @Bean
+    public EnvironmentTemplateModelProvider environmentTemplateModelProvider() {
+        return mock(EnvironmentTemplateModelProvider.class);
+    }
+
+    @Bean
     public AnalyticsDefinitionQueryService analyticsDefinitionQueryService() {
         return new AnalyticsDefinitionYAMLQueryService();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -170,6 +170,8 @@ import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomain
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiPortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
@@ -1293,7 +1295,9 @@ public class ResourceContextConfiguration {
             gmdValidator,
             portalNavigationItemsQueryService,
             mock(PortalNavigationEnclosingApiDomainService.class),
-            mock(PortalNavigationTemplatingService.class)
+            mock(PortalNavigationTemplatingService.class),
+            mock(ApiTemplateModelProvider.class),
+            mock(EnvironmentTemplateModelProvider.class)
         );
         OpenApiValidator openApiValidator = new OpenApiValidator();
         OpenApiPortalPageContentValidatorService openApiContentValidator = new OpenApiPortalPageContentValidatorService(openApiValidator);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -173,11 +173,13 @@ import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudServi
 import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiPortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.apim.core.portal_page.use_case.BulkCreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
@@ -1283,10 +1285,16 @@ public class ResourceContextConfiguration {
     @Bean
     public UpdatePortalPageContentUseCase updatePortalPageContentUseCase(
         PortalPageContentQueryService portalPageContentQueryService,
-        PortalPageContentCrudService portalPageContentCrudService
+        PortalPageContentCrudService portalPageContentCrudService,
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService
     ) {
         GraviteeMarkdownValidator gmdValidator = new GraviteeMarkdownValidator();
-        GraviteePortalPageContentValidatorService gmdContentValidator = new GraviteePortalPageContentValidatorService(gmdValidator);
+        GraviteePortalPageContentValidatorService gmdContentValidator = new GraviteePortalPageContentValidatorService(
+            gmdValidator,
+            portalNavigationItemsQueryService,
+            mock(PortalNavigationEnclosingApiDomainService.class),
+            mock(PortalNavigationTemplatingService.class)
+        );
         OpenApiValidator openApiValidator = new OpenApiValidator();
         OpenApiPortalPageContentValidatorService openApiContentValidator = new OpenApiPortalPageContentValidatorService(openApiValidator);
         PortalPageContentValidatorService validatorService = new PortalPageContentValidatorService(
@@ -1302,6 +1310,11 @@ public class ResourceContextConfiguration {
         PortalNavigationApiVisibilityDomainService portalNavigationApiVisibilityDomainService
     ) {
         return new ListPortalNavigationItemsUseCase(portalNavigationItemsQueryService, portalNavigationApiVisibilityDomainService);
+    }
+
+    @Bean
+    public PortalNavigationTemplatingService portalNavigationTemplatingService() {
+        return mock(PortalNavigationTemplatingService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -71,6 +71,7 @@ import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
@@ -128,6 +129,7 @@ import io.gravitee.apim.core.documentation.domain_service.DocumentationValidatio
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageAccessControlsDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePagesDomainService;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.group.crud_service.GroupCrudService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
@@ -170,8 +172,6 @@ import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomain
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
-import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
-import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.OpenApiPortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -60,6 +60,7 @@ import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
@@ -97,6 +98,7 @@ import io.gravitee.apim.core.cluster.use_case.members.TransferClusterOwnershipUs
 import io.gravitee.apim.core.cluster.use_case.members.UpdateClusterMemberUseCase;
 import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDomainService;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.group.crud_service.GroupCrudService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
@@ -1278,6 +1280,16 @@ public class ResourceContextConfiguration {
     @Bean
     public PortalNavigationTemplatingService portalNavigationTemplatingService() {
         return mock(PortalNavigationTemplatingService.class);
+    }
+
+    @Bean
+    public ApiTemplateModelProvider apiTemplateModelProvider() {
+        return mock(ApiTemplateModelProvider.class);
+    }
+
+    @Bean
+    public EnvironmentTemplateModelProvider environmentTemplateModelProvider() {
+        return mock(EnvironmentTemplateModelProvider.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -131,6 +131,7 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDoma
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
@@ -1272,6 +1273,11 @@ public class ResourceContextConfiguration {
     @Bean
     public ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase() {
         return mock(ListPortalNavigationItemsUseCase.class);
+    }
+
+    @Bean
+    public PortalNavigationTemplatingService portalNavigationTemplatingService() {
+        return mock(PortalNavigationTemplatingService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.rest.api.portal.rest.mapper;
 
-import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
-import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
@@ -24,8 +22,8 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
-import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.util.List;
@@ -62,16 +60,9 @@ public interface PortalNavigationItemMapper {
     io.gravitee.rest.api.portal.rest.model.PortalNavigationPage map(PortalNavigationPage page);
     io.gravitee.rest.api.portal.rest.model.PortalNavigationApi map(PortalNavigationApi api);
 
-    default String extractContent(PortalPageContent<?> content) {
-        return switch (content) {
-            case GraviteeMarkdownPageContent gmd -> gmd.getContent().value();
-            case OpenApiPageContent oapi -> oapi.getContent().value();
-        };
-    }
-
-    @Mapping(target = "content", expression = "java(extractContent(content))")
+    @Mapping(source = "value", target = "content")
     @Mapping(source = "type", target = "type")
-    io.gravitee.rest.api.portal.rest.model.PortalPageContent map(PortalPageContent<?> content);
+    io.gravitee.rest.api.portal.rest.model.PortalPageContent map(RenderedPageContent content);
 
     default String map(@Nullable PortalNavigationItemId portalNavigationItemId) {
         if (portalNavigationItemId == null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
@@ -72,6 +72,6 @@ public class PortalNavigationItemResource extends AbstractResource {
             )
         );
 
-        return Response.ok(portalNavigationItemMapper.map(result.portalPageContent())).build();
+        return Response.ok(portalNavigationItemMapper.map(result.renderedContent())).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResource.java
@@ -66,6 +66,7 @@ public class PortalNavigationItemResource extends AbstractResource {
         var result = getPortalPageContentByNavigationIdUseCase.execute(
             new GetPortalPageContentByNavigationIdUseCase.Input(
                 portalNavigationItemId,
+                executionContext.getOrganizationId(),
                 executionContext.getEnvironmentId(),
                 PortalNavigationItemViewerContext.forPortal(getAuthenticatedUserOrNull())
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceNotAuthenticatedTest.java
@@ -24,6 +24,7 @@ import fixtures.core.model.PortalPageContentFixtures;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
 import io.gravitee.rest.api.portal.rest.model.PortalPageContent;
@@ -69,7 +70,10 @@ public class PortalNavigationItemResourceNotAuthenticatedTest extends AbstractRe
         GraviteeContext.setCurrentEnvironment(ENV_ID);
         doAnswer(invocation -> {
             var in = (PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput) invocation.getArgument(0);
-            return in.rawMarkdown();
+            return RenderedPageContent.of(
+                in.rawMarkdown().value(),
+                io.gravitee.apim.core.portal_page.model.PortalPageContentType.GRAVITEE_MARKDOWN
+            );
         })
             .when(portalNavigationTemplatingService)
             .renderGraviteeMarkdown(any());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceNotAuthenticatedTest.java
@@ -17,11 +17,14 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static fixtures.core.model.PortalPageContentFixtures.ORGANIZATION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 
 import fixtures.core.model.PortalPageContentFixtures;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
 import io.gravitee.rest.api.portal.rest.model.PortalPageContent;
 import io.gravitee.rest.api.portal.rest.model.PortalPageContentType;
@@ -48,6 +51,9 @@ public class PortalNavigationItemResourceNotAuthenticatedTest extends AbstractRe
     @Autowired
     private PortalPageContentQueryServiceInMemory portalPageContentQueryService;
 
+    @Autowired
+    private PortalNavigationTemplatingService portalNavigationTemplatingService;
+
     @Override
     protected String contextPath() {
         return "portal-navigation-items/";
@@ -61,6 +67,12 @@ public class PortalNavigationItemResourceNotAuthenticatedTest extends AbstractRe
     @BeforeEach
     public void init() {
         GraviteeContext.setCurrentEnvironment(ENV_ID);
+        doAnswer(invocation -> {
+            var in = (PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput) invocation.getArgument(0);
+            return in.rawMarkdown();
+        })
+            .when(portalNavigationTemplatingService)
+            .renderGraviteeMarkdown(any());
     }
 
     @AfterEach

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
@@ -18,7 +18,7 @@ package io.gravitee.rest.api.portal.rest.resource;
 import static fixtures.core.model.PortalPageContentFixtures.ORGANIZATION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
 
 import fixtures.core.model.PortalPageContentFixtures;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
 import io.gravitee.rest.api.portal.rest.model.PortalPageContent;
 import io.gravitee.rest.api.portal.rest.model.PortalPageContentType;
@@ -52,6 +53,9 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
     @Autowired
     private PortalPageContentQueryServiceInMemory portalPageContentQueryService;
 
+    @Autowired
+    private PortalNavigationTemplatingService portalNavigationTemplatingService;
+
     @Override
     protected String contextPath() {
         return "portal-navigation-items/";
@@ -60,6 +64,12 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
     @BeforeEach
     public void init() {
         GraviteeContext.setCurrentEnvironment(ENV_ID);
+        doAnswer(invocation -> {
+            var in = (PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput) invocation.getArgument(0);
+            return in.rawMarkdown();
+        })
+            .when(portalNavigationTemplatingService)
+            .renderGraviteeMarkdown(any());
     }
 
     @AfterEach

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PortalNavigationItemResourceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.rest.api.portal.rest.fixture.PortalNavigationFixtures;
 import io.gravitee.rest.api.portal.rest.model.PortalPageContent;
@@ -66,7 +67,10 @@ public class PortalNavigationItemResourceTest extends AbstractResourceTest {
         GraviteeContext.setCurrentEnvironment(ENV_ID);
         doAnswer(invocation -> {
             var in = (PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput) invocation.getArgument(0);
-            return in.rawMarkdown();
+            return RenderedPageContent.of(
+                in.rawMarkdown().value(),
+                io.gravitee.apim.core.portal_page.model.PortalPageContentType.GRAVITEE_MARKDOWN
+            );
         })
             .when(portalNavigationTemplatingService)
             .renderGraviteeMarkdown(any());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -63,6 +63,7 @@ import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
@@ -101,6 +102,7 @@ import io.gravitee.apim.core.dashboard.use_case.GetDashboardUseCase;
 import io.gravitee.apim.core.dashboard.use_case.ListDashboardsUseCase;
 import io.gravitee.apim.core.dictionary.domain_service.DictionaryAutomationDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDomainService;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.group.crud_service.GroupCrudService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
@@ -1261,6 +1263,16 @@ public class ResourceContextConfiguration {
     @Bean
     public PortalNavigationTemplatingService portalNavigationTemplatingService() {
         return mock(PortalNavigationTemplatingService.class);
+    }
+
+    @Bean
+    public ApiTemplateModelProvider apiTemplateModelProvider() {
+        return mock(ApiTemplateModelProvider.class);
+    }
+
+    @Bean
+    public EnvironmentTemplateModelProvider environmentTemplateModelProvider() {
+        return mock(EnvironmentTemplateModelProvider.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -139,6 +139,7 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDoma
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
@@ -1255,6 +1256,11 @@ public class ResourceContextConfiguration {
     @Bean
     public GetPortalPageContentUseCase getPortalPageContentUseCase() {
         return mock(GetPortalPageContentUseCase.class);
+    }
+
+    @Bean
+    public PortalNavigationTemplatingService portalNavigationTemplatingService() {
+        return mock(PortalNavigationTemplatingService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/service_provider/ApiTemplateModelProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/service_provider/ApiTemplateModelProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.service_provider;
+
+public interface ApiTemplateModelProvider {
+    /**
+     * Returns an API model object suitable for FreeMarker template rendering (e.g. {@code ${api.name}}).
+     *
+     * @param organizationId the organization the API belongs to
+     * @param environmentId  the environment the API belongs to
+     * @param apiId          the technical API ID
+     * @return an object exposing API properties that FreeMarker can navigate
+     */
+    Object getApiTemplateModel(String organizationId, String environmentId, String apiId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/environment/service_provider/EnvironmentTemplateModelProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/environment/service_provider/EnvironmentTemplateModelProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.environment.service_provider;
+
+import java.util.Map;
+
+public interface EnvironmentTemplateModelProvider {
+    /**
+     * Returns the environment metadata as a flat key→value map suitable for FreeMarker template rendering
+     * (e.g. {@code ${metadata.someKey}}).
+     *
+     * @param environmentId the environment whose metadata to fetch
+     * @return a map of metadata key/value pairs; never {@code null}
+     */
+    Map<String, String> getEnvironmentMetadata(String environmentId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/ContentRenderer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/ContentRenderer.java
@@ -13,16 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.exception;
+package io.gravitee.apim.core.portal_page.domain_service;
 
-/** Thrown when portal navigation page markdown fails FreeMarker evaluation (invalid syntax or missing model data). */
-public class PortalPageContentTemplateException extends RendererException {
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 
-    public PortalPageContentTemplateException(String message) {
-        super(message);
-    }
+public interface ContentRenderer {
+    boolean appliesTo(PortalPageContent<?> content);
 
-    public PortalPageContentTemplateException(String message, Throwable cause) {
-        super(message, cause);
-    }
+    RenderedPageContent render(PortalNavigationItem item, PortalPageContent<?> content);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/DefaultContentRenderer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/DefaultContentRenderer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.portal_page.exception.RendererException;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
+
+@DomainService
+public class DefaultContentRenderer implements ContentRenderer {
+
+    @Override
+    public boolean appliesTo(PortalPageContent<?> content) {
+        return !(content instanceof GraviteeMarkdownPageContent);
+    }
+
+    @Override
+    public RenderedPageContent render(PortalNavigationItem item, PortalPageContent<?> content) {
+        return switch (content) {
+            case OpenApiPageContent oapi -> RenderedPageContent.of(oapi.getContent().value(), PortalPageContentType.OPENAPI);
+            default -> throw new RendererException("Content type not supported: " + content.getType());
+        };
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/GraviteeMarkdownContentRenderer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/GraviteeMarkdownContentRenderer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class GraviteeMarkdownContentRenderer implements ContentRenderer {
+
+    private final PortalNavigationEnclosingApiDomainService enclosingApiDomainService;
+    private final PortalNavigationTemplatingService portalNavigationTemplatingService;
+    private final ApiTemplateModelProvider apiTemplateModelProvider;
+    private final EnvironmentTemplateModelProvider environmentTemplateModelProvider;
+
+    @Override
+    public boolean appliesTo(PortalPageContent<?> content) {
+        return content instanceof GraviteeMarkdownPageContent;
+    }
+
+    @Override
+    public RenderedPageContent render(PortalNavigationItem item, PortalPageContent<?> content) {
+        var markdownPage = (GraviteeMarkdownPageContent) content;
+        var page = (PortalNavigationPage) item;
+        var enclosingApiId = enclosingApiDomainService.findEnclosingApiId(content.getEnvironmentId(), page);
+        Map<String, Object> model = enclosingApiId
+            .<Map<String, Object>>map(id ->
+                Map.of("api", apiTemplateModelProvider.getApiTemplateModel(content.getOrganizationId(), content.getEnvironmentId(), id))
+            )
+            .orElseGet(() -> Map.of("metadata", environmentTemplateModelProvider.getEnvironmentMetadata(content.getEnvironmentId())));
+        return portalNavigationTemplatingService.renderGraviteeMarkdown(
+            new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(markdownPage.getContent(), model)
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/GraviteePortalPageContentValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/GraviteePortalPageContentValidatorService.java
@@ -18,9 +18,16 @@ package io.gravitee.apim.core.portal_page.domain_service;
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalPageContentTemplateException;
+import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -28,6 +35,9 @@ import lombok.RequiredArgsConstructor;
 public class GraviteePortalPageContentValidatorService implements PortalPageContentValidator {
 
     private final GraviteeMarkdownValidator graviteeMarkdownValidator;
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationEnclosingApiDomainService portalNavigationEnclosingApiDomainService;
+    private final PortalNavigationTemplatingService portalNavigationTemplatingService;
 
     @Override
     public boolean appliesTo(PortalPageContent<?> existingContent) {
@@ -35,7 +45,39 @@ public class GraviteePortalPageContentValidatorService implements PortalPageCont
     }
 
     @Override
-    public void validate(UpdatePortalPageContent updateContent) {
+    public void validate(PortalPageContent<?> existingContent, UpdatePortalPageContent updateContent) {
         graviteeMarkdownValidator.validateNotEmpty(GraviteeMarkdown.of(updateContent.getContent()));
+
+        final var environmentId = existingContent.getEnvironmentId();
+        final var portalPageContentId = existingContent.getId();
+        final var navigationPage = portalNavigationItemsQueryService.findNavigationPageByPortalPageContentId(
+            environmentId,
+            portalPageContentId
+        );
+        if (navigationPage.isEmpty()) {
+            return;
+        }
+
+        final var markdown = updateContent.getContent();
+        final var organizationId = existingContent.getOrganizationId();
+        final var enclosingApiId = portalNavigationEnclosingApiDomainService.findEnclosingApiId(environmentId, navigationPage.get());
+
+        tryDryRender(markdown, portalPageContentId, organizationId, environmentId, enclosingApiId);
+    }
+
+    private void tryDryRender(
+        String markdown,
+        PortalPageContentId templateKey,
+        String orgId,
+        String envId,
+        Optional<String> enclosingApiId
+    ) {
+        try {
+            portalNavigationTemplatingService.renderGraviteeMarkdown(
+                new RenderPortalNavigationMarkdownInput(markdown, templateKey.json(), orgId, envId, enclosingApiId)
+            );
+        } catch (PortalPageContentTemplateException e) {
+            throw new InvalidPortalPageContentTemplateException(e.getMessage(), e);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/GraviteePortalPageContentValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/GraviteePortalPageContentValidatorService.java
@@ -16,17 +16,19 @@
 package io.gravitee.apim.core.portal_page.domain_service;
 
 import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalPageContentTemplateException;
 import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
-import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
@@ -38,6 +40,8 @@ public class GraviteePortalPageContentValidatorService implements PortalPageCont
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
     private final PortalNavigationEnclosingApiDomainService portalNavigationEnclosingApiDomainService;
     private final PortalNavigationTemplatingService portalNavigationTemplatingService;
+    private final ApiTemplateModelProvider apiTemplateModelProvider;
+    private final EnvironmentTemplateModelProvider environmentTemplateModelProvider;
 
     @Override
     public boolean appliesTo(PortalPageContent<?> existingContent) {
@@ -62,19 +66,16 @@ public class GraviteePortalPageContentValidatorService implements PortalPageCont
         final var organizationId = existingContent.getOrganizationId();
         final var enclosingApiId = portalNavigationEnclosingApiDomainService.findEnclosingApiId(environmentId, navigationPage.get());
 
-        tryDryRender(markdown, portalPageContentId, organizationId, environmentId, enclosingApiId);
+        tryDryRender(markdown, organizationId, environmentId, enclosingApiId);
     }
 
-    private void tryDryRender(
-        String markdown,
-        PortalPageContentId templateKey,
-        String orgId,
-        String envId,
-        Optional<String> enclosingApiId
-    ) {
+    private void tryDryRender(String markdown, String organizationId, String environmentId, Optional<String> enclosingApiId) {
+        final Map<String, Object> model = enclosingApiId
+            .<Map<String, Object>>map(id -> Map.of("api", apiTemplateModelProvider.getApiTemplateModel(organizationId, environmentId, id)))
+            .orElseGet(() -> Map.of("metadata", environmentTemplateModelProvider.getEnvironmentMetadata(environmentId)));
         try {
             portalNavigationTemplatingService.renderGraviteeMarkdown(
-                new RenderPortalNavigationMarkdownInput(markdown, templateKey.json(), orgId, envId, enclosingApiId)
+                new RenderPortalNavigationMarkdownInput(GraviteeMarkdown.of(markdown), model)
             );
         } catch (PortalPageContentTemplateException e) {
             throw new InvalidPortalPageContentTemplateException(e.getMessage(), e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/OpenApiPortalPageContentValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/OpenApiPortalPageContentValidatorService.java
@@ -35,7 +35,7 @@ public class OpenApiPortalPageContentValidatorService implements PortalPageConte
     }
 
     @Override
-    public void validate(UpdatePortalPageContent updateContent) {
+    public void validate(PortalPageContent<?> existingContent, UpdatePortalPageContent updateContent) {
         openApiValidator.validateNotEmpty(OpenApi.of(updateContent.getContent()));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidator.java
@@ -21,5 +21,5 @@ import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
 public interface PortalPageContentValidator {
     boolean appliesTo(PortalPageContent<?> existingContent);
 
-    void validate(UpdatePortalPageContent updateContent);
+    void validate(PortalPageContent<?> existingContent, UpdatePortalPageContent updateContent);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorService.java
@@ -31,6 +31,6 @@ public class PortalPageContentValidatorService {
         validators
             .stream()
             .filter(validator -> validator.appliesTo(existingContent))
-            .forEach(validator -> validator.validate(updateContent));
+            .forEach(validator -> validator.validate(existingContent, updateContent));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/RendererException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/exception/RendererException.java
@@ -15,14 +15,15 @@
  */
 package io.gravitee.apim.core.portal_page.exception;
 
-/** Thrown when portal navigation page markdown fails FreeMarker evaluation (invalid syntax or missing model data). */
-public class PortalPageContentTemplateException extends RendererException {
+import io.gravitee.apim.core.exception.TechnicalDomainException;
 
-    public PortalPageContentTemplateException(String message) {
+public class RendererException extends TechnicalDomainException {
+
+    public RendererException(String message) {
         super(message);
     }
 
-    public PortalPageContentTemplateException(String message, Throwable cause) {
+    public RendererException(String message, Throwable cause) {
         super(message, cause);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/RenderedPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/RenderedPageContent.java
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.service_provider;
+package io.gravitee.apim.core.portal_page.model;
 
-/**
- * Rendered page content after FreeMarker template processing.
- */
-public record RenderedPageContent(String value) {
-    public static RenderedPageContent of(String value) {
-        return new RenderedPageContent(value);
+public record RenderedPageContent(String value, PortalPageContentType type) {
+    public static RenderedPageContent of(String value, PortalPageContentType type) {
+        return new RenderedPageContent(value, type);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/PortalNavigationTemplatingService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/service_provider/PortalNavigationTemplatingService.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_page.service_provider;
 
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 import java.util.Map;
 
 public interface PortalNavigationTemplatingService {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
@@ -34,6 +36,7 @@ import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import java.util.Map;
 import java.util.Optional;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -48,6 +51,8 @@ public class GetPortalPageContentByNavigationIdUseCase {
     private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
     private final PortalNavigationEnclosingApiDomainService enclosingApiDomainService;
     private final PortalNavigationTemplatingService portalNavigationTemplatingService;
+    private final ApiTemplateModelProvider apiTemplateModelProvider;
+    private final EnvironmentTemplateModelProvider environmentTemplateModelProvider;
 
     public Output execute(Input input) {
         // Get the portal navigation item by id and env id
@@ -88,20 +93,22 @@ public class GetPortalPageContentByNavigationIdUseCase {
             final var markdownValue = markdownPage.getContent().value();
             if (markdownValue != null) {
                 try {
-                    final var renderedMarkdown = portalNavigationTemplatingService.renderGraviteeMarkdown(
-                        new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
-                            markdownValue,
-                            portalPageContent.getId().json(),
-                            page.getOrganizationId(),
-                            input.environmentId(),
-                            enclosingApiDomainService.findEnclosingApiId(input.environmentId(), page)
+                    final var enclosingApiId = enclosingApiDomainService.findEnclosingApiId(input.environmentId(), page);
+                    final Map<String, Object> model = enclosingApiId
+                        .<Map<String, Object>>map(id ->
+                            Map.of("api", apiTemplateModelProvider.getApiTemplateModel(input.organizationId(), input.environmentId(), id))
                         )
+                        .orElseGet(() ->
+                            Map.of("metadata", environmentTemplateModelProvider.getEnvironmentMetadata(input.environmentId()))
+                        );
+                    final var renderedMarkdown = portalNavigationTemplatingService.renderGraviteeMarkdown(
+                        new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(markdownPage.getContent(), model)
                     );
                     portalPageContent = new GraviteeMarkdownPageContent(
                         markdownPage.getId(),
                         markdownPage.getOrganizationId(),
                         markdownPage.getEnvironmentId(),
-                        GraviteeMarkdown.of(renderedMarkdown)
+                        GraviteeMarkdown.of(renderedMarkdown.value())
                     );
                 } catch (PortalPageContentTemplateException e) {
                     log.warn(
@@ -117,7 +124,12 @@ public class GetPortalPageContentByNavigationIdUseCase {
         return new Output(portalPageContent, portalNavigationItem);
     }
 
-    public record Input(String portalNavigationItemId, String environmentId, PortalNavigationItemViewerContext viewerContext) {}
+    public record Input(
+        String portalNavigationItemId,
+        String organizationId,
+        String environmentId,
+        PortalNavigationItemViewerContext viewerContext
+    ) {}
 
     public record Output(PortalPageContent<?> portalPageContent, PortalNavigationItem portalNavigationItem) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
@@ -16,46 +16,35 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
-import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
-import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_page.domain_service.ContentRenderer;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
-import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
-import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
-import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.exception.RendererException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
-import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
-import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
-import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
-@CustomLog
 public class GetPortalPageContentByNavigationIdUseCase {
 
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
     private final PortalPageContentQueryService portalPageContentQueryService;
     private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
-    private final PortalNavigationEnclosingApiDomainService enclosingApiDomainService;
-    private final PortalNavigationTemplatingService portalNavigationTemplatingService;
-    private final ApiTemplateModelProvider apiTemplateModelProvider;
-    private final EnvironmentTemplateModelProvider environmentTemplateModelProvider;
+    private final List<ContentRenderer> contentRenderers;
 
     public Output execute(Input input) {
-        // Get the portal navigation item by id and env id
         final var portalNavigationItem = Optional.ofNullable(
             portalNavigationItemsQueryService.findByIdAndEnvironmentId(
                 input.environmentId(),
@@ -76,7 +65,6 @@ public class GetPortalPageContentByNavigationIdUseCase {
             throw new PortalNavigationItemNotFoundException(portalNavigationItem.getId().json());
         }
 
-        // If the nav item is not a page, throw exception
         if (!(portalNavigationItem instanceof PortalNavigationPage page)) {
             throw InvalidPortalNavigationItemDataException.typeMismatch(
                 PortalNavigationItemType.PAGE.name(),
@@ -84,44 +72,18 @@ public class GetPortalPageContentByNavigationIdUseCase {
             );
         }
 
-        // Then get the portal page content by the content id from the navigation item
         var portalPageContent = portalPageContentQueryService
             .findById(page.getPortalPageContentId())
             .orElseThrow(() -> new PageContentNotFoundException(page.getPortalPageContentId().toString()));
 
-        if (portalPageContent instanceof GraviteeMarkdownPageContent markdownPage) {
-            final var markdownValue = markdownPage.getContent().value();
-            if (markdownValue != null) {
-                try {
-                    final var enclosingApiId = enclosingApiDomainService.findEnclosingApiId(input.environmentId(), page);
-                    final Map<String, Object> model = enclosingApiId
-                        .<Map<String, Object>>map(id ->
-                            Map.of("api", apiTemplateModelProvider.getApiTemplateModel(input.organizationId(), input.environmentId(), id))
-                        )
-                        .orElseGet(() ->
-                            Map.of("metadata", environmentTemplateModelProvider.getEnvironmentMetadata(input.environmentId()))
-                        );
-                    final var renderedMarkdown = portalNavigationTemplatingService.renderGraviteeMarkdown(
-                        new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(markdownPage.getContent(), model)
-                    );
-                    portalPageContent = new GraviteeMarkdownPageContent(
-                        markdownPage.getId(),
-                        markdownPage.getOrganizationId(),
-                        markdownPage.getEnvironmentId(),
-                        GraviteeMarkdown.of(renderedMarkdown.value())
-                    );
-                } catch (PortalPageContentTemplateException e) {
-                    log.warn(
-                        "Skipping Gravitee markdown templating for portal navigation page [{}] in environment [{}]: {}",
-                        page.getId().json(),
-                        input.environmentId(),
-                        e.getMessage()
-                    );
-                }
-            }
-        }
+        var rendered = contentRenderers
+            .stream()
+            .filter(r -> r.appliesTo(portalPageContent))
+            .findFirst()
+            .orElseThrow(() -> new RendererException("No renderer found for content type: " + portalPageContent.getType()))
+            .render(page, portalPageContent);
 
-        return new Output(portalPageContent, portalNavigationItem);
+        return new Output(rendered, portalNavigationItem);
     }
 
     public record Input(
@@ -131,5 +93,5 @@ public class GetPortalPageContentByNavigationIdUseCase {
         PortalNavigationItemViewerContext viewerContext
     ) {}
 
-    public record Output(PortalPageContent<?> portalPageContent, PortalNavigationItem portalNavigationItem) {}
+    public record Output(RenderedPageContent renderedContent, PortalNavigationItem portalNavigationItem) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCase.java
@@ -16,10 +16,14 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
@@ -29,16 +33,21 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import java.util.Optional;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
+@CustomLog
 public class GetPortalPageContentByNavigationIdUseCase {
 
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
     private final PortalPageContentQueryService portalPageContentQueryService;
     private final PortalNavigationApiVisibilityDomainService apiVisibilityDomainService;
+    private final PortalNavigationEnclosingApiDomainService enclosingApiDomainService;
+    private final PortalNavigationTemplatingService portalNavigationTemplatingService;
 
     public Output execute(Input input) {
         // Get the portal navigation item by id and env id
@@ -71,9 +80,39 @@ public class GetPortalPageContentByNavigationIdUseCase {
         }
 
         // Then get the portal page content by the content id from the navigation item
-        final var portalPageContent = portalPageContentQueryService
+        var portalPageContent = portalPageContentQueryService
             .findById(page.getPortalPageContentId())
             .orElseThrow(() -> new PageContentNotFoundException(page.getPortalPageContentId().toString()));
+
+        if (portalPageContent instanceof GraviteeMarkdownPageContent markdownPage) {
+            final var markdownValue = markdownPage.getContent().value();
+            if (markdownValue != null) {
+                try {
+                    final var renderedMarkdown = portalNavigationTemplatingService.renderGraviteeMarkdown(
+                        new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(
+                            markdownValue,
+                            portalPageContent.getId().json(),
+                            page.getOrganizationId(),
+                            input.environmentId(),
+                            enclosingApiDomainService.findEnclosingApiId(input.environmentId(), page)
+                        )
+                    );
+                    portalPageContent = new GraviteeMarkdownPageContent(
+                        markdownPage.getId(),
+                        markdownPage.getOrganizationId(),
+                        markdownPage.getEnvironmentId(),
+                        GraviteeMarkdown.of(renderedMarkdown)
+                    );
+                } catch (PortalPageContentTemplateException e) {
+                    log.warn(
+                        "Skipping Gravitee markdown templating for portal navigation page [{}] in environment [{}]: {}",
+                        page.getId().json(),
+                        input.environmentId(),
+                        e.getMessage()
+                    );
+                }
+            }
+        }
 
         return new Output(portalPageContent, portalNavigationItem);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/api/ApiTemplateModelProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/api/ApiTemplateModelProviderImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.api;
+
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.ApiTemplateService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApiTemplateModelProviderImpl implements ApiTemplateModelProvider {
+
+    private final ApiTemplateService apiTemplateService;
+
+    @Override
+    public Object getApiTemplateModel(String organizationId, String environmentId, String apiId) {
+        return apiTemplateService.findByIdForTemplates(new ExecutionContext(organizationId, environmentId), apiId, true);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/environment/EnvironmentTemplateModelProviderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/environment/EnvironmentTemplateModelProviderImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.environment;
+
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
+import io.gravitee.repository.management.model.MetadataReferenceType;
+import io.gravitee.rest.api.model.MetadataEntity;
+import io.gravitee.rest.api.service.MetadataService;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EnvironmentTemplateModelProviderImpl implements EnvironmentTemplateModelProvider {
+
+    private final MetadataService metadataService;
+
+    @Override
+    public Map<String, String> getEnvironmentMetadata(String environmentId) {
+        List<MetadataEntity> metadataList = metadataService.findByReferenceTypeAndReferenceId(
+            MetadataReferenceType.ENVIRONMENT,
+            environmentId
+        );
+        if (metadataList == null) {
+            return Map.of();
+        }
+        return metadataList.stream().collect(Collectors.toMap(MetadataEntity::getKey, MetadataEntity::getValue));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImpl.java
@@ -17,8 +17,9 @@ package io.gravitee.apim.infra.portal_page;
 
 import freemarker.template.TemplateException;
 import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
-import io.gravitee.apim.core.portal_page.service_provider.RenderedPageContent;
 import io.gravitee.apim.core.template.TemplateProcessor;
 import io.gravitee.apim.core.template.TemplateProcessorException;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +34,10 @@ public class PortalNavigationTemplatingServiceImpl implements PortalNavigationTe
     @Override
     public RenderedPageContent renderGraviteeMarkdown(RenderPortalNavigationMarkdownInput input) {
         try {
-            return RenderedPageContent.of(templateProcessor.processInlineTemplate(input.rawMarkdown().value(), input.model()));
+            return RenderedPageContent.of(
+                templateProcessor.processInlineTemplate(input.rawMarkdown().value(), input.model()),
+                PortalPageContentType.GRAVITEE_MARKDOWN
+            );
         } catch (TemplateProcessorException e) {
             // Evaluation failures wrap a freemarker.template.TemplateException; parse failures wrap an IOException
             // (FreeMarker's ParseException extends IOException, not TemplateException).

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/GraviteePortalPageContentValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/GraviteePortalPageContentValidatorServiceTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.gravitee_markdown.exception.GraviteeMarkdownContentEmptyException;
@@ -38,6 +40,7 @@ import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -51,6 +54,8 @@ class GraviteePortalPageContentValidatorServiceTest {
     private PortalNavigationItemsQueryService portalNavigationItemsQueryService;
     private PortalNavigationEnclosingApiDomainService portalNavigationEnclosingApiDomainService;
     private PortalNavigationTemplatingService portalNavigationTemplatingService;
+    private ApiTemplateModelProvider apiTemplateModelProvider;
+    private EnvironmentTemplateModelProvider environmentTemplateModelProvider;
     private GraviteePortalPageContentValidatorService validator;
 
     @BeforeEach
@@ -59,11 +64,16 @@ class GraviteePortalPageContentValidatorServiceTest {
         portalNavigationItemsQueryService = mock(PortalNavigationItemsQueryService.class);
         portalNavigationEnclosingApiDomainService = mock(PortalNavigationEnclosingApiDomainService.class);
         portalNavigationTemplatingService = mock(PortalNavigationTemplatingService.class);
+        apiTemplateModelProvider = mock(ApiTemplateModelProvider.class);
+        environmentTemplateModelProvider = mock(EnvironmentTemplateModelProvider.class);
+        when(environmentTemplateModelProvider.getEnvironmentMetadata(any())).thenReturn(Map.of());
         validator = new GraviteePortalPageContentValidatorService(
             gmdValidator,
             portalNavigationItemsQueryService,
             portalNavigationEnclosingApiDomainService,
-            portalNavigationTemplatingService
+            portalNavigationTemplatingService,
+            apiTemplateModelProvider,
+            environmentTemplateModelProvider
         );
     }
 
@@ -132,6 +142,7 @@ class GraviteePortalPageContentValidatorServiceTest {
         var update = UpdatePortalPageContent.builder().content("Hello ${metadata.nope}").build();
 
         assertThatThrownBy(() -> validator.validate(existing, update)).isInstanceOf(InvalidPortalPageContentTemplateException.class);
+        verify(portalNavigationTemplatingService).renderGraviteeMarkdown(argThat(input -> input.model().containsKey("metadata")));
     }
 
     @Test
@@ -159,19 +170,20 @@ class GraviteePortalPageContentValidatorServiceTest {
         when(portalNavigationEnclosingApiDomainService.findEnclosingApiId(eq(PortalNavigationItemFixtures.ENV_ID), eq(page))).thenReturn(
             Optional.of("api-1")
         );
+        var fakeApiModel = new Object();
+        when(
+            apiTemplateModelProvider.getApiTemplateModel(
+                eq(PortalNavigationItemFixtures.ORG_ID),
+                eq(PortalNavigationItemFixtures.ENV_ID),
+                eq("api-1")
+            )
+        ).thenReturn(fakeApiModel);
 
         var update = UpdatePortalPageContent.builder().content("${api.name}").build();
         validator.validate(existing, update);
 
         verify(portalNavigationTemplatingService).renderGraviteeMarkdown(
-            argThat(
-                input ->
-                    input.rawMarkdown().equals("${api.name}") &&
-                    input.templateKey().equals(contentId.json()) &&
-                    input.organizationId().equals(PortalNavigationItemFixtures.ORG_ID) &&
-                    input.environmentId().equals(PortalNavigationItemFixtures.ENV_ID) &&
-                    input.enclosingApiId().equals(Optional.of("api-1"))
-            )
+            argThat(input -> input.rawMarkdown().value().equals("${api.name}") && input.model().get("api") == fakeApiModel)
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/GraviteePortalPageContentValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/GraviteePortalPageContentValidatorServiceTest.java
@@ -19,16 +19,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import fixtures.core.model.PortalNavigationItemFixtures;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.gravitee_markdown.exception.GraviteeMarkdownContentEmptyException;
+import io.gravitee.apim.core.portal_page.exception.InvalidPortalPageContentTemplateException;
+import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -38,18 +48,29 @@ import org.junit.jupiter.api.Test;
 class GraviteePortalPageContentValidatorServiceTest {
 
     private GraviteeMarkdownValidator gmdValidator;
+    private PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private PortalNavigationEnclosingApiDomainService portalNavigationEnclosingApiDomainService;
+    private PortalNavigationTemplatingService portalNavigationTemplatingService;
     private GraviteePortalPageContentValidatorService validator;
 
     @BeforeEach
     void setUp() {
         gmdValidator = mock(GraviteeMarkdownValidator.class);
-        validator = new GraviteePortalPageContentValidatorService(gmdValidator);
+        portalNavigationItemsQueryService = mock(PortalNavigationItemsQueryService.class);
+        portalNavigationEnclosingApiDomainService = mock(PortalNavigationEnclosingApiDomainService.class);
+        portalNavigationTemplatingService = mock(PortalNavigationTemplatingService.class);
+        validator = new GraviteePortalPageContentValidatorService(
+            gmdValidator,
+            portalNavigationItemsQueryService,
+            portalNavigationEnclosingApiDomainService,
+            portalNavigationTemplatingService
+        );
     }
 
     @Test
     void should_apply_to_gravitee_markdown_content() {
         // Given
-        PortalPageContent content = GraviteeMarkdownPageContent.create("org", "env", "content");
+        PortalPageContent<?> content = GraviteeMarkdownPageContent.create("org", "env", "content");
 
         // When
         boolean result = validator.appliesTo(content);
@@ -61,24 +82,96 @@ class GraviteePortalPageContentValidatorServiceTest {
     @Test
     void should_delegate_validation_to_gmd_validator() {
         // Given
+        PortalPageContent<?> existing = GraviteeMarkdownPageContent.create("org", "env", "old");
         UpdatePortalPageContent updateContent = UpdatePortalPageContent.builder().content("test content").build();
+        when(portalNavigationItemsQueryService.findNavigationPageByPortalPageContentId(any(), any())).thenReturn(Optional.empty());
 
         // When
-        validator.validate(updateContent);
+        validator.validate(existing, updateContent);
 
         // Then
         verify(gmdValidator).validateNotEmpty(argThat(gmd -> gmd.value().equals("test content")));
+        verify(portalNavigationTemplatingService, never()).renderGraviteeMarkdown(any());
     }
 
     @Test
     void should_throw_when_validator_rejects_content() {
         // Given
+        PortalPageContent<?> existing = GraviteeMarkdownPageContent.create("org", "env", "old");
         UpdatePortalPageContent updateContent = UpdatePortalPageContent.builder().content("").build();
         doThrow(new GraviteeMarkdownContentEmptyException()).when(gmdValidator).validateNotEmpty(any());
 
         // When / Then
-        assertThatThrownBy(() -> validator.validate(updateContent))
+        assertThatThrownBy(() -> validator.validate(existing, updateContent))
             .isInstanceOf(GraviteeMarkdownContentEmptyException.class)
             .hasMessage("Content must not be null or empty");
+    }
+
+    @Test
+    void should_map_template_failure_to_validation_exception_when_page_linked_without_api_ancestor() {
+        var contentId = PortalPageContentId.random();
+        var existing = new GraviteeMarkdownPageContent(
+            contentId,
+            PortalNavigationItemFixtures.ORG_ID,
+            PortalNavigationItemFixtures.ENV_ID,
+            GraviteeMarkdown.of("Hello ${metadata.nope}")
+        );
+        var page = PortalNavigationItemFixtures.aPage("00000000-0000-0000-0000-000000000081", "Page", null, contentId);
+        page.markAsRoot();
+        when(
+            portalNavigationItemsQueryService.findNavigationPageByPortalPageContentId(
+                eq(PortalNavigationItemFixtures.ENV_ID),
+                eq(contentId)
+            )
+        ).thenReturn(Optional.of(page));
+        when(portalNavigationEnclosingApiDomainService.findEnclosingApiId(eq(PortalNavigationItemFixtures.ENV_ID), eq(page))).thenReturn(
+            Optional.empty()
+        );
+        when(portalNavigationTemplatingService.renderGraviteeMarkdown(any())).thenThrow(new PortalPageContentTemplateException("missing"));
+
+        var update = UpdatePortalPageContent.builder().content("Hello ${metadata.nope}").build();
+
+        assertThatThrownBy(() -> validator.validate(existing, update)).isInstanceOf(InvalidPortalPageContentTemplateException.class);
+    }
+
+    @Test
+    void should_validate_under_api_context_when_enclosing_api_exists() {
+        var contentId = PortalPageContentId.random();
+        var existing = new GraviteeMarkdownPageContent(
+            contentId,
+            PortalNavigationItemFixtures.ORG_ID,
+            PortalNavigationItemFixtures.ENV_ID,
+            GraviteeMarkdown.of("${api.name}")
+        );
+        var folder = PortalNavigationItemFixtures.aFolder("00000000-0000-0000-0000-000000000080", "Folder");
+        folder.markAsRoot();
+        var apiNode = PortalNavigationItemFixtures.anApi("00000000-0000-0000-0000-000000000082", "API", folder.getId(), "api-1");
+        apiNode.updateParent(folder);
+        var page = PortalNavigationItemFixtures.aPage("00000000-0000-0000-0000-000000000083", "Page", apiNode.getId(), contentId);
+        page.updateParent(apiNode);
+
+        when(
+            portalNavigationItemsQueryService.findNavigationPageByPortalPageContentId(
+                eq(PortalNavigationItemFixtures.ENV_ID),
+                eq(contentId)
+            )
+        ).thenReturn(Optional.of(page));
+        when(portalNavigationEnclosingApiDomainService.findEnclosingApiId(eq(PortalNavigationItemFixtures.ENV_ID), eq(page))).thenReturn(
+            Optional.of("api-1")
+        );
+
+        var update = UpdatePortalPageContent.builder().content("${api.name}").build();
+        validator.validate(existing, update);
+
+        verify(portalNavigationTemplatingService).renderGraviteeMarkdown(
+            argThat(
+                input ->
+                    input.rawMarkdown().equals("${api.name}") &&
+                    input.templateKey().equals(contentId.json()) &&
+                    input.organizationId().equals(PortalNavigationItemFixtures.ORG_ID) &&
+                    input.environmentId().equals(PortalNavigationItemFixtures.ENV_ID) &&
+                    input.enclosingApiId().equals(Optional.of("api-1"))
+            )
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/OpenApiPortalPageContentValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/OpenApiPortalPageContentValidatorServiceTest.java
@@ -74,10 +74,11 @@ class OpenApiPortalPageContentValidatorServiceTest {
     @Test
     void should_delegate_validation_to_open_api_validator() {
         // Given
+        PortalPageContent<?> existing = OpenApiPageContent.create("org", "env", "old");
         UpdatePortalPageContent updateContent = UpdatePortalPageContent.builder().content("openapi: 3.0.0").build();
 
         // When
-        validator.validate(updateContent);
+        validator.validate(existing, updateContent);
 
         // Then
         verify(openApiValidator).validateNotEmpty(eq(new OpenApi("openapi: 3.0.0")));
@@ -86,11 +87,12 @@ class OpenApiPortalPageContentValidatorServiceTest {
     @Test
     void should_throw_when_validator_rejects_content() {
         // Given
+        PortalPageContent<?> existing = OpenApiPageContent.create("org", "env", "old");
         UpdatePortalPageContent updateContent = UpdatePortalPageContent.builder().content("").build();
         doThrow(new OpenApiContentEmptyException()).when(openApiValidator).validateNotEmpty(any());
 
         // When / Then
-        assertThatThrownBy(() -> validator.validate(updateContent))
+        assertThatThrownBy(() -> validator.validate(existing, updateContent))
             .isInstanceOf(OpenApiContentEmptyException.class)
             .hasMessage("Content must not be null or empty");
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalPageContentValidatorServiceTest.java
@@ -54,7 +54,7 @@ class PortalPageContentValidatorServiceTest {
 
         // Then
         verify(mockValidator).appliesTo(existingContent);
-        verify(mockValidator).validate(updateContent);
+        verify(mockValidator).validate(existingContent, updateContent);
     }
 
     @Test
@@ -69,6 +69,6 @@ class PortalPageContentValidatorServiceTest {
 
         // Then
         verify(mockValidator).appliesTo(existingContent);
-        verify(mockValidator, never()).validate(any());
+        verify(mockValidator, never()).validate(any(), any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
@@ -38,6 +38,8 @@ import inmemory.SubscriptionQueryServiceInMemory;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.DefaultContentRenderer;
+import io.gravitee.apim.core.portal_page.domain_service.GraviteeMarkdownContentRenderer;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
@@ -48,8 +50,9 @@ import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
-import io.gravitee.apim.core.portal_page.service_provider.RenderedPageContent;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,17 +100,20 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
         var enclosingApiDomainService = new PortalNavigationEnclosingApiDomainService(navigationItemsQueryService);
         when(portalNavigationTemplatingService.renderGraviteeMarkdown(any())).thenAnswer(invocation -> {
             var in = (PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput) invocation.getArgument(0);
-            return RenderedPageContent.of(in.rawMarkdown().value());
+            return RenderedPageContent.of(in.rawMarkdown().value(), PortalPageContentType.GRAVITEE_MARKDOWN);
         });
         when(environmentTemplateModelProvider.getEnvironmentMetadata(any())).thenReturn(Map.of());
-        useCase = new GetPortalPageContentByNavigationIdUseCase(
-            navigationItemsQueryService,
-            pageContentQueryService,
-            apiVisibilityDomainService,
+        var gmdRenderer = new GraviteeMarkdownContentRenderer(
             enclosingApiDomainService,
             portalNavigationTemplatingService,
             apiTemplateModelProvider,
             environmentTemplateModelProvider
+        );
+        useCase = new GetPortalPageContentByNavigationIdUseCase(
+            navigationItemsQueryService,
+            pageContentQueryService,
+            apiVisibilityDomainService,
+            List.of(gmdRenderer, new DefaultContentRenderer())
         );
 
         clearInvocations(portalNavigationTemplatingService);
@@ -143,17 +149,19 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
         var output = useCase.execute(input);
 
-        assertThat(output.portalPageContent()).isNotNull();
-        assertThat(output.portalPageContent()).isInstanceOf(GraviteeMarkdownPageContent.class);
+        assertThat(output.renderedContent()).isNotNull();
+        assertThat(output.renderedContent().type()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
+        assertThat(output.renderedContent().value()).isEqualTo("Page 11 content");
         assertThat(output.portalNavigationItem()).isNotNull();
         assertThat(output.portalNavigationItem()).isInstanceOf(PortalNavigationPage.class);
         assertThat(output.portalNavigationItem().getId().toString()).isEqualTo(PAGE11_ID);
-        assertThat(((GraviteeMarkdownPageContent) output.portalPageContent()).getContent().value()).isEqualTo("Page 11 content");
     }
 
     @Test
     void should_apply_portal_navigation_templating_to_gravitee_markdown() {
-        doReturn(RenderedPageContent.of("templated")).when(portalNavigationTemplatingService).renderGraviteeMarkdown(any());
+        doReturn(RenderedPageContent.of("templated", PortalPageContentType.GRAVITEE_MARKDOWN))
+            .when(portalNavigationTemplatingService)
+            .renderGraviteeMarkdown(any());
 
         var input = new GetPortalPageContentByNavigationIdUseCase.Input(
             PAGE11_ID,
@@ -164,7 +172,7 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
         var output = useCase.execute(input);
 
-        assertThat(((GraviteeMarkdownPageContent) output.portalPageContent()).getContent().value()).isEqualTo("templated");
+        assertThat(output.renderedContent().value()).isEqualTo("templated");
         assertThat(
             ((GraviteeMarkdownPageContent) pageContentQueryService
                     .findById(PortalPageContentId.of(PAGE11_CONTENT_ID))
@@ -196,7 +204,7 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
     }
 
     @Test
-    void should_leave_original_markdown_when_template_rendering_fails() {
+    void should_throw_when_template_rendering_fails() {
         doThrow(new PortalPageContentTemplateException("Invalid expression or value is missing"))
             .when(portalNavigationTemplatingService)
             .renderGraviteeMarkdown(any());
@@ -208,9 +216,7 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
             PortalNavigationItemViewerContext.forConsole()
         );
 
-        var output = useCase.execute(input);
-
-        assertThat(((GraviteeMarkdownPageContent) output.portalPageContent()).getContent().value()).isEqualTo("Page 11 content");
+        assertThatThrownBy(() -> useCase.execute(input)).isInstanceOf(PortalPageContentTemplateException.class);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
@@ -21,6 +21,7 @@ import static fixtures.core.model.PortalNavigationItemFixtures.PAGE11_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -34,6 +35,8 @@ import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
@@ -46,7 +49,9 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
+import io.gravitee.apim.core.portal_page.service_provider.RenderedPageContent;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -58,6 +63,7 @@ import org.mockito.MockitoAnnotations;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class GetPortalPageContentByNavigationIdUseCaseTest {
 
+    private static final String ORGANIZATION_ID = PortalPageContentFixtures.ORGANIZATION_ID;
     private static final String ENVIRONMENT_ID = ENV_ID;
     private static final String UNPUBLISHED_ID = PortalNavigationItemFixtures.UNPUBLISHED_ID;
     private static final String PRIVATE_ID = PortalNavigationItemFixtures.PRIVATE_ID;
@@ -68,6 +74,12 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
     @Mock
     private PortalNavigationTemplatingService portalNavigationTemplatingService;
+
+    @Mock
+    private ApiTemplateModelProvider apiTemplateModelProvider;
+
+    @Mock
+    private EnvironmentTemplateModelProvider environmentTemplateModelProvider;
 
     @BeforeEach
     void setUp() {
@@ -85,14 +97,17 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
         var enclosingApiDomainService = new PortalNavigationEnclosingApiDomainService(navigationItemsQueryService);
         when(portalNavigationTemplatingService.renderGraviteeMarkdown(any())).thenAnswer(invocation -> {
             var in = (PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput) invocation.getArgument(0);
-            return in.rawMarkdown();
+            return RenderedPageContent.of(in.rawMarkdown().value());
         });
+        when(environmentTemplateModelProvider.getEnvironmentMetadata(any())).thenReturn(Map.of());
         useCase = new GetPortalPageContentByNavigationIdUseCase(
             navigationItemsQueryService,
             pageContentQueryService,
             apiVisibilityDomainService,
             enclosingApiDomainService,
-            portalNavigationTemplatingService
+            portalNavigationTemplatingService,
+            apiTemplateModelProvider,
+            environmentTemplateModelProvider
         );
 
         clearInvocations(portalNavigationTemplatingService);
@@ -101,14 +116,14 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
         var supportContent = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
             supportContentId,
-            PortalPageContentFixtures.ORGANIZATION_ID,
+            ORGANIZATION_ID,
             ENVIRONMENT_ID,
             "Support page content"
         );
 
         var page11Content = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
             page11ContentId,
-            PortalPageContentFixtures.ORGANIZATION_ID,
+            ORGANIZATION_ID,
             ENVIRONMENT_ID,
             "Page 11 content"
         );
@@ -119,17 +134,15 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
     @Test
     void should_return_portal_page_content_when_navigation_page_found() {
-        // Given
         var input = new GetPortalPageContentByNavigationIdUseCase.Input(
             PAGE11_ID,
+            ORGANIZATION_ID,
             ENVIRONMENT_ID,
             PortalNavigationItemViewerContext.forConsole()
         );
 
-        // When
         var output = useCase.execute(input);
 
-        // Then
         assertThat(output.portalPageContent()).isNotNull();
         assertThat(output.portalPageContent()).isInstanceOf(GraviteeMarkdownPageContent.class);
         assertThat(output.portalNavigationItem()).isNotNull();
@@ -140,10 +153,11 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
     @Test
     void should_apply_portal_navigation_templating_to_gravitee_markdown() {
-        doReturn("templated").when(portalNavigationTemplatingService).renderGraviteeMarkdown(any());
+        doReturn(RenderedPageContent.of("templated")).when(portalNavigationTemplatingService).renderGraviteeMarkdown(any());
 
         var input = new GetPortalPageContentByNavigationIdUseCase.Input(
             PAGE11_ID,
+            ORGANIZATION_ID,
             ENVIRONMENT_ID,
             PortalNavigationItemViewerContext.forConsole()
         );
@@ -158,11 +172,27 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
         ).isEqualTo("Page 11 content");
         var captor = ArgumentCaptor.forClass(PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput.class);
         verify(portalNavigationTemplatingService).renderGraviteeMarkdown(captor.capture());
-        assertThat(captor.getValue().rawMarkdown()).isEqualTo("Page 11 content");
-        assertThat(captor.getValue().templateKey()).isEqualTo(PAGE11_CONTENT_ID);
-        assertThat(captor.getValue().organizationId()).isEqualTo(PortalNavigationItemFixtures.ORG_ID);
-        assertThat(captor.getValue().environmentId()).isEqualTo(ENVIRONMENT_ID);
-        assertThat(captor.getValue().enclosingApiId()).isEmpty();
+        assertThat(captor.getValue().rawMarkdown().value()).isEqualTo("Page 11 content");
+        assertThat(captor.getValue().model()).containsKey("metadata");
+    }
+
+    @Test
+    void should_pass_environment_metadata_when_page_has_no_api_ancestor() {
+        var envMetadata = Map.of("supportEmail", "support@example.com");
+        when(environmentTemplateModelProvider.getEnvironmentMetadata(eq(ENVIRONMENT_ID))).thenReturn(envMetadata);
+
+        var input = new GetPortalPageContentByNavigationIdUseCase.Input(
+            PAGE11_ID,
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            PortalNavigationItemViewerContext.forConsole()
+        );
+
+        useCase.execute(input);
+
+        var captor = ArgumentCaptor.forClass(PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput.class);
+        verify(portalNavigationTemplatingService).renderGraviteeMarkdown(captor.capture());
+        assertThat(captor.getValue().model()).containsEntry("metadata", envMetadata);
     }
 
     @Test
@@ -173,6 +203,7 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
         var input = new GetPortalPageContentByNavigationIdUseCase.Input(
             PAGE11_ID,
+            ORGANIZATION_ID,
             ENVIRONMENT_ID,
             PortalNavigationItemViewerContext.forConsole()
         );
@@ -183,7 +214,7 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
     }
 
     @Test
-    void should_pass_enclosing_api_id_when_page_is_under_api_branch() {
+    void should_pass_api_model_when_page_is_under_api_branch() {
         var apiNav = PortalNavigationItemFixtures.anApi(PortalNavigationItemFixtures.API1_ID, "API One", null, "api-technical-id");
         apiNav.markAsRoot();
         var folderUnderApi = PortalNavigationItemFixtures.aFolder(PortalNavigationItemFixtures.API1_FOLDER_ID, "Docs", apiNav.getId());
@@ -193,35 +224,39 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
         var pageUnderFolder = PortalNavigationItemFixtures.aPage(pageId, "API doc page", folderUnderApi.getId(), contentId);
         pageUnderFolder.updateParent(folderUnderApi);
 
-        var md = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
-            contentId,
-            PortalPageContentFixtures.ORGANIZATION_ID,
-            ENVIRONMENT_ID,
-            "Hello"
-        );
+        var md = PortalPageContentFixtures.aGraviteeMarkdownPageContent(contentId, ORGANIZATION_ID, ENVIRONMENT_ID, "Hello");
         pageContentQueryService.initWith(List.of(md));
         navigationItemsQueryService.initWith(List.of(apiNav, folderUnderApi, pageUnderFolder));
 
+        var fakeApiModel = new Object();
+        when(apiTemplateModelProvider.getApiTemplateModel(eq(ORGANIZATION_ID), eq(ENVIRONMENT_ID), eq("api-technical-id"))).thenReturn(
+            fakeApiModel
+        );
+
         useCase.execute(
-            new GetPortalPageContentByNavigationIdUseCase.Input(pageId, ENVIRONMENT_ID, PortalNavigationItemViewerContext.forConsole())
+            new GetPortalPageContentByNavigationIdUseCase.Input(
+                pageId,
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                PortalNavigationItemViewerContext.forConsole()
+            )
         );
 
         var captor = ArgumentCaptor.forClass(PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput.class);
         verify(portalNavigationTemplatingService).renderGraviteeMarkdown(captor.capture());
-        assertThat(captor.getValue().enclosingApiId()).contains("api-technical-id");
+        assertThat(captor.getValue().model()).containsEntry("api", fakeApiModel);
     }
 
     @Test
     void should_throw_when_navigation_item_not_found() {
-        // Given
         var unknownId = "00000000-0000-0000-0000-000000000099";
         var input = new GetPortalPageContentByNavigationIdUseCase.Input(
             unknownId,
+            ORGANIZATION_ID,
             ENVIRONMENT_ID,
             PortalNavigationItemViewerContext.forConsole()
         );
 
-        // When & Then
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(PortalNavigationItemNotFoundException.class)
             .hasMessage("Portal navigation item not found");
@@ -229,14 +264,13 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
     @Test
     void should_throw_when_navigation_item_is_not_a_page() {
-        // Given
         var input = new GetPortalPageContentByNavigationIdUseCase.Input(
             PortalNavigationItemFixtures.APIS_ID,
+            ORGANIZATION_ID,
             ENVIRONMENT_ID,
             PortalNavigationItemViewerContext.forConsole()
         );
 
-        // When & Then
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(InvalidPortalNavigationItemDataException.class)
             .hasMessageContaining("Navigation item type cannot be changed or is mismatched");
@@ -244,16 +278,15 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
     @Test
     void should_throw_when_page_content_not_found() {
-        // Given
         pageContentQueryService.initWith(List.of());
 
         var input = new GetPortalPageContentByNavigationIdUseCase.Input(
             PAGE11_ID,
+            ORGANIZATION_ID,
             ENVIRONMENT_ID,
             PortalNavigationItemViewerContext.forConsole()
         );
 
-        // When & Then
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(PageContentNotFoundException.class)
             .hasMessage("Page content not found");
@@ -261,14 +294,13 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
     @Test
     void should_throw_when_navigation_item_exists_in_different_environment() {
-        // Given
         var input = new GetPortalPageContentByNavigationIdUseCase.Input(
             PAGE11_ID,
+            ORGANIZATION_ID,
             "different-env",
             PortalNavigationItemViewerContext.forConsole()
         );
 
-        // When & Then
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(PortalNavigationItemNotFoundException.class)
             .hasMessage("Portal navigation item not found");
@@ -276,14 +308,13 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
     @Test
     void should_throw_when_navigation_item_not_visible_in_portal() {
-        // Given
         var input = new GetPortalPageContentByNavigationIdUseCase.Input(
             UNPUBLISHED_ID,
+            ORGANIZATION_ID,
             ENVIRONMENT_ID,
             PortalNavigationItemViewerContext.forPortal(true)
         );
 
-        // When & Then
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(PortalNavigationItemNotFoundException.class)
             .hasMessage("Portal navigation item not found");
@@ -291,14 +322,13 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
     @Test
     void should_throw_when_navigation_item_private_and_user_not_authenticated() {
-        // Given
         var input = new GetPortalPageContentByNavigationIdUseCase.Input(
             PRIVATE_ID,
+            ORGANIZATION_ID,
             ENVIRONMENT_ID,
             PortalNavigationItemViewerContext.forPortal(false)
         );
 
-        // When & Then
         assertThatThrownBy(() -> useCase.execute(input))
             .isInstanceOf(PortalNavigationItemNotFoundException.class)
             .hasMessage("Portal navigation item not found");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalPageContentByNavigationIdUseCaseTest.java
@@ -16,9 +16,16 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import static fixtures.core.model.PortalNavigationItemFixtures.ENV_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.PAGE11_CONTENT_ID;
 import static fixtures.core.model.PortalNavigationItemFixtures.PAGE11_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PortalNavigationItemFixtures;
 import fixtures.core.model.PortalPageContentFixtures;
@@ -29,18 +36,24 @@ import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
 import io.gravitee.apim.core.membership.domain_service.ApiPortalMembershipDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.exception.InvalidPortalNavigationItemDataException;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.exception.PortalNavigationItemNotFoundException;
+import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class GetPortalPageContentByNavigationIdUseCaseTest {
@@ -51,10 +64,15 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
 
     private GetPortalPageContentByNavigationIdUseCase useCase;
     private PortalPageContentQueryServiceInMemory pageContentQueryService;
+    private PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService;
+
+    @Mock
+    private PortalNavigationTemplatingService portalNavigationTemplatingService;
 
     @BeforeEach
     void setUp() {
-        PortalNavigationItemsQueryServiceInMemory navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
+        MockitoAnnotations.openMocks(this);
+        navigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory();
         pageContentQueryService = new PortalPageContentQueryServiceInMemory();
         var apiVisibilityDomainService = new PortalNavigationApiVisibilityDomainService(
             navigationItemsQueryService,
@@ -64,13 +82,20 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
                 new ApiQueryServiceInMemory()
             )
         );
+        var enclosingApiDomainService = new PortalNavigationEnclosingApiDomainService(navigationItemsQueryService);
+        when(portalNavigationTemplatingService.renderGraviteeMarkdown(any())).thenAnswer(invocation -> {
+            var in = (PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput) invocation.getArgument(0);
+            return in.rawMarkdown();
+        });
         useCase = new GetPortalPageContentByNavigationIdUseCase(
             navigationItemsQueryService,
             pageContentQueryService,
-            apiVisibilityDomainService
+            apiVisibilityDomainService,
+            enclosingApiDomainService,
+            portalNavigationTemplatingService
         );
 
-        // Create page contents first with known IDs
+        clearInvocations(portalNavigationTemplatingService);
         var supportContentId = PortalPageContentId.of(PortalNavigationItemFixtures.SUPPORT_CONTENT_ID);
         var page11ContentId = PortalPageContentId.of(PortalNavigationItemFixtures.PAGE11_CONTENT_ID);
 
@@ -111,6 +136,79 @@ class GetPortalPageContentByNavigationIdUseCaseTest {
         assertThat(output.portalNavigationItem()).isInstanceOf(PortalNavigationPage.class);
         assertThat(output.portalNavigationItem().getId().toString()).isEqualTo(PAGE11_ID);
         assertThat(((GraviteeMarkdownPageContent) output.portalPageContent()).getContent().value()).isEqualTo("Page 11 content");
+    }
+
+    @Test
+    void should_apply_portal_navigation_templating_to_gravitee_markdown() {
+        doReturn("templated").when(portalNavigationTemplatingService).renderGraviteeMarkdown(any());
+
+        var input = new GetPortalPageContentByNavigationIdUseCase.Input(
+            PAGE11_ID,
+            ENVIRONMENT_ID,
+            PortalNavigationItemViewerContext.forConsole()
+        );
+
+        var output = useCase.execute(input);
+
+        assertThat(((GraviteeMarkdownPageContent) output.portalPageContent()).getContent().value()).isEqualTo("templated");
+        assertThat(
+            ((GraviteeMarkdownPageContent) pageContentQueryService
+                    .findById(PortalPageContentId.of(PAGE11_CONTENT_ID))
+                    .orElseThrow()).getContent().value()
+        ).isEqualTo("Page 11 content");
+        var captor = ArgumentCaptor.forClass(PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput.class);
+        verify(portalNavigationTemplatingService).renderGraviteeMarkdown(captor.capture());
+        assertThat(captor.getValue().rawMarkdown()).isEqualTo("Page 11 content");
+        assertThat(captor.getValue().templateKey()).isEqualTo(PAGE11_CONTENT_ID);
+        assertThat(captor.getValue().organizationId()).isEqualTo(PortalNavigationItemFixtures.ORG_ID);
+        assertThat(captor.getValue().environmentId()).isEqualTo(ENVIRONMENT_ID);
+        assertThat(captor.getValue().enclosingApiId()).isEmpty();
+    }
+
+    @Test
+    void should_leave_original_markdown_when_template_rendering_fails() {
+        doThrow(new PortalPageContentTemplateException("Invalid expression or value is missing"))
+            .when(portalNavigationTemplatingService)
+            .renderGraviteeMarkdown(any());
+
+        var input = new GetPortalPageContentByNavigationIdUseCase.Input(
+            PAGE11_ID,
+            ENVIRONMENT_ID,
+            PortalNavigationItemViewerContext.forConsole()
+        );
+
+        var output = useCase.execute(input);
+
+        assertThat(((GraviteeMarkdownPageContent) output.portalPageContent()).getContent().value()).isEqualTo("Page 11 content");
+    }
+
+    @Test
+    void should_pass_enclosing_api_id_when_page_is_under_api_branch() {
+        var apiNav = PortalNavigationItemFixtures.anApi(PortalNavigationItemFixtures.API1_ID, "API One", null, "api-technical-id");
+        apiNav.markAsRoot();
+        var folderUnderApi = PortalNavigationItemFixtures.aFolder(PortalNavigationItemFixtures.API1_FOLDER_ID, "Docs", apiNav.getId());
+        folderUnderApi.updateParent(apiNav);
+        var contentId = PortalPageContentId.random();
+        var pageId = "00000000-0000-0000-0000-000000000097";
+        var pageUnderFolder = PortalNavigationItemFixtures.aPage(pageId, "API doc page", folderUnderApi.getId(), contentId);
+        pageUnderFolder.updateParent(folderUnderApi);
+
+        var md = PortalPageContentFixtures.aGraviteeMarkdownPageContent(
+            contentId,
+            PortalPageContentFixtures.ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            "Hello"
+        );
+        pageContentQueryService.initWith(List.of(md));
+        navigationItemsQueryService.initWith(List.of(apiNav, folderUnderApi, pageUnderFolder));
+
+        useCase.execute(
+            new GetPortalPageContentByNavigationIdUseCase.Input(pageId, ENVIRONMENT_ID, PortalNavigationItemViewerContext.forConsole())
+        );
+
+        var captor = ArgumentCaptor.forClass(PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput.class);
+        verify(portalNavigationTemplatingService).renderGraviteeMarkdown(captor.capture());
+        assertThat(captor.getValue().enclosingApiId()).contains("api-technical-id");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.when;
 import fixtures.core.model.PortalPageContentFixtures;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
+import io.gravitee.apim.core.environment.service_provider.EnvironmentTemplateModelProvider;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.gravitee_markdown.exception.GraviteeMarkdownContentEmptyException;
 import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
@@ -60,7 +62,9 @@ class UpdatePortalPageContentUseCaseTest {
             gmdValidator,
             portalNavigationItemsQueryService,
             mock(PortalNavigationEnclosingApiDomainService.class),
-            mock(PortalNavigationTemplatingService.class)
+            mock(PortalNavigationTemplatingService.class),
+            mock(ApiTemplateModelProvider.class),
+            mock(EnvironmentTemplateModelProvider.class)
         );
         PortalPageContentValidatorService validatorService = new PortalPageContentValidatorService(java.util.List.of(gmdContentValidator));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalPageContentUseCaseTest.java
@@ -20,6 +20,9 @@ import static fixtures.core.model.PortalPageContentFixtures.ENVIRONMENT_ID;
 import static fixtures.core.model.PortalPageContentFixtures.ORGANIZATION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PortalPageContentFixtures;
 import inmemory.PortalPageContentCrudServiceInMemory;
@@ -27,11 +30,14 @@ import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdownValidator;
 import io.gravitee.apim.core.gravitee_markdown.exception.GraviteeMarkdownContentEmptyException;
 import io.gravitee.apim.core.portal_page.domain_service.GraviteePortalPageContentValidatorService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationEnclosingApiDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalPageContentValidatorService;
 import io.gravitee.apim.core.portal_page.exception.PageContentNotFoundException;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -47,9 +53,15 @@ class UpdatePortalPageContentUseCaseTest {
         PortalPageContentQueryServiceInMemory queryService = new PortalPageContentQueryServiceInMemory();
         PortalPageContentCrudServiceInMemory crudService = new PortalPageContentCrudServiceInMemory();
 
-        // Create validator chain
         GraviteeMarkdownValidator gmdValidator = new GraviteeMarkdownValidator();
-        GraviteePortalPageContentValidatorService gmdContentValidator = new GraviteePortalPageContentValidatorService(gmdValidator);
+        PortalNavigationItemsQueryService portalNavigationItemsQueryService = mock(PortalNavigationItemsQueryService.class);
+        when(portalNavigationItemsQueryService.search(any())).thenReturn(java.util.List.of());
+        GraviteePortalPageContentValidatorService gmdContentValidator = new GraviteePortalPageContentValidatorService(
+            gmdValidator,
+            portalNavigationItemsQueryService,
+            mock(PortalNavigationEnclosingApiDomainService.class),
+            mock(PortalNavigationTemplatingService.class)
+        );
         PortalPageContentValidatorService validatorService = new PortalPageContentValidatorService(java.util.List.of(gmdContentValidator));
 
         useCase = new UpdatePortalPageContentUseCase(queryService, crudService, validatorService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/portal_page/PortalNavigationTemplatingServiceImplTest.java
@@ -25,8 +25,9 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.exception.PortalPageContentTemplateException;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
-import io.gravitee.apim.core.portal_page.service_provider.RenderedPageContent;
 import io.gravitee.apim.core.template.TemplateProcessor;
 import io.gravitee.apim.core.template.TemplateProcessorException;
 import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
@@ -61,7 +62,7 @@ class PortalNavigationTemplatingServiceImplTest {
 
         var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(GraviteeMarkdown.of("${api}"), model);
 
-        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo(RenderedPageContent.of("my-api"));
+        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo(RenderedPageContent.of("my-api", PortalPageContentType.GRAVITEE_MARKDOWN));
     }
 
     @Test
@@ -70,7 +71,7 @@ class PortalNavigationTemplatingServiceImplTest {
 
         var input = new PortalNavigationTemplatingService.RenderPortalNavigationMarkdownInput(GraviteeMarkdown.of("plain"), Map.of());
 
-        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo(RenderedPageContent.of("plain"));
+        assertThat(cut.renderGraviteeMarkdown(input)).isEqualTo(RenderedPageContent.of("plain", PortalPageContentType.GRAVITEE_MARKDOWN));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14001

### Stacked PRs
- **master**
  - https://github.com/gravitee-io/gravitee-api-management/pull/16696 
    - https://github.com/gravitee-io/gravitee-api-management/pull/16779
      - https://github.com/gravitee-io/gravitee-api-management/pull/16780 👈
        - https://github.com/gravitee-io/gravitee-api-management/pull/16781

### Validate and render GMD with navigation template context

Gravitee Markdown on portal navigation pages can now reference `${api.*}` or `${metadata.*}`: validates templates on save and renders on read.

### Scope

- `PortalPageContentValidator#validate(existing, update)`; OpenAPI validator adapted.
- `GraviteePortalPageContentValidatorService`: dry render via templating when content is linked to a navigation page.
- `GetPortalPageContentByNavigationIdUseCase`: render GMD for response; warn and skip on technical template errors.
- Management v2 `ResourceContextConfiguration` + unit test updates.

### Screenshots / video

https://github.com/user-attachments/assets/82697193-7cd9-4474-8611-0f9b07a4e943

