### PR TITLE
feat(rest-api): reflect sanitized flows on v4 dry-run PATCH

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
@@ -79,34 +79,32 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
             : original.getVisibility();
         var sanitizedDefinition = originalDefinition
             .toBuilder()
-            .tags(sanitized.getTags() != null ? sanitized.getTags() : originalDefinition.getTags())
-            .flows(sanitized.getFlows() != null ? sanitized.getFlows() : originalDefinition.getFlows())
-            .analytics(sanitized.getAnalytics() != null ? sanitized.getAnalytics() : originalDefinition.getAnalytics())
-            .failover(sanitized.getFailover() != null ? sanitized.getFailover() : originalDefinition.getFailover())
-            .flowExecution(sanitized.getFlowExecution() != null ? sanitized.getFlowExecution() : originalDefinition.getFlowExecution())
-            .services(sanitized.getServices() != null ? sanitized.getServices() : originalDefinition.getServices())
-            .allowedInApiProducts(
-                sanitized.getAllowedInApiProducts() != null
-                    ? sanitized.getAllowedInApiProducts()
-                    : originalDefinition.getAllowedInApiProducts()
-            )
-            .responseTemplates(
-                sanitized.getResponseTemplates() != null ? sanitized.getResponseTemplates() : originalDefinition.getResponseTemplates()
-            )
+            .tags(coalesce(sanitized.getTags(), originalDefinition.getTags()))
+            .flows(coalesce(sanitized.getFlows(), originalDefinition.getFlows()))
+            .analytics(coalesce(sanitized.getAnalytics(), originalDefinition.getAnalytics()))
+            .failover(coalesce(sanitized.getFailover(), originalDefinition.getFailover()))
+            .flowExecution(coalesce(sanitized.getFlowExecution(), originalDefinition.getFlowExecution()))
+            .services(coalesce(sanitized.getServices(), originalDefinition.getServices()))
+            .allowedInApiProducts(coalesce(sanitized.getAllowedInApiProducts(), originalDefinition.getAllowedInApiProducts()))
+            .responseTemplates(coalesce(sanitized.getResponseTemplates(), originalDefinition.getResponseTemplates()))
             .build();
         return original
             .toBuilder()
-            .name(sanitized.getName() != null ? sanitized.getName() : original.getName())
-            .description(sanitized.getDescription() != null ? sanitized.getDescription() : original.getDescription())
-            .version(sanitized.getApiVersion() != null ? sanitized.getApiVersion() : original.getVersion())
+            .name(coalesce(sanitized.getName(), original.getName()))
+            .description(coalesce(sanitized.getDescription(), original.getDescription()))
+            .version(coalesce(sanitized.getApiVersion(), original.getVersion()))
             .visibility(sanitizedVisibility)
             .apiLifecycleState(sanitizedLifecycle)
-            .labels(sanitized.getLabels() != null ? sanitized.getLabels() : original.getLabels())
-            .categories(sanitized.getCategories() != null ? sanitized.getCategories() : original.getCategories())
-            .groups(sanitized.getGroups() != null ? sanitized.getGroups() : original.getGroups())
+            .labels(coalesce(sanitized.getLabels(), original.getLabels()))
+            .categories(coalesce(sanitized.getCategories(), original.getCategories()))
+            .groups(coalesce(sanitized.getGroups(), original.getGroups()))
             .allowMultiJwtOauth2Subscriptions(sanitized.isAllowMultiJwtOauth2Subscriptions())
             .disableMembershipNotifications(sanitized.isDisableMembershipNotifications())
             .apiDefinitionValue(sanitizedDefinition)
             .build();
+    }
+
+    private static <T> T coalesce(T sanitized, T original) {
+        return sanitized != null ? sanitized : original;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
@@ -80,6 +80,7 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
         var sanitizedDefinition = originalDefinition
             .toBuilder()
             .tags(sanitized.getTags() != null ? sanitized.getTags() : originalDefinition.getTags())
+            .flows(sanitized.getFlows() != null ? sanitized.getFlows() : originalDefinition.getFlows())
             .analytics(sanitized.getAnalytics() != null ? sanitized.getAnalytics() : originalDefinition.getAnalytics())
             .failover(sanitized.getFailover() != null ? sanitized.getFailover() : originalDefinition.getFailover())
             .flowExecution(sanitized.getFlowExecution() != null ? sanitized.getFlowExecution() : originalDefinition.getFlowExecution())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
@@ -240,6 +240,18 @@ class UpdateApiDomainServiceImplTest {
     }
 
     @Test
+    void should_return_null_flows_when_erased_definition_has_null_flows() {
+        var erasedDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().flows(null).build();
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(erasedDefinition).build();
+        stubValidate(entity -> entity.setFlows(null));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getFlows()).isNull();
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
     void should_preserve_original_allowed_in_api_products_when_validator_returns_null() {
         var originalDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().allowedInApiProducts(true).build();
         var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
@@ -17,8 +17,11 @@ package io.gravitee.apim.infra.domain_service.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.AuditInfoFixtures;
@@ -28,11 +31,13 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.failover.Failover;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.service.v4.ApiService;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -207,6 +212,31 @@ class UpdateApiDomainServiceImplTest {
         var result = cut.validateV4(api, auditInfo);
 
         assertThat(result.getApiDefinitionHttpV4().getResponseTemplates()).isEqualTo(sanitizedResponseTemplates);
+    }
+
+    @Test
+    void should_return_sanitized_flows_from_mutated_update_api_entity() {
+        var api = ApiFixtures.aProxyApiV4();
+        var sanitizedFlows = List.of(new Flow());
+        stubValidate(entity -> entity.setFlows(sanitizedFlows));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getFlows()).isEqualTo(sanitizedFlows);
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_preserve_original_flows_when_validator_returns_null() {
+        var originalFlows = List.of(new Flow());
+        var originalDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().flows(originalFlows).build();
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
+        stubValidate(entity -> entity.setFlows(null));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getFlows()).isEqualTo(originalFlows);
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
     @Test


### PR DESCRIPTION
## Issue

[APIM-13982](https://gravitee.atlassian.net/browse/APIM-13982) — Dry-run fidelity for flows.

## Why

`PATCH /apis/{apiId}?dryRun=true` on a v4 HTTP Proxy API currently echoes the caller's raw `flows` payload even when the validator would have sanitized parts of it on a real save. Callers who rely on the dry-run to preview the saved state therefore see a body the server would never actually persist. This change is the dry-run mirror of the parent epic's PATCH allow-list extension (APIM-12244 / APIM-13981) so the preview matches what a real PUT would have written.

## What changed

- **`UpdateApiDomainServiceImpl.applySanitizedValues`** — added a single `.flows(sanitized.getFlows() != null ? sanitized.getFlows() : originalDefinition.getFlows())` line to the rebuild chain (`gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java:83`). Same null-fallback shape as the surrounding `tags` / `analytics` / `groups` / `lifecycleState` lines from PR #16453. Direct domain assignment — no mapper call, since `UpdateApiEntity.flows` is already `List<Flow>`.
- **`UpdateApiDomainServiceImplTest`** — two new unit tests using the existing `stubValidate` helper (no Spring/Jersey stack, no policy-plugin dependency):
  - `should_return_sanitized_flows_from_mutated_update_api_entity` — verifies the validator's mutated `flows` are projected onto the returned `Api`.
  - `should_preserve_original_flows_when_validator_returns_null` — explicitly seeds a non-empty `flows` list (overriding `aProxyApiV4()`'s `List.of()` default so the assertion is non-vacuous), then asserts the null-fallback to the original definition.
  - Both tests include `verify(delegate, never()).update(...)` to make the no-persistence guarantee testable.

Scope is strict: only `flows` is added to the copy-back chain. `endpointGroups`, `listeners`, and `resources` are out of scope and owned by APIM-13946 / APIM-13947 / APIM-13948.

## User-facing impact

- **Behaviour change.** A v4 HTTP Proxy `PATCH /apis/{apiId}?dryRun=true` request that includes `flows` will now return the validator-sanitized `flows` in the response body instead of the caller's raw payload. Nothing is persisted.
- **No breaking change.** Existing PATCH dry-run behaviour for `tags` / `analytics` / `groups` / `lifecycleState` / other already-copied-back fields is unchanged.
- **Documentation.** The mAPI v2 reference note about dry-run reflecting sanitized `flows` is tracked as a separate follow-up — the doc lives outside this Java repository.

## How to test

- Unit tests: `mvnd test -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service -am -Dskip.validation -Dtest=UpdateApiDomainServiceImplTest -Dsurefire.failIfNoSpecifiedTests=false` — 16 tests pass, including the two new `should_*_flows_*` cases.
- Manual API check: send `PATCH /management/v2/environments/{envId}/apis/{apiId}?dryRun=true` on a v4 HTTP Proxy API with a `flows` payload that the validator normalizes (e.g. a condition expression with surrounding whitespace). Assert the response body's `flows` reflect the normalized form. Then `GET /apis/{apiId}` and confirm the persisted resource is unchanged.

## Known Issues

- AC-7 (no new DB queries / audits / logs) is satisfied by construction — the change is a single in-memory builder line in `applySanitizedValues`. No dedicated executable assertion was added; the `verify(delegate, never()).update(...)` clauses on both tests cover the persistence side implicitly.

[APIM-13982]: https://gravitee.atlassian.net/browse/APIM-13982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ