### PR TITLE
fix: validate secondary context paths (APIM-14004)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/VerifyApiPathDomainService.java
@@ -165,8 +165,8 @@ public class VerifyApiPathDomainService implements Validator<VerifyApiPathDomain
     private Optional<Error> findConflictingPathError(String path, List<String> existingPaths) {
         return existingPaths
             .stream()
-            .findFirst()
             .filter(existingPath -> existingPath.startsWith(path) || path.startsWith(existingPath))
+            .findFirst()
             .map(conflictingPath -> Error.severe("Path [%s] already exists", conflictingPath));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiPathDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiPathDomainServiceTest.java
@@ -300,6 +300,24 @@ class VerifyApiPathDomainServiceTest {
     }
 
     @Test
+    public void should_return_error_if_path_already_used_by_secondary_api_v4_path() {
+        givenExistingRestrictedDomains(ENVIRONMENT_ID, null);
+
+        givenExistingApis(
+            ENVIRONMENT_ID,
+            Stream.of(buildApiHttpV4WithPaths(ENVIRONMENT_ID, "api1", List.of(Pair.of("", "/path1/"), Pair.of("", "/path2/"))))
+        );
+
+        var errors = service
+            .validateAndSanitize(
+                new VerifyApiPathDomainService.Input(ENVIRONMENT_ID, API_ID, List.of(Path.builder().host("").path("/path2/").build()))
+            )
+            .severe();
+
+        assertThat(errors).isPresent().hasValue(List.of(Validator.Error.severe("Path [/path2/] already exists")));
+    }
+
+    @Test
     public void should_ignore_path_already_used_by_same_api_v4() {
         givenExistingRestrictedDomains(ENVIRONMENT_ID, null);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14004

## Description

Fixed API path validation so it checks all existing context paths when looking for conflicts, including secondary paths on V4 HTTP APIs.

Previously, the validator only checked the first existing path before deciding whether there was a conflict. This allowed a new API to reuse a secondary context path from another API.

Added a regression test covering an existing V4 API with /path1/ and /path2/, verifying that /path2/ is rejected.


