### PR TITLE
feat(patch-api): allow resources in v4 HTTP Proxy API PATCH allow-list

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -298,11 +298,15 @@ paths:
                 Partially update a V4 HTTP Proxy API using JSON Patch (RFC 6902) or JSON Merge Patch (RFC 7396).
 
                 Only the following fields are patchable: name, description, apiVersion, visibility, labels, tags,
-                lifecycleState, categories, analytics, failover, flowExecution, flows, services, allowedInApiProducts,
-                allowMultiJwtOauth2Subscriptions, disableMembershipNotifications, groups, properties,
-                responseTemplates.
+                lifecycleState, categories, analytics, failover, flowExecution, flows, services, resources,
+                allowedInApiProducts, allowMultiJwtOauth2Subscriptions, disableMembershipNotifications,
+                properties, responseTemplates.
 
-                Use dryRun=true to preview the result without persisting.
+                JSON Patch operations targeting /resources/N/configuration/... (any depth under configuration) are
+                rejected with 400. Replace the full configuration object at /resources/N/configuration instead.
+
+                Use dryRun=true to preview the result without persisting. The response body reflects
+                validator-sanitised values, including plugin-default-injected resource configuration.
 
                 User must have API_DEFINITION[UPDATE] or API_GATEWAY_DEFINITION[UPDATE] permissions.
             operationId: patchApi

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -213,22 +213,24 @@ public class PatchApiUseCase {
             }
             var opType = op.path("op").asText();
             if ("move".equals(opType) || "copy".equals(opType)) {
-                var fromNode = op.path("from");
-                if (fromNode.isMissingNode()) {
-                    throw new ValidationDomainException("JSON Patch operation at index " + index + " is missing required 'from' field");
-                }
-                if (!fromNode.isTextual()) {
-                    throw new ValidationDomainException(
-                        "JSON Patch operation at index " + index + " has invalid 'from' field: must be a string"
-                    );
-                }
-                var rawFrom = fromNode.asText();
-                validateJsonPatchField(index, "from", rawFrom);
-                if (isResourceConfigurationDeepPath(rawFrom)) {
-                    throw new ApiPatchNotAllowedException(rawFrom, RESOURCE_CONFIGURATION_DEEP_PATH_MESSAGE);
-                }
+                validateMoveOrCopyFromField(index, op);
             }
             index++;
+        }
+    }
+
+    private void validateMoveOrCopyFromField(int opIndex, JsonNode op) {
+        var fromNode = op.path("from");
+        if (fromNode.isMissingNode()) {
+            throw new ValidationDomainException("JSON Patch operation at index " + opIndex + " is missing required 'from' field");
+        }
+        if (!fromNode.isTextual()) {
+            throw new ValidationDomainException("JSON Patch operation at index " + opIndex + " has invalid 'from' field: must be a string");
+        }
+        var rawFrom = fromNode.asText();
+        validateJsonPatchField(opIndex, "from", rawFrom);
+        if (isResourceConfigurationDeepPath(rawFrom)) {
+            throw new ApiPatchNotAllowedException(rawFrom, RESOURCE_CONFIGURATION_DEEP_PATH_MESSAGE);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -48,12 +48,14 @@ import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.definition.model.v4.property.Property;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -83,8 +85,13 @@ public class PatchApiUseCase {
     private static final String FIELD_PROPERTIES = "properties";
     private static final String FIELD_RESPONSE_TEMPLATES = "responseTemplates";
     private static final String FIELD_FLOWS = "flows";
+    private static final String FIELD_RESOURCES = "resources";
 
     private static final String JSON_PATCH_PATH_PREFIX = "/";
+
+    private static final Pattern RESOURCE_CONFIGURATION_DEEP_PATH = Pattern.compile("/resources/(\\d+|-)/configuration/.+");
+    private static final String RESOURCE_CONFIGURATION_DEEP_PATH_MESSAGE =
+        "operations under /resources/N/configuration/... are not supported; replace the full configuration object at /resources/N/configuration";
 
     private static final Set<String> ALLOWED_FIELDS = Set.of(
         FIELD_NAME,
@@ -104,13 +111,14 @@ public class PatchApiUseCase {
         FIELD_DISABLE_MEMBERSHIP_NOTIFICATIONS,
         FIELD_PROPERTIES,
         FIELD_RESPONSE_TEMPLATES,
-        FIELD_FLOWS
+        FIELD_FLOWS,
+        FIELD_RESOURCES
     );
 
     private static final int MAX_PATCH_OPS = 200;
 
     private static final Set<String> BLOCKED_WITH_HINT = Set.of("state");
-    private static final Set<String> BLOCKED_WITHOUT_HINT = Set.of("endpointGroups", "listeners", "resources");
+    private static final Set<String> BLOCKED_WITHOUT_HINT = Set.of("endpointGroups", "listeners");
 
     private static final String NULL_NOT_ALLOWED_MESSAGE_FORMAT =
         "'%s' cannot be null; omit the field to leave it unchanged, or send an explicit value";
@@ -198,7 +206,11 @@ public class PatchApiUseCase {
             if (pathNode.isMissingNode() || !pathNode.isTextual()) {
                 throw new ValidationDomainException("JSON Patch operation at index " + index + " is missing required 'path' field");
             }
-            validateJsonPatchField(index, "path", pathNode.asText());
+            var rawPath = pathNode.asText();
+            validateJsonPatchField(index, "path", rawPath);
+            if (isResourceConfigurationDeepPath(rawPath)) {
+                throw new ApiPatchNotAllowedException(rawPath, RESOURCE_CONFIGURATION_DEEP_PATH_MESSAGE);
+            }
             var opType = op.path("op").asText();
             if ("move".equals(opType) || "copy".equals(opType)) {
                 var fromNode = op.path("from");
@@ -210,10 +222,18 @@ public class PatchApiUseCase {
                         "JSON Patch operation at index " + index + " has invalid 'from' field: must be a string"
                     );
                 }
-                validateJsonPatchField(index, "from", fromNode.asText());
+                var rawFrom = fromNode.asText();
+                validateJsonPatchField(index, "from", rawFrom);
+                if (isResourceConfigurationDeepPath(rawFrom)) {
+                    throw new ApiPatchNotAllowedException(rawFrom, RESOURCE_CONFIGURATION_DEEP_PATH_MESSAGE);
+                }
             }
             index++;
         }
+    }
+
+    private static boolean isResourceConfigurationDeepPath(String path) {
+        return path != null && RESOURCE_CONFIGURATION_DEEP_PATH.matcher(path).matches();
     }
 
     private void validateJsonPatchField(int opIndex, String pointerName, String pointer) {
@@ -351,6 +371,7 @@ public class PatchApiUseCase {
         );
         var responseTemplates = resolveResponseTemplates(patchType, rawPatchNode, patchedNode, httpV4.getResponseTemplates());
         var flows = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_FLOWS, Flow.class, httpV4.getFlows());
+        var resources = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_RESOURCES, Resource.class, httpV4.getResources());
 
         var updatedDefinition = httpV4
             .toBuilder()
@@ -365,6 +386,7 @@ public class PatchApiUseCase {
             .properties(properties)
             .responseTemplates(responseTemplates)
             .flows(flows)
+            .resources(resources)
             .build();
 
         return existingApi
@@ -767,7 +789,8 @@ public class PatchApiUseCase {
         boolean disableMembershipNotifications,
         List<Property> properties,
         Map<String, Map<String, PatchableResponseTemplate>> responseTemplates,
-        List<Flow> flows
+        List<Flow> flows,
+        List<Resource> resources
     ) {
         static PatchableView from(Api api, io.gravitee.definition.model.v4.Api httpV4) {
             return new PatchableView(
@@ -788,7 +811,8 @@ public class PatchApiUseCase {
                 api.isDisableMembershipNotifications(),
                 httpV4.getProperties(),
                 toPatchableResponseTemplates(httpV4.getResponseTemplates()),
-                httpV4.getFlows()
+                httpV4.getFlows(),
+                httpV4.getResources()
             );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
@@ -87,6 +87,7 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
             .services(coalesce(sanitized.getServices(), originalDefinition.getServices()))
             .allowedInApiProducts(coalesce(sanitized.getAllowedInApiProducts(), originalDefinition.getAllowedInApiProducts()))
             .responseTemplates(coalesce(sanitized.getResponseTemplates(), originalDefinition.getResponseTemplates()))
+            .resources(coalesce(sanitized.getResources(), originalDefinition.getResources()))
             .build();
         return original
             .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -1809,7 +1809,7 @@ class PatchApiUseCaseTest {
 
         @Test
         void json_patch_replace_resource_configuration_atomically() {
-            var existing = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            var existing = Resource.builder().name("r1").type("cache").configuration("{\"oldKey\":\"oldValue\"}").enabled(true).build();
             givenExistingApi(apiWithResources(List.of(existing)));
 
             var output = execute(
@@ -1818,8 +1818,10 @@ class PatchApiUseCaseTest {
                 false
             );
 
+            var config = httpV4Def(output.api()).getResources().getFirst().getConfiguration();
             assertThat(httpV4Def(output.api()).getResources()).hasSize(1);
-            assertThat(httpV4Def(output.api()).getResources().getFirst().getConfiguration()).contains("\"ttl\"");
+            assertThat(config).contains("\"ttl\"");
+            assertThat(config).doesNotContain("oldKey");
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -1841,6 +1841,17 @@ class PatchApiUseCaseTest {
         }
 
         @Test
+        void dry_run_with_null_erases_resources() {
+            var existing = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+            stubValidateV4ReturnsArgument();
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("resources", null), true);
+
+            assertThat(httpV4Def(output.api()).getResources()).isNull();
+        }
+
+        @Test
         void dry_run_returns_sanitised_resources() {
             var sanitisedResources = List.of(
                 Resource.builder().name("r1").type("cache").configuration("{\"timeToLiveSeconds\":0}").enabled(true).build()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -1749,6 +1749,7 @@ class PatchApiUseCaseTest {
         @ParameterizedTest
         @ValueSource(strings = { "SOME_UNKNOWN_TYPE", "CACHE" })
         void merge_patch_accepts_resource_type_verbatim(String type) {
+            stubValidateV4ReturnsArgument();
             givenExistingApi(apiWithResources(null));
 
             var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("resources", List.of(resourceMap("r1", type))), false);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -1709,7 +1709,7 @@ class PatchApiUseCaseTest {
 
             var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("resources", null), false);
 
-            assertThat(httpV4Def(output.api()).getResources()).isNullOrEmpty();
+            assertThat(httpV4Def(output.api()).getResources()).isNull();
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -53,6 +53,7 @@ import io.gravitee.definition.model.v4.flow.selector.ConditionSelector;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.definition.model.v4.property.Property;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,6 +72,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 /**
@@ -259,6 +261,15 @@ class PatchApiUseCaseTest {
     static Api apiWithFlows(List<Flow> flows) {
         var base = ApiFixtures.aProxyApiV4();
         return base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().flows(flows).build()).build();
+    }
+
+    static Api apiWithResources(List<Resource> resources) {
+        var base = ApiFixtures.aProxyApiV4();
+        return base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().resources(resources).build()).build();
+    }
+
+    static Map<String, Object> resourceMap(String name, String type) {
+        return Map.of("name", name, "type", type, "configuration", Map.of(), "enabled", true);
     }
 
     private static io.gravitee.definition.model.v4.Api httpV4Def(Api api) {
@@ -471,14 +482,6 @@ class PatchApiUseCaseTest {
             assertThatThrownBy(() -> execute(type, setField(type, "endpointGroups", List.of()), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
                 .hasMessageContaining("endpointGroups");
-        }
-
-        @ParameterizedTest
-        @EnumSource(PatchApiUseCase.PatchType.class)
-        void resources_field_is_rejected(PatchApiUseCase.PatchType type) {
-            assertThatThrownBy(() -> execute(type, setField(type, "resources", List.of()), false))
-                .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("resources");
         }
 
         @ParameterizedTest
@@ -704,6 +707,14 @@ class PatchApiUseCaseTest {
             var output = execute(type, body, false);
 
             assertThat(httpV4Def(output.api()).getProperties()).isNull();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void resources_field_is_allowed(PatchApiUseCase.PatchType type) {
+            var output = execute(type, setField(type, "resources", List.of(resourceMap("my-cache", "cache"))), false);
+
+            assertThat(httpV4Def(output.api()).getResources()).hasSize(1);
         }
     }
 
@@ -1042,6 +1053,39 @@ class PatchApiUseCaseTest {
             var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/categories"), false);
 
             assertThat(output.api().getCategories()).isEmpty();
+        }
+
+        static Stream<Arguments> deepPathUnderResourceConfigurationCases() {
+            return Stream.of(
+                Arguments.of(patch("replace", "/resources/0/configuration/someField", "value"), "/resources/0/configuration/someField"),
+                Arguments.of(patch("replace", "/resources/0/configuration/a/b", "value"), "/resources/0/configuration/a/b"),
+                Arguments.of(patch("remove", "/resources/0/configuration/someField"), "/resources/0/configuration/someField"),
+                Arguments.of(movePatch("/resources/0/configuration/key", "/name"), "/resources/0/configuration/key"),
+                Arguments.of(copyPatch("/resources/0/configuration/key", "/name"), "/resources/0/configuration/key"),
+                Arguments.of(patch("add", "/resources/-/configuration/someKey", "value"), "/resources/-/configuration/someKey")
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("deepPathUnderResourceConfigurationCases")
+        void deep_path_under_resource_configuration_is_rejected(String patchJson, String expectedPath) {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patchJson, false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining(expectedPath);
+        }
+
+        @Test
+        void json_patch_exact_configuration_path_is_accepted() {
+            var existing = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+
+            var output = execute(
+                PatchApiUseCase.PatchType.JSON_PATCH,
+                patch("replace", "/resources/0/configuration", Map.of("ttl", 300)),
+                false
+            );
+
+            assertThat(httpV4Def(output.api()).getResources()).hasSize(1);
         }
     }
 
@@ -1637,6 +1681,185 @@ class PatchApiUseCaseTest {
             );
 
             assertThat(httpV4Def(output.api()).getFlowExecution()).isEqualTo(flowExecution);
+        }
+    }
+
+    @Nested
+    class ResourcesResolution {
+
+        @Test
+        void merge_patch_replaces_resources_list() {
+            var existing = Resource.builder().name("old").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+
+            var output = execute(
+                PatchApiUseCase.PatchType.MERGE_PATCH,
+                mergePatch("resources", List.of(resourceMap("new-r", "oauth2"))),
+                false
+            );
+
+            assertThat(httpV4Def(output.api()).getResources()).hasSize(1);
+            assertThat(httpV4Def(output.api()).getResources().getFirst().getName()).isEqualTo("new-r");
+        }
+
+        @Test
+        void merge_patch_with_null_erases_resources() {
+            var existing = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("resources", null), false);
+
+            assertThat(httpV4Def(output.api()).getResources()).isNullOrEmpty();
+        }
+
+        @Test
+        void merge_patch_with_empty_array_clears_resources() {
+            var existing = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("resources", List.of()), false);
+
+            assertThat(httpV4Def(output.api()).getResources()).isEmpty();
+        }
+
+        @Test
+        void merge_patch_omitting_resources_leaves_them_unchanged() {
+            var existing = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "renamed"), false);
+
+            assertThat(httpV4Def(output.api()).getResources()).containsExactly(existing);
+        }
+
+        @Test
+        void merge_patch_sets_resources_when_previously_absent() {
+            givenExistingApi(apiWithResources(null));
+
+            var output = execute(
+                PatchApiUseCase.PatchType.MERGE_PATCH,
+                mergePatch("resources", List.of(resourceMap("r1", "cache"))),
+                false
+            );
+
+            assertThat(httpV4Def(output.api()).getResources()).hasSize(1);
+            assertThat(httpV4Def(output.api()).getResources().getFirst().getName()).isEqualTo("r1");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "SOME_UNKNOWN_TYPE", "CACHE" })
+        void merge_patch_accepts_resource_type_verbatim(String type) {
+            givenExistingApi(apiWithResources(null));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("resources", List.of(resourceMap("r1", type))), false);
+
+            assertThat(httpV4Def(output.api()).getResources()).hasSize(1);
+            assertThat(httpV4Def(output.api()).getResources().getFirst().getType()).isEqualTo(type);
+        }
+
+        @Test
+        void json_patch_replace_resources_list() {
+            var existing = Resource.builder().name("old").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+
+            var output = execute(
+                PatchApiUseCase.PatchType.JSON_PATCH,
+                patch("replace", "/resources", List.of(resourceMap("new-r", "oauth2"))),
+                false
+            );
+
+            assertThat(httpV4Def(output.api()).getResources()).hasSize(1);
+            assertThat(httpV4Def(output.api()).getResources().getFirst().getName()).isEqualTo("new-r");
+        }
+
+        @Test
+        void json_patch_add_single_resource() {
+            var existing = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/resources/0", resourceMap("r0", "oauth2")), false);
+
+            assertThat(httpV4Def(output.api()).getResources()).hasSize(2);
+            assertThat(httpV4Def(output.api()).getResources().getFirst().getName()).isEqualTo("r0");
+        }
+
+        @Test
+        void json_patch_append_resource_using_dash() {
+            var existing = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/resources/-", resourceMap("r2", "oauth2")), false);
+
+            assertThat(httpV4Def(output.api()).getResources()).hasSize(2);
+            assertThat(httpV4Def(output.api()).getResources().get(1).getName()).isEqualTo("r2");
+        }
+
+        @Test
+        void json_patch_remove_single_resource() {
+            var r1 = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            var r2 = Resource.builder().name("r2").type("oauth2").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(r1, r2)));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/resources/0"), false);
+
+            assertThat(httpV4Def(output.api()).getResources()).hasSize(1);
+            assertThat(httpV4Def(output.api()).getResources().getFirst().getName()).isEqualTo("r2");
+        }
+
+        @Test
+        void json_patch_replace_resource_configuration_atomically() {
+            var existing = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+
+            var output = execute(
+                PatchApiUseCase.PatchType.JSON_PATCH,
+                patch("replace", "/resources/0/configuration", Map.of("ttl", 300)),
+                false
+            );
+
+            assertThat(httpV4Def(output.api()).getResources()).hasSize(1);
+            assertThat(httpV4Def(output.api()).getResources().getFirst().getConfiguration()).contains("\"ttl\"");
+        }
+
+        @Test
+        void json_patch_replace_resource_non_configuration_field() {
+            var existing = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+            givenExistingApi(apiWithResources(List.of(existing)));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/resources/0/name", "renamed"), false);
+
+            assertThat(httpV4Def(output.api()).getResources().getFirst().getName()).isEqualTo("renamed");
+        }
+
+        @Test
+        void dry_run_resources_not_persisted() {
+            stubValidateV4ReturnsArgument();
+
+            execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("resources", List.of(resourceMap("r1", "cache"))), true);
+
+            verify(updateApiDomainService, never()).updateV4(any(), any());
+        }
+
+        @Test
+        void dry_run_returns_sanitised_resources() {
+            var sanitisedResources = List.of(
+                Resource.builder().name("r1").type("cache").configuration("{\"timeToLiveSeconds\":0}").enabled(true).build()
+            );
+            when(updateApiDomainService.validateV4(any(), any())).thenAnswer(inv -> {
+                Api api = inv.getArgument(0);
+                var def = (io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue();
+                return api.toBuilder().apiDefinitionValue(def.toBuilder().resources(sanitisedResources).build()).build();
+            });
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("resources", List.of(resourceMap("r1", "cache"))), true);
+
+            var apiCaptor = ArgumentCaptor.forClass(Api.class);
+            verify(updateApiDomainService).validateV4(apiCaptor.capture(), any());
+            assertThat(httpV4Def(apiCaptor.getValue()).getResources()).containsExactly(
+                Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build()
+            );
+
+            assertThat(httpV4Def(output.api()).getResources()).isEqualTo(sanitisedResources);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
@@ -33,6 +33,7 @@ import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.service.v4.ApiService;
@@ -249,6 +250,33 @@ class UpdateApiDomainServiceImplTest {
 
         assertThat(result.getApiDefinitionHttpV4().getFlows()).isNull();
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_return_sanitized_resources_from_mutated_update_api_entity() {
+        var api = ApiFixtures.aProxyApiV4();
+        var sanitizedResources = List.of(Resource.builder().name("r1").type("cache").configuration("{\"ttl\":300}").enabled(true).build());
+        stubValidate(entity -> entity.setResources(sanitizedResources));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getResources()).isEqualTo(sanitizedResources);
+    }
+
+    @Test
+    void should_preserve_original_resources_when_validator_returns_null() {
+        var existingResource = Resource.builder().name("r1").type("cache").configuration("{}").enabled(true).build();
+        var originalDefinition = ApiFixtures.aProxyApiV4()
+            .getApiDefinitionHttpV4()
+            .toBuilder()
+            .resources(List.of(existingResource))
+            .build();
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
+        stubValidate(entity -> entity.setResources(null));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getResources()).containsExactly(existingResource);
     }
 
     @Test


### PR DESCRIPTION
## Issue

[APIM-13948](https://gravitee.atlassian.net/browse/APIM-13948)

## Why

DevOps engineers automating API management via mAPI need to PATCH the `resources` field on a v4 HTTP Proxy API without resending the full definition. The existing PATCH allow-list blocked `resources`, forcing full-definition PUT requests for targeted resource updates. This brings v4 HTTP Proxy PATCH coverage in line with what v2 already supports.

## What changed

- **`PatchApiUseCase`**: added `resources` to `ALLOWED_FIELDS`; added a precompiled-regex guard that rejects JSON Patch operations targeting deep paths under `/resources/N/configuration/...` (configuration objects must be replaced atomically); wired `resources` into `PatchableView` and `applyPatchedValues`.
- **`UpdateApiDomainServiceImpl`**: propagates validator-sanitised resources back through the dry-run path (`applySanitizedValues`), falling back to the original resource list when the validator returns null.
- **`openapi-apis.yaml`**: updated the PATCH operation description to document the new `resources` allow-list entry, the deep-path rejection behaviour, and the dry-run sanitisation guarantee.
- Refactors (earlier commits): JSON Patch services moved to a generic `core/json_patch` package; `coalesce` helper extracted to reduce cognitive complexity.

## User-facing impact

- `PATCH /apis/{apiId}` now accepts `resources` in both JSON Patch and Merge Patch bodies for v4 HTTP Proxy APIs.
- JSON Patch operations targeting `/resources/N/configuration/<sub-field>` are rejected with an explanatory hint — callers must replace `/resources/N/configuration` atomically.
- Dry-run (`?dryRun=true`) responses now reflect validator-sanitised resource configuration and never persist changes.
- No breaking changes to existing callers; previously blocked operations now succeed.

## How to test

1. `PATCH /apis/{apiId}` with `Content-Type: application/json-patch+json` and a body containing `[{"op":"replace","path":"/resources","value":[...]}]` → `200` with updated resources.
2. Repeat with `Content-Type: application/merge-patch+json` and `{"resources":[...]}` → `200`.
3. Send a JSON Patch op targeting `/resources/0/configuration/someField` → `400` with a descriptive error.
4. Send with `?dryRun=true` → `200` with sanitised resource defaults in the body; subsequent `GET` shows resources unchanged.
5. Run existing unit tests: `mvnd test -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service -Dskip.validation -Dtest="PatchApiUseCaseTest,UpdateApiDomainServiceImplTest"` — 211 tests, 0 failures.

[APIM-13948]: https://gravitee.atlassian.net/browse/APIM-13948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ