### PR TITLE
feat: Avoid duplicate snackbar on portal page save errors.

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -1147,6 +1147,27 @@ describe('PortalNavigationItemsComponent', () => {
       expect(await harness.isSaveButtonDisabled()).toBe(true);
       expect(await harness.getEditorContentText()).toBe('Edited content');
     });
+
+    it('should not display a generic snackbar when save fails with an HTTP error (interceptor handles it)', async () => {
+      await harness.setEditorContentText('Edited content with ${api.invalid}');
+      expect(await harness.isSaveButtonDisabled()).toBe(false);
+
+      const saveButton = await rootLoader.getHarness(MatButtonHarness.with({ text: /Save/i }));
+      await saveButton.click();
+
+      const req = httpTestingController.expectOne({
+        method: 'PUT',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-page-contents/nav-item-1-content`,
+      });
+      req.flush({ message: 'Invalid template: api.invalid' }, { status: 400, statusText: 'Bad Request' });
+
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(document.body.textContent).not.toContain('Failed to update page content');
+      expect(await harness.getEditorContentText()).toBe('Edited content with ${api.invalid}');
+      expect(await harness.isSaveButtonDisabled()).toBe(false);
+    });
   });
 
   describe('publishing and unpublishing a navigation item', () => {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -34,6 +34,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
 import { AsyncPipe, NgTemplateOutlet, TitleCasePipe } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { CdkScrollable } from '@angular/cdk/scrolling';
@@ -523,8 +524,12 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         .updatePageContent(pageId, { content: this.contentControl.value })
         .pipe(
           map(({ content }) => content),
-          catchError(() => {
-            this.snackBarService.error('Failed to update page content');
+          catchError(error => {
+            // HTTP errors are already caught by HttpErrorInterceptor and displayed in the snackbar.
+            // Suppress here to avoid replacing a specific backend message with a generic one.
+            if (!(error instanceof HttpErrorResponse)) {
+              this.snackBarService.error('Failed to update page content');
+            }
             return EMPTY;
           }),
           takeUntilDestroyed(this.destroyRef),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14001

### Stacked PRs
- **master**
  - https://github.com/gravitee-io/gravitee-api-management/pull/16696 
    - https://github.com/gravitee-io/gravitee-api-management/pull/16779
      - https://github.com/gravitee-io/gravitee-api-management/pull/16780
        - https://github.com/gravitee-io/gravitee-api-management/pull/16781 👈

### Console: avoid duplicate snackbar on portal page save errors

If save fails with an HTTP error, the interceptor already shows the backend message; the editor no longer adds a second generic “Failed to update page content” snackbar.

### Scope

- `portal-navigation-items`: `catchError` only shows generic snackbar for non-`HttpErrorResponse` failures.
- Spec: invalid template → 400, assert no duplicate generic message.

### Screenshots / video


