### PR TITLE
chore: reject null pathOperator in V4 HTTP flow selector validation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainService.java
@@ -231,14 +231,17 @@ public class FlowValidationDomainService {
     }
 
     private static void checkForInvalidSelectors(List<Flow> apiFlowList, List<Flow> planFlowList) {
-        Stream.concat(apiFlowList.stream(), planFlowList.stream())
+        var httpSelectors = Stream.concat(apiFlowList.stream(), planFlowList.stream())
             .flatMap(flow -> flow.selectorByType(SelectorType.HTTP).stream())
             .map(HttpSelector.class::cast)
-            .filter(selector -> selector.getPath() == null)
-            .findAny()
-            .ifPresent(selector -> {
-                throw new InvalidDataException("flows[].selectors[].path is required");
-            });
+            .toList();
+
+        if (httpSelectors.stream().anyMatch(selector -> selector.getPath() == null)) {
+            throw new InvalidDataException("flows[].selectors[].path is required");
+        }
+        if (httpSelectors.stream().anyMatch(selector -> selector.getPathOperator() == null)) {
+            throw new InvalidDataException("flows[].selectors[].pathOperator is required");
+        }
     }
 
     private Stream<Flow> filterFlowsWithPathParam(ApiType apiType, Stream<Flow> apiFlows, Stream<Flow> planFlows) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainServiceTest.java
@@ -486,6 +486,15 @@ public class FlowValidationDomainServiceTest {
         }
 
         @Test
+        void should_return_validation_exception_when_http_selector_path_operator_is_null() {
+            var flow = Flow.builder().selectors(List.of(HttpSelector.builder().path("/").pathOperator(null).build())).build();
+
+            var throwable = catchThrowable(() -> service.validatePathParameters(ApiType.PROXY, Stream.of(flow), Stream.empty()));
+
+            assertThat(throwable).isInstanceOf(InvalidDataException.class);
+        }
+
+        @Test
         void should_not_throw_on_overlapping_paths_when_flows_are_disabled() {
             var flow1 = Flow.builder()
                 .enabled(false)


### PR DESCRIPTION
## Jira ticket

APIM-13983

## Why

A V4 HTTP flow selector with a null `pathOperator` would bypass the existing path validation and reach `FlowOperator.valueOf(null)` downstream, producing a `NullPointerException` instead of a clean 400. The `path` field already had a null guard; this extends the same pattern to `pathOperator`.

## What changed

- `FlowValidationDomainService`: added a null check for `pathOperator` inside `checkForInvalidSelectors`, throwing `InvalidDataException("flows[].selectors[].pathOperator is required")` before any further processing.
- `FlowValidationDomainServiceTest`: added a test asserting that a flow with `pathOperator: null` raises `InvalidDataException`.

## How to test

POST or PUT a V4 proxy API with a flow whose HTTP selector omits `pathOperator` (sends `null`). Expect a `400 Bad Request` response instead of a `500`.

Existing tests pass: `mvn -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service test -Dskip.validation -Dtest=FlowValidationDomainServiceTest`