### PR TITLE
fix: add GAMMA_API_URL to CSP style-src for gamma-console

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/docker/config/default.conf
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/docker/config/default.conf
@@ -4,7 +4,7 @@ server {
     server_name $SERVER_NAME;
 
     add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline' $GAMMA_API_URL; object-src 'none'; frame-ancestors 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline' $GAMMA_API_URL $GAMMA_API_URL/; object-src 'none'; frame-ancestors 'self'; style-src 'self' 'unsafe-inline' $GAMMA_API_URL $GAMMA_API_URL/; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self' $GAMMA_API_URL $GAMMA_API_URL/;" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/docker/config/default.no-ipv6.conf
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/docker/config/default.no-ipv6.conf
@@ -4,7 +4,7 @@ server {
     server_name $SERVER_NAME;
 
     add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline' $GAMMA_API_URL; object-src 'none'; frame-ancestors 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self';" always;
+    add_header Content-Security-Policy "default-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline' $GAMMA_API_URL $GAMMA_API_URL/; object-src 'none'; frame-ancestors 'self'; style-src 'self' 'unsafe-inline' $GAMMA_API_URL $GAMMA_API_URL/; img-src 'self' data: https: http:; connect-src http: https:; base-uri 'self'; form-action 'self'; font-src 'self' $GAMMA_API_URL $GAMMA_API_URL/;" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;


### PR DESCRIPTION
## Summary

- Updates the gamma-console nginx CSP in both `default.conf` and `default.no-ipv6.conf` so Gamma module assets served by the management API can load from `$GAMMA_API_URL`.
- Adds both `$GAMMA_API_URL` and `$GAMMA_API_URL/` to `script-src`, `style-src`, and `font-src`. The trailing-slash form is required for CSP path-prefix matching when module assets are served from nested paths such as `/gamma/organizations/{orgId}/modules/{moduleId}/assets/...`.
- Keeps the trust boundary unchanged: the management API origin was already trusted for Module Federation JavaScript execution, and this aligns CSS and font loading with that same remote-module origin.

## Context

Gamma module plugins (for example AIM) are Module Federation remotes. Their JS, CSS, and possibly font assets are served by the APIM/Gamma management API, which can be a different origin than the gamma-console host. Without the nested-path CSP allowance, browsers block remote chunks with errors like:

- `Loading the stylesheet ... violates Content Security Policy directive: style-src ...`
- `Loading the script ... violates Content Security Policy directive: script-src ...`
- `[ Federation Runtime ]: remoteEntryExports is undefined`

The runtime error is a consequence of CSP blocking the remote entry or async chunks before Module Federation can register the remote global.

## Test plan

- [x] Run gamma-console through its nginx Docker image with `GAMMA_API_URL="http://localhost:8083/gamma"`.
- [x] Load a Gamma module that emits an external CSS chunk (AIM without the `injectStyles: true` workaround).
- [x] Verify the browser no longer reports CSP violations for remote JS chunks, CSS chunks, or the remote entry.
- [x] Verify the module bootstraps successfully and styles are applied.
- [x] Verify both IPv6 and non-IPv6 nginx configs contain the same CSP update.