### PR TITLE
Fix/apim 12728 native kafka tracing toggle save banner

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.spec.ts
@@ -26,6 +26,7 @@ import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { ReporterSettingsComponent } from '../reporter-settings.component';
 
 describe('ReporterSettingsComponent', () => {
@@ -240,9 +241,79 @@ describe('ReporterSettingsComponent', () => {
       const saveBar = await harnessLoader.getHarness(GioSaveBarHarness);
       await saveBar.clickSubmit();
 
+      // submit() fetches the latest API state before issuing the PUT
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: false, verbose: false } }, true);
+
       const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`, method: 'PUT' });
       expect(req.request.body.analytics.tracing).toEqual({ enabled: true, verbose: true });
       req.flush(req.request.body);
+    });
+
+    it('should dismiss the save bar and show a success snackbar after saving', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: false, verbose: false } }, true);
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+
+      await toggles[1].check();
+
+      const saveBar = await harnessLoader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isVisible()).toEqual(true);
+
+      const snackBarService = TestBed.inject(SnackBarService);
+      const successSpy = jest.spyOn(snackBarService, 'success').mockImplementation(() => undefined);
+
+      await saveBar.clickSubmit();
+
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: false, verbose: false } }, true);
+      const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`, method: 'PUT' });
+      req.flush(req.request.body);
+      fixture.detectChanges();
+
+      expect(successSpy).toHaveBeenCalledWith('Configuration successfully saved!');
+      expect(await saveBar.isVisible()).toEqual(false);
+    });
+
+    it('should show an error snackbar when save fails', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: false, verbose: false } }, true);
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+
+      await toggles[1].check();
+
+      const snackBarService = TestBed.inject(SnackBarService);
+      const errorSpy = jest.spyOn(snackBarService, 'error');
+
+      const saveBar = await harnessLoader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: false, verbose: false } }, true);
+      const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`, method: 'PUT' });
+      req.flush({ message: 'Validation failed' }, { status: 400, statusText: 'Bad Request' });
+
+      expect(errorSpy).toHaveBeenCalledWith('Validation failed');
+    });
+
+    it('should show a fallback error snackbar when save fails without a body', async () => {
+      await init(['api-definition-r', 'api-definition-u']);
+      fixture.detectChanges();
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: false, verbose: false } }, true);
+      const toggles = await harnessLoader.getAllHarnesses(MatSlideToggleHarness);
+
+      await toggles[1].check();
+
+      const snackBarService = TestBed.inject(SnackBarService);
+      const errorSpy = jest.spyOn(snackBarService, 'error');
+
+      const saveBar = await harnessLoader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      expectGetAPI('V4', 'NATIVE', API_ID, { enabled: true, tracing: { enabled: false, verbose: false } }, true);
+      const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`, method: 'PUT' });
+      req.error(new ProgressEvent('error'));
+
+      expect(errorSpy).toHaveBeenCalledWith('Failed to save analytics settings');
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-native/reporter-settings-native.component.ts
@@ -15,8 +15,10 @@
  */
 import { Component, DestroyRef, inject, input, InputSignal, OnInit } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { tap } from 'rxjs/operators';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
 import { MatCardModule } from '@angular/material/card';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { GioFormSlideToggleModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
@@ -25,6 +27,7 @@ import { MatIcon } from '@angular/material/icon';
 
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { ApiV4 } from '../../../../entities/management-api-v2';
 
 type NativeReporterFormType = {
@@ -37,7 +40,17 @@ type NativeReporterFormType = {
   selector: 'reporter-settings-native',
   templateUrl: './reporter-settings-native.component.html',
   styleUrls: ['./reporter-settings-native.component.scss'],
-  imports: [MatCardModule, FormsModule, GioFormSlideToggleModule, GioSaveBarModule, ReactiveFormsModule, MatSlideToggle, MatHint, MatIcon],
+  imports: [
+    MatCardModule,
+    MatSnackBarModule,
+    FormsModule,
+    GioFormSlideToggleModule,
+    GioSaveBarModule,
+    ReactiveFormsModule,
+    MatSlideToggle,
+    MatHint,
+    MatIcon,
+  ],
 })
 export class ReporterSettingsNativeComponent implements OnInit {
   reporterSettingsForm: FormGroup<NativeReporterFormType>;
@@ -48,6 +61,7 @@ export class ReporterSettingsNativeComponent implements OnInit {
   constructor(
     private readonly apiService: ApiV2Service,
     private readonly permissionService: GioPermissionService,
+    private readonly snackBarService: SnackBarService,
   ) {}
 
   ngOnInit(): void {
@@ -101,25 +115,37 @@ export class ReporterSettingsNativeComponent implements OnInit {
   }
 
   submit(): void {
-    const values = this.reporterSettingsForm.getRawValue();
-    const currentApi = this.api();
-    const updatedApi: ApiV4 = {
-      ...currentApi,
-      analytics: {
-        ...(currentApi.analytics ?? {}),
-        enabled: values.enabled,
-        tracing: {
-          enabled: values.tracingEnabled,
-          verbose: values.tracingVerbose,
-        },
-      },
-    };
-
     this.apiService
-      .update(updatedApi.id, updatedApi)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.defaultConfiguration = this.reporterSettingsForm.getRawValue();
-      });
+      .get(this.api().id)
+      .pipe(
+        switchMap((api: ApiV4) => {
+          const values = this.reporterSettingsForm.getRawValue();
+          const updatedApi: ApiV4 = {
+            ...api,
+            analytics: {
+              ...(api.analytics ?? {}),
+              enabled: values.enabled,
+              tracing: {
+                enabled: values.tracingEnabled,
+                verbose: values.tracingVerbose,
+              },
+            },
+          };
+          return this.apiService.update(api.id, updatedApi);
+        }),
+        tap(() => {
+          this.defaultConfiguration = this.reporterSettingsForm.getRawValue();
+          this.reporterSettingsForm.markAsPristine();
+        }),
+        map(() => {
+          this.snackBarService.success('Configuration successfully saved!');
+        }),
+        catchError(err => {
+          this.snackBarService.error(err?.error?.message ?? 'Failed to save analytics settings');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/nativeapi/NativeApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/nativeapi/NativeApiEntity.java
@@ -197,6 +197,7 @@ public class NativeApiEntity implements GenericApiEntity {
     @JsonIgnore
     private String referenceId;
 
+    @DeploymentRequired
     @Schema(description = "Analytics settings")
     private NativeAnalytics analytics;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_IsSynchronizedTest.java
@@ -398,6 +398,58 @@ public class ApiStateServiceImpl_IsSynchronizedTest {
     }
 
     @Test
+    public void should_return_false_for_V4_native_API_when_analytics_changed() throws JsonProcessingException {
+        var apiDefinition = io.gravitee.definition.model.v4.nativeapi.NativeApi.builder()
+            .id("apiId")
+            .name("Api name")
+            .definitionVersion(DefinitionVersion.V4)
+            .build();
+        Api api = new Api();
+        api.setId("apiId");
+        api.setName("Api name");
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setDefinition(objectMapper.writeValueAsString(apiDefinition));
+
+        Event event = new Event();
+        event.setType(io.gravitee.repository.management.model.EventType.PUBLISH_API);
+        event.setPayload(objectMapper.writeValueAsString(api));
+
+        when(
+            eventLatestRepository.search(
+                EventCriteria.builder()
+                    .types(
+                        List.of(
+                            io.gravitee.repository.management.model.EventType.PUBLISH_API,
+                            io.gravitee.repository.management.model.EventType.STOP_API,
+                            io.gravitee.repository.management.model.EventType.START_API,
+                            io.gravitee.repository.management.model.EventType.UNPUBLISH_API
+                        )
+                    )
+                    .properties(Map.of(Event.EventProperties.API_ID.getValue(), "apiId"))
+                    .build(),
+                Event.EventProperties.API_ID,
+                0L,
+                1L
+            )
+        ).thenReturn(List.of(event));
+
+        var apiEntity = apiMapper.toNativeEntity(GraviteeContext.getExecutionContext(), api, null, false, false, false);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        // Enable per-API tracing on the current entity. Deployed payload has no tracing →
+        // isSynchronized must return false so the redeploy banner is shown.
+        var analytics = new io.gravitee.definition.model.v4.nativeapi.NativeAnalytics();
+        var tracing = new io.gravitee.definition.model.v4.analytics.tracing.Tracing();
+        tracing.setEnabled(true);
+        analytics.setTracing(tracing);
+        apiEntity.setAnalytics(analytics);
+
+        final boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(isSynchronized).isFalse();
+        verify(synchronizationService, times(1)).checkSynchronization(any(), any(), any());
+    }
+
+    @Test
     public void should_return_false_for_V4_API() throws JsonProcessingException {
         var apiDefinition = io.gravitee.definition.model.v4.nativeapi.NativeApi.builder()
             .id("apiId")

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
         <gravitee-resource-schema-registry-embedded.version>1.0.0-alpha.1</gravitee-resource-schema-registry-embedded.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0-alpha.2</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>7.0.0-alpha.9</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>7.0.0-alpha.13</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.2</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>2.9.0</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13485

## Description

1. Bump reactor.
2. The console submit handler now fetches the latest API state, shows a success or error snackbar, and marks the form as pristine so the save bar dismisses. 
3. NativeApiEntity.analytics is also marked @DeploymentRequired (already the case for ApiEntity.analytics) so the synchronization check picks up tracing toggle changes and the navigation banner prompts for a redeploy.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

