### PR TITLE
refactor: add GammaRootResource to have routes with environments

### DIFF
--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
@@ -16,7 +16,7 @@
 package io.gravitee.gamma.rest;
 
 import com.fasterxml.jackson.core.util.JacksonFeature;
-import io.gravitee.gamma.rest.resources.GammaModulesResource;
+import io.gravitee.gamma.rest.resources.GammaRootResource;
 import io.gravitee.gamma.rest.resources.GammaUIResource;
 import io.gravitee.rest.api.management.rest.mapper.ObjectMapperResolver;
 import io.gravitee.rest.api.management.rest.provider.BadRequestExceptionMapper;
@@ -50,7 +50,7 @@ import org.glassfish.jersey.server.ResourceConfig;
 public class GammaModuleApplication extends ResourceConfig {
 
     public GammaModuleApplication() {
-        register(GammaModulesResource.class);
+        register(GammaRootResource.class);
         register(GammaUIResource.class);
 
         register(MultiPartFeature.class);

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaRootResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaRootResource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.plugin.gamma.internal.GammaModuleDefinition;
+import io.gravitee.plugin.gamma.internal.GammaModuleService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * Root REST resource for Gamma.
+ */
+@Path("/")
+public class GammaRootResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Path("/organizations/{orgId}/modules")
+    public GammaModulesResource getModulesResourceFromOrganization() {
+        return resourceContext.getResource( GammaModulesResource.class);
+    }
+
+    @Path("/organizations/{orgId}/environments/{envId}/modules")
+    public GammaModulesResource getModulesResourceFromEnvironment() {
+        return resourceContext.getResource( GammaModulesResource.class);
+    }
+}


### PR DESCRIPTION
## Description

This allows to have routes like:
- `/organizations/:orgId/modules/:moduleId/my-resources`
- `/organizations/:orgId/environments/:envId/modules/:moduleId/my-resources`

Thanks to that the organizationId and environmentId can be retrieved from the [io.gravitee.rest.api.service.common.GraviteeContext](https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/GraviteeContext.java)




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

