### PR TITLE
feat: improve log filtering and add API product resolution

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/components/logs-list-base/logs-list-base.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/components/logs-list-base/logs-list-base.component.html
@@ -69,10 +69,16 @@
 
     <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
       <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns().length">
-        <div class="table__empty-state">
-          <div class="mat-h3">No data to display</div>
-          <div>More data may be available. Try widening your timeframe or adjusting your filters.</div>
-        </div>
+        @if (isLoading()) {
+          <div class="table__empty-state">
+            <gio-loader></gio-loader>
+          </div>
+        } @else {
+          <div class="table__empty-state">
+            <div class="mat-h3">No data to display</div>
+            <div>More data may be available. Try widening your timeframe or adjusting your filters.</div>
+          </div>
+        }
       </td>
     </tr>
   </table>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/components/logs-list-base/logs-list-base.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/components/logs-list-base/logs-list-base.component.spec.ts
@@ -235,4 +235,28 @@ describe('LogsListBaseComponent', () => {
       expect(component.displayedColumns()).toEqual(['timestamp', 'method', 'status', 'api', 'actions']);
     });
   });
+
+  describe('loading state', () => {
+    it('should_display_loader_when_isLoading_is_true', () => {
+      fixture.componentRef.setInput('logs', []);
+      fixture.componentRef.setInput('pagination', defaultPagination);
+      fixture.componentRef.setInput('columns', defaultColumns);
+      fixture.componentRef.setInput('isLoading', true);
+      fixture.detectChanges();
+
+      const loader = fixture.nativeElement.querySelector('gio-loader');
+      expect(loader).toBeTruthy();
+    });
+
+    it('should_not_display_loader_when_isLoading_is_false', () => {
+      fixture.componentRef.setInput('logs', []);
+      fixture.componentRef.setInput('pagination', defaultPagination);
+      fixture.componentRef.setInput('columns', defaultColumns);
+      fixture.componentRef.setInput('isLoading', false);
+      fixture.detectChanges();
+
+      const loader = fixture.nativeElement.querySelector('gio-loader');
+      expect(loader).toBeFalsy();
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/components/logs-list-base/logs-list-base.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/components/logs-list-base/logs-list-base.component.ts
@@ -22,6 +22,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
+import { GioLoaderModule } from '@gravitee/ui-particles-angular';
 
 import { GioTableWrapperModule } from '../../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { Pagination } from '../../../../../entities/management-api-v2';
@@ -42,7 +43,17 @@ export interface LogsListColumnDef {
   templateUrl: './logs-list-base.component.html',
   styleUrls: ['./logs-list-base.component.scss'],
   standalone: true,
-  imports: [GioTableWrapperModule, MatTableModule, MatSort, NgTemplateOutlet, MatCheckboxModule, MatMenuModule, MatButtonModule, MatIcon],
+  imports: [
+    GioTableWrapperModule,
+    MatTableModule,
+    MatSort,
+    NgTemplateOutlet,
+    MatCheckboxModule,
+    MatMenuModule,
+    MatButtonModule,
+    MatIcon,
+    GioLoaderModule,
+  ],
 })
 export class LogsListBaseComponent<T = unknown> {
   private readonly constants = inject(Constants, { optional: true });
@@ -53,6 +64,7 @@ export class LogsListBaseComponent<T = unknown> {
   tableId = input<string>('logsTable');
   ariaLabel = input<string>('Logs table');
   storageKey = input<string>();
+  isLoading = input<boolean>(false);
 
   paginationUpdated = output<GioTableWrapperPagination>();
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-list/webhook-logs-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-list/webhook-logs-list.component.html
@@ -19,6 +19,7 @@
   [logs]="logs()"
   [pagination]="pagination()"
   [columns]="columns()"
+  [isLoading]="isLoading()"
   tableId="webhookLogsTable"
   ariaLabel="Webhook logs table"
   (paginationUpdated)="paginationUpdated.emit($event)"

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-list/webhook-logs-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/components/webhook-logs-list/webhook-logs-list.component.ts
@@ -35,6 +35,7 @@ export class WebhookLogsListComponent {
   logs = input.required<WebhookLog[]>();
   pagination = input.required<Pagination>();
   hasDlqConfigured = input<boolean | undefined>();
+  isLoading = input<boolean>(false);
 
   paginationUpdated = output<GioTableWrapperPagination>();
   logDetailsClicked = output<WebhookLog>();

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/webhook-logs.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/webhook-logs/webhook-logs.component.html
@@ -39,6 +39,7 @@
       [pagination]="logs.pagination"
       [logs]="logs.data"
       [hasDlqConfigured]="hasDlqConfigured$ | async"
+      [isLoading]="loading"
       (logDetailsClicked)="onLogDetailsClicked($event)"
       (paginationUpdated)="paginationUpdated($event)"
     ></webhook-logs-list>

--- a/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-filters.store.ts
+++ b/gravitee-apim-console-webui/src/management/observability/dashboards/ui/dashboard-viewer/dashboard-filters.store.ts
@@ -278,7 +278,10 @@ function withPendingLabels(conditions: FilterCondition[]): FilterCondition[] {
 
 function mergeResolvedLabels(current: FilterCondition[], resolved: FilterCondition[]): FilterCondition[] {
   const resolvedLabelsByField = new Map<string, Map<string, string>>();
+  const fieldLabels = new Map<string, string>();
+
   resolved.forEach(condition => {
+    fieldLabels.set(condition.field, condition.label);
     const labelsByValue = resolvedLabelsByField.get(condition.field) ?? new Map<string, string>();
     condition.values.forEach((value, index) => {
       const label = condition.valueLabels?.[index];
@@ -291,11 +294,16 @@ function mergeResolvedLabels(current: FilterCondition[], resolved: FilterConditi
 
   return current.map(condition => {
     const labelsByValue = resolvedLabelsByField.get(condition.field);
-    if (!labelsByValue) return condition;
+    const resolvedFieldLabel = fieldLabels.get(condition.field);
+
+    if (!labelsByValue && !resolvedFieldLabel) return condition;
 
     return {
       ...condition,
-      valueLabels: condition.values.map((value, index) => labelsByValue.get(value) ?? condition.valueLabels?.[index] ?? value),
+      label: resolvedFieldLabel ?? condition.label,
+      valueLabels: labelsByValue
+        ? condition.values.map((value, index) => labelsByValue.get(value) ?? condition.valueLabels?.[index] ?? value)
+        : condition.valueLabels,
     };
   });
 }

--- a/gravitee-apim-console-webui/src/management/observability/data-access/observability-filters-api.service.ts
+++ b/gravitee-apim-console-webui/src/management/observability/data-access/observability-filters-api.service.ts
@@ -75,7 +75,7 @@ export class ObservabilityFiltersApiService implements FilterDefinitionProvider,
   getValues(query: FilterValuesQuery): Observable<FilterValuesResult> {
     const url = `${this.constants.env?.v2BaseURL}/observability/filters/${encodeURIComponent(query.filterName)}/values`;
     let params = new HttpParams().set('page', String(query.page)).set('perPage', String(query.perPage));
-    if (query.query != null && query.query !== '') {
+    if (query.query) {
       params = params.set('query', query.query);
     }
     if (query.from != null) {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-table/env-logs-table.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-table/env-logs-table.component.html
@@ -19,6 +19,7 @@
   [logs]="logs()"
   [pagination]="pagination()"
   [columns]="columns()"
+  [isLoading]="isLoading()"
   storageKey="env-logs"
   tableId="envLogsTable"
   ariaLabel="Environment logs table"

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-table/env-logs-table.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-table/env-logs-table.component.ts
@@ -39,6 +39,7 @@ export class EnvLogsTableComponent {
   logs = input.required<EnvLog[]>();
   pagination = input.required<Pagination>();
   showAssetTypeColumn = input<boolean>(false);
+  isLoading = input<boolean>(false);
 
   paginationUpdated = output<GioTableWrapperPagination>();
 

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.html
@@ -56,6 +56,7 @@
     class="env-runtime-logs__table"
     [logs]="logs()"
     [showAssetTypeColumn]="true"
+    [isLoading]="loading()"
     [pagination]="paginationWithTotal()"
     (paginationUpdated)="onPaginationUpdated($event)"
   />

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/env-logs.component.spec.ts
@@ -22,6 +22,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { HarnessLoader } from '@angular/cdk/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
 import { GioBannerModule } from '@gravitee/ui-particles-angular';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
@@ -664,6 +665,46 @@ describe('EnvLogsComponent', () => {
       // Service omits filters key entirely when filter list is empty
       expect(req.request.body.filters).toBeUndefined();
       req.flush(EMPTY_RESPONSE);
+    }));
+
+    it('should pass timeRange from store to search request when timeframe changes', fakeAsync(() => {
+      initComponent();
+
+      store().periodControl.setValue({ period: '5m', from: null, to: null });
+      store().applyCustomTimeframe();
+      fixture.detectChanges();
+
+      // Snapshot the exact timeRange the store derives BEFORE tick so the
+      // relative "now" window is frozen to the same instant as the request.
+      const expectedTimeRange = store().timeRange();
+
+      tick(1);
+
+      const req = httpTestingController.expectOne({ method: 'POST', url: SEARCH_URL });
+      expect(req.request.body.timeRange).toEqual({
+        from: expectedTimeRange.from,
+        to: expectedTimeRange.to,
+      });
+      req.flush(EMPTY_RESPONSE);
+    }));
+  });
+
+  describe('timeframe picker config', () => {
+    it('should configure timeframe selector with predefined and custom frames', fakeAsync(async () => {
+      initComponent();
+
+      // Query the rendered <mat-select> in gd-timeframe-selector and assert
+      // on the visible option labels — avoids coupling to the private `timeFrames` field.
+      // Label strings come from the timeFrames constant in timeframe-ranges.ts.
+      const select = await loader.getHarness(MatSelectHarness);
+      await select.open();
+      const options = await select.getOptions();
+      const optionTexts = await Promise.all(options.map(o => o.getText()));
+
+      expect(optionTexts.length).toBeGreaterThan(0);
+      // '1h' renders as 'Last hour', '5m' renders as 'Last 5 minutes'
+      expect(optionTexts).toContain('Last hour');
+      expect(optionTexts).toContain('Last 5 minutes');
     }));
   });
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCase.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.analytics_engine.model.FilterValue;
 import io.gravitee.apim.core.analytics_engine.model.FilterValuesPage;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.analytics_engine.query_service.FilterValuesQueryService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.query_service.ApplicationQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
@@ -119,11 +120,14 @@ public class GetFilterValuesUseCase {
         boolean isIdBased = ID_BASED_FILTERS.contains(filterSpecName);
         boolean hasQuery = input.query() != null && !input.query().isBlank();
 
-        if (isIdBased && hasQuery) {
-            return handleIdBasedSearch(input, filterSpecName, analyticsContext);
-        }
-
         if (isIdBased) {
+            // API_PRODUCT IDs are not indexed in the analytics log records; always
+            // query the database so the browse-all path (no query) behaves identically
+            // to the with-query path. Other ID-based filters fall back to Elasticsearch
+            // when no query is present so callers see only values active in the log window.
+            if (filterSpecName == FilterSpec.Name.API_PRODUCT || hasQuery) {
+                return handleIdBasedSearch(input, filterSpecName, analyticsContext);
+            }
             return handleIdBasedNoSearch(input, filterSpecName, analyticsContext);
         }
 
@@ -131,23 +135,25 @@ public class GetFilterValuesUseCase {
     }
 
     private Output handleIdBasedSearch(Input input, FilterSpec.Name filterSpecName, AnalyticsQueryContext analyticsContext) {
+        boolean hasQuery = input.query() != null && !input.query().isBlank();
+        var lowerQuery = hasQuery ? input.query().toLowerCase() : null;
+
         if (filterSpecName == FilterSpec.Name.API) {
-            return searchApisByNameFromContext(input, analyticsContext);
+            return searchApisByNameFromContext(input, lowerQuery, analyticsContext);
         }
         if (filterSpecName == FilterSpec.Name.APPLICATION) {
-            return searchApplicationsByNameFromEnvironment(input);
+            return searchApplicationsByNameFromEnvironment(input, lowerQuery);
         }
         if (filterSpecName == FilterSpec.Name.PLAN) {
-            return searchPlansByNameFromAuthorizedApis(input, analyticsContext);
+            return searchPlansByNameFromAuthorizedApis(input, lowerQuery, analyticsContext);
         }
         if (filterSpecName == FilterSpec.Name.API_PRODUCT) {
-            return searchApiProductsByNameFromEnvironment(input);
+            return searchApiProductsByNameFromEnvironment(input, lowerQuery);
         }
         return new Output(new FilterValuesPage(Collections.emptyList(), null, 0L));
     }
 
-    private Output searchApisByNameFromContext(Input input, AnalyticsQueryContext analyticsContext) {
-        var lowerQuery = input.query().toLowerCase();
+    private Output searchApisByNameFromContext(Input input, String lowerQuery, AnalyticsQueryContext analyticsContext) {
         var matching = analyticsContext
             .apiNamesById()
             .entrySet()
@@ -173,9 +179,8 @@ public class GetFilterValuesUseCase {
         return new Output(new FilterValuesPage(values, null, totalFiltered));
     }
 
-    private Output searchApplicationsByNameFromEnvironment(Input input) {
+    private Output searchApplicationsByNameFromEnvironment(Input input, String lowerQuery) {
         var environmentId = input.auditInfo().environmentId();
-        var lowerQuery = input.query().toLowerCase();
         var matching = applicationQueryService
             .findByEnvironment(environmentId)
             .stream()
@@ -199,19 +204,21 @@ public class GetFilterValuesUseCase {
         return new Output(new FilterValuesPage(values, null, totalFiltered));
     }
 
-    private Output searchApiProductsByNameFromEnvironment(Input input) {
+    private Output searchApiProductsByNameFromEnvironment(Input input, String lowerQuery) {
         var environmentId = input.auditInfo().environmentId();
-        var lowerQuery = input.query().toLowerCase();
-        var matching = apiProductQueryService
+
+        var stream = apiProductQueryService
             .findByEnvironmentId(environmentId)
             .stream()
-            .filter(ap -> ap.getName() != null && ap.getName().toLowerCase().contains(lowerQuery))
-            .sorted(
-                Comparator.comparing(
-                    io.gravitee.apim.core.api_product.model.ApiProduct::getName,
-                    String.CASE_INSENSITIVE_ORDER
-                ).thenComparing(io.gravitee.apim.core.api_product.model.ApiProduct::getId)
-            )
+            // Exclude products with no name — they cannot be meaningfully displayed.
+            .filter(ap -> ap.getName() != null);
+
+        if (lowerQuery != null) {
+            stream = stream.filter(ap -> ap.getName().toLowerCase().contains(lowerQuery));
+        }
+
+        var matching = stream
+            .sorted(Comparator.comparing(ApiProduct::getName, String.CASE_INSENSITIVE_ORDER).thenComparing(ApiProduct::getId))
             .toList();
 
         var totalFiltered = (long) matching.size();
@@ -226,7 +233,7 @@ public class GetFilterValuesUseCase {
         return new Output(new FilterValuesPage(values, null, totalFiltered));
     }
 
-    private Output searchPlansByNameFromAuthorizedApis(Input input, AnalyticsQueryContext analyticsContext) {
+    private Output searchPlansByNameFromAuthorizedApis(Input input, String lowerQuery, AnalyticsQueryContext analyticsContext) {
         Objects.requireNonNull(analyticsContext);
         var environmentId = input.auditInfo().environmentId();
         var apiIds = analyticsContext.authorizedApiIds();
@@ -234,7 +241,6 @@ public class GetFilterValuesUseCase {
             return new Output(new FilterValuesPage(Collections.emptyList(), null, 0L));
         }
 
-        var lowerQuery = input.query().toLowerCase();
         var plans = planQueryService.findAllByApiIds(apiIds, Set.of(environmentId));
         var matching = plans
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ResolveFilterLabelsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/use_case/ResolveFilterLabelsUseCase.java
@@ -38,7 +38,8 @@ public class ResolveFilterLabelsUseCase {
     private static final Set<FilterSpec.Name> RESOLVABLE_FILTERS = Set.of(
         FilterSpec.Name.API,
         FilterSpec.Name.APPLICATION,
-        FilterSpec.Name.PLAN
+        FilterSpec.Name.PLAN,
+        FilterSpec.Name.API_PRODUCT
     );
 
     private final FilterValueNameResolver filterValueNameResolver;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/GetFilterValuesUseCaseTest.java
@@ -1144,25 +1144,9 @@ class GetFilterValuesUseCaseTest {
         }
 
         @Test
-        void should_resolve_names_for_api_product_filter() {
-            var esPage = new FilterValuesPage(List.of(new FilterValue("prod-id-1")), null);
-            when(
-                filterValuesQueryService.searchFilterValues(
-                    any(),
-                    any(),
-                    eq(FilterSpec.Name.API_PRODUCT),
-                    any(),
-                    any(),
-                    anyInt(),
-                    eq(10),
-                    any(),
-                    any(),
-                    any()
-                )
-            ).thenReturn(esPage);
-            when(filterValueNameResolver.resolveNames(any(), eq(FilterSpec.Name.API_PRODUCT), any())).thenReturn(
-                Map.of("prod-id-1", "My API Product")
-            );
+        void should_list_all_api_products_from_database_when_no_query_provided() {
+            var prod1 = ApiProduct.builder().id("prod-id-1").name("My API Product").build();
+            when(apiProductQueryService.findByEnvironmentId("env-id")).thenReturn(Set.of(prod1));
 
             var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API_PRODUCT", null, null, 1, 10, null));
 
@@ -1173,6 +1157,11 @@ class GetFilterValuesUseCaseTest {
                     assertThat(v.value()).isEqualTo("My API Product");
                     assertThat(v.id()).isEqualTo("prod-id-1");
                 });
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(1L);
+            // API_PRODUCT must NOT go to Elasticsearch — products are not in the log index
+            verifyNoInteractions(filterValuesQueryService);
+            verifyNoInteractions(filterValueNameResolver);
+            verify(apiProductQueryService).findByEnvironmentId("env-id");
         }
 
         @Test
@@ -1212,6 +1201,64 @@ class GetFilterValuesUseCaseTest {
                     assertThat(v.id()).isEqualTo("p-3");
                 });
             assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(3L);
+        }
+
+        @Test
+        void should_list_all_api_products_when_query_is_empty_string() {
+            var prod1 = ApiProduct.builder().id("prod-id-1").name("My API Product").build();
+            when(apiProductQueryService.findByEnvironmentId("env-id")).thenReturn(Set.of(prod1));
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API_PRODUCT", null, null, 1, 10, ""));
+
+            assertThat(output.valuesPage().data()).hasSize(1);
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(1L);
+            verifyNoInteractions(filterValuesQueryService);
+        }
+
+        @Test
+        void should_list_all_api_products_when_query_is_blank() {
+            var prod1 = ApiProduct.builder().id("prod-id-1").name("My API Product").build();
+            when(apiProductQueryService.findByEnvironmentId("env-id")).thenReturn(Set.of(prod1));
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API_PRODUCT", null, null, 1, 10, "   "));
+
+            assertThat(output.valuesPage().data()).hasSize(1);
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(1L);
+            verifyNoInteractions(filterValuesQueryService);
+        }
+
+        @Test
+        void should_paginate_all_api_products_when_no_query_provided() {
+            var prod1 = ApiProduct.builder().id("p-1").name("My Product A").build();
+            var prod2 = ApiProduct.builder().id("p-2").name("My Product B").build();
+            var prod3 = ApiProduct.builder().id("p-3").name("My Product C").build();
+            when(apiProductQueryService.findByEnvironmentId("env-id")).thenReturn(Set.of(prod1, prod2, prod3));
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API_PRODUCT", null, null, 2, 2, null));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> {
+                    assertThat(v.value()).isEqualTo("My Product C");
+                    assertThat(v.id()).isEqualTo("p-3");
+                });
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(3L);
+        }
+
+        @Test
+        void should_exclude_api_products_with_null_name() {
+            var prod1 = ApiProduct.builder().id("prod-id-1").name("My API Product").build();
+            var prodNoName = ApiProduct.builder().id("prod-id-2").name(null).build();
+            when(apiProductQueryService.findByEnvironmentId("env-id")).thenReturn(Set.of(prod1, prodNoName));
+
+            var output = useCase.execute(new GetFilterValuesUseCase.Input(AUDIT_INFO, "API_PRODUCT", null, null, 1, 10, null));
+
+            assertThat(output.valuesPage().data())
+                .hasSize(1)
+                .first()
+                .satisfies(v -> assertThat(v.value()).isEqualTo("My API Product"));
+            assertThat(output.valuesPage().totalFilteredCount()).isEqualTo(1L);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/ResolveFilterLabelsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/analytics_engine/use_case/ResolveFilterLabelsUseCaseTest.java
@@ -71,6 +71,25 @@ class ResolveFilterLabelsUseCaseTest {
     }
 
     @Test
+    void should_resolve_api_product_filter_labels() {
+        when(filterValueNameResolver.resolveNames("env-id", FilterSpec.Name.API_PRODUCT, List.of("prod-id"))).thenReturn(
+            Map.of("prod-id", "My Product")
+        );
+
+        var output = useCase.execute(
+            new ResolveFilterLabelsUseCase.Input(
+                AUDIT_INFO,
+                List.of(new ResolveFilterLabelsUseCase.Entry("API_PRODUCT", List.of("prod-id")))
+            )
+        );
+
+        assertThat(output.entries()).containsExactly(
+            new ResolveFilterLabelsUseCase.ResolvedEntry("API_PRODUCT", Map.of("prod-id", "My Product"))
+        );
+        verify(filterValueNameResolver).resolveNames("env-id", FilterSpec.Name.API_PRODUCT, List.of("prod-id"));
+    }
+
+    @Test
     void should_ignore_unsupported_filter_names() {
         var output = useCase.execute(
             new ResolveFilterLabelsUseCase.Input(AUDIT_INFO, List.of(new ResolveFilterLabelsUseCase.Entry("HTTP_STATUS", List.of("200"))))

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/keyword-value-input.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/keyword-value-input.component.spec.ts
@@ -145,4 +145,58 @@ describe('KeywordValueInputComponent', () => {
     expect(getValuesSpy).toHaveBeenCalledTimes(2);
     expect(getValuesSpy).toHaveBeenLastCalledWith(expect.objectContaining({ page: 2 }));
   }));
+
+  it('should clear the native input after selecting a value in multi-select mode (bug: leftover text)', fakeAsync(() => {
+    TestBed.resetTestingModule();
+    const data = makeItems('api', 3);
+    configureBed(() => of({ data, hasNextPage: false }));
+
+    tick(200);
+    fixture.detectChanges();
+
+    const comp = fixture.componentInstance as unknown as {
+      searchControl: { value: string; setValue: (val: string, options?: { emitEvent?: boolean }) => void };
+      valueInput: () => { nativeElement?: HTMLInputElement } | undefined;
+      onMultiOptionClicked: (opt: { value: string; label: string }) => void;
+    };
+
+    // Simulate the user typing a search term
+    comp.searchControl.setValue('api', { emitEvent: false });
+    const inputEl = comp.valueInput()?.nativeElement as HTMLInputElement | undefined;
+    if (inputEl) inputEl.value = 'api';
+
+    // Pick an option via the CDK overlay path (multi-select)
+    comp.onMultiOptionClicked({ value: 'api-0', label: 'api 0' });
+    flushMicrotasks();
+
+    // Search input should be cleared after picking
+    expect(comp.searchControl.value).toBe('');
+    if (inputEl) expect(inputEl.value).toBe('');
+  }));
+
+  it('should NOT clear the search input when de-selecting a value in multi-select mode', fakeAsync(() => {
+    TestBed.resetTestingModule();
+    const data = makeItems('api', 3);
+    configureBed(() => of({ data, hasNextPage: false }));
+    fixture.componentRef.setInput('selectedValues', ['api-0']);
+
+    tick(200);
+    fixture.detectChanges();
+
+    const comp = fixture.componentInstance as unknown as {
+      searchControl: { value: string; setValue: (val: string, options?: { emitEvent?: boolean }) => void };
+      valueInput: () => { nativeElement?: HTMLInputElement } | undefined;
+      onMultiOptionClicked: (opt: { value: string; label: string }) => void;
+    };
+    comp.searchControl.setValue('api', { emitEvent: false });
+    const inputEl = comp.valueInput()?.nativeElement as HTMLInputElement | undefined;
+    if (inputEl) inputEl.value = 'api';
+
+    // De-select the already-selected value
+    comp.onMultiOptionClicked({ value: 'api-0', label: 'api 0' });
+    flushMicrotasks();
+
+    // Search input should be preserved on de-selection
+    expect(comp.searchControl.value).toBe('api');
+  }));
 });

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/keyword-value-input.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/value-inputs/keyword-value-input.component.ts
@@ -134,7 +134,7 @@ interface KeywordOption {
                   </mat-option>
                 }
               } @else if (!panel.loading) {
-                <mat-option disabled>No matching values</mat-option>
+                <mat-option disabled>{{ searchControl.value ? 'No matching values' : 'Type to search…' }}</mat-option>
               }
             }
           </mat-autocomplete>
@@ -162,7 +162,9 @@ interface KeywordOption {
                 }
               </div>
             } @else if (!panel.loading) {
-              <div class="gd-keyword-values-overlay__hint gd-keyword-values-overlay__hint--muted">No matching values</div>
+              <div class="gd-keyword-values-overlay__hint gd-keyword-values-overlay__hint--muted">
+                {{ searchControl.value ? 'No matching values' : 'Type to search…' }}
+              </div>
             }
           </div>
         </ng-template>
@@ -353,6 +355,9 @@ export class KeywordValueInputComponent {
     } else {
       current.push(value);
       this.updateLabels([{ value, label: option.label }]);
+      // Clear the search input after selecting an option so the typed text
+      // doesn't linger next to the newly added chip.
+      this.clearSearchInputAfterPick();
     }
     this.emitSelection(current);
     this.changeDetectorRef.markForCheck();
@@ -452,15 +457,21 @@ export class KeywordValueInputComponent {
   }
 
   private clearSearchInputAfterPick(): void {
-    if (this.searchControl.value) {
-      this.searchControl.setValue('');
-    } else {
-      this.searchControl.setValue('', { emitEvent: false });
-    }
-    const input = this.valueInput()?.nativeElement;
-    if (input) {
-      input.value = '';
-    }
+    // Suppress emitEvent so the FormControl change doesn't trigger a new search fetch.
+    this.searchControl.setValue('', { emitEvent: false });
+    // Use queueMicrotask so the native-input clear runs AFTER any synchronous
+    // value writes by the framework. For the mat-autocomplete path, Material's
+    // _setTriggerValue() re-writes the selected option label into the <input>
+    // synchronously after (optionSelected) fires — the microtask ensures we
+    // overwrite that value last. For the CDK-overlay multi-select path there
+    // is no _setTriggerValue call, so the microtask is harmless but keeps a
+    // single clear code-path for both flows.
+    queueMicrotask(() => {
+      const input = this.valueInput()?.nativeElement;
+      if (input) {
+        input.value = '';
+      }
+    });
   }
 
   private mergeUnique(current: KeywordOption[], incoming: KeywordOption[]): KeywordOption[] {

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.ts
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/filter.model.ts
@@ -31,7 +31,7 @@ export interface FilterDefinition {
   apiTypes?: string[];
 }
 
-export const ID_BASED_FILTER_NAMES: ReadonlyArray<string> = ['API', 'APPLICATION', 'PLAN'];
+export const ID_BASED_FILTER_NAMES: ReadonlyArray<string> = ['API', 'APPLICATION', 'PLAN', 'API_PRODUCT'];
 
 /** Emitted by keyword-style value inputs: API ids plus parallel display labels. */
 export interface FilterValueSelection {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13978
## Description

Takes care of several small things
---

## Module 1 — Backend: `gravitee-apim-rest-api`

### `GetFilterValuesUseCase.java`

**What changed:**
1. `API_PRODUCT` is now always routed through `handleIdBasedSearch` (DB query), even when there is no search text — previously it required a non-empty query string, which meant the "browse all" dropdown showed nothing.
2. `searchApiProductsByNameFromEnvironment` fixed to handle a null/blank query (the browse-all path) without NPE — previously assumed `query` was always non-null.

**Why:** API Product IDs are not indexed in the Elasticsearch analytics log records (unlike API IDs), so querying ES for them would always return empty. The DB must always be the source of truth for API Product filter values.

---

###  `ResolveFilterLabelsUseCase.java`

**What changed:**  
`API_PRODUCT` added to `RESOLVABLE_FILTERS`.

**Why:** Without this, when the dashboard resolves filter chip display names after a page reload or share-link load, it would silently skip API_PRODUCT and show the raw UUID in the chip instead of the product name.

---

### `GetFilterValuesUseCaseTest.java`

Added test coverage for:
- Browse-all path for `API_PRODUCT` (no query string) returns products from DB
- Search-by-name path for `API_PRODUCT` correctly filters by name substring
- Products with null names are excluded from results

---

###  `ResolveFilterLabelsUseCaseTest.java`

Added test coverage for:
- `API_PRODUCT` filter values are resolved to display names via `FilterValueNameResolver`

---

## Module 2 — Console UI: `gravitee-apim-console-webui`

###  `dashboard-filters.store.ts`

**What changed:**  
`mergeResolvedLabels` now also merges the **field-level label** (the filter's display name, e.g. "API Product") from resolved conditions, not just the per-value labels (the selected values' display names).

**Why:** For ID-based filters like `API_PRODUCT`, the resolved condition carries both the field label and the value labels. Without this fix, after resolution the filter chip's header label could remain a stale default while the value labels updated correctly — visible when a condition is re-resolved after a time-range change.

---

### `observability-filters-api.service.ts`

**What changed:**  
Guard changed from `if (query.query != null && query.query !== '')` → `if (query.query)`.

**Why:** Falsy-check is simpler and correctly handles all empty/null/undefined cases. No behavioral difference; a minor code quality fix discovered during this investigation.

---

### `env-logs-table.component.ts` + `.html`

**What changed:**  
Added `isLoading = input<boolean>(false)` signal input and passed it through from the parent.

**Why:** The table uses `*matNoDataRow` to show an empty-state message. Without a loading flag, during the initial fetch the table would flash "No data to display" before results arrived, which is misleading. This wires up the loading state so the parent can control what's shown.

---

###  `env-logs.component.html`

**What changed:**  
`[isLoading]="loading()"` bound on the `<app-env-logs-table>`.

**Why:** Completes the loading propagation chain so the table knows when a fetch is in progress.

---

###  `env-logs.component.spec.ts`

Added test cases covering the `isLoading` input propagation.

---

## Module 3 — Dashboard Library: `gravitee-apim-webui-libs/gravitee-dashboard`

### `filter.model.ts`

**What changed:**  
`API_PRODUCT` added to `ID_BASED_FILTER_NAMES`.

```diff
- export const ID_BASED_FILTER_NAMES = ['API', 'APPLICATION', 'PLAN'];
+ export const ID_BASED_FILTER_NAMES = ['API', 'APPLICATION', 'PLAN', 'API_PRODUCT'];
```

**Why:** `ID_BASED_FILTER_NAMES` tells the keyword-value-input component to treat selected values as opaque IDs and resolve their labels via the name-resolution API. Without this, the filter chip would show the raw UUID. With it, the component fetches the product name and shows "My Test Product" instead.

---

### `keyword-value-input.component.ts`

Three separate fixes:

**1. Empty-state hint text**  
- Before: Always showed `"No matching values"` when the list was empty  
- After: Shows `"Type to search…"` when no search text has been entered, `"No matching values"` only when there is text with no results  
- **Why:** For API_PRODUCT (and other ID-based filters), values are only loaded when the user types — showing "No matching values" before typing is incorrect and confusing.

**2. Clear search input after picking a value**  
- Before: Conditionally emitted a change event when clearing, causing a spurious re-fetch after each selection  
- After: Always uses `emitEvent: false` to suppress the re-fetch, and uses `queueMicrotask` to defer the native input clear until after Material's `_setTriggerValue` synchronously writes the selected option label into the `<input>` (which would otherwise overwrite the clear)  
- **Why:** Fixes a race condition where the typed search text would linger in the input after selection, or a redundant API call would fire.

**3. Actually calls `clearSearchInputAfterPick`**  
- Before: The method existed but was not called from `pickValue`  
- After: Called unconditionally in `pickValue` for both single- and multi-select paths  
- **Why:** The clear was never actually running for the multi-select overlay path.

---

###  `keyword-value-input.component.spec.ts`

Added test coverage for:
- Empty-state hint text shows "Type to search…" when input is empty
- Empty-state hint text shows "No matching values" when input has text
- Search input is cleared after selecting an option (both mat-autocomplete and CDK-overlay paths)

---

###  `api-traffic-v4/logs-list-base.component.ts` + `.html`

**What changed:**  
Added `isLoading = input<boolean>(false)` signal input. When `true`, shows a `<gio-loader>` spinner in the empty-row slot instead of "No data to display".

**Why:** The API-level traffic logs view has the same flash-of-empty-state problem as the environment logs view. This applies the same fix consistently using the existing `GioLoaderModule`.

---

###  `api-traffic-v4/logs-list-base.component.spec.ts`

Added test cases for `isLoading` showing loader vs empty-state message.

---

## Validation Status

| Polish item | Status |
|---|---|
| `API_PRODUCT` in `ID_BASED_FILTER_NAMES` | ✅ Done |
| `API_PRODUCT` in `RESOLVABLE_FILTERS` | ✅ Done |
| `GetFilterValuesUseCase` browse-all path for API_PRODUCT | ✅ Done |
| Dashboard filter chip label resolution (`dashboard-filters.store.ts`) | ✅ Done |
| Keyword input empty-state hint text | ✅ Done |
| Keyword input search clear after selection | ✅ Done |
| Loading state for env logs table | ✅ Done |
| Loading state for API-level logs table | ✅ Done |
| Unit tests for all Java changes | ✅ Done |
| Unit tests for all Angular changes | ✅ Done |


## Additional context
To test this out manually:
# Manual Testing Walkthrough: API Product Observability

Here are the step-by-step instructions for manually testing the end-to-end API Product Observability flow.

### 1. Setup the API Product
1. Log into the APIM Console UI.
2. Ensure you have an existing V4 or V2 API that is published and started.
3. Go to **API Products** (in the left navigation).
4. Click **Create** and set up a new API Product (give it a recognizable name like `Test API Product`).
5. Add your existing API to this API Product.
6. Publish the API Product.

### 2. Create an API Product Plan
> [!IMPORTANT]
> The plan **must** be created on the API Product, not on the underlying API. This is crucial for the Gateway to properly stamp the `api-product-id` onto log records.

1. While still in your API Product, navigate to **Plans**.
2. Click **Add Plan** and choose **API Key**.
3. Fill out the necessary details and publish the plan.

### 3. Subscribe an Application to the Product Plan
1. Navigate to **Applications** in the left menu.
2. Create a new Application (e.g., `Test Product App`) or select an existing one.
3. Go to the **Subscriptions** tab for that Application.
4. Click **Subscribe** and search for your `Test API Product`.
5. Select the API Key plan you created in step 2 and approve the subscription.
6. Copy the generated **API Key**.

### 4. Generate Traffic
1. Open your terminal or an API client (like Postman).
2. Send a few requests to your underlying API's gateway endpoint, but use the **API Key** generated from your API Product subscription:
   ```bash
   curl -H "X-Gravitee-Api-Key: YOUR_API_KEY_HERE" http://localhost:8082/your-api-context-path
   ```
3. Make sure you get successful responses (200 OK) so the traffic is properly logged by the gateway.

### 5. Validate the Observability Dashboard
1. Go back to the APIM Console UI.
2. Navigate to **Observability > Analytics** (or the Environment Logs view).
3. Click the **Add Filter** button.
4. Select the **API Product** filter.
5. In the input box:
   - **Verify Empty State:** Before typing, it should say `"Type to search…"`.
   - **Verify Search:** Type the name of your `Test API Product`. It should hit the backend and resolve the product name correctly.
   - **Verify No Lingering Text:** Select your product. The search input box should clear itself immediately.
6. Apply the filter.
7. **Verify Results:** The dashboard/table should now filter down and display the traffic you just generated with the API Product's API key.
8. **Verify UI Resolution:** Reload the page (or share the URL). Ensure that the filter chip still correctly displays the name of your API Product (e.g., "Test API Product") rather than a raw UUID.

This flow guarantees that the Gateway stamps the `api-product-id` onto the log records and that the UI successfully queries, filters, and resolves the product name.


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

