### PR TITLE
Guard null HttpSelector.path/pathOperator and scalar Step.configuration to return 400

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ConfigurationSerializationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ConfigurationSerializationMapper.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.node.logging.NodeLoggerFactory;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -40,16 +41,26 @@ public interface ConfigurationSerializationMapper {
         if (Objects.isNull(configuration)) {
             return null;
         }
+        ObjectMapper mapper = new GraviteeMapper();
         if (configuration instanceof LinkedHashMap) {
-            ObjectMapper mapper = new GraviteeMapper();
             try {
                 JsonNode jsonNode = mapper.valueToTree(configuration);
                 return mapper.writeValueAsString(jsonNode);
             } catch (IllegalArgumentException | JsonProcessingException e) {
                 throw new TechnicalManagementException("An error occurred while trying to parse configuration " + e);
             }
+        } else if (configuration instanceof String) {
+            try {
+                JsonNode node = mapper.readTree((String) configuration);
+                if (!node.isObject()) {
+                    throw new InvalidDataException("Step.configuration must be a JSON object");
+                }
+                return (String) configuration;
+            } catch (JsonProcessingException e) {
+                throw new InvalidDataException("Step.configuration must be a JSON object");
+            }
         } else {
-            return configuration.toString();
+            throw new InvalidDataException("Step.configuration must be a JSON object");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ConfigurationSerializationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ConfigurationSerializationMapper.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
@@ -35,23 +34,23 @@ import org.slf4j.Logger;
 public interface ConfigurationSerializationMapper {
     ConfigurationSerializationMapper INSTANCE = Mappers.getMapper(ConfigurationSerializationMapper.class);
     Logger log = NodeLoggerFactory.getLogger(ConfigurationSerializationMapper.class);
+    GraviteeMapper JSON_MAPPER = new GraviteeMapper();
 
     @Named("serializeConfiguration")
     default String serializeConfiguration(Object configuration) {
         if (Objects.isNull(configuration)) {
             return null;
         }
-        ObjectMapper mapper = new GraviteeMapper();
         if (configuration instanceof LinkedHashMap) {
             try {
-                JsonNode jsonNode = mapper.valueToTree(configuration);
-                return mapper.writeValueAsString(jsonNode);
+                JsonNode jsonNode = JSON_MAPPER.valueToTree(configuration);
+                return JSON_MAPPER.writeValueAsString(jsonNode);
             } catch (IllegalArgumentException | JsonProcessingException e) {
                 throw new TechnicalManagementException("An error occurred while trying to parse configuration " + e);
             }
         } else if (configuration instanceof String) {
             try {
-                JsonNode node = mapper.readTree((String) configuration);
+                JsonNode node = JSON_MAPPER.readTree((String) configuration);
                 if (!node.isObject()) {
                     throw new InvalidDataException("Step.configuration must be a JSON object");
                 }
@@ -82,15 +81,14 @@ public interface ConfigurationSerializationMapper {
             return null;
         }
 
-        ObjectMapper mapper = new GraviteeMapper();
         try {
-            return mapper.readValue(configuration, LinkedHashMap.class);
+            return JSON_MAPPER.readValue(configuration, LinkedHashMap.class);
         } catch (JsonProcessingException jse) {
             log.debug("Cannot parse configuration as LinkedHashMap: " + configuration);
         }
 
         try {
-            return mapper.readValue(configuration, List.class);
+            return JSON_MAPPER.readValue(configuration, List.class);
         } catch (JsonProcessingException jse) {
             log.debug("Cannot parse configuration as List: " + configuration);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
@@ -45,7 +45,9 @@ import io.gravitee.rest.api.management.v2.rest.model.ApiType;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV2;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.FlowV4;
 import io.gravitee.rest.api.management.v2.rest.model.GenericApi;
+import io.gravitee.rest.api.management.v2.rest.model.StepV4;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV2;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV4;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -154,6 +156,19 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
             eq(false),
             eq(USER_NAME)
         );
+    }
+
+    @Test
+    public void should_return_400_when_a_step_has_a_scalar_configuration() {
+        ApiEntity apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).build();
+        when(apiSearchServiceV4.findGenericById(GraviteeContext.getExecutionContext(), API, false, false, false)).thenReturn(apiEntity);
+
+        var updateApiV4 = ApiFixtures.anUpdateApiV4().flows(
+            List.of(new FlowV4().request(List.of(new StepV4().enabled(true).policy("my-policy").configuration("a-string"))))
+        );
+
+        final Response response = rootTarget(API).request().put(Entity.json(updateApiV4));
+        assertEquals(BAD_REQUEST_400, response.getStatus());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
@@ -353,6 +353,17 @@ class ApisResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_return_400_when_a_step_has_a_scalar_configuration() {
+            var newApi = aValidV4Api().flows(
+                List.of(new FlowV4().request(List.of(new StepV4().enabled(true).policy("my-policy").configuration("a-string"))))
+            );
+
+            final Response response = target.request().post(Entity.json(newApi));
+
+            assertThat(response).hasStatus(BAD_REQUEST_400).asError().hasHttpStatus(BAD_REQUEST_400);
+        }
+
+        @Test
         void should_return_created_api() {
             when(validateApiDomainService.validateAndSanitizeForCreation(any(), any(), any(), any())).thenAnswer(invocation ->
                 invocation.getArgument(0)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainService.java
@@ -30,6 +30,7 @@ import io.gravitee.definition.model.v4.flow.selector.Selector;
 import io.gravitee.definition.model.v4.flow.selector.SelectorType;
 import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -68,6 +69,7 @@ public class FlowValidationDomainService {
             .selectorByType(SelectorType.HTTP)
             .stream()
             .map(selector -> ((HttpSelector) selector).getPath())
+            .filter(Objects::nonNull)
             .findFirst();
 
     private static final Map<ApiType, Function<Flow, Optional<String>>> PATH_EXTRACTOR = Map.of(
@@ -221,11 +223,22 @@ public class FlowValidationDomainService {
     }
 
     public void validatePathParameters(ApiType apiType, Stream<Flow> apiFlows, Stream<Flow> planFlows) {
-        apiFlows = apiFlows == null ? Stream.empty() : apiFlows;
-        planFlows = planFlows == null ? Stream.empty() : planFlows;
-        // group all flows in one stream
-        final Stream<Flow> flowsWithPathParam = filterFlowsWithPathParam(apiType, apiFlows, planFlows);
+        var apiFlowList = apiFlows == null ? List.<Flow>of() : apiFlows.toList();
+        var planFlowList = planFlows == null ? List.<Flow>of() : planFlows.toList();
+        checkForInvalidSelectors(apiFlowList, planFlowList);
+        final var flowsWithPathParam = filterFlowsWithPathParam(apiType, apiFlowList.stream(), planFlowList.stream());
         checkOverlappingPaths(apiType, flowsWithPathParam);
+    }
+
+    private static void checkForInvalidSelectors(List<Flow> apiFlowList, List<Flow> planFlowList) {
+        Stream.concat(apiFlowList.stream(), planFlowList.stream())
+            .flatMap(flow -> flow.selectorByType(SelectorType.HTTP).stream())
+            .map(HttpSelector.class::cast)
+            .filter(selector -> selector.getPath() == null)
+            .findAny()
+            .ifPresent(selector -> {
+                throw new InvalidDataException("flows[].selectors[].path is required");
+            });
     }
 
     private Stream<Flow> filterFlowsWithPathParam(ApiType apiType, Stream<Flow> apiFlows, Stream<Flow> planFlows) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/FlowMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/FlowMapper.java
@@ -33,6 +33,7 @@ import io.gravitee.repository.management.model.flow.selector.FlowMcpSelector;
 import io.gravitee.repository.management.model.flow.selector.FlowOperator;
 import io.gravitee.repository.management.model.flow.selector.FlowSelector;
 import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.util.Date;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -151,6 +152,9 @@ public class FlowMapper {
             FlowHttpSelector repositoryFlowHttpSelector = new FlowHttpSelector();
             repositoryFlowHttpSelector.setMethods(definitionHttpSelector.getMethods());
             repositoryFlowHttpSelector.setPath(definitionHttpSelector.getPath());
+            if (definitionHttpSelector.getPathOperator() == null) {
+                throw new InvalidDataException("flows[].selectors[].pathOperator is required");
+            }
             repositoryFlowHttpSelector.setPathOperator(FlowOperator.valueOf(definitionHttpSelector.getPathOperator().name()));
             return repositoryFlowHttpSelector;
         } else if (definitionSelector instanceof ChannelSelector) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainServiceTest.java
@@ -473,5 +473,39 @@ public class FlowValidationDomainServiceTest {
                 .stream()
                 .flatMap(plan -> plan.getFlows() == null ? Stream.empty() : plan.getFlows().stream());
         }
+
+        @Test
+        void should_return_validation_exception_when_http_selector_path_is_null() {
+            var flow = Flow.builder()
+                .selectors(List.of(HttpSelector.builder().path(null).pathOperator(Operator.STARTS_WITH).build()))
+                .build();
+
+            var throwable = catchThrowable(() -> service.validatePathParameters(ApiType.PROXY, Stream.of(flow), Stream.empty()));
+
+            assertThat(throwable).isInstanceOf(InvalidDataException.class);
+        }
+
+        @Test
+        void should_not_throw_on_overlapping_paths_when_flows_are_disabled() {
+            var flow1 = Flow.builder()
+                .enabled(false)
+                .selectors(List.of(HttpSelector.builder().path("/products/:productId").build()))
+                .build();
+            var flow2 = Flow.builder().enabled(false).selectors(List.of(HttpSelector.builder().path("/products/:id").build())).build();
+
+            assertThatNoException().isThrownBy(() ->
+                service.validatePathParameters(ApiType.PROXY, Stream.of(flow1, flow2), Stream.empty())
+            );
+        }
+
+        @Test
+        void should_not_throw_on_flows_with_static_paths_only() {
+            var flow1 = Flow.builder().enabled(true).selectors(List.of(HttpSelector.builder().path("/products/list").build())).build();
+            var flow2 = Flow.builder().enabled(true).selectors(List.of(HttpSelector.builder().path("/products/list").build())).build();
+
+            assertThatNoException().isThrownBy(() ->
+                service.validatePathParameters(ApiType.PROXY, Stream.of(flow1, flow2), Stream.empty())
+            );
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/FlowMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/FlowMapperTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.v4.mapper;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -134,6 +135,22 @@ public class FlowMapperTest {
         assertEquals("ip-filtering", mappedStep.getPolicy());
         assertEquals(POLICY_CONDITION, mappedStep.getCondition());
         assertEquals("{\"blacklistIps\":[\"127.0.0.1\"]}", mappedStep.getConfiguration());
+    }
+
+    @Test
+    public void toRepositoryShouldThrowValidationExceptionWhenHttpSelectorPathOperatorIsNull() {
+        HttpSelector httpSelector = new HttpSelector();
+        httpSelector.setPath("/");
+        httpSelector.setPathOperator(null);
+
+        Flow flowDefinition = new Flow();
+        flowDefinition.setName("bad_flow");
+        flowDefinition.setSelectors(List.of(httpSelector));
+        flowDefinition.setEnabled(true);
+
+        assertThatThrownBy(() -> flowMapper.toRepository(flowDefinition, FlowReferenceType.ORGANIZATION, "DEFAULT", 0)).isInstanceOf(
+            io.gravitee.rest.api.service.exceptions.InvalidDataException.class
+        );
     }
 
     @Test


### PR DESCRIPTION
## Issue

[APIM-13983](https://gravitee.atlassian.net/browse/APIM-13983)

## Why

Three unguarded null/type paths in `PUT` and `POST /management/v2/environments/{envId}/apis` caused 500 NullPointerExceptions instead of 400 validation errors:

- `HttpSelector.path = null` — null propagated to a path-param check without a prior guard
- `HttpSelector.pathOperator = null` — `FlowOperator.name()` called on null during selector persistence
- `Step.configuration` is a scalar (e.g. `"a-string"`) — the value bypassed the type check and reached a JSON schema validator that expects an object, causing an NPE

All three inputs are already forbidden by the OpenAPI spec; the fix enforces the spec at the validation layer and returns 400 with a field-level error in each case.

## What changed

- **`FlowValidationDomainService`** — `HTTP_PATH_EXTRACTOR` now filters null paths instead of forwarding them; `validatePathParameters` materialises both input streams to lists upfront so they can be iterated twice (null-path scan + param-overlap check) without an `IllegalStateException`; `validateInvalidSelectors` pipelines directly without an intermediate `.toList()`
- **`ConfigurationSerializationMapper`** — `serializeConfiguration` now validates that `String` configurations are well-formed JSON objects and rejects any non-`LinkedHashMap`, non-`String` type with `InvalidDataException` (400) instead of forwarding invalid input downstream
- **`FlowMapper`** — added import for `InvalidDataException`; replaced the inline fully-qualified reference
- **`JsonSchemaServiceImpl`** — removed dead `catch (NullPointerException e)` block; the upstream mapper fix prevents invalid input from reaching the validator

## How to test

Against a running Management API, send a `PUT` or `POST /management/v2/environments/DEFAULT/apis` payload with any of:

1. `"flows": [{"selectors": [{"type": "HTTP", "path": null, "pathOperator": "STARTS_WITH"}]}]` → expect `400`
2. `"flows": [{"selectors": [{"type": "HTTP", "path": "/", "pathOperator": null}]}]` → expect `400`
3. A step with `"configuration": "a-string"` (scalar, not an object) → expect `400`

Before this fix each of the above returned `500` with a Java NPE in the body.

[APIM-13983]: https://gravitee.atlassian.net/browse/APIM-13983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ