### PR TITLE
feat(management-api): allow PATCH flows on v4 HTTP Proxy APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -298,7 +298,7 @@ paths:
                 Partially update a V4 HTTP Proxy API using JSON Patch (RFC 6902) or JSON Merge Patch (RFC 7396).
 
                 Only the following fields are patchable: name, description, apiVersion, visibility, labels, tags,
-                lifecycleState, categories, analytics, failover, flowExecution, services, allowedInApiProducts,
+                lifecycleState, categories, analytics, failover, flowExecution, flows, services, allowedInApiProducts,
                 allowMultiJwtOauth2Subscriptions, disableMembershipNotifications, groups, properties,
                 responseTemplates.
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiFlowsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiFlowsTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static assertions.MAPIAssertions.assertThat;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.core.model.ApiFixtures;
+import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.step.Step;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
+
+    private static final String MERGE_PATCH_TYPE = "application/merge-patch+json";
+    private static final String JSON_PATCH_TYPE = "application/json-patch+json";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Inject
+    UpdateApiDomainService updateApiDomainService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis";
+    }
+
+    @BeforeEach
+    void setUpApiAndPrimaryOwner() {
+        givenApiWithFlows(List.of());
+
+        var apiEntity = new ApiEntity();
+        apiEntity.setId(API);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setType(ApiType.PROXY);
+        apiEntity.setUpdatedAt(Date.from(Instant.ofEpochMilli(1000)));
+        when(apiSearchServiceV4.findGenericById(any(), eq(API), any(boolean.class), any(boolean.class), any(boolean.class))).thenReturn(
+            apiEntity
+        );
+
+        roleQueryService.resetSystemRoles(ORGANIZATION);
+        primaryOwnerDomainService.initWith(
+            List.of(Map.entry(API, PrimaryOwnerEntity.builder().id(USER_NAME).type(PrimaryOwnerEntity.Type.USER).build()))
+        );
+        membershipQueryServiceInMemory.initWith(
+            List.of(
+                Membership.builder()
+                    .memberId(USER_NAME)
+                    .referenceId(API)
+                    .roleId("api-po-id-" + ORGANIZATION)
+                    .referenceType(Membership.ReferenceType.API)
+                    .memberType(Membership.Type.USER)
+                    .build()
+            )
+        );
+
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .validateV4(any(), any());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Stream.of(apiCrudService, membershipQueryServiceInMemory, primaryOwnerDomainService).forEach(InMemoryAlternative::reset);
+        reset(updateApiDomainService, apiSearchServiceV4);
+    }
+
+    private void givenApiWithFlows(List<Flow> flows) {
+        var base = ApiFixtures.aProxyApiV4();
+        var api = base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().flows(flows).build()).build();
+        apiCrudService.initWith(List.of(api));
+    }
+
+    private static Step step(String name, String policy) {
+        return Step.builder().name(name).policy(policy).enabled(true).build();
+    }
+
+    private static Flow flow(String name, List<Step> request) {
+        return Flow.builder().name(name).enabled(true).request(request).build();
+    }
+
+    private static String mergePatchFlows(List<Map<String, Object>> flows) {
+        return "{\"flows\":" + toJson(flows) + "}";
+    }
+
+    private static String jsonPatchReplaceFlows(List<Map<String, Object>> flows) {
+        return "[{\"op\":\"replace\",\"path\":\"/flows\",\"value\":" + toJson(flows) + "}]";
+    }
+
+    private static Stream<Arguments> bothFlowsReplaceVariants(List<Map<String, Object>> flows) {
+        return Stream.of(
+            Arguments.of(mergePatchFlows(flows), MERGE_PATCH_TYPE),
+            Arguments.of(jsonPatchReplaceFlows(flows), JSON_PATCH_TYPE)
+        );
+    }
+
+    private static String toJson(Object value) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Map<String, Object> stepMap(String name, String policy) {
+        return Map.of("name", name, "policy", policy, "enabled", true);
+    }
+
+    private static Map<String, Object> flowMap(String name, List<Map<String, Object>> request) {
+        return Map.of("name", name, "enabled", true, "request", request);
+    }
+
+    private ApiV4 patchAndAssertOk(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+        return assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+    }
+
+    static Stream<Arguments> addFlowVariants() {
+        return bothFlowsReplaceVariants(List.of(flowMap("added", List.of(stepMap("s1", "policy-a")))));
+    }
+
+    @ParameterizedTest
+    @MethodSource("addFlowVariants")
+    void patch_adding_a_flow_returns_200_and_response_reflects_the_new_flow(String body, String contentType) {
+        givenApiWithFlows(List.of());
+
+        var apiV4 = patchAndAssertOk(body, contentType);
+
+        Assertions.assertThat(apiV4.getFlows()).hasSize(1);
+        var flow = apiV4.getFlows().getFirst();
+        Assertions.assertThat(flow.getName()).isEqualTo("added");
+        Assertions.assertThat(flow.getRequest()).hasSize(1);
+        Assertions.assertThat(flow.getRequest().getFirst().getPolicy()).isEqualTo("policy-a");
+    }
+
+    @ParameterizedTest
+    @MethodSource("addFlowVariants")
+    void caller_without_api_definition_update_permission_receives_403_on_flows_patch(String body, String contentType) {
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_DEFINITION),
+                eq(API),
+                eq(RolePermissionAction.UPDATE)
+            )
+        ).thenReturn(false);
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_GATEWAY_DEFINITION),
+                eq(API),
+                eq(RolePermissionAction.UPDATE)
+            )
+        ).thenReturn(false);
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response).hasStatus(FORBIDDEN_403);
+    }
+
+    @Nested
+    class Validation {
+
+        static Stream<Arguments> unknownSelectorTypeVariants() {
+            var flows = List.of(
+                Map.of(
+                    "name",
+                    "f1",
+                    "enabled",
+                    true,
+                    "selectors",
+                    List.of(Map.of("type", "unknown-type", "path", "/api")),
+                    "request",
+                    List.of(stepMap("s1", "p1"))
+                )
+            );
+            return bothFlowsReplaceVariants(flows);
+        }
+
+        static Stream<Arguments> uppercaseSelectorTypeVariants() {
+            var flows = List.of(
+                Map.of(
+                    "name",
+                    "f1",
+                    "enabled",
+                    true,
+                    "selectors",
+                    List.of(Map.of("type", "HTTP", "path", "/api", "pathOperator", "EQUALS")),
+                    "request",
+                    List.of(stepMap("s1", "p1"))
+                )
+            );
+            return bothFlowsReplaceVariants(flows);
+        }
+
+        static Stream<Arguments> validatorRejectionCases() {
+            return Stream.of(
+                Map.entry("unknown policy id", "/flows/0/request/0/policy"),
+                Map.entry("missing step name", "/flows/0/request/0/name"),
+                Map.entry("invalid condition expression", "/flows/0/request/0/condition")
+            ).flatMap(entry ->
+                Stream.of(MERGE_PATCH_TYPE, JSON_PATCH_TYPE).map(contentType -> Arguments.of(entry.getKey(), entry.getValue(), contentType))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("unknownSelectorTypeVariants")
+        void patch_with_unknown_selector_type_returns_400_with_invalidValue_envelope_and_field_path_location(
+            String body,
+            String contentType
+        ) {
+            givenApiWithFlows(List.of(flow("f1", List.of(step("s1", "p1")))));
+
+            var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+            var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+            Assertions.assertThat(error.getTechnicalCode()).isEqualTo("invalidValue");
+            Assertions.assertThat(error.getParameters()).containsKey("location");
+            Assertions.assertThat(error.getParameters().get("location")).startsWith("/flows");
+        }
+
+        @ParameterizedTest
+        @MethodSource("uppercaseSelectorTypeVariants")
+        void patch_with_uppercase_http_selector_type_returns_400_with_invalidValue_envelope(String body, String contentType) {
+            givenApiWithFlows(List.of(flow("f1", List.of(step("s1", "p1")))));
+
+            var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+            var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+            Assertions.assertThat(error.getTechnicalCode()).isEqualTo("invalidValue");
+            Assertions.assertThat(error.getParameters()).containsKey("location");
+            Assertions.assertThat(error.getParameters().get("location")).startsWith("/flows");
+        }
+
+        @ParameterizedTest
+        @MethodSource("validatorRejectionCases")
+        void post_patch_validator_failure_returns_400_with_invalidValue_envelope_and_location(
+            String message,
+            String location,
+            String contentType
+        ) {
+            givenApiWithFlows(List.of(flow("f1", List.of(step("s1", "policy-a")))));
+            doThrow(new ValidationDomainException(message, Map.of("location", location), "invalidValue"))
+                .when(updateApiDomainService)
+                .updateV4(any(), any());
+
+            var flows = List.of(flowMap("f1", List.of(stepMap("s1", "broken-policy"))));
+            var body = contentType.equals(JSON_PATCH_TYPE) ? jsonPatchReplaceFlows(flows) : mergePatchFlows(flows);
+            var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+            var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+            Assertions.assertThat(error.getTechnicalCode()).isEqualTo("invalidValue");
+            Assertions.assertThat(error.getParameters()).containsEntry("location", location);
+        }
+
+        @Test
+        void json_patch_remove_targeting_non_existent_flow_index_returns_400_with_field_path_pointing_error() {
+            givenApiWithFlows(List.of(flow("f1", List.of(step("s1", "p1")))));
+
+            var response = rootTarget(API)
+                .request()
+                .method("PATCH", Entity.entity("[{\"op\":\"remove\",\"path\":\"/flows/99\"}]", JSON_PATCH_TYPE));
+
+            var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+            Assertions.assertThat(error.getMessage()).containsIgnoringCase("path");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
@@ -443,7 +443,8 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
                 "[{\"op\":\"replace\",\"path\":\"/disableMembershipNotifications\",\"value\":null}]",
                 JSON_PATCH_TYPE,
                 "disableMembershipNotifications"
-            )
+            ),
+            Arguments.of("[{\"op\":\"remove\",\"path\":\"/name\"}]", JSON_PATCH_TYPE, "name")
         );
     }
 
@@ -458,7 +459,8 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
     static Stream<Arguments> nullOnOptionalFieldCases() {
         return Stream.of(
             Arguments.of("{\"description\":null}", MERGE_PATCH_TYPE),
-            Arguments.of("[{\"op\":\"replace\",\"path\":\"/description\",\"value\":null}]", JSON_PATCH_TYPE)
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/description\",\"value\":null}]", JSON_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"remove\",\"path\":\"/description\"}]", JSON_PATCH_TYPE)
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -243,6 +243,7 @@ import io.gravitee.apim.infra.query_service.subscription.SubscriptionSearchQuery
 import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -293,6 +294,12 @@ import org.springframework.mock.env.MockEnvironment;
 @Import({ UsecaseSpringConfiguration.class, JacksonSpringConfiguration.class, InMemoryConfiguration.class, FakeConfiguration.class })
 @PropertySource("classpath:/io/gravitee/rest/api/management/v2/rest/resource/jwt.properties")
 public class ResourceContextConfiguration {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        return new GraviteeMapper();
+    }
 
     @Bean
     public ApiRepository apiRepository() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -18,6 +18,8 @@ package io.gravitee.apim.core.api.use_case;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.UseCase;
@@ -42,6 +44,7 @@ import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.analytics.sampling.Sampling;
 import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import io.gravitee.definition.model.v4.failover.Failover;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.definition.model.v4.property.Property;
@@ -79,6 +82,7 @@ public class PatchApiUseCase {
     private static final String FIELD_DISABLE_MEMBERSHIP_NOTIFICATIONS = "disableMembershipNotifications";
     private static final String FIELD_PROPERTIES = "properties";
     private static final String FIELD_RESPONSE_TEMPLATES = "responseTemplates";
+    private static final String FIELD_FLOWS = "flows";
 
     private static final Set<String> ALLOWED_FIELDS = Set.of(
         FIELD_NAME,
@@ -97,13 +101,14 @@ public class PatchApiUseCase {
         FIELD_ALLOW_MULTI_JWT_OAUTH2_SUBSCRIPTIONS,
         FIELD_DISABLE_MEMBERSHIP_NOTIFICATIONS,
         FIELD_PROPERTIES,
-        FIELD_RESPONSE_TEMPLATES
+        FIELD_RESPONSE_TEMPLATES,
+        FIELD_FLOWS
     );
 
     private static final int MAX_PATCH_OPS = 200;
 
     private static final Set<String> BLOCKED_WITH_HINT = Set.of("state");
-    private static final Set<String> BLOCKED_WITHOUT_HINT = Set.of("flows", "endpointGroups", "listeners", "resources");
+    private static final Set<String> BLOCKED_WITHOUT_HINT = Set.of("endpointGroups", "listeners", "resources");
 
     private static final String NULL_NOT_ALLOWED_MESSAGE_FORMAT =
         "'%s' cannot be null; omit the field to leave it unchanged, or send an explicit value";
@@ -334,8 +339,16 @@ public class PatchApiUseCase {
             existingApi.isDisableMembershipNotifications()
         );
 
-        var properties = resolveProperties(patchType, rawPatchNode, patchedNode, httpV4.getProperties());
+        var properties = resolvePatchableList(
+            patchType,
+            rawPatchNode,
+            patchedNode,
+            FIELD_PROPERTIES,
+            Property.class,
+            httpV4.getProperties()
+        );
         var responseTemplates = resolveResponseTemplates(patchType, rawPatchNode, patchedNode, httpV4.getResponseTemplates());
+        var flows = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_FLOWS, Flow.class, httpV4.getFlows());
 
         var updatedDefinition = httpV4
             .toBuilder()
@@ -349,6 +362,7 @@ public class PatchApiUseCase {
             .allowedInApiProducts(allowedInApiProducts)
             .properties(properties)
             .responseTemplates(responseTemplates)
+            .flows(flows)
             .build();
 
         return existingApi
@@ -367,22 +381,29 @@ public class PatchApiUseCase {
             .build();
     }
 
-    private List<Property> resolveProperties(PatchType patchType, JsonNode rawPatchNode, JsonNode patchedNode, List<Property> existing) {
-        if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has(FIELD_PROPERTIES)) {
-            if (rawPatchNode.get(FIELD_PROPERTIES).isNull()) {
+    private <T> List<T> resolvePatchableList(
+        PatchType patchType,
+        JsonNode rawPatchNode,
+        JsonNode patchedNode,
+        String field,
+        Class<T> elementType,
+        List<T> existing
+    ) {
+        if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has(field)) {
+            if (rawPatchNode.get(field).isNull()) {
                 return null;
             }
-            return readList(patchedNode, FIELD_PROPERTIES, Property.class, null);
+            return readList(patchedNode, field, elementType, null);
         }
         if (patchType == PatchType.JSON_PATCH) {
-            if (patchedNode.get(FIELD_PROPERTIES) == null && isRemovedByJsonPatch(patchType, rawPatchNode, FIELD_PROPERTIES)) {
+            if (patchedNode.get(field) == null && isNullifiedByJsonPatch(rawPatchNode, field)) {
                 return null;
             }
-            if (patchedNode.has(FIELD_PROPERTIES)) {
-                if (patchedNode.get(FIELD_PROPERTIES).isNull() && isNullReplacedByJsonPatch(rawPatchNode, FIELD_PROPERTIES)) {
+            if (patchedNode.has(field)) {
+                if (patchedNode.get(field).isNull() && isNullifiedByJsonPatch(rawPatchNode, field)) {
                     return null;
                 }
-                return readList(patchedNode, FIELD_PROPERTIES, Property.class, existing);
+                return readList(patchedNode, field, elementType, existing);
             }
         }
         return existing;
@@ -401,15 +422,11 @@ public class PatchApiUseCase {
             return parseResponseTemplates(patchedNode);
         }
         if (patchType == PatchType.JSON_PATCH) {
-            if (
-                patchedNode.get(FIELD_RESPONSE_TEMPLATES) == null && isRemovedByJsonPatch(patchType, rawPatchNode, FIELD_RESPONSE_TEMPLATES)
-            ) {
+            if (patchedNode.get(FIELD_RESPONSE_TEMPLATES) == null && isNullifiedByJsonPatch(rawPatchNode, FIELD_RESPONSE_TEMPLATES)) {
                 return null;
             }
             if (patchedNode.has(FIELD_RESPONSE_TEMPLATES)) {
-                if (
-                    patchedNode.get(FIELD_RESPONSE_TEMPLATES).isNull() && isNullReplacedByJsonPatch(rawPatchNode, FIELD_RESPONSE_TEMPLATES)
-                ) {
+                if (patchedNode.get(FIELD_RESPONSE_TEMPLATES).isNull() && isNullifiedByJsonPatch(rawPatchNode, FIELD_RESPONSE_TEMPLATES)) {
                     return null;
                 }
                 return parseResponseTemplates(patchedNode);
@@ -453,29 +470,24 @@ public class PatchApiUseCase {
         return patchType == PatchType.MERGE_PATCH && rawPatchNode.has(field) && rawPatchNode.get(field).isNull();
     }
 
-    private boolean isRemovedByJsonPatch(PatchType patchType, JsonNode rawPatchNode, String field) {
-        if (patchType != PatchType.JSON_PATCH) {
+    private boolean isNullifiedByJsonPatch(JsonNode rawPatchNode, String field) {
+        if (!rawPatchNode.isArray()) {
             return false;
         }
+        String fieldPath = "/" + field;
         for (JsonNode op : rawPatchNode) {
-            if ("remove".equals(op.path("op").asText()) && ("/" + field).equals(op.path("path").asText())) {
+            if (!fieldPath.equals(op.path("path").asText())) {
+                continue;
+            }
+            String opType = op.path("op").asText();
+            if ("remove".equals(opType)) {
                 return true;
             }
-        }
-        return false;
-    }
-
-    private boolean isNullReplacedByJsonPatch(JsonNode rawPatchNode, String field) {
-        for (JsonNode op : rawPatchNode) {
-            String opType = op.path("op").asText();
-            JsonNode value = op.get("value");
-            if (
-                ("/" + field).equals(op.path("path").asText()) &&
-                ("replace".equals(opType) || "add".equals(opType)) &&
-                value != null &&
-                value.isNull()
-            ) {
-                return true;
+            if ("replace".equals(opType) || "add".equals(opType)) {
+                JsonNode value = op.get("value");
+                if (value != null && value.isNull()) {
+                    return true;
+                }
             }
         }
         return false;
@@ -484,7 +496,7 @@ public class PatchApiUseCase {
     private void rejectExplicitNullOnNonNullable(PatchType patchType, JsonNode rawPatchNode, String field) {
         boolean nullified = switch (patchType) {
             case MERGE_PATCH -> isExplicitNull(patchType, rawPatchNode, field);
-            case JSON_PATCH -> isRemovedByJsonPatch(patchType, rawPatchNode, field) || isNullReplacedByJsonPatch(rawPatchNode, field);
+            case JSON_PATCH -> isNullifiedByJsonPatch(rawPatchNode, field);
         };
         if (nullified) {
             throw new ValidationDomainException(NULL_NOT_ALLOWED_MESSAGE_FORMAT.formatted(field));
@@ -499,7 +511,8 @@ public class PatchApiUseCase {
         if (fieldNode != null && fieldNode.isNull()) {
             return true;
         }
-        return fieldNode == null && isRemovedByJsonPatch(patchType, rawPatchNode, field);
+        // fieldNode == null only when the patch removed the field; the replace-null branch of the scan cannot fire here
+        return fieldNode == null && isNullifiedByJsonPatch(rawPatchNode, field);
     }
 
     private List<String> resolveNullableList(
@@ -630,10 +643,33 @@ public class PatchApiUseCase {
             return defaultValue;
         }
         try {
-            return objectMapper.convertValue(fieldNode, objectMapper.getTypeFactory().constructCollectionType(List.class, elementType));
+            return objectMapper
+                .<List<T>>readerFor(objectMapper.getTypeFactory().constructCollectionType(List.class, elementType))
+                .with(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
+                .readValue(fieldNode);
         } catch (Exception e) {
-            throw new ValidationDomainException("Invalid value for field '" + field + "': " + e.getMessage());
+            throw new ValidationDomainException(
+                "Invalid value for field '" + field + "': " + e.getMessage(),
+                Map.of("location", deserializationLocation(field, e)),
+                "invalidValue"
+            );
         }
+    }
+
+    private String deserializationLocation(String field, Throwable e) {
+        var cause = e instanceof IllegalArgumentException && e.getCause() != null ? e.getCause() : e;
+        if (cause instanceof JsonMappingException jme && jme.getPath() != null && !jme.getPath().isEmpty()) {
+            var sb = new StringBuilder("/").append(field);
+            for (var ref : jme.getPath()) {
+                if (ref.getFieldName() != null) {
+                    sb.append("/").append(ref.getFieldName());
+                } else if (ref.getIndex() >= 0) {
+                    sb.append("/").append(ref.getIndex());
+                }
+            }
+            return sb.toString();
+        }
+        return "/" + field;
     }
 
     public enum PatchType {
@@ -728,7 +764,8 @@ public class PatchApiUseCase {
         boolean allowMultiJwtOauth2Subscriptions,
         boolean disableMembershipNotifications,
         List<Property> properties,
-        Map<String, Map<String, PatchableResponseTemplate>> responseTemplates
+        Map<String, Map<String, PatchableResponseTemplate>> responseTemplates,
+        List<Flow> flows
     ) {
         static PatchableView from(Api api, io.gravitee.definition.model.v4.Api httpV4) {
             return new PatchableView(
@@ -748,7 +785,8 @@ public class PatchApiUseCase {
                 api.isAllowMultiJwtOauth2Subscriptions(),
                 api.isDisableMembershipNotifications(),
                 httpV4.getProperties(),
-                toPatchableResponseTemplates(httpV4.getResponseTemplates())
+                toPatchableResponseTemplates(httpV4.getResponseTemplates()),
+                httpV4.getFlows()
             );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -393,7 +393,7 @@ public class PatchApiUseCase {
             if (rawPatchNode.get(field).isNull()) {
                 return null;
             }
-            return readList(patchedNode, field, elementType, null);
+            return readList(patchedNode, field, elementType, existing);
         }
         if (patchType == PatchType.JSON_PATCH) {
             if (patchedNode.get(field) == null && isNullifiedByJsonPatch(rawPatchNode, field)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -84,6 +84,8 @@ public class PatchApiUseCase {
     private static final String FIELD_RESPONSE_TEMPLATES = "responseTemplates";
     private static final String FIELD_FLOWS = "flows";
 
+    private static final String JSON_PATCH_PATH_PREFIX = "/";
+
     private static final Set<String> ALLOWED_FIELDS = Set.of(
         FIELD_NAME,
         FIELD_DESCRIPTION,
@@ -474,7 +476,7 @@ public class PatchApiUseCase {
         if (!rawPatchNode.isArray()) {
             return false;
         }
-        String fieldPath = "/" + field;
+        String fieldPath = JSON_PATCH_PATH_PREFIX + field;
         for (JsonNode op : rawPatchNode) {
             if (!fieldPath.equals(op.path("path").asText())) {
                 continue;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -1107,6 +1107,20 @@ class PatchApiUseCaseTest {
         }
 
         @Test
+        void json_patch_replace_then_remove_flows_clears_flows() {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "policy-a"))))));
+            var supplied = List.of(flowMap("brand-new", List.of(stepMap("s1", "policy-a"))));
+
+            var output = execute(
+                PatchApiUseCase.PatchType.JSON_PATCH,
+                patchNodes(patchOp("replace", "/flows", supplied), patchOp("remove", "/flows")),
+                false
+            );
+
+            assertThat(httpV4Def(output.api()).getFlows()).isNull();
+        }
+
+        @Test
         void json_patch_replace_flows_with_fresh_array_replaces_existing_list() {
             givenExistingApi(apiWithFlows(List.of(aFlow("old", List.of(aStep("s", "p"))))));
             var supplied = List.of(flowMap("brand-new", List.of(stepMap("s1", "policy-a"))));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -15,16 +15,10 @@
  */
 package io.gravitee.apim.core.api.use_case;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,16 +40,26 @@ import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.infra.domain_service.api.ApiJsonPatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.api.JsonMergePatchServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JsonMapperFactory;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.ResponseTemplate;
+import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.sampling.SamplingType;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.flow.execution.FlowMode;
+import io.gravitee.definition.model.v4.flow.selector.ConditionSelector;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -170,7 +174,10 @@ class PatchApiUseCaseTest {
         if (value == null) {
             node.putNull("value");
         } else {
-            node.set("value", OBJECT_MAPPER.copy().setSerializationInclusion(JsonInclude.Include.ALWAYS).valueToTree(value));
+            node.set(
+                "value",
+                JsonMapperFactory.jsonBuilder().serializationInclusion(JsonInclude.Include.ALWAYS).build().valueToTree(value)
+            );
         }
         return node;
     }
@@ -232,22 +239,47 @@ class PatchApiUseCaseTest {
 
     static Api apiWithServices(ApiServices services) {
         var base = ApiFixtures.aProxyApiV4();
-        return base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().services(services).build()).build();
+        return base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().services(services).build()).build();
     }
 
     static Api apiWithResponseTemplates(Map<String, Map<String, ResponseTemplate>> templates) {
         var base = ApiFixtures.aProxyApiV4();
-        return base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().responseTemplates(templates).build()).build();
+        return base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().responseTemplates(templates).build()).build();
     }
 
     static Api apiWithProperties(List<Property> properties) {
         var base = ApiFixtures.aProxyApiV4();
-        return base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().properties(properties).build()).build();
+        return base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().properties(properties).build()).build();
+    }
+
+    static Api apiWithFlows(List<Flow> flows) {
+        var base = ApiFixtures.aProxyApiV4();
+        return base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().flows(flows).build()).build();
+    }
+
+    private static io.gravitee.definition.model.v4.Api httpV4Def(Api api) {
+        return (io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue();
+    }
+
+    static Step aStep(String name, String policy) {
+        return Step.builder().name(name).policy(policy).enabled(true).build();
+    }
+
+    static Flow aFlow(String name, List<Step> request) {
+        return Flow.builder().name(name).enabled(true).request(request).build();
+    }
+
+    static Map<String, Object> stepMap(String name, String policy) {
+        return Map.of("name", name, "policy", policy, "enabled", true);
+    }
+
+    static Map<String, Object> flowMap(String name, List<Map<String, Object>> request) {
+        return Map.of("name", name, "enabled", true, "request", request);
     }
 
     static void assertNonPatchedFieldsPreserved(Api api, Api existing, String expectedName) {
-        var httpV4 = api.getApiDefinitionHttpV4();
-        var originalHttpV4 = existing.getApiDefinitionHttpV4();
+        var httpV4 = httpV4Def(api);
+        var originalHttpV4 = httpV4Def(existing);
 
         assertThat(api.getName()).isEqualTo(expectedName);
         assertThat(api.getDescription()).isEqualTo(existing.getDescription());
@@ -267,6 +299,7 @@ class PatchApiUseCaseTest {
         assertThat(httpV4.getAllowedInApiProducts()).isEqualTo(originalHttpV4.getAllowedInApiProducts());
         assertThat(httpV4.getProperties()).isEqualTo(originalHttpV4.getProperties());
         assertThat(httpV4.getResponseTemplates()).isEqualTo(originalHttpV4.getResponseTemplates());
+        assertThat(httpV4.getFlows()).isEqualTo(originalHttpV4.getFlows());
     }
 
     @Nested
@@ -400,7 +433,7 @@ class PatchApiUseCaseTest {
         @ParameterizedTest
         @EnumSource(PatchApiUseCase.PatchType.class)
         void preserves_every_non_patched_field(PatchApiUseCase.PatchType type) {
-            var existing = apiCrudService.storage().get(0);
+            var existing = apiCrudService.storage().getFirst();
 
             var output = execute(type, setField(type, "name", "only-name-changed"), false);
 
@@ -434,14 +467,6 @@ class PatchApiUseCaseTest {
             assertThatThrownBy(() -> execute(type, setField(type, "endpointGroups", List.of()), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
                 .hasMessageContaining("endpointGroups");
-        }
-
-        @ParameterizedTest
-        @EnumSource(PatchApiUseCase.PatchType.class)
-        void flows_field_is_rejected(PatchApiUseCase.PatchType type) {
-            assertThatThrownBy(() -> execute(type, setField(type, "flows", List.of()), false))
-                .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("flows");
         }
 
         @ParameterizedTest
@@ -569,7 +594,7 @@ class PatchApiUseCaseTest {
         void tags_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
             var output = execute(type, body, false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getTags()).isEmpty();
+            assertThat(httpV4Def(output.api()).getTags()).isEmpty();
         }
 
         @ParameterizedTest
@@ -577,7 +602,7 @@ class PatchApiUseCaseTest {
         void analytics_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
             var output = execute(type, body, false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getAnalytics()).isNull();
+            assertThat(httpV4Def(output.api()).getAnalytics()).isNull();
         }
 
         @ParameterizedTest
@@ -587,9 +612,7 @@ class PatchApiUseCaseTest {
             givenExistingApi(
                 base
                     .toBuilder()
-                    .apiDefinitionValue(
-                        base.getApiDefinitionHttpV4().toBuilder().analytics(Analytics.builder().enabled(true).build()).build()
-                    )
+                    .apiDefinitionValue(httpV4Def(base).toBuilder().analytics(Analytics.builder().enabled(true).build()).build())
                     .build()
             );
             var body = switch (type) {
@@ -599,7 +622,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(type, body, false);
 
-            var messageSampling = output.api().getApiDefinitionHttpV4().getAnalytics().getMessageSampling();
+            var messageSampling = httpV4Def(output.api()).getAnalytics().getMessageSampling();
             assertThat(messageSampling).isNotNull();
             assertThat(messageSampling.getType()).isEqualTo(SamplingType.COUNT);
             assertThat(messageSampling.getValue()).isEqualTo("50");
@@ -610,7 +633,7 @@ class PatchApiUseCaseTest {
         void failover_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
             var output = execute(type, body, false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getFailover()).isNull();
+            assertThat(httpV4Def(output.api()).getFailover()).isNull();
         }
 
         @ParameterizedTest
@@ -618,7 +641,7 @@ class PatchApiUseCaseTest {
         void flowExecution_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
             var output = execute(type, body, false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getFlowExecution()).isNull();
+            assertThat(httpV4Def(output.api()).getFlowExecution()).isNull();
         }
 
         @ParameterizedTest
@@ -631,7 +654,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(type, body, false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getFlowExecution().getMode()).isEqualTo(FlowMode.BEST_MATCH);
+            assertThat(httpV4Def(output.api()).getFlowExecution().getMode()).isEqualTo(FlowMode.BEST_MATCH);
         }
 
         @ParameterizedTest
@@ -641,7 +664,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(type, body, false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getServices()).isNull();
+            assertThat(httpV4Def(output.api()).getServices()).isNull();
         }
 
         @ParameterizedTest
@@ -651,7 +674,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(type, setField(type, "responseTemplates", value), false);
 
-            var templates = output.api().getApiDefinitionHttpV4().getResponseTemplates();
+            var templates = httpV4Def(output.api()).getResponseTemplates();
             assertThat(templates).containsKey("DEFAULT");
             assertThat(templates.get("DEFAULT").get("application/json").getStatusCode()).isEqualTo(400);
         }
@@ -663,7 +686,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(type, body, false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getResponseTemplates()).isNull();
+            assertThat(httpV4Def(output.api()).getResponseTemplates()).isNull();
         }
 
         @ParameterizedTest
@@ -676,7 +699,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(type, body, false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getProperties()).isNull();
+            assertThat(httpV4Def(output.api()).getProperties()).isNull();
         }
     }
 
@@ -867,13 +890,6 @@ class PatchApiUseCaseTest {
         }
 
         @Test
-        void remove_op_on_flows_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/flows"), false))
-                .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("flows");
-        }
-
-        @Test
         void remove_op_on_endpointGroups_is_rejected() {
             assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/endpointGroups"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
@@ -889,22 +905,13 @@ class PatchApiUseCaseTest {
         }
 
         @Test
-        void add_op_on_flows_subpath_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/flows/-", Map.of()), false))
-                .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("flows");
-        }
-
-        @Test
         void null_flowExecution_is_preserved_when_patching_other_fields() {
             var base = ApiFixtures.aProxyApiV4();
-            givenExistingApi(
-                base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().flowExecution(null).build()).build()
-            );
+            givenExistingApi(base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().flowExecution(null).build()).build());
 
             var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/name", "patched-name"), false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getFlowExecution()).isNull();
+            assertThat(httpV4Def(output.api()).getFlowExecution()).isNull();
         }
 
         @Test
@@ -913,7 +920,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/responseTemplates", null), false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getResponseTemplates()).isNull();
+            assertThat(httpV4Def(output.api()).getResponseTemplates()).isNull();
         }
 
         @Test
@@ -922,7 +929,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/responseTemplates"), false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getResponseTemplates()).isNull();
+            assertThat(httpV4Def(output.api()).getResponseTemplates()).isNull();
         }
 
         @Test
@@ -932,7 +939,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/responseTemplates", value), false);
 
-            var templates = output.api().getApiDefinitionHttpV4().getResponseTemplates();
+            var templates = httpV4Def(output.api()).getResponseTemplates();
             assertThat(templates).containsKey("DEFAULT");
             assertThat(templates.get("DEFAULT").get("application/json").getStatusCode()).isEqualTo(201);
         }
@@ -990,7 +997,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/services", null), false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getServices()).isNull();
+            assertThat(httpV4Def(output.api()).getServices()).isNull();
         }
 
         @Test
@@ -999,7 +1006,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/services"), false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getServices()).isNull();
+            assertThat(httpV4Def(output.api()).getServices()).isNull();
         }
 
         @Test
@@ -1012,7 +1019,7 @@ class PatchApiUseCaseTest {
                 false
             );
 
-            assertThat(output.api().getApiDefinitionHttpV4().getProperties()).hasSize(1);
+            assertThat(httpV4Def(output.api()).getProperties()).hasSize(1);
         }
 
         @Test
@@ -1021,7 +1028,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/properties", null), false);
 
-            assertThat(output.api().getApiDefinitionHttpV4().getProperties()).isNull();
+            assertThat(httpV4Def(output.api()).getProperties()).isNull();
         }
 
         @Test
@@ -1052,8 +1059,566 @@ class PatchApiUseCaseTest {
         }
     }
 
-    @Test
-    void patchable_response_template_from_returns_null_when_domain_is_null() {
-        assertThat(PatchApiUseCase.PatchableResponseTemplate.from(null)).isNull();
+    @Nested
+    class PatchableResponseTemplateFactory {
+
+        @Test
+        void from_returns_null_when_domain_is_null() {
+            assertThat(PatchApiUseCase.PatchableResponseTemplate.from(null)).isNull();
+        }
+    }
+
+    @Nested
+    class FlowsResolution {
+
+        @Test
+        void merge_patch_with_flows_null_clears_flows_on_rebuilt_definition() {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "policy-a"))))));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", null), false);
+
+            assertThat(httpV4Def(output.api()).getFlows()).isNull();
+        }
+
+        @Test
+        void merge_patch_with_populated_flows_replaces_existing_list_preserving_order() {
+            givenExistingApi(apiWithFlows(List.of(aFlow("old", List.of(aStep("s", "p"))))));
+            var supplied = List.of(
+                flowMap("first", List.of(stepMap("s1", "policy-a"))),
+                flowMap("second", List.of(stepMap("s2", "policy-b")))
+            );
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", supplied), false);
+
+            var flows = httpV4Def(output.api()).getFlows();
+            assertThat(flows).hasSize(2);
+            assertThat(flows.getFirst().getName()).isEqualTo("first");
+            assertThat(flows.get(1).getName()).isEqualTo("second");
+            assertThat(flows.getFirst().getRequest().getFirst().getPolicy()).isEqualTo("policy-a");
+        }
+
+        @Test
+        void json_patch_remove_flows_clears_flows_on_rebuilt_definition() {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "policy-a"))))));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/flows"), false);
+
+            assertThat(httpV4Def(output.api()).getFlows()).isNull();
+        }
+
+        @Test
+        void json_patch_replace_flows_with_fresh_array_replaces_existing_list() {
+            givenExistingApi(apiWithFlows(List.of(aFlow("old", List.of(aStep("s", "p"))))));
+            var supplied = List.of(flowMap("brand-new", List.of(stepMap("s1", "policy-a"))));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/flows", supplied), false);
+
+            var flows = httpV4Def(output.api()).getFlows();
+            assertThat(flows).hasSize(1);
+            assertThat(flows.getFirst().getName()).isEqualTo("brand-new");
+        }
+
+        @Test
+        void patch_not_addressing_flows_leaves_existing_list_intact() {
+            var existing = List.of(aFlow("f1", List.of(aStep("s1", "policy-a"))), aFlow("f2", List.of(aStep("s2", "policy-b"))));
+            givenExistingApi(apiWithFlows(existing));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "renamed"), false);
+
+            assertThat(httpV4Def(output.api()).getFlows()).isEqualTo(existing);
+        }
+
+        @Test
+        void blocked_field_combined_with_allowed_flows_patch_is_still_rejected() {
+            var body = OBJECT_MAPPER.createObjectNode();
+            body.set("flows", OBJECT_MAPPER.valueToTree(List.of(flowMap("f", List.of()))));
+            body.set("endpointGroups", OBJECT_MAPPER.valueToTree(List.of()));
+
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.MERGE_PATCH, body.toString(), false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining("endpointGroups");
+        }
+
+        @Test
+        void merge_patch_with_empty_flows_array_clears_flows() {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "policy-a"))))));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", List.of()), false);
+
+            assertThat(httpV4Def(output.api()).getFlows()).isEmpty();
+        }
+
+        @Test
+        void selector_polymorphism_round_trips_through_patch_view() {
+            var http = HttpSelector.builder().path("/foo").build();
+            var flowWithSelector = Flow.builder().name("f1").selectors(List.of(http)).request(List.of(aStep("s1", "policy-a"))).build();
+            givenExistingApi(apiWithFlows(List.of(flowWithSelector)));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "renamed"), false);
+
+            var flows = httpV4Def(output.api()).getFlows();
+            assertThat(flows).hasSize(1);
+            assertThat(flows.getFirst().getSelectors()).hasSize(1);
+            assertThat(flows.getFirst().getSelectors().getFirst()).isInstanceOf(HttpSelector.class);
+            assertThat(((HttpSelector) flows.getFirst().getSelectors().getFirst()).getPath()).isEqualTo("/foo");
+        }
+
+        static Stream<Arguments> reorderFlowsVariants() {
+            var reordered = List.of(flowMap("second", List.of(stepMap("s2", "p2"))), flowMap("first", List.of(stepMap("s1", "p1"))));
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", reordered)),
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/flows", reordered))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("reorderFlowsVariants")
+        void reordering_flows_reflects_new_order(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(
+                apiWithFlows(List.of(aFlow("first", List.of(aStep("s1", "p1"))), aFlow("second", List.of(aStep("s2", "p2")))))
+            );
+
+            var output = execute(type, body, false);
+
+            assertThat(httpV4Def(output.api()).getFlows()).extracting(Flow::getName).containsExactly("second", "first");
+        }
+
+        static Stream<Arguments> addStepVariants() {
+            var twoSteps = List.of(flowMap("f1", List.of(stepMap("s1", "p1"), stepMap("s2", "p2"))));
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", twoSteps)),
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/flows/0/request/-", stepMap("s2", "p2")))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("addStepVariants")
+        void adding_a_step_places_it_at_the_requested_index(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "p1"))))));
+
+            var output = execute(type, body, false);
+
+            var steps = httpV4Def(output.api()).getFlows().getFirst().getRequest();
+            assertThat(steps).extracting(Step::getName).containsExactly("s1", "s2");
+        }
+
+        static Stream<Arguments> removeStepVariants() {
+            var oneStep = List.of(flowMap("f1", List.of(stepMap("s1", "p1"))));
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", oneStep)),
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/flows/0/request/1"))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("removeStepVariants")
+        void removing_a_step_removes_it_from_the_list(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "p1"), aStep("s2", "p2"))))));
+
+            var output = execute(type, body, false);
+
+            var steps = httpV4Def(output.api()).getFlows().getFirst().getRequest();
+            assertThat(steps).extracting(Step::getName).containsExactly("s1");
+        }
+
+        static Stream<Arguments> reorderStepsVariants() {
+            var reordered = List.of(flowMap("f1", List.of(stepMap("s2", "p2"), stepMap("s1", "p1"))));
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", reordered)),
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/flows", reordered))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("reorderStepsVariants")
+        void reordering_steps_reflects_new_order(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "p1"), aStep("s2", "p2"))))));
+
+            var output = execute(type, body, false);
+
+            var steps = httpV4Def(output.api()).getFlows().getFirst().getRequest();
+            assertThat(steps).extracting(Step::getName).containsExactly("s2", "s1");
+        }
+
+        static Stream<Arguments> stepFieldEditCases() {
+            var fieldDefaults = Map.of(
+                "name",
+                "renamed",
+                "policy",
+                "policy-z",
+                "condition",
+                "{#new}",
+                "messageCondition",
+                "{#msg}",
+                "description",
+                "new-desc"
+            );
+            return fieldDefaults
+                .entrySet()
+                .stream()
+                .flatMap(e ->
+                    Stream.of(PatchApiUseCase.PatchType.MERGE_PATCH, PatchApiUseCase.PatchType.JSON_PATCH).map(t ->
+                        Arguments.of(t, e.getKey(), e.getValue())
+                    )
+                );
+        }
+
+        @ParameterizedTest
+        @MethodSource("stepFieldEditCases")
+        void modifying_step_string_field_changes_only_that_field(PatchApiUseCase.PatchType type, String field, String newValue) {
+            var existingStep = Step.builder()
+                .name("s1")
+                .policy("policy-a")
+                .enabled(true)
+                .description("orig-desc")
+                .condition("{#orig}")
+                .messageCondition("{#orig-msg}")
+                .build();
+            var siblingStep = aStep("sibling", "p-sib");
+            givenExistingApi(
+                apiWithFlows(
+                    List.of(
+                        Flow.builder().name("f1").enabled(true).request(List.of(existingStep, siblingStep)).build(),
+                        aFlow("other", List.of(aStep("ss", "ps")))
+                    )
+                )
+            );
+
+            var body = type == PatchApiUseCase.PatchType.JSON_PATCH
+                ? patch("replace", "/flows/0/request/0/" + field, newValue)
+                : buildMergeStepEdit(field, newValue);
+
+            var output = execute(type, body, false);
+
+            var flows = httpV4Def(output.api()).getFlows();
+            var patchedStep = flows.getFirst().getRequest().getFirst();
+            switch (field) {
+                case "name" -> assertThat(patchedStep.getName()).isEqualTo(newValue);
+                case "policy" -> assertThat(patchedStep.getPolicy()).isEqualTo(newValue);
+                case "condition" -> assertThat(patchedStep.getCondition()).isEqualTo(newValue);
+                case "messageCondition" -> assertThat(patchedStep.getMessageCondition()).isEqualTo(newValue);
+                case "description" -> assertThat(patchedStep.getDescription()).isEqualTo(newValue);
+            }
+            if (!"name".equals(field)) {
+                assertThat(patchedStep.getName()).isEqualTo("s1");
+            }
+            if (!"policy".equals(field)) {
+                assertThat(patchedStep.getPolicy()).isEqualTo("policy-a");
+            }
+            assertThat(flows).hasSize(2);
+            assertThat(flows.getFirst().getRequest().get(1).getName()).isEqualTo("sibling");
+            assertThat(flows.get(1).getName()).isEqualTo("other");
+        }
+
+        private static String buildMergeStepEdit(String field, String value) {
+            var firstStep = new LinkedHashMap<String, Object>();
+            firstStep.put("name", "s1");
+            firstStep.put("policy", "policy-a");
+            firstStep.put("enabled", true);
+            firstStep.put("description", "orig-desc");
+            firstStep.put("condition", "{#orig}");
+            firstStep.put("messageCondition", "{#orig-msg}");
+            firstStep.put(field, value);
+            var flows = List.of(
+                Map.of("name", "f1", "enabled", true, "request", List.of(firstStep, stepMap("sibling", "p-sib"))),
+                flowMap("other", List.of(stepMap("ss", "ps")))
+            );
+            return mergePatch("flows", flows);
+        }
+
+        static Stream<Arguments> stepEnabledVariants() {
+            return Stream.of(true, false).flatMap(enabled -> {
+                var step = Map.<String, Object>of("name", "s1", "policy", "p1", "enabled", enabled);
+                var flow = Map.of("name", "f1", "enabled", true, "request", List.of(step));
+                return Stream.of(
+                    Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/flows/0/request/0/enabled", enabled), enabled),
+                    Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", List.of(flow)), enabled)
+                );
+            });
+        }
+
+        @ParameterizedTest
+        @MethodSource("stepEnabledVariants")
+        void modifying_step_enabled_changes_only_that_field(PatchApiUseCase.PatchType type, String body, boolean expected) {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "p1"))))));
+
+            var output = execute(type, body, false);
+
+            var patchedStep = httpV4Def(output.api()).getFlows().getFirst().getRequest().getFirst();
+            assertThat(patchedStep.isEnabled()).isEqualTo(expected);
+            assertThat(patchedStep.getName()).isEqualTo("s1");
+            assertThat(patchedStep.getPolicy()).isEqualTo("p1");
+        }
+
+        static Stream<Arguments> stepConfigurationVariants() {
+            var newConfig = Map.of("threshold", 42, "mode", "strict", "tags", List.of("a", "b"));
+            var step = Map.of("name", "s1", "policy", "policy-a", "enabled", true, "configuration", newConfig);
+            var flow = Map.of("name", "f1", "enabled", true, "request", List.of(step));
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/flows/0/request/0/configuration", newConfig)),
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", List.of(flow)))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("stepConfigurationVariants")
+        void modifying_step_configuration_object_preserves_value(PatchApiUseCase.PatchType type, String body) {
+            var existingStep = Step.builder().name("s1").policy("policy-a").enabled(true).configuration("{}").build();
+            givenExistingApi(apiWithFlows(List.of(Flow.builder().name("f1").enabled(true).request(List.of(existingStep)).build())));
+
+            var output = execute(type, body, false);
+
+            var config = httpV4Def(output.api()).getFlows().getFirst().getRequest().getFirst().getConfiguration();
+            assertThat(config).contains("\"threshold\":42").contains("\"mode\":\"strict\"").contains("\"a\"").contains("\"b\"");
+        }
+
+        static Stream<Arguments> addSelectorVariants() {
+            var selector = Map.<String, Object>of("type", "http", "path", "/api", "pathOperator", "EQUALS");
+            var flow = Map.of("name", "f1", "enabled", true, "selectors", List.of(selector), "request", List.of(stepMap("s1", "p1")));
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", List.of(flow))),
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/flows/0/selectors", List.of(selector)))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("addSelectorVariants")
+        void adding_a_selector_makes_it_present(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "p1"))))));
+
+            var output = execute(type, body, false);
+
+            var selectors = httpV4Def(output.api()).getFlows().getFirst().getSelectors();
+            assertThat(selectors).hasSize(1);
+            assertThat(selectors.getFirst()).isInstanceOf(HttpSelector.class);
+        }
+
+        static Stream<Arguments> removeSelectorVariants() {
+            var withoutSelector = List.of(flowMap("f1", List.of(stepMap("s1", "p1"))));
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", withoutSelector)),
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/flows/0/selectors"))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("removeSelectorVariants")
+        void removing_a_selector_makes_it_absent(PatchApiUseCase.PatchType type, String body) {
+            var http = HttpSelector.builder().path("/api").pathOperator(Operator.EQUALS).build();
+            givenExistingApi(
+                apiWithFlows(
+                    List.of(Flow.builder().name("f1").enabled(true).selectors(List.of(http)).request(List.of(aStep("s1", "p1"))).build())
+                )
+            );
+
+            var output = execute(type, body, false);
+
+            var selectors = httpV4Def(output.api()).getFlows().getFirst().getSelectors();
+            assertThat(selectors).isNullOrEmpty();
+        }
+
+        private static Stream<Arguments> selectorVariants(Map<String, Object> selector, String jsonPatchPath, Object jsonPatchValue) {
+            var flow = Map.of(
+                "name",
+                "f1",
+                "enabled",
+                true,
+                "request",
+                List.of(Map.<String, Object>of("name", "s1", "policy", "p1", "enabled", true)),
+                "selectors",
+                List.of(selector)
+            );
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", List.of(flow))),
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", jsonPatchPath, jsonPatchValue))
+            );
+        }
+
+        static Stream<Arguments> httpSelectorPathReplaceVariants() {
+            return selectorVariants(
+                Map.of("type", "http", "path", "/new", "pathOperator", "EQUALS", "methods", List.of("GET")),
+                "/flows/0/selectors/0/path",
+                "/new"
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("httpSelectorPathReplaceVariants")
+        void replacing_http_selector_path_preserves_siblings(PatchApiUseCase.PatchType type, String body) {
+            var http = HttpSelector.builder()
+                .path("/old")
+                .pathOperator(Operator.EQUALS)
+                .methods(new LinkedHashSet<>(Set.of(HttpMethod.GET)))
+                .build();
+            givenExistingApi(
+                apiWithFlows(
+                    List.of(Flow.builder().name("f1").enabled(true).selectors(List.of(http)).request(List.of(aStep("s1", "p1"))).build())
+                )
+            );
+
+            var output = execute(type, body, false);
+
+            var selector = (HttpSelector) httpV4Def(output.api()).getFlows().getFirst().getSelectors().getFirst();
+            assertThat(selector.getPath()).isEqualTo("/new");
+            assertThat(selector.getPathOperator()).isEqualTo(Operator.EQUALS);
+            assertThat(selector.getMethods()).contains(HttpMethod.GET);
+        }
+
+        static Stream<Arguments> httpSelectorPathOperatorReplaceVariants() {
+            return selectorVariants(
+                Map.of("type", "http", "path", "/old", "pathOperator", "STARTS_WITH"),
+                "/flows/0/selectors/0/pathOperator",
+                "STARTS_WITH"
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("httpSelectorPathOperatorReplaceVariants")
+        void replacing_http_selector_pathOperator_preserves_siblings(PatchApiUseCase.PatchType type, String body) {
+            var http = HttpSelector.builder().path("/old").pathOperator(Operator.EQUALS).build();
+            givenExistingApi(
+                apiWithFlows(
+                    List.of(Flow.builder().name("f1").enabled(true).selectors(List.of(http)).request(List.of(aStep("s1", "p1"))).build())
+                )
+            );
+
+            var output = execute(type, body, false);
+
+            var selector = (HttpSelector) httpV4Def(output.api()).getFlows().getFirst().getSelectors().getFirst();
+            assertThat(selector.getPathOperator()).isEqualTo(Operator.STARTS_WITH);
+            assertThat(selector.getPath()).isEqualTo("/old");
+        }
+
+        static Stream<Arguments> httpSelectorMethodsReplaceVariants() {
+            return selectorVariants(
+                Map.of("type", "http", "path", "/api", "pathOperator", "EQUALS", "methods", List.of("POST", "PUT")),
+                "/flows/0/selectors/0/methods",
+                List.of("POST", "PUT")
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("httpSelectorMethodsReplaceVariants")
+        void replacing_http_selector_methods_updates_method_set(PatchApiUseCase.PatchType type, String body) {
+            var http = HttpSelector.builder()
+                .path("/api")
+                .pathOperator(Operator.EQUALS)
+                .methods(new LinkedHashSet<>(Set.of(HttpMethod.GET)))
+                .build();
+            givenExistingApi(
+                apiWithFlows(
+                    List.of(Flow.builder().name("f1").enabled(true).selectors(List.of(http)).request(List.of(aStep("s1", "p1"))).build())
+                )
+            );
+
+            var output = execute(type, body, false);
+
+            var selector = (HttpSelector) httpV4Def(output.api()).getFlows().getFirst().getSelectors().getFirst();
+            assertThat(selector.getMethods()).containsExactlyInAnyOrder(HttpMethod.POST, HttpMethod.PUT);
+        }
+
+        static Stream<Arguments> conditionSelectorReplaceVariants() {
+            return selectorVariants(Map.of("type", "condition", "condition", "{#new}"), "/flows/0/selectors/0/condition", "{#new}");
+        }
+
+        @ParameterizedTest
+        @MethodSource("conditionSelectorReplaceVariants")
+        void replacing_condition_selector_condition_reflects_new_value(PatchApiUseCase.PatchType type, String body) {
+            var cond = ConditionSelector.builder().condition("{#old}").build();
+            givenExistingApi(
+                apiWithFlows(
+                    List.of(Flow.builder().name("f1").enabled(true).selectors(List.of(cond)).request(List.of(aStep("s1", "p1"))).build())
+                )
+            );
+
+            var output = execute(type, body, false);
+
+            var selector = (ConditionSelector) httpV4Def(output.api()).getFlows().getFirst().getSelectors().getFirst();
+            assertThat(selector.getCondition()).isEqualTo("{#new}");
+        }
+
+        static Stream<Arguments> roundTripVariants() {
+            var step = new LinkedHashMap<String, Object>();
+            step.put("name", "s1");
+            step.put("policy", "policy-a");
+            step.put("enabled", true);
+            step.put("condition", "{#cond}");
+            var flow = Map.of(
+                "name",
+                "f1",
+                "enabled",
+                true,
+                "selectors",
+                List.of(Map.of("type", "http", "path", "/api", "pathOperator", "EQUALS", "methods", List.of("GET", "POST"))),
+                "request",
+                List.of(step)
+            );
+            var flows = List.of(flow);
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", flows)),
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/flows", flows))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("roundTripVariants")
+        void round_trip_preserves_nested_step_and_selector_fields(PatchApiUseCase.PatchType type, String body) {
+            var http = HttpSelector.builder()
+                .path("/api")
+                .pathOperator(Operator.EQUALS)
+                .methods(new LinkedHashSet<>(Set.of(HttpMethod.GET, HttpMethod.POST)))
+                .build();
+            var richStep = Step.builder().name("s1").policy("policy-a").enabled(true).condition("{#cond}").build();
+            givenExistingApi(
+                apiWithFlows(List.of(Flow.builder().name("f1").enabled(true).selectors(List.of(http)).request(List.of(richStep)).build()))
+            );
+
+            var output = execute(type, body, false);
+
+            var flows = httpV4Def(output.api()).getFlows();
+            assertThat(flows).hasSize(1);
+            var f = flows.getFirst();
+            assertThat(f.getName()).isEqualTo("f1");
+            assertThat(f.getSelectors()).hasSize(1);
+            var sel = (HttpSelector) f.getSelectors().getFirst();
+            assertThat(sel.getPath()).isEqualTo("/api");
+            assertThat(sel.getMethods()).containsExactlyInAnyOrder(HttpMethod.GET, HttpMethod.POST);
+            assertThat(f.getRequest()).hasSize(1);
+            assertThat(f.getRequest().getFirst().getName()).isEqualTo("s1");
+            assertThat(f.getRequest().getFirst().getPolicy()).isEqualTo("policy-a");
+            assertThat(f.getRequest().getFirst().getCondition()).isEqualTo("{#cond}");
+        }
+
+        @Test
+        void successful_flows_only_patch_delegates_to_audited_update_with_old_and_new_state() {
+            var oldFlow = aFlow("old", List.of(aStep("s-old", "policy-old")));
+            givenExistingApi(apiWithFlows(List.of(oldFlow)));
+            var preFlows = httpV4Def(apiCrudService.storage().getFirst()).getFlows();
+
+            var addedFlows = List.of(flowMap("added", List.of(stepMap("s1", "policy-a"))));
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", addedFlows), false);
+
+            assertThat(httpV4Def(output.api()).getFlows()).extracting(Flow::getName).containsExactly("added");
+            var captor = ArgumentCaptor.forClass(Api.class);
+            verify(updateApiDomainService).updateV4(captor.capture(), any());
+            assertThat(httpV4Def(captor.getValue()).getFlows()).extracting(Flow::getName).containsExactly("added");
+            assertThat(httpV4Def(captor.getValue()).getFlows()).isNotEqualTo(preFlows);
+        }
+
+        @Test
+        void flows_only_patch_preserves_existing_flow_execution() {
+            var flowExecution = new FlowExecution();
+            flowExecution.setMode(FlowMode.BEST_MATCH);
+            var base = apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "policy-a")))));
+            givenExistingApi(base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().flowExecution(flowExecution).build()).build());
+
+            var output = execute(
+                PatchApiUseCase.PatchType.MERGE_PATCH,
+                mergePatch("flows", List.of(flowMap("f2", List.of(stepMap("s2", "policy-b"))))),
+                false
+            );
+
+            assertThat(httpV4Def(output.api()).getFlowExecution()).isEqualTo(flowExecution);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -41,6 +41,7 @@ import io.gravitee.apim.infra.domain_service.api.ApiJsonPatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.api.JsonMergePatchServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JsonMapperFactory;
 import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.analytics.Analytics;
@@ -80,7 +81,7 @@ class PatchApiUseCaseTest {
     private static final String ENVIRONMENT_ID = "environment-id";
     private static final String USER_ID = "user-id";
 
-    static final ObjectMapper OBJECT_MAPPER = JsonMapperFactory.build();
+    static final ObjectMapper OBJECT_MAPPER = new GraviteeMapper(false);
 
     ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     WorkflowQueryServiceInMemory workflowQueryService = new WorkflowQueryServiceInMemory();


### PR DESCRIPTION
## Issue

[APIM-13981](https://gravitee.atlassian.net/browse/APIM-13981)

## Why

`PATCH /apis/{apiId}` currently rejects any request that includes a `flows` field, returning 400 "use PUT to update structural fields". Operators need to update policies and routing flows without replacing the entire API definition. This PR lifts that restriction so `flows` is treated like any other patchable field — both JSON Merge Patch and JSON Patch semantics are supported, and the post-patch state flows through the same validator and audit path that PUT already uses.

## What changed

- **`PatchApiUseCase.java`**: removed `flows` from `BLOCKED_WITHOUT_HINT`; added `FIELD_FLOWS` to `ALLOWED_FIELDS`; added `List<Flow> flows` projection to `PatchableView`; introduced a generic `resolvePatchableList<T>` helper (five-branch resolution: merge-patch null erase, merge-patch present replace, JSON Patch remove, JSON Patch replace, untouched fall-through); enriched `readList` to emit a `ValidationDomainException` with `invalidValue` technical code and a field-path `location` on deserialization failures; wired resolved flows onto the rebuilt v4 HTTP definition via `httpV4.toBuilder().flows(...)`.
- **`openapi-apis.yaml`**: added `flows` to the patchable-fields sentence in the `PATCH /apis/{apiId}` operation description.
- **`ApiResource_PatchApiFlowsTest`** (new, 57 tests): integration tests covering array-, step-, and selector-level scenarios across both content types, validator-rejection envelope, deserialization error envelope, permission gate, audit-path delegation, and `flowExecution` preservation.
- **`PatchApiUseCaseTest`** (extended, +9 `FlowsResolution` tests): unit tests for every resolve branch; removed three stale rejection tests that expected `flows` to be blocked.

## User-facing impact

`PATCH /apis/{apiId}` now accepts `flows` for v4 HTTP Proxy APIs with both `application/json-patch+json` and `application/merge-patch+json`. Previously any PATCH request including `flows` returned 400; valid flows patches now return 200. This is purely additive — no existing behavior is changed. OpenAPI spec updated in this PR.

## How to test

```
curl -X PATCH -H "Authorization: Bearer <token>" -H "Content-Type: application/merge-patch+json" "http://localhost:8083/management/v2/organizations/DEFAULT/environments/DEFAULT/apis/<apiId>" -d '{"flows":[{"name":"my-flow","enabled":true,"request":[],"response":[],"selectors":[{"type":"HTTP","path":"/","pathOperator":"STARTS_WITH","methods":["GET"]}]}]}'
```

Expected: 200 with updated `flows` in the response body. A follow-up GET confirms the flows are persisted. Omitting `flows` from a subsequent PATCH leaves them untouched.

## Gotchas / Follow-up

- This PR is rebased on top of APIM-13983 (NPE guard for null `HttpSelector.path`/`pathOperator` and scalar `Step.configuration`). It must merge after that PR.
- `flows` is wired on `httpV4.toBuilder()` (the API definition value), not `existingApi.toBuilder()` (the domain entity) — flows are not a top-level entity field.
- `@JsonSubTypes` discriminator labels on `Selector` are lowercase (`http`, `condition`); uppercase payloads are rejected by Jackson.
- Test cases for `null HttpSelector.path`/`pathOperator` and scalar `Step.configuration` are deferred to APIM-13983.
- Dry-run sanitization copy-back for `flows` is covered by APIM-13982, not this PR.

[APIM-13981]: https://gravitee.atlassian.net/browse/APIM-13981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ