### PR TITLE
fix: export allowedInApiProducts for legacy v4 APIs (APIM-13807)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ExportApiDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ExportApiDefinitionTest.java
@@ -152,6 +152,17 @@ class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
     }
 
     @Test
+    void should_export_allowedInApiProducts_false_for_v4_proxy_api() {
+        when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(fakeExportApiEntity(fakeApiEntityV4())));
+
+        Response response = rootTarget().request().get();
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+
+        var json = response.readEntity(String.class);
+        assertThat(json).contains("\"allowedInApiProducts\" : false");
+    }
+
+    @Test
     void should_export_NativeApiEntityV4() {
         when(exportApiUseCase.execute(any())).thenReturn(new ExportApiUseCase.Output(fakeExportApiEntity(fakeNativeApiEntityV4())));
 
@@ -281,6 +292,7 @@ class ApiResource_ExportApiDefinitionTest extends ApiResourceTest {
             .analytics(new Analytics())
             .endpointGroups(List.of(endpointGroup))
             .flows(List.of(flow))
+            .allowedInApiProducts(false)
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapter.java
@@ -29,6 +29,7 @@ import io.gravitee.apim.core.metadata.model.Metadata;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.federation.FederatedApi;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
@@ -107,10 +108,7 @@ public interface GraviteeDefinitionAdapter {
         expression = "java(apiEntity.getApiDefinitionHttpV4() != null ? apiEntity.getApiDefinitionHttpV4().getFailover() : null)"
     )
     @Mapping(target = "endpointGroups", source = "apiEntity.apiDefinitionHttpV4.endpointGroups")
-    @Mapping(
-        target = "allowedInApiProducts",
-        expression = "java(apiEntity.getApiDefinitionHttpV4() != null ? apiEntity.getApiDefinitionHttpV4().getAllowedInApiProducts() : null)"
-    )
+    @Mapping(target = "allowedInApiProducts", expression = "java(exportedAllowedInApiProducts(apiEntity.getApiDefinitionHttpV4()))")
     @Mapping(target = "primaryOwner", source = "primaryOwner")
     @Mapping(target = "workflowState", source = "workflowState")
     @Mapping(target = "groups", source = "groups")
@@ -176,6 +174,13 @@ public interface GraviteeDefinitionAdapter {
 
     default String providerId(ApiDefinition apiDefinition) {
         return apiDefinition instanceof FederatedApi federatedApi ? federatedApi.getProviderId() : null;
+    }
+
+    default Boolean exportedAllowedInApiProducts(io.gravitee.definition.model.v4.Api apiDefinition) {
+        if (apiDefinition == null || apiDefinition.getType() != ApiType.PROXY) {
+            return null;
+        }
+        return Boolean.TRUE.equals(apiDefinition.getAllowedInApiProducts());
     }
 
     @Mapping(target = "id", expression = "java(excludeIds ? null : apiEntity.getId())")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/GraviteeDefinitionAdapterTest.java
@@ -77,7 +77,7 @@ class GraviteeDefinitionAdapterTest {
     }
 
     @Test
-    void mapV4_should_leave_allowedInApiProducts_null_when_missing_in_definition() {
+    void mapV4_should_default_allowedInApiProducts_to_false_when_missing_from_proxy_definition() {
         var v4Definition = new io.gravitee.definition.model.v4.Api();
         v4Definition.setDefinitionVersion(DefinitionVersion.V4);
         v4Definition.setType(ApiType.PROXY);
@@ -91,6 +91,44 @@ class GraviteeDefinitionAdapterTest {
             .version("1.0.0")
             .definitionVersion(DefinitionVersion.V4)
             .type(ApiType.PROXY)
+            .apiDefinitionHttpV4(v4Definition)
+            .build();
+
+        var primaryOwner = PrimaryOwnerEntity.builder()
+            .id("po-id")
+            .email("po@acme.test")
+            .displayName("PO")
+            .type(PrimaryOwnerEntity.Type.USER)
+            .build();
+        var metadata = java.util.Collections.<NewApiMetadata>emptyList();
+
+        ApiDescriptor.ApiDescriptorV4 descriptor = GraviteeDefinitionAdapter.INSTANCE.mapV4(
+            coreApi,
+            primaryOwner,
+            WorkflowState.REVIEW_OK,
+            Set.of("group-1"),
+            (java.util.Collection<NewApiMetadata>) metadata,
+            List.of(new Flow()),
+            false
+        );
+
+        assertThat(descriptor.allowedInApiProducts()).isFalse();
+    }
+
+    @Test
+    void mapV4_should_leave_allowedInApiProducts_null_for_non_proxy_api() {
+        var v4Definition = new io.gravitee.definition.model.v4.Api();
+        v4Definition.setDefinitionVersion(DefinitionVersion.V4);
+        v4Definition.setType(ApiType.MESSAGE);
+        v4Definition.setApiVersion("1.0.0");
+        v4Definition.setName("my-api");
+
+        Api coreApi = Api.builder()
+            .id("api-id")
+            .environmentId("env-id")
+            .version("1.0.0")
+            .definitionVersion(DefinitionVersion.V4)
+            .type(ApiType.MESSAGE)
             .apiDefinitionHttpV4(v4Definition)
             .build();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiExportDomainServiceImplTest.java
@@ -293,6 +293,24 @@ class ApiExportDomainServiceImplTest {
     }
 
     @Test
+    void should_default_allowedInApiProducts_to_false_when_exporting_legacy_v4_proxy_api() {
+        String apiId = UUID.randomUUID().toString();
+        var definition = new io.gravitee.definition.model.v4.Api();
+        definition.setType(ApiType.PROXY);
+        Api api = Api.builder()
+            .id(apiId)
+            .type(ApiType.PROXY)
+            .definitionVersion(DefinitionVersion.V4)
+            .apiDefinitionHttpV4(definition)
+            .build();
+        when(apiCrudService.findById(anyString())).thenReturn(Optional.of(api));
+
+        GraviteeDefinition export = sut.export(apiId, getAuditInfo(), EnumSet.noneOf(Excludable.class));
+
+        assertThat(((GraviteeDefinition.V4) export).api().allowedInApiProducts()).isFalse();
+    }
+
+    @Test
     void should_export_v4_native_api_categories_as_keys_not_ids() {
         // Given
         String apiId = UUID.randomUUID().toString();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13807

## Description

Ensures V4 HTTP Proxy API definition exports always include allowedInApiProducts, even for legacy APIs where the field is missing from the persisted definition. Missing legacy values are exported as false, while non-proxy APIs still omit the field.

Added regression coverage at both the export mapping layer and the Management API v2 _export/definition endpoint response.

## Additional context

Regression verified with Docker-based Maven builds using the local .m2 mount.

