### PR TITLE
fix: API Product group issues

### DIFF
--- a/gravitee-apim-console-webui/src/entities/group/group.ts
+++ b/gravitee-apim-console-webui/src/entities/group/group.ts
@@ -33,6 +33,7 @@ export interface Group {
   email_invitation?: boolean;
   disable_membership_notifications?: boolean;
   apiPrimaryOwner?: boolean;
+  apiProductPrimaryOwner?: string;
   environmentName?: string;
   environmentId?: string;
 }

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.html
@@ -17,7 +17,7 @@
 -->
 <h2 mat-dialog-title>Remove Member</h2>
 <mat-dialog-content>
-  @if (member.roles['API'] === 'PRIMARY_OWNER') {
+  @if (isPrimaryOwner()) {
     <form [formGroup]="deleteMemberForm" class="delete-member__form">
       <mat-form-field appearance="outline">
         <mat-label>Search Members</mat-label>

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, computed, Inject, OnInit, signal } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { CommonModule } from '@angular/common';
@@ -29,10 +29,15 @@ import { MatListModule } from '@angular/material/list';
 import { MatChip, MatChipRemove, MatChipSet } from '@angular/material/chips';
 import { GioBannerModule } from '@gravitee/ui-particles-angular';
 
-import { GroupMembership } from '../../../../../entities/group/groupMember';
+import { GroupMembership, GroupMembershipMemberRoleEntity } from '../../../../../entities/group/groupMember';
 import { Member, RoleName } from '../membershipState';
 import { UsersService } from '../../../../../services-ngx/users.service';
 import { DeleteMemberDialogData } from '../group.component';
+
+const SCOPE_LABELS: Readonly<Record<'API' | 'API_PRODUCT', string>> = {
+  API: 'API',
+  API_PRODUCT: 'API Product',
+};
 
 @Component({
   selector: 'delete-member-dialog',
@@ -64,6 +69,8 @@ export class DeleteMemberDialogComponent implements OnInit {
   }>;
   ownershipTransferMessage: string = null;
   disableSubmit = false;
+  readonly primaryOwnerScopes = signal<('API' | 'API_PRODUCT')[]>([]);
+  readonly isPrimaryOwner = computed(() => this.primaryOwnerScopes().length > 0);
 
   private members: Member[] = [];
   private primaryOwnerMembership: GroupMembership = null;
@@ -83,15 +90,17 @@ export class DeleteMemberDialogComponent implements OnInit {
   private initializeDataFromInput() {
     this.member = this.data.member;
     this.members = this.data.members;
+    this.primaryOwnerScopes.set(
+      (['API', 'API_PRODUCT'] as ('API' | 'API_PRODUCT')[]).filter(scope => this.member.roles[scope] === RoleName.PRIMARY_OWNER),
+    );
   }
 
   private initializeForm() {
     this.deleteMemberForm = new FormGroup({
       searchTerm: new FormControl<string>({ value: '', disabled: true }),
     });
-    const isPrimaryOwner = this.member.roles['API'] === RoleName.PRIMARY_OWNER;
 
-    if (isPrimaryOwner) {
+    if (this.isPrimaryOwner()) {
       this.deleteMemberForm.controls.searchTerm.enable();
       this.deleteMemberForm.controls.searchTerm.addValidators(Validators.required);
       this.disableSubmit = true;
@@ -125,7 +134,10 @@ export class DeleteMemberDialogComponent implements OnInit {
     this.deleteMemberForm.controls.searchTerm.setValue('');
     this.deleteMemberForm.controls.searchTerm.disable();
     this.deleteMemberForm.controls.searchTerm.removeValidators(Validators.required);
-    this.ownershipTransferMessage = `${this.member.displayName} is the API primary owner. Primary ownership of the group will be transferred from ${this.member.displayName} to ${this.newPrimaryOwner.displayName}.`;
+    const scopesLabel = this.primaryOwnerScopes()
+      .map(scope => SCOPE_LABELS[scope])
+      .join(' and ');
+    this.ownershipTransferMessage = `${this.member.displayName} is the ${scopesLabel} primary owner. Primary ownership of the group will be transferred from ${this.member.displayName} to ${this.newPrimaryOwner.displayName}.`;
     this.mapGroupMembership();
     this.disableSubmit = false;
   }
@@ -144,23 +156,24 @@ export class DeleteMemberDialogComponent implements OnInit {
     this.usersService.search(this.newPrimaryOwner.displayName).subscribe({
       next: response => {
         const reference = response.find(user => user.id === this.newPrimaryOwner.id).reference;
+        const roles: GroupMembershipMemberRoleEntity[] = [];
+        for (const [scope, name] of Object.entries(this.newPrimaryOwner.roles)) {
+          if (name) {
+            roles.push({ name: name as string, scope: scope as GroupMembershipMemberRoleEntity['scope'] });
+          }
+        }
+        for (const scope of this.primaryOwnerScopes()) {
+          const existing = roles.find(role => role.scope === scope);
+          if (existing) {
+            existing.name = RoleName.PRIMARY_OWNER;
+          } else {
+            roles.push({ name: RoleName.PRIMARY_OWNER, scope });
+          }
+        }
         this.primaryOwnerMembership = {
           id: this.newPrimaryOwner.id,
           reference: reference,
-          roles: [
-            {
-              name: RoleName.PRIMARY_OWNER,
-              scope: 'API',
-            },
-            {
-              name: this.newPrimaryOwner.roles['APPLICATION'],
-              scope: 'APPLICATION',
-            },
-            {
-              name: this.newPrimaryOwner.roles['INTEGRATION'],
-              scope: 'INTEGRATION',
-            },
-          ],
+          roles,
         };
       },
     });

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/delete-member-dialog/delete-member-dialog.component.ts
@@ -159,7 +159,7 @@ export class DeleteMemberDialogComponent implements OnInit {
         const roles: GroupMembershipMemberRoleEntity[] = [];
         for (const [scope, name] of Object.entries(this.newPrimaryOwner.roles)) {
           if (name) {
-            roles.push({ name: name as string, scope: scope as GroupMembershipMemberRoleEntity['scope'] });
+            roles.push({ name, scope: scope as GroupMembershipMemberRoleEntity['scope'] });
           }
         }
         for (const scope of this.primaryOwnerScopes()) {

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
@@ -415,6 +415,105 @@ describe('GroupComponent', () => {
       expectDeleteMember('1');
     });
 
+    it('should disable remove member when sole member is API primary owner', async () => {
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: {
+            API: 'PRIMARY_OWNER',
+            API_PRODUCT: 'OWNER',
+            APPLICATION: 'OWNER',
+            INTEGRATION: 'OWNER',
+            CLUSTER: 'USER',
+          },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      fixture.detectChanges();
+
+      expect(component.deleteDisabled).toEqual(true);
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const deleteButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Remove member from group"]' }));
+      expect(await deleteButton.isDisabled()).toEqual(true);
+    });
+
+    it('should disable remove member when sole member is API Product primary owner only', async () => {
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: {
+            API: 'OWNER',
+            API_PRODUCT: 'PRIMARY_OWNER',
+            APPLICATION: 'OWNER',
+            INTEGRATION: 'OWNER',
+            CLUSTER: 'USER',
+          },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      fixture.detectChanges();
+
+      expect(component.deleteDisabled).toEqual(true);
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const deleteButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Remove member from group"]' }));
+      expect(await deleteButton.isDisabled()).toEqual(true);
+    });
+
+    it('should not disable remove member when group has more than one member', async () => {
+      expectGetDefaultRoles();
+      expectGetGroupMembers([
+        {
+          id: '1',
+          displayName: 'Test Member 1',
+          roles: {
+            API: 'OWNER',
+            API_PRODUCT: 'PRIMARY_OWNER',
+            APPLICATION: 'OWNER',
+            INTEGRATION: 'OWNER',
+            CLUSTER: 'USER',
+          },
+        },
+        {
+          id: '2',
+          displayName: 'Test Member 2',
+          roles: {
+            API: 'OWNER',
+            API_PRODUCT: 'OWNER',
+            APPLICATION: 'OWNER',
+            INTEGRATION: 'OWNER',
+            CLUSTER: 'USER',
+          },
+        },
+      ]);
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+      fixture.detectChanges();
+
+      expect(component.deleteDisabled).toEqual(false);
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const deleteButtonRow0 = await (
+        await rows[0].getCells({ columnName: 'actions' }).then(c => c[0])
+      ).getHarness(MatButtonHarness.with({ selector: '[mattooltip="Remove member from group"]' }));
+      expect(await deleteButtonRow0.isDisabled()).toEqual(false);
+    });
+
     it('should update member', async () => {
       expectGetDefaultRoles();
       expectGetGroupMembers();

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.spec.ts
@@ -1141,6 +1141,183 @@ describe('GroupComponent', () => {
     });
   });
 
+  describe('Transfer of Primary Ownership via Delete Member dialog', () => {
+    const TWO_MEMBER_ROSTER = (poScope: 'API' | 'API_PRODUCT' | 'BOTH'): Member[] => {
+      const baseRoles = { API: 'OWNER', API_PRODUCT: 'OWNER', APPLICATION: 'OWNER', INTEGRATION: 'OWNER', CLUSTER: 'USER' };
+      const targetRoles =
+        poScope === 'API'
+          ? { ...baseRoles, API: 'PRIMARY_OWNER' }
+          : poScope === 'API_PRODUCT'
+            ? { ...baseRoles, API_PRODUCT: 'PRIMARY_OWNER' }
+            : { ...baseRoles, API: 'PRIMARY_OWNER', API_PRODUCT: 'PRIMARY_OWNER' };
+      return [
+        { id: '1', displayName: 'Test Member 1', roles: targetRoles },
+        { id: '2', displayName: 'Test Member 2', roles: { ...baseRoles } },
+      ];
+    };
+
+    const openDeleteDialogForFirstRow = async () => {
+      const tableHarness = await harnessLoader.getHarness(MatTableHarness.with({ selector: '#membersDataTable' }));
+      const rows = await tableHarness.getRows();
+      const cell = await rows[0].getCells({ columnName: 'actions' }).then(cells => cells[0]);
+      const deleteButton = await cell.getHarness(MatButtonHarness.with({ selector: '[mattooltip="Remove member from group"]' }));
+      await deleteButton.click();
+      return rootLoader.getHarness(MatDialogHarness);
+    };
+
+    const pickSuccessor = async (displayName: string) => {
+      const autoCompleteHarness = await rootLoader.getHarness(MatAutocompleteHarness);
+      await autoCompleteHarness.enterText(displayName);
+      const successors = await autoCompleteHarness.getOptions();
+      await successors[0].click();
+    };
+
+    it('should expose the search field and transfer API primary ownership when removing the API primary owner', async () => {
+      await init(GROUP.id);
+      expectGetGroup();
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers(TWO_MEMBER_ROSTER('API'));
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+
+      const dialogHarness = await openDeleteDialogForFirstRow();
+      const autoCompleteHarness = await rootLoader.getHarness(MatAutocompleteHarness);
+      expect(autoCompleteHarness).toBeTruthy();
+
+      await pickSuccessor('Test Member 2');
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Delete' }));
+      await confirmButtonHarness.click();
+
+      expectDeleteMember('1');
+
+      const transferReq = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      expect(transferReq.request.body).toEqual([
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'PRIMARY_OWNER', scope: 'API' },
+            { name: 'OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      transferReq.flush({});
+    });
+
+    it('should expose the search field and transfer API Product primary ownership when removing the API Product primary owner', async () => {
+      await init(GROUP.id);
+      expectGetGroup();
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers(TWO_MEMBER_ROSTER('API_PRODUCT'));
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+
+      const dialogHarness = await openDeleteDialogForFirstRow();
+      const autoCompleteHarness = await rootLoader.getHarness(MatAutocompleteHarness);
+      expect(autoCompleteHarness).toBeTruthy();
+
+      await pickSuccessor('Test Member 2');
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Delete' }));
+      await confirmButtonHarness.click();
+
+      expectDeleteMember('1');
+
+      const transferReq = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      expect(transferReq.request.body).toEqual([
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'OWNER', scope: 'API' },
+            { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      transferReq.flush({});
+    });
+
+    it('should transfer both API and API Product primary ownership in one update when removing a dual primary owner', async () => {
+      await init(GROUP.id);
+      expectGetGroup();
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers(TWO_MEMBER_ROSTER('BOTH'));
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+
+      const dialogHarness = await openDeleteDialogForFirstRow();
+      await pickSuccessor('Test Member 2');
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Delete' }));
+      await confirmButtonHarness.click();
+
+      expectDeleteMember('1');
+
+      const transferReq = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+      expect(transferReq.request.body).toEqual([
+        {
+          id: '2',
+          reference: 'testmember2',
+          roles: [
+            { name: 'PRIMARY_OWNER', scope: 'API' },
+            { name: 'PRIMARY_OWNER', scope: 'API_PRODUCT' },
+            { name: 'OWNER', scope: 'APPLICATION' },
+            { name: 'OWNER', scope: 'INTEGRATION' },
+            { name: 'USER', scope: 'CLUSTER' },
+          ],
+        },
+      ]);
+      transferReq.flush({});
+    });
+
+    it('should not show the search field nor issue a transfer when the member is not a primary owner', async () => {
+      await init(GROUP.id);
+      expectGetGroup();
+      fixture.detectChanges();
+      expectGetDefaultRoles();
+      expectGetGroupMembers();
+      expectGetCurrentUser();
+      expectGetGroupAPIs();
+      expectGetGroupAPIProducts();
+      expectGetGroupApplications();
+
+      const dialogHarness = await openDeleteDialogForFirstRow();
+      const autoCompletes = await dialogHarness.getAllHarnesses(MatAutocompleteHarness);
+      expect(autoCompletes).toEqual([]);
+
+      const confirmButtonHarness = await dialogHarness.getHarness(MatButtonHarness.with({ text: 'Delete' }));
+      await confirmButtonHarness.click();
+
+      expectDeleteMember('1');
+      httpTestingController.expectNone({
+        url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members`,
+        method: 'POST',
+      });
+    });
+  });
+
   describe('Invitations', () => {
     beforeEach(async () => {
       await init(GROUP.id);
@@ -1914,10 +2091,11 @@ describe('GroupComponent', () => {
   }
 
   function expectDeleteMember(memberId: string) {
-    httpTestingController.expectOne({
+    const req = httpTestingController.expectOne({
       url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups/${GROUP.id}/members/${memberId}`,
       method: 'DELETE',
     });
+    req.flush({});
   }
 
   function expectPostInvitation() {

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
@@ -574,7 +574,7 @@ export class GroupComponent implements OnInit {
   }
 
   private handleOwnershipTransfer(member: Member, dialogResult: DeleteMemberDialogResult): Observable<void> {
-    if (member.roles['API'] === RoleName.PRIMARY_OWNER) {
+    if (member.roles['API'] === RoleName.PRIMARY_OWNER || member.roles['API_PRODUCT'] === RoleName.PRIMARY_OWNER) {
       return this.groupService.addOrUpdateMemberships(this.groupId, [dialogResult.primaryOwnerMembership]).pipe(
         tap(() => {
           this.snackBarService.success('Successfully transferred the ownership.');

--- a/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/group/group.component.ts
@@ -875,7 +875,9 @@ export class GroupComponent implements OnInit {
 
   private disableDeleteMember(): void {
     const groupMembers = this.groupMembers.value;
-    this.deleteDisabled = groupMembers.length === 1 && groupMembers[0].roles['API'] === RoleName.PRIMARY_OWNER;
+    this.deleteDisabled =
+      groupMembers.length === 1 &&
+      (groupMembers[0].roles['API'] === RoleName.PRIMARY_OWNER || groupMembers[0].roles['API_PRODUCT'] === RoleName.PRIMARY_OWNER);
   }
 
   private disableForm() {

--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.html
@@ -54,8 +54,8 @@
           <td mat-cell *matCellDef="let row">
             <div>
               {{ row.name }}
-              @if (row.apiPrimaryOwner) {
-                <span class="gio-badge-primary" tooltip="Group has a member with API role primary owner">Primary Owner</span>
+              @if (row.apiPrimaryOwner || row.apiProductPrimaryOwner) {
+                <span class="gio-badge-primary" tooltip="Group has a member with API or API Product role primary owner">Primary Owner</span>
               }
               @if (row.shouldAddToNewAPIs) {
                 <span class="gio-badge-warning" tooltip="Group will be automatically added to new applications"

--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.spec.ts
@@ -159,6 +159,21 @@ describe('GroupsComponent', () => {
       expect(await deleteButton.isDisabled()).toEqual(true);
     });
 
+    it('should not delete when API Product role is primary owner', async () => {
+      expectGetGroupsList(
+        fakePagedResult([{ id: '1', name: 'Group 1', manageable: true, apiProductPrimaryOwner: 'user-1', apiPrimaryOwner: false }], {
+          current: 1,
+          per_page: 10,
+          size: 2,
+          total_elements: 2,
+          total_pages: 1,
+        }),
+      );
+      const deleteButton = await getButtonByRowIndexAndTooltip(0, 'Delete group');
+
+      expect(await deleteButton.isDisabled()).toEqual(true);
+    });
+
     it('should delete group', async () => {
       expectGetGroupsList(
         fakePagedResult([{ id: '1', name: 'Group 1', manageable: true, roles: { API: 'OWNER' } }], {

--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.ts
@@ -271,7 +271,9 @@ export class GroupsComponent implements OnInit {
     if (!this.permissionService.hasAnyMatching(['environment-group-d'])) {
       this.protectedGroups = new Set(this.groups.value.map(group => group.id));
     } else {
-      this.protectedGroups = new Set(this.groups.value.filter(group => group.apiPrimaryOwner).map(group => group.id));
+      this.protectedGroups = new Set(
+        this.groups.value.filter(group => group.apiPrimaryOwner || !!group.apiProductPrimaryOwner).map(group => group.id),
+      );
     }
   }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/RoleEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/RoleEntity.java
@@ -57,6 +57,10 @@ public class RoleEntity {
         return scope == RoleScope.API && SystemRole.PRIMARY_OWNER.name().equals(name);
     }
 
+    public boolean isApiProductPrimaryOwner() {
+        return scope == RoleScope.API_PRODUCT && SystemRole.PRIMARY_OWNER.name().equals(name);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductAccessibleIdsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductAccessibleIdsDomainService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Resolves the API Products a user can access via direct memberships and via group memberships.
+ * <p>
+ * Group-based API Product access is stored on the API Product itself (the {@code groups} field) when
+ * a group is assigned, not as a {@code GROUP -> API_PRODUCT} membership row. To match the behaviour
+ * of the API authorization path, both sources must be unioned.
+ */
+@DomainService
+@RequiredArgsConstructor
+public class ApiProductAccessibleIdsDomainService {
+
+    private final ApiProductQueryService apiProductQueryService;
+    private final MembershipQueryService membershipQueryService;
+
+    /**
+     * Returns the union of direct API Product memberships and API Products inherited via the user's
+     * group memberships, scoped to the given environment.
+     *
+     * @param environmentId the environment to scope group-derived lookups to
+     * @param userId the user whose memberships are evaluated
+     * @return the set of API Product ids the user can see
+     */
+    public Set<String> findAccessibleApiProductIds(String environmentId, String userId) {
+        Set<String> directIds = membershipQueryService
+            .findByMemberIdAndMemberTypeAndReferenceType(userId, Membership.Type.USER, Membership.ReferenceType.API_PRODUCT)
+            .stream()
+            .map(Membership::getReferenceId)
+            .collect(Collectors.toSet());
+
+        Set<String> userGroupIds = membershipQueryService
+            .findGroupsThatUserBelongsTo(userId)
+            .stream()
+            .map(Membership::getReferenceId)
+            .collect(Collectors.toSet());
+
+        Set<String> groupApiProductIds = userGroupIds.isEmpty()
+            ? Set.of()
+            : apiProductQueryService.findIdsByEnvironmentIdAndGroups(environmentId, userGroupIds);
+
+        Set<String> allowedIds = new HashSet<>(directIds);
+        allowedIds.addAll(groupApiProductIds);
+        return allowedIds;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductQueryService.java
@@ -30,4 +30,5 @@ public interface ApiProductQueryService {
     Set<ApiProduct> findByApiId(String apiId);
     Map<String, Set<ApiProduct>> findProductsByApiIds(Set<String> apiIds);
     Page<ApiProduct> searchByIds(Set<String> ids, String environmentId, Pageable pageable);
+    Set<String> findIdsByEnvironmentIdAndGroups(String environmentId, Set<String> groupIds);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
@@ -18,15 +18,14 @@ package io.gravitee.apim.core.api_product.use_case;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.event.model.Event;
 import io.gravitee.apim.core.event.query_service.EventLatestQueryService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
-import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
-import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.EventType;
@@ -48,7 +47,7 @@ public class GetApiProductsUseCase {
     private final EventLatestQueryService eventLatestQueryService;
     private final PlanQueryService planQueryService;
     private final ObjectMapper objectMapper;
-    private final MembershipQueryService membershipQueryService;
+    private final ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService;
 
     public Output execute(Input input) {
         if (input.apiProductId() != null) {
@@ -76,11 +75,7 @@ public class GetApiProductsUseCase {
         if (input.isAdmin()) {
             return apiProductQueryService.findByEnvironmentId(input.environmentId());
         }
-        Set<String> allowedIds = membershipQueryService
-            .findByMemberIdAndMemberTypeAndReferenceType(input.userId(), Membership.Type.USER, Membership.ReferenceType.API_PRODUCT)
-            .stream()
-            .map(Membership::getReferenceId)
-            .collect(Collectors.toSet());
+        Set<String> allowedIds = apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(input.environmentId(), input.userId());
         if (allowedIds.isEmpty()) {
             return Set.of();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCase.java
@@ -16,10 +16,9 @@
 package io.gravitee.apim.core.api_product.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
-import io.gravitee.apim.core.membership.model.Membership;
-import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
@@ -34,7 +33,7 @@ import lombok.RequiredArgsConstructor;
 public class SearchApiProductsUseCase {
 
     private final ApiProductSearchQueryService apiProductSearchQueryService;
-    private final MembershipQueryService membershipQueryService;
+    private final ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService;
 
     public Output execute(Input input) {
         if (input.isAdmin()) {
@@ -48,11 +47,7 @@ public class SearchApiProductsUseCase {
     }
 
     private Optional<Set<String>> findAccessibleApiProductIds(Input input) {
-        Set<String> allowedIds = membershipQueryService
-            .findByMemberIdAndMemberTypeAndReferenceType(input.userId(), Membership.Type.USER, Membership.ReferenceType.API_PRODUCT)
-            .stream()
-            .map(Membership::getReferenceId)
-            .collect(Collectors.toSet());
+        Set<String> allowedIds = apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(input.environmentId(), input.userId());
         if (allowedIds.isEmpty()) {
             return Optional.empty();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.search.ApiProductCriteria;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -144,6 +145,26 @@ public class ApiProductQueryServiceImpl extends AbstractService implements ApiPr
             return new Page<>(content, pageable.getPageNumber(), content.size(), page.getTotalElements());
         } catch (TechnicalException e) {
             throw new TechnicalManagementException("Failed to search API Products by ids", e);
+        }
+    }
+
+    @Override
+    public Set<String> findIdsByEnvironmentIdAndGroups(String environmentId, Set<String> groupIds) {
+        if (groupIds == null || groupIds.isEmpty()) {
+            return Set.of();
+        }
+        try {
+            log.debug("Finding API Product ids in environment {} attached to groups {}", environmentId, groupIds);
+            ApiProductCriteria criteria = new ApiProductCriteria.Builder().environmentId(environmentId).groups(groupIds).build();
+            Page<String> page = apiProductRepository.searchIds(
+                List.of(criteria),
+                new PageableBuilder().pageNumber(0).pageSize(Integer.MAX_VALUE).build(),
+                null
+            );
+            List<String> content = page.getContent();
+            return content == null ? Set.of() : new HashSet<>(content);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Failed to find API Products by groups", e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ApiProductOwnershipTransferException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ApiProductOwnershipTransferException.java
@@ -20,36 +20,31 @@ import static java.util.Collections.singletonMap;
 import io.gravitee.common.http.HttpStatusCode;
 import java.util.Map;
 
-public class PrimaryOwnerNotFoundException extends AbstractManagementException {
+public class ApiProductOwnershipTransferException extends AbstractManagementException {
 
-    private final String api;
+    private final String apiProductId;
 
-    public PrimaryOwnerNotFoundException(String api) {
-        this.api = api;
-    }
-
-    public PrimaryOwnerNotFoundException(String api, Throwable cause) {
-        super(cause);
-        this.api = api;
+    public ApiProductOwnershipTransferException(String apiProductId) {
+        this.apiProductId = apiProductId;
     }
 
     @Override
     public int getHttpStatusCode() {
-        return HttpStatusCode.INTERNAL_SERVER_ERROR_500;
+        return HttpStatusCode.BAD_REQUEST_400;
     }
 
     @Override
     public String getMessage() {
-        return "Primary owner not found for API [" + api + "]";
+        return "Api Product [" + apiProductId + "] transfer not allowed.";
     }
 
     @Override
     public String getTechnicalCode() {
-        return "primaryOwner.notFound";
+        return "apiProduct.transferNotAllowed";
     }
 
     @Override
     public Map<String, String> getParameters() {
-        return singletonMap("api", api);
+        return singletonMap("apiProduct", apiProductId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -89,6 +89,7 @@ import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.GroupNameAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
 import io.gravitee.rest.api.service.exceptions.GroupsNotFoundException;
+import io.gravitee.rest.api.service.exceptions.StillApiProductPrimaryOwnerException;
 import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.ApiHook;
@@ -708,22 +709,8 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 throw new GroupNotFoundException(groupId);
             }
 
-            RoleEntity apiPORole = roleService
-                .findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
-                .orElseThrow(() -> new TechnicalManagementException("API System Role 'PRIMARY_OWNER' not found."));
-
-            final long apiCount = membershipService
-                .getMembershipsByMemberAndReferenceAndRole(
-                    MembershipMemberType.GROUP,
-                    groupId,
-                    MembershipReferenceType.API,
-                    apiPORole.getId()
-                )
-                .size();
-
-            if (apiCount > 0) {
-                throw new StillPrimaryOwnerException(apiCount, ApiPrimaryOwnerMode.GROUP);
-            }
+            assertGroupIsNotPrimaryOwner(executionContext, groupId, RoleScope.API);
+            assertGroupIsNotPrimaryOwner(executionContext, groupId, RoleScope.API_PRODUCT);
 
             //remove all members
             membershipService.deleteReference(executionContext, MembershipReferenceType.GROUP, groupId);
@@ -1279,10 +1266,8 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     private void verifyUserCanBeDeletedFromGroup(ExecutionContext executionContext, String groupId, String username) {
-        // Check if this group is the primary owner of any API and if the user to remove has the API primary owner role in this group
-        RoleEntity apiPORole = roleService
-            .findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
-            .orElseThrow(() -> new TechnicalManagementException("API System Role 'PRIMARY_OWNER' not found."));
+        RoleEntity apiPORole = getPrimaryOwnerRoleOrThrow(executionContext, RoleScope.API);
+        RoleEntity apiProductPORole = getPrimaryOwnerRoleOrThrow(executionContext, RoleScope.API_PRODUCT);
 
         Set<MembershipEntity> groupApiPrimaryOwnerMemberships = membershipService.getMembershipsByMemberAndReferenceAndRole(
             MembershipMemberType.GROUP,
@@ -1290,24 +1275,62 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             MembershipReferenceType.API,
             apiPORole.getId()
         );
+        Set<MembershipEntity> groupApiProductPrimaryOwnerMemberships = membershipService.getMembershipsByMemberAndReferenceAndRole(
+            MembershipMemberType.GROUP,
+            groupId,
+            MembershipReferenceType.API_PRODUCT,
+            apiProductPORole.getId()
+        );
 
-        if (!groupApiPrimaryOwnerMemberships.isEmpty()) {
-            // Check if the user has the API primary owner role in this group
-            Set<RoleEntity> userRolesInGroup = membershipService.getRoles(
-                MembershipReferenceType.GROUP,
-                groupId,
-                MembershipMemberType.USER,
-                username
-            );
+        Set<RoleEntity> userRolesInGroup = membershipService.getRoles(
+            MembershipReferenceType.GROUP,
+            groupId,
+            MembershipMemberType.USER,
+            username
+        );
 
-            boolean userHasApiPrimaryOwnerRole = userRolesInGroup
-                .stream()
-                .anyMatch(role -> role.getScope() == RoleScope.API && SystemRole.PRIMARY_OWNER.name().equals(role.getName()));
-
-            if (userHasApiPrimaryOwnerRole) {
-                throw new StillPrimaryOwnerException(groupApiPrimaryOwnerMemberships.size(), ApiPrimaryOwnerMode.GROUP);
-            }
+        if (!groupApiPrimaryOwnerMemberships.isEmpty() && userHasPrimaryOwnerRoleForScope(userRolesInGroup, RoleScope.API)) {
+            throw new StillPrimaryOwnerException(groupApiPrimaryOwnerMemberships.size(), ApiPrimaryOwnerMode.GROUP);
         }
+        if (!groupApiProductPrimaryOwnerMemberships.isEmpty() && userHasPrimaryOwnerRoleForScope(userRolesInGroup, RoleScope.API_PRODUCT)) {
+            throw new StillApiProductPrimaryOwnerException(groupApiProductPrimaryOwnerMemberships.size());
+        }
+    }
+
+    /**
+     * Resolves the {@link SystemRole#PRIMARY_OWNER} role for the given scope. Loud-fails if the role
+     * is missing — the {@code DefaultRolesUpgrader} / {@code ApiProductRolesUpgrader} run at startup
+     * and create these roles, so a missing role means the boot sequence didn't complete.
+     */
+    private RoleEntity getPrimaryOwnerRoleOrThrow(ExecutionContext executionContext, RoleScope scope) {
+        return roleService
+            .findByScopeAndName(scope, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+            .orElseThrow(() -> new TechnicalManagementException(scope.name() + " System Role 'PRIMARY_OWNER' not found."));
+    }
+
+    /**
+     * Refuses to delete the group if it still holds the {@code PRIMARY_OWNER} role for the given
+     * scope on at least one reference (API or API Product), to prevent orphan PO memberships.
+     */
+    private void assertGroupIsNotPrimaryOwner(ExecutionContext executionContext, String groupId, RoleScope scope) {
+        RoleEntity poRole = getPrimaryOwnerRoleOrThrow(executionContext, scope);
+        long count = membershipService
+            .getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.valueOf(scope.name()),
+                poRole.getId()
+            )
+            .size();
+        if (count > 0) {
+            throw scope == RoleScope.API
+                ? new StillPrimaryOwnerException(count, ApiPrimaryOwnerMode.GROUP)
+                : new StillApiProductPrimaryOwnerException(count);
+        }
+    }
+
+    private boolean userHasPrimaryOwnerRoleForScope(Set<RoleEntity> userRoles, RoleScope scope) {
+        return userRoles.stream().anyMatch(role -> role.getScope() == scope && SystemRole.PRIMARY_OWNER.name().equals(role.getName()));
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -28,11 +28,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.utils.UUID;
 import io.gravitee.node.api.Node;
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.CommandRepository;
@@ -88,6 +90,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.ApiOwnershipTransferException;
+import io.gravitee.rest.api.service.exceptions.ApiProductOwnershipTransferException;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import io.gravitee.rest.api.service.exceptions.MembershipAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.NotAuthorizedMembershipException;
@@ -170,6 +173,8 @@ public class MembershipServiceImpl extends AbstractService implements Membership
 
     private final ApiRepository apiRepository;
 
+    private final ApiProductsRepository apiProductsRepository;
+
     private final ApplicationRepository applicationRepository;
 
     private final EventManager eventManager;
@@ -201,6 +206,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         @Autowired ApiSearchService apiSearchService,
         @Autowired @Lazy ApiGroupService apiGroupService,
         @Autowired @Lazy ApiRepository apiRepository,
+        @Autowired @Lazy ApiProductsRepository apiProductsRepository,
         @Autowired @Lazy GroupService groupService,
         @Autowired AuditService auditService,
         @Autowired ParameterService parameterService,
@@ -225,6 +231,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         this.apiSearchService = apiSearchService;
         this.apiGroupService = apiGroupService;
         this.apiRepository = apiRepository;
+        this.apiProductsRepository = apiProductsRepository;
         this.groupService = groupService;
         this.auditService = auditService;
         this.parameterService = parameterService;
@@ -1572,6 +1579,10 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                     .findById(referenceId)
                     .orElseThrow(() -> new ApiNotFoundException(referenceId))
                     .getGroups();
+                case API_PRODUCT -> apiProductsRepository
+                    .findById(referenceId)
+                    .orElseThrow(() -> new ApiProductNotFoundException(referenceId))
+                    .getGroups();
                 case APPLICATION -> applicationRepository
                     .findById(referenceId)
                     .orElseThrow(() -> new ApplicationNotFoundException(referenceId))
@@ -1625,18 +1636,25 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                     .collect(Collectors.toSet());
                 Map<String, RoleEntity> rolesById = roleService.findByIds(roleIds);
 
-                // Pre-fetch primary owner for API reference type (used in mapApiPrimaryOwnerRoleToGroupRole)
+                // Pre-fetch the reference's primary owner (only relevant for API and API_PRODUCT). It is used to
+                // tell whether the group itself is the PO of the reference, which decides whether a user holding
+                // the group's PRIMARY_OWNER role should resolve to PRIMARY_OWNER on the reference or be
+                // downgraded to the group's default role for that scope. Legacy API products may not yet have
+                // a PO assigned, so absence is treated as "no group is PO".
                 PrimaryOwnerEntity primaryOwner = null;
                 if (MembershipReferenceType.API.equals(referenceType)) {
                     primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext.getOrganizationId(), referenceId);
+                } else if (MembershipReferenceType.API_PRODUCT.equals(referenceType)) {
+                    primaryOwner = primaryOwnerService.getApiProductPrimaryOwner(executionContext.getOrganizationId(), referenceId);
                 }
 
-                // Batch fetch groups that have API Primary Owner role
+                // Batch fetch groups whose user-membership role is a PRIMARY_OWNER role for the requested scope
+                // (API or API_PRODUCT). For other scopes this set is empty and the group lookup is skipped.
                 Set<String> groupIdsWithPrimaryOwnerRole = groupMemberships
                     .stream()
                     .filter(m -> {
                         RoleEntity role = rolesById.get(m.getRoleId());
-                        return role != null && role.isApiPrimaryOwner();
+                        return role != null && (role.isApiPrimaryOwner() || role.isApiProductPrimaryOwner());
                     })
                     .map(io.gravitee.repository.management.model.Membership::getReferenceId)
                     .collect(Collectors.toSet());
@@ -1660,15 +1678,27 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                         .map(entry -> {
                             RoleEntity role = entry.getValue();
                             String groupId = entry.getKey();
-                            return role.isApiPrimaryOwner()
-                                ? mapApiPrimaryOwnerRoleToGroupRole(
+                            if (role.isApiPrimaryOwner()) {
+                                return mapPrimaryOwnerRoleToGroupRole(
                                     executionContext,
                                     finalPrimaryOwner,
                                     groupsById.get(groupId),
                                     groupId,
-                                    role
-                                )
-                                : role;
+                                    role,
+                                    RoleScope.API
+                                );
+                            }
+                            if (role.isApiProductPrimaryOwner()) {
+                                return mapPrimaryOwnerRoleToGroupRole(
+                                    executionContext,
+                                    finalPrimaryOwner,
+                                    groupsById.get(groupId),
+                                    groupId,
+                                    role,
+                                    RoleScope.API_PRODUCT
+                                );
+                            }
+                            return role;
                         })
                         .filter(Objects::nonNull)
                         .collect(Collectors.toSet())
@@ -1690,25 +1720,32 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         }
     }
 
-    private RoleEntity mapApiPrimaryOwnerRoleToGroupRole(
+    /**
+     * If the user's group holds the {@link SystemRole#PRIMARY_OWNER} role for the given scope but the
+     * group itself is not the reference's primary owner, fall back to the group's default role for
+     * that scope. Otherwise (group IS the PO) keep the PRIMARY_OWNER role. Used for both API and
+     * API_PRODUCT permission resolution paths.
+     */
+    private RoleEntity mapPrimaryOwnerRoleToGroupRole(
         ExecutionContext executionContext,
-        PrimaryOwnerEntity apiPrimaryOwner,
+        PrimaryOwnerEntity primaryOwner,
         GroupEntity userGroup,
         String groupId,
-        RoleEntity role
+        RoleEntity role,
+        RoleScope roleScope
     ) {
-        if (apiPrimaryOwner != null && apiPrimaryOwner.getId().equals(groupId)) {
+        if (primaryOwner != null && primaryOwner.getId().equals(groupId)) {
             return role;
         }
 
-        if (userGroup == null) {
+        if (userGroup == null || userGroup.getRoles() == null) {
             return null;
         }
 
-        String groupApiRole = userGroup.getRoles().get(RoleScope.API);
-        return groupApiRole == null
+        String groupDefaultRoleName = userGroup.getRoles().get(roleScope);
+        return groupDefaultRoleName == null
             ? null
-            : roleService.findByScopeAndName(RoleScope.API, groupApiRole, executionContext.getOrganizationId()).orElse(null);
+            : roleService.findByScopeAndName(roleScope, groupDefaultRoleName, executionContext.getOrganizationId()).orElse(null);
     }
 
     private Map<String, char[]> computeGlobalPermissions(Set<RoleEntity> userRoles) {
@@ -1952,6 +1989,14 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         MembershipMember newOwnerMember,
         List<RoleEntity> newPrimaryOwnerRoles
     ) {
+        if (
+            newOwnerMember.getMemberType() == MembershipMemberType.GROUP &&
+            membershipReferenceType == MembershipReferenceType.API_PRODUCT &&
+            !this.hasPrimaryOwnerMemberInGroup(executionContext, newOwnerMember.getMemberId(), roleScope)
+        ) {
+            throw new ApiProductOwnershipTransferException(itemId);
+        }
+
         List<RoleEntity> newRoles;
         if (newPrimaryOwnerRoles == null || newPrimaryOwnerRoles.isEmpty()) {
             newRoles = roleService.findDefaultRoleByScopes(executionContext.getOrganizationId(), roleScope);
@@ -2244,9 +2289,18 @@ public class MembershipServiceImpl extends AbstractService implements Membership
     }
 
     private boolean hasApiPrimaryOwnerMemberInGroup(ExecutionContext executionContext, String groupId) {
+        return this.hasPrimaryOwnerMemberInGroup(executionContext, groupId, RoleScope.API);
+    }
+
+    private boolean hasPrimaryOwnerMemberInGroup(ExecutionContext executionContext, String groupId, RoleScope roleScope) {
         return this.getMembersByReference(executionContext, MembershipReferenceType.GROUP, groupId)
             .stream()
-            .anyMatch(member -> member.getRoles().stream().anyMatch(RoleEntity::isApiPrimaryOwner));
+            .anyMatch(member ->
+                member
+                    .getRoles()
+                    .stream()
+                    .anyMatch(role -> role.getScope() == roleScope && PRIMARY_OWNER.name().equals(role.getName()))
+            );
     }
 
     public void invalidateRoleCacheAndSendCommand(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AssignDefaultApiProductRoleToGroupsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AssignDefaultApiProductRoleToGroupsUpgrader.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_USER;
+import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.ASSIGN_DEFAULT_API_PRODUCT_ROLE_TO_GROUPS_UPGRADER;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.GroupRepository;
+import io.gravitee.repository.management.api.MembershipRepository;
+import io.gravitee.repository.management.api.RoleRepository;
+import io.gravitee.repository.management.model.Group;
+import io.gravitee.repository.management.model.Membership;
+import io.gravitee.repository.management.model.MembershipMemberType;
+import io.gravitee.repository.management.model.MembershipReferenceType;
+import io.gravitee.repository.management.model.Role;
+import io.gravitee.repository.management.model.RoleReferenceType;
+import io.gravitee.repository.management.model.RoleScope;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.util.Date;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * Backfills the default API_PRODUCT role membership for groups that pre-date the API_PRODUCT scope.
+ *
+ * <p>For every group across every environment, if no membership of the form
+ * {@code (referenceType=API_PRODUCT, referenceId=null, memberType=GROUP, memberId=<groupId>)} exists,
+ * this upgrader creates one with the {@code USER} role. This makes {@code GroupEntity.roles[API_PRODUCT]}
+ * resolve to a real value going forward, so that adding the group to an API_PRODUCT actually grants its
+ * members an effective role through {@link io.gravitee.rest.api.service.impl.MembershipServiceImpl#getUserMember}.
+ *
+ * <p>Existing group members are intentionally left untouched (conservative migration): they keep their
+ * current API/APPLICATION/INTEGRATION roles and only newly added members will pick up the default
+ * API_PRODUCT role from the seeded group default.
+ */
+@Component
+@CustomLog
+public class AssignDefaultApiProductRoleToGroupsUpgrader implements Upgrader {
+
+    private static final String DEFAULT_SOURCE = "system";
+
+    private final EnvironmentRepository environmentRepository;
+    private final GroupRepository groupRepository;
+    private final MembershipRepository membershipRepository;
+    private final RoleRepository roleRepository;
+
+    @Autowired
+    public AssignDefaultApiProductRoleToGroupsUpgrader(
+        @Lazy EnvironmentRepository environmentRepository,
+        @Lazy GroupRepository groupRepository,
+        @Lazy MembershipRepository membershipRepository,
+        @Lazy RoleRepository roleRepository
+    ) {
+        this.environmentRepository = environmentRepository;
+        this.groupRepository = groupRepository;
+        this.membershipRepository = membershipRepository;
+        this.roleRepository = roleRepository;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::applyUpgrade);
+    }
+
+    private boolean applyUpgrade() throws TechnicalException {
+        environmentRepository
+            .findAll()
+            .forEach(environment -> {
+                ExecutionContext executionContext = new ExecutionContext(environment);
+                try {
+                    backfillDefaultApiProductRoleForGroups(executionContext);
+                } catch (TechnicalException e) {
+                    log.error(
+                        "Error backfilling default API_PRODUCT role on groups for environment {}",
+                        executionContext.getEnvironmentId(),
+                        e
+                    );
+                }
+            });
+        return true;
+    }
+
+    private void backfillDefaultApiProductRoleForGroups(ExecutionContext executionContext) throws TechnicalException {
+        Optional<String> userRoleId = findApiProductUserRoleId(executionContext.getOrganizationId());
+        if (userRoleId.isEmpty()) {
+            log.warn(
+                "API_PRODUCT '{}' role not found for organization {} — skipping group backfill (run ApiProductRolesUpgrader first)",
+                ROLE_API_PRODUCT_USER.getName(),
+                executionContext.getOrganizationId()
+            );
+            return;
+        }
+
+        for (Group group : groupRepository.findAllByEnvironment(executionContext.getEnvironmentId())) {
+            if (hasDefaultApiProductRole(group.getId())) {
+                continue;
+            }
+            createDefaultApiProductRoleMembership(group.getId(), userRoleId.get());
+            log.info(
+                "Assigned default API_PRODUCT role '{}' to group {} (env {})",
+                ROLE_API_PRODUCT_USER.getName(),
+                group.getId(),
+                executionContext.getEnvironmentId()
+            );
+        }
+    }
+
+    private Optional<String> findApiProductUserRoleId(String organizationId) throws TechnicalException {
+        return roleRepository
+            .findByScopeAndNameAndReferenceIdAndReferenceType(
+                RoleScope.API_PRODUCT,
+                ROLE_API_PRODUCT_USER.getName(),
+                organizationId,
+                RoleReferenceType.ORGANIZATION
+            )
+            .map(Role::getId);
+    }
+
+    private boolean hasDefaultApiProductRole(String groupId) throws TechnicalException {
+        return membershipRepository
+            .findByMemberIdAndMemberTypeAndReferenceType(groupId, MembershipMemberType.GROUP, MembershipReferenceType.API_PRODUCT)
+            .stream()
+            .anyMatch(m -> m.getReferenceId() == null);
+    }
+
+    private void createDefaultApiProductRoleMembership(String groupId, String roleId) throws TechnicalException {
+        Membership membership = new Membership(
+            UuidString.generateRandom(),
+            groupId,
+            MembershipMemberType.GROUP,
+            null,
+            MembershipReferenceType.API_PRODUCT,
+            roleId
+        );
+        Date now = new Date();
+        membership.setCreatedAt(now);
+        membership.setUpdatedAt(now);
+        membership.setSource(DEFAULT_SOURCE);
+        membershipRepository.create(membership);
+    }
+
+    @Override
+    public int getOrder() {
+        return ASSIGN_DEFAULT_API_PRODUCT_ROLE_TO_GROUPS_UPGRADER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -71,4 +71,5 @@ public class UpgraderOrder {
     public static final int API_PRODUCT_ROLES_UPGRADER = 950;
     public static final int API_PRODUCT_MEMBER_PERMISSION_UPGRADER = 951;
     public static final int CLUSTER_TYPE_UPGRADER = 952;
+    public static final int ASSIGN_DEFAULT_API_PRODUCT_ROLE_TO_GROUPS_UPGRADER = 953;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PrimaryOwnerService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PrimaryOwnerService.java
@@ -38,6 +38,19 @@ public interface PrimaryOwnerService {
     PrimaryOwnerEntity getPrimaryOwner(String organizationId, String apiId) throws TechnicalManagementException;
 
     /**
+     * Resolves the primary owner for the given API Product.
+     *
+     * @param organizationId the organization id
+     * @param apiProductId the API Product id
+     * @return The primary owner
+     * @throws TechnicalManagementException if an error occurs while resolving the primary owner
+     * @throws io.gravitee.rest.api.service.exceptions.PrimaryOwnerNotFoundException if no primary owner is set on the API Product
+     * @deprecated use {@link io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService#getApiProductPrimaryOwner(String, String)} instead
+     */
+    @Deprecated
+    PrimaryOwnerEntity getApiProductPrimaryOwner(String organizationId, String apiProductId) throws TechnicalManagementException;
+
+    /**
      * Resolves the primary owner email for the given API.
      * If the primary owner is a user, the email is returned.
      * If the primary owner is a group, the email of the member entitled as an API primary owner is returned.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PrimaryOwnerServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PrimaryOwnerServiceImpl.java
@@ -18,7 +18,9 @@ package io.gravitee.rest.api.service.v4.impl;
 import static java.util.stream.Collectors.toSet;
 
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.exception.ApiPrimaryOwnerNotFoundException;
+import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
 import io.gravitee.apim.infra.adapter.PrimaryOwnerAdapter;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.parameters.Key;
@@ -61,6 +63,7 @@ public class PrimaryOwnerServiceImpl extends TransactionalService implements Pri
     private final ParameterService parameterService;
     private final RoleService roleService;
     private final ApiPrimaryOwnerDomainService primaryOwnerDomainService;
+    private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
 
     public PrimaryOwnerServiceImpl(
         final UserService userService,
@@ -68,7 +71,8 @@ public class PrimaryOwnerServiceImpl extends TransactionalService implements Pri
         final GroupService groupService,
         final ParameterService parameterService,
         final RoleService roleService,
-        final ApiPrimaryOwnerDomainService primaryOwnerDomainService
+        final ApiPrimaryOwnerDomainService primaryOwnerDomainService,
+        final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService
     ) {
         this.userService = userService;
         this.membershipService = membershipService;
@@ -76,6 +80,7 @@ public class PrimaryOwnerServiceImpl extends TransactionalService implements Pri
         this.parameterService = parameterService;
         this.roleService = roleService;
         this.primaryOwnerDomainService = primaryOwnerDomainService;
+        this.apiProductPrimaryOwnerDomainService = apiProductPrimaryOwnerDomainService;
     }
 
     @Override
@@ -88,6 +93,20 @@ public class PrimaryOwnerServiceImpl extends TransactionalService implements Pri
             return PrimaryOwnerAdapter.INSTANCE.toRestEntity(po);
         } catch (ApiPrimaryOwnerNotFoundException e) {
             throw new PrimaryOwnerNotFoundException(e.getApiId());
+        }
+    }
+
+    @Override
+    public PrimaryOwnerEntity getApiProductPrimaryOwner(final String organizationId, final String apiProductId)
+        throws TechnicalManagementException {
+        try {
+            io.gravitee.apim.core.membership.model.PrimaryOwnerEntity po = apiProductPrimaryOwnerDomainService.getApiProductPrimaryOwner(
+                organizationId,
+                apiProductId
+            );
+            return PrimaryOwnerAdapter.INSTANCE.toRestEntity(po);
+        } catch (ApiProductPrimaryOwnerNotFoundException e) {
+            throw new PrimaryOwnerNotFoundException(e.getApiProductId(), e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductQueryServiceInMemory.java
@@ -96,6 +96,24 @@ public class ApiProductQueryServiceInMemory extends AbstractQueryServiceInMemory
     }
 
     @Override
+    public Set<String> findIdsByEnvironmentIdAndGroups(String environmentId, Set<String> groupIds) {
+        if (groupIds == null || groupIds.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> result = new HashSet<>();
+        for (ApiProduct apiProduct : storage) {
+            if (
+                Objects.equals(environmentId, apiProduct.getEnvironmentId()) &&
+                apiProduct.getGroups() != null &&
+                apiProduct.getGroups().stream().anyMatch(groupIds::contains)
+            ) {
+                result.add(apiProduct.getId());
+            }
+        }
+        return result;
+    }
+
+    @Override
     public Map<String, Set<ApiProduct>> findProductsByApiIds(Set<String> apiIds) {
         Map<String, Set<ApiProduct>> result = new HashMap<>();
         if (apiIds == null || apiIds.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ApiProductAccessibleIdsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ApiProductAccessibleIdsDomainServiceTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.membership.model.Membership;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ApiProductAccessibleIdsDomainServiceTest {
+
+    private static final String ENV_ID = "env-1";
+    private static final String OTHER_ENV_ID = "env-2";
+    private static final String USER_ID = "sam";
+    private static final String GROUP_ID = "s-group";
+    private static final String OTHER_GROUP_ID = "other-group";
+    private static final String ROLE_ID = "role-id";
+
+    private ApiProductQueryServiceInMemory apiProductQueryService;
+    private MembershipCrudServiceInMemory membershipCrudService;
+    private MembershipQueryServiceInMemory membershipQueryService;
+    private ApiProductAccessibleIdsDomainService domainService;
+
+    @BeforeEach
+    void setUp() {
+        apiProductQueryService = new ApiProductQueryServiceInMemory();
+        membershipCrudService = new MembershipCrudServiceInMemory();
+        membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
+        domainService = new ApiProductAccessibleIdsDomainService(apiProductQueryService, membershipQueryService);
+    }
+
+    @Test
+    void should_return_empty_set_when_user_has_no_memberships() {
+        apiProductQueryService.initWith(List.of(apiProduct("ap-1", ENV_ID, null), apiProduct("ap-2", ENV_ID, null)));
+
+        Set<String> result = domainService.findAccessibleApiProductIds(ENV_ID, USER_ID);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void should_return_only_directly_owned_api_products() {
+        apiProductQueryService.initWith(List.of(apiProduct("ap-1", ENV_ID, null), apiProduct("ap-2", ENV_ID, null)));
+        membershipCrudService.initWith(List.of(directApiProductMembership("m-1", "ap-1")));
+
+        Set<String> result = domainService.findAccessibleApiProductIds(ENV_ID, USER_ID);
+
+        assertThat(result).containsExactly("ap-1");
+    }
+
+    @Test
+    void should_return_only_group_inherited_api_products_when_user_has_no_direct_memberships() {
+        apiProductQueryService.initWith(List.of(apiProduct("ap-1", ENV_ID, null), apiProduct("ap-2", ENV_ID, Set.of(GROUP_ID))));
+        membershipCrudService.initWith(List.of(groupMembership("m-1", GROUP_ID)));
+
+        Set<String> result = domainService.findAccessibleApiProductIds(ENV_ID, USER_ID);
+
+        assertThat(result).containsExactly("ap-2");
+    }
+
+    @Test
+    void should_union_direct_and_group_inherited_api_products() {
+        apiProductQueryService.initWith(
+            List.of(apiProduct("ap-1", ENV_ID, null), apiProduct("ap-2", ENV_ID, Set.of(GROUP_ID)), apiProduct("ap-3", ENV_ID, null))
+        );
+        membershipCrudService.initWith(List.of(directApiProductMembership("m-1", "ap-1"), groupMembership("m-2", GROUP_ID)));
+
+        Set<String> result = domainService.findAccessibleApiProductIds(ENV_ID, USER_ID);
+
+        assertThat(result).containsExactlyInAnyOrder("ap-1", "ap-2");
+    }
+
+    @Test
+    void should_dedupe_when_direct_and_group_inherited_overlap() {
+        apiProductQueryService.initWith(List.of(apiProduct("ap-1", ENV_ID, Set.of(GROUP_ID))));
+        membershipCrudService.initWith(List.of(directApiProductMembership("m-1", "ap-1"), groupMembership("m-2", GROUP_ID)));
+
+        Set<String> result = domainService.findAccessibleApiProductIds(ENV_ID, USER_ID);
+
+        assertThat(result).containsExactly("ap-1");
+    }
+
+    @Test
+    void should_scope_group_inherited_lookup_to_the_requested_environment() {
+        // ap-other-env is in a different environment but attached to the same group: must NOT leak.
+        apiProductQueryService.initWith(
+            List.of(apiProduct("ap-here", ENV_ID, Set.of(GROUP_ID)), apiProduct("ap-other-env", OTHER_ENV_ID, Set.of(GROUP_ID)))
+        );
+        membershipCrudService.initWith(List.of(groupMembership("m-1", GROUP_ID)));
+
+        Set<String> result = domainService.findAccessibleApiProductIds(ENV_ID, USER_ID);
+
+        assertThat(result).containsExactly("ap-here");
+    }
+
+    @Test
+    void should_ignore_groups_the_user_does_not_belong_to() {
+        // ap-other is attached to a different group than the one sam belongs to.
+        apiProductQueryService.initWith(
+            List.of(apiProduct("ap-mine", ENV_ID, Set.of(GROUP_ID)), apiProduct("ap-other", ENV_ID, Set.of(OTHER_GROUP_ID)))
+        );
+        membershipCrudService.initWith(List.of(groupMembership("m-1", GROUP_ID)));
+
+        Set<String> result = domainService.findAccessibleApiProductIds(ENV_ID, USER_ID);
+
+        assertThat(result).containsExactly("ap-mine");
+    }
+
+    private static ApiProduct apiProduct(String id, String environmentId, Set<String> groups) {
+        ApiProduct apiProduct = ApiProduct.builder().id(id).name(id).environmentId(environmentId).build();
+        apiProduct.setGroups(groups == null ? null : new HashSet<>(groups));
+        return apiProduct;
+    }
+
+    private static Membership directApiProductMembership(String id, String apiProductId) {
+        return Membership.builder()
+            .id(id)
+            .memberId(USER_ID)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.API_PRODUCT)
+            .referenceId(apiProductId)
+            .roleId(ROLE_ID)
+            .build();
+    }
+
+    private static Membership groupMembership(String id, String groupId) {
+        return Membership.builder()
+            .id(id)
+            .memberId(USER_ID)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.GROUP)
+            .referenceId(groupId)
+            .roleId(ROLE_ID)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
@@ -95,13 +95,18 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
             userCrudService
         );
 
+        var apiProductAccessibleIdsDomainService =
+            new io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService(
+                apiProductQueryService,
+                membershipQueryService
+            );
         getApiProductsUseCase = new GetApiProductsUseCase(
             apiProductQueryService,
             apiProductPrimaryOwnerDomainService,
             eventLatestQueryService,
             planQueryService,
             objectMapper,
-            membershipQueryService
+            apiProductAccessibleIdsDomainService
         );
     }
 
@@ -225,6 +230,74 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
 
         var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID, USER_ID, false));
         assertThat(output.apiProducts()).isEmpty();
+    }
+
+    @Test
+    void should_include_api_products_inherited_via_group_membership_for_non_admin() {
+        ApiProduct product1 = ApiProduct.builder().id("id1").name("Direct").environmentId(ENV_ID).build();
+        ApiProduct product2 = ApiProduct.builder()
+            .id("id2")
+            .name("Inherited")
+            .environmentId(ENV_ID)
+            .groups(java.util.Set.of("s-group"))
+            .build();
+        apiProductQueryService.initWith(List.of(product1, product2));
+
+        membershipCrudService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("group-membership-id")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.GROUP)
+                    .referenceId("s-group")
+                    .roleId(apiProductPrimaryOwnerRoleId(ORG_ID))
+                    .source("system")
+                    .build()
+            )
+        );
+
+        var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID, USER_ID, false));
+        assertThat(output.apiProducts()).extracting(ApiProduct::getId).containsExactly("id2");
+    }
+
+    @Test
+    void should_union_direct_and_group_inherited_api_products_for_non_admin() {
+        ApiProduct product1 = ApiProduct.builder().id("id1").name("Direct").environmentId(ENV_ID).build();
+        ApiProduct product2 = ApiProduct.builder()
+            .id("id2")
+            .name("Inherited")
+            .environmentId(ENV_ID)
+            .groups(java.util.Set.of("s-group"))
+            .build();
+        ApiProduct product3 = ApiProduct.builder().id("id3").name("Other").environmentId(ENV_ID).build();
+        apiProductQueryService.initWith(List.of(product1, product2, product3));
+
+        membershipCrudService.initWith(
+            List.of(
+                Membership.builder()
+                    .id("direct")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.API_PRODUCT)
+                    .referenceId("id1")
+                    .roleId(apiProductPrimaryOwnerRoleId(ORG_ID))
+                    .source("system")
+                    .build(),
+                Membership.builder()
+                    .id("group")
+                    .memberId(USER_ID)
+                    .memberType(Membership.Type.USER)
+                    .referenceType(Membership.ReferenceType.GROUP)
+                    .referenceId("s-group")
+                    .roleId(apiProductPrimaryOwnerRoleId(ORG_ID))
+                    .source("system")
+                    .build()
+            )
+        );
+
+        var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, ORG_ID, USER_ID, false));
+        assertThat(output.apiProducts()).extracting(ApiProduct::getId).containsExactlyInAnyOrder("id1", "id2");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/SearchApiProductsUseCaseTest.java
@@ -16,37 +16,48 @@
 package io.gravitee.apim.core.api_product.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import inmemory.ApiProductSearchQueryServiceInMemory;
-import inmemory.MembershipCrudServiceInMemory;
-import inmemory.MembershipQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductAccessibleIdsDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
-import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.common.SortableImpl;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class SearchApiProductsUseCaseTest {
 
     private static final String ENV_ID = "env-id";
     private static final String ORG_ID = "org-id";
     private static final String USER_ID = "user-id";
-    private static final String ROLE_ID = "role-id";
 
     private ApiProductSearchQueryServiceInMemory apiProductSearchQueryService;
-    private MembershipCrudServiceInMemory membershipCrudService;
-    private MembershipQueryServiceInMemory membershipQueryService;
+
+    @Mock
+    private ApiProductAccessibleIdsDomainService apiProductAccessibleIdsDomainService;
+
     private SearchApiProductsUseCase useCase;
 
     @BeforeEach
     void setUp() {
         apiProductSearchQueryService = new ApiProductSearchQueryServiceInMemory();
-        membershipCrudService = new MembershipCrudServiceInMemory();
-        membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
-        useCase = new SearchApiProductsUseCase(apiProductSearchQueryService, membershipQueryService);
+        useCase = new SearchApiProductsUseCase(apiProductSearchQueryService, apiProductAccessibleIdsDomainService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        verifyNoMoreInteractions(apiProductAccessibleIdsDomainService);
     }
 
     @Test
@@ -136,26 +147,7 @@ class SearchApiProductsUseCaseTest {
         var product3 = ApiProduct.builder().id("id-3").name("Product Three").environmentId(ENV_ID).build();
         apiProductSearchQueryService.initWith(List.of(product1, product2, product3));
 
-        membershipCrudService.initWith(
-            List.of(
-                Membership.builder()
-                    .id("m-1")
-                    .memberId(USER_ID)
-                    .memberType(Membership.Type.USER)
-                    .referenceType(Membership.ReferenceType.API_PRODUCT)
-                    .referenceId("id-1")
-                    .roleId(ROLE_ID)
-                    .build(),
-                Membership.builder()
-                    .id("m-2")
-                    .memberId(USER_ID)
-                    .memberType(Membership.Type.USER)
-                    .referenceType(Membership.ReferenceType.API_PRODUCT)
-                    .referenceId("id-3")
-                    .roleId(ROLE_ID)
-                    .build()
-            )
-        );
+        when(apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(ENV_ID, USER_ID)).thenReturn(Set.of("id-1", "id-3"));
 
         var pageable = new PageableImpl(1, 10);
         var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, pageable, null, USER_ID, false);
@@ -163,6 +155,7 @@ class SearchApiProductsUseCaseTest {
         var output = useCase.execute(input);
 
         assertThat(output.page().getContent()).extracting(ApiProduct::getId).containsExactlyInAnyOrder("id-1", "id-3");
+        verify(apiProductAccessibleIdsDomainService).findAccessibleApiProductIds(eq(ENV_ID), eq(USER_ID));
     }
 
     @Test
@@ -171,32 +164,23 @@ class SearchApiProductsUseCaseTest {
         var product2 = ApiProduct.builder().id("id-2").name("Product Two").environmentId(ENV_ID).build();
         apiProductSearchQueryService.initWith(List.of(product1, product2));
 
-        membershipCrudService.initWith(
-            List.of(
-                Membership.builder()
-                    .id("m-1")
-                    .memberId(USER_ID)
-                    .memberType(Membership.Type.USER)
-                    .referenceType(Membership.ReferenceType.API_PRODUCT)
-                    .referenceId("id-1")
-                    .roleId(ROLE_ID)
-                    .build()
-            )
-        );
+        when(apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(ENV_ID, USER_ID)).thenReturn(Set.of("id-1"));
 
         var pageable = new PageableImpl(1, 10);
-        // User requests id-1 and id-2 but only owns id-1
         var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, Set.of("id-1", "id-2"), pageable, null, USER_ID, false);
 
         var output = useCase.execute(input);
 
         assertThat(output.page().getContent()).extracting(ApiProduct::getId).containsExactly("id-1");
+        verify(apiProductAccessibleIdsDomainService).findAccessibleApiProductIds(eq(ENV_ID), eq(USER_ID));
     }
 
     @Test
     void should_return_empty_page_for_non_admin_with_no_memberships() {
         var product1 = ApiProduct.builder().id("id-1").name("Product One").environmentId(ENV_ID).build();
         apiProductSearchQueryService.initWith(List.of(product1));
+
+        when(apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(ENV_ID, USER_ID)).thenReturn(Set.of());
 
         var pageable = new PageableImpl(1, 10);
         var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, pageable, null, USER_ID, false);
@@ -205,6 +189,58 @@ class SearchApiProductsUseCaseTest {
 
         assertThat(output.page().getContent()).isEmpty();
         assertThat(output.page().getTotalElements()).isZero();
+        verify(apiProductAccessibleIdsDomainService).findAccessibleApiProductIds(eq(ENV_ID), eq(USER_ID));
+    }
+
+    @Test
+    void should_include_api_products_inherited_via_group_membership_for_non_admin() {
+        var product1 = ApiProduct.builder().id("id-1").name("Product One").environmentId(ENV_ID).build();
+        var product2 = ApiProduct.builder().id("id-2").name("Product Two").environmentId(ENV_ID).build();
+        apiProductSearchQueryService.initWith(List.of(product1, product2));
+
+        when(apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(ENV_ID, USER_ID)).thenReturn(Set.of("id-2"));
+
+        var pageable = new PageableImpl(1, 10);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, pageable, null, USER_ID, false);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page().getContent()).extracting(ApiProduct::getId).containsExactly("id-2");
+        verify(apiProductAccessibleIdsDomainService).findAccessibleApiProductIds(eq(ENV_ID), eq(USER_ID));
+    }
+
+    @Test
+    void should_union_direct_and_group_inherited_api_products_for_non_admin() {
+        var product1 = ApiProduct.builder().id("id-1").name("Direct").environmentId(ENV_ID).build();
+        var product2 = ApiProduct.builder().id("id-2").name("Inherited").environmentId(ENV_ID).build();
+        apiProductSearchQueryService.initWith(List.of(product1, product2));
+
+        when(apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(ENV_ID, USER_ID)).thenReturn(Set.of("id-1", "id-2"));
+
+        var pageable = new PageableImpl(1, 10);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, null, pageable, null, USER_ID, false);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page().getContent()).extracting(ApiProduct::getId).containsExactlyInAnyOrder("id-1", "id-2");
+        verify(apiProductAccessibleIdsDomainService).findAccessibleApiProductIds(eq(ENV_ID), eq(USER_ID));
+    }
+
+    @Test
+    void should_intersect_requested_ids_with_group_inherited_ids_for_non_admin() {
+        var product1 = ApiProduct.builder().id("id-1").name("Inherited One").environmentId(ENV_ID).build();
+        var product2 = ApiProduct.builder().id("id-2").name("Other").environmentId(ENV_ID).build();
+        apiProductSearchQueryService.initWith(List.of(product1, product2));
+
+        when(apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(ENV_ID, USER_ID)).thenReturn(Set.of("id-1"));
+
+        var pageable = new PageableImpl(1, 10);
+        var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, Set.of("id-1", "id-2"), pageable, null, USER_ID, false);
+
+        var output = useCase.execute(input);
+
+        assertThat(output.page().getContent()).extracting(ApiProduct::getId).containsExactly("id-1");
+        verify(apiProductAccessibleIdsDomainService).findAccessibleApiProductIds(eq(ENV_ID), eq(USER_ID));
     }
 
     @Test
@@ -212,25 +248,14 @@ class SearchApiProductsUseCaseTest {
         var product1 = ApiProduct.builder().id("id-1").name("Product One").environmentId(ENV_ID).build();
         apiProductSearchQueryService.initWith(List.of(product1));
 
-        membershipCrudService.initWith(
-            List.of(
-                Membership.builder()
-                    .id("m-2")
-                    .memberId(USER_ID)
-                    .memberType(Membership.Type.USER)
-                    .referenceType(Membership.ReferenceType.API_PRODUCT)
-                    .referenceId("id-2")
-                    .roleId(ROLE_ID)
-                    .build()
-            )
-        );
+        when(apiProductAccessibleIdsDomainService.findAccessibleApiProductIds(ENV_ID, USER_ID)).thenReturn(Set.of("id-2"));
 
         var pageable = new PageableImpl(1, 10);
-        // User owns id-2 but requests id-1 (which they don't own)
         var input = SearchApiProductsUseCase.Input.of(ENV_ID, ORG_ID, null, Set.of("id-1"), pageable, null, USER_ID, false);
 
         var output = useCase.execute(input);
 
         assertThat(output.page().getContent()).isEmpty();
+        verify(apiProductAccessibleIdsDomainService).findAccessibleApiProductIds(eq(ENV_ID), eq(USER_ID));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
@@ -48,6 +48,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
+import io.gravitee.rest.api.service.exceptions.StillApiProductPrimaryOwnerException;
 import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import io.gravitee.rest.api.service.impl.GroupServiceImpl;
 import io.gravitee.rest.api.service.notification.ApiHook;
@@ -122,6 +123,45 @@ public class GroupService_DeleteTest {
     @Mock
     private ApiTemplateService apiTemplateService;
 
+    private void stubPrimaryOwnerGuardAllowsDeletion() {
+        RoleEntity apiRole = new RoleEntity();
+        apiRole.setId("API_PRIMARY_OWNER_ID");
+        when(
+            roleService.findByScopeAndName(
+                RoleScope.API,
+                SystemRole.PRIMARY_OWNER.name(),
+                GraviteeContext.getExecutionContext().getOrganizationId()
+            )
+        ).thenReturn(Optional.of(apiRole));
+
+        RoleEntity apiProductRole = new RoleEntity();
+        apiProductRole.setId("API_PRODUCT_PRIMARY_OWNER_ID");
+        when(
+            roleService.findByScopeAndName(
+                RoleScope.API_PRODUCT,
+                SystemRole.PRIMARY_OWNER.name(),
+                GraviteeContext.getExecutionContext().getOrganizationId()
+            )
+        ).thenReturn(Optional.of(apiProductRole));
+
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                GROUP_ID,
+                MembershipReferenceType.API,
+                "API_PRIMARY_OWNER_ID"
+            )
+        ).thenReturn(Collections.emptySet());
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                GROUP_ID,
+                MembershipReferenceType.API_PRODUCT,
+                "API_PRODUCT_PRIMARY_OWNER_ID"
+            )
+        ).thenReturn(Collections.emptySet());
+    }
+
     @Test(expected = GroupNotFoundException.class)
     public void throwGroupNotFoundException() throws Exception {
         when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.empty());
@@ -166,23 +206,23 @@ public class GroupService_DeleteTest {
         groupService.delete(GraviteeContext.getExecutionContext(), GROUP_ID);
     }
 
-    @Test
-    public void shouldDeleteGroup() throws Exception {
+    @Test(expected = StillApiProductPrimaryOwnerException.class)
+    public void throwStillApiProductPrimaryOwnerException() throws Exception {
         final Group group = new Group();
         group.setId(GROUP_ID);
         group.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
         when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
 
-        RoleEntity role = new RoleEntity();
-        role.setId("API_PRIMARY_OWNER_ID");
+        // API guard passes (no API PO membership for the group).
+        RoleEntity apiRole = new RoleEntity();
+        apiRole.setId("API_PRIMARY_OWNER_ID");
         when(
             roleService.findByScopeAndName(
                 RoleScope.API,
                 SystemRole.PRIMARY_OWNER.name(),
                 GraviteeContext.getExecutionContext().getOrganizationId()
             )
-        ).thenReturn(Optional.of(role));
-
+        ).thenReturn(Optional.of(apiRole));
         when(
             membershipService.getMembershipsByMemberAndReferenceAndRole(
                 MembershipMemberType.GROUP,
@@ -191,6 +231,38 @@ public class GroupService_DeleteTest {
                 "API_PRIMARY_OWNER_ID"
             )
         ).thenReturn(Collections.emptySet());
+
+        // Group is the primary owner of an API Product → must refuse deletion with the
+        // API-Product-specific exception so the admin gets accurate wording.
+        RoleEntity apiProductRole = new RoleEntity();
+        apiProductRole.setId("API_PRODUCT_PRIMARY_OWNER_ID");
+        when(
+            roleService.findByScopeAndName(
+                RoleScope.API_PRODUCT,
+                SystemRole.PRIMARY_OWNER.name(),
+                GraviteeContext.getExecutionContext().getOrganizationId()
+            )
+        ).thenReturn(Optional.of(apiProductRole));
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                GROUP_ID,
+                MembershipReferenceType.API_PRODUCT,
+                "API_PRODUCT_PRIMARY_OWNER_ID"
+            )
+        ).thenReturn(Set.of(new MembershipEntity()));
+
+        groupService.delete(GraviteeContext.getExecutionContext(), GROUP_ID);
+    }
+
+    @Test
+    public void shouldDeleteGroup() throws Exception {
+        final Group group = new Group();
+        group.setId(GROUP_ID);
+        group.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
+
+        stubPrimaryOwnerGuardAllowsDeletion();
 
         when(
             apiRepository.search(
@@ -283,24 +355,7 @@ public class GroupService_DeleteTest {
         group.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
         when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
 
-        RoleEntity role = new RoleEntity();
-        role.setId("API_PRIMARY_OWNER_ID");
-        when(
-            roleService.findByScopeAndName(
-                RoleScope.API,
-                SystemRole.PRIMARY_OWNER.name(),
-                GraviteeContext.getExecutionContext().getOrganizationId()
-            )
-        ).thenReturn(Optional.of(role));
-
-        when(
-            membershipService.getMembershipsByMemberAndReferenceAndRole(
-                MembershipMemberType.GROUP,
-                GROUP_ID,
-                MembershipReferenceType.API,
-                "API_PRIMARY_OWNER_ID"
-            )
-        ).thenReturn(Collections.emptySet());
+        stubPrimaryOwnerGuardAllowsDeletion();
 
         UserEntity mockUser = mock(UserEntity.class);
         when(mockUser.getDisplayName()).thenReturn("Mock User");
@@ -374,23 +429,7 @@ public class GroupService_DeleteTest {
         group.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
         when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
 
-        RoleEntity role = new RoleEntity();
-        role.setId("API_PRIMARY_OWNER_ID");
-        when(
-            roleService.findByScopeAndName(
-                RoleScope.API,
-                SystemRole.PRIMARY_OWNER.name(),
-                GraviteeContext.getExecutionContext().getOrganizationId()
-            )
-        ).thenReturn(Optional.of(role));
-        when(
-            membershipService.getMembershipsByMemberAndReferenceAndRole(
-                MembershipMemberType.GROUP,
-                GROUP_ID,
-                MembershipReferenceType.API,
-                "API_PRIMARY_OWNER_ID"
-            )
-        ).thenReturn(Collections.emptySet());
+        stubPrimaryOwnerGuardAllowsDeletion();
 
         when(
             apiRepository.search(
@@ -432,24 +471,7 @@ public class GroupService_DeleteTest {
         group.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
         when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
 
-        RoleEntity role = new RoleEntity();
-        role.setId("API_PRIMARY_OWNER_ID");
-        when(
-            roleService.findByScopeAndName(
-                RoleScope.API,
-                SystemRole.PRIMARY_OWNER.name(),
-                GraviteeContext.getExecutionContext().getOrganizationId()
-            )
-        ).thenReturn(Optional.of(role));
-
-        when(
-            membershipService.getMembershipsByMemberAndReferenceAndRole(
-                MembershipMemberType.GROUP,
-                GROUP_ID,
-                MembershipReferenceType.API,
-                "API_PRIMARY_OWNER_ID"
-            )
-        ).thenReturn(Collections.emptySet());
+        stubPrimaryOwnerGuardAllowsDeletion();
 
         // No APIs found by group membership search (the API is NOT in the group's groups[])
         when(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindPrimaryOwnerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindPrimaryOwnerTest.java
@@ -93,7 +93,8 @@ public class ApiService_FindPrimaryOwnerTest {
             groupService,
             parameterService,
             roleService,
-            primaryOwnerDomainService
+            primaryOwnerDomainService,
+            null
         );
         ReflectionTestUtils.setField(apiService, "primaryOwnerService", primaryOwnerService);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupServiceImplTest.java
@@ -48,6 +48,7 @@ import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.StillApiProductPrimaryOwnerException;
 import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import java.util.List;
 import java.util.Optional;
@@ -268,18 +269,34 @@ public class GroupServiceImplTest {
         String username = "user-1";
 
         RoleEntity apiPORole = RoleEntity.builder().id("api-po-role-id").name(SystemRole.PRIMARY_OWNER.name()).scope(RoleScope.API).build();
+        RoleEntity apiProductPORole = RoleEntity.builder()
+            .id("api-product-po-role-id")
+            .name(SystemRole.PRIMARY_OWNER.name())
+            .scope(RoleScope.API_PRODUCT)
+            .build();
 
         when(
             roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
         ).thenReturn(Optional.of(apiPORole));
+        when(
+            roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiProductPORole));
 
-        // Group is NOT a primary owner of any API (empty memberships)
+        // Group is NOT a primary owner of any API or API Product.
         when(
             membershipService.getMembershipsByMemberAndReferenceAndRole(
                 MembershipMemberType.GROUP,
                 groupId,
                 MembershipReferenceType.API,
                 apiPORole.getId()
+            )
+        ).thenReturn(Set.of());
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.API_PRODUCT,
+                apiProductPORole.getId()
             )
         ).thenReturn(Set.of());
 
@@ -307,10 +324,18 @@ public class GroupServiceImplTest {
         String username = "user-1";
 
         RoleEntity apiPORole = RoleEntity.builder().id("api-po-role-id").name(SystemRole.PRIMARY_OWNER.name()).scope(RoleScope.API).build();
+        RoleEntity apiProductPORole = RoleEntity.builder()
+            .id("api-product-po-role-id")
+            .name(SystemRole.PRIMARY_OWNER.name())
+            .scope(RoleScope.API_PRODUCT)
+            .build();
 
         when(
             roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
         ).thenReturn(Optional.of(apiPORole));
+        when(
+            roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiProductPORole));
 
         // Group IS a primary owner of some APIs
         MembershipEntity groupApiPOMembership = MembershipEntity.builder()
@@ -326,6 +351,15 @@ public class GroupServiceImplTest {
                 apiPORole.getId()
             )
         ).thenReturn(Set.of(groupApiPOMembership));
+        // Group is NOT API_PRODUCT primary owner.
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.API_PRODUCT,
+                apiProductPORole.getId()
+            )
+        ).thenReturn(Set.of());
 
         // User does NOT have API PRIMARY_OWNER role in this group (has a different role)
         RoleEntity userApiRole = RoleEntity.builder().id("api-user-role-id").name("USER").scope(RoleScope.API).build();
@@ -356,10 +390,18 @@ public class GroupServiceImplTest {
         String username = "user-1";
 
         RoleEntity apiPORole = RoleEntity.builder().id("api-po-role-id").name(SystemRole.PRIMARY_OWNER.name()).scope(RoleScope.API).build();
+        RoleEntity apiProductPORole = RoleEntity.builder()
+            .id("api-product-po-role-id")
+            .name(SystemRole.PRIMARY_OWNER.name())
+            .scope(RoleScope.API_PRODUCT)
+            .build();
 
         when(
             roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
         ).thenReturn(Optional.of(apiPORole));
+        when(
+            roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiProductPORole));
 
         // Group IS a primary owner of some APIs
         MembershipEntity groupApiPOMembership = MembershipEntity.builder()
@@ -375,6 +417,14 @@ public class GroupServiceImplTest {
                 apiPORole.getId()
             )
         ).thenReturn(Set.of(groupApiPOMembership));
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.API_PRODUCT,
+                apiProductPORole.getId()
+            )
+        ).thenReturn(Set.of());
 
         // User HAS API PRIMARY_OWNER role in this group
         when(membershipService.getRoles(MembershipReferenceType.GROUP, groupId, MembershipMemberType.USER, username)).thenReturn(
@@ -384,6 +434,143 @@ public class GroupServiceImplTest {
         assertThatThrownBy(() -> service.deleteUserFromGroup(executionContext, groupId, username)).isInstanceOf(
             StillPrimaryOwnerException.class
         );
+    }
+
+    @Test
+    public void deleteUserFromGroup_shouldThrow_whenGroupIsApiProductPrimaryOwner_andUserHasApiProductPrimaryOwnerRole() {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String groupId = "group-1";
+        String username = "user-1";
+
+        // The API guard is satisfied (no API PO membership for the group).
+        RoleEntity apiPORole = RoleEntity.builder().id("api-po-role-id").name(SystemRole.PRIMARY_OWNER.name()).scope(RoleScope.API).build();
+        when(
+            roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiPORole));
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.API,
+                apiPORole.getId()
+            )
+        ).thenReturn(Set.of());
+
+        // The group IS the primary owner of an API Product.
+        RoleEntity apiProductPORole = RoleEntity.builder()
+            .id("api-product-po-role-id")
+            .name(SystemRole.PRIMARY_OWNER.name())
+            .scope(RoleScope.API_PRODUCT)
+            .build();
+        when(
+            roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiProductPORole));
+        MembershipEntity groupApiProductPOMembership = MembershipEntity.builder()
+            .id("ap-membership-1")
+            .referenceId("api-product-1")
+            .referenceType(MembershipReferenceType.API_PRODUCT)
+            .build();
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.API_PRODUCT,
+                apiProductPORole.getId()
+            )
+        ).thenReturn(Set.of(groupApiProductPOMembership));
+
+        // The user holds the API_PRODUCT PRIMARY_OWNER role inside the group.
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, groupId, MembershipMemberType.USER, username)).thenReturn(
+            Set.of(apiProductPORole)
+        );
+
+        assertThatThrownBy(() -> service.deleteUserFromGroup(executionContext, groupId, username)).isInstanceOf(
+            StillApiProductPrimaryOwnerException.class
+        );
+    }
+
+    @Test
+    public void deleteUserFromGroup_shouldSucceed_whenGroupIsApiProductPrimaryOwner_butUserDoesNotHaveApiProductPrimaryOwnerRole()
+        throws Exception {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String groupId = "group-1";
+        String username = "user-1";
+
+        RoleEntity apiPORole = RoleEntity.builder().id("api-po-role-id").name(SystemRole.PRIMARY_OWNER.name()).scope(RoleScope.API).build();
+        when(
+            roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiPORole));
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.API,
+                apiPORole.getId()
+            )
+        ).thenReturn(Set.of());
+
+        RoleEntity apiProductPORole = RoleEntity.builder()
+            .id("api-product-po-role-id")
+            .name(SystemRole.PRIMARY_OWNER.name())
+            .scope(RoleScope.API_PRODUCT)
+            .build();
+        when(
+            roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiProductPORole));
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                groupId,
+                MembershipReferenceType.API_PRODUCT,
+                apiProductPORole.getId()
+            )
+        ).thenReturn(
+            Set.of(
+                MembershipEntity.builder().id("ap").referenceId("api-product-1").referenceType(MembershipReferenceType.API_PRODUCT).build()
+            )
+        );
+
+        // The user has only an API_PRODUCT USER role, not PRIMARY_OWNER → removal must succeed.
+        RoleEntity userApiProductRole = RoleEntity.builder().id("user-role").name("USER").scope(RoleScope.API_PRODUCT).build();
+        when(membershipService.getRoles(MembershipReferenceType.GROUP, groupId, MembershipMemberType.USER, username)).thenReturn(
+            Set.of(userApiProductRole)
+        );
+
+        when(groupRepository.findById(groupId)).thenReturn(
+            Optional.of(Group.builder().id(groupId).environmentId(executionContext.getEnvironmentId()).build())
+        );
+
+        service.deleteUserFromGroup(executionContext, groupId, username);
+
+        verify(membershipService).deleteReferenceMember(
+            executionContext,
+            MembershipReferenceType.GROUP,
+            groupId,
+            MembershipMemberType.USER,
+            username
+        );
+    }
+
+    @Test
+    public void deleteUserFromGroup_shouldThrow_whenApiProductPrimaryOwnerRoleNotInOrg() {
+        // The PO-role lookup is symmetric: missing API_PRODUCT PRIMARY_OWNER role means startup
+        // didn't complete (ApiProductRolesUpgrader didn't run). Loud-fail rather than silently
+        // skipping the guard, otherwise the user could be removed and orphan a PO group's contact.
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String groupId = "group-1";
+        String username = "user-1";
+
+        RoleEntity apiPORole = RoleEntity.builder().id("api-po-role-id").name(SystemRole.PRIMARY_OWNER.name()).scope(RoleScope.API).build();
+        when(
+            roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.of(apiPORole));
+        when(
+            roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), executionContext.getOrganizationId())
+        ).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.deleteUserFromGroup(executionContext, groupId, username))
+            .isInstanceOf(io.gravitee.rest.api.service.exceptions.TechnicalManagementException.class)
+            .hasMessageContaining("API_PRODUCT");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_AddRoleToMemberOnReferenceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_AddRoleToMemberOnReferenceTest.java
@@ -129,6 +129,7 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
             apiSearchService,
             null,
             apiRepository,
+            null,
             groupService,
             auditService,
             parameterService,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiProductTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiProductTest.java
@@ -31,8 +31,10 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.node.api.Node;
+import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.CommandRepository;
 import io.gravitee.repository.management.api.MembershipRepository;
+import io.gravitee.repository.management.model.ApiProduct;
 import io.gravitee.repository.management.model.Membership;
 import io.gravitee.rest.api.model.MemberEntity;
 import io.gravitee.rest.api.model.MembershipReferenceType;
@@ -98,6 +100,9 @@ class MembershipService_CreateNewMembershipForApiProductTest {
     @Mock
     private PrimaryOwnerService primaryOwnerService;
 
+    @Mock
+    private ApiProductsRepository apiProductsRepository;
+
     @BeforeEach
     void setUp() {
         reset(membershipRepository, apiSearchService, userService, auditService, roleService, identityService);
@@ -116,6 +121,7 @@ class MembershipService_CreateNewMembershipForApiProductTest {
             apiSearchService,
             null,
             null,
+            apiProductsRepository,
             null,
             auditService,
             null,
@@ -129,6 +135,17 @@ class MembershipService_CreateNewMembershipForApiProductTest {
         );
 
         mockRole();
+        mockApiProductLookup();
+    }
+
+    private void mockApiProductLookup() {
+        try {
+            ApiProduct apiProduct = new ApiProduct();
+            apiProduct.setId(API_PRODUCT_ID);
+            lenient().when(apiProductsRepository.findById(API_PRODUCT_ID)).thenReturn(Optional.of(apiProduct));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiTest.java
@@ -123,6 +123,7 @@ public class MembershipService_CreateNewMembershipForApiTest {
             null,
             apiRepository,
             null,
+            null,
             auditService,
             null,
             null,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
@@ -87,6 +87,7 @@ public class MembershipService_DeleteMemberTest {
             null,
             null,
             null,
+            null,
             null
         );
         when(roleService.findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
@@ -87,6 +87,7 @@ public class MembershipService_EditMemberTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipMetadataTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipMetadataTest.java
@@ -89,6 +89,7 @@ public class MembershipService_FindUserMembershipMetadataTest {
             null,
             null,
             mockApiRepository,
+            null,
             mockGroupService,
             null,
             null,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipTest.java
@@ -99,6 +99,7 @@ public class MembershipService_FindUserMembershipTest {
             null,
             null,
             mockApiRepository,
+            null,
             mockGroupService,
             null,
             null,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMemberPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMemberPermissionsTest.java
@@ -112,6 +112,7 @@ public class MembershipService_GetMemberPermissionsTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembersTest.java
@@ -88,6 +88,7 @@ public class MembershipService_GetMembersTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembershipsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembershipsTest.java
@@ -73,6 +73,7 @@ public class MembershipService_GetMembershipsTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberPermissionsTest.java
@@ -76,6 +76,7 @@ public class MembershipService_GetUserMemberPermissionsTest {
             null,
             null,
             null,
+            null,
             node,
             objectMapper,
             commandRepository,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberTest.java
@@ -79,6 +79,7 @@ public class MembershipService_GetUserMemberTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_IntegrationMembershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_IntegrationMembershipTest.java
@@ -141,6 +141,7 @@ public class MembershipService_IntegrationMembershipTest {
             null,
             apiRepository,
             null,
+            null,
             auditService,
             null,
             integrationRepository,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_InvalidateCacheForRoleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_InvalidateCacheForRoleTest.java
@@ -73,6 +73,7 @@ public class MembershipService_InvalidateCacheForRoleTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_TransferOwnershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_TransferOwnershipTest.java
@@ -49,6 +49,7 @@ import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.ApiOwnershipTransferException;
+import io.gravitee.rest.api.service.exceptions.ApiProductOwnershipTransferException;
 import io.gravitee.rest.api.service.exceptions.RoleNotFoundException;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiGroupService;
@@ -129,6 +130,9 @@ public class MembershipService_TransferOwnershipTest {
     @Mock
     private ApiProductGroupService apiProductGroupService;
 
+    @Mock
+    private io.gravitee.repository.management.api.ApiProductsRepository apiProductsRepository;
+
     @BeforeEach
     public void setUp() throws TechnicalException {
         membershipService = new MembershipServiceImpl(
@@ -145,6 +149,7 @@ public class MembershipService_TransferOwnershipTest {
             apiSearchService,
             apiGroupService,
             apiRepository,
+            apiProductsRepository,
             groupService,
             auditService,
             null,
@@ -156,6 +161,13 @@ public class MembershipService_TransferOwnershipTest {
             searchEngineService,
             apiProductGroupService
         );
+
+        // Stub API_PRODUCT lookup for tests that exercise getUserMember(API_PRODUCT, ...). Returning an
+        // ApiProduct with no groups keeps the legacy behaviour (no group-derived roles).
+        io.gravitee.repository.management.model.ApiProduct apiProductStub = new io.gravitee.repository.management.model.ApiProduct();
+        org.mockito.Mockito.lenient()
+            .when(apiProductsRepository.findById(org.mockito.ArgumentMatchers.anyString()))
+            .thenReturn(java.util.Optional.of(apiProductStub));
         newPrimaryOwnerRole.setId(USER_ROLE_ID);
         newPrimaryOwnerRole.setName(USER_ROLE_NAME);
         newPrimaryOwnerRole.setScope(RoleScope.API);
@@ -494,6 +506,19 @@ public class MembershipService_TransferOwnershipTest {
             membershipRepository.findByReferenceAndRoleId(MembershipReferenceType.API_PRODUCT, apiProductId, apiProductPoRoleId)
         ).thenReturn(Set.of(userPoMembership));
 
+        // Pre-flight guard now requires the new owner GROUP to have at least one user holding the
+        // API_PRODUCT PRIMARY_OWNER role. Stub a group membership for the same user/role.
+        Membership groupPoUserMembership = new Membership();
+        groupPoUserMembership.setReferenceType(MembershipReferenceType.GROUP);
+        groupPoUserMembership.setReferenceId(GROUP_ID);
+        groupPoUserMembership.setRoleId(apiProductPoRoleId);
+        groupPoUserMembership.setMemberId(USER_ID);
+        groupPoUserMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.USER);
+        lenient()
+            .when(membershipRepository.findByReferencesAndRoleId(MembershipReferenceType.GROUP, List.of(GROUP_ID), null))
+            .thenReturn(Set.of(groupPoUserMembership));
+        lenient().when(roleService.findById(apiProductPoRoleId)).thenReturn(poRole);
+
         RoleEntity fallbackRole = new RoleEntity();
         fallbackRole.setId("API_PRODUCT_USER");
         fallbackRole.setName("USER");
@@ -514,6 +539,93 @@ public class MembershipService_TransferOwnershipTest {
 
         verify(apiGroupService, never()).addGroup(any(), any(), any());
         verify(apiProductGroupService).addGroup(EXECUTION_CONTEXT, apiProductId, GROUP_ID);
+    }
+
+    @Test
+    public void should_throw_when_transferring_api_product_ownership_to_group_with_no_primary_owner_member() throws TechnicalException {
+        String apiProductId = "api-product-id-1";
+
+        lenient()
+            .when(roleService.findScopeByMembershipReferenceType(io.gravitee.rest.api.model.MembershipReferenceType.API_PRODUCT))
+            .thenReturn(RoleScope.API_PRODUCT);
+
+        // Group exists but has NO user with API_PRODUCT PRIMARY_OWNER role.
+        Membership unrelatedGroupMembership = new Membership();
+        unrelatedGroupMembership.setReferenceType(MembershipReferenceType.GROUP);
+        unrelatedGroupMembership.setReferenceId(GROUP_ID);
+        unrelatedGroupMembership.setRoleId("API_PRODUCT_USER_ROLE_ID");
+        unrelatedGroupMembership.setMemberId(USER_ID);
+        unrelatedGroupMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.USER);
+        lenient()
+            .when(membershipRepository.findByReferencesAndRoleId(MembershipReferenceType.GROUP, List.of(GROUP_ID), null))
+            .thenReturn(Set.of(unrelatedGroupMembership));
+
+        RoleEntity userRole = new RoleEntity();
+        userRole.setId("API_PRODUCT_USER_ROLE_ID");
+        userRole.setName("USER");
+        userRole.setScope(RoleScope.API_PRODUCT);
+        lenient().when(roleService.findById("API_PRODUCT_USER_ROLE_ID")).thenReturn(userRole);
+
+        assertThatThrownBy(() ->
+            membershipService.transferOwnership(
+                EXECUTION_CONTEXT,
+                io.gravitee.rest.api.model.MembershipReferenceType.API_PRODUCT,
+                RoleScope.API_PRODUCT,
+                apiProductId,
+                new MembershipService.MembershipMember(GROUP_ID, null, MembershipMemberType.GROUP),
+                List.of()
+            )
+        )
+            .isInstanceOf(ApiProductOwnershipTransferException.class)
+            .hasMessage("Api Product [" + apiProductId + "] transfer not allowed.");
+
+        // No PO assignment must happen when the guard fires.
+        verify(membershipRepository, never()).create(any());
+        verify(apiProductGroupService, never()).addGroup(any(), any(), any());
+    }
+
+    @Test
+    public void should_not_throw_when_transferring_api_product_ownership_to_user() throws TechnicalException {
+        String apiProductId = "api-product-id-2";
+        String apiProductPoRoleId = "API_PRODUCT_PRIMARY_OWNER";
+
+        RoleEntity poRole = new RoleEntity();
+        poRole.setId(apiProductPoRoleId);
+        poRole.setScope(RoleScope.API_PRODUCT);
+        poRole.setName(SystemRole.PRIMARY_OWNER.name());
+
+        lenient()
+            .when(roleService.findScopeByMembershipReferenceType(io.gravitee.rest.api.model.MembershipReferenceType.API_PRODUCT))
+            .thenReturn(RoleScope.API_PRODUCT);
+        lenient().when(roleService.findPrimaryOwnerRoleByOrganization(ORGANIZATION_ID, RoleScope.API_PRODUCT)).thenReturn(poRole);
+        lenient()
+            .when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, SystemRole.PRIMARY_OWNER.name(), ORGANIZATION_ID))
+            .thenReturn(Optional.of(poRole));
+
+        Membership groupPoMembership = new Membership();
+        groupPoMembership.setReferenceType(MembershipReferenceType.API_PRODUCT);
+        groupPoMembership.setRoleId(apiProductPoRoleId);
+        groupPoMembership.setReferenceId(apiProductId);
+        groupPoMembership.setMemberId(GROUP_ID);
+        groupPoMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.GROUP);
+
+        lenient()
+            .when(membershipRepository.findByReferenceAndRoleId(MembershipReferenceType.API_PRODUCT, apiProductId, apiProductPoRoleId))
+            .thenReturn(Set.of(groupPoMembership));
+
+        // The new owner is a USER, so the new "group has PO member" guard must NOT trigger.
+        assertThatNoExceptionFromTransfer(apiProductId);
+    }
+
+    private void assertThatNoExceptionFromTransfer(String apiProductId) throws TechnicalException {
+        membershipService.transferOwnership(
+            EXECUTION_CONTEXT,
+            io.gravitee.rest.api.model.MembershipReferenceType.API_PRODUCT,
+            RoleScope.API_PRODUCT,
+            apiProductId,
+            new MembershipService.MembershipMember(USER_ID, null, MembershipMemberType.USER),
+            List.of()
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
@@ -109,6 +109,7 @@ public class MembershipService_UpdateMembershipForApiTest {
             null,
             apiRepository,
             null,
+            null,
             auditService,
             null,
             null,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AssignDefaultApiProductRoleToGroupsUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AssignDefaultApiProductRoleToGroupsUpgraderTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_PRODUCT_USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.GroupRepository;
+import io.gravitee.repository.management.api.MembershipRepository;
+import io.gravitee.repository.management.api.RoleRepository;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.repository.management.model.Group;
+import io.gravitee.repository.management.model.Membership;
+import io.gravitee.repository.management.model.MembershipMemberType;
+import io.gravitee.repository.management.model.MembershipReferenceType;
+import io.gravitee.repository.management.model.Role;
+import io.gravitee.repository.management.model.RoleReferenceType;
+import io.gravitee.repository.management.model.RoleScope;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AssignDefaultApiProductRoleToGroupsUpgraderTest {
+
+    private static final String ORG_ID = "org-1";
+    private static final String ENV_ID = "env-1";
+    private static final String API_PRODUCT_USER_ROLE_ID = "api-product-user-role-id";
+
+    @InjectMocks
+    AssignDefaultApiProductRoleToGroupsUpgrader upgrader;
+
+    @Mock
+    EnvironmentRepository environmentRepository;
+
+    @Mock
+    GroupRepository groupRepository;
+
+    @Mock
+    MembershipRepository membershipRepository;
+
+    @Mock
+    RoleRepository roleRepository;
+
+    @Test(expected = UpgraderException.class)
+    public void upgrade_throws_when_environment_lookup_fails() throws UpgraderException, TechnicalException {
+        when(environmentRepository.findAll()).thenThrow(new RuntimeException("boom"));
+        upgrader.upgrade();
+    }
+
+    @Test
+    public void should_create_default_api_product_membership_for_groups_missing_one() throws UpgraderException, TechnicalException {
+        Environment env = environment();
+        when(environmentRepository.findAll()).thenReturn(Set.of(env));
+
+        Role userRole = role();
+        when(
+            roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(
+                eq(RoleScope.API_PRODUCT),
+                eq(ROLE_API_PRODUCT_USER.getName()),
+                eq(ORG_ID),
+                eq(RoleReferenceType.ORGANIZATION)
+            )
+        ).thenReturn(Optional.of(userRole));
+
+        Group g1 = group("g1");
+        Group g2 = group("g2");
+        when(groupRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(g1, g2));
+
+        // g1 has no API_PRODUCT default role; g2 already has one
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
+                "g1",
+                MembershipMemberType.GROUP,
+                MembershipReferenceType.API_PRODUCT
+            )
+        ).thenReturn(Set.of());
+        Membership g2Existing = new Membership();
+        g2Existing.setReferenceId(null);
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
+                "g2",
+                MembershipMemberType.GROUP,
+                MembershipReferenceType.API_PRODUCT
+            )
+        ).thenReturn(Set.of(g2Existing));
+
+        upgrader.upgrade();
+
+        ArgumentCaptor<Membership> membershipCaptor = ArgumentCaptor.forClass(Membership.class);
+        verify(membershipRepository, times(1)).create(membershipCaptor.capture());
+        Membership created = membershipCaptor.getValue();
+        assertThat(created.getMemberId()).isEqualTo("g1");
+        assertThat(created.getMemberType()).isEqualTo(MembershipMemberType.GROUP);
+        assertThat(created.getReferenceType()).isEqualTo(MembershipReferenceType.API_PRODUCT);
+        assertThat(created.getReferenceId()).isNull();
+        assertThat(created.getRoleId()).isEqualTo(API_PRODUCT_USER_ROLE_ID);
+    }
+
+    @Test
+    public void should_skip_environment_when_api_product_user_role_is_missing() throws UpgraderException, TechnicalException {
+        Environment env = environment();
+        when(environmentRepository.findAll()).thenReturn(Set.of(env));
+
+        when(
+            roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(
+                eq(RoleScope.API_PRODUCT),
+                eq(ROLE_API_PRODUCT_USER.getName()),
+                eq(ORG_ID),
+                eq(RoleReferenceType.ORGANIZATION)
+            )
+        ).thenReturn(Optional.empty());
+
+        upgrader.upgrade();
+
+        verify(groupRepository, never()).findAllByEnvironment(any());
+        verify(membershipRepository, never()).create(any());
+    }
+
+    @Test
+    public void should_be_idempotent_when_all_groups_already_have_default_role() throws UpgraderException, TechnicalException {
+        Environment env = environment();
+        when(environmentRepository.findAll()).thenReturn(Set.of(env));
+
+        when(
+            roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(
+                eq(RoleScope.API_PRODUCT),
+                eq(ROLE_API_PRODUCT_USER.getName()),
+                eq(ORG_ID),
+                eq(RoleReferenceType.ORGANIZATION)
+            )
+        ).thenReturn(Optional.of(role()));
+
+        Group g1 = group("g1");
+        when(groupRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(g1));
+
+        Membership existing = new Membership();
+        existing.setReferenceId(null);
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
+                "g1",
+                MembershipMemberType.GROUP,
+                MembershipReferenceType.API_PRODUCT
+            )
+        ).thenReturn(Set.of(existing));
+
+        upgrader.upgrade();
+
+        verify(membershipRepository, never()).create(any());
+    }
+
+    @Test
+    public void test_order() {
+        assertThat(upgrader.getOrder()).isEqualTo(UpgraderOrder.ASSIGN_DEFAULT_API_PRODUCT_ROLE_TO_GROUPS_UPGRADER);
+    }
+
+    private Environment environment() {
+        Environment env = new Environment();
+        env.setId(ENV_ID);
+        env.setOrganizationId(ORG_ID);
+        return env;
+    }
+
+    private Group group(String id) {
+        Group group = new Group();
+        group.setId(id);
+        group.setEnvironmentId(ENV_ID);
+        return group;
+    }
+
+    private Role role() {
+        Role role = new Role();
+        role.setId(API_PRODUCT_USER_ROLE_ID);
+        return role;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PrimaryOwnerServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PrimaryOwnerServiceImplTest.java
@@ -94,7 +94,8 @@ public class PrimaryOwnerServiceImplTest {
             groupService,
             parameterService,
             roleService,
-            primaryOwnerDomainService
+            primaryOwnerDomainService,
+            null
         );
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13783

## Description


Console — Remove group member | Delete dialog treats API Product PRIMARY_OWNER like API PRIMARY_OWNER: shows Search members / transfer flow when either scope is PO. | Users removing an API Product PO from a group were not prompted to transfer ownership.
-- | -- | --
Console — Transfer payload | When picking a successor, all existing roles on that user (API, API_PRODUCT, APPLICATION, INTEGRATION, CLUSTER, etc.) are sent; transferred scope(s) are forced to PRIMARY_OWNER. | Transfer no longer wiped API / CLUSTER (and other) roles on the new owner.
Console — Parent | handleOwnershipTransfer runs when removing a member who is PO on API or API_PRODUCT. | Ownership transfer API was skipped for API Product–only PO cases.
REST API — List / search API Products | Non-admins: allowed product IDs = direct USER → API_PRODUCT memberships ∪ products whose groups intersect the user’s groups (findIdsByEnvironmentIdAndGroups). | Users with only group-linked products could not see them; parity with API visibility.
REST API — Query layer | ApiProductQueryService + impl: findIdsByEnvironmentIdAndGroups; in-memory test double updated. | Efficient lookup of products by environment + group ids.
REST API — Memberships | MembershipServiceImpl: API_PRODUCT in group-reference flows, mapApiProductPrimaryOwnerRoleToGroupRole, ApiProductsRepository for product groups, getApiProductPrimaryOwner usage; transfer to GROUP for API_PRODUCT blocked if no member in group has API_PRODUCT PRIMARY_OWNER (ApiProductOwnershipTransferException). | Correct effective roles via groups; safe ownership transfer to groups.
REST API — Primary owner | PrimaryOwnerService / impl: getApiProductPrimaryOwner (delegates to domain service). | Resolves API Product PO for membership logic.
REST API — Model | RoleEntity.isApiProductPrimaryOwner(). | Reuse same patterns as isApiPrimaryOwner().
REST API — Upgrade | AssignDefaultApiProductRoleToGroupsUpgrader (+ order in UpgraderOrder): backfill default API_PRODUCT group membership for legacy groups. | Old groups without API_PRODUCT default got no effective role when linked to products.
REST API — Groups | GroupServiceImpl: block deleting a group that is still API Product PO; block removing a user from a group if the group is API Product PO and that user is API_PRODUCT PRIMARY_OWNER in the group (StillApiProductPrimaryOwnerException). Best-effort if API_PRODUCT PO role missing in org. | Avoid dangling PO / unusable PO contact; mirror API PO checks.
Tests | JUnit updates: GetApiProductsUseCaseTest, SearchApiProductsUseCaseTest, MembershipService_*, MembershipService_TransferOwnershipTest, PrimaryOwnerServiceImplTest, ApiService_FindPrimaryOwnerTest, upgrader test, GroupService_DeleteTest, GroupServiceImplTest. | Lock in behavior and regressions.

Deletion of API product PO asks for TO
https://github.com/user-attachments/assets/d97e45bf-ae41-483a-be33-2efc30027e19


Group member having only read permission to API product via group can see the API product
https://github.com/user-attachments/assets/6a26cdd8-3b0c-4b8b-a231-45ee48800c49

Disabled delete button when group has API product PO
<img width="1501" height="479" alt="image" src="https://github.com/user-attachments/assets/dcd1b997-8825-4f55-ab61-c09b43c160b4" />

