### PR TITLE
chore: bump gravitee-policy-transform-avro-json from 3.0.0 to 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <gravitee-policy-role-based-access-control.version>2.0.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.6.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>3.0.0</gravitee-policy-traffic-shadowing.version>
-        <gravitee-policy-transform-avro-json.version>3.0.0</gravitee-policy-transform-avro-json.version>
+        <gravitee-policy-transform-avro-json.version>4.0.0</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>
         <gravitee-policy-transform-protobuf-json.version>2.0.1</gravitee-policy-transform-protobuf-json.version>
         <gravitee-policy-transformheaders.version>5.1.0</gravitee-policy-transformheaders.version>


### PR DESCRIPTION
## Summary
- Bump `gravitee-policy-transform-avro-json` from 3.0.0 to 4.0.0

## Test plan
- [ ] CI is green