### PR TITLE
Disable notifications support for api product

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
@@ -59,6 +59,11 @@ export interface ApiProduct {
    * Indicates whether the API Product is in sync with the latest deployment.
    */
   deploymentState?: ApiProductDeploymentState;
+  /**
+   * Disable membership notifications.
+   * @default false
+   */
+  disableMembershipNotifications?: boolean;
 
   _links?: { [key: string]: string };
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/updateApiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/updateApiProduct.ts
@@ -35,4 +35,9 @@ export interface UpdateApiProduct {
    * Groups attached to this API Product.
    */
   groups?: string[];
+  /**
+   * Disable membership notifications.
+   * @default false
+   */
+  disableMembershipNotifications?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.html
@@ -21,9 +21,11 @@
       <h1>APIs</h1>
       <p class="subtitle">Manage APIs grouped together in your API Product.</p>
     </div>
-    <button mat-raised-button color="primary" (click)="onAddApi()" data-testid="add-api-button" aria-label="Add API">
-      <mat-icon svgIcon="gio:plus"></mat-icon> Add API
-    </button>
+    @if (canUpdate()) {
+      <button mat-raised-button color="primary" (click)="onAddApi()" data-testid="add-api-button" aria-label="Add API">
+        <mat-icon svgIcon="gio:plus"></mat-icon> Add API
+      </button>
+    }
   </div>
 
   <gio-table-wrapper
@@ -66,26 +68,28 @@
           }
         </td>
       </ng-container>
-      <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let element">
-          <button
-            mat-icon-button
-            [matTooltip]="'Remove from API Product'"
-            (click)="onDeleteApi(element)"
-            [attr.data-testid]="'delete-api-button-' + element.id"
-            aria-label="Remove API"
-          >
-            <mat-icon svgIcon="gio:trash"></mat-icon>
-          </button>
-        </td>
-      </ng-container>
+      @if (canUpdate()) {
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef></th>
+          <td mat-cell *matCellDef="let element">
+            <button
+              mat-icon-button
+              [matTooltip]="'Remove from API Product'"
+              (click)="onDeleteApi(element)"
+              [attr.data-testid]="'delete-api-button-' + element.id"
+              aria-label="Remove API"
+            >
+              <mat-icon svgIcon="gio:trash"></mat-icon>
+            </button>
+          </td>
+        </ng-container>
+      }
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns()"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns()"></tr>
 
       <tr class="mat-mdc-row mdc-data-table__row" *matNoDataRow>
-        <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns.length">
+        <td class="mat-mdc-cell mdc-data-table__cell" [attr.colspan]="displayedColumns().length">
           @if (isLoadingData) {
             <div class="api-product-apis-empty-state">
               <p>Loading...</p>

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.spec.ts
@@ -30,6 +30,7 @@ import { ApiProductApisComponent } from './api-product-apis.component';
 
 import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
 import { Api, fakeProxyApiV4 } from '../../../entities/management-api-v2';
 import { ApiProduct } from '../../../entities/management-api-v2/api-product';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
@@ -81,14 +82,15 @@ describe('ApiProductApisComponent', () => {
     ],
   });
 
-  beforeEach(() => {
+  async function init(permissions: string[] = ['api_product-definition-u']) {
     queryParams$ = new BehaviorSubject<Record<string, string>>({});
 
-    TestBed.configureTestingModule({
+    await TestBed.configureTestingModule({
       imports: [ApiProductApisComponent, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
       providers: [
         { provide: Constants, useValue: CONSTANTS_TESTING },
         { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: GioTestingPermissionProvider, useValue: permissions },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -122,19 +124,24 @@ describe('ApiProductApisComponent', () => {
       }
       return Promise.resolve(true);
     });
-  });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
 
   afterEach(() => {
-    httpTestingController.verify();
+    httpTestingController?.verify();
     jest.clearAllMocks();
   });
 
-  it('should create', () => {
-    fixture.detectChanges();
+  it('should create', async () => {
+    await init();
+    await initComponent([]);
     expect(fixture.componentInstance).toBeTruthy();
   });
 
   it('should display empty state when no APIs in product', async () => {
+    await init();
     await initComponent([]);
 
     const emptyState = await loader.getHarness(DivHarness.with({ selector: '.api-product-apis-empty-state' }));
@@ -142,6 +149,7 @@ describe('ApiProductApisComponent', () => {
   });
 
   it('should display table with API rows when product has APIs', async () => {
+    await init();
     await initComponent([fakeApi1, fakeApi2]);
 
     const table = await loader.getHarness(MatTableHarness.with({ selector: 'table' }));
@@ -158,8 +166,7 @@ describe('ApiProductApisComponent', () => {
   });
 
   it('should display Loading... then data', async () => {
-    fixture.detectChanges();
-    await fixture.whenStable();
+    await init();
 
     const emptyState = await loader.getHarness(DivHarness.with({ selector: '.api-product-apis-empty-state' }));
     expect(await emptyState.getText()).toContain('Loading...');
@@ -176,8 +183,7 @@ describe('ApiProductApisComponent', () => {
   });
 
   it('should handle error when loading API product', async () => {
-    fixture.detectChanges();
-    await fixture.whenStable();
+    await init();
 
     const req = expectApisRequest();
     req.flush({ message: 'Error' }, { status: 500, statusText: 'Server Error' });
@@ -188,8 +194,7 @@ describe('ApiProductApisComponent', () => {
   });
 
   it('should show error and navigate to list when API Product not found (404)', async () => {
-    fixture.detectChanges();
-    await fixture.whenStable();
+    await init();
 
     const req = expectApisRequest();
     req.flush({ message: 'API Product not found' }, { status: 404, statusText: 'Not Found' });
@@ -201,13 +206,23 @@ describe('ApiProductApisComponent', () => {
   });
 
   it('should have Add API button', async () => {
+    await init();
     await initComponent([fakeApi1]);
 
     const addButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="add-api-button"]' }));
     expect(await addButton.getText()).toContain('Add API');
   });
 
+  it('should hide Add API button when user cannot update', async () => {
+    await init(['api_product-definition-r']);
+    await initComponent([fakeApi1]);
+
+    const addButton = await loader.getHarnessOrNull(MatButtonHarness.with({ selector: '[data-testid="add-api-button"]' }));
+    expect(addButton).toBeNull();
+  });
+
   it('should open Add API dialog when Add API clicked', async () => {
+    await init();
     const matDialog = TestBed.inject(MatDialog);
     const dialogOpenSpy = jest.spyOn(matDialog, 'open');
     await initComponent([fakeApi1]);
@@ -232,6 +247,7 @@ describe('ApiProductApisComponent', () => {
   });
 
   it('should filter APIs by search term', async () => {
+    await init();
     await initComponent([fakeApi1, fakeApi2]);
 
     const tableWrapper = await loader.getHarness(GioTableWrapperHarness);
@@ -262,9 +278,6 @@ describe('ApiProductApisComponent', () => {
   }
 
   async function initComponent(apis: Api[] = []) {
-    fixture.detectChanges();
-    await fixture.whenStable();
-
     const apisReq = expectApisRequest();
     apisReq.flush({ data: apis, pagination: { totalCount: apis.length } });
 

--- a/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/apis/api-product-apis.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, DestroyRef, inject, Injector, OnInit } from '@angular/core';
+import { Component, computed, DestroyRef, inject, Injector, OnInit } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -47,6 +47,7 @@ import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wra
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 
 export type ApiProductApiTableDS = {
   id: string;
@@ -97,8 +98,15 @@ export class ApiProductApisComponent implements OnInit {
   private readonly apiProductV2Service = inject(ApiProductV2Service);
   private readonly snackBarService = inject(SnackBarService);
   private readonly matDialog = inject(MatDialog);
+  private readonly permissionService = inject(GioPermissionService);
 
-  readonly displayedColumns = ['picture', 'name', 'contextPath', 'definition', 'version', 'actions'] as const;
+  protected readonly canUpdate = computed(() => this.permissionService.hasAnyMatching(['api_product-definition-u']));
+
+  readonly displayedColumns = computed(() =>
+    this.canUpdate()
+      ? (['picture', 'name', 'contextPath', 'definition', 'version', 'actions'] as const)
+      : (['picture', 'name', 'contextPath', 'definition', 'version'] as const),
+  );
   apisTableDS: ApiProductApiTableDS = [];
   apisTableDSUnpaginatedLength = 0;
   searchLabel = 'Search APIs...';

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.harness.ts
@@ -16,6 +16,7 @@
 import { ComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { MatTableHarness } from '@angular/material/table/testing';
 import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 
@@ -36,6 +37,10 @@ export function getApiProductManageGroupsDialogPredicate(): HarnessPredicate<Mat
 
 export class ApiProductMembersComponentHarness extends ComponentHarness {
   static hostSelector = 'api-product-members';
+
+  private async getMembersNotificationToggle(): Promise<MatSlideToggleHarness> {
+    return this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-testid="api_product_members_notify_toggle"]' }))();
+  }
 
   async getTitle(): Promise<string> {
     const el = await this.locatorFor('[data-testid="api_product_members_title"]')();
@@ -82,6 +87,18 @@ export class ApiProductMembersComponentHarness extends ComponentHarness {
 
   async getManageGroupsButton(): Promise<MatButtonHarness | null> {
     return this.locatorForOptional(MatButtonHarness.with({ selector: '[data-testid="api_product_members_manage_groups_button"]' }))();
+  }
+
+  async isMembersNotificationToggleChecked(): Promise<boolean> {
+    return (await this.getMembersNotificationToggle()).isChecked();
+  }
+
+  async isMembersNotificationToggleDisabled(): Promise<boolean> {
+    return (await this.getMembersNotificationToggle()).isDisabled();
+  }
+
+  async toggleMembersNotification(): Promise<void> {
+    await (await this.getMembersNotificationToggle()).toggle();
   }
 
   /** Clicks **Manage groups** (throws if the control is absent, e.g. missing permission). */

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.html
@@ -65,14 +65,17 @@
         </div>
       </div>
 
-      <gio-form-slide-toggle class="card__enable-notification-toggle">
-        Notify members when they are added to the API Product
-        <mat-slide-toggle
-          gioFormSlideToggle
-          formControlName="isNotificationsEnabled"
-          aria-label="Enable notifications when members are added to this API Product"
-        ></mat-slide-toggle>
-      </gio-form-slide-toggle>
+      @if (state.apiProduct !== null) {
+        <gio-form-slide-toggle class="card__enable-notification-toggle">
+          Notify members when they are added to the API Product
+          <mat-slide-toggle
+            gioFormSlideToggle
+            formControlName="isNotificationsEnabled"
+            aria-label="Enable notifications when members are added to this API Product"
+            data-testid="api_product_members_notify_toggle"
+          ></mat-slide-toggle>
+        </gio-form-slide-toggle>
+      }
     </mat-card-content>
     <gio-table-wrapper
       [disableSearchInput]="true"

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.spec.ts
@@ -206,6 +206,16 @@ describe('ApiProductMembersComponent', () => {
     expect(await harness.getDescription()).toContain('Manage who can interact with your API Product');
   }));
 
+  it('should disable notification toggle when read-only', fakeAsync(async () => {
+    await init(['api_product-member-r']);
+    expectMembersPageRequests([]);
+    expectRolesRequest();
+    tick();
+    fixture.detectChanges();
+
+    expect(await harness.isMembersNotificationToggleDisabled()).toBe(true);
+  }));
+
   it('should render picture, Name and Role column headers', fakeAsync(async () => {
     await init();
     expectMembersPageRequests([]);
@@ -588,4 +598,51 @@ describe('ApiProductMembersComponent', () => {
 
     expect((await harness.getInheritedGroupMemberCards()).length).toBe(0);
   }));
+
+  describe('notification toggle', () => {
+    it('should reflect disableMembershipNotifications=true as unchecked toggle', fakeAsync(async () => {
+      await init(['api_product-member-r', 'api_product-member-u']);
+      expectMembersPageRequests([], 0, 1, 10, { disableMembershipNotifications: true });
+      expectRolesRequest();
+      tick();
+      fixture.detectChanges();
+
+      expect(await harness.isMembersNotificationToggleChecked()).toBe(false);
+    }));
+
+    it('should reflect disableMembershipNotifications=false as checked toggle', fakeAsync(async () => {
+      await init(['api_product-member-r', 'api_product-member-u']);
+      expectMembersPageRequests([], 0, 1, 10, { disableMembershipNotifications: false });
+      expectRolesRequest();
+      tick();
+      fixture.detectChanges();
+
+      expect(await harness.isMembersNotificationToggleChecked()).toBe(true);
+    }));
+
+    it('should PUT API Product with disableMembershipNotifications=true when toggle is unchecked and saved', fakeAsync(async () => {
+      await init(['api_product-member-r', 'api_product-member-u']);
+      expectMembersPageRequests([], 0, 1, 10, { disableMembershipNotifications: false });
+      expectRolesRequest();
+      tick();
+      fixture.detectChanges();
+
+      await harness.toggleMembersNotification();
+      fixture.detectChanges();
+
+      await harness.clickSave();
+      tick();
+      fixture.detectChanges();
+
+      const putReq = httpTestingController.expectOne(
+        req => req.method === 'PUT' && req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`,
+      );
+      expect(putReq.request.body.disableMembershipNotifications).toEqual(true);
+      putReq.flush({ id: API_PRODUCT_ID, name: 'Test API Product', version: '1.0', apiIds: [], groups: [] });
+      tick();
+      fixture.detectChanges();
+
+      expectMembersPageRequests([]);
+    }));
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.spec.ts
@@ -628,7 +628,6 @@ describe('ApiProductMembersComponent', () => {
       fixture.detectChanges();
 
       await harness.toggleMembersNotification();
-      fixture.detectChanges();
 
       await harness.clickSave();
       tick();

--- a/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/members/api-product-members.component.ts
@@ -198,7 +198,7 @@ export class ApiProductMembersComponent {
   protected readonly roleFieldShowsRequiredError = signal<Readonly<Record<string, boolean>>>({});
 
   protected readonly form = new FormGroup({
-    isNotificationsEnabled: new FormControl(true),
+    isNotificationsEnabled: new FormControl({ value: false, disabled: this.isReadOnly }, { nonNullable: true }),
     members: new FormGroup({}),
   });
 
@@ -245,6 +245,7 @@ export class ApiProductMembersComponent {
         ),
       ),
       tap(state => {
+        this.syncNotificationControl(state.apiProduct);
         this.syncMembersFormGroup(state.rows);
         this.syncGroupInheritedMembersState(state);
       }),
@@ -493,6 +494,24 @@ export class ApiProductMembersComponent {
     const dirtyEntries = Object.entries(controls).filter(([, c]) => c.dirty) as [string, FormControl<string>][];
 
     const requests: Observable<unknown>[] = [];
+
+    const notificationControl = this.form.controls.isNotificationsEnabled;
+    if (notificationControl.dirty) {
+      const apiProduct = this.membersLoadState().apiProduct;
+      if (apiProduct) {
+        requests.push(
+          this.apiProductV2Service.update(apiProductId, {
+            name: apiProduct.name,
+            version: apiProduct.version,
+            description: apiProduct.description,
+            apiIds: apiProduct.apiIds ?? [],
+            groups: apiProduct.groups,
+            disableMembershipNotifications: !notificationControl.value,
+          }),
+        );
+      }
+    }
+
     for (const [key, ctrl] of dirtyEntries) {
       if (key.startsWith('pending-')) {
         const user = this.pendingUsers().find(u => u.viewId === key);
@@ -687,6 +706,15 @@ export class ApiProductMembersComponent {
       isPrimaryOwner: (member.roles ?? []).some(r => r.name === 'PRIMARY_OWNER'),
       isPending: false,
     };
+  }
+
+  private syncNotificationControl(apiProduct: ApiProduct | null): void {
+    const ctrl = this.form.controls.isNotificationsEnabled;
+    if (ctrl.dirty) {
+      return;
+    }
+    ctrl.setValue(!apiProduct?.disableMembershipNotifications, { emitEvent: false });
+    ctrl.markAsPristine();
   }
 
   private syncMembersFormGroup(rows: MemberRow[]): void {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiProduct.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiProduct.java
@@ -44,6 +44,7 @@ public class ApiProduct {
     private Set<String> groups;
     private Date createdAt;
     private Date updatedAt;
+    private boolean disableMembershipNotifications;
 
     public boolean addGroup(String groupId) {
         if (groups == null) {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
@@ -58,6 +58,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             .addColumn("version", Types.NVARCHAR, String.class)
             .addColumn("created_at", Types.TIMESTAMP, Date.class)
             .addColumn("updated_at", Types.TIMESTAMP, Date.class)
+            .addColumn("disable_membership_notifications", Types.BOOLEAN, boolean.class)
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/08_add_disable_membership_notifications_to_api_products.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/08_add_disable_membership_notifications_to_api_products.yml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_08_add_disable_membership_notifications_to_api_products
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}api_products
+            columns:
+              - column:
+                  name: disable_membership_notifications
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -343,3 +343,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/06_add_hrid_to_groups_table.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/07_add_api_product_primary_owner_to_groups.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/08_add_disable_membership_notifications_to_api_products.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiProductMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiProductMongo.java
@@ -49,4 +49,5 @@ public class ApiProductMongo {
     private List<String> groups;
     private Date createdAt;
     private Date updatedAt;
+    private boolean disableMembershipNotifications;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -2030,6 +2030,10 @@ components:
             type: string
           example:
             - "group-uuid-1"
+        disableMembershipNotifications:
+          type: boolean
+          description: Disable membership notifications.
+          default: false
       required:
         - name
         - version
@@ -2088,6 +2092,10 @@ components:
           $ref: '#/components/schemas/PrimaryOwner'
         deploymentState:
           $ref: '#/components/schemas/ApiProductDeploymentState'
+        disableMembershipNotifications:
+          type: boolean
+          description: Disable membership notifications.
+          default: false
 
     ApiProductDeploymentState:
       type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
@@ -47,6 +47,7 @@ public class ApiProduct {
     private ZonedDateTime updatedAt;
     private PrimaryOwnerEntity primaryOwner;
     private DeploymentState deploymentState;
+    private boolean disableMembershipNotifications;
 
     public void update(UpdateApiProduct updateApiProduct) {
         this.updatedAt = ZonedDateTime.now(TimeProvider.clock());
@@ -64,6 +65,9 @@ public class ApiProduct {
         }
         if (updateApiProduct.getGroups() != null) {
             this.groups = updateApiProduct.getGroups();
+        }
+        if (updateApiProduct.getDisableMembershipNotifications() != null) {
+            this.disableMembershipNotifications = updateApiProduct.getDisableMembershipNotifications();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/UpdateApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/UpdateApiProduct.java
@@ -35,4 +35,5 @@ public class UpdateApiProduct {
     private Set<String> apiIds;
     private Set<String> groups;
     private ZonedDateTime updatedAt;
+    private Boolean disableMembershipNotifications;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/query_service/ApiProductQueryService.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.api_product.query_service;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -27,6 +28,7 @@ public interface ApiProductQueryService {
     Set<ApiProduct> findByEnvironmentId(String environmentId);
     Set<ApiProduct> findByEnvironmentIdAndIdIn(String environmentId, Set<String> ids);
     Optional<ApiProduct> findById(String apiProductId);
+    ApiProduct findById(ExecutionContext executionContext, String apiProductId);
     Set<ApiProduct> findByApiId(String apiId);
     Map<String, Set<ApiProduct>> findProductsByApiIds(Set<String> apiIds);
     Page<ApiProduct> searchByIds(Set<String> ids, String environmentId, Pageable pageable);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImpl.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.query_service.api_product;
 
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
@@ -26,6 +27,7 @@ import io.gravitee.repository.management.api.search.ApiProductCriteria;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.AbstractService;
 import java.util.HashMap;
@@ -112,6 +114,19 @@ public class ApiProductQueryServiceImpl extends AbstractService implements ApiPr
         } catch (TechnicalException ex) {
             String errorMessage = String.format("An error occurred while finding API Product by apiProductId: %s", apiProductId);
             throw new TechnicalDomainException(errorMessage, ex);
+        }
+    }
+
+    @Override
+    public ApiProduct findById(ExecutionContext executionContext, String apiProductId) {
+        try {
+            Optional<io.gravitee.repository.management.model.ApiProduct> optApiProduct = apiProductRepository.findById(apiProductId);
+            if (executionContext.hasEnvironmentId()) {
+                optApiProduct = optApiProduct.filter(result -> result.getEnvironmentId().equals(executionContext.getEnvironmentId()));
+            }
+            return optApiProduct.map(ApiProductAdapter.INSTANCE::toModel).orElseThrow(() -> new ApiProductNotFoundException(apiProductId));
+        } catch (TechnicalException ex) {
+            throw new TechnicalManagementException("An error occurs while trying to find an API Product using its ID: " + apiProductId, ex);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.utils.UUID;
@@ -175,6 +177,8 @@ public class MembershipServiceImpl extends AbstractService implements Membership
 
     private final ApiProductsRepository apiProductsRepository;
 
+    private final ApiProductQueryService apiProductQueryService;
+
     private final ApplicationRepository applicationRepository;
 
     private final EventManager eventManager;
@@ -207,6 +211,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         @Autowired @Lazy ApiGroupService apiGroupService,
         @Autowired @Lazy ApiRepository apiRepository,
         @Autowired @Lazy ApiProductsRepository apiProductsRepository,
+        @Autowired @Lazy ApiProductQueryService apiProductQueryService,
         @Autowired @Lazy GroupService groupService,
         @Autowired AuditService auditService,
         @Autowired ParameterService parameterService,
@@ -232,6 +237,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
         this.apiGroupService = apiGroupService;
         this.apiRepository = apiRepository;
         this.apiProductsRepository = apiProductsRepository;
+        this.apiProductQueryService = apiProductQueryService;
         this.groupService = groupService;
         this.auditService = auditService;
         this.parameterService = parameterService;
@@ -383,6 +389,9 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                     } else if (MembershipReferenceType.APPLICATION.equals(reference.getType())) {
                         final ApplicationEntity application = applicationService.findById(executionContext, reference.getId());
                         shouldNotify = !application.isDisableMembershipNotifications();
+                    } else if (MembershipReferenceType.API_PRODUCT.equals(reference.getType())) {
+                        final ApiProduct apiProduct = apiProductQueryService.findById(executionContext, reference.getId());
+                        shouldNotify = !apiProduct.isDisableMembershipNotifications();
                     }
                 }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiProductQueryServiceInMemory.java
@@ -15,10 +15,12 @@
  */
 package inmemory;
 
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -65,6 +67,15 @@ public class ApiProductQueryServiceInMemory extends AbstractQueryServiceInMemory
             .stream()
             .filter(apiProduct -> apiProduct.getId().equals(apiProductId))
             .findFirst();
+    }
+
+    @Override
+    public ApiProduct findById(ExecutionContext executionContext, String apiProductId) {
+        Optional<ApiProduct> apiProduct = findById(apiProductId);
+        if (executionContext.hasEnvironmentId()) {
+            apiProduct = apiProduct.filter(ap -> executionContext.getEnvironmentId().equals(ap.getEnvironmentId()));
+        }
+        return apiProduct.orElseThrow(() -> new ApiProductNotFoundException(apiProductId));
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_product/ApiProductQueryServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.exception.TechnicalDomainException;
@@ -29,6 +30,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Date;
@@ -212,6 +214,68 @@ class ApiProductQueryServiceImplTest {
             when(apiProductRepository.findById(API_PRODUCT_ID)).thenThrow(new TechnicalException("Database error"));
             var throwable = catchThrowable(() -> service.findById(API_PRODUCT_ID));
             assertThat(throwable).isInstanceOf(TechnicalDomainException.class);
+        }
+    }
+
+    @Nested
+    class FindByIdWithExecutionContext {
+
+        private final ExecutionContext executionContext = new ExecutionContext(ORG_ID, ENV_ID);
+
+        @Test
+        void should_return_api_product_when_found_in_correct_environment() throws TechnicalException {
+            var repoApiProduct = buildRepositoryApiProduct();
+            when(apiProductRepository.findById(API_PRODUCT_ID)).thenReturn(Optional.of(repoApiProduct));
+
+            var result = service.findById(executionContext, API_PRODUCT_ID);
+
+            assertAll(
+                () -> assertThat(result.getId()).isEqualTo(API_PRODUCT_ID),
+                () -> assertThat(result.getName()).isEqualTo(API_PRODUCT_NAME),
+                () -> assertThat(result.getEnvironmentId()).isEqualTo(ENV_ID)
+            );
+        }
+
+        @Test
+        void should_throw_not_found_when_product_does_not_exist() throws TechnicalException {
+            when(apiProductRepository.findById(API_PRODUCT_ID)).thenReturn(Optional.empty());
+
+            var throwable = catchThrowable(() -> service.findById(executionContext, API_PRODUCT_ID));
+            assertThat(throwable).isInstanceOf(ApiProductNotFoundException.class);
+        }
+
+        @Test
+        void should_throw_not_found_when_product_belongs_to_another_environment() throws TechnicalException {
+            var repoApiProduct = io.gravitee.repository.management.model.ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .environmentId("other-env")
+                .name(API_PRODUCT_NAME)
+                .version("1.0.0")
+                .createdAt(new Date())
+                .updatedAt(new Date())
+                .build();
+            when(apiProductRepository.findById(API_PRODUCT_ID)).thenReturn(Optional.of(repoApiProduct));
+
+            var throwable = catchThrowable(() -> service.findById(executionContext, API_PRODUCT_ID));
+            assertThat(throwable).isInstanceOf(ApiProductNotFoundException.class);
+        }
+
+        @Test
+        void should_return_api_product_when_no_environment_in_execution_context() throws TechnicalException {
+            var repoApiProduct = buildRepositoryApiProduct();
+            when(apiProductRepository.findById(API_PRODUCT_ID)).thenReturn(Optional.of(repoApiProduct));
+
+            var result = service.findById(new ExecutionContext(ORG_ID), API_PRODUCT_ID);
+
+            assertThat(result.getId()).isEqualTo(API_PRODUCT_ID);
+        }
+
+        @Test
+        void should_throw_technical_exception_when_repository_fails() throws TechnicalException {
+            when(apiProductRepository.findById(API_PRODUCT_ID)).thenThrow(new TechnicalException("Database error"));
+
+            var throwable = catchThrowable(() -> service.findById(executionContext, API_PRODUCT_ID));
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_AddRoleToMemberOnReferenceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_AddRoleToMemberOnReferenceTest.java
@@ -28,7 +28,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.node.api.Node;
+import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.CommandRepository;
 import io.gravitee.repository.management.api.MembershipRepository;
@@ -55,6 +58,7 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.NotAuthorizedMembershipException;
 import io.gravitee.rest.api.service.exceptions.RoleNotFoundException;
+import io.gravitee.rest.api.service.v4.ApiProductGroupService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import java.util.Collections;
 import java.util.Optional;
@@ -113,6 +117,15 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
     @Mock
     private ApiRepository apiRepository;
 
+    @Mock
+    private ApiProductsRepository apiProductsRepository;
+
+    @Mock
+    private ApiProductQueryService apiProductQueryService;
+
+    @Mock
+    private ApiProductGroupService apiProductGroupService;
+
     @BeforeEach
     public void setUp() throws Exception {
         membershipService = new MembershipServiceImpl(
@@ -129,7 +142,8 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
             apiSearchService,
             null,
             apiRepository,
-            null,
+            apiProductsRepository,
+            apiProductQueryService,
             groupService,
             auditService,
             parameterService,
@@ -139,7 +153,7 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
             commandRepository,
             null,
             null,
-            null
+            apiProductGroupService
         );
     }
 
@@ -497,6 +511,70 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
                 new MembershipService.MembershipRole(RoleScope.APPLICATION, "PRIMARY_OWNER")
             )
         ).isInstanceOf(NotAuthorizedMembershipException.class);
+    }
+
+    @Test
+    public void shouldNotSendEmailNotificationWhenApiProductMembershipNotificationsAreDisabled() throws Exception {
+        String apiProductId = "api-product-id-1";
+        RoleEntity role = RoleEntity.builder().id("API_PRODUCT_OWNER").scope(RoleScope.API_PRODUCT).build();
+        when(roleService.findByScopeAndName(RoleScope.API_PRODUCT, "OWNER", GraviteeContext.getCurrentOrganization())).thenReturn(
+            Optional.of(role)
+        );
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId("user-id");
+        userEntity.setEmail("user@mail.com");
+        when(userService.findById(GraviteeContext.getExecutionContext(), userEntity.getId())).thenReturn(userEntity);
+
+        Membership newMembership = new Membership();
+        newMembership.setReferenceType(io.gravitee.repository.management.model.MembershipReferenceType.API_PRODUCT);
+        newMembership.setRoleId("API_PRODUCT_OWNER");
+        newMembership.setReferenceId(apiProductId);
+        newMembership.setMemberId(userEntity.getId());
+        newMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.USER);
+
+        ApiProduct coreApiProduct = ApiProduct.builder()
+            .id(apiProductId)
+            .environmentId(GraviteeContext.getDefaultEnvironment())
+            .disableMembershipNotifications(true)
+            .build();
+        when(apiProductQueryService.findById(any(), eq(apiProductId))).thenReturn(coreApiProduct);
+        when(apiProductsRepository.findById(apiProductId)).thenReturn(
+            Optional.of(
+                io.gravitee.repository.management.model.ApiProduct.builder()
+                    .id(apiProductId)
+                    .environmentId(GraviteeContext.getDefaultEnvironment())
+                    .build()
+            )
+        );
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceIdAndRoleId(
+                userEntity.getId(),
+                io.gravitee.repository.management.model.MembershipMemberType.USER,
+                io.gravitee.repository.management.model.MembershipReferenceType.API_PRODUCT,
+                apiProductId,
+                "API_PRODUCT_OWNER"
+            )
+        ).thenReturn(Collections.emptySet());
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
+                userEntity.getId(),
+                io.gravitee.repository.management.model.MembershipMemberType.USER,
+                io.gravitee.repository.management.model.MembershipReferenceType.API_PRODUCT,
+                apiProductId
+            )
+        ).thenReturn(Set.of(newMembership), Collections.emptySet());
+        when(membershipRepository.create(any())).thenReturn(newMembership);
+
+        membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getExecutionContext(),
+            new MembershipService.MembershipReference(MembershipReferenceType.API_PRODUCT, apiProductId),
+            new MembershipService.MembershipMember(userEntity.getId(), null, MembershipMemberType.USER),
+            new MembershipService.MembershipRole(RoleScope.API_PRODUCT, "OWNER")
+        );
+
+        verify(apiProductQueryService).findById(any(), eq(apiProductId));
+        verify(emailService, never()).sendAsyncEmailNotification(any(), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiProductTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiProductTest.java
@@ -30,11 +30,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.node.api.Node;
 import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.CommandRepository;
 import io.gravitee.repository.management.api.MembershipRepository;
-import io.gravitee.repository.management.model.ApiProduct;
 import io.gravitee.repository.management.model.Membership;
 import io.gravitee.rest.api.model.MemberEntity;
 import io.gravitee.rest.api.model.MembershipReferenceType;
@@ -50,6 +51,7 @@ import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.MembershipAlreadyExistsException;
+import io.gravitee.rest.api.service.v4.ApiProductGroupService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
 import java.util.Collections;
@@ -103,6 +105,12 @@ class MembershipService_CreateNewMembershipForApiProductTest {
     @Mock
     private ApiProductsRepository apiProductsRepository;
 
+    @Mock
+    private ApiProductQueryService apiProductQueryService;
+
+    @Mock
+    private ApiProductGroupService apiProductGroupService;
+
     @BeforeEach
     void setUp() {
         reset(membershipRepository, apiSearchService, userService, auditService, roleService, identityService);
@@ -122,6 +130,7 @@ class MembershipService_CreateNewMembershipForApiProductTest {
             null,
             null,
             apiProductsRepository,
+            apiProductQueryService,
             null,
             auditService,
             null,
@@ -131,7 +140,7 @@ class MembershipService_CreateNewMembershipForApiProductTest {
             commandRepository,
             null,
             null,
-            null
+            apiProductGroupService
         );
 
         mockRole();
@@ -140,12 +149,18 @@ class MembershipService_CreateNewMembershipForApiProductTest {
 
     private void mockApiProductLookup() {
         try {
-            ApiProduct apiProduct = new ApiProduct();
-            apiProduct.setId(API_PRODUCT_ID);
-            lenient().when(apiProductsRepository.findById(API_PRODUCT_ID)).thenReturn(Optional.of(apiProduct));
+            io.gravitee.repository.management.model.ApiProduct repoApiProduct = new io.gravitee.repository.management.model.ApiProduct();
+            repoApiProduct.setId(API_PRODUCT_ID);
+            lenient().when(apiProductsRepository.findById(API_PRODUCT_ID)).thenReturn(Optional.of(repoApiProduct));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+        ApiProduct coreApiProduct = ApiProduct.builder()
+            .id(API_PRODUCT_ID)
+            .environmentId(GraviteeContext.getDefaultEnvironment())
+            .disableMembershipNotifications(false)
+            .build();
+        lenient().when(apiProductQueryService.findById(any(), eq(API_PRODUCT_ID))).thenReturn(coreApiProduct);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_CreateNewMembershipForApiTest.java
@@ -124,6 +124,7 @@ public class MembershipService_CreateNewMembershipForApiTest {
             apiRepository,
             null,
             null,
+            null,
             auditService,
             null,
             null,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_DeleteMemberTest.java
@@ -88,6 +88,7 @@ public class MembershipService_DeleteMemberTest {
             null,
             null,
             null,
+            null,
             null
         );
         when(roleService.findByScopeAndName(RoleScope.API, PRIMARY_OWNER.name(), ORG_ID)).thenReturn(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_EditMemberTest.java
@@ -88,6 +88,7 @@ public class MembershipService_EditMemberTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipMetadataTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipMetadataTest.java
@@ -90,6 +90,7 @@ public class MembershipService_FindUserMembershipMetadataTest {
             null,
             mockApiRepository,
             null,
+            null,
             mockGroupService,
             null,
             null,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_FindUserMembershipTest.java
@@ -100,6 +100,7 @@ public class MembershipService_FindUserMembershipTest {
             null,
             mockApiRepository,
             null,
+            null,
             mockGroupService,
             null,
             null,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMemberPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMemberPermissionsTest.java
@@ -113,6 +113,7 @@ public class MembershipService_GetMemberPermissionsTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembersTest.java
@@ -89,6 +89,7 @@ public class MembershipService_GetMembersTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembershipsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetMembershipsTest.java
@@ -74,6 +74,7 @@ public class MembershipService_GetMembershipsTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberPermissionsTest.java
@@ -77,6 +77,7 @@ public class MembershipService_GetUserMemberPermissionsTest {
             null,
             null,
             null,
+            null,
             node,
             objectMapper,
             commandRepository,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_GetUserMemberTest.java
@@ -80,6 +80,7 @@ public class MembershipService_GetUserMemberTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_IntegrationMembershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_IntegrationMembershipTest.java
@@ -142,6 +142,7 @@ public class MembershipService_IntegrationMembershipTest {
             apiRepository,
             null,
             null,
+            null,
             auditService,
             null,
             integrationRepository,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_InvalidateCacheForRoleTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_InvalidateCacheForRoleTest.java
@@ -74,6 +74,7 @@ public class MembershipService_InvalidateCacheForRoleTest {
             null,
             null,
             null,
+            null,
             null
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_TransferOwnershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_TransferOwnershipTest.java
@@ -150,6 +150,7 @@ public class MembershipService_TransferOwnershipTest {
             apiGroupService,
             apiRepository,
             apiProductsRepository,
+            null,
             groupService,
             auditService,
             null,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MembershipService_UpdateMembershipForApiTest.java
@@ -110,6 +110,7 @@ public class MembershipService_UpdateMembershipForApiTest {
             apiRepository,
             null,
             null,
+            null,
             auditService,
             null,
             null,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14038

## Description

Added DisableMembershipNotifications support for API Product
Made add/delete api button role based 

Disable Notification button is editable for Admin Role User:
<img width="1504" height="723" alt="image" src="https://github.com/user-attachments/assets/fb34cbbb-aa6d-420c-b902-a754df621eb9" />

<img width="1504" height="723" alt="image" src="https://github.com/user-attachments/assets/2a0e80b4-fe65-4bce-9f00-1e7a9d0d6cf2" />


Disabled Notification button is readonly for User Role User:
<img width="1504" height="609" alt="image" src="https://github.com/user-attachments/assets/97a0ec97-36d5-48db-98d9-d8047204676a" />

<img width="1504" height="723" alt="image" src="https://github.com/user-attachments/assets/a62aa6cb-32d5-41cb-996e-915c3298e318" />


API add/delete is not accessible to User having User Role:

<img width="1504" height="622" alt="image" src="https://github.com/user-attachments/assets/2a72809e-3901-426a-a0da-7b5177d25700" />


<img width="1504" height="622" alt="image" src="https://github.com/user-attachments/assets/2172f3bb-fc72-4cc2-ac96-6d25559810a0" />
