### PR TITLE
feat(repository-mongodb): bound event aggregations with maxTimeMS

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/event/EventMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/event/EventMongoRepositoryImpl.java
@@ -64,6 +64,9 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
     @Value("${management.mongodb.prefix:}")
     private String collectionPrefix;
 
+    @Value("${management.mongodb.maxQueryTime:30000}")
+    private long maxQueryTimeMs;
+
     @PostConstruct
     void setup() {
         backupCollection = collectionPrefix + BACKUP_COLLECTION;
@@ -77,6 +80,8 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
 
         // set sort by updated at
         query.with(Sort.by(Sort.Direction.DESC, UPDATED_AT_FIELD, "_id"));
+
+        query.maxTimeMsec(maxQueryTimeMs);
 
         long total = mongoTemplate.count(query, EventMongo.class);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/eventLatest/event/EventLatestMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/eventLatest/event/EventLatestMongoRepositoryImpl.java
@@ -21,16 +21,19 @@ import static org.springframework.util.CollectionUtils.isEmpty;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.mongodb.management.internal.model.EventLatestMongo;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOptions;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.data.mongodb.core.query.Criteria;
 
@@ -42,6 +45,9 @@ public class EventLatestMongoRepositoryImpl implements EventLatestMongoRepositor
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Value("${management.mongodb.maxQueryTime:30000}")
+    private long maxQueryTimeMs;
 
     public List<EventLatestMongo> search(EventCriteria criteria, Event.EventProperties group, Long page, Long size) {
         final String collectionName = mongoTemplate.getCollectionName(EventLatestMongo.class);
@@ -78,7 +84,9 @@ public class EventLatestMongoRepositoryImpl implements EventLatestMongoRepositor
         aggregationOperations.add(Aggregation.unwind("lookup_events"));
         aggregationOperations.add(Aggregation.replaceRoot("lookup_events"));
 
-        aggregation = Aggregation.newAggregation(aggregationOperations);
+        aggregation = Aggregation.newAggregation(aggregationOperations).withOptions(
+            AggregationOptions.builder().maxTime(Duration.ofMillis(maxQueryTimeMs)).build()
+        );
 
         final AggregationResults<EventLatestMongo> events = mongoTemplate.aggregate(aggregation, collectionName, EventLatestMongo.class);
 


### PR DESCRIPTION
## Summary

Adds an explicit per-query `maxTimeMS` to the **sync-path** event repository calls so that a slow MongoDB cannot silently park the bridge worker thread for tens of seconds without an upstream error signal.

- New property: `management.mongodb.maxQueryTime` (default **30000** ms = 30 s)
- `EventLatestMongoRepositoryImpl.search` — aggregation pipeline gets `AggregationOptions.builder().maxTime(Duration.ofMillis(maxQueryTimeMs))`
- `EventMongoRepositoryImpl.search` — `Query.maxTimeMsec(maxQueryTimeMs)`

## Why

During a customer incident, the gateway sync layer logged `"0 shared policy groups synchronized in 61300ms"` as a success and flipped the `sync-process` probe to healthy — while upstream bridge worker threads were parked on a slow MongoDB aggregation. The pod accepted traffic with zero APIs deployed.

`mongoTemplate.aggregate(...)` previously had **no** server-side time bound on these specific sync-path queries. With this change, a stuck Mongo causes the server to abort with `MongoExecutionTimeoutException`, the bridge handler returns HTTP 500, and the gateway sync errors out loudly through `LatestEventFetcher` → `retrySynchronizer` → `DefaultSyncManager.lastSyncOnError=true`. The `sync-process` probe (HTTP `/_node/health?probes=sync-process`) stays at 500.

## Scope (intentionally small)

This PR bounds only the **two event repository search methods** that every initial sync call goes through. Background jobs and exports that may legitimately run long are **not** touched. They can be addressed later under a separate property if desired.

## Default rationale

Customer log analysis (38 h window, 75 files):

| Synchronizer | Healthy max | Stressed-but-recovered max | Incident |
|---|---|---|---|
| shared policy groups | <5 s | 27.5 s (count=23, recovered) | 61.3 s (count=0, the lie) |
| organizations | <200 ms | 5.8 s | n/a |
| access points | <200 ms | 5.0 s | n/a |
| licenses / dictionaries | <500 ms | <2.2 s | n/a |

30 s = comfortably above any observed healthy operation, well under the customer's 61 s incident. Operators can tune via `management.mongodb.maxQueryTime`.

## Related PR

Complementary gateway-side timeout in the bridge HTTP client: gravitee-io/gravitee-apim-repository-bridge#128

## Backport

Should be backported to **4.10.x** (active customer baseline).

## Test plan

- [x] Code compiles, existing tests pass
- [x] Local lab: with MongoDB failpoint `maxTimeAlwaysTimeOut` armed, the bridge returns 500 (`MongoExecutionTimeoutException`), gateway sync retries 3× then `Latest attempt of synchronizer X has failed`, probe stays at HTTP 500 indefinitely
- [x] No-regression: with failpoint disarmed, aggregation completes <500 ms, probe goes healthy
- [ ] CI smoke test
- [ ] Backport PR against `4.10.x`