### PR TITLE
feat(apim): enable v4 API creation from remote URL (APIM-12140)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -27,6 +27,8 @@ import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDoc
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE_VALUE;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_VISIBILITY;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.exception.InvalidPathsException;
@@ -34,6 +36,7 @@ import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
 import io.gravitee.apim.core.api.use_case.CreateHttpApiUseCase;
 import io.gravitee.apim.core.api.use_case.CreateNativeApiUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiCRDUseCase;
+import io.gravitee.apim.core.api.use_case.ImportApiDefinitionFromUrlUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToImportApiUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
@@ -75,10 +78,15 @@ import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.security.utils.ImageUtils;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.v4.ApiStateService;
 import io.gravitee.rest.api.service.v4.exception.InvalidPathException;
 import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.BeanParam;
@@ -149,7 +157,18 @@ public class ApisResource extends AbstractResource {
     private ImportApiDefinitionUseCase importApiDefinitionUseCase;
 
     @Inject
+    private ImportApiDefinitionFromUrlUseCase importApiDefinitionFromUrlUseCase;
+
+    @Inject
     private OAIToImportApiUseCase oaiToImportApiUseCase;
+
+    @Inject
+    private ImportConfiguration importConfiguration;
+
+    @Inject
+    private ObjectMapper objectMapper;
+
+    private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
@@ -271,6 +290,36 @@ public class ApisResource extends AbstractResource {
                 .build();
         } catch (InvalidPathsException e) {
             throw new InvalidPathException("Cannot import API with invalid paths", e);
+        }
+    }
+
+    @POST
+    @Path("/_import/definition-url")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.CREATE) })
+    public Response createApiWithDefinitionFromUrl(@NotNull String apiDefinitionUrl) {
+        var input = new ImportApiDefinitionFromUrlUseCase.Input(
+            apiDefinitionUrl,
+            importConfiguration.getImportWhitelist(),
+            importConfiguration.isAllowImportFromPrivate()
+        );
+        var output = importApiDefinitionFromUrlUseCase.execute(input);
+
+        ExportApiV4 apiToImport = parseApiDefinition(output.apiDefinitionContent());
+        Set<ConstraintViolation<ExportApiV4>> violations = VALIDATOR.validate(apiToImport);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+        return createApiWithDefinition(apiToImport);
+    }
+
+    private ExportApiV4 parseApiDefinition(String apiDefinitionContent) {
+        try {
+            return objectMapper.readValue(apiDefinitionContent, ExportApiV4.class);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to parse API definition fetched from URL", e);
+            throw new BadRequestException("Invalid API definition format");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -162,6 +162,37 @@ paths:
                                 $ref: "#/components/schemas/ApiV4"
                 default:
                     $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/_import/definition-url:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+        post:
+            tags:
+                - APIs
+            summary: Import API definition from a remote URL
+            description: |-
+                ⚠️ Support only v4 API for the moment. ⚠️<br>
+                Create an API by fetching an API definition from a remote URL.<br>
+                The URL must be permitted by the configured import whitelist.
+
+                User must have the ENVIRONMENT_API[CREATE] permission.
+            operationId: createApiWithImportDefinitionFromUrl
+            requestBody:
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            format: uri
+                            example: https://example.com/api-definition.json
+                required: true
+            responses:
+                "201":
+                    description: API successfully created
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiV4"
+                default:
+                    $ref: "#/components/responses/Error"
     /environments/{envId}/apis/_search:
         parameters:
             - $ref: "#/components/parameters/envIdParam"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/JerseySpringTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/JerseySpringTest.java
@@ -135,6 +135,10 @@ public abstract class JerseySpringTest {
                 @Override
                 protected void configure() {
                     bind(response).to(HttpServletResponse.class);
+                    // Bind ObjectMapper for Jersey @Inject in resource classes
+                    bind(new io.gravitee.definition.jackson.datatype.GraviteeMapper()).to(
+                        com.fasterxml.jackson.databind.ObjectMapper.class
+                    );
                 }
             }
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiWithDefinitionFromUrlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiWithDefinitionFromUrlTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.INTERNAL_SERVER_ERROR_500;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.use_case.ImportApiDefinitionUseCase;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.HttpClientService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import io.vertx.core.buffer.Buffer;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ApisResource_CreateApiWithDefinitionFromUrlTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT_ID = "my-env";
+    private static final String TEST_URL = "https://example.com/api-definition.json";
+    private static final String VALID_API_DEFINITION_JSON = """
+        {
+          "api": {
+            "id": "test-api-id",
+            "name": "Test API",
+            "description": "Test API Description",
+            "version": "1.0.0",
+            "definitionVersion": "V4",
+            "type": "PROXY",
+            "apiVersion": "1.0.0",
+            "listeners": [
+              {
+                "type": "HTTP",
+                "paths": [
+                  {
+                    "path": "/test"
+                  }
+                ],
+                "entrypoints": [
+                  {
+                    "type": "http-proxy"
+                  }
+                ]
+              }
+            ],
+            "endpointGroups": [
+              {
+                "name": "default-group",
+                "type": "http-proxy",
+                "endpoints": [
+                  {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                      "target": "http://localhost:8080/endpoint"
+                    }
+                  }
+                ]
+              }
+            ],
+            "flowExecution": {
+              "mode": "DEFAULT",
+              "matchRequired": false
+            },
+            "flows": [],
+            "responseTemplates": {},
+            "analytics": {
+              "enabled": false
+            },
+            "lifecycleState": "CREATED"
+          },
+          "plans": []
+        }
+        """;
+
+    @Autowired
+    private HttpClientService httpClientService;
+
+    @Autowired
+    private ImportConfiguration importConfiguration;
+
+    @Autowired
+    private ImportApiDefinitionUseCase importApiDefinitionUseCase;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT_ID + "/apis/_import/definition-url";
+    }
+
+    @BeforeEach
+    public void init() throws TechnicalException {
+        reset(apiServiceV4, httpClientService, importConfiguration, importApiDefinitionUseCase);
+        GraviteeContext.cleanContext();
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+
+        EnvironmentEntity environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENVIRONMENT_ID);
+        environmentEntity.setOrganizationId(ORGANIZATION);
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT_ID)).thenReturn(environmentEntity);
+
+        when(importConfiguration.getImportWhitelist()).thenReturn(Collections.emptyList());
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
+    }
+
+    @Test
+    public void should_not_import_when_no_definition_permission() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_API,
+                ENVIRONMENT_ID,
+                RolePermissionAction.CREATE
+            )
+        ).thenReturn(false);
+        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(TEST_URL));
+        assertEquals(FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void should_import_api_from_url_when_url_is_valid() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_API,
+                ENVIRONMENT_ID,
+                RolePermissionAction.CREATE
+            )
+        ).thenReturn(true);
+
+        Buffer buffer = Buffer.buffer(VALID_API_DEFINITION_JSON);
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenReturn(buffer);
+
+        ApiWithFlows mockApi = ApiWithFlows.builder().id("test-api-id").name("Test API").build();
+        when(importApiDefinitionUseCase.execute(any())).thenReturn(new ImportApiDefinitionUseCase.Output(mockApi));
+
+        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(TEST_URL));
+        assertEquals(CREATED_201, response.getStatus());
+
+        verify(httpClientService).request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any());
+        verify(importApiDefinitionUseCase).execute(any());
+    }
+
+    @Test
+    public void should_return_bad_request_when_url_is_forbidden() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_API,
+                ENVIRONMENT_ID,
+                RolePermissionAction.CREATE
+            )
+        ).thenReturn(true);
+
+        when(importConfiguration.getImportWhitelist()).thenReturn(Collections.emptyList());
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
+
+        String privateUrl = "http://localhost:8080/api-definition.json";
+        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(privateUrl));
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void should_return_bad_request_when_url_returns_invalid_json() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_API,
+                ENVIRONMENT_ID,
+                RolePermissionAction.CREATE
+            )
+        ).thenReturn(true);
+
+        Buffer buffer = Buffer.buffer("invalid json content");
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenReturn(buffer);
+
+        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(TEST_URL));
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void should_return_internal_server_error_when_http_client_throws() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_API,
+                ENVIRONMENT_ID,
+                RolePermissionAction.CREATE
+            )
+        ).thenReturn(true);
+
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenThrow(
+            new RuntimeException("Connection refused")
+        );
+
+        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(TEST_URL));
+        assertEquals(INTERNAL_SERVER_ERROR_500, response.getStatus());
+    }
+
+    @Test
+    public void should_reject_url_not_in_whitelist() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_API,
+                ENVIRONMENT_ID,
+                RolePermissionAction.CREATE
+            )
+        ).thenReturn(true);
+
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of("https://allowed.example.com"));
+
+        String notWhitelistedUrl = "https://other.example.com/api-definition.json";
+        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(notWhitelistedUrl));
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -64,6 +64,7 @@ import io.gravitee.apim.core.api.domain_service.ApiMetadataDomainService;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.domain_service.CategoryDomainService;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.FetchApiDefinitionFromUrlDomainService;
 import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiCRDDomainService;
@@ -74,6 +75,8 @@ import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
+import io.gravitee.apim.core.api.use_case.ImportApiDefinitionFromUrlUseCase;
+import io.gravitee.apim.core.api.use_case.ImportApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
@@ -228,6 +231,7 @@ import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapterImpl;
 import io.gravitee.apim.infra.domain_service.analytics_engine.definition.AnalyticsDefinitionYAMLQueryService;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.UnitEnrichmentPostProcessorImpl;
+import io.gravitee.apim.infra.domain_service.api.FetchApiDefinitionFromUrlDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
@@ -260,6 +264,7 @@ import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.GenericNotificationConfigService;
 import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.HttpClientService;
 import io.gravitee.rest.api.service.InstanceService;
 import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.MembershipService;
@@ -274,6 +279,7 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.impl.configuration.application.ApplicationTypeServiceImpl;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
 import io.gravitee.rest.api.service.v4.ApiWorkflowStateService;
@@ -1485,5 +1491,33 @@ public class ResourceContextConfiguration {
     @Bean
     public DictionaryAutomationDomainService dictionaryAutomationDomainService() {
         return mock(DictionaryAutomationDomainService.class);
+    }
+
+    @Bean
+    public HttpClientService httpClientService() {
+        return mock(HttpClientService.class);
+    }
+
+    @Bean
+    public ImportConfiguration importConfiguration() {
+        return mock(ImportConfiguration.class);
+    }
+
+    @Bean
+    @Primary
+    public FetchApiDefinitionFromUrlDomainService fetchApiDefinitionFromUrlDomainService(HttpClientService httpClientService) {
+        return new FetchApiDefinitionFromUrlDomainServiceImpl(httpClientService);
+    }
+
+    @Bean
+    public ImportApiDefinitionFromUrlUseCase importApiDefinitionFromUrlUseCase(
+        FetchApiDefinitionFromUrlDomainService fetchApiDefinitionFromUrlDomainService
+    ) {
+        return new ImportApiDefinitionFromUrlUseCase(fetchApiDefinitionFromUrlDomainService);
+    }
+
+    @Bean
+    public ImportApiDefinitionUseCase importApiDefinitionUseCase() {
+        return mock(ImportApiDefinitionUseCase.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/FetchApiDefinitionFromUrlDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/FetchApiDefinitionFromUrlDomainService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import java.util.List;
+
+@DomainService
+public interface FetchApiDefinitionFromUrlDomainService {
+    String fetch(String url, List<String> whitelist, boolean allowPrivate);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionFromUrlUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiDefinitionFromUrlUseCase.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.FetchApiDefinitionFromUrlDomainService;
+import java.util.List;
+
+@UseCase
+public class ImportApiDefinitionFromUrlUseCase {
+
+    public record Input(String url, List<String> whitelist, boolean allowPrivate) {}
+
+    public record Output(String apiDefinitionContent) {}
+
+    private final FetchApiDefinitionFromUrlDomainService fetchApiDefinitionFromUrlDomainService;
+
+    public ImportApiDefinitionFromUrlUseCase(FetchApiDefinitionFromUrlDomainService fetchApiDefinitionFromUrlDomainService) {
+        this.fetchApiDefinitionFromUrlDomainService = fetchApiDefinitionFromUrlDomainService;
+    }
+
+    public Output execute(Input input) {
+        String apiDefinitionContent = fetchApiDefinitionFromUrlDomainService.fetch(input.url(), input.whitelist(), input.allowPrivate());
+        return new Output(apiDefinitionContent);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/FetchApiDefinitionFromUrlDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/FetchApiDefinitionFromUrlDomainServiceImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import io.gravitee.apim.core.api.domain_service.FetchApiDefinitionFromUrlDomainService;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.rest.api.service.HttpClientService;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.sanitizer.UrlSanitizerUtils;
+import io.vertx.core.buffer.Buffer;
+import java.util.List;
+import lombok.CustomLog;
+import org.springframework.stereotype.Service;
+
+@CustomLog
+@Service
+public class FetchApiDefinitionFromUrlDomainServiceImpl implements FetchApiDefinitionFromUrlDomainService {
+
+    private final HttpClientService httpClientService;
+
+    public FetchApiDefinitionFromUrlDomainServiceImpl(HttpClientService httpClientService) {
+        this.httpClientService = httpClientService;
+    }
+
+    @Override
+    public String fetch(String url, List<String> whitelist, boolean allowPrivate) {
+        UrlSanitizerUtils.checkAllowed(url, whitelist, allowPrivate);
+
+        log.debug("Fetching API definition from URL '{}'", url);
+        try {
+            Buffer buffer = httpClientService.request(HttpMethod.GET, url, null, null, null);
+            String body = buffer == null ? "" : buffer.toString();
+            log.debug("Fetched API definition from URL '{}' ({} bytes)", url, body.length());
+            return body;
+        } catch (AbstractManagementException e) {
+            log.warn("Failed to fetch API definition from URL '{}': {}", url, e.getMessage());
+            throw e;
+        } catch (RuntimeException e) {
+            log.warn("Failed to fetch API definition from URL '{}'", url, e);
+            throw new TechnicalManagementException("Failed to fetch API definition from URL '" + url + "'", e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/FetchApiDefinitionFromUrlDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/FetchApiDefinitionFromUrlDomainServiceInMemory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.api.domain_service.FetchApiDefinitionFromUrlDomainService;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FetchApiDefinitionFromUrlDomainServiceInMemory implements FetchApiDefinitionFromUrlDomainService, InMemoryAlternative<String> {
+
+    private final List<String> storage = new ArrayList<>();
+    private RuntimeException toThrow;
+
+    public void willThrow(RuntimeException ex) {
+        this.toThrow = ex;
+    }
+
+    @Override
+    public String fetch(String url, List<String> whitelist, boolean allowPrivate) {
+        if (toThrow != null) {
+            throw toThrow;
+        }
+        return storage.isEmpty() ? "" : storage.get(0);
+    }
+
+    @Override
+    public void initWith(List<String> items) {
+        reset();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+        toThrow = null;
+    }
+
+    @Override
+    public List<String> storage() {
+        return storage;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -337,6 +337,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public FetchApiDefinitionFromUrlDomainServiceInMemory fetchApiDefinitionFromUrlDomainService() {
+        return new FetchApiDefinitionFromUrlDomainServiceInMemory();
+    }
+
+    @Bean
     public ApplicationMetadataQueryServiceInMemory applicationMetadataQueryService() {
         return new ApplicationMetadataQueryServiceInMemory();
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12140
## Description

Adds backend support for creating a v4 API by submitting a remote URL pointing to a Gravitee definition. New endpoint `POST /environments/{envId}/apis/_import/definition-url` (text/plain
  body) fetches the definition server-side, validates via the existing `UrlSanitizerUtils` whitelist + private-IP gate, then delegates to the existing import use case.

 Builds on POC `APIM-12140-enable-remote-source-for-v4`.

  Scope: APIM-12140 only — Gravitee Definition / Create flow.

  ## Out of scope (separate PRs)
  - UI: wire stepper to call the new endpoint instead of doing browser-side fetch (fixes CORS issue with raw.githubusercontent.com)
  - APIM-12142 — Update existing v4 API from URL
  - APIM-12143 / APIM-12144 — OpenAPI flows
  - Authorization-header forwarding (the UI exposes it; backend currently ignores it)

  ## Test plan
  - [x] 6 integration tests pass — happy path, permission, forbidden private URL, invalid JSON, HttpClient throws, URL not in whitelist
  - [x] `mvn prettier:write` clean
  
## Jira subtask alignment
  The existing subtasks (APIM-13647 → APIM-13658) describe UI work against the pre-refactor
  component that no longer exists. This PR implements backend support not anticipated by
  those subtasks. Recommend closing them and tracking the actual work as:
  - Backend endpoint (this PR)
  - UI rewire (follow-up PR)
<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

