### PR TITLE
[4.11.x] fix(ci): use matrix form for strict-PK JDBC job

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -304,14 +304,17 @@ workflows:
                 - sqlserver~2022-latest
                 - sqlserver~2025-latest
       - job-jdbc-test-container:
-          name: Management repository tests - JDBC - mysql~8.4 (strict-PK)
+          name: Management repository tests - JDBC - << matrix.jdbcType >> (strict-PK)
           context:
             - cicd-orchestrator
           requires:
             - Build
-          parameters:
-            jdbcType: mysql~8.4
-            strictPrimaryKey: "true"
+          matrix:
+            parameters:
+              jdbcType:
+                - mysql~8.4
+              strictPrimaryKey:
+                - "true"
       - job-mongo-test-container:
           name: Management repository tests - Mongo << matrix.mongoVersion >>
           context:

--- a/.circleci/ci/src/workflows/workflow-repositories-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-repositories-tests.ts
@@ -73,13 +73,19 @@ export class RepositoriesTestsWorkflow {
       // the MariaDB 12.1 testcontainer refused to start with --sql-require-primary-key=ON
       // (container exits 1 before any test runs), and MariaDB strict-PK is not the customer
       // scenario this PR was filed for.
+      // Single-cell matrix is intentional. The cleaner `parameters: { … }` form
+      // CircleCI's docs suggest is rejected at runtime here with
+      // "Unexpected argument(s): parameters" — the @circleci/circleci-config-sdk
+      // emits the keys nested under a `parameters:` map, but the runtime expects
+      // them at workflow-job level. Matrix is the only form the SDK serialises in
+      // the shape CircleCI accepts.
       new workflow.WorkflowJob(jdbcTestContainerJob, {
-        name: 'Management repository tests - JDBC - mysql~8.4 (strict-PK)',
+        name: 'Management repository tests - JDBC - << matrix.jdbcType >> (strict-PK)',
         context: ['cicd-orchestrator'],
         requires: [buildJobName],
-        parameters: {
-          jdbcType: 'mysql~8.4',
-          strictPrimaryKey: 'true',
+        matrix: {
+          jdbcType: ['mysql~8.4'],
+          strictPrimaryKey: ['true'],
         },
       }),
       new workflow.WorkflowJob(mongoTestContainerJob, {


### PR DESCRIPTION
## Summary
- Backport of the workflow portion of master commit `a3ac25421b` to `4.11.x`.
- The strict-PK JDBC job introduced in `856e0dbf66` failed CircleCI config validation with `Error calling job: 'job-jdbc-test-container' — Unexpected argument(s): parameters`.
- Switch to the single-cell `matrix.parameters` form (the only shape `@circleci/circleci-config-sdk` serialises in a way the CircleCI runtime accepts here).

The v4_12_0 changelog hunk from `a3ac25421b` is intentionally **not** included — that table does not exist on `4.11.x`.

## Test plan
- [ ] CircleCI `repositories-tests` workflow passes config validation
- [ ] `Management repository tests - JDBC - mysql~8.4 (strict-PK)` job runs and passes