### PR TITLE
fix(console): align file picker accept with API format in V4 import flow

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
@@ -52,8 +52,8 @@ describe('ApiImportV4FormComponent', () => {
   });
 
   it.each([
-    ['gravitee', 'Supported file formats: json'],
-    ['openapi', 'Supported file formats: yml, yaml'],
+    ['gravitee', 'Supported file formats: yml, yaml, json'],
+    ['openapi', 'Supported file formats: yml, yaml, json'],
   ])('should surface supported file formats in the UI for format %s', async (format, expectedBanner) => {
     await harness.selectFormat(format as string);
     fixture.detectChanges();
@@ -70,6 +70,7 @@ describe('ApiImportV4FormComponent', () => {
     const accept = await harness.getFilePickerInputAccept();
     expect(accept).toContain('.yml');
     expect(accept).toContain('.yaml');
+    expect(accept).toContain('.json');
   });
 
   it('should keep picked file when going back from configure step to format step without changing API format', async () => {

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
@@ -178,16 +178,7 @@ export class ApiImportV4FormComponent {
 
   protected readonly allowedImportFileExtensions = computed((): string[] => {
     const format = this.importFormat();
-    switch (format) {
-      case 'wsdl':
-        return ['wsdl', 'xml'];
-      case 'openapi':
-        return ['yml', 'yaml'];
-      case 'gravitee':
-        return ['json'];
-      default:
-        return ['json'];
-    }
+    return format === 'wsdl' ? ['wsdl', 'xml'] : ['yml', 'yaml', 'json'];
   });
 
   protected readonly allowedImportFileExtensionsLabel = computed(() => this.allowedImportFileExtensions().join(', '));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13831
Non-WSDL formats (Gravitee definition and OpenAPI specification) now use the same allowed extensions: yml, yaml, json. This lets users pick OpenAPI/Swagger as JSON while keeping YAML support. WSDL remains restricted to wsdl and xml. The UI “Supported file formats” banner and the native file input accept attribute follow this logic via allowedImportFileExtensions.


