### PR TITLE
fix(analytics): allow correcting invalid custom timeframe

### DIFF
--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/filter/timeframe-selector/timeframe-selector.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/filter/timeframe-selector/timeframe-selector.component.spec.ts
@@ -209,6 +209,50 @@ describe('TimeframeSelectorComponent', () => {
         to: toDate,
       });
     });
+
+    it('should not propagate the value while the custom range is invalid (To < From)', () => {
+      const onChangeSpy = jest.fn();
+      component.registerOnChange(onChangeSpy);
+
+      const fromDate = moment('2024-01-15');
+      const invalidToDate = moment('2024-01-10');
+      component.form.patchValue({ period: 'custom', from: fromDate, to: invalidToDate });
+
+      expect(component.form.hasError('dateRange')).toBe(true);
+      expect(onChangeSpy).not.toHaveBeenCalled();
+
+      // Fixing the To date resumes propagation.
+      const validToDate = moment('2024-01-20');
+      component.form.patchValue({ to: validToDate });
+
+      expect(component.form.hasError('dateRange')).toBe(false);
+      expect(onChangeSpy).toHaveBeenCalledWith({
+        period: 'custom',
+        from: fromDate,
+        to: validToDate,
+      });
+    });
+
+    it('should still propagate when switching away from custom even if the stale custom range is invalid', () => {
+      const onChangeSpy = jest.fn();
+      component.registerOnChange(onChangeSpy);
+
+      const fromDate = moment('2024-01-15');
+      const invalidToDate = moment('2024-01-10');
+      component.form.patchValue({ period: 'custom', from: fromDate, to: invalidToDate });
+      onChangeSpy.mockClear();
+
+      // Switching to a preset must propagate the new period so the host and the
+      // visible dropdown don't desync, even though the stale from/to still
+      // violate the dateRange validator.
+      component.form.controls.period.setValue('1h');
+
+      expect(onChangeSpy).toHaveBeenCalledWith({
+        period: '1h',
+        from: fromDate,
+        to: invalidToDate,
+      });
+    });
   });
 
   describe('ControlValueAccessor - registerOnTouched', () => {

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/filter/timeframe-selector/timeframe-selector.component.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/filter/timeframe-selector/timeframe-selector.component.ts
@@ -24,6 +24,7 @@ import { MatOption, MatSelect } from '@angular/material/select';
 import { OWL_DATE_TIME_FORMATS, OwlDateTimeModule } from '@danielmoncada/angular-datetime-picker';
 import { OwlMomentDateTimeModule } from '@danielmoncada/angular-datetime-picker-moment-adapter';
 import moment, { Moment } from 'moment';
+import { filter } from 'rxjs';
 
 import { dateRangeGroupValidator } from './utils/date-range.validator';
 import { DATE_TIME_FORMATS } from './utils/timeframe-ranges';
@@ -88,9 +89,14 @@ export class TimeframeSelectorComponent implements ControlValueAccessor {
       { validators: dateRangeGroupValidator() },
     );
 
-    this.form.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(value => {
-      this.onChange({ period: value.period ?? '', from: value.from ?? null, to: value.to ?? null });
-    });
+    this.form.valueChanges
+      .pipe(
+        filter(() => this.form.controls.period.value !== this.customPeriod() || this.form.valid),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(value => {
+        this.onChange({ period: value.period ?? '', from: value.from ?? null, to: value.to ?? null });
+      });
 
     this.form.controls.from.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(from => {
       this.minDate = from ?? null;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12753

## Description

When a user types a custom From/To range with To earlier than From, the V4 Dashboard now keeps the last valid range instead of re-querying analytics on every keystroke — letting the user correct the To date without refreshing the page

## Additional context

Before:
<img width="1726" height="870" alt="image" src="https://github.com/user-attachments/assets/091913b2-ca8f-4f14-9d6a-99a371269758" />


After:
<img width="1726" height="870" alt="image" src="https://github.com/user-attachments/assets/356049c3-6c0c-431b-a5d2-dd7f30d571a6" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

