### PR TITLE
fix: remove default 10 item pagination.

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImpl.java
@@ -78,17 +78,28 @@ public class ApiPortalSearchQueryServiceImpl implements ApiPortalSearchQueryServ
         List<String> intersected = luceneIds.stream().filter(allowedApiIds::contains).toList();
 
         int total = intersected.size();
-        int pageSize = pageable.map(Pageable::getPageSize).orElse(10);
 
-        if (total == 0 || pageSize <= 0) {
-            return new Page<>(List.of(), pageNumber, 0, total);
+        if (total == 0) {
+            return new Page<>(List.of(), pageNumber, 0, 0);
         }
 
-        int start = (pageNumber - 1) * pageSize;
-        if (start >= total) {
-            return new Page<>(List.of(), pageNumber, 0, total);
+        final List<String> pageSubset;
+        final int resultPageNumber;
+        if (pageable.isEmpty()) {
+            pageSubset = intersected;
+            resultPageNumber = 1;
+        } else {
+            resultPageNumber = pageNumber;
+            int pageSize = pageable.get().getPageSize();
+            if (pageSize <= 0) {
+                return new Page<>(List.of(), resultPageNumber, 0, total);
+            }
+            int start = (resultPageNumber - 1) * pageSize;
+            if (start >= total) {
+                return new Page<>(List.of(), resultPageNumber, 0, total);
+            }
+            pageSubset = intersected.subList(start, Math.min(start + pageSize, total));
         }
-        List<String> pageSubset = intersected.subList(start, Math.min(start + pageSize, total));
 
         // Fetch by IDs then reorder to preserve Lucene relevance order
         Map<String, Api> apiById = apiQueryService
@@ -99,7 +110,7 @@ public class ApiPortalSearchQueryServiceImpl implements ApiPortalSearchQueryServ
 
         List<Api> pageContent = pageSubset.stream().map(apiById::get).filter(Objects::nonNull).toList();
 
-        return new Page<>(pageContent, pageNumber, pageContent.size(), total);
+        return new Page<>(pageContent, resultPageNumber, pageContent.size(), total);
     }
 
     private io.gravitee.apim.core.api.model.Sortable toCoreSortable(Sortable sortable) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImpl.java
@@ -84,19 +84,16 @@ public class ApiPortalSearchQueryServiceImpl implements ApiPortalSearchQueryServ
         }
 
         final List<String> pageSubset;
-        final int resultPageNumber;
         if (pageable.isEmpty()) {
             pageSubset = intersected;
-            resultPageNumber = 1;
         } else {
-            resultPageNumber = pageNumber;
-            int pageSize = pageable.get().getPageSize();
+            int pageSize = Math.min(pageable.get().getPageSize(), 100);
             if (pageSize <= 0) {
-                return new Page<>(List.of(), resultPageNumber, 0, total);
+                return new Page<>(List.of(), pageNumber, 0, total);
             }
-            int start = (resultPageNumber - 1) * pageSize;
+            int start = (pageNumber - 1) * pageSize;
             if (start >= total) {
-                return new Page<>(List.of(), resultPageNumber, 0, total);
+                return new Page<>(List.of(), pageNumber, 0, total);
             }
             pageSubset = intersected.subList(start, Math.min(start + pageSize, total));
         }
@@ -110,7 +107,7 @@ public class ApiPortalSearchQueryServiceImpl implements ApiPortalSearchQueryServ
 
         List<Api> pageContent = pageSubset.stream().map(apiById::get).filter(Objects::nonNull).toList();
 
-        return new Page<>(pageContent, resultPageNumber, pageContent.size(), total);
+        return new Page<>(pageContent, pageNumber, pageContent.size(), total);
     }
 
     private io.gravitee.apim.core.api.model.Sortable toCoreSortable(Sortable sortable) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiPortalSearchQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiPortalSearchQueryServiceInMemory.java
@@ -37,9 +37,7 @@ public class ApiPortalSearchQueryServiceInMemory extends AbstractQueryServiceInM
         Sortable sortable = q.sortable().orElse(null);
 
         int pageNumber = pageable != null ? pageable.getPageNumber() : 1;
-        int pageSize = pageable != null
-            ? pageable.getPageSize()
-            : (query != null && !query.isBlank() ? Integer.MAX_VALUE : 10);
+        int pageSize = pageable != null ? pageable.getPageSize() : (query != null && !query.isBlank() ? Integer.MAX_VALUE : 10);
 
         if (allowedApiIds != null && allowedApiIds.isEmpty()) {
             return new Page<>(List.of(), pageNumber, 0, 0);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiPortalSearchQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiPortalSearchQueryServiceInMemory.java
@@ -37,7 +37,9 @@ public class ApiPortalSearchQueryServiceInMemory extends AbstractQueryServiceInM
         Sortable sortable = q.sortable().orElse(null);
 
         int pageNumber = pageable != null ? pageable.getPageNumber() : 1;
-        int pageSize = pageable != null ? pageable.getPageSize() : 10;
+        int pageSize = pageable != null
+            ? pageable.getPageSize()
+            : (query != null && !query.isBlank() ? Integer.MAX_VALUE : 10);
 
         if (allowedApiIds != null && allowedApiIds.isEmpty()) {
             return new Page<>(List.of(), pageNumber, 0, 0);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetVisiblePortalNavigationApisUseCaseTest.java
@@ -28,12 +28,14 @@ import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -215,6 +217,33 @@ class GetVisiblePortalNavigationApisUseCaseTest {
         );
 
         assertThat(result.apis().getContent()).extracting(PortalNavigationApi::getApiId).containsExactly("api-auth");
+    }
+
+    @Test
+    void search_with_query_does_not_cap_results_before_catalog_pagination() {
+        List<PortalNavigationItem> navItems = IntStream.rangeClosed(1, 12)
+            .mapToObj(i -> (PortalNavigationItem) publishedApiNavItem("api-" + i, PortalVisibility.PUBLIC))
+            .toList();
+        navQueryService.initWith(navItems);
+
+        List<Api> apis = IntStream.rangeClosed(1, 12)
+            .mapToObj(i -> anApi("api-" + i, "Catalog Service " + i, ENV_ID))
+            .toList();
+        apiSearchQueryService.initWith(apis);
+
+        var result = useCase.execute(
+            new GetVisiblePortalNavigationApisUseCase.Input(
+                ENV_ID,
+                ORG_ID,
+                Optional.empty(),
+                new PageableImpl(1, 10),
+                Optional.of("Catalog"),
+                Set.of()
+            )
+        );
+
+        assertThat(result.apis().getTotalElements()).isEqualTo(12);
+        assertThat(result.apis().getContent()).hasSize(10);
     }
 
     // --- helpers ---

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImplTest.java
@@ -189,6 +189,27 @@ class ApiPortalSearchQueryServiceImplTest {
             assertThat(result.getContent()).hasSize(2);
             assertThat(result.getTotalElements()).isEqualTo(3);
         }
+
+        @Test
+        void should_return_all_intersected_matches_when_pageable_is_null() {
+            when(apiSearchService.searchIds(any(), any(), any(), any()))
+                .thenReturn(List.of("api-1", "api-2", "api-3", "api-4", "api-5"));
+            givenApis(
+                List.of(
+                    anApi("api-1"),
+                    anApi("api-2"),
+                    anApi("api-3"),
+                    anApi("api-4"),
+                    anApi("api-5")
+                )
+            );
+
+            var result = service.search("env", "org", "term", Set.of("api-1", "api-2", "api-3", "api-4", "api-5"), null, null);
+
+            assertThat(result.getContent()).hasSize(5);
+            assertThat(result.getTotalElements()).isEqualTo(5);
+            assertThat(result.getPageNumber()).isEqualTo(1);
+        }
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImplTest.java
@@ -192,17 +192,8 @@ class ApiPortalSearchQueryServiceImplTest {
 
         @Test
         void should_return_all_intersected_matches_when_pageable_is_null() {
-            when(apiSearchService.searchIds(any(), any(), any(), any()))
-                .thenReturn(List.of("api-1", "api-2", "api-3", "api-4", "api-5"));
-            givenApis(
-                List.of(
-                    anApi("api-1"),
-                    anApi("api-2"),
-                    anApi("api-3"),
-                    anApi("api-4"),
-                    anApi("api-5")
-                )
-            );
+            when(apiSearchService.searchIds(any(), any(), any(), any())).thenReturn(List.of("api-1", "api-2", "api-3", "api-4", "api-5"));
+            givenApis(List.of(anApi("api-1"), anApi("api-2"), anApi("api-3"), anApi("api-4"), anApi("api-5")));
 
             var result = service.search("env", "org", "term", Set.of("api-1", "api-2", "api-3", "api-4", "api-5"), null, null);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14013

### Description

Portal API search treated a missing pageable as page size 10, so Lucene-backed search could return at most ten IDs before any higher-level pagination ran.

### Changes

#### ApiPortalSearchQueryServiceImpl

When `pageable` is empty, the service returns all IDs that survive the Lucene and allow-list intersection, with page number forced to 1 and no implicit cap of ten. When `pageable` is present, page size and offsets are taken from it; invalid or empty pages still yield empty content with the correct totals.
