### PR TITLE
feat(EXT-124): add AsyncAPI page type to portal navigation

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalPageContent.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalPageContent.java
@@ -35,6 +35,7 @@ public class PortalPageContent {
     public enum Type {
         GRAVITEE_MARKDOWN,
         OPENAPI,
+        ASYNCAPI,
     }
 
     @EqualsAndHashCode.Include

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapper.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
@@ -31,6 +32,7 @@ public interface PortalPageContentMapper {
         return switch (portalPageContent) {
             case GraviteeMarkdownPageContent markdownContent -> map(markdownContent);
             case OpenApiPageContent openApiContent -> map(openApiContent);
+            case AsyncApiPageContent asyncApiContent -> map(asyncApiContent);
         };
     }
 
@@ -45,6 +47,10 @@ public interface PortalPageContentMapper {
     @Mapping(target = "type", constant = "OPENAPI")
     @Mapping(target = "content", expression = "java(openApiContent.getContent().value())")
     io.gravitee.rest.api.management.v2.rest.model.PortalPageContent map(OpenApiPageContent openApiContent);
+
+    @Mapping(target = "type", constant = "ASYNCAPI")
+    @Mapping(target = "content", expression = "java(asyncApiContent.getContent().value())")
+    io.gravitee.rest.api.management.v2.rest.model.PortalPageContent map(AsyncApiPageContent asyncApiContent);
 
     UpdatePortalPageContent map(io.gravitee.rest.api.management.v2.rest.model.UpdatePortalPageContent portalPageContent);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -2339,6 +2339,7 @@ components:
       enum:
         - GRAVITEE_MARKDOWN
         - OPENAPI
+        - ASYNCAPI
 
     PortalPageContent:
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalPageContentMapperTest.java
@@ -86,4 +86,25 @@ class PortalPageContentMapperTest {
         assertThat(result.getContent()).isEqualTo("Test content");
         assertThat(result.getType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
     }
+
+    @Test
+    void should_map_asyncapi_page_content() {
+        // Given
+        var contentId = PortalPageContentId.of("12345678-1234-1234-1234-123456789abd");
+        var asyncApiContent = PortalPageContentFixtures.anAsyncApiPageContent(
+            contentId,
+            "ORG",
+            "ENV",
+            "asyncapi: '3.0.0'\ninfo:\n  title: Test AsyncAPI"
+        );
+
+        // When
+        var result = mapper.map(asyncApiContent);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("12345678-1234-1234-1234-123456789abd");
+        assertThat(result.getContent()).isEqualTo("asyncapi: '3.0.0'\ninfo:\n  title: Test AsyncAPI");
+        assertThat(result.getType()).isEqualTo(PortalPageContentType.ASYNCAPI);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PortalNavigationItemMapper.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.rest.api.portal.rest.mapper;
 
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
@@ -22,6 +25,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.RenderedPageContent;
 import jakarta.annotation.Nonnull;
@@ -59,6 +63,15 @@ public interface PortalNavigationItemMapper {
     io.gravitee.rest.api.portal.rest.model.PortalNavigationLink map(PortalNavigationLink link);
     io.gravitee.rest.api.portal.rest.model.PortalNavigationPage map(PortalNavigationPage page);
     io.gravitee.rest.api.portal.rest.model.PortalNavigationApi map(PortalNavigationApi api);
+
+    @Mapping(source = "value", target = "content")
+    default String extractContent(PortalPageContent<?> content) {
+        return switch (content) {
+            case GraviteeMarkdownPageContent gmd -> gmd.getContent().value();
+            case OpenApiPageContent oapi -> oapi.getContent().value();
+            case AsyncApiPageContent aapi -> aapi.getContent().value();
+        };
+    }
 
     @Mapping(source = "value", target = "content")
     @Mapping(source = "type", target = "type")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -8136,6 +8136,7 @@ components:
             enum:
                 - GRAVITEE_MARKDOWN
                 - OPENAPI
+                - ASYNCAPI
 
         ValidateCertificateRequest:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/async_api/AsyncApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/async_api/AsyncApi.java
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.model;
+package io.gravitee.apim.core.async_api;
 
-public enum PortalPageContentType {
-    GRAVITEE_MARKDOWN,
-    OPENAPI,
-    ASYNCAPI,
+/**
+ * AsyncAPI specification content value for portal pages.
+ */
+public record AsyncApi(String value) {
+    public static AsyncApi of(String value) {
+        return new AsyncApi(value);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/async_api/AsyncApiValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/async_api/AsyncApiValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.async_api;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.async_api.exception.AsyncApiContentEmptyException;
+
+/**
+ * Domain service for validating AsyncAPI specification content.
+ *
+ * <p>Provides shared validation logic that can be reused across multiple domains
+ * (portal pages, documentation, etc.).</p>
+ *
+ * @author Gravitee.io Team
+ */
+@DomainService
+public class AsyncApiValidator {
+
+    /**
+     * Validates that AsyncAPI content is not null or empty.
+     *
+     * @param content the AsyncAPI content to validate
+     * @throws AsyncApiContentEmptyException if content is null, empty, or whitespace-only
+     */
+    public void validateNotEmpty(AsyncApi content) {
+        if (content.value() == null || content.value().trim().isEmpty()) {
+            throw new AsyncApiContentEmptyException();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/async_api/exception/AsyncApiContentEmptyException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/async_api/exception/AsyncApiContentEmptyException.java
@@ -13,10 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.model;
+package io.gravitee.apim.core.async_api.exception;
 
-public enum PortalPageContentType {
-    GRAVITEE_MARKDOWN,
-    OPENAPI,
-    ASYNCAPI,
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+/**
+ * Exception thrown when AsyncAPI content is null, empty, or contains only whitespace.
+ *
+ * @author Gravitee.io Team
+ */
+public class AsyncApiContentEmptyException extends ValidationDomainException {
+
+    public AsyncApiContentEmptyException() {
+        super("Content must not be null or empty");
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/AsyncApiPortalPageContentValidatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/AsyncApiPortalPageContentValidatorService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.async_api.AsyncApi;
+import io.gravitee.apim.core.async_api.AsyncApiValidator;
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@DomainService
+public class AsyncApiPortalPageContentValidatorService implements PortalPageContentValidator {
+
+    private final AsyncApiValidator asyncApiValidator;
+
+    @Override
+    public boolean appliesTo(PortalPageContent<?> existingContent) {
+        return existingContent instanceof AsyncApiPageContent;
+    }
+
+    @Override
+    public void validate(PortalPageContent<?> existingContent, UpdatePortalPageContent updateContent) {
+        asyncApiValidator.validateNotEmpty(AsyncApi.of(updateContent.getContent()));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/AsyncApiPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/AsyncApiPageContent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.model;
+
+import io.gravitee.apim.core.async_api.AsyncApi;
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public final class AsyncApiPageContent extends PortalPageContent<AsyncApi> {
+
+    private static final PortalPageContentType TYPE = PortalPageContentType.ASYNCAPI;
+
+    @Setter
+    @Nonnull
+    private AsyncApi content;
+
+    public AsyncApiPageContent(
+        @Nonnull PortalPageContentId id,
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nonnull AsyncApi content
+    ) {
+        super(id, organizationId, environmentId);
+        this.content = content;
+    }
+
+    public static AsyncApiPageContent create(@Nonnull String organizationId, @Nonnull String environmentId, @Nonnull String content) {
+        return new AsyncApiPageContent(PortalPageContentId.random(), organizationId, environmentId, AsyncApi.of(content));
+    }
+
+    public PortalPageContentType getType() {
+        return TYPE;
+    }
+
+    @Override
+    public void update(@Nonnull UpdatePortalPageContent updatePortalPageContent) {
+        this.content = AsyncApi.of(updatePortalPageContent.getContent());
+    }
+
+    @Override
+    public String toString() {
+        return "AsyncApi[id=" + getId() + ", content=" + content + "]";
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
@@ -19,7 +19,7 @@ import jakarta.annotation.Nonnull;
 import lombok.Getter;
 
 @Getter
-public abstract sealed class PortalPageContent<T> permits GraviteeMarkdownPageContent, OpenApiPageContent {
+public abstract sealed class PortalPageContent<T> permits GraviteeMarkdownPageContent, OpenApiPageContent, AsyncApiPageContent {
 
     @Nonnull
     private final PortalPageContentId id;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapter.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import io.gravitee.apim.core.async_api.AsyncApi;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.open_api.OpenApi;
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
@@ -32,6 +34,7 @@ public interface PortalPageContentAdapter {
         return switch (portalPageContent.getType()) {
             case GRAVITEE_MARKDOWN -> graviteeMarkdownPageContentFromRepository(portalPageContent);
             case OPENAPI -> openApiPageContentFromRepository(portalPageContent);
+            case ASYNCAPI -> asyncApiPageContentFromRepository(portalPageContent);
         };
     }
 
@@ -57,10 +60,22 @@ public interface PortalPageContentAdapter {
         );
     }
 
+    default AsyncApiPageContent asyncApiPageContentFromRepository(
+        io.gravitee.repository.management.model.PortalPageContent portalPageContent
+    ) {
+        return new AsyncApiPageContent(
+            PortalPageContentId.of(portalPageContent.getId()),
+            portalPageContent.getOrganizationId(),
+            portalPageContent.getEnvironmentId(),
+            AsyncApi.of(portalPageContent.getContent())
+        );
+    }
+
     default io.gravitee.repository.management.model.PortalPageContent toRepository(PortalPageContent<?> portalPageContent) {
         String rawContent = switch (portalPageContent) {
             case GraviteeMarkdownPageContent gmd -> gmd.getContent().value();
             case OpenApiPageContent oapi -> oapi.getContent().value();
+            case AsyncApiPageContent aapi -> aapi.getContent().value();
         };
         return io.gravitee.repository.management.model.PortalPageContent.builder()
             .id(portalPageContent.getId().toString())
@@ -77,6 +92,7 @@ public interface PortalPageContentAdapter {
         return switch (type) {
             case GRAVITEE_MARKDOWN -> io.gravitee.repository.management.model.PortalPageContent.Type.GRAVITEE_MARKDOWN;
             case OPENAPI -> io.gravitee.repository.management.model.PortalPageContent.Type.OPENAPI;
+            case ASYNCAPI -> io.gravitee.repository.management.model.PortalPageContent.Type.ASYNCAPI;
         };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/adapter/DefaultAsyncApiProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_page/adapter/DefaultAsyncApiProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal_page.adapter;
+
+import io.gravitee.apim.core.async_api.AsyncApi;
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultAsyncApiProvider implements DefaultPortalPageContentProvider {
+
+    private final AsyncApi defaultAsyncApiContent;
+
+    public DefaultAsyncApiProvider() {
+        try {
+            final var resource = new ClassPathResource("templates/default-portal-asyncapi-page-content.yaml");
+            this.defaultAsyncApiContent = AsyncApi.of(resource.getContentAsString(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not load default AsyncAPI portal page template", e);
+        }
+    }
+
+    @Override
+    public boolean appliesTo(PortalPageContentType contentType) {
+        return contentType == PortalPageContentType.ASYNCAPI;
+    }
+
+    @Override
+    public PortalPageContent<?> provide(String organizationId, String environmentId) {
+        return new AsyncApiPageContent(PortalPageContentId.random(), organizationId, environmentId, defaultAsyncApiContent);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/default-portal-asyncapi-page-content.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/default-portal-asyncapi-page-content.yaml
@@ -1,0 +1,22 @@
+asyncapi: 3.0.0
+info:
+  title: Default AsyncAPI Page
+  version: 1.0.0
+  description: Default AsyncAPI page content
+channels:
+  user/signedup:
+    address: user/signedup
+    messages:
+      UserSignedUp:
+        payload:
+          type: object
+          properties:
+            userId:
+              type: string
+            email:
+              type: string
+operations:
+  onUserSignedUp:
+    action: receive
+    channel:
+      $ref: '#/channels/user~1signedup'

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalPageContentFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalPageContentFixtures.java
@@ -15,7 +15,9 @@
  */
 package fixtures.core.model;
 
+import io.gravitee.apim.core.async_api.AsyncApi;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
@@ -57,5 +59,23 @@ public class PortalPageContentFixtures {
 
     public static List<PortalPageContent<?>> samplePortalPageContents() {
         return List.of(aGraviteeMarkdownPageContent());
+    }
+
+    public static AsyncApiPageContent anAsyncApiPageContent() {
+        return new AsyncApiPageContent(
+            PortalPageContentId.of(CONTENT_ID),
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            new AsyncApi("asyncapi: '3.0.0'\ninfo:\n  title: Test")
+        );
+    }
+
+    public static AsyncApiPageContent anAsyncApiPageContent(
+        PortalPageContentId id,
+        String organizationId,
+        String environmentId,
+        String content
+    ) {
+        return new AsyncApiPageContent(id, organizationId, environmentId, new AsyncApi(content));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentCrudServiceInMemory.java
@@ -15,8 +15,10 @@
  */
 package inmemory;
 
+import io.gravitee.apim.core.async_api.AsyncApi;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
@@ -56,6 +58,7 @@ public class PortalPageContentCrudServiceInMemory implements InMemoryAlternative
         final var pageContentId = PortalPageContentId.random();
         PortalPageContent<?> portalPageContent = switch (contentType) {
             case OPENAPI -> OpenApiPageContent.create(organizationId, environmentId, "openapi: 3.0.3");
+            case ASYNCAPI -> AsyncApiPageContent.create(organizationId, environmentId, "asyncapi: '3.0.0'");
             case GRAVITEE_MARKDOWN -> new GraviteeMarkdownPageContent(
                 pageContentId,
                 organizationId,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/async_api/AsyncApiValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/async_api/AsyncApiValidatorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.async_api;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.apim.core.async_api.exception.AsyncApiContentEmptyException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AsyncApiValidatorTest {
+
+    private final AsyncApiValidator validator = new AsyncApiValidator();
+
+    @Nested
+    class ValidateNotEmpty {
+
+        @ParameterizedTest
+        @ValueSource(
+            strings = {
+                "asyncapi: '3.0.0'\ninfo:\n  title: Test", "asyncapi: '2.6.0'\ninfo:\n  title: Test", "  \n  asyncapi: '3.0.0'  \n  ",
+            }
+        )
+        void should_accept_valid_content(String validContent) {
+            assertThatCode(() -> validator.validateNotEmpty(new AsyncApi(validContent))).doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = { "   ", "  \n  \t  " })
+        void should_throw_exception_when_content_is_invalid(String invalidContent) {
+            assertThatThrownBy(() -> validator.validateNotEmpty(new AsyncApi(invalidContent)))
+                .isInstanceOf(AsyncApiContentEmptyException.class)
+                .hasMessage("Content must not be null or empty");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/AsyncApiPortalPageContentValidatorServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/AsyncApiPortalPageContentValidatorServiceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.apim.core.async_api.AsyncApiValidator;
+import io.gravitee.apim.core.async_api.exception.AsyncApiContentEmptyException;
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AsyncApiPortalPageContentValidatorServiceTest {
+
+    private AsyncApiValidator asyncApiValidator;
+    private AsyncApiPortalPageContentValidatorService validator;
+
+    @BeforeEach
+    void setUp() {
+        asyncApiValidator = new AsyncApiValidator();
+        validator = new AsyncApiPortalPageContentValidatorService(asyncApiValidator);
+    }
+
+    @Test
+    void should_apply_to_asyncapi_content() {
+        PortalPageContent<?> content = AsyncApiPageContent.create("org", "env", "asyncapi: '3.0.0'");
+        assertThat(validator.appliesTo(content)).isTrue();
+    }
+
+    @Test
+    void should_not_apply_to_gravitee_markdown_content() {
+        PortalPageContent<?> content = GraviteeMarkdownPageContent.create("org", "env", "content");
+        assertThat(validator.appliesTo(content)).isFalse();
+    }
+
+    @Test
+    void should_validate_asyncapi_content() {
+        PortalPageContent<?> content = GraviteeMarkdownPageContent.create("org", "env", "content");
+        UpdatePortalPageContent updateContent = UpdatePortalPageContent.builder().content("asyncapi: '3.0.0'").build();
+
+        assertThatCode(() -> validator.validate(content, updateContent)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_throw_when_content_is_empty() {
+        PortalPageContent<?> content = GraviteeMarkdownPageContent.create("org", "env", "content");
+        UpdatePortalPageContent updateContent = UpdatePortalPageContent.builder().content("").build();
+
+        assertThatThrownBy(() -> validator.validate(content, updateContent))
+            .isInstanceOf(AsyncApiContentEmptyException.class)
+            .hasMessage("Content must not be null or empty");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapterTest.java
@@ -17,7 +17,9 @@ package io.gravitee.apim.infra.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.gravitee.apim.core.async_api.AsyncApi;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
@@ -95,6 +97,27 @@ class PortalPageContentAdapterTest {
             assertThat(openApiContent.getId()).isEqualTo(PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440002"));
             assertThat(openApiContent.getContent().value()).isEqualTo("openapi: 3.0.0\ninfo:\n  title: Test API");
         }
+
+        @Test
+        void should_map_asyncapi_content_to_entity() {
+            // Given
+            var repositoryContent = io.gravitee.repository.management.model.PortalPageContent.builder()
+                .id("550e8400-e29b-41d4-a716-446655440003")
+                .organizationId("ORG")
+                .environmentId("ENV")
+                .type(io.gravitee.repository.management.model.PortalPageContent.Type.ASYNCAPI)
+                .content("asyncapi: '3.0.0'\ninfo:\n  title: Test API")
+                .build();
+
+            // When
+            var entity = adapter.toEntity(repositoryContent);
+
+            // Then
+            assertThat(entity).isInstanceOf(AsyncApiPageContent.class);
+            var asyncApiContent = (AsyncApiPageContent) entity;
+            assertThat(asyncApiContent.getId()).isEqualTo(PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440003"));
+            assertThat(asyncApiContent.getContent().value()).isEqualTo("asyncapi: '3.0.0'\ninfo:\n  title: Test API");
+        }
     }
 
     @Nested
@@ -115,6 +138,27 @@ class PortalPageContentAdapterTest {
 
             // Then
             assertThat(repositoryContent.getType()).isEqualTo(PortalPageContent.Type.GRAVITEE_MARKDOWN);
+            assertThat(repositoryContent.getId()).isEqualTo(entityContent.getId().toString());
+            assertThat(repositoryContent.getOrganizationId()).isEqualTo("DEFAULT_ORG");
+            assertThat(repositoryContent.getEnvironmentId()).isEqualTo("DEFAULT_ENV");
+            assertThat(repositoryContent.getContent()).isEqualTo(entityContent.getContent().value());
+        }
+
+        @Test
+        void should_map_asyncapi_content_to_repository() {
+            // Given
+            final var entityContent = new AsyncApiPageContent(
+                PortalPageContentId.of("550e8400-e29b-41d4-a716-446655440003"),
+                "DEFAULT_ORG",
+                "DEFAULT_ENV",
+                new AsyncApi("asyncapi: '3.0.0'\ninfo:\n  title: Test")
+            );
+
+            // When
+            var repositoryContent = adapter.toRepository(entityContent);
+
+            // Then
+            assertThat(repositoryContent.getType()).isEqualTo(PortalPageContent.Type.ASYNCAPI);
             assertThat(repositoryContent.getId()).isEqualTo(entityContent.getId().toString());
             assertThat(repositoryContent.getOrganizationId()).isEqualTo("DEFAULT_ORG");
             assertThat(repositoryContent.getEnvironmentId()).isEqualTo("DEFAULT_ENV");


### PR DESCRIPTION
Adds backend support for AsyncAPI documentation pages in portal navigation ([EXT-124](https://gravitee.atlassian.net/browse/EXT-124)).

Introduces AsyncApi value object and AsyncApiContentEmptyException
AsyncApiValidator enforcing non-empty content
AsyncApiPageContent sealed-class entry with full adapter/mapper support — wires into PortalPageContent, PortalPageContentType, PortalPageContentAdapter, and PortalPageContentMapper
AsyncApiPortalPageContentValidatorService delegating to AsyncApiValidator
DefaultAsyncApiProvider seeding new ASYNCAPI pages with a minimal AsyncAPI 3.0 starter template
PortalNavigationItemMapper and both OpenAPI specs updated to recognise the ASYNCAPI content type


[EXT-124]: https://gravitee.atlassian.net/browse/EXT-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ