### PR TITLE
feat(console): native api runtime logs page

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/index.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-export * from './apiLogsResponse';
-export * from './apiLogsResponse.fixture';
-export * from './connectionLog';
-export * from './connectionLog.fixture';
-export * from './messageLog';
-export * from './messageLog.fixture';
-export * from './native';
+export * from './nativeApiLog';
+export * from './nativeApiLog.fixture';
+export * from './nativeApiLogsResponse';
+export * from './nativeApiLogsResponse.fixture';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLog.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLog.fixture.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isFunction } from 'lodash';
+
+import { NativeApiLog } from './nativeApiLog';
+
+export function fakeNativeApiLog(modifier?: Partial<NativeApiLog> | ((base: NativeApiLog) => NativeApiLog)): NativeApiLog {
+  const base: NativeApiLog = {
+    timestamp: '2026-01-01T00:00:00.000Z',
+    apiId: '117e79a3-6023-4b72-be79-a36023ab72f9',
+    requestId: 'aee23b1e-34b1-4551-a23b-1e34b165516a',
+    transactionId: 'tx-aee23b1e-34b1-4551-a23b-1e34b165516a',
+    applicationId: 'app-fc1bff13-6e25-4c4c-9bff-136e251c4cdf',
+    planId: 'plan-a30f6fab-be08-4717-8f6f-abbe089717b1',
+    clientIdentifier: 'kafka-client-1',
+    subscriptionId: 'sub-b94e0b4a-a92b-46ba-8e0b-4aa92b06ba7d',
+    entrypointId: 'native-kafka',
+    gateway: 'gateway-instance-1',
+    remoteAddress: '10.0.0.1',
+    localAddress: '10.0.0.2',
+    host: 'kafka.example.com',
+    connectionStatus: 'CONNECTED',
+    connectionDurationMs: 4200,
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLog.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLog.ts
@@ -14,10 +14,26 @@
  * limitations under the License.
  */
 
-export * from './apiLogsResponse';
-export * from './apiLogsResponse.fixture';
-export * from './connectionLog';
-export * from './connectionLog.fixture';
-export * from './messageLog';
-export * from './messageLog.fixture';
-export * from './native';
+export type NativeConnectionStatus = 'CONNECTED' | 'CONNECTION_ERROR' | 'SESSION_ERROR' | 'INTERNAL_ERROR';
+
+export interface NativeApiLog {
+  timestamp?: string;
+  apiId?: string;
+  requestId?: string;
+  transactionId?: string;
+  applicationId?: string;
+  planId?: string;
+  clientIdentifier?: string;
+  subscriptionId?: string;
+  entrypointId?: string;
+  gateway?: string;
+  remoteAddress?: string;
+  localAddress?: string;
+  host?: string;
+  errorKey?: string;
+  errorMessage?: string;
+  connectionStatus?: NativeConnectionStatus;
+  clientId?: string;
+  brokerId?: string;
+  connectionDurationMs?: number;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLogsResponse.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLogsResponse.fixture.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isFunction } from 'lodash';
+
+import { NativeApiLogsResponse } from './nativeApiLogsResponse';
+import { fakeNativeApiLog } from './nativeApiLog.fixture';
+
+export function fakeNativeApiLogsResponse(
+  modifier?: Partial<NativeApiLogsResponse> | ((base: NativeApiLogsResponse) => NativeApiLogsResponse),
+): NativeApiLogsResponse {
+  const base: NativeApiLogsResponse = {
+    data: [fakeNativeApiLog()],
+    pagination: {
+      totalCount: 1,
+      page: 1,
+      pageCount: 1,
+      pageItemsCount: 1,
+      perPage: 10,
+    },
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+
+export function fakeEmptyNativeApiLogsResponse(): NativeApiLogsResponse {
+  return {
+    data: [],
+    pagination: {},
+    links: { self: 'self' },
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLogsResponse.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLogsResponse.ts
@@ -14,10 +14,23 @@
  * limitations under the License.
  */
 
-export * from './apiLogsResponse';
-export * from './apiLogsResponse.fixture';
-export * from './connectionLog';
-export * from './connectionLog.fixture';
-export * from './messageLog';
-export * from './messageLog.fixture';
-export * from './native';
+import { NativeApiLog } from './nativeApiLog';
+
+import { Links } from '../../links';
+import { Pagination } from '../../pagination';
+
+export interface NativeApiLogsParam {
+  page?: number;
+  perPage?: number;
+  from?: number;
+  to?: number;
+  applicationIds?: string;
+  planIds?: string;
+  connectionStatuses?: string;
+}
+
+export interface NativeApiLogsResponse {
+  data?: NativeApiLog[];
+  pagination?: Pagination;
+  links?: Links;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLogsSummary.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLogsSummary.fixture.ts
@@ -13,10 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { isFunction } from 'lodash';
 
-export * from './nativeApiLog';
-export * from './nativeApiLog.fixture';
-export * from './nativeApiLogsResponse';
-export * from './nativeApiLogsResponse.fixture';
-export * from './nativeApiLogsSummary';
-export * from './nativeApiLogsSummary.fixture';
+import { NativeApiLogsSummary } from './nativeApiLogsSummary';
+
+export function fakeNativeApiLogsSummary(
+  modifier?: Partial<NativeApiLogsSummary> | ((base: NativeApiLogsSummary) => NativeApiLogsSummary),
+): NativeApiLogsSummary {
+  const base: NativeApiLogsSummary = {
+    countByConnectionStatus: {
+      CONNECTED: 184,
+      SESSION_ERROR: 32,
+      CONNECTION_ERROR: 28,
+      INTERNAL_ERROR: 4,
+    },
+  };
+
+  if (isFunction(modifier)) return modifier(base);
+  return { ...base, ...modifier };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLogsSummary.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/log/native/nativeApiLogsSummary.ts
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { NativeConnectionStatus } from './nativeApiLog';
 
-export * from './nativeApiLog';
-export * from './nativeApiLog.fixture';
-export * from './nativeApiLogsResponse';
-export * from './nativeApiLogsResponse.fixture';
-export * from './nativeApiLogsSummary';
-export * from './nativeApiLogsSummary.fixture';
+export interface NativeApiLogsSummary {
+  countByConnectionStatus: Partial<Record<NativeConnectionStatus, number>>;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.spec.ts
@@ -114,4 +114,27 @@ describe('ApiV4MenuService', () => {
 
     expect(menu.subMenuItems.some(item => item.displayName === 'Webhooks')).toBe(false);
   });
+
+  describe('Logs menu for NATIVE API', () => {
+    it('should include Logs menu pointing to v4/runtime-logs-native when user has api-native_log-r permission', () => {
+      TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: ['api-native_log-r'] });
+      service = TestBed.inject(ApiV4MenuService);
+
+      const api = fakeApiV4({ type: 'NATIVE' });
+      const menu = service.getMenu(api);
+
+      const logsEntry = menu.subMenuItems.find(item => item.displayName === 'Logs');
+      expect(logsEntry).toBeDefined();
+      expect(logsEntry.routerLink).toBe('v4/runtime-logs-native');
+    });
+
+    it('should not include Logs menu for NATIVE API when user has only api-log-r permission', () => {
+      service = TestBed.inject(ApiV4MenuService);
+
+      const api = fakeApiV4({ type: 'NATIVE' });
+      const menu = service.getMenu(api);
+
+      expect(menu.subMenuItems.some(item => item.displayName === 'Logs')).toBe(false);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -52,7 +52,7 @@ export class ApiV4MenuService implements ApiMenuService {
       this.addDocumentationMenuEntry(api),
       this.addDeploymentMenuEntry(),
       this.addApiTrafficMenuEntry(hasTcpListeners, api.type),
-      ...(api.type !== 'NATIVE' ? [this.addLogs(hasTcpListeners)] : []),
+      ...(api.type === 'NATIVE' ? [this.addNativeLogs()] : [this.addLogs(hasTcpListeners)]),
       ...(webhooksMenuEntry ? [webhooksMenuEntry] : []),
       ...(api.type !== 'NATIVE' ? [this.addApiRuntimeAlertsMenuEntry()] : []),
       ...(api.type !== 'LLM_PROXY' ? this.addAlertsMenuEntry() : []),
@@ -400,6 +400,17 @@ export class ApiV4MenuService implements ApiMenuService {
         displayName: 'Logs',
         icon: 'align-justify',
         routerLink: hasTcpListeners ? 'DISABLED' : 'v4/runtime-logs',
+      };
+    }
+    return null;
+  }
+
+  private addNativeLogs(): MenuItem | null {
+    if (this.permissionService.hasAnyMatching(['api-native_log-r'])) {
+      return {
+        displayName: 'Logs',
+        icon: 'align-justify',
+        routerLink: 'v4/runtime-logs-native',
       };
     }
     return null;

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/api-traffic-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/api-traffic-v4.module.ts
@@ -17,11 +17,19 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { ApiRuntimeLogsModule } from './runtime-logs/api-runtime-logs.module';
+import { ApiRuntimeLogsNativeComponent } from './runtime-logs-native/api-runtime-logs-native.component';
 import { ApiRuntimeLogsDetailsModule } from './runtime-logs-details/api-runtime-logs-details.module';
 import { WebhookLogsComponent } from './webhook-logs/webhook-logs.component';
 import { WebhookLogsDetailsComponent } from './webhook-logs-details/webhook-logs-details.component';
 
 @NgModule({
-  imports: [CommonModule, ApiRuntimeLogsModule, ApiRuntimeLogsDetailsModule, WebhookLogsComponent, WebhookLogsDetailsComponent],
+  imports: [
+    CommonModule,
+    ApiRuntimeLogsModule,
+    ApiRuntimeLogsNativeComponent,
+    ApiRuntimeLogsDetailsModule,
+    WebhookLogsComponent,
+    WebhookLogsDetailsComponent,
+  ],
 })
 export class ApiTrafficV4Module {}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/api-traffic-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/api-traffic-v4.module.ts
@@ -18,6 +18,7 @@ import { NgModule } from '@angular/core';
 
 import { ApiRuntimeLogsModule } from './runtime-logs/api-runtime-logs.module';
 import { ApiRuntimeLogsNativeComponent } from './runtime-logs-native/api-runtime-logs-native.component';
+import { ApiRuntimeLogsNativeDetailsComponent } from './runtime-logs-native-details/api-runtime-logs-native-details.component';
 import { ApiRuntimeLogsDetailsModule } from './runtime-logs-details/api-runtime-logs-details.module';
 import { WebhookLogsComponent } from './webhook-logs/webhook-logs.component';
 import { WebhookLogsDetailsComponent } from './webhook-logs-details/webhook-logs-details.component';
@@ -27,6 +28,7 @@ import { WebhookLogsDetailsComponent } from './webhook-logs-details/webhook-logs
     CommonModule,
     ApiRuntimeLogsModule,
     ApiRuntimeLogsNativeComponent,
+    ApiRuntimeLogsNativeDetailsComponent,
     ApiRuntimeLogsDetailsModule,
     WebhookLogsComponent,
     WebhookLogsDetailsComponent,

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.harness.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ApiRuntimeLogsNativeDetailsHarness extends ComponentHarness {
+  static hostSelector = 'api-runtime-logs-native-details';
+
+  private readonly notFoundBanner = this.locatorForOptional('[data-testid=native_log_not_found]');
+  private readonly loadFailedBanner = this.locatorForOptional('[data-testid=native_log_load_failed]');
+  private readonly title = this.locatorForOptional('[data-testid=native_log_title]');
+  private readonly connectionCard = this.locatorForOptional('[data-testid=native_log_connection_card]');
+  private readonly clientCard = this.locatorForOptional('[data-testid=native_log_client_card]');
+  private readonly serverCard = this.locatorForOptional('[data-testid=native_log_server_card]');
+  private readonly errorCard = this.locatorForOptional('[data-testid=native_log_error_card]');
+  private readonly backLink = this.locatorForOptional('[data-testid=native_log_back]');
+
+  isNotFoundBannerVisible(): Promise<boolean> {
+    return this.notFoundBanner().then(el => el != null);
+  }
+
+  isLoadFailedBannerVisible(): Promise<boolean> {
+    return this.loadFailedBanner().then(el => el != null);
+  }
+
+  isTitleVisible(): Promise<boolean> {
+    return this.title().then(el => el != null);
+  }
+
+  isConnectionCardVisible(): Promise<boolean> {
+    return this.connectionCard().then(el => el != null);
+  }
+
+  isClientCardVisible(): Promise<boolean> {
+    return this.clientCard().then(el => el != null);
+  }
+
+  isServerCardVisible(): Promise<boolean> {
+    return this.serverCard().then(el => el != null);
+  }
+
+  isErrorCardVisible(): Promise<boolean> {
+    return this.errorCard().then(el => el != null);
+  }
+
+  isBackLinkVisible(): Promise<boolean> {
+    return this.backLink().then(el => el != null);
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.html
@@ -1,0 +1,116 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="details-page">
+  <a class="back-link" [routerLink]="['..']" [queryParams]="backQueryParams" data-testid="native_log_back">
+    <mat-icon svgIcon="gio:arrow-left"></mat-icon>Back to Connection Logs
+  </a>
+
+  @if (state$ | async; as state) {
+    @if (state.kind === 'not-found') {
+      <gio-banner-error data-testid="native_log_not_found">
+        Log not found
+        <div gioBannerBody>
+          No log was found for request id <strong>{{ requestId }}</strong> within the selected time window. The window may be outside the
+          configured retention.
+        </div>
+      </gio-banner-error>
+    } @else if (state.kind === 'load-failed') {
+      <gio-banner-error data-testid="native_log_load_failed">
+        Failed to load connection log
+        <div gioBannerBody>
+          An unexpected error occurred while loading the log for request id <strong>{{ requestId }}</strong
+          >.
+        </div>
+      </gio-banner-error>
+    } @else {
+      <h1 class="title" data-testid="native_log_title">Connection detail</h1>
+
+      <div class="cards">
+        <mat-card appearance="outlined" class="card" data-testid="native_log_connection_card">
+          <h2 class="card__title">Connection</h2>
+          <dl class="card__list">
+            <dt>Timestamp</dt>
+            <dd>{{ state.log.timestamp | date: 'yyyy-MM-dd HH:mm:ss.SSS' }}</dd>
+            <dt>API id</dt>
+            <dd>{{ state.log.apiId || '—' }}</dd>
+            <dt>Transaction id</dt>
+            <dd>{{ state.log.transactionId || '—' }}</dd>
+            <dt>Request id</dt>
+            <dd>{{ state.log.requestId || '—' }}</dd>
+            <dt>Status</dt>
+            <dd>
+              @if (state.log.connectionStatus && statusMeta[state.log.connectionStatus]; as meta) {
+                <span [class]="meta.badgeClass"> <mat-icon [svgIcon]="meta.icon"></mat-icon>&nbsp;{{ meta.label }} </span>
+              } @else {
+                —
+              }
+            </dd>
+            <dt>Duration</dt>
+            <dd>{{ state.log.connectionDurationMs != null ? (state.log.connectionDurationMs | formatDuration) : '—' }}</dd>
+          </dl>
+        </mat-card>
+
+        <mat-card appearance="outlined" class="card" data-testid="native_log_client_card">
+          <h2 class="card__title">Client</h2>
+          <dl class="card__list">
+            <dt>Application id</dt>
+            <dd>{{ state.log.applicationId || '—' }}</dd>
+            <dt>Plan id</dt>
+            <dd>{{ state.log.planId || '—' }}</dd>
+            <dt>Subscription id</dt>
+            <dd>{{ state.log.subscriptionId || '—' }}</dd>
+            <dt>Client identifier</dt>
+            <dd>{{ state.log.clientIdentifier || '—' }}</dd>
+            <dt>Client id</dt>
+            <dd>{{ state.log.clientId || '—' }}</dd>
+            <dt>Remote address</dt>
+            <dd>{{ state.log.remoteAddress || '—' }}</dd>
+          </dl>
+        </mat-card>
+
+        <mat-card appearance="outlined" class="card" data-testid="native_log_server_card">
+          <h2 class="card__title">Server</h2>
+          <dl class="card__list">
+            <dt>Gateway</dt>
+            <dd>{{ state.log.gateway || '—' }}</dd>
+            <dt>Entrypoint id</dt>
+            <dd>{{ state.log.entrypointId || '—' }}</dd>
+            <dt>Local address</dt>
+            <dd>{{ state.log.localAddress || '—' }}</dd>
+            <dt>Host</dt>
+            <dd>{{ state.log.host || '—' }}</dd>
+            <dt>Broker id</dt>
+            <dd>{{ state.log.brokerId || '—' }}</dd>
+          </dl>
+        </mat-card>
+
+        @if (isErrored(state.log.connectionStatus)) {
+          <mat-card appearance="outlined" class="card card--error" data-testid="native_log_error_card">
+            <h2 class="card__title card__title--error"><mat-icon svgIcon="gio:alert-circle"></mat-icon>Error details</h2>
+            <dl class="card__list">
+              <dt>Error key</dt>
+              <dd>{{ state.log.errorKey || '—' }}</dd>
+              <dt>Error message</dt>
+              <dd>{{ state.log.errorMessage || '—' }}</dd>
+            </dl>
+          </mat-card>
+        }
+      </div>
+    }
+  }
+</div>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.scss
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$foreground: map.get(gio.$mat-theme, foreground);
+$typography: map.get(gio.$mat-theme, typography);
+
+:host {
+  display: block;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 8px;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.title {
+  @include mat.m2-typography-level($typography, headline-6);
+  margin: 0 0 12px 0;
+}
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card {
+  padding: 16px 20px;
+}
+
+.card__title {
+  @include mat.m2-typography-level($typography, subtitle-2);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 12px 0;
+}
+
+.card__title.card__title--error,
+.card__title.card__title--error mat-icon {
+  color: mat.m2-get-color-from-palette(gio.$mat-error-palette, default);
+}
+
+.card__list {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 16px;
+  row-gap: 8px;
+  margin: 0;
+
+  dt {
+    margin: 0;
+    color: mat.m2-get-color-from-palette($foreground, secondary-text);
+  }
+
+  dd {
+    margin: 0;
+    word-break: break-all;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.spec.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ActivatedRoute } from '@angular/router';
+
+import { ApiRuntimeLogsNativeDetailsComponent } from './api-runtime-logs-native-details.component';
+import { ApiRuntimeLogsNativeDetailsHarness } from './api-runtime-logs-native-details.component.harness';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import { fakeNativeApiLog, NativeApiLog } from '../../../../entities/management-api-v2';
+
+describe('ApiRuntimeLogsNativeDetailsComponent', () => {
+  let fixture: ComponentFixture<ApiRuntimeLogsNativeDetailsComponent>;
+  let httpTestingController: HttpTestingController;
+  let harness: ApiRuntimeLogsNativeDetailsHarness;
+
+  const API_ID = 'api-1';
+  const REQUEST_ID = 'req-1';
+
+  const setup = async (queryParams: Record<string, string> = { from: '1000', to: '2000' }) => {
+    TestBed.configureTestingModule({
+      imports: [ApiRuntimeLogsNativeDetailsComponent, MatIconTestingModule, GioTestingModule],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID, requestId: REQUEST_ID }, queryParams } } },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        provideAnimationsAsync('noop'),
+      ],
+    });
+    fixture = TestBed.createComponent(ApiRuntimeLogsNativeDetailsComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiRuntimeLogsNativeDetailsHarness);
+  };
+
+  const flushLog = (log: NativeApiLog) =>
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/${REQUEST_ID}?from=1000&to=2000`)
+      .flush(log);
+
+  const errorLog = (status = 404, statusText = 'Not Found') =>
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/${REQUEST_ID}?from=1000&to=2000`)
+      .error(new ProgressEvent(statusText), { status, statusText });
+
+  afterEach(() => {
+    httpTestingController?.verify();
+  });
+
+  it('renders title + connection + client + server cards on a successful CONNECTED log', async () => {
+    await setup();
+    flushLog(fakeNativeApiLog({ connectionStatus: 'CONNECTED', clientId: 'kafka-consumer-1', brokerId: '0' }));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.isTitleVisible()).toBe(true);
+    expect(await harness.isConnectionCardVisible()).toBe(true);
+    expect(await harness.isClientCardVisible()).toBe(true);
+    expect(await harness.isServerCardVisible()).toBe(true);
+    expect(await harness.isErrorCardVisible()).toBe(false);
+  });
+
+  it('renders error card when connectionStatus is not CONNECTED', async () => {
+    await setup();
+    flushLog(
+      fakeNativeApiLog({
+        connectionStatus: 'CONNECTION_ERROR',
+        errorKey: 'AUTH_FAILED',
+        errorMessage: 'SASL handshake failed: invalid credentials',
+      }),
+    );
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.isErrorCardVisible()).toBe(true);
+    const errorCard: HTMLElement = fixture.nativeElement.querySelector('[data-testid=native_log_error_card]');
+    expect(errorCard.textContent).toContain('AUTH_FAILED');
+    expect(errorCard.textContent).toContain('SASL handshake failed: invalid credentials');
+  });
+
+  it('hides the error card when status is CONNECTED', async () => {
+    await setup();
+    flushLog(fakeNativeApiLog({ connectionStatus: 'CONNECTED' }));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.isErrorCardVisible()).toBe(false);
+  });
+
+  it('renders the not-found banner and keeps the back link visible when the endpoint returns 404', async () => {
+    await setup();
+    errorLog(404, 'Not Found');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.isNotFoundBannerVisible()).toBe(true);
+    expect(await harness.isLoadFailedBannerVisible()).toBe(false);
+    expect(await harness.isTitleVisible()).toBe(false);
+    expect(await harness.isBackLinkVisible()).toBe(true);
+  });
+
+  it('renders the load-failed banner (not the not-found banner) on non-404 errors', async () => {
+    await setup();
+    errorLog(500, 'Internal Server Error');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.isLoadFailedBannerVisible()).toBe(true);
+    expect(await harness.isNotFoundBannerVisible()).toBe(false);
+    expect(await harness.isBackLinkVisible()).toBe(true);
+  });
+
+  it('renders the load-failed banner without firing an HTTP call when from/to query params are missing', async () => {
+    await setup({});
+    httpTestingController.expectNone(req => req.url.includes(`/logs/native/${REQUEST_ID}`));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.isLoadFailedBannerVisible()).toBe(true);
+    expect(await harness.isNotFoundBannerVisible()).toBe(false);
+    expect(await harness.isBackLinkVisible()).toBe(true);
+  });
+
+  it('renders a dash for Duration in the connection card when connectionDurationMs is null', async () => {
+    await setup();
+    flushLog(fakeNativeApiLog({ connectionDurationMs: undefined }));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const card: HTMLElement = fixture.nativeElement.querySelector('[data-testid=native_log_connection_card]');
+    expect(card.textContent).toContain('Duration');
+    expect(card.textContent).toContain('—');
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.stories.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { of, throwError } from 'rxjs';
+import { ActivatedRoute } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+
+import { ApiRuntimeLogsNativeDetailsComponent } from './api-runtime-logs-native-details.component';
+
+import { ApiNativeLogsV2Service } from '../../../../services-ngx/api-native-logs-v2.service';
+import { fakeNativeApiLog, NativeApiLog } from '../../../../entities/management-api-v2';
+
+const activatedRoute = {
+  snapshot: {
+    params: { apiId: 'api-native-demo', requestId: 'req-demo' },
+    queryParams: { from: '1000', to: '2000', period: '1h' },
+  },
+};
+
+const stubService = (log: NativeApiLog | null | HttpErrorResponse) =>
+  ({
+    getConnectionLog: () =>
+      log instanceof HttpErrorResponse || log == null
+        ? throwError(() => log ?? new HttpErrorResponse({ status: 404, statusText: 'Not Found' }))
+        : of(log),
+  }) as unknown as ApiNativeLogsV2Service;
+
+const meta: Meta<ApiRuntimeLogsNativeDetailsComponent> = {
+  title: 'API / Logs / Native / Details',
+  component: ApiRuntimeLogsNativeDetailsComponent,
+  decorators: [moduleMetadata({ imports: [ApiRuntimeLogsNativeDetailsComponent] })],
+  parameters: { layout: 'padded' },
+  render: () => ({
+    template: `
+      <div style="min-width: 960px; padding: 24px; background-color: #f4f6fb;">
+        <api-runtime-logs-native-details />
+      </div>
+    `,
+  }),
+};
+
+export default meta;
+
+export const Connected: StoryObj<ApiRuntimeLogsNativeDetailsComponent> = {
+  decorators: [
+    moduleMetadata({
+      providers: [
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        {
+          provide: ApiNativeLogsV2Service,
+          useValue: stubService(fakeNativeApiLog({ connectionStatus: 'CONNECTED', clientId: 'kafka-consumer-1', brokerId: '0' })),
+        },
+      ],
+    }),
+  ],
+};
+
+export const ConnectionError: StoryObj<ApiRuntimeLogsNativeDetailsComponent> = {
+  decorators: [
+    moduleMetadata({
+      providers: [
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        {
+          provide: ApiNativeLogsV2Service,
+          useValue: stubService(
+            fakeNativeApiLog({
+              connectionStatus: 'CONNECTION_ERROR',
+              errorKey: 'AUTH_FAILED',
+              errorMessage: 'SASL handshake failed: invalid credentials',
+            }),
+          ),
+        },
+      ],
+    }),
+  ],
+};
+
+export const NotFound: StoryObj<ApiRuntimeLogsNativeDetailsComponent> = {
+  decorators: [
+    moduleMetadata({
+      providers: [
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        { provide: ApiNativeLogsV2Service, useValue: stubService(null) },
+      ],
+    }),
+  ],
+};
+
+export const LoadFailed: StoryObj<ApiRuntimeLogsNativeDetailsComponent> = {
+  decorators: [
+    moduleMetadata({
+      providers: [
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        {
+          provide: ApiNativeLogsV2Service,
+          useValue: stubService(new HttpErrorResponse({ status: 500, statusText: 'Internal Server Error' })),
+        },
+      ],
+    }),
+  ],
+};

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, inject } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { AsyncPipe, DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { GioBannerModule, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+import { NATIVE_STATUS_META, isNativeConnectionErrored } from '../runtime-logs-native/api-runtime-logs-native.models';
+import { ApiNativeLogsV2Service } from '../../../../services-ngx/api-native-logs-v2.service';
+import { FormatDurationPipe } from '../../../../shared/pipes/format-duration.pipe';
+import { NativeApiLog } from '../../../../entities/management-api-v2';
+
+type LogState = { kind: 'ok'; log: NativeApiLog } | { kind: 'not-found' } | { kind: 'load-failed' };
+
+@Component({
+  selector: 'api-runtime-logs-native-details',
+  templateUrl: './api-runtime-logs-native-details.component.html',
+  styleUrls: ['./api-runtime-logs-native-details.component.scss'],
+  standalone: true,
+  imports: [AsyncPipe, DatePipe, RouterLink, MatCardModule, MatIconModule, GioBannerModule, GioIconsModule, FormatDurationPipe],
+})
+export class ApiRuntimeLogsNativeDetailsComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly logsService = inject(ApiNativeLogsV2Service);
+
+  private readonly apiId = this.route.snapshot.params.apiId as string;
+  protected readonly requestId = this.route.snapshot.params.requestId as string;
+  private readonly from = Number(this.route.snapshot.queryParams.from);
+  private readonly to = Number(this.route.snapshot.queryParams.to);
+
+  protected readonly backQueryParams = this.route.snapshot.queryParams;
+
+  protected readonly statusMeta = NATIVE_STATUS_META;
+
+  protected readonly state$: Observable<LogState> =
+    Number.isFinite(this.from) && Number.isFinite(this.to)
+      ? this.logsService.getConnectionLog(this.apiId, this.requestId, this.from, this.to).pipe(
+          map(log => ({ kind: 'ok', log }) as LogState),
+          catchError((err: HttpErrorResponse) => of({ kind: err.status === 404 ? 'not-found' : 'load-failed' } as LogState)),
+        )
+      : of({ kind: 'load-failed' } as LogState);
+
+  protected readonly isErrored = isNativeConnectionErrored;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.harness.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { DivHarness } from '@gravitee/ui-particles-angular/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class ApiRuntimeLogsNativeHarness extends ComponentHarness {
+  static hostSelector = 'api-runtime-logs-native';
+
+  public reportingDisabledBanner = this.locatorForOptional(
+    DivHarness.with({ selector: '[data-testid=native_logs_reporting_disabled_banner]' }),
+  );
+  public emptyState = this.locatorForOptional(DivHarness.with({ selector: '.table__empty-state' }));
+  public configureReportingLink = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid=native_logs_configure_reporting]' }));
+
+  async isReportingDisabledBannerVisible(): Promise<boolean> {
+    return this.reportingDisabledBanner().then(banner => banner != null);
+  }
+
+  async getEmptyStateText(): Promise<string | null> {
+    return this.emptyState().then(div => (div ? div.getText() : null));
+  }
+
+  async getConfigureReportingLabel(): Promise<string> {
+    return this.configureReportingLink().then(link => link.getText());
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.html
@@ -1,0 +1,70 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<api-navigation-header [menuItemHeader]="{ title: 'Runtime Logs' }">
+  <div actionButtons>
+    <a mat-raised-button [routerLink]="['../../reporter-settings']" data-testid="native_logs_configure_reporting"> Configure Reporting </a>
+  </div>
+</api-navigation-header>
+
+@if (isReportingDisabled$ | async) {
+  <gio-banner-info class="banner-warning">
+    <div class="banner-warning__content" data-testid="native_logs_reporting_disabled_banner">
+      Reporting is disabled
+      <span class="mat-body"
+        >You’re seeing outdated or no data because reporting is disabled. To view the latest data, please enable reporting.</span
+      >
+    </div>
+  </gio-banner-info>
+}
+
+<mat-card>
+  <mat-card-content class="filters">
+    <form [formGroup]="form" class="filters__form">
+      <gio-select-search
+        formControlName="applicationIds"
+        label="Applications"
+        placeholder="Search applications..."
+        [resultsLoader]="applicationsResultsLoader"
+      />
+
+      <gio-select-search formControlName="planIds" label="Plans" placeholder="Search plans..." [options]="(planOptions$ | async) ?? []" />
+
+      <gio-select-search formControlName="connectionStatuses" label="Connection status" [options]="connectionStatusOptions" />
+
+      <div class="filters__timeframe">
+        <gio-timeframe
+          formControlName="timeframe"
+          [timeFrames]="timeFrames"
+          appearance="outline"
+          (apply)="applyCustomTimeframe()"
+          (refresh)="refresh()"
+        />
+      </div>
+    </form>
+  </mat-card-content>
+
+  @if (logs$ | async; as logs) {
+    <api-runtime-logs-native-list
+      [pagination]="logs.pagination"
+      [logs]="logs.data ?? []"
+      [applications]="(rowApplications$ | async) ?? []"
+      [plans]="(plans$ | async) ?? []"
+      (paginationUpdated)="paginationUpdated($event)"
+    ></api-runtime-logs-native-list>
+  }
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.html
@@ -67,6 +67,7 @@
       [applications]="(rowApplications$ | async) ?? []"
       [plans]="(plans$ | async) ?? []"
       (paginationUpdated)="paginationUpdated($event)"
+      (viewRequested)="onViewLog($event)"
     ></api-runtime-logs-native-list>
   }
 </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<api-navigation-header [menuItemHeader]="{ title: 'Runtime Logs' }">
+<api-navigation-header [menuItemHeader]="{ title: 'Connection Logs' }">
   <div actionButtons>
     <a mat-raised-button [routerLink]="['../../reporter-settings']" data-testid="native_logs_configure_reporting"> Configure Reporting </a>
   </div>
@@ -30,6 +30,8 @@
       >
     </div>
   </gio-banner-info>
+} @else {
+  <api-runtime-logs-native-summary [apiId]="apiId" [from]="summaryRange().from" [to]="summaryRange().to" />
 }
 
 <mat-card>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.scss
@@ -14,10 +14,21 @@
  * limitations under the License.
  */
 
-export * from './apiLogsResponse';
-export * from './apiLogsResponse.fixture';
-export * from './connectionLog';
-export * from './connectionLog.fixture';
-export * from './messageLog';
-export * from './messageLog.fixture';
-export * from './native';
+.banner-warning {
+  margin: 0 0 16px;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+}
+
+.filters {
+  &__form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 16px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.scss
@@ -30,5 +30,15 @@
     flex-wrap: wrap;
     align-items: flex-start;
     gap: 16px;
+
+    // MDC's default form-field margin + subscript area push gio-timeframe below the other
+    // filter triggers; no theme token exposed, so override the internal layout here.
+    ::ng-deep .mat-mdc-form-field {
+      margin: 0;
+    }
+
+    ::ng-deep .mat-mdc-form-field-subscript-wrapper {
+      display: none;
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -49,7 +49,7 @@ describe('ApiRuntimeLogsNativeComponent', () => {
         { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID }, queryParams } } },
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
-        provideNoopAnimations(),
+        provideAnimationsAsync('noop'),
       ],
     });
 
@@ -120,7 +120,7 @@ describe('ApiRuntimeLogsNativeComponent', () => {
     expect(await harness.getConfigureReportingLabel()).toBe('Configure Reporting');
   });
 
-  it('shows reporting-disabled banner when reporterMetricsEnabled is false', async () => {
+  it('shows reporting-disabled banner and hides the summary widget when reporterMetricsEnabled is false', async () => {
     await initComponent();
     httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`).flush(
       fakeApiV4({
@@ -141,6 +141,8 @@ describe('ApiRuntimeLogsNativeComponent', () => {
     fixture.detectChanges();
 
     expect(await harness.isReportingDisabledBannerVisible()).toBe(true);
+    httpTestingController.expectNone(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary`);
+    expect(fixture.nativeElement.querySelector('api-runtime-logs-native-summary')).toBeNull();
   });
 
   it('refresh re-triggers search', fakeAsync(async () => {
@@ -220,7 +222,7 @@ describe('ApiRuntimeLogsNativeComponent', () => {
     flush();
   }));
 
-  it('does not trigger a search when timeframe period switches to custom (waits for explicit Apply)', fakeAsync(async () => {
+  it('does not trigger a search OR a summary refetch when timeframe period switches to custom (waits for explicit Apply)', fakeAsync(async () => {
     await initComponent();
     expectApiCalls();
     httpTestingController
@@ -234,6 +236,7 @@ describe('ApiRuntimeLogsNativeComponent', () => {
     flush();
 
     httpTestingController.expectNone(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native`);
+    httpTestingController.expectNone(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary`);
   }));
 
   it('hydrates form from query params and fires initial search with from/to derived from preset', fakeAsync(async () => {
@@ -250,9 +253,11 @@ describe('ApiRuntimeLogsNativeComponent', () => {
     );
     req.flush(fakeNativeApiLogsResponse());
     flushRowAppResolution();
+    httpTestingController
+      .match(r => r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary`)
+      .forEach(r => r.flush({ countByConnectionStatus: {} }));
     flush();
 
-    // Verify URL sync also carried the period for shareable links
     expect(routerNavigateSpy).toHaveBeenCalledWith(
       ['.'],
       expect.objectContaining({ queryParams: expect.objectContaining({ period: '1h' }) }),

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.spec.ts
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { ApiRuntimeLogsNativeComponent } from './api-runtime-logs-native.component';
+import { ApiRuntimeLogsNativeHarness } from './api-runtime-logs-native.component.harness';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
+import {
+  fakeApiV4,
+  fakeEmptyNativeApiLogsResponse,
+  fakeNativeApiLogsResponse,
+  fakePagedResult,
+  fakePlanV4,
+} from '../../../../entities/management-api-v2';
+import { fakeApplication } from '../../../../entities/application/Application.fixture';
+
+describe('ApiRuntimeLogsNativeComponent', () => {
+  let fixture: ComponentFixture<ApiRuntimeLogsNativeComponent>;
+  let httpTestingController: HttpTestingController;
+  let routerNavigateSpy: jest.SpyInstance;
+  let harness: ApiRuntimeLogsNativeHarness;
+
+  const API_ID = 'an-api-id';
+
+  const initComponent = async (queryParams: Record<string, unknown> = {}) => {
+    TestBed.configureTestingModule({
+      imports: [ApiRuntimeLogsNativeComponent, MatIconTestingModule, GioTestingModule],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID }, queryParams } } },
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+      ],
+    });
+
+    await TestBed.compileComponents();
+    fixture = TestBed.createComponent(ApiRuntimeLogsNativeComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    routerNavigateSpy = jest.spyOn(TestBed.inject(Router), 'navigate');
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiRuntimeLogsNativeHarness);
+    fixture.detectChanges();
+  };
+
+  const expectApiCalls = () => {
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`).flush(fakeApiV4({ id: API_ID, type: 'NATIVE' }));
+    httpTestingController
+      .match(req => req.url.includes(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans`))
+      .forEach(req => req.flush({ data: [fakePlanV4({ id: 'plan-1', name: 'Plan 1' })], pagination: {} }));
+    httpTestingController
+      .match(req => req.url.includes(`${CONSTANTS_TESTING.env.baseURL}/applications/_paged`))
+      .forEach(req => req.flush(fakePagedResult([fakeApplication({ id: 'app-1', name: 'App 1' })])));
+  };
+
+  const flushRowAppResolution = () => {
+    httpTestingController
+      .match(req => req.url.includes(`${CONSTANTS_TESTING.env.baseURL}/applications/_paged`) && req.params.has('ids'))
+      .forEach(req =>
+        req.flush(fakePagedResult([fakeApplication({ id: 'app-fc1bff13-6e25-4c4c-9bff-136e251c4cdf', name: 'Resolved App' })])),
+      );
+  };
+
+  afterEach(() => {
+    httpTestingController?.verify();
+  });
+
+  it('renders empty state when no rows', async () => {
+    await initComponent();
+    expectApiCalls();
+    httpTestingController
+      .expectOne(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native` && req.method === 'GET')
+      .flush(fakeEmptyNativeApiLogsResponse());
+    fixture.detectChanges();
+
+    expect(await harness.getEmptyStateText()).toContain('No data to display');
+  });
+
+  it('triggers initial search with apiId and pagination defaults', async () => {
+    await initComponent();
+    expectApiCalls();
+    const req = httpTestingController.expectOne(
+      r =>
+        r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native` &&
+        r.params.get('page') === '1' &&
+        r.params.get('perPage') === '10',
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+  });
+
+  it('exposes Configure Reporting link', async () => {
+    await initComponent();
+    expectApiCalls();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
+      .flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    fixture.detectChanges();
+
+    expect(await harness.getConfigureReportingLabel()).toBe('Configure Reporting');
+  });
+
+  it('shows reporting-disabled banner when reporterMetricsEnabled is false', async () => {
+    await initComponent();
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`).flush(
+      fakeApiV4({
+        id: API_ID,
+        type: 'NATIVE',
+        analytics: { enabled: true, reporterMetricsEnabled: false },
+      }),
+    );
+    httpTestingController
+      .match(req => req.url.includes(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans`))
+      .forEach(req => req.flush({ data: [], pagination: {} }));
+    httpTestingController
+      .match(req => req.url.includes(`${CONSTANTS_TESTING.env.baseURL}/applications/_paged`))
+      .forEach(req => req.flush(fakePagedResult([])));
+    httpTestingController
+      .expectOne(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native`)
+      .flush(fakeEmptyNativeApiLogsResponse());
+    fixture.detectChanges();
+
+    expect(await harness.isReportingDisabledBannerVisible()).toBe(true);
+  });
+
+  it('refresh re-triggers search', fakeAsync(async () => {
+    await initComponent();
+    expectApiCalls();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
+      .flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+    fixture.detectChanges();
+    routerNavigateSpy.mockClear();
+
+    fixture.componentInstance['refresh']();
+    flush();
+
+    httpTestingController
+      .expectOne(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native`)
+      .flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+    expect(routerNavigateSpy).toHaveBeenCalled();
+  }));
+
+  it('filter change triggers search with serialized NativeApiLogsParam shape', fakeAsync(async () => {
+    await initComponent();
+    expectApiCalls();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
+      .flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+    fixture.detectChanges();
+
+    fixture.componentInstance['form'].patchValue({
+      applicationIds: ['app-1', 'app-2'],
+      planIds: ['plan-1'],
+      connectionStatuses: ['CONNECTED', 'CONNECTION_ERROR'],
+    });
+    flush();
+
+    const req = httpTestingController.expectOne(
+      r =>
+        r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native` &&
+        r.params.get('applicationIds') === 'app-1,app-2' &&
+        r.params.get('planIds') === 'plan-1' &&
+        r.params.get('connectionStatuses') === 'CONNECTED,CONNECTION_ERROR' &&
+        r.params.get('page') === '1' &&
+        r.params.get('perPage') === '10',
+    );
+    req.flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+  }));
+
+  it('pagination event triggers search with new page and perPage', fakeAsync(async () => {
+    await initComponent();
+    expectApiCalls();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
+      .flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+    fixture.detectChanges();
+
+    fixture.componentInstance['paginationUpdated']({ index: 3, size: 25 });
+    flush();
+
+    const req = httpTestingController.expectOne(
+      r =>
+        r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native` &&
+        r.params.get('page') === '3' &&
+        r.params.get('perPage') === '25',
+    );
+    req.flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+  }));
+
+  it('does not trigger a search when timeframe period switches to custom (waits for explicit Apply)', fakeAsync(async () => {
+    await initComponent();
+    expectApiCalls();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
+      .flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+    fixture.detectChanges();
+
+    fixture.componentInstance['form'].patchValue({ timeframe: { period: 'custom', from: null, to: null } });
+    flush();
+
+    httpTestingController.expectNone(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native`);
+  }));
+
+  it('hydrates form from query params and fires initial search with from/to derived from preset', fakeAsync(async () => {
+    await initComponent({ period: '1h' });
+    expectApiCalls();
+
+    const req = httpTestingController.expectOne(
+      r =>
+        r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native` &&
+        !!r.params.get('from') &&
+        !!r.params.get('to') &&
+        r.params.get('page') === '1' &&
+        r.params.get('perPage') === '10',
+    );
+    req.flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+
+    // Verify URL sync also carried the period for shareable links
+    expect(routerNavigateSpy).toHaveBeenCalledWith(
+      ['.'],
+      expect.objectContaining({ queryParams: expect.objectContaining({ period: '1h' }) }),
+    );
+  }));
+
+  it('omits empty filter arrays from the query string', fakeAsync(async () => {
+    await initComponent();
+    expectApiCalls();
+
+    const req = httpTestingController.expectOne(r => r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native`);
+    expect(req.request.params.has('applicationIds')).toBe(false);
+    expect(req.request.params.has('planIds')).toBe(false);
+    expect(req.request.params.has('connectionStatuses')).toBe(false);
+    req.flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+  }));
+
+  it('keeps the search Subject alive after a failed search request', fakeAsync(async () => {
+    await initComponent();
+    expectApiCalls();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
+      .error(new ProgressEvent('Network error'), { status: 500, statusText: 'Internal Server Error' });
+    flush();
+    fixture.detectChanges();
+
+    fixture.componentInstance['refresh']();
+    flush();
+
+    const retry = httpTestingController.expectOne(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native`);
+    retry.flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+  }));
+
+  it('still publishes logs when row name resolution fails', fakeAsync(async () => {
+    await initComponent();
+    expectApiCalls();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
+      .flush(fakeNativeApiLogsResponse());
+    httpTestingController
+      .match(req => req.url.includes(`${CONSTANTS_TESTING.env.baseURL}/applications/_paged`) && req.params.has('ids'))
+      .forEach(req => req.error(new ProgressEvent('Network error'), { status: 500, statusText: 'Internal Server Error' }));
+    flush();
+
+    let publishedRows: number | null = null;
+    fixture.componentInstance['logs$'].subscribe(r => (publishedRows = (r.data ?? []).length));
+    flush();
+    expect(publishedRows).toBeGreaterThan(0);
+  }));
+});

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.spec.ts
@@ -311,4 +311,22 @@ describe('ApiRuntimeLogsNativeComponent', () => {
     flush();
     expect(publishedRows).toBeGreaterThan(0);
   }));
+
+  it('navigates to the detail route preserving current query params on view request', fakeAsync(async () => {
+    await initComponent({ period: '1h' });
+    expectApiCalls();
+    httpTestingController
+      .expectOne(r => r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native`)
+      .flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    httpTestingController
+      .match(r => r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary`)
+      .forEach(r => r.flush({ countByConnectionStatus: {} }));
+    flush();
+    routerNavigateSpy.mockClear();
+
+    fixture.componentInstance['onViewLog']('req-42');
+
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['req-42'], expect.objectContaining({ queryParamsHandling: 'preserve' }));
+  }));
 });

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.stories.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { of } from 'rxjs';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { action } from 'storybook/actions';
+
+import { ApiRuntimeLogsNativeComponent } from './api-runtime-logs-native.component';
+
+import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
+import { ApiPlanV2Service } from '../../../../services-ngx/api-plan-v2.service';
+import { ApplicationService } from '../../../../services-ngx/application.service';
+import { ApiNativeLogsV2Service } from '../../../../services-ngx/api-native-logs-v2.service';
+import { ApiV4, fakeApiV4, fakeNativeApiLog, fakeNativeApiLogsResponse, fakePlanV4 } from '../../../../entities/management-api-v2';
+import { fakeApplication } from '../../../../entities/application/Application.fixture';
+import { PagedResult } from '../../../../entities/pagedResult';
+
+const APP_1 = fakeApplication({ id: 'app-1', name: 'Order Service' });
+const APP_2 = fakeApplication({ id: 'app-2', name: 'Payment Service' });
+
+const PLAN_1 = fakePlanV4({ id: 'plan-1', name: 'Free' });
+const PLAN_2 = fakePlanV4({ id: 'plan-2', name: 'Premium' });
+
+const apiMock: ApiV4 = fakeApiV4({
+  id: 'api-native-demo',
+  name: 'Acme Native Kafka',
+  type: 'NATIVE',
+  analytics: { enabled: true, reporterMetricsEnabled: true },
+});
+
+const apiDisabledReportingMock: ApiV4 = fakeApiV4({
+  id: 'api-native-demo',
+  name: 'Acme Native Kafka',
+  type: 'NATIVE',
+  analytics: { enabled: true, reporterMetricsEnabled: false },
+});
+
+const populatedLogs = fakeNativeApiLogsResponse({
+  data: [
+    fakeNativeApiLog({
+      requestId: 'req-1',
+      timestamp: '2026-05-10T10:30:15.000Z',
+      applicationId: 'app-1',
+      planId: 'plan-1',
+      clientIdentifier: 'kafka-client-orders-prod',
+      connectionStatus: 'CONNECTED',
+      connectionDurationMs: 4200,
+    }),
+    fakeNativeApiLog({
+      requestId: 'req-2',
+      timestamp: '2026-05-10T10:31:42.000Z',
+      applicationId: 'app-2',
+      planId: 'plan-2',
+      clientIdentifier: 'kafka-client-payments',
+      connectionStatus: 'CONNECTION_ERROR',
+      connectionDurationMs: 134,
+    }),
+    fakeNativeApiLog({
+      requestId: 'req-3',
+      timestamp: '2026-05-10T10:33:01.000Z',
+      applicationId: 'app-1',
+      planId: 'plan-2',
+      clientIdentifier: 'kafka-client-orders-staging',
+      connectionStatus: 'SESSION_ERROR',
+      connectionDurationMs: 982347,
+    }),
+  ],
+  pagination: { page: 1, perPage: 10, pageCount: 3, pageItemsCount: 3, totalCount: 23 },
+});
+
+const emptyLogs = fakeNativeApiLogsResponse({
+  data: [],
+  pagination: { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 0, totalCount: 0 },
+});
+
+const apiServiceMock = (api: ApiV4) =>
+  ({
+    get: () => of(api),
+  }) as unknown as ApiV2Service;
+
+const planServiceMock = {
+  list: () =>
+    of({
+      data: [PLAN_1, PLAN_2],
+      pagination: { page: 1, perPage: 9999, pageCount: 1, pageItemsCount: 2, totalCount: 2 },
+    }),
+} as unknown as ApiPlanV2Service;
+
+const applicationServiceMock = {
+  list: () => {
+    const result = new PagedResult<typeof APP_1>();
+    result.data = [APP_1, APP_2];
+    result.page = { current: 1, size: 25, per_page: 25, total_pages: 1, total_elements: 2 };
+    return of(result);
+  },
+  findByIds: () => {
+    const result = new PagedResult<typeof APP_1>();
+    result.data = [APP_1, APP_2];
+    result.page = { current: 1, size: 2, per_page: 2, total_pages: 1, total_elements: 2 };
+    return of(result);
+  },
+} as unknown as ApplicationService;
+
+const logsServiceMock = (response: typeof populatedLogs) =>
+  ({
+    searchConnectionLogs: () => of(response),
+  }) as unknown as ApiNativeLogsV2Service;
+
+const activatedRouteMock = {
+  snapshot: {
+    params: { apiId: 'api-native-demo' },
+    queryParams: {},
+    queryParamMap: convertToParamMap({}),
+  },
+};
+
+const routerMock: Partial<Router> = {
+  navigate: (...args: Parameters<Router['navigate']>) => {
+    action('router.navigate')(args);
+    return Promise.resolve(true);
+  },
+};
+
+const buildProviders = (api: ApiV4, response: typeof populatedLogs) => [
+  { provide: ApiV2Service, useValue: apiServiceMock(api) },
+  { provide: ApiPlanV2Service, useValue: planServiceMock },
+  { provide: ApplicationService, useValue: applicationServiceMock },
+  { provide: ApiNativeLogsV2Service, useValue: logsServiceMock(response) },
+  { provide: ActivatedRoute, useValue: activatedRouteMock },
+  { provide: Router, useValue: routerMock },
+];
+
+const meta: Meta<ApiRuntimeLogsNativeComponent> = {
+  title: 'API / Logs / Native / Page',
+  parameters: { layout: 'fullscreen' },
+  render: () => ({
+    template: `
+      <div style="min-height: 900px; padding: 24px; background-color: #f4f6fb;">
+        <api-runtime-logs-native></api-runtime-logs-native>
+      </div>
+    `,
+  }),
+};
+
+export default meta;
+
+export const WithRows: StoryObj<ApiRuntimeLogsNativeComponent> = {
+  decorators: [moduleMetadata({ imports: [ApiRuntimeLogsNativeComponent], providers: buildProviders(apiMock, populatedLogs) })],
+};
+
+export const Empty: StoryObj<ApiRuntimeLogsNativeComponent> = {
+  decorators: [moduleMetadata({ imports: [ApiRuntimeLogsNativeComponent], providers: buildProviders(apiMock, emptyLogs) })],
+};
+
+export const ReportingDisabled: StoryObj<ApiRuntimeLogsNativeComponent> = {
+  decorators: [
+    moduleMetadata({ imports: [ApiRuntimeLogsNativeComponent], providers: buildProviders(apiDisabledReportingMock, populatedLogs) }),
+  ],
+};

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.ts
@@ -27,7 +27,7 @@ import { EMPTY, Observable, of, ReplaySubject, Subject } from 'rxjs';
 import { isEqual } from 'lodash';
 import moment from 'moment';
 
-import { NATIVE_CONNECTION_STATUSES } from './api-runtime-logs-native.models';
+import { NATIVE_CONNECTION_STATUSES, NATIVE_STATUS_META } from './api-runtime-logs-native.models';
 import { ApiRuntimeLogsNativeListComponent } from './components/api-runtime-logs-native-list/api-runtime-logs-native-list.component';
 import { ApiRuntimeLogsNativeSummaryComponent } from './components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component';
 
@@ -160,7 +160,12 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
               this.logs$.next(response);
               this.router.navigate(['.'], { relativeTo: this.activatedRoute, queryParams: params, queryParamsHandling: '' });
             }),
-            catchError(() => EMPTY),
+            catchError(() => {
+              // Clear the table so stale rows don't sit under the new (failed) filter. HTTP interceptor surfaces the snackbar.
+              this.logs$.next({ data: [], pagination: { page, perPage, totalCount: 0, pageItemsCount: 0, pageCount: 0 } });
+              this.rowApplications$.next([]);
+              return EMPTY;
+            }),
             finalize(() => this.loading.set(false)),
           );
         }),
@@ -181,6 +186,10 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
 
   protected paginationUpdated(event: GioTableWrapperPagination) {
     this.searchTrigger$.next({ page: event.index, perPage: event.size });
+  }
+
+  protected onViewLog(requestId: string) {
+    this.router.navigate([requestId], { relativeTo: this.activatedRoute, queryParamsHandling: 'preserve' });
   }
 
   protected refresh() {
@@ -212,7 +221,9 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
     return this.applicationService.findByIds(ids, 1, ids.length).pipe(
       tap(paged => this.rowApplications$.next(paged.data ?? [])),
       map(() => response),
-      catchError(() => {
+      catchError(err => {
+        // eslint-disable-next-line angular/log
+        console.error('Failed to resolve application names for native logs', err, { apiId: this.apiId, idsCount: ids.length });
         this.rowApplications$.next([]);
         return of(response);
       }),
@@ -244,7 +255,11 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
         timeframe: { period, from: period === CUSTOM_PERIOD ? fromQp : null, to: period === CUSTOM_PERIOD ? toQp : null },
         applicationIds: qp?.applicationIds ? qp.applicationIds.split(',') : [],
         planIds: qp?.planIds ? qp.planIds.split(',') : [],
-        connectionStatuses: qp?.connectionStatuses ? (qp.connectionStatuses.split(',') as NativeConnectionStatus[]) : [],
+        connectionStatuses: qp?.connectionStatuses
+          ? (qp.connectionStatuses.split(',') as NativeConnectionStatus[]).filter(
+              (s): s is NativeConnectionStatus => s in NATIVE_STATUS_META,
+            )
+          : [],
       },
       { emitEvent: false },
     );

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.ts
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { AsyncPipe } from '@angular/common';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { GioBannerModule } from '@gravitee/ui-particles-angular';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { catchError, distinctUntilChanged, finalize, map, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { EMPTY, Observable, of, ReplaySubject, Subject } from 'rxjs';
+import { isEqual } from 'lodash';
+import moment from 'moment';
+
+import { NATIVE_CONNECTION_STATUSES } from './api-runtime-logs-native.models';
+import { ApiRuntimeLogsNativeListComponent } from './components/api-runtime-logs-native-list/api-runtime-logs-native-list.component';
+
+import { ApiNativeLogsV2Service } from '../../../../services-ngx/api-native-logs-v2.service';
+import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
+import { ApiPlanV2Service } from '../../../../services-ngx/api-plan-v2.service';
+import { ApplicationService } from '../../../../services-ngx/application.service';
+import {
+  ApiV4,
+  NativeApiLog,
+  NativeApiLogsParam,
+  NativeApiLogsResponse,
+  NativeConnectionStatus,
+} from '../../../../entities/management-api-v2';
+import { GioTableWrapperPagination } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { Application } from '../../../../entities/application/Application';
+import { customTimeFrames, timeFrameRangesParams, timeFrames } from '../../../../shared/utils/timeFrameRanges';
+import {
+  GioSelectSearchComponent,
+  ResultsLoaderInput,
+  ResultsLoaderOutput,
+  SelectOption,
+} from '../../../../shared/components/gio-select-search/gio-select-search.component';
+import { GioTimeframeComponent, TimeframeValue } from '../../../../shared/components/gio-timeframe/gio-timeframe.component';
+import { ActionButtonsDirective } from '../../api-navigation/api-navigation-header/action-buttons.directive';
+import { ApiNavigationModule } from '../../api-navigation/api-navigation.module';
+
+const CUSTOM_PERIOD = 'custom';
+
+interface NativeLogFiltersForm {
+  timeframe: FormControl<TimeframeValue | null>;
+  applicationIds: FormControl<string[]>;
+  planIds: FormControl<string[]>;
+  connectionStatuses: FormControl<NativeConnectionStatus[]>;
+}
+
+interface SearchInput {
+  page: number;
+  perPage: number;
+}
+
+@Component({
+  selector: 'api-runtime-logs-native',
+  templateUrl: './api-runtime-logs-native.component.html',
+  styleUrls: ['./api-runtime-logs-native.component.scss'],
+  standalone: true,
+  imports: [
+    AsyncPipe,
+    ReactiveFormsModule,
+    RouterLink,
+    MatButtonModule,
+    MatCardModule,
+    GioBannerModule,
+    GioTimeframeComponent,
+    GioSelectSearchComponent,
+    ApiRuntimeLogsNativeListComponent,
+    ActionButtonsDirective,
+    ApiNavigationModule,
+  ],
+})
+export class ApiRuntimeLogsNativeComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly apiService = inject(ApiV2Service);
+  private readonly logsService = inject(ApiNativeLogsV2Service);
+  private readonly planService = inject(ApiPlanV2Service);
+  private readonly applicationService = inject(ApplicationService);
+
+  protected readonly connectionStatusOptions: SelectOption[] = NATIVE_CONNECTION_STATUSES.map(s => ({ value: s.value, label: s.label }));
+  protected readonly timeFrames = [...timeFrames, ...customTimeFrames];
+
+  private readonly api$ = this.apiService
+    .get(this.activatedRoute.snapshot.params.apiId)
+    .pipe(shareReplay({ bufferSize: 1, refCount: true }));
+  protected readonly isReportingDisabled$ = this.api$.pipe(map((api: ApiV4) => api.analytics?.reporterMetricsEnabled === false));
+
+  protected readonly plans$ = this.planService
+    .list(this.activatedRoute.snapshot.params.apiId, undefined, undefined, undefined, undefined, 1, 9999)
+    .pipe(
+      map(response => response.data ?? []),
+      shareReplay({ bufferSize: 1, refCount: true }),
+    );
+  protected readonly planOptions$: Observable<SelectOption[]> = this.plans$.pipe(
+    map(plans => plans.map(p => ({ value: p.id, label: p.name }))),
+  );
+
+  protected readonly logs$ = new ReplaySubject<NativeApiLogsResponse>(1);
+  protected readonly rowApplications$ = new ReplaySubject<Application[]>(1);
+  protected readonly loading = signal(true);
+
+  private readonly searchTrigger$ = new Subject<SearchInput>();
+
+  protected readonly applicationsResultsLoader = (input: ResultsLoaderInput): Observable<ResultsLoaderOutput> => {
+    const perPage = 25;
+    return this.applicationService.list(undefined, input.searchTerm || undefined, undefined, input.page, perPage).pipe(
+      map(paged => {
+        const data: SelectOption[] = (paged.data ?? []).map(app => ({ value: app.id, label: app.name }));
+        const total = paged.page?.total_elements;
+        const hasNextPage = total != null ? input.page * perPage < total : data.length === perPage;
+        return { data, hasNextPage };
+      }),
+    );
+  };
+
+  protected readonly form = new FormGroup<NativeLogFiltersForm>({
+    timeframe: new FormControl<TimeframeValue | null>({ period: '', from: null, to: null }),
+    applicationIds: new FormControl<string[]>([], { nonNullable: true }),
+    planIds: new FormControl<string[]>([], { nonNullable: true }),
+    connectionStatuses: new FormControl<NativeConnectionStatus[]>([], { nonNullable: true }),
+  });
+
+  ngOnInit(): void {
+    this.hydrateFormFromQueryParams();
+
+    // Each trigger runs as its own inner observable with catchError + finalize so a failed
+    // request never terminates the outer Subject. Without inner isolation, one HTTP error
+    // would silently kill all subsequent filter / pagination / refresh interactions.
+    this.searchTrigger$
+      .pipe(
+        switchMap(({ page, perPage }) => {
+          this.loading.set(true);
+          const params = this.toQueryParams(page, perPage);
+          return this.logsService.searchConnectionLogs(this.activatedRoute.snapshot.params.apiId, params).pipe(
+            switchMap(response => this.resolveRowApplications(response)),
+            tap(response => {
+              this.logs$.next(response);
+              this.router.navigate(['.'], { relativeTo: this.activatedRoute, queryParams: params, queryParamsHandling: '' });
+            }),
+            catchError(() => EMPTY),
+            finalize(() => this.loading.set(false)),
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+
+    this.searchTrigger$.next({ page: this.currentPage(), perPage: this.currentPerPage() });
+
+    this.form.valueChanges.pipe(distinctUntilChanged(isEqual), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      // Custom timeframe needs explicit Apply via gio-timeframe (apply event); preset emits here.
+      const tf = this.form.controls.timeframe.value;
+      if (tf?.period === CUSTOM_PERIOD) return;
+      this.searchTrigger$.next({ page: 1, perPage: this.currentPerPage() });
+    });
+  }
+
+  protected paginationUpdated(event: GioTableWrapperPagination) {
+    this.searchTrigger$.next({ page: event.index, perPage: event.size });
+  }
+
+  protected refresh() {
+    this.searchTrigger$.next({ page: this.currentPage(), perPage: this.currentPerPage() });
+  }
+
+  protected applyCustomTimeframe() {
+    this.searchTrigger$.next({ page: 1, perPage: this.currentPerPage() });
+  }
+
+  private currentPage(): number {
+    return +(this.activatedRoute.snapshot.queryParams.page ?? 1);
+  }
+
+  private currentPerPage(): number {
+    return +(this.activatedRoute.snapshot.queryParams.perPage ?? 10);
+  }
+
+  // Returns the original response so the search pipeline can flow through a single switchMap.
+  // Name resolution is non-essential — degrade gracefully on failure so log rows still render with raw IDs.
+  private resolveRowApplications(response: NativeApiLogsResponse): Observable<NativeApiLogsResponse> {
+    const ids = uniqueIds(response.data);
+    if (ids.length === 0) {
+      this.rowApplications$.next([]);
+      return of(response);
+    }
+    return this.applicationService.findByIds(ids, 1, ids.length).pipe(
+      tap(paged => this.rowApplications$.next(paged.data ?? [])),
+      map(() => response),
+      catchError(() => {
+        this.rowApplications$.next([]);
+        return of(response);
+      }),
+    );
+  }
+
+  private toQueryParams(page: number, perPage: number): NativeApiLogsParam & { period?: string } {
+    const value = this.form.getRawValue();
+    const tf = value.timeframe;
+    const { from, to } = !tf?.period
+      ? {}
+      : tf.period === CUSTOM_PERIOD
+        ? { from: tf.from?.valueOf(), to: tf.to?.valueOf() }
+        : timeFrameRangesParams(tf.period);
+    return {
+      page,
+      perPage,
+      period: tf?.period || undefined,
+      from,
+      to,
+      applicationIds: value.applicationIds?.length ? value.applicationIds.join(',') : undefined,
+      planIds: value.planIds?.length ? value.planIds.join(',') : undefined,
+      connectionStatuses: value.connectionStatuses?.length ? value.connectionStatuses.join(',') : undefined,
+    };
+  }
+
+  private hydrateFormFromQueryParams() {
+    const qp = this.activatedRoute.snapshot.queryParams;
+    const period = qp?.period ?? '';
+    const fromQp = qp?.from ? moment(Number(qp.from)) : null;
+    const toQp = qp?.to ? moment(Number(qp.to)) : null;
+    this.form.patchValue(
+      {
+        timeframe: { period, from: period === CUSTOM_PERIOD ? fromQp : null, to: period === CUSTOM_PERIOD ? toQp : null },
+        applicationIds: qp?.applicationIds ? qp.applicationIds.split(',') : [],
+        planIds: qp?.planIds ? qp.planIds.split(',') : [],
+        connectionStatuses: qp?.connectionStatuses ? (qp.connectionStatuses.split(',') as NativeConnectionStatus[]) : [],
+      },
+      { emitEvent: false },
+    );
+  }
+}
+
+function uniqueIds(rows: NativeApiLog[] | undefined): string[] {
+  if (!rows?.length) return [];
+  return Array.from(new Set(rows.map(r => r.applicationId).filter((id): id is string => !!id)));
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, OnInit, signal, viewChild } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { AsyncPipe } from '@angular/common';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -29,6 +29,7 @@ import moment from 'moment';
 
 import { NATIVE_CONNECTION_STATUSES } from './api-runtime-logs-native.models';
 import { ApiRuntimeLogsNativeListComponent } from './components/api-runtime-logs-native-list/api-runtime-logs-native-list.component';
+import { ApiRuntimeLogsNativeSummaryComponent } from './components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component';
 
 import { ApiNativeLogsV2Service } from '../../../../services-ngx/api-native-logs-v2.service';
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
@@ -83,6 +84,7 @@ interface SearchInput {
     GioTimeframeComponent,
     GioSelectSearchComponent,
     ApiRuntimeLogsNativeListComponent,
+    ApiRuntimeLogsNativeSummaryComponent,
     ActionButtonsDirective,
     ApiNavigationModule,
   ],
@@ -98,27 +100,36 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
 
   protected readonly connectionStatusOptions: SelectOption[] = NATIVE_CONNECTION_STATUSES.map(s => ({ value: s.value, label: s.label }));
   protected readonly timeFrames = [...timeFrames, ...customTimeFrames];
-
-  private readonly api$ = this.apiService
-    .get(this.activatedRoute.snapshot.params.apiId)
-    .pipe(shareReplay({ bufferSize: 1, refCount: true }));
-  protected readonly isReportingDisabled$ = this.api$.pipe(map((api: ApiV4) => api.analytics?.reporterMetricsEnabled === false));
-
-  protected readonly plans$ = this.planService
-    .list(this.activatedRoute.snapshot.params.apiId, undefined, undefined, undefined, undefined, 1, 9999)
-    .pipe(
-      map(response => response.data ?? []),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-  protected readonly planOptions$: Observable<SelectOption[]> = this.plans$.pipe(
-    map(plans => plans.map(p => ({ value: p.id, label: p.name }))),
-  );
+  protected readonly apiId = this.activatedRoute.snapshot.params.apiId as string;
 
   protected readonly logs$ = new ReplaySubject<NativeApiLogsResponse>(1);
   protected readonly rowApplications$ = new ReplaySubject<Application[]>(1);
   protected readonly loading = signal(true);
+  protected readonly form = new FormGroup<NativeLogFiltersForm>({
+    timeframe: new FormControl<TimeframeValue | null>({ period: '', from: null, to: null }),
+    applicationIds: new FormControl<string[]>([], { nonNullable: true }),
+    planIds: new FormControl<string[]>([], { nonNullable: true }),
+    connectionStatuses: new FormControl<NativeConnectionStatus[]>([], { nonNullable: true }),
+  });
 
+  // Mirrors the search "apply" semantics — only preset valueChanges and applyCustomTimeframe
+  // update this, so custom-period keystrokes don't spam /summary.
+  private readonly summaryTimeframe = signal<TimeframeValue | null>(null);
   private readonly searchTrigger$ = new Subject<SearchInput>();
+  private readonly summaryRef = viewChild(ApiRuntimeLogsNativeSummaryComponent);
+
+  private readonly api$ = this.apiService.get(this.apiId).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+  protected readonly isReportingDisabled$ = this.api$.pipe(map((api: ApiV4) => api.analytics?.reporterMetricsEnabled === false));
+
+  protected readonly plans$ = this.planService.list(this.apiId, undefined, undefined, undefined, undefined, 1, 9999).pipe(
+    map(response => response.data ?? []),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+  protected readonly planOptions$: Observable<SelectOption[]> = this.plans$.pipe(
+    map(plans => plans.map(p => ({ value: p.id, label: p.name }))),
+  );
+
+  protected readonly summaryRange = computed(() => toFromTo(this.summaryTimeframe()));
 
   protected readonly applicationsResultsLoader = (input: ResultsLoaderInput): Observable<ResultsLoaderOutput> => {
     const perPage = 25;
@@ -132,25 +143,18 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
     );
   };
 
-  protected readonly form = new FormGroup<NativeLogFiltersForm>({
-    timeframe: new FormControl<TimeframeValue | null>({ period: '', from: null, to: null }),
-    applicationIds: new FormControl<string[]>([], { nonNullable: true }),
-    planIds: new FormControl<string[]>([], { nonNullable: true }),
-    connectionStatuses: new FormControl<NativeConnectionStatus[]>([], { nonNullable: true }),
-  });
-
   ngOnInit(): void {
     this.hydrateFormFromQueryParams();
+    this.summaryTimeframe.set(this.form.controls.timeframe.value);
 
-    // Each trigger runs as its own inner observable with catchError + finalize so a failed
-    // request never terminates the outer Subject. Without inner isolation, one HTTP error
-    // would silently kill all subsequent filter / pagination / refresh interactions.
+    // Inner-observable catchError keeps the outer Subject alive after an HTTP error,
+    // otherwise one failure would silently kill all subsequent filter/pagination interactions.
     this.searchTrigger$
       .pipe(
         switchMap(({ page, perPage }) => {
           this.loading.set(true);
           const params = this.toQueryParams(page, perPage);
-          return this.logsService.searchConnectionLogs(this.activatedRoute.snapshot.params.apiId, params).pipe(
+          return this.logsService.searchConnectionLogs(this.apiId, params).pipe(
             switchMap(response => this.resolveRowApplications(response)),
             tap(response => {
               this.logs$.next(response);
@@ -170,6 +174,7 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
       // Custom timeframe needs explicit Apply via gio-timeframe (apply event); preset emits here.
       const tf = this.form.controls.timeframe.value;
       if (tf?.period === CUSTOM_PERIOD) return;
+      this.summaryTimeframe.set(tf);
       this.searchTrigger$.next({ page: 1, perPage: this.currentPerPage() });
     });
   }
@@ -180,9 +185,12 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
 
   protected refresh() {
     this.searchTrigger$.next({ page: this.currentPage(), perPage: this.currentPerPage() });
+    // Re-fetch summary too — same from/to wouldn't re-trigger rxResource without an explicit reload.
+    this.summaryRef()?.reload();
   }
 
   protected applyCustomTimeframe() {
+    this.summaryTimeframe.set(this.form.controls.timeframe.value);
     this.searchTrigger$.next({ page: 1, perPage: this.currentPerPage() });
   }
 
@@ -194,8 +202,7 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
     return +(this.activatedRoute.snapshot.queryParams.perPage ?? 10);
   }
 
-  // Returns the original response so the search pipeline can flow through a single switchMap.
-  // Name resolution is non-essential — degrade gracefully on failure so log rows still render with raw IDs.
+  // Name resolution is non-essential — degrade gracefully so rows still render with raw IDs.
   private resolveRowApplications(response: NativeApiLogsResponse): Observable<NativeApiLogsResponse> {
     const ids = uniqueIds(response.data);
     if (ids.length === 0) {
@@ -214,18 +221,13 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
 
   private toQueryParams(page: number, perPage: number): NativeApiLogsParam & { period?: string } {
     const value = this.form.getRawValue();
-    const tf = value.timeframe;
-    const { from, to } = !tf?.period
-      ? {}
-      : tf.period === CUSTOM_PERIOD
-        ? { from: tf.from?.valueOf(), to: tf.to?.valueOf() }
-        : timeFrameRangesParams(tf.period);
+    const { from, to } = toFromTo(value.timeframe);
     return {
       page,
       perPage,
-      period: tf?.period || undefined,
-      from,
-      to,
+      period: value.timeframe?.period || undefined,
+      from: from ?? undefined,
+      to: to ?? undefined,
       applicationIds: value.applicationIds?.length ? value.applicationIds.join(',') : undefined,
       planIds: value.planIds?.length ? value.planIds.join(',') : undefined,
       connectionStatuses: value.connectionStatuses?.length ? value.connectionStatuses.join(',') : undefined,
@@ -252,4 +254,13 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
 function uniqueIds(rows: NativeApiLog[] | undefined): string[] {
   if (!rows?.length) return [];
   return Array.from(new Set(rows.map(r => r.applicationId).filter((id): id is string => !!id)));
+}
+
+function toFromTo(tf: TimeframeValue | null | undefined): { from: number | null; to: number | null } {
+  if (!tf?.period) return { from: null, to: null };
+  if (tf.period === CUSTOM_PERIOD) {
+    return { from: tf.from?.valueOf() ?? null, to: tf.to?.valueOf() ?? null };
+  }
+  const { from, to } = timeFrameRangesParams(tf.period);
+  return { from, to };
 }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.models.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.models.ts
@@ -20,14 +20,15 @@ export interface NativeConnectionStatusMeta {
   // gio-badge-* utility class — colors the badge in both the table cell and the summary card.
   badgeClass: string;
   icon: string;
+  isErrored: boolean;
 }
 
 // Record forces compile-time exhaustiveness — adding a new status to the union without an entry here is a build error.
 export const NATIVE_STATUS_META: Record<NativeConnectionStatus, NativeConnectionStatusMeta> = {
-  CONNECTED: { label: 'Connected', badgeClass: 'gio-badge-success', icon: 'gio:check-circled-outline' },
-  SESSION_ERROR: { label: 'Disconnected', badgeClass: 'gio-badge-warning', icon: 'gio:alert-circle' },
-  CONNECTION_ERROR: { label: 'Failed', badgeClass: 'gio-badge-error', icon: 'gio:error' },
-  INTERNAL_ERROR: { label: 'Unknown', badgeClass: 'gio-badge-accent', icon: 'gio:shield-alert' },
+  CONNECTED: { label: 'Connected', badgeClass: 'gio-badge-success', icon: 'gio:check-circled-outline', isErrored: false },
+  SESSION_ERROR: { label: 'Disconnected', badgeClass: 'gio-badge-warning', icon: 'gio:alert-circle', isErrored: true },
+  CONNECTION_ERROR: { label: 'Failed', badgeClass: 'gio-badge-error', icon: 'gio:error', isErrored: true },
+  INTERNAL_ERROR: { label: 'Unknown', badgeClass: 'gio-badge-accent', icon: 'gio:shield-alert', isErrored: true },
 };
 
 export const NATIVE_CONNECTION_STATUSES: { value: NativeConnectionStatus; label: string }[] = (
@@ -37,3 +38,6 @@ export const NATIVE_CONNECTION_STATUSES: { value: NativeConnectionStatus; label:
 // Derived from the meta table to stay in sync: adding a new status to NATIVE_STATUS_META
 // auto-appears in the summary widget at the position it was inserted at (healthy → degraded → fatal).
 export const NATIVE_SUMMARY_STATUSES = Object.keys(NATIVE_STATUS_META) as NativeConnectionStatus[];
+
+export const isNativeConnectionErrored = (status: NativeConnectionStatus | undefined): boolean =>
+  status != null && NATIVE_STATUS_META[status].isErrored;

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.models.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.models.ts
@@ -17,17 +17,23 @@ import { NativeConnectionStatus } from '../../../../entities/management-api-v2';
 
 export interface NativeConnectionStatusMeta {
   label: string;
+  // gio-badge-* utility class — colors the badge in both the table cell and the summary card.
   badgeClass: string;
+  icon: string;
 }
 
 // Record forces compile-time exhaustiveness — adding a new status to the union without an entry here is a build error.
 export const NATIVE_STATUS_META: Record<NativeConnectionStatus, NativeConnectionStatusMeta> = {
-  CONNECTED: { label: 'Connected', badgeClass: 'gio-badge-success' },
-  CONNECTION_ERROR: { label: 'Failed', badgeClass: 'gio-badge-warning' },
-  SESSION_ERROR: { label: 'Disconnected', badgeClass: 'gio-badge-warning' },
-  INTERNAL_ERROR: { label: 'Unknown', badgeClass: 'gio-badge-error' },
+  CONNECTED: { label: 'Connected', badgeClass: 'gio-badge-success', icon: 'gio:check-circled-outline' },
+  SESSION_ERROR: { label: 'Disconnected', badgeClass: 'gio-badge-warning', icon: 'gio:alert-circle' },
+  CONNECTION_ERROR: { label: 'Failed', badgeClass: 'gio-badge-error', icon: 'gio:error' },
+  INTERNAL_ERROR: { label: 'Unknown', badgeClass: 'gio-badge-accent', icon: 'gio:shield-alert' },
 };
 
 export const NATIVE_CONNECTION_STATUSES: { value: NativeConnectionStatus; label: string }[] = (
   Object.entries(NATIVE_STATUS_META) as [NativeConnectionStatus, NativeConnectionStatusMeta][]
 ).map(([value, meta]) => ({ value, label: meta.label }));
+
+// Derived from the meta table to stay in sync: adding a new status to NATIVE_STATUS_META
+// auto-appears in the summary widget at the position it was inserted at (healthy → degraded → fatal).
+export const NATIVE_SUMMARY_STATUSES = Object.keys(NATIVE_STATUS_META) as NativeConnectionStatus[];

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.models.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.models.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NativeConnectionStatus } from '../../../../entities/management-api-v2';
+
+export interface NativeConnectionStatusMeta {
+  label: string;
+  badgeClass: string;
+}
+
+// Record forces compile-time exhaustiveness — adding a new status to the union without an entry here is a build error.
+export const NATIVE_STATUS_META: Record<NativeConnectionStatus, NativeConnectionStatusMeta> = {
+  CONNECTED: { label: 'Connected', badgeClass: 'gio-badge-success' },
+  CONNECTION_ERROR: { label: 'Failed', badgeClass: 'gio-badge-warning' },
+  SESSION_ERROR: { label: 'Disconnected', badgeClass: 'gio-badge-warning' },
+  INTERNAL_ERROR: { label: 'Unknown', badgeClass: 'gio-badge-error' },
+};
+
+export const NATIVE_CONNECTION_STATUSES: { value: NativeConnectionStatus; label: string }[] = (
+  Object.entries(NATIVE_STATUS_META) as [NativeConnectionStatus, NativeConnectionStatusMeta][]
+).map(([value, meta]) => ({ value, label: meta.label }));

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.harness.ts
@@ -25,6 +25,7 @@ export class ApiRuntimeLogsNativeListHarness extends ComponentHarness {
 
   private readonly statusBadgeElements = this.locatorForAll('td.mat-column-connectionStatus span');
   private readonly durationCells = this.locatorForAll('td.mat-column-duration');
+  private readonly viewButtons = this.locatorForAll('td.mat-column-view button');
 
   async getStatusBadges(): Promise<StatusBadge[]> {
     const spans = await this.statusBadgeElements();
@@ -39,5 +40,9 @@ export class ApiRuntimeLogsNativeListHarness extends ComponentHarness {
   async getDurationTexts(): Promise<string[]> {
     const cells = await this.durationCells();
     return Promise.all(cells.map(async cell => (await cell.text()).trim()));
+  }
+
+  async getViewButtonCount(): Promise<number> {
+    return (await this.viewButtons()).length;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.harness.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export interface StatusBadge {
+  text: string;
+  classes: string[];
+}
+
+export class ApiRuntimeLogsNativeListHarness extends ComponentHarness {
+  static hostSelector = 'api-runtime-logs-native-list';
+
+  private readonly statusBadgeElements = this.locatorForAll('td.mat-column-connectionStatus span');
+  private readonly durationCells = this.locatorForAll('td.mat-column-duration');
+
+  async getStatusBadges(): Promise<StatusBadge[]> {
+    const spans = await this.statusBadgeElements();
+    return Promise.all(
+      spans.map(async span => ({
+        text: (await span.text()).trim(),
+        classes: ((await span.getAttribute('class')) ?? '').split(/\s+/).filter(Boolean),
+      })),
+    );
+  }
+
+  async getDurationTexts(): Promise<string[]> {
+    const cells = await this.durationCells();
+    return Promise.all(cells.map(async cell => (await cell.text()).trim()));
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.html
@@ -1,0 +1,77 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<gio-table-wrapper
+  class="table-wrapper"
+  [disableSearchInput]="true"
+  [paginationPageSizeOptions]="pageSizeOptions"
+  [filters]="gioTableWrapperFilters()"
+  [length]="pagination().totalCount"
+  (filtersChange)="onFiltersChanged($event)"
+>
+  <table mat-table [dataSource]="logs()" id="nativeLogsTable" aria-label="Native API logs table" class="table">
+    <ng-container matColumnDef="timestamp">
+      <th mat-header-cell *matHeaderCellDef id="timestamp">Timestamp</th>
+      <td mat-cell *matCellDef="let log">{{ log.timestamp | date: 'dd/MM/yyyy HH:mm:ss.SSS' }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="application">
+      <th mat-header-cell *matHeaderCellDef id="application">Application</th>
+      <td mat-cell *matCellDef="let log">{{ applicationName(log.applicationId) }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="plan">
+      <th mat-header-cell *matHeaderCellDef id="plan">Plan</th>
+      <td mat-cell *matCellDef="let log">{{ planName(log.planId) }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="clientIdentifier">
+      <th mat-header-cell *matHeaderCellDef id="clientIdentifier">Client identifier</th>
+      <td mat-cell *matCellDef="let log">{{ log.clientIdentifier }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="connectionStatus">
+      <th mat-header-cell *matHeaderCellDef id="connectionStatus">Connection status</th>
+      <td mat-cell *matCellDef="let log">
+        @if (log.connectionStatus && statusMeta[log.connectionStatus]; as meta) {
+          <span [class]="meta.badgeClass" [matTooltip]="meta.label">{{ meta.label }}</span>
+        }
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="duration">
+      <th mat-header-cell *matHeaderCellDef id="duration">Duration</th>
+      <td mat-cell *matCellDef="let log">
+        @if (log.connectionDurationMs != null) {
+          {{ log.connectionDurationMs | formatDuration }}
+        }
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns" data-testid="native_logs_table_header"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns" data-testid="native_logs_table_row"></tr>
+
+    <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
+      <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
+        <div class="table__empty-state">
+          <div class="mat-h3">No data to display</div>
+          <div>More data may be available. Try widening your timeframe or adjusting your filters.</div>
+        </div>
+      </td>
+    </tr>
+  </table>
+</gio-table-wrapper>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.html
@@ -62,6 +62,23 @@
       </td>
     </ng-container>
 
+    <ng-container matColumnDef="view">
+      <th mat-header-cell *matHeaderCellDef id="view"></th>
+      <td mat-cell *matCellDef="let log">
+        @if (log.requestId && canViewDetail) {
+          <button
+            mat-icon-button
+            type="button"
+            aria-label="View log details"
+            [attr.data-testid]="'native_logs_view_' + log.requestId"
+            (click)="viewRequested.emit(log.requestId)"
+          >
+            <mat-icon svgIcon="gio:eye-empty"></mat-icon>
+          </button>
+        }
+      </td>
+    </ng-container>
+
     <tr mat-header-row *matHeaderRowDef="displayedColumns" data-testid="native_logs_table_header"></tr>
     <tr mat-row *matRowDef="let row; columns: displayedColumns" data-testid="native_logs_table_row"></tr>
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.html
@@ -48,7 +48,7 @@
       <th mat-header-cell *matHeaderCellDef id="connectionStatus">Connection status</th>
       <td mat-cell *matCellDef="let log">
         @if (log.connectionStatus && statusMeta[log.connectionStatus]; as meta) {
-          <span [class]="meta.badgeClass" [matTooltip]="meta.label">{{ meta.label }}</span>
+          <span [class]="meta.badgeClass"> <mat-icon [svgIcon]="meta.icon"></mat-icon>&nbsp;{{ meta.label }} </span>
         }
       </td>
     </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.scss
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-export * from './apiLogsResponse';
-export * from './apiLogsResponse.fixture';
-export * from './connectionLog';
-export * from './connectionLog.fixture';
-export * from './messageLog';
-export * from './messageLog.fixture';
-export * from './native';
+.table {
+  width: 100%;
+}
+
+.table__empty-state {
+  padding: 24px 16px;
+  text-align: center;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { ApiRuntimeLogsNativeListComponent } from './api-runtime-logs-native-list.component';
+import { ApiRuntimeLogsNativeListHarness } from './api-runtime-logs-native-list.component.harness';
+
+import { fakeNativeApiLog, fakePlanV4 } from '../../../../../../entities/management-api-v2';
+import { fakeApplication } from '../../../../../../entities/application/Application.fixture';
+
+describe('ApiRuntimeLogsNativeListComponent', () => {
+  let fixture: ComponentFixture<ApiRuntimeLogsNativeListComponent>;
+  let component: ApiRuntimeLogsNativeListComponent;
+  let harness: ApiRuntimeLogsNativeListHarness;
+
+  const apps = [fakeApplication({ id: 'app-1', name: 'Order Service' })];
+  const plans = [fakePlanV4({ id: 'plan-1', name: 'Free' })];
+
+  const setup = async (logs: ReturnType<typeof fakeNativeApiLog>[], applications = apps, knownPlans = plans) => {
+    TestBed.configureTestingModule({
+      imports: [ApiRuntimeLogsNativeListComponent, MatIconTestingModule],
+      providers: [provideNoopAnimations()],
+    });
+    fixture = TestBed.createComponent(ApiRuntimeLogsNativeListComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('logs', logs);
+    fixture.componentRef.setInput('pagination', { page: 1, perPage: 10, totalCount: logs.length });
+    fixture.componentRef.setInput('applications', applications);
+    fixture.componentRef.setInput('plans', knownPlans);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiRuntimeLogsNativeListHarness);
+  };
+
+  it('renders application name when id is in the resolved set', async () => {
+    await setup([fakeNativeApiLog({ applicationId: 'app-1' })]);
+    expect(component.applicationName('app-1')).toBe('Order Service');
+  });
+
+  it('renders empty when application is not in the resolved set', async () => {
+    await setup([fakeNativeApiLog({ applicationId: 'app-unknown' })]);
+    expect(component.applicationName('app-unknown')).toBe('');
+  });
+
+  it('renders plan name when id is in the resolved set', async () => {
+    await setup([fakeNativeApiLog({ planId: 'plan-1' })]);
+    expect(component.planName('plan-1')).toBe('Free');
+  });
+
+  it('renders empty when plan is not in the resolved set', async () => {
+    await setup([fakeNativeApiLog({ planId: 'plan-removed' })]);
+    expect(component.planName('plan-removed')).toBe('');
+  });
+
+  it('renders the friendly status label and badge class for known statuses', async () => {
+    await setup([fakeNativeApiLog({ connectionStatus: 'CONNECTED' }), fakeNativeApiLog({ connectionStatus: 'CONNECTION_ERROR' })]);
+    const badges = await harness.getStatusBadges();
+    expect(badges).toHaveLength(2);
+    expect(badges[0].text).toBe('Connected');
+    expect(badges[0].classes).toContain('gio-badge-success');
+    expect(badges[1].text).toBe('Failed');
+    expect(badges[1].classes).toContain('gio-badge-warning');
+  });
+
+  it('omits the badge cell when connectionStatus is missing', async () => {
+    await setup([fakeNativeApiLog({ connectionStatus: undefined })]);
+    expect(await harness.getStatusBadges()).toHaveLength(0);
+  });
+
+  it('omits the duration cell value when connectionDurationMs is null', async () => {
+    await setup([fakeNativeApiLog({ connectionDurationMs: undefined })]);
+    expect(await harness.getDurationTexts()).toEqual(['']);
+  });
+
+  it('does not re-emit pagination when the event matches current state', async () => {
+    await setup([fakeNativeApiLog()]);
+    const emitSpy = jest.spyOn(component.paginationUpdated, 'emit');
+    component.onFiltersChanged({ pagination: { index: 1, size: 10 }, searchTerm: '' });
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  it('re-emits pagination when the size changes', async () => {
+    await setup([fakeNativeApiLog()]);
+    const emitSpy = jest.spyOn(component.paginationUpdated, 'emit');
+    component.onFiltersChanged({ pagination: { index: 1, size: 25 }, searchTerm: '' });
+    expect(emitSpy).toHaveBeenCalledWith({ index: 1, size: 25 });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 
@@ -35,7 +35,7 @@ describe('ApiRuntimeLogsNativeListComponent', () => {
   const setup = async (logs: ReturnType<typeof fakeNativeApiLog>[], applications = apps, knownPlans = plans) => {
     TestBed.configureTestingModule({
       imports: [ApiRuntimeLogsNativeListComponent, MatIconTestingModule],
-      providers: [provideNoopAnimations()],
+      providers: [provideAnimationsAsync('noop')],
     });
     fixture = TestBed.createComponent(ApiRuntimeLogsNativeListComponent);
     component = fixture.componentInstance;
@@ -74,7 +74,7 @@ describe('ApiRuntimeLogsNativeListComponent', () => {
     expect(badges[0].text).toBe('Connected');
     expect(badges[0].classes).toContain('gio-badge-success');
     expect(badges[1].text).toBe('Failed');
-    expect(badges[1].classes).toContain('gio-badge-warning');
+    expect(badges[1].classes).toContain('gio-badge-error');
   });
 
   it('omits the badge cell when connectionStatus is missing', async () => {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.spec.ts
@@ -23,6 +23,8 @@ import { ApiRuntimeLogsNativeListHarness } from './api-runtime-logs-native-list.
 
 import { fakeNativeApiLog, fakePlanV4 } from '../../../../../../entities/management-api-v2';
 import { fakeApplication } from '../../../../../../entities/application/Application.fixture';
+import { GioTestingPermissionProvider } from '../../../../../../shared/components/gio-permission/gio-permission.service';
+import { GioTestingModule } from '../../../../../../shared/testing';
 
 describe('ApiRuntimeLogsNativeListComponent', () => {
   let fixture: ComponentFixture<ApiRuntimeLogsNativeListComponent>;
@@ -32,10 +34,15 @@ describe('ApiRuntimeLogsNativeListComponent', () => {
   const apps = [fakeApplication({ id: 'app-1', name: 'Order Service' })];
   const plans = [fakePlanV4({ id: 'plan-1', name: 'Free' })];
 
-  const setup = async (logs: ReturnType<typeof fakeNativeApiLog>[], applications = apps, knownPlans = plans) => {
+  const setup = async (
+    logs: ReturnType<typeof fakeNativeApiLog>[],
+    applications = apps,
+    knownPlans = plans,
+    permissions: string[] = ['api-native_analytics-r'],
+  ) => {
     TestBed.configureTestingModule({
-      imports: [ApiRuntimeLogsNativeListComponent, MatIconTestingModule],
-      providers: [provideAnimationsAsync('noop')],
+      imports: [ApiRuntimeLogsNativeListComponent, MatIconTestingModule, GioTestingModule],
+      providers: [provideAnimationsAsync('noop'), { provide: GioTestingPermissionProvider, useValue: permissions }],
     });
     fixture = TestBed.createComponent(ApiRuntimeLogsNativeListComponent);
     component = fixture.componentInstance;
@@ -99,5 +106,24 @@ describe('ApiRuntimeLogsNativeListComponent', () => {
     const emitSpy = jest.spyOn(component.paginationUpdated, 'emit');
     component.onFiltersChanged({ pagination: { index: 1, size: 25 }, searchTerm: '' });
     expect(emitSpy).toHaveBeenCalledWith({ index: 1, size: 25 });
+  });
+
+  it('emits viewRequested with the row requestId when the view button is clicked', async () => {
+    await setup([fakeNativeApiLog({ requestId: 'req-42' })]);
+    const emitSpy = jest.spyOn(component.viewRequested, 'emit');
+    const btn: HTMLButtonElement = fixture.nativeElement.querySelector('[data-testid="native_logs_view_req-42"]');
+    expect(btn).not.toBeNull();
+    btn.click();
+    expect(emitSpy).toHaveBeenCalledWith('req-42');
+  });
+
+  it('omits the view button when requestId is missing', async () => {
+    await setup([fakeNativeApiLog({ requestId: undefined })]);
+    expect(await harness.getViewButtonCount()).toBe(0);
+  });
+
+  it('hides the view button when the user lacks api-native_analytics-r permission', async () => {
+    await setup([fakeNativeApiLog({ requestId: 'req-42' })], apps, plans, []);
+    expect(await harness.getViewButtonCount()).toBe(0);
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.ts
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
-import { Component, computed, input, output } from '@angular/core';
+import { Component, computed, inject, input, output } from '@angular/core';
 import { DatePipe } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
+import { GioIconsModule } from '@gravitee/ui-particles-angular';
 
 import { NATIVE_STATUS_META } from '../../api-runtime-logs-native.models';
+import { GioPermissionService } from '../../../../../../shared/components/gio-permission/gio-permission.service';
 import { FormatDurationPipe } from '../../../../../../shared/pipes/format-duration.pipe';
 import { GioTableWrapperModule } from '../../../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import {
@@ -29,25 +32,29 @@ import {
 import { NativeApiLog, Pagination, Plan } from '../../../../../../entities/management-api-v2';
 import { Application } from '../../../../../../entities/application/Application';
 
-const DISPLAYED_COLUMNS = ['timestamp', 'application', 'plan', 'clientIdentifier', 'connectionStatus', 'duration'];
+const BASE_COLUMNS = ['timestamp', 'application', 'plan', 'clientIdentifier', 'connectionStatus', 'duration'];
 
 @Component({
   selector: 'api-runtime-logs-native-list',
   templateUrl: './api-runtime-logs-native-list.component.html',
   styleUrls: ['./api-runtime-logs-native-list.component.scss'],
   standalone: true,
-  imports: [GioTableWrapperModule, MatTableModule, MatIconModule, DatePipe, FormatDurationPipe],
+  imports: [GioTableWrapperModule, MatTableModule, MatButtonModule, MatIconModule, GioIconsModule, DatePipe, FormatDurationPipe],
 })
 export class ApiRuntimeLogsNativeListComponent {
+  private readonly permissionService = inject(GioPermissionService);
+
   logs = input.required<NativeApiLog[]>();
   pagination = input.required<Pagination>();
   applications = input<Application[]>([]);
   plans = input<Plan[]>([]);
 
   paginationUpdated = output<GioTableWrapperPagination>();
+  viewRequested = output<string>();
   pageSizeOptions: number[] = [10, 25, 50, 100];
-  displayedColumns = DISPLAYED_COLUMNS;
   protected readonly statusMeta = NATIVE_STATUS_META;
+  protected readonly canViewDetail = this.permissionService.hasAnyMatching(['api-native_analytics-r']);
+  displayedColumns = this.canViewDetail ? [...BASE_COLUMNS, 'view'] : BASE_COLUMNS;
 
   readonly gioTableWrapperFilters = computed(() => {
     const pagination = this.pagination();

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, computed, input, output } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import { NATIVE_STATUS_META } from '../../api-runtime-logs-native.models';
+import { FormatDurationPipe } from '../../../../../../shared/pipes/format-duration.pipe';
+import { GioTableWrapperModule } from '../../../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+import {
+  GioTableWrapperFilters,
+  GioTableWrapperPagination,
+} from '../../../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { NativeApiLog, Pagination, Plan } from '../../../../../../entities/management-api-v2';
+import { Application } from '../../../../../../entities/application/Application';
+
+const DISPLAYED_COLUMNS = ['timestamp', 'application', 'plan', 'clientIdentifier', 'connectionStatus', 'duration'];
+
+@Component({
+  selector: 'api-runtime-logs-native-list',
+  templateUrl: './api-runtime-logs-native-list.component.html',
+  styleUrls: ['./api-runtime-logs-native-list.component.scss'],
+  standalone: true,
+  imports: [GioTableWrapperModule, MatTableModule, MatTooltipModule, DatePipe, FormatDurationPipe],
+})
+export class ApiRuntimeLogsNativeListComponent {
+  logs = input.required<NativeApiLog[]>();
+  pagination = input.required<Pagination>();
+  applications = input<Application[]>([]);
+  plans = input<Plan[]>([]);
+
+  paginationUpdated = output<GioTableWrapperPagination>();
+  pageSizeOptions: number[] = [10, 25, 50, 100];
+  displayedColumns = DISPLAYED_COLUMNS;
+  protected readonly statusMeta = NATIVE_STATUS_META;
+
+  readonly gioTableWrapperFilters = computed(() => {
+    const pagination = this.pagination();
+    return {
+      searchTerm: '',
+      pagination: {
+        index: pagination.page ?? 1,
+        size: pagination.perPage ?? 10,
+      },
+    };
+  });
+
+  private readonly applicationsById = computed(() => new Map(this.applications().map(a => [a.id, a.name] as const)));
+  private readonly plansById = computed(() => new Map(this.plans().map(p => [p.id, p.name] as const)));
+
+  onFiltersChanged(event: GioTableWrapperFilters) {
+    const eventPagination = event.pagination;
+    const currentPagination = this.pagination();
+    // Suppress the initial mount emission when pagination has not been hydrated yet.
+    const sizeChanged = currentPagination.perPage != null && currentPagination.perPage !== eventPagination.size;
+    const pageChanged = currentPagination.page != null && currentPagination.page !== eventPagination.index;
+    if (sizeChanged || pageChanged) {
+      this.paginationUpdated.emit({ index: eventPagination.index, size: eventPagination.size });
+    }
+  }
+
+  applicationName(id?: string): string {
+    if (!id) return '';
+    return this.applicationsById().get(id) ?? '';
+  }
+
+  planName(id?: string): string {
+    if (!id) return '';
+    return this.plansById().get(id) ?? '';
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.component.ts
@@ -16,8 +16,8 @@
 
 import { Component, computed, input, output } from '@angular/core';
 import { DatePipe } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
-import { MatTooltipModule } from '@angular/material/tooltip';
 
 import { NATIVE_STATUS_META } from '../../api-runtime-logs-native.models';
 import { FormatDurationPipe } from '../../../../../../shared/pipes/format-duration.pipe';
@@ -36,7 +36,7 @@ const DISPLAYED_COLUMNS = ['timestamp', 'application', 'plan', 'clientIdentifier
   templateUrl: './api-runtime-logs-native-list.component.html',
   styleUrls: ['./api-runtime-logs-native-list.component.scss'],
   standalone: true,
-  imports: [GioTableWrapperModule, MatTableModule, MatTooltipModule, DatePipe, FormatDurationPipe],
+  imports: [GioTableWrapperModule, MatTableModule, MatIconModule, DatePipe, FormatDurationPipe],
 })
 export class ApiRuntimeLogsNativeListComponent {
   logs = input.required<NativeApiLog[]>();

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-list/api-runtime-logs-native-list.stories.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+
+import { ApiRuntimeLogsNativeListComponent } from './api-runtime-logs-native-list.component';
+
+import { fakeNativeApiLog, fakePlanV4 } from '../../../../../../entities/management-api-v2';
+import { fakeApplication } from '../../../../../../entities/application/Application.fixture';
+
+const APPS = [fakeApplication({ id: 'app-1', name: 'Order Service' }), fakeApplication({ id: 'app-2', name: 'Payment Service' })];
+
+const PLANS = [fakePlanV4({ id: 'plan-1', name: 'Free' }), fakePlanV4({ id: 'plan-2', name: 'Premium' })];
+
+const logs = [
+  fakeNativeApiLog({
+    requestId: 'req-1',
+    timestamp: '2026-05-10T10:30:15.000Z',
+    applicationId: 'app-1',
+    planId: 'plan-1',
+    clientIdentifier: 'kafka-client-orders-prod',
+    connectionStatus: 'CONNECTED',
+    connectionDurationMs: 4200,
+  }),
+  fakeNativeApiLog({
+    requestId: 'req-2',
+    timestamp: '2026-05-10T10:31:42.000Z',
+    applicationId: 'app-2',
+    planId: 'plan-2',
+    clientIdentifier: 'kafka-client-payments',
+    connectionStatus: 'CONNECTION_ERROR',
+    connectionDurationMs: 134,
+  }),
+  fakeNativeApiLog({
+    requestId: 'req-3',
+    timestamp: '2026-05-10T10:33:01.000Z',
+    applicationId: 'app-1',
+    planId: 'plan-2',
+    clientIdentifier: 'kafka-client-orders-staging',
+    connectionStatus: 'SESSION_ERROR',
+    connectionDurationMs: 982347,
+  }),
+  fakeNativeApiLog({
+    requestId: 'req-4',
+    timestamp: '2026-05-10T10:35:21.000Z',
+    applicationId: 'app-2',
+    planId: 'plan-1',
+    clientIdentifier: 'kafka-client-batch-job',
+    connectionStatus: 'INTERNAL_ERROR',
+    connectionDurationMs: 27,
+  }),
+];
+
+export default {
+  title: 'API / Logs / Native / List',
+  component: ApiRuntimeLogsNativeListComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [ApiRuntimeLogsNativeListComponent],
+    }),
+  ],
+  argTypes: {},
+  render: args => ({
+    template: `
+      <div style="width: 1200px">
+        <api-runtime-logs-native-list
+          [logs]="logs"
+          [pagination]="pagination"
+          [applications]="applications"
+          [plans]="plans"
+        ></api-runtime-logs-native-list>
+      </div>
+    `,
+    props: args,
+  }),
+} as Meta;
+
+export const Empty: StoryObj = {};
+Empty.args = {
+  pagination: { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 0, totalCount: 0 },
+  logs: [],
+  applications: APPS,
+  plans: PLANS,
+};
+
+export const FirstPage: StoryObj = {};
+FirstPage.args = {
+  pagination: { page: 1, perPage: 10, pageCount: 3, pageItemsCount: 4, totalCount: 24 },
+  logs,
+  applications: APPS,
+  plans: PLANS,
+};
+
+export const UnresolvedNames: StoryObj = {};
+UnresolvedNames.args = {
+  pagination: { page: 1, perPage: 10, pageCount: 1, pageItemsCount: 4, totalCount: 4 },
+  logs,
+  applications: [],
+  plans: [],
+};

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.harness.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+import { NativeConnectionStatus } from '../../../../../../entities/management-api-v2';
+
+const STATUSES: NativeConnectionStatus[] = ['CONNECTED', 'SESSION_ERROR', 'CONNECTION_ERROR', 'INTERNAL_ERROR'];
+
+export class ApiRuntimeLogsNativeSummaryHarness extends ComponentHarness {
+  static hostSelector = 'api-runtime-logs-native-summary';
+
+  async getCounts(): Promise<Record<NativeConnectionStatus, string>> {
+    const entries = await Promise.all(
+      STATUSES.map(async status => {
+        const card = await this.locatorForOptional(`[data-testid="native_logs_summary_card_${status}"] .summary__card__count`)();
+        return [status, card ? (await card.text()).trim() : ''] as const;
+      }),
+    );
+    return Object.fromEntries(entries) as Record<NativeConnectionStatus, string>;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.html
@@ -1,0 +1,35 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="summary" data-testid="native_logs_summary">
+  @for (card of cards; track card.status) {
+    <mat-card class="summary__card" appearance="outlined" [attr.data-testid]="'native_logs_summary_card_' + card.status">
+      <span class="summary__card__badge" [class]="card.badgeClass">
+        <mat-icon [svgIcon]="card.icon"></mat-icon>&nbsp;{{ card.label }}
+      </span>
+      <div class="summary__card__count">
+        @if (summary.hasValue()) {
+          {{ counts()[card.status] ?? 0 }}
+        } @else if (summary.error()) {
+          <button mat-button class="summary__card__retry" data-testid="native_logs_summary_retry" (click)="reload()">Failed — retry</button>
+        } @else {
+          —
+        }
+      </div>
+    </mat-card>
+  }
+</div>

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.scss
@@ -13,10 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+.summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
 
-export * from './nativeApiLog';
-export * from './nativeApiLog.fixture';
-export * from './nativeApiLogsResponse';
-export * from './nativeApiLogsResponse.fixture';
-export * from './nativeApiLogsSummary';
-export * from './nativeApiLogsSummary.fixture';
+  &__card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 16px 20px;
+
+    &__badge {
+      align-self: flex-start;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { ApiRuntimeLogsNativeSummaryComponent } from './api-runtime-logs-native-summary.component';
+import { ApiRuntimeLogsNativeSummaryHarness } from './api-runtime-logs-native-summary.component.harness';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../../shared/testing';
+import { fakeNativeApiLogsSummary } from '../../../../../../entities/management-api-v2';
+
+describe('ApiRuntimeLogsNativeSummaryComponent', () => {
+  let fixture: ComponentFixture<ApiRuntimeLogsNativeSummaryComponent>;
+  let httpTestingController: HttpTestingController;
+
+  const API_ID = 'an-api-id';
+
+  const setup = ({ from, to }: { from: number | null; to: number | null }) => {
+    TestBed.configureTestingModule({
+      imports: [ApiRuntimeLogsNativeSummaryComponent, MatIconTestingModule, GioTestingModule],
+      providers: [provideHttpClient(withInterceptorsFromDi()), provideHttpClientTesting(), provideAnimationsAsync('noop')],
+    });
+    fixture = TestBed.createComponent(ApiRuntimeLogsNativeSummaryComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.componentRef.setInput('apiId', API_ID);
+    fixture.componentRef.setInput('from', from);
+    fixture.componentRef.setInput('to', to);
+    fixture.detectChanges();
+  };
+
+  const getHarness = () => TestbedHarnessEnvironment.harnessForFixture(fixture, ApiRuntimeLogsNativeSummaryHarness);
+
+  afterEach(() => {
+    httpTestingController?.verify();
+  });
+
+  it('does not call the summary endpoint when from or to are null', async () => {
+    setup({ from: null, to: null });
+    httpTestingController.expectNone(req => req.url.endsWith('/logs/native/summary'));
+    const harness = await getHarness();
+    expect(await harness.getCounts()).toEqual({ CONNECTED: '—', SESSION_ERROR: '—', CONNECTION_ERROR: '—', INTERNAL_ERROR: '—' });
+  });
+
+  it('renders counts from the summary endpoint when from/to are set', async () => {
+    setup({ from: 1000, to: 2000 });
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary?from=1000&to=2000`)
+      .flush(fakeNativeApiLogsSummary());
+    fixture.detectChanges();
+    const harness = await getHarness();
+    expect(await harness.getCounts()).toEqual({ CONNECTED: '184', SESSION_ERROR: '32', CONNECTION_ERROR: '28', INTERNAL_ERROR: '4' });
+  });
+
+  it('falls back to 0 for statuses missing in the response', async () => {
+    setup({ from: 1000, to: 2000 });
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary?from=1000&to=2000`)
+      .flush({ countByConnectionStatus: { CONNECTED: 5 } });
+    fixture.detectChanges();
+    const harness = await getHarness();
+    expect(await harness.getCounts()).toEqual({ CONNECTED: '5', SESSION_ERROR: '0', CONNECTION_ERROR: '0', INTERNAL_ERROR: '0' });
+  });
+
+  it('refetches when from/to change', async () => {
+    setup({ from: 1000, to: 2000 });
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary?from=1000&to=2000`)
+      .flush(fakeNativeApiLogsSummary());
+    fixture.detectChanges();
+
+    fixture.componentRef.setInput('from', 3000);
+    fixture.componentRef.setInput('to', 4000);
+    fixture.detectChanges();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary?from=3000&to=4000`)
+      .flush(
+        fakeNativeApiLogsSummary({ countByConnectionStatus: { CONNECTED: 1, SESSION_ERROR: 2, CONNECTION_ERROR: 3, INTERNAL_ERROR: 4 } }),
+      );
+    fixture.detectChanges();
+    const harness = await getHarness();
+    expect(await harness.getCounts()).toEqual({ CONNECTED: '1', SESSION_ERROR: '2', CONNECTION_ERROR: '3', INTERNAL_ERROR: '4' });
+  });
+
+  it('shows a retry button when the summary endpoint errors, and re-fetches on click', async () => {
+    setup({ from: 1000, to: 2000 });
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary?from=1000&to=2000`)
+      .error(new ProgressEvent('Network error'), { status: 500, statusText: 'Internal Server Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const retry: HTMLButtonElement | null = fixture.nativeElement.querySelector('[data-testid="native_logs_summary_retry"]');
+    expect(retry).not.toBeNull();
+    retry!.click();
+    fixture.detectChanges();
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary?from=1000&to=2000`)
+      .flush(fakeNativeApiLogsSummary());
+    fixture.detectChanges();
+    const harness = await getHarness();
+    expect(await harness.getCounts()).toEqual({ CONNECTED: '184', SESSION_ERROR: '32', CONNECTION_ERROR: '28', INTERNAL_ERROR: '4' });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.stories.ts
@@ -43,6 +43,8 @@ const stubLogsService = (response: NativeApiLogsSummary | null) =>
 
 const meta: Meta<ApiRuntimeLogsNativeSummaryComponent> = {
   title: 'API / Logs / Native / Summary',
+  component: ApiRuntimeLogsNativeSummaryComponent,
+  decorators: [moduleMetadata({ imports: [ApiRuntimeLogsNativeSummaryComponent] })],
   parameters: { layout: 'padded' },
   render: () => ({
     template: `

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.stories.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { of, NEVER } from 'rxjs';
+
+import { ApiRuntimeLogsNativeSummaryComponent } from './api-runtime-logs-native-summary.component';
+
+import { ApiNativeLogsV2Service } from '../../../../../../services-ngx/api-native-logs-v2.service';
+import { NativeApiLogsSummary } from '../../../../../../entities/management-api-v2';
+
+const NOW = Date.now();
+const HOUR = 60 * 60 * 1000;
+
+const populated: NativeApiLogsSummary = {
+  countByConnectionStatus: { CONNECTED: 184, SESSION_ERROR: 32, CONNECTION_ERROR: 28, INTERNAL_ERROR: 4 },
+};
+
+const allZeros: NativeApiLogsSummary = {
+  countByConnectionStatus: { CONNECTED: 0, SESSION_ERROR: 0, CONNECTION_ERROR: 0, INTERNAL_ERROR: 0 },
+};
+
+const partial: NativeApiLogsSummary = {
+  countByConnectionStatus: { CONNECTED: 12 },
+};
+
+const stubLogsService = (response: NativeApiLogsSummary | null) =>
+  ({
+    searchSummary: () => (response == null ? NEVER : of(response)),
+  }) as unknown as ApiNativeLogsV2Service;
+
+const meta: Meta<ApiRuntimeLogsNativeSummaryComponent> = {
+  title: 'API / Logs / Native / Summary',
+  parameters: { layout: 'padded' },
+  render: () => ({
+    template: `
+      <div style="min-width: 960px; padding: 24px; background-color: #f4f6fb;">
+        <api-runtime-logs-native-summary [apiId]="apiId" [from]="from" [to]="to" />
+      </div>
+    `,
+    props: { apiId: 'api-native-demo', from: NOW - HOUR, to: NOW },
+  }),
+};
+
+export default meta;
+
+export const Populated: StoryObj<ApiRuntimeLogsNativeSummaryComponent> = {
+  decorators: [moduleMetadata({ providers: [{ provide: ApiNativeLogsV2Service, useValue: stubLogsService(populated) }] })],
+};
+
+export const AllZeros: StoryObj<ApiRuntimeLogsNativeSummaryComponent> = {
+  decorators: [moduleMetadata({ providers: [{ provide: ApiNativeLogsV2Service, useValue: stubLogsService(allZeros) }] })],
+};
+
+export const OneNonZero: StoryObj<ApiRuntimeLogsNativeSummaryComponent> = {
+  decorators: [moduleMetadata({ providers: [{ provide: ApiNativeLogsV2Service, useValue: stubLogsService(partial) }] })],
+};
+
+export const Loading: StoryObj<ApiRuntimeLogsNativeSummaryComponent> = {
+  decorators: [moduleMetadata({ providers: [{ provide: ApiNativeLogsV2Service, useValue: stubLogsService(null) }] })],
+};
+
+export const NoTimeframe: StoryObj<ApiRuntimeLogsNativeSummaryComponent> = {
+  decorators: [moduleMetadata({ providers: [{ provide: ApiNativeLogsV2Service, useValue: stubLogsService(populated) }] })],
+  render: () => ({
+    template: `
+      <div style="min-width: 960px; padding: 24px; background-color: #f4f6fb;">
+        <api-runtime-logs-native-summary [apiId]="apiId" [from]="null" [to]="null" />
+      </div>
+    `,
+    props: { apiId: 'api-native-demo' },
+  }),
+};

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject, input } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { GioIconsModule } from '@gravitee/ui-particles-angular';
+
+import { NATIVE_STATUS_META, NATIVE_SUMMARY_STATUSES } from '../../api-runtime-logs-native.models';
+import { ApiNativeLogsV2Service } from '../../../../../../services-ngx/api-native-logs-v2.service';
+import { NativeConnectionStatus } from '../../../../../../entities/management-api-v2';
+
+@Component({
+  selector: 'api-runtime-logs-native-summary',
+  templateUrl: './api-runtime-logs-native-summary.component.html',
+  styleUrls: ['./api-runtime-logs-native-summary.component.scss'],
+  standalone: true,
+  imports: [MatButtonModule, MatCardModule, MatIconModule, GioIconsModule],
+})
+export class ApiRuntimeLogsNativeSummaryComponent {
+  private readonly logsService = inject(ApiNativeLogsV2Service);
+
+  apiId = input.required<string>();
+  from = input<number | null>(null);
+  to = input<number | null>(null);
+
+  protected readonly cards = NATIVE_SUMMARY_STATUSES.map(status => ({ status, ...NATIVE_STATUS_META[status] }));
+
+  protected readonly summary = rxResource({
+    params: () => {
+      const from = this.from();
+      const to = this.to();
+      if (from == null || to == null) return undefined;
+      return { apiId: this.apiId(), from, to };
+    },
+    stream: ({ params }) => this.logsService.searchSummary(params.apiId, params.from, params.to),
+  });
+
+  protected readonly counts = computed<Partial<Record<NativeConnectionStatus, number>>>(
+    () => this.summary.value()?.countByConnectionStatus ?? {},
+  );
+
+  // Forces a re-fetch with the current params — used by the parent's refresh button.
+  reload(): void {
+    this.summary.reload();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -52,6 +52,7 @@ import { ApiEndpointGroupCreateComponent } from './endpoints-v4/endpoint-group/c
 import { ApiLlmProviderComponent } from './endpoints-v4/llm-provider/api-llm-provider.component';
 import { ApiRuntimeLogsComponent } from './api-traffic-v4/runtime-logs/api-runtime-logs.component';
 import { ApiRuntimeLogsNativeComponent } from './api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component';
+import { ApiRuntimeLogsNativeDetailsComponent } from './api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component';
 import { ApiListComponent } from './list/api-list.component';
 import { ApiCreationGetStartedComponent } from './creation-get-started/api-creation-get-started.component';
 import { ApiCreationV4Component } from './creation-v4/api-creation-v4.component';
@@ -1020,6 +1021,18 @@ const apisRoutes: Routes = [
           },
         },
         component: ApiRuntimeLogsNativeComponent,
+      },
+      {
+        path: 'v4/runtime-logs-native/:requestId',
+        data: {
+          permissions: {
+            anyOf: ['api-native_analytics-r'],
+          },
+          docs: {
+            page: 'management-api-logs',
+          },
+        },
+        component: ApiRuntimeLogsNativeDetailsComponent,
       },
       {
         path: 'v4/runtime-logs/:requestId',

--- a/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis-routing.module.ts
@@ -51,6 +51,7 @@ import { ApiEndpointGroupComponent } from './endpoints-v4/endpoint-group/api-end
 import { ApiEndpointGroupCreateComponent } from './endpoints-v4/endpoint-group/create/api-endpoint-group-create.component';
 import { ApiLlmProviderComponent } from './endpoints-v4/llm-provider/api-llm-provider.component';
 import { ApiRuntimeLogsComponent } from './api-traffic-v4/runtime-logs/api-runtime-logs.component';
+import { ApiRuntimeLogsNativeComponent } from './api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component';
 import { ApiListComponent } from './list/api-list.component';
 import { ApiCreationGetStartedComponent } from './creation-get-started/api-creation-get-started.component';
 import { ApiCreationV4Component } from './creation-v4/api-creation-v4.component';
@@ -1007,6 +1008,18 @@ const apisRoutes: Routes = [
           },
         },
         component: ApiRuntimeLogsComponent,
+      },
+      {
+        path: 'v4/runtime-logs-native',
+        data: {
+          permissions: {
+            anyOf: ['api-native_log-r'],
+          },
+          docs: {
+            page: 'management-api-logs',
+          },
+        },
+        component: ApiRuntimeLogsNativeComponent,
       },
       {
         path: 'v4/runtime-logs/:requestId',

--- a/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.spec.ts
@@ -20,7 +20,7 @@ import { firstValueFrom } from 'rxjs';
 import { ApiNativeLogsV2Service } from './api-native-logs-v2.service';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
-import { fakeNativeApiLog, NativeApiLogsParam, NativeApiLogsResponse } from '../entities/management-api-v2';
+import { fakeNativeApiLog, fakeNativeApiLogsSummary, NativeApiLogsParam, NativeApiLogsResponse } from '../entities/management-api-v2';
 
 interface Row {
   queryParams: NativeApiLogsParam;
@@ -78,6 +78,24 @@ describe('ApiNativeLogsV2Service', () => {
 
       const response = await responsePromise;
       expect(response.data).toEqual(fakeResponse.data);
+    });
+  });
+
+  describe('searchSummary', () => {
+    it('calls GET /logs/native/summary with from and to params', async () => {
+      const fakeResponse = fakeNativeApiLogsSummary();
+
+      const responsePromise = firstValueFrom(service.searchSummary(API_ID, 1000, 2000));
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary?from=1000&to=2000`,
+          method: 'GET',
+        })
+        .flush(fakeResponse);
+
+      const response = await responsePromise;
+      expect(response.countByConnectionStatus).toEqual(fakeResponse.countByConnectionStatus);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+
+import { ApiNativeLogsV2Service } from './api-native-logs-v2.service';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
+import { fakeNativeApiLog, NativeApiLogsParam, NativeApiLogsResponse } from '../entities/management-api-v2';
+
+interface Row {
+  queryParams: NativeApiLogsParam;
+  queryURL: string;
+}
+
+describe('ApiNativeLogsV2Service', () => {
+  let httpTestingController: HttpTestingController;
+  let service: ApiNativeLogsV2Service;
+  const API_ID = 'api-id';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject<ApiNativeLogsV2Service>(ApiNativeLogsV2Service);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  const cases: Row[] = [
+    { queryParams: {}, queryURL: '?page=1&perPage=10' },
+    { queryParams: { page: 2, perPage: 12 }, queryURL: '?page=2&perPage=12' },
+    { queryParams: { from: 222, to: 333 }, queryURL: '?page=1&perPage=10&from=222&to=333' },
+    { queryParams: { applicationIds: '1,2' }, queryURL: '?page=1&perPage=10&applicationIds=1,2' },
+    { queryParams: { planIds: '1,2' }, queryURL: '?page=1&perPage=10&planIds=1,2' },
+    {
+      queryParams: { connectionStatuses: 'CONNECTED,CONNECTION_ERROR' },
+      queryURL: '?page=1&perPage=10&connectionStatuses=CONNECTED,CONNECTION_ERROR',
+    },
+    {
+      queryParams: { from: 222, to: 333, applicationIds: '1,2', planIds: '3,4', connectionStatuses: 'CONNECTED' },
+      queryURL: '?page=1&perPage=10&from=222&to=333&applicationIds=1,2&planIds=3,4&connectionStatuses=CONNECTED',
+    },
+  ];
+
+  describe('searchConnectionLogs', () => {
+    it.each(cases)('call the service with: $queryParams should call API with: $queryURL', async ({ queryParams, queryURL }) => {
+      const fakeResponse: NativeApiLogsResponse = {
+        data: [fakeNativeApiLog({ apiId: API_ID })],
+      };
+
+      const responsePromise = firstValueFrom(service.searchConnectionLogs(API_ID, queryParams));
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native${queryURL}`,
+          method: 'GET',
+        })
+        .flush(fakeResponse);
+
+      const response = await responsePromise;
+      expect(response.data).toEqual(fakeResponse.data);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.spec.ts
@@ -98,4 +98,23 @@ describe('ApiNativeLogsV2Service', () => {
       expect(response.countByConnectionStatus).toEqual(fakeResponse.countByConnectionStatus);
     });
   });
+
+  describe('getConnectionLog', () => {
+    it('calls GET /logs/native/{requestId} with from and to params', async () => {
+      const REQUEST_ID = 'req-1';
+      const fakeResponse = fakeNativeApiLog({ requestId: REQUEST_ID });
+
+      const responsePromise = firstValueFrom(service.getConnectionLog(API_ID, REQUEST_ID, 1000, 2000));
+
+      httpTestingController
+        .expectOne({
+          url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/${REQUEST_ID}?from=1000&to=2000`,
+          method: 'GET',
+        })
+        .flush(fakeResponse);
+
+      const response = await responsePromise;
+      expect(response.requestId).toEqual(REQUEST_ID);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { NativeApiLogsParam, NativeApiLogsResponse } from '../entities/management-api-v2';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApiNativeLogsV2Service {
+  private readonly http = inject(HttpClient);
+  private readonly constants = inject(Constants);
+
+  searchConnectionLogs(apiId: string, queryParam?: NativeApiLogsParam): Observable<NativeApiLogsResponse> {
+    let params = new HttpParams();
+    params = params.append('page', queryParam?.page ?? 1);
+    params = params.append('perPage', queryParam?.perPage ?? 10);
+
+    if (queryParam?.from) params = params.append('from', queryParam.from);
+    if (queryParam?.to) params = params.append('to', queryParam.to);
+    if (queryParam?.applicationIds) params = params.append('applicationIds', queryParam.applicationIds);
+    if (queryParam?.planIds) params = params.append('planIds', queryParam.planIds);
+    if (queryParam?.connectionStatuses) params = params.append('connectionStatuses', queryParam.connectionStatuses);
+
+    return this.http.get<NativeApiLogsResponse>(`${this.constants.env?.v2BaseURL}/apis/${apiId}/logs/native`, {
+      params,
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.ts
@@ -18,7 +18,7 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { NativeApiLogsParam, NativeApiLogsResponse, NativeApiLogsSummary } from '../entities/management-api-v2';
+import { NativeApiLog, NativeApiLogsParam, NativeApiLogsResponse, NativeApiLogsSummary } from '../entities/management-api-v2';
 
 @Injectable({
   providedIn: 'root',
@@ -46,5 +46,10 @@ export class ApiNativeLogsV2Service {
   searchSummary(apiId: string, from: number, to: number): Observable<NativeApiLogsSummary> {
     const params = new HttpParams().set('from', from).set('to', to);
     return this.http.get<NativeApiLogsSummary>(`${this.constants.env?.v2BaseURL}/apis/${apiId}/logs/native/summary`, { params });
+  }
+
+  getConnectionLog(apiId: string, requestId: string, from: number, to: number): Observable<NativeApiLog> {
+    const params = new HttpParams().set('from', from).set('to', to);
+    return this.http.get<NativeApiLog>(`${this.constants.env?.v2BaseURL}/apis/${apiId}/logs/native/${requestId}`, { params });
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-native-logs-v2.service.ts
@@ -18,7 +18,7 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { NativeApiLogsParam, NativeApiLogsResponse } from '../entities/management-api-v2';
+import { NativeApiLogsParam, NativeApiLogsResponse, NativeApiLogsSummary } from '../entities/management-api-v2';
 
 @Injectable({
   providedIn: 'root',
@@ -41,5 +41,10 @@ export class ApiNativeLogsV2Service {
     return this.http.get<NativeApiLogsResponse>(`${this.constants.env?.v2BaseURL}/apis/${apiId}/logs/native`, {
       params,
     });
+  }
+
+  searchSummary(apiId: string, from: number, to: number): Observable<NativeApiLogsSummary> {
+    const params = new HttpParams().set('from', from).set('to', to);
+    return this.http.get<NativeApiLogsSummary>(`${this.constants.env?.v2BaseURL}/apis/${apiId}/logs/native/summary`, { params });
   }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-timeframe/gio-timeframe.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-timeframe/gio-timeframe.component.html
@@ -16,7 +16,7 @@
 
 -->
 <div class="gio-timeframe" [formGroup]="form">
-  <mat-form-field>
+  <mat-form-field [appearance]="appearance()">
     <mat-label>Timeframe</mat-label>
     <mat-select formControlName="period" (selectionChange)="onPeriodChange($event.value)">
       @for (timeFrame of timeFrames(); track timeFrame.id) {
@@ -28,7 +28,7 @@
   </mat-form-field>
 
   @if (form.controls.period.value === customPeriod()) {
-    <mat-form-field class="custom-date">
+    <mat-form-field class="custom-date" [appearance]="appearance()">
       <mat-label>From</mat-label>
       <input
         matInput
@@ -41,7 +41,7 @@
       <owl-date-time #fromDateTimePicker></owl-date-time>
     </mat-form-field>
 
-    <mat-form-field class="custom-date">
+    <mat-form-field class="custom-date" [appearance]="appearance()">
       <mat-label>To</mat-label>
       <input
         matInput

--- a/gravitee-apim-console-webui/src/shared/components/gio-timeframe/gio-timeframe.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-timeframe/gio-timeframe.component.ts
@@ -31,7 +31,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DATE_TIME_FORMATS } from '../../utils/timeFrameRanges';
 import { dateRangeGroupValidator } from '../../validators/date-range.validator';
 
-interface TimeframeValue {
+export interface TimeframeValue {
   period: string;
   from: Moment | null;
   to: Moment | null;
@@ -67,6 +67,8 @@ interface TimeframeValue {
 export class GioTimeframeComponent implements ControlValueAccessor {
   timeFrames = input.required<{ id: string; label: string }[]>();
   customPeriod = input<string>('custom');
+
+  appearance = input<'fill' | 'outline'>('fill');
 
   apply = output<void>();
   refresh = output<void>();


### PR DESCRIPTION
[APIM-13590](https://gravitee.atlassian.net/browse/APIM-13590)

Adds a Runtime Logs page for NATIVE-type APIs in the console. New menu entry, route (`v4/runtime-logs-native`), service, and SDK types. Mirrors the API Analytics native filter UX (`gio-timeframe` + `gio-select-search`).

## Summary

- New page: `api-runtime-logs-native` (standalone) + child list component, filters (Period, Applications, Plans, Connection status), table (Timestamp / Application / Plan / Client identifier / Connection status / Duration), Configure Reporting link, reporting-disabled banner.
- New service: `ApiNativeLogsV2Service.searchConnectionLogs` → `GET /apis/{apiId}/logs/native`.
- Hand-written SDK types under `entities/management-api-v2/log/native/`.
- Menu entry guarded by `api-native_log-r`.
- Stories for page (WithRows / Empty / ReportingDisabled) and list child.

## Notes for reviewers

- Detail page, summary widget, and \`errorKey\` column are intentionally **out of scope** — deferred to next iteration.
- The first commit cherry-picks the \`reporterMetricsEnabled\` field from [#apim-13594](https://github.com/gravitee-io/gravitee-api-management/tree/apim-13594) (commit \`9f930acde7\`). When that branch merges to master, this commit auto-drops on rebase (or one \`git rebase --skip\` for squash merge).
- Test plan
  - [x] 31 unit tests pass (page + service + menu + gio-timeframe)
  - [ ] Manual smoke: navigate to Native API → Logs, exercise filters
  - [ ] Verify reporting-disabled banner when \`reporterMetricsEnabled === false\`

[APIM-13590]: https://gravitee.atlassian.net/browse/APIM-13590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1428" height="624" alt="Screenshot 2026-05-11 at 1 33 49 PM" src="https://github.com/user-attachments/assets/f74cef96-63ce-474b-83d7-4d0322246b30" />
<img width="1429" height="579" alt="Screenshot 2026-05-11 at 1 33 42 PM" src="https://github.com/user-attachments/assets/8dad2141-1409-4983-b0a9-b523ba34de11" />
<img width="1426" height="642" alt="Screenshot 2026-05-11 at 1 33 32 PM" src="https://github.com/user-attachments/assets/84c13202-fafa-4a8e-945b-739d22c5fd77" />
<img width="1385" height="831" alt="Screenshot 2026-05-11 at 4 49 05 PM" src="https://github.com/user-attachments/assets/591e6bdc-673d-43d0-902e-74645472a295" />
<img width="1373" height="946" alt="Screenshot 2026-05-11 at 4 49 25 PM" src="https://github.com/user-attachments/assets/0856c13a-a7bc-42eb-9b38-fcf79a528811" />

