### PR TITLE
ci: trigger jobs when only gamma modules are updated

### DIFF
--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -795,6 +795,9 @@ function shouldBuildBackend(changedFiles: string[]): boolean {
     'gravitee-apim-reporter',
     'gravitee-apim-repository',
     'gravitee-apim-rest-api',
+    'gravitee-gamma-module-apim',
+    'gravitee-gamma-plugin',
+    'gravitee-gamma-rest-api',
   ];
   return (
     shouldBuildAll(changedFiles) || changedFiles.some((file) => mavenProjectsIdentifiers.some((identifier) => file.includes(identifier)))


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

When only Gamma Maven modules was changed, the CI was not triggering Backend build jobs

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

