### PR TITLE
feat(gamma-apim): Create API wizard with scratch and template modes

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/jest.config.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/jest.config.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default {
+    displayName: 'gravitee-gamma-module-apim',
+    testEnvironment: 'jest-fixed-jsdom',
+    setupFilesAfterEnv: ['<rootDir>/src/main/ui/test-setup.ts'],
+    transformIgnorePatterns: ['/node_modules/(?!(until-async|@gravitee/graphene-core)/)'],
+    moduleNameMapper: {
+        '^react$': '<rootDir>/../../node_modules/react/index.js',
+        '^react/jsx-runtime$': '<rootDir>/../../node_modules/react/jsx-runtime.js',
+        '^react/jsx-dev-runtime$': '<rootDir>/../../node_modules/react/jsx-dev-runtime.js',
+        '^react-dom$': '<rootDir>/../../node_modules/react-dom/index.js',
+        '^react-dom/client$': '<rootDir>/../../node_modules/react-dom/client.js',
+        '^@tanstack/react-query$': '<rootDir>/../../node_modules/@tanstack/react-query/build/modern/index.js',
+        '^@gravitee/graphene-core$': '<rootDir>/../../node_modules/@gravitee/graphene-core/dist/index.js',
+        '^@gravitee/graphene-core/(.*)$': '<rootDir>/../../node_modules/@gravitee/graphene-core/dist/$1',
+        '^@gravitee/gamma-modules-sdk$': '<rootDir>/src/main/ui/shared/gamma-modules-sdk.ts',
+    },
+    transform: {
+        '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+        '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
+    },
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+    coverageDirectory: __dirname + '/coverage',
+};

--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "@gravitee/gamma-modules-sdk": "1.0.0-alpha.2",
         "@gravitee/graphene-core": "2.3.2",
-        "lucide-react": "1.6.0",
+        "@tanstack/react-query": "^5.80.1",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-router-dom": "7.13.1"

--- a/gravitee-gamma/gravitee-gamma-module-apim/project.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/project.json
@@ -11,6 +11,13 @@
                 "lintFilePatterns": ["{projectRoot}/**/*.ts", "{projectRoot}/**/*.tsx"]
             }
         },
-        "lint-license": {}
+        "lint-license": {},
+        "test": {
+            "executor": "@nx/jest:jest",
+            "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+            "options": {
+                "jestConfig": "gravitee-gamma/gravitee-gamma-module-apim/jest.config.ts"
+            }
+        }
     }
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -15,8 +15,11 @@
  */
 import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
 import { buildLinearBreadcrumbs, SidebarNavigation, useLayoutConfig } from '@gravitee/graphene-core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { Outlet, Route, Routes, useNavigate } from 'react-router-dom';
+
+const queryClient = new QueryClient();
 
 import { NAV_GROUPS } from '../config/navigation';
 import { APIM_ROUTE_CONFIG } from '../config/routes';
@@ -26,7 +29,9 @@ import { ApisPage } from '../pages/ApisPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { CreateApiProxyPage } from '../pages/CreateApiProxyPage';
 import { DashboardPage } from '../pages/DashboardPage';
+import { ScratchWizardPage } from '../pages/ScratchWizardPage';
 import { SettingsPage } from '../pages/SettingsPage';
+import { TemplateWizardPage } from '../pages/TemplateWizardPage';
 
 function ModuleLayout() {
     const navigate = useNavigate();
@@ -51,19 +56,25 @@ function ModuleLayout() {
 /** Route tree for this module: mounted under the host router when federated, or under the local dev root for standalone. */
 export function AppRoutes() {
     return (
-        <Routes>
-            <Route element={<ModuleLayout />}>
-                <Route index element={<DashboardPage />} />
-                <Route path="dashboard" element={<DashboardPage />} />
-                <Route path="apis">
-                    <Route index element={<ApisPage />} />
-                    <Route path="new" element={<CreateApiProxyPage />} />
+        <QueryClientProvider client={queryClient}>
+            <Routes>
+                <Route element={<ModuleLayout />}>
+                    <Route index element={<DashboardPage />} />
+                    <Route path="dashboard" element={<DashboardPage />} />
+                    <Route path="apis">
+                        <Route index element={<ApisPage />} />
+                        <Route path="new">
+                            <Route index element={<CreateApiProxyPage />} />
+                            <Route path="scratch" element={<ScratchWizardPage />} />
+                            <Route path="template/:id" element={<TemplateWizardPage />} />
+                        </Route>
+                    </Route>
+                    <Route path="api-products" element={<ApiProductsPage />} />
+                    <Route path="applications" element={<ApplicationsPage />} />
+                    <Route path="analytics" element={<AnalyticsPage />} />
+                    <Route path="settings" element={<SettingsPage />} />
                 </Route>
-                <Route path="api-products" element={<ApiProductsPage />} />
-                <Route path="applications" element={<ApplicationsPage />} />
-                <Route path="analytics" element={<AnalyticsPage />} />
-                <Route path="settings" element={<SettingsPage />} />
-            </Route>
-        </Routes>
+            </Routes>
+        </QueryClientProvider>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/DetailsStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/DetailsStep.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Input, Label, Textarea } from '@gravitee/graphene-core';
+import type { CSSProperties } from 'react';
+
+import { useApiCreation } from '../../store/apiCreationStore';
+
+export function DetailsStep() {
+    const { state, dispatch } = useApiCreation();
+    const { form, validationErrors: errors } = state;
+
+    function update(patch: Partial<typeof form>) {
+        dispatch({ type: 'UPDATE_FORM', patch });
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-1">
+                <h2 className="text-base font-semibold">API Details</h2>
+                <p className="text-sm text-muted-foreground">Name and describe your API proxy.</p>
+            </div>
+
+            <div className="space-y-5">
+                <div className="grid grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="details-api-name">
+                            API Name <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="details-api-name"
+                            placeholder="e.g. Payment Service API"
+                            value={form.apiName}
+                            onChange={e => update({ apiName: e.target.value })}
+                            aria-invalid={Boolean(errors['apiName'])}
+                        />
+                        {errors['apiName'] && <p className="text-xs text-destructive">{errors['apiName']}</p>}
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="details-api-version">
+                            Version <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="details-api-version"
+                            placeholder="e.g. 1.0.0"
+                            value={form.apiVersion}
+                            onChange={e => update({ apiVersion: e.target.value })}
+                            aria-invalid={Boolean(errors['apiVersion'])}
+                        />
+                        {errors['apiVersion'] && <p className="text-xs text-destructive">{errors['apiVersion']}</p>}
+                    </div>
+                </div>
+
+                <div className="space-y-2">
+                    <Label htmlFor="details-description">Description</Label>
+                    <Textarea
+                        id="details-description"
+                        placeholder="Describe what this API does and who should use it."
+                        value={form.apiDescription}
+                        onChange={e => update({ apiDescription: e.target.value })}
+                        maxLength={250}
+                        rows={3}
+                        style={{ fieldSizing: 'fixed' } as unknown as CSSProperties}
+                    />
+                    <p className="text-xs text-muted-foreground text-right">{form.apiDescription.length}/250</p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/EntrypointsStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/EntrypointsStep.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Input, Label, Switch } from '@gravitee/graphene-core';
+import { PlusIcon, ServerIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+
+import { useVerifyContextPath } from '../../hooks/useVerifyContextPath';
+import { useApiCreation } from '../../store/apiCreationStore';
+import type { VirtualHostEntry } from '../../types/apiCreation';
+import { GATEWAY_URL_PLACEHOLDER } from '../../utils/apiProxyMapper';
+
+export function EntrypointsStep() {
+    const { state, dispatch } = useApiCreation();
+    const { form, validationErrors: errors } = state;
+    useVerifyContextPath();
+
+    function update(patch: Partial<typeof form>) {
+        dispatch({ type: 'UPDATE_FORM', patch });
+    }
+
+    function updateVirtualHost(index: number, patch: Omit<Partial<VirtualHostEntry>, 'id'>) {
+        dispatch({ type: 'UPDATE_VIRTUAL_HOST', index, patch });
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-1">
+                <h2 className="text-base font-semibold">Entrypoints & Backend</h2>
+                <p className="text-sm text-muted-foreground">Define how clients reach the gateway and where requests are forwarded.</p>
+            </div>
+
+            <div className="space-y-5">
+                {/* Context path / virtual hosts */}
+                <div className="space-y-4 rounded-xl border bg-muted/30 p-4">
+                    <div className="flex items-center justify-between">
+                        <div>
+                            <p className="text-sm font-medium">Gateway path</p>
+                            <p className="text-xs text-muted-foreground">The path clients use to reach this API on the gateway.</p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <span className="text-xs text-muted-foreground">Virtual hosts</span>
+                            <Switch
+                                checked={form.virtualHostsEnabled}
+                                onCheckedChange={enabled => update({ virtualHostsEnabled: enabled })}
+                                size="sm"
+                                aria-label="Enable virtual hosts"
+                            />
+                        </div>
+                    </div>
+
+                    {form.virtualHostsEnabled ? (
+                        <div className="space-y-3">
+                            {form.virtualHosts.map((vh, index) => (
+                                <div key={vh.id} className="grid grid-cols-2 gap-3 items-end">
+                                    <div className="space-y-1.5">
+                                        <Label htmlFor={`vh-host-${index}`} className="text-xs">
+                                            Host
+                                        </Label>
+                                        <Input
+                                            id={`vh-host-${index}`}
+                                            placeholder="e.g. api.example.com"
+                                            value={vh.host}
+                                            onChange={e => updateVirtualHost(index, { host: e.target.value })}
+                                        />
+                                    </div>
+                                    <div className="flex items-end gap-2">
+                                        <div className="flex-1 space-y-1.5">
+                                            <Label htmlFor={`vh-path-${index}`} className="text-xs">
+                                                Path
+                                            </Label>
+                                            <Input
+                                                id={`vh-path-${index}`}
+                                                placeholder="/"
+                                                value={vh.path}
+                                                onChange={e => updateVirtualHost(index, { path: e.target.value })}
+                                            />
+                                        </div>
+                                        {form.virtualHosts.length > 1 && (
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() => dispatch({ type: 'REMOVE_VIRTUAL_HOST', index })}
+                                                aria-label="Remove virtual host"
+                                                className="shrink-0"
+                                            >
+                                                <Trash2Icon className="size-4 text-muted-foreground" aria-hidden />
+                                            </Button>
+                                        )}
+                                    </div>
+                                </div>
+                            ))}
+                            {errors['virtualHosts'] && <p className="text-xs text-destructive">{errors['virtualHosts']}</p>}
+                            <Button variant="outline" size="sm" onClick={() => dispatch({ type: 'ADD_VIRTUAL_HOST' })} className="w-full">
+                                <PlusIcon className="size-4" aria-hidden />
+                                Add virtual host
+                            </Button>
+                        </div>
+                    ) : (
+                        <div className="space-y-2">
+                            <Label htmlFor="context-path">
+                                Context path <span className="text-destructive">*</span>
+                            </Label>
+                            <div
+                                className="flex items-stretch rounded-md border overflow-hidden"
+                                style={errors['contextPath'] ? { borderColor: 'var(--color-destructive)' } : undefined}
+                            >
+                                <span
+                                    className="flex items-center px-3 text-sm font-mono text-muted-foreground whitespace-nowrap border-r bg-muted/30 select-none"
+                                    aria-hidden
+                                >
+                                    {GATEWAY_URL_PLACEHOLDER}
+                                </span>
+                                <Input
+                                    id="context-path"
+                                    placeholder="/my-api"
+                                    value={form.contextPath}
+                                    onChange={e => update({ contextPath: e.target.value })}
+                                    aria-invalid={Boolean(errors['contextPath'])}
+                                    style={{ border: 'none', borderRadius: 0, boxShadow: 'none', flex: 1, fontFamily: 'monospace' }}
+                                />
+                            </div>
+                            {errors['contextPath'] && <p className="text-xs text-destructive">{errors['contextPath']}</p>}
+                            <p className="text-xs text-muted-foreground">Path prefix clients will use to access this API.</p>
+                        </div>
+                    )}
+                </div>
+
+                {/* Target URL */}
+                <div className="space-y-2">
+                    <Label htmlFor="target-url">
+                        Target URL <span className="text-destructive">*</span>
+                    </Label>
+                    <div className="relative">
+                        <ServerIcon
+                            className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
+                            aria-hidden
+                        />
+                        <Input
+                            id="target-url"
+                            placeholder="https://api.internal.example.com"
+                            value={form.targetUrl}
+                            onChange={e => update({ targetUrl: e.target.value })}
+                            aria-invalid={Boolean(errors['targetUrl'])}
+                            style={{ paddingLeft: '2.5rem' }}
+                        />
+                    </div>
+                    {errors['targetUrl'] && <p className="text-xs text-destructive">{errors['targetUrl']}</p>}
+                    <p className="text-xs text-muted-foreground">The upstream backend the gateway will forward requests to.</p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/EssentialsStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/EssentialsStep.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Input, Label, Textarea } from '@gravitee/graphene-core';
+import { ServerIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
+import type { CSSProperties } from 'react';
+
+import { SecurityPlanFields } from './SecurityPlanFields';
+import { useVerifyContextPath } from '../../hooks/useVerifyContextPath';
+import { useApiCreation } from '../../store/apiCreationStore';
+import { GATEWAY_URL_PLACEHOLDER } from '../../utils/apiProxyMapper';
+import { AUTH_LABEL } from '../../utils/securityFormatters';
+
+export function EssentialsStep() {
+    const { state, dispatch } = useApiCreation();
+    const { form, validationErrors: errors } = state;
+    useVerifyContextPath();
+
+    function update(patch: Partial<typeof form>) {
+        dispatch({ type: 'UPDATE_FORM', patch });
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-1">
+                <h2 className="text-base font-semibold">Essentials</h2>
+                <p className="text-sm text-muted-foreground">
+                    Name your API and point it at your backend. Security is pre-configured from the template.
+                </p>
+            </div>
+
+            <div className="space-y-5">
+                {/* Name + Version in same row */}
+                <div className="grid gap-4" style={{ gridTemplateColumns: '1fr auto' }}>
+                    <div className="space-y-2">
+                        <Label htmlFor="essentials-api-name">
+                            API Name <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="essentials-api-name"
+                            placeholder="e.g. Payment Service API"
+                            value={form.apiName}
+                            onChange={e => update({ apiName: e.target.value })}
+                            aria-invalid={Boolean(errors['apiName'])}
+                        />
+                        {errors['apiName'] && <p className="text-xs text-destructive">{errors['apiName']}</p>}
+                    </div>
+
+                    <div className="space-y-2" style={{ minWidth: '7rem' }}>
+                        <Label htmlFor="essentials-api-version">
+                            Version <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="essentials-api-version"
+                            placeholder="1.0.0"
+                            value={form.apiVersion}
+                            onChange={e => update({ apiVersion: e.target.value })}
+                            aria-invalid={Boolean(errors['apiVersion'])}
+                        />
+                        {errors['apiVersion'] && <p className="text-xs text-destructive">{errors['apiVersion']}</p>}
+                    </div>
+                </div>
+
+                {/* Description with char counter */}
+                <div className="space-y-2">
+                    <Label htmlFor="essentials-description">Description</Label>
+                    <Textarea
+                        id="essentials-description"
+                        placeholder="Describe what this API does and who should use it."
+                        value={form.apiDescription}
+                        onChange={e => update({ apiDescription: e.target.value })}
+                        maxLength={250}
+                        rows={3}
+                        style={{ fieldSizing: 'fixed' } as unknown as CSSProperties}
+                    />
+                    <p className="text-xs text-muted-foreground text-right">{form.apiDescription.length}/250</p>
+                </div>
+
+                {/* Target URL */}
+                <div className="space-y-2">
+                    <Label htmlFor="essentials-target-url">
+                        Target URL <span className="text-destructive">*</span>
+                    </Label>
+                    <div className="relative">
+                        <ServerIcon
+                            className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
+                            aria-hidden
+                        />
+                        <Input
+                            id="essentials-target-url"
+                            placeholder="https://api.internal.example.com"
+                            value={form.targetUrl}
+                            onChange={e => update({ targetUrl: e.target.value })}
+                            aria-invalid={Boolean(errors['targetUrl'])}
+                            style={{ paddingLeft: '2.5rem' }}
+                        />
+                    </div>
+                    {errors['targetUrl'] && <p className="text-xs text-destructive">{errors['targetUrl']}</p>}
+                    <p className="text-xs text-muted-foreground">The upstream backend the gateway will forward requests to.</p>
+                </div>
+
+                {/* Context Path with gateway prefix */}
+                <div className="space-y-2">
+                    <Label htmlFor="essentials-context-path">
+                        Context path <span className="text-destructive">*</span>
+                    </Label>
+                    <div
+                        className="flex items-stretch rounded-md border overflow-hidden"
+                        style={errors['contextPath'] ? { borderColor: 'var(--color-destructive)' } : undefined}
+                    >
+                        <span
+                            className="flex items-center px-3 text-sm font-mono text-muted-foreground whitespace-nowrap border-r bg-muted/30 select-none"
+                            aria-hidden
+                        >
+                            {GATEWAY_URL_PLACEHOLDER}
+                        </span>
+                        <Input
+                            id="essentials-context-path"
+                            placeholder="/my-api"
+                            value={form.contextPath}
+                            onChange={e => update({ contextPath: e.target.value })}
+                            aria-invalid={Boolean(errors['contextPath'])}
+                            style={{ border: 'none', borderRadius: 0, boxShadow: 'none', flex: 1, fontFamily: 'monospace' }}
+                        />
+                    </div>
+                    {errors['contextPath'] && <p className="text-xs text-destructive">{errors['contextPath']}</p>}
+                    <p className="text-xs text-muted-foreground">Path prefix clients use to reach this API on the gateway.</p>
+                </div>
+
+                {/* Security — pre-configured from template */}
+                <div className="space-y-4 rounded-xl border border-primary/20 bg-primary/5 p-4">
+                    <div>
+                        <div className="flex items-center gap-2">
+                            <ShieldIcon className="size-4 shrink-0 text-primary" aria-hidden />
+                            <p className="text-sm font-semibold text-primary">Security — {AUTH_LABEL[form.authType]}</p>
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                            Pre-configured from the template. Adjust the plan name below if needed.
+                        </p>
+                    </div>
+                    <SecurityPlanFields showAuthSelector={false} />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/ReviewDeployStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/ReviewDeployStep.tsx
@@ -1,0 +1,211 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, Button, Switch } from '@gravitee/graphene-core';
+import { ChevronDownIcon, ChevronUpIcon, GlobeIcon, PencilIcon, RocketIcon, ServerIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+
+import { SecurityPlanFields } from './SecurityPlanFields';
+import { useApiCreation } from '../../store/apiCreationStore';
+import { buildPlanName, buildPreviewGatewayUrl } from '../../utils/apiProxyMapper';
+import { AUTH_LABEL } from '../../utils/securityFormatters';
+
+interface SectionHeaderProps {
+    title: string;
+    icon?: ReactNode;
+    onEdit?: () => void;
+    trailing?: ReactNode;
+}
+
+function SectionHeader({ title, icon, onEdit, trailing }: SectionHeaderProps) {
+    return (
+        <div className="flex items-center justify-between border-b px-4 py-3 bg-muted/30">
+            <div className="flex items-center gap-2">
+                {icon}
+                <p className="text-xs font-semibold text-muted-foreground" style={{ letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+                    {title}
+                </p>
+            </div>
+            {onEdit && (
+                <Button variant="ghost" size="sm" onClick={onEdit} className="h-7 px-2 text-xs gap-1">
+                    <PencilIcon className="size-3" aria-hidden />
+                    Edit
+                </Button>
+            )}
+            {trailing}
+        </div>
+    );
+}
+
+type ReviewRowProps =
+    | { label: string; value: string; mono?: boolean; children?: never }
+    | { label: string; children: ReactNode; value?: never; mono?: never };
+
+function ReviewRow({ label, value, mono, children }: ReviewRowProps) {
+    return (
+        <div className="flex items-start justify-between gap-4 px-4 py-2.5 border-b last:border-b-0">
+            <span className="text-xs text-muted-foreground shrink-0">{label}</span>
+            {children ?? (
+                <span
+                    className="text-xs font-medium text-right"
+                    style={{
+                        maxWidth: '60%',
+                        wordBreak: 'break-word',
+                        overflowWrap: 'break-word',
+                        fontFamily: mono ? 'monospace' : undefined,
+                    }}
+                >
+                    {value || <span className="text-muted-foreground italic font-sans">Not set</span>}
+                </span>
+            )}
+        </div>
+    );
+}
+
+export function ReviewDeployStep() {
+    const { state, dispatch } = useApiCreation();
+    const { form, creationMode } = state;
+    const isTemplate = creationMode === 'template';
+
+    const [customizeSecurity, setCustomizeSecurity] = useState(false);
+
+    function update(patch: Partial<typeof form>) {
+        dispatch({ type: 'UPDATE_FORM', patch });
+    }
+
+    function goToStep(step: number) {
+        dispatch({ type: 'CLEAR_VALIDATION_ERRORS' });
+        dispatch({ type: 'SET_STEP', step });
+    }
+
+    const gatewayUrl = buildPreviewGatewayUrl(form);
+    const planName = buildPlanName(form);
+
+    // template: step 0 = Essentials (covers details + proxy + security)
+    // scratch: step 0 = Details, step 1 = Entrypoints, step 2 = Security
+    const detailsStep = 0;
+    const proxyStep = isTemplate ? 0 : 1;
+    const securityStep = isTemplate ? null : 2; // template uses inline Customize instead
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-1">
+                <h2 className="text-base font-semibold">Review & Deploy</h2>
+                <p className="text-sm text-muted-foreground">Check the details below before creating your API proxy.</p>
+            </div>
+
+            <div className="space-y-4">
+                {/* API Details */}
+                <div className="rounded-xl border bg-card overflow-hidden">
+                    <SectionHeader title="API Details" onEdit={() => goToStep(detailsStep)} />
+                    <ReviewRow label="Name" value={form.apiName} />
+                    <ReviewRow label="Version" value={form.apiVersion} />
+                    {form.apiDescription && <ReviewRow label="Description" value={form.apiDescription} />}
+                    <ReviewRow label="Protocol">
+                        <Badge variant="secondary" className="text-xs">
+                            REST
+                        </Badge>
+                    </ReviewRow>
+                </div>
+
+                {/* Proxy Configuration */}
+                <div className="rounded-xl border bg-card overflow-hidden">
+                    <SectionHeader title="Proxy Configuration" onEdit={() => goToStep(proxyStep)} />
+                    <div className="flex items-start justify-between gap-4 px-4 py-2.5 border-b">
+                        <span className="text-xs text-muted-foreground shrink-0 flex items-center gap-1.5">
+                            <GlobeIcon className="size-3" aria-hidden />
+                            Gateway path
+                        </span>
+                        <span
+                            className="text-xs font-medium font-mono text-right"
+                            style={{ maxWidth: '60%', wordBreak: 'break-word', overflowWrap: 'break-word' }}
+                        >
+                            {gatewayUrl}
+                        </span>
+                    </div>
+                    <div className="flex items-start justify-between gap-4 px-4 py-2.5">
+                        <span className="text-xs text-muted-foreground shrink-0 flex items-center gap-1.5">
+                            <ServerIcon className="size-3" aria-hidden />
+                            Upstream
+                        </span>
+                        <span
+                            className="text-xs font-medium font-mono text-right"
+                            style={{ maxWidth: '60%', wordBreak: 'break-word', overflowWrap: 'break-word' }}
+                        >
+                            {form.targetUrl || <span className="text-muted-foreground font-sans italic">Not set</span>}
+                        </span>
+                    </div>
+                </div>
+
+                {/* Security */}
+                <div className="rounded-xl border bg-card overflow-hidden">
+                    <SectionHeader
+                        title="Security"
+                        icon={<ShieldIcon className="size-3.5 text-primary" aria-hidden />}
+                        onEdit={securityStep !== null ? () => goToStep(securityStep) : undefined}
+                        trailing={
+                            isTemplate ? (
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => setCustomizeSecurity(v => !v)}
+                                    className="h-7 px-2 text-xs gap-1"
+                                >
+                                    {customizeSecurity ? (
+                                        <ChevronUpIcon className="size-3" aria-hidden />
+                                    ) : (
+                                        <ChevronDownIcon className="size-3" aria-hidden />
+                                    )}
+                                    Customize
+                                </Button>
+                            ) : undefined
+                        }
+                    />
+
+                    <div className="flex items-center justify-between gap-4 px-4 py-2.5 border-b">
+                        <span className="text-xs text-muted-foreground">Auth type</span>
+                        <Badge variant="secondary">{AUTH_LABEL[form.authType]}</Badge>
+                    </div>
+                    <ReviewRow label="Plan name" value={planName} />
+
+                    {isTemplate && customizeSecurity && (
+                        <div className="px-4 pb-4 pt-3 border-t">
+                            <SecurityPlanFields showAuthSelector={true} />
+                        </div>
+                    )}
+                </div>
+
+                {/* Deploy toggle */}
+                <div className="flex items-center gap-4 rounded-xl border p-4">
+                    <div className="rounded-lg bg-primary/10 p-2 shrink-0">
+                        <RocketIcon className="size-5 text-primary" aria-hidden />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                        <p className="text-sm font-semibold">Deploy and start API immediately</p>
+                        <p className="text-xs text-muted-foreground mt-0.5">
+                            The API will be live on the gateway as soon as it is created. Disable to save as a draft first.
+                        </p>
+                    </div>
+                    <Switch
+                        checked={form.deployImmediately}
+                        onCheckedChange={v => update({ deployImmediately: v })}
+                        aria-label="Deploy immediately"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/SecurityPlanFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/SecurityPlanFields.tsx
@@ -16,8 +16,8 @@
 import { cn, Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
 import { SparklesIcon, CircleCheckIcon } from '@gravitee/graphene-core/icons';
 
-import { useWizard } from '../../store/wizardStore';
-import type { AuthType, WizardFormState } from '../../types/wizard';
+import { useApiCreation } from '../../store/apiCreationStore';
+import type { ApiProxyDraft } from '../../types/apiCreation';
 import { AUTH_OPTIONS, JWKS_RESOLVERS, JWT_SIGNATURES, OAUTH2_RESOURCES } from '../../utils/securityFormatters';
 
 interface SecurityPlanFieldsProps {
@@ -25,10 +25,11 @@ interface SecurityPlanFieldsProps {
 }
 
 export function SecurityPlanFields({ showAuthSelector = true }: SecurityPlanFieldsProps) {
-    const { state, dispatch } = useWizard();
+    const { state, dispatch } = useApiCreation();
     const { authType } = state.form;
+    const errors = state.validationErrors;
 
-    function update(patch: Partial<WizardFormState>) {
+    function update(patch: Partial<ApiProxyDraft>) {
         dispatch({ type: 'UPDATE_FORM', patch });
     }
 
@@ -43,7 +44,7 @@ export function SecurityPlanFields({ showAuthSelector = true }: SecurityPlanFiel
                             <button
                                 key={opt.id}
                                 type="button"
-                                onClick={() => update({ authType: opt.id as AuthType })}
+                                onClick={() => update({ authType: opt.id })}
                                 className={cn(
                                     'flex items-start gap-3 rounded-xl border-2 p-4 text-left transition-all',
                                     selected ? 'border-primary bg-primary/5' : 'border-border hover:border-foreground/20',
@@ -52,7 +53,7 @@ export function SecurityPlanFields({ showAuthSelector = true }: SecurityPlanFiel
                                 <div
                                     className={cn(
                                         'size-10 rounded-lg flex items-center justify-center shrink-0',
-                                        selected ? 'bg-primary/15' : 'bg-muted',
+                                        selected ? 'bg-primary/10' : 'bg-muted',
                                     )}
                                 >
                                     <Icon className="size-5" style={selected ? undefined : opt.iconStyle} aria-hidden />
@@ -83,25 +84,30 @@ export function SecurityPlanFields({ showAuthSelector = true }: SecurityPlanFiel
             )}
 
             {authType === 'api-key' && (
-                <div className="rounded-lg border bg-muted/20 p-4 space-y-4">
+                <div className="rounded-lg border bg-muted/30 p-4 space-y-4">
                     <p className="text-sm font-medium">API Key Plan</p>
                     <div className="space-y-2">
                         <Label htmlFor="apikey-plan-name">
-                            API Key Name <span className="text-destructive">*</span>
+                            API Key Plan Name <span className="text-destructive">*</span>
                         </Label>
                         <Input
                             id="apikey-plan-name"
                             placeholder="e.g. Default API Key plan"
                             value={state.form.apiKeyPlanName}
                             onChange={e => update({ apiKeyPlanName: e.target.value })}
+                            aria-invalid={Boolean(errors['apiKeyPlanName'])}
                         />
-                        <p className="text-xs text-muted-foreground">Name shown to consumers when they subscribe to the plan.</p>
+                        {errors['apiKeyPlanName'] ? (
+                            <p className="text-xs text-destructive">{errors['apiKeyPlanName']}</p>
+                        ) : (
+                            <p className="text-xs text-muted-foreground">Name shown to consumers when they subscribe to the plan.</p>
+                        )}
                     </div>
                 </div>
             )}
 
             {authType === 'jwt' && (
-                <div className="rounded-lg border bg-muted/20 p-4 space-y-4">
+                <div className="rounded-lg border bg-muted/30 p-4 space-y-4">
                     <p className="text-sm font-medium">JWT Plan</p>
                     <div className="grid grid-cols-2 gap-4">
                         <div className="space-y-2">
@@ -113,14 +119,16 @@ export function SecurityPlanFields({ showAuthSelector = true }: SecurityPlanFiel
                                 placeholder="e.g. Default JWT plan"
                                 value={state.form.jwtPlanName}
                                 onChange={e => update({ jwtPlanName: e.target.value })}
+                                aria-invalid={Boolean(errors['jwtPlanName'])}
                             />
+                            {errors['jwtPlanName'] && <p className="text-xs text-destructive">{errors['jwtPlanName']}</p>}
                         </div>
                         <div className="space-y-2">
                             <Label htmlFor="jwt-signature">
                                 Signature <span className="text-destructive">*</span>
                             </Label>
                             <Select value={state.form.jwtSignature} onValueChange={v => update({ jwtSignature: v })}>
-                                <SelectTrigger id="jwt-signature">
+                                <SelectTrigger id="jwt-signature" className="w-full">
                                     <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>
@@ -137,7 +145,7 @@ export function SecurityPlanFields({ showAuthSelector = true }: SecurityPlanFiel
                                 JWKS Resolver <span className="text-destructive">*</span>
                             </Label>
                             <Select value={state.form.jwtJwksResolver} onValueChange={v => update({ jwtJwksResolver: v })}>
-                                <SelectTrigger id="jwt-jwks-resolver">
+                                <SelectTrigger id="jwt-jwks-resolver" className="w-full">
                                     <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>
@@ -170,7 +178,7 @@ export function SecurityPlanFields({ showAuthSelector = true }: SecurityPlanFiel
             )}
 
             {authType === 'oauth2' && (
-                <div className="rounded-lg border bg-muted/20 p-4 space-y-4">
+                <div className="rounded-lg border bg-muted/30 p-4 space-y-4">
                     <p className="text-sm font-medium">OAuth 2.0 Plan</p>
                     <div className="grid grid-cols-2 gap-4">
                         <div className="space-y-2">
@@ -182,14 +190,16 @@ export function SecurityPlanFields({ showAuthSelector = true }: SecurityPlanFiel
                                 placeholder="e.g. Default OAuth2 plan"
                                 value={state.form.oauth2PlanName}
                                 onChange={e => update({ oauth2PlanName: e.target.value })}
+                                aria-invalid={Boolean(errors['oauth2PlanName'])}
                             />
+                            {errors['oauth2PlanName'] && <p className="text-xs text-destructive">{errors['oauth2PlanName']}</p>}
                         </div>
                         <div className="space-y-2">
                             <Label htmlFor="oauth2-resource">
                                 OAuth2 Resource <span className="text-destructive">*</span>
                             </Label>
                             <Select value={state.form.oauth2Resource} onValueChange={v => update({ oauth2Resource: v })}>
-                                <SelectTrigger id="oauth2-resource">
+                                <SelectTrigger id="oauth2-resource" className="w-full">
                                     <SelectValue placeholder="Select an OAuth2 resource" />
                                 </SelectTrigger>
                                 <SelectContent>
@@ -207,21 +217,26 @@ export function SecurityPlanFields({ showAuthSelector = true }: SecurityPlanFiel
             )}
 
             {authType === 'mtls' && (
-                <div className="rounded-lg border bg-muted/20 p-4 space-y-4">
+                <div className="rounded-lg border bg-muted/30 p-4 space-y-4">
                     <p className="text-sm font-medium">Mutual TLS Plan</p>
                     <div className="space-y-2">
                         <Label htmlFor="mtls-plan-name">
-                            MTLS Plan Name <span className="text-destructive">*</span>
+                            mTLS Plan Name <span className="text-destructive">*</span>
                         </Label>
                         <Input
                             id="mtls-plan-name"
                             placeholder="e.g. Default mTLS plan"
                             value={state.form.mtlsPlanName}
                             onChange={e => update({ mtlsPlanName: e.target.value })}
+                            aria-invalid={Boolean(errors['mtlsPlanName'])}
                         />
-                        <p className="text-xs text-muted-foreground">
-                            Consumers are identified by the X.509 certificate presented during the TLS handshake.
-                        </p>
+                        {errors['mtlsPlanName'] ? (
+                            <p className="text-xs text-destructive">{errors['mtlsPlanName']}</p>
+                        ) : (
+                            <p className="text-xs text-muted-foreground">
+                                Consumers are identified by the X.509 certificate presented during the TLS handshake.
+                            </p>
+                        )}
                     </div>
                 </div>
             )}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/SecurityStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/SecurityStep.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SecurityPlanFields } from './SecurityPlanFields';
+
+export function SecurityStep() {
+    return (
+        <div className="space-y-6">
+            <div className="space-y-1">
+                <h2 className="text-base font-semibold">Security & Plans</h2>
+                <p className="text-sm text-muted-foreground">Choose how consumers authenticate and configure the access plan.</p>
+            </div>
+
+            <SecurityPlanFields showAuthSelector />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/wizard/ApiProxyWizard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/wizard/ApiProxyWizard.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Alert, AlertDescription, Button, Separator } from '@gravitee/graphene-core';
+import {
+    ArrowLeftIcon,
+    ArrowRightIcon,
+    FileTextIcon,
+    GlobeIcon,
+    Loader2Icon,
+    RocketIcon,
+    ShieldIcon,
+    ZapIcon,
+} from '@gravitee/graphene-core/icons';
+import type { ComponentType } from 'react';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { ProxyFlowVisualization } from './ProxyFlowVisualization';
+import type { StepConfig } from './StepProgress';
+import { StepProgress } from './StepProgress';
+import { useCreateApiProxy } from '../../hooks/useCreateApiProxy';
+import { useApiCreation } from '../../store/apiCreationStore';
+import type { ApiProxyDraft, ValidationErrors } from '../../types/apiCreation';
+import { validateDetails, validateEntrypoints, validateEssentials, validateSecurity } from '../../utils/apiCreationValidation';
+import { DetailsStep } from '../steps/DetailsStep';
+import { EntrypointsStep } from '../steps/EntrypointsStep';
+import { EssentialsStep } from '../steps/EssentialsStep';
+import { ReviewDeployStep } from '../steps/ReviewDeployStep';
+import { SecurityStep } from '../steps/SecurityStep';
+
+// ─── Step configuration ───────────────────────────────────────────────────────
+
+const SCRATCH_STEPS: StepConfig[] = [
+    { label: 'API Details', Icon: FileTextIcon },
+    { label: 'Configure Proxy', Icon: GlobeIcon },
+    { label: 'Secure', Icon: ShieldIcon },
+    { label: 'Review & Deploy', Icon: RocketIcon },
+];
+
+const TEMPLATE_STEPS: StepConfig[] = [
+    { label: 'Essentials', Icon: ZapIcon },
+    { label: 'Review & Deploy', Icon: RocketIcon },
+];
+
+const SCRATCH_CONTENT: Record<number, ComponentType> = {
+    0: DetailsStep,
+    1: EntrypointsStep,
+    2: SecurityStep,
+    3: ReviewDeployStep,
+};
+
+const TEMPLATE_CONTENT: Record<number, ComponentType> = {
+    0: EssentialsStep,
+    1: ReviewDeployStep,
+};
+
+const SCRATCH_VALIDATORS: Record<number, (form: ApiProxyDraft) => ValidationErrors> = {
+    0: validateDetails,
+    1: validateEntrypoints,
+    2: validateSecurity,
+};
+
+const TEMPLATE_VALIDATORS: Record<number, (form: ApiProxyDraft) => ValidationErrors> = {
+    0: validateEssentials,
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface ApiProxyWizardProps {
+    mode: 'scratch' | 'template';
+}
+
+export function ApiProxyWizard({ mode }: ApiProxyWizardProps) {
+    const navigate = useNavigate();
+    const { state, dispatch } = useApiCreation();
+    const { mutate, isPending, error: createError, isSuccess } = useCreateApiProxy();
+
+    const steps = mode === 'scratch' ? SCRATCH_STEPS : TEMPLATE_STEPS;
+    const contentMap = mode === 'scratch' ? SCRATCH_CONTENT : TEMPLATE_CONTENT;
+    const validatorMap = mode === 'scratch' ? SCRATCH_VALIDATORS : TEMPLATE_VALIDATORS;
+    const activeStep = state.step;
+    const isLastStep = activeStep === steps.length - 1;
+
+    const StepContent = contentMap[activeStep];
+
+    useEffect(() => {
+        if (isSuccess) navigate('../..');
+    }, [isSuccess, navigate]);
+
+    function handleNext() {
+        const validator = validatorMap[activeStep];
+        if (validator) {
+            const errors = validator(state.form);
+            if (Object.keys(errors).length > 0) {
+                dispatch({ type: 'SET_VALIDATION_ERRORS', errors });
+                return;
+            }
+        }
+        dispatch({ type: 'CLEAR_VALIDATION_ERRORS' });
+        dispatch({ type: 'SET_STEP', step: activeStep + 1 });
+    }
+
+    function handleBack() {
+        if (activeStep === 0) {
+            navigate('..');
+        } else {
+            dispatch({ type: 'CLEAR_VALIDATION_ERRORS' });
+            dispatch({ type: 'SET_STEP', step: activeStep - 1 });
+        }
+    }
+
+    function handleCreate() {
+        mutate(state.form);
+    }
+
+    const hasErrors = Object.keys(state.validationErrors).length > 0;
+    const isBusy = isPending || state.isPathVerifying;
+
+    return (
+        <div className="space-y-4">
+            {/* Full-width step progress — compact height */}
+            <div className="rounded-xl border bg-card px-4 py-2">
+                <StepProgress steps={steps} activeStep={activeStep} />
+            </div>
+
+            {/* Two-column layout: step content left, flow visualization right */}
+            <div className="grid gap-6 items-start" style={{ gridTemplateColumns: '1fr min(20rem, 36vw)' }}>
+                <div className="space-y-4">
+                    <div className="rounded-xl border bg-card p-6">{StepContent && <StepContent />}</div>
+
+                    {createError && (
+                        <Alert variant="destructive">
+                            <AlertDescription>{createError.message}</AlertDescription>
+                        </Alert>
+                    )}
+                </div>
+
+                <aside aria-label="Request path through the proxy">
+                    <ProxyFlowVisualization mode={mode} />
+                </aside>
+            </div>
+
+            <Separator />
+
+            <div className="flex items-center justify-between">
+                <Button variant="outline" onClick={handleBack} disabled={isBusy}>
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    {activeStep === 0 ? 'Cancel' : 'Back'}
+                </Button>
+
+                {isLastStep ? (
+                    <Button onClick={handleCreate} disabled={isBusy || hasErrors}>
+                        {isPending ? (
+                            <Loader2Icon className="size-4 animate-spin" aria-hidden />
+                        ) : (
+                            <RocketIcon className="size-4" aria-hidden />
+                        )}
+                        {state.form.deployImmediately ? 'Create & Deploy' : 'Create API'}
+                    </Button>
+                ) : (
+                    <Button onClick={handleNext} disabled={isBusy || hasErrors}>
+                        <ArrowRightIcon className="size-4" aria-hidden />
+                        Next
+                    </Button>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/wizard/ProxyFlowVisualization.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/wizard/ProxyFlowVisualization.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cn } from '@gravitee/graphene-core';
+
+import { useApiCreation } from '../../store/apiCreationStore';
+import { buildPreviewGatewayUrl } from '../../utils/apiProxyMapper';
+import { AUTH_LABEL } from '../../utils/securityFormatters';
+
+type NodeState = 'active' | 'muted' | 'complete';
+type ArrowVariant = 'muted' | 'emphasized' | 'complete';
+
+const NODE_CLASSES: Record<NodeState, string> = {
+    active: 'border-primary text-primary bg-primary/5',
+    muted: 'border-border text-muted-foreground bg-muted/30',
+    complete: 'border-success text-success bg-success/5',
+};
+
+function arrowColor(variant: ArrowVariant): string {
+    if (variant === 'complete') return 'var(--color-success)';
+    if (variant === 'emphasized') return 'var(--color-primary)';
+    return 'var(--color-muted-foreground)';
+}
+
+function arrowOpacity(variant: ArrowVariant): number {
+    if (variant === 'muted') return 0.3;
+    if (variant === 'complete') return 1;
+    return 0.5;
+}
+
+function DNode({ label, state, mono, centered }: { label: string; state: NodeState; mono?: boolean; centered?: boolean }) {
+    return (
+        <div
+            className={cn('rounded-md border px-2 py-1.5 text-xs font-medium', NODE_CLASSES[state])}
+            style={{
+                fontFamily: mono ? 'monospace' : undefined,
+                wordBreak: mono ? 'break-all' : undefined,
+                overflowWrap: mono ? 'break-word' : undefined,
+                whiteSpace: 'normal',
+                lineHeight: '1.4',
+                textAlign: centered ? 'center' : undefined,
+            }}
+        >
+            {label}
+        </div>
+    );
+}
+
+function DArrowDown({ variant }: { variant: ArrowVariant }) {
+    const color = arrowColor(variant);
+    const opacity = arrowOpacity(variant);
+    return (
+        <div className="flex flex-col items-center self-center py-0.5" aria-hidden>
+            <div style={{ width: '1px', height: '0.75rem', backgroundColor: color, opacity }} />
+            <span style={{ fontSize: '8px', lineHeight: 1, color, opacity }}>▼</span>
+        </div>
+    );
+}
+
+function nodeState(which: 'client' | 'gateway' | 'security' | 'upstream', mode: 'scratch' | 'template', step: number): NodeState {
+    const complete = (mode === 'scratch' && step === 3) || (mode === 'template' && step === 1);
+    if (complete) return 'complete';
+
+    if (mode === 'scratch') {
+        if (step === 0) return 'muted';
+        if (step === 1) return which === 'gateway' || which === 'upstream' ? 'active' : 'muted';
+        if (step === 2) return which === 'security' ? 'active' : 'muted';
+    }
+    if (mode === 'template' && step === 0) {
+        return which === 'client' ? 'muted' : 'active';
+    }
+    return 'muted';
+}
+
+function toArrowVariant(state: NodeState): ArrowVariant {
+    if (state === 'complete') return 'complete';
+    if (state === 'active') return 'emphasized';
+    return 'muted';
+}
+
+function stepCaption(mode: 'scratch' | 'template', step: number): string {
+    if (mode === 'scratch') {
+        switch (step) {
+            case 0:
+                return 'Defining API identity';
+            case 1:
+                return 'Configuring entrypoints & upstream';
+            case 2:
+                return 'Configuring security & access';
+            case 3:
+                return 'Ready to review & deploy';
+            default:
+                return '';
+        }
+    }
+    if (step === 0) return 'Filling in essentials';
+    return 'Ready to review & deploy';
+}
+
+interface ProxyFlowVisualizationProps {
+    mode: 'scratch' | 'template';
+}
+
+export function ProxyFlowVisualization({ mode }: ProxyFlowVisualizationProps) {
+    const { state } = useApiCreation();
+    const { form, step } = state;
+
+    const client = nodeState('client', mode, step);
+    const gateway = nodeState('gateway', mode, step);
+    const security = nodeState('security', mode, step);
+    const upstream = nodeState('upstream', mode, step);
+
+    // Strip protocol prefix — URL is already clear from context
+    const gatewayDisplay = buildPreviewGatewayUrl(form).replace(/^https?:\/\//, '');
+    const upstreamDisplay = form.targetUrl.trim() || 'upstream:port';
+    const securityLabel = AUTH_LABEL[form.authType];
+    const caption = stepCaption(mode, step);
+
+    return (
+        <div
+            className="rounded-xl border bg-card p-4"
+            role="img"
+            aria-label={`Request path: Client → ${gatewayDisplay} → ${securityLabel} → ${upstreamDisplay}. ${caption}`}
+        >
+            <p className="mb-3 text-center text-xs font-medium" style={{ color: 'var(--color-foreground)', opacity: 0.9 }}>
+                Request path
+            </p>
+
+            <div className="flex flex-col items-stretch">
+                <DNode label="Client" state={client} centered />
+                <DArrowDown variant={toArrowVariant(gateway)} />
+                <DNode label={gatewayDisplay} state={gateway} mono />
+                <DArrowDown variant={toArrowVariant(security)} />
+                <DNode label={securityLabel} state={security} centered />
+                <DArrowDown variant={toArrowVariant(upstream)} />
+                <DNode label={upstreamDisplay} state={upstream} mono />
+            </div>
+
+            {caption && (
+                <p className="mt-3 text-center text-muted-foreground" style={{ fontSize: '11px' }}>
+                    {caption}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/wizard/StepProgress.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/wizard/StepProgress.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cn } from '@gravitee/graphene-core';
+import { CircleCheckIcon } from '@gravitee/graphene-core/icons';
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
+
+export interface StepConfig {
+    label: string;
+    Icon: LucideIcon;
+}
+
+interface StepProgressProps {
+    steps: StepConfig[];
+    activeStep: number;
+}
+
+export function StepProgress({ steps, activeStep }: StepProgressProps) {
+    return (
+        <nav aria-label="Creation steps" className="flex items-center">
+            {steps.map((step, index) => {
+                const isDone = index < activeStep;
+                const isActive = index === activeStep;
+                const Icon = step.Icon;
+
+                return (
+                    <div key={step.label} className="flex flex-1 items-center" aria-current={isActive ? 'step' : undefined}>
+                        <div
+                            className={cn(
+                                'flex w-full items-center justify-center rounded-lg px-3 py-2 text-sm transition-colors',
+                                isActive && 'font-medium',
+                            )}
+                            style={{ gap: '0.625rem' }}
+                        >
+                            {/* Icon badge */}
+                            <span
+                                className={cn(
+                                    'flex shrink-0 items-center justify-center rounded-full text-xs',
+                                    isActive && 'bg-primary text-primary-foreground',
+                                    !isActive && !isDone && 'bg-muted text-muted-foreground',
+                                )}
+                                style={{
+                                    width: '1.5rem',
+                                    height: '1.5rem',
+                                    ...(isDone ? { backgroundColor: 'rgba(34,197,94,0.1)', color: 'var(--color-success)' } : {}),
+                                }}
+                            >
+                                {isDone ? (
+                                    <CircleCheckIcon style={{ width: '0.875rem', height: '0.875rem' }} aria-hidden />
+                                ) : (
+                                    <Icon style={{ width: '0.875rem', height: '0.875rem' }} aria-hidden />
+                                )}
+                            </span>
+
+                            {/* Label */}
+                            <span
+                                className={cn('whitespace-nowrap text-sm', !isActive && !isDone && 'text-muted-foreground')}
+                                style={
+                                    isActive ? { color: 'var(--color-foreground)' } : isDone ? { color: 'var(--color-success)' } : undefined
+                                }
+                            >
+                                {step.label}
+                            </span>
+                        </div>
+
+                        {/* Connector */}
+                        {index < steps.length - 1 && (
+                            <div
+                                className="h-px w-6 shrink-0"
+                                style={{
+                                    backgroundColor: isDone ? 'var(--color-success)' : 'var(--color-border)',
+                                    opacity: isDone ? 0.5 : 1,
+                                }}
+                            />
+                        )}
+                    </div>
+                );
+            })}
+        </nav>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useCreateApiProxy.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useCreateApiProxy.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation } from '@tanstack/react-query';
+
+import { ApimApiError } from '../../../shared/api/apimClient';
+import { createApiPlan, createApiProxy, publishApiPlan, startApiProxy } from '../services/apiProxy';
+import type { ApiProxyCreated } from '../types/api';
+import type { ApiProxyDraft } from '../types/apiCreation';
+import { mapFormToCreateRequest, mapFormToPlanRequest } from '../utils/apiProxyMapper';
+import { apiProxyKeys } from '../utils/queryKeys';
+
+export type { ApiProxyCreated };
+
+export function useCreateApiProxy() {
+    const env = useEnvironment();
+
+    return useMutation<ApiProxyCreated, ApimApiError, ApiProxyDraft>({
+        mutationKey: apiProxyKeys.create(),
+        mutationFn: async (form: ApiProxyDraft) => {
+            if (!env) throw new ApimApiError(0, 'Environment not ready');
+            const { id: environmentId } = env;
+
+            const created = await createApiProxy(environmentId, mapFormToCreateRequest(form)).catch(err => {
+                throw new ApimApiError(
+                    err instanceof ApimApiError ? err.status : 0,
+                    err instanceof ApimApiError ? err.message : 'Failed to create the API. Please check your details and try again.',
+                );
+            });
+
+            const plan = await createApiPlan(environmentId, created.id, mapFormToPlanRequest(form)).catch(err => {
+                throw new ApimApiError(
+                    err instanceof ApimApiError ? err.status : 0,
+                    `API "${created.name}" was created but plan creation failed. Open the API to configure a plan manually.`,
+                );
+            });
+
+            await publishApiPlan(environmentId, created.id, plan.id).catch(err => {
+                throw new ApimApiError(
+                    err instanceof ApimApiError ? err.status : 0,
+                    `API "${created.name}" was created but the plan could not be published. Open the API to publish the plan.`,
+                );
+            });
+
+            if (form.deployImmediately) {
+                await startApiProxy(environmentId, created.id).catch(err => {
+                    throw new ApimApiError(
+                        err instanceof ApimApiError ? err.status : 0,
+                        `API "${created.name}" was created successfully but could not be started. Start it from the API detail page.`,
+                    );
+                });
+            }
+
+            return created;
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useVerifyContextPath.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useVerifyContextPath.spec.tsx
@@ -1,0 +1,230 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useVerifyContextPath } from './useVerifyContextPath';
+import { verifyContextPath } from '../services/apiProxy';
+import { ApiCreationProvider, useApiCreation } from '../store/apiCreationStore';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({ useEnvironment: jest.fn() }));
+jest.mock('../services/apiProxy', () => ({ verifyContextPath: jest.fn() }));
+
+const mockUseEnvironment = useEnvironment as jest.Mock;
+const mockVerifyContextPath = verifyContextPath as jest.Mock;
+
+function wrapper({ children }: { children: ReactNode }) {
+    return <ApiCreationProvider>{children}</ApiCreationProvider>;
+}
+
+// Composite hook so we can drive the store and read its state in one renderHook call.
+function useHook() {
+    useVerifyContextPath();
+    return useApiCreation();
+}
+
+describe('useVerifyContextPath', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        mockUseEnvironment.mockReturnValue({ id: 'env-1' });
+        mockVerifyContextPath.mockResolvedValue({ ok: true });
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.clearAllMocks();
+    });
+
+    it('does not call the API when contextPath is empty', async () => {
+        renderHook(() => useHook(), { wrapper });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyContextPath).not.toHaveBeenCalled();
+    });
+
+    it('does not call the API when contextPath fails local validation (too short)', async () => {
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/ab' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyContextPath).not.toHaveBeenCalled();
+        expect(result.current.state.isPathVerifying).toBe(false);
+    });
+
+    it('does not call the API when contextPath contains invalid characters', async () => {
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/my api' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyContextPath).not.toHaveBeenCalled();
+    });
+
+    it('does not call the API when virtualHostsEnabled is true', async () => {
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/valid-path', virtualHostsEnabled: true } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyContextPath).not.toHaveBeenCalled();
+    });
+
+    it('does not call the API when the environment is unavailable', async () => {
+        mockUseEnvironment.mockReturnValue(null);
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/valid-path' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyContextPath).not.toHaveBeenCalled();
+    });
+
+    it('calls the API with the correct arguments after the debounce delay', async () => {
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/valid-path' } });
+        });
+
+        expect(mockVerifyContextPath).not.toHaveBeenCalled();
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyContextPath).toHaveBeenCalledTimes(1);
+        expect(mockVerifyContextPath).toHaveBeenCalledWith('env-1', [{ path: '/valid-path' }]);
+        expect(result.current.state.isPathVerifying).toBe(false);
+    });
+
+    it('sets a contextPath error when the API reports the path is already taken', async () => {
+        mockVerifyContextPath.mockResolvedValue({ ok: false, reason: 'Path already in use.' });
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/taken-path' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(result.current.state.validationErrors['contextPath']).toBe('Path already in use.');
+        expect(result.current.state.isPathVerifying).toBe(false);
+    });
+
+    it('uses a fallback message when the API returns ok: false without a reason', async () => {
+        mockVerifyContextPath.mockResolvedValue({ ok: false });
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/taken-path' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(result.current.state.validationErrors['contextPath']).toBe('This context path is already in use by another API.');
+    });
+
+    it('clears a previous uniqueness error when the path becomes available', async () => {
+        mockVerifyContextPath.mockResolvedValueOnce({ ok: false, reason: 'Already taken.' });
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        // First check: path is taken.
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/taken-path' } });
+        });
+        await act(async () => {
+            jest.runAllTimers();
+        });
+        expect(result.current.state.validationErrors['contextPath']).toBe('Already taken.');
+
+        // Second check: path is now free.
+        mockVerifyContextPath.mockResolvedValueOnce({ ok: true });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/free-path' } });
+        });
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(result.current.state.validationErrors).not.toHaveProperty('contextPath');
+    });
+
+    it('does not set an error and resets isPathVerifying on network failure', async () => {
+        mockVerifyContextPath.mockRejectedValue(new Error('network error'));
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/valid-path' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(result.current.state.isPathVerifying).toBe(false);
+        expect(result.current.state.validationErrors).not.toHaveProperty('contextPath');
+    });
+
+    it('debounces rapid changes — fires the API only once for the final value', async () => {
+        const { result } = renderHook(() => useHook(), { wrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/path-one' } });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/path-two' } });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { contextPath: '/path-three' } });
+        });
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+
+        expect(mockVerifyContextPath).toHaveBeenCalledTimes(1);
+        expect(mockVerifyContextPath).toHaveBeenCalledWith('env-1', [{ path: '/path-three' }]);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useVerifyContextPath.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useVerifyContextPath.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useEffect, useRef } from 'react';
+
+import { verifyContextPath } from '../services/apiProxy';
+import { useApiCreation } from '../store/apiCreationStore';
+import { validateContextPath } from '../utils/apiCreationValidation';
+
+const DEBOUNCE_MS = 500;
+
+/**
+ * Watches `form.contextPath` and, when virtual hosts are disabled, fires a
+ * debounced uniqueness check against the gateway (matching legacy console
+ * webui behaviour). Writes the result directly into store validation errors.
+ */
+export function useVerifyContextPath() {
+    const { state, dispatch } = useApiCreation();
+    const env = useEnvironment();
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const contextPath = state.form.contextPath;
+    const virtualHostsEnabled = state.form.virtualHostsEnabled;
+
+    useEffect(() => {
+        if (timerRef.current) clearTimeout(timerRef.current);
+
+        // Clear any previous path error immediately when input changes.
+        dispatch({ type: 'SET_PATH_VERIFYING', value: false });
+
+        if (virtualHostsEnabled || validateContextPath(contextPath) !== null || !env?.id) return;
+
+        dispatch({ type: 'SET_PATH_VERIFYING', value: true });
+
+        timerRef.current = setTimeout(async () => {
+            try {
+                const result = await verifyContextPath(env.id, [{ path: contextPath }]);
+                if (!result.ok) {
+                    dispatch({
+                        type: 'SET_FIELD_ERROR',
+                        field: 'contextPath',
+                        message: result.reason ?? 'This context path is already in use by another API.',
+                    });
+                } else {
+                    // Patching contextPath with the same value clears any stale uniqueness error via UPDATE_FORM's error-clearing logic.
+                    dispatch({ type: 'UPDATE_FORM', patch: { contextPath } });
+                }
+            } catch {
+                // Network/server error: don't block the user — backend enforces on submit.
+            } finally {
+                dispatch({ type: 'SET_PATH_VERIFYING', value: false });
+            }
+        }, DEBOUNCE_MS);
+
+        return () => {
+            if (timerRef.current) clearTimeout(timerRef.current);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [contextPath, virtualHostsEnabled, env?.id]);
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiProxy.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiProxy.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
+import type {
+    ApiPlanCreated,
+    ApiProxyCreated,
+    CreateApiPlanRequest,
+    CreateApiProxyRequest,
+    PathToVerify,
+    VerifyApiPathResponse,
+} from '../types/api';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+export async function verifyContextPath(environmentId: string, paths: PathToVerify[]): Promise<VerifyApiPathResponse> {
+    return apimFetchJsonV2<VerifyApiPathResponse>(environmentId, `/apis/_verify/paths`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ paths }),
+    });
+}
+
+export async function createApiProxy(environmentId: string, request: CreateApiProxyRequest): Promise<ApiProxyCreated> {
+    return apimFetchJsonV2<ApiProxyCreated>(environmentId, `/apis`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(request),
+    });
+}
+
+export async function createApiPlan(environmentId: string, apiId: string, plan: CreateApiPlanRequest): Promise<ApiPlanCreated> {
+    return apimFetchJsonV2<ApiPlanCreated>(environmentId, `/apis/${apiId}/plans`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(plan),
+    });
+}
+
+export async function publishApiPlan(environmentId: string, apiId: string, planId: string): Promise<void> {
+    return apimFetchJsonV2<void>(environmentId, `/apis/${apiId}/plans/${planId}/_publish`, { method: 'POST' });
+}
+
+export async function startApiProxy(environmentId: string, apiId: string): Promise<void> {
+    return apimFetchJsonV2<void>(environmentId, `/apis/${apiId}/_start`, { method: 'POST' });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/store/apiCreationStore.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/store/apiCreationStore.spec.tsx
@@ -1,0 +1,305 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { ApiCreationProvider, useApiCreation } from './apiCreationStore';
+import type { ProxyTemplate } from '../types/apiCreation';
+
+// ─── Shared test data ─────────────────────────────────────────────────────────
+
+const MOCK_TEMPLATE: ProxyTemplate = {
+    id: 'tpl-api-key',
+    title: 'API Key Template',
+    subtitle: 'Subtitle',
+    description: 'Description',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    Icon: (() => null) as any,
+    color: 'blue',
+    tags: ['api-key'],
+    defaults: {
+        authType: 'api-key',
+        apiKeyPlanName: 'Template API Key Plan',
+    },
+};
+
+// ─── Wrapper helpers ──────────────────────────────────────────────────────────
+
+function defaultWrapper({ children }: { children: ReactNode }) {
+    return <ApiCreationProvider>{children}</ApiCreationProvider>;
+}
+
+function templateWrapper({ children }: { children: ReactNode }) {
+    return <ApiCreationProvider initialTemplate={MOCK_TEMPLATE}>{children}</ApiCreationProvider>;
+}
+
+function modeWrapper({ children }: { children: ReactNode }) {
+    return <ApiCreationProvider initialMode="scratch">{children}</ApiCreationProvider>;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useApiCreation — guard', () => {
+    it('throws when used outside ApiCreationProvider', () => {
+        const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        expect(() => renderHook(() => useApiCreation())).toThrow('useApiCreation must be used inside ApiCreationProvider');
+        spy.mockRestore();
+    });
+});
+
+describe('ApiCreationProvider — initial state', () => {
+    it('initialises with picker mode, step 0, and an empty form', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+        const { state } = result.current;
+
+        expect(state.creationMode).toBe('picker');
+        expect(state.step).toBe(0);
+        expect(state.form.apiName).toBe('');
+        expect(state.form.authType).toBe('keyless');
+        expect(state.form.deployImmediately).toBe(true);
+        expect(state.validationErrors).toEqual({});
+    });
+
+    it('applies template defaults and sets template mode when initialTemplate is provided', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: templateWrapper });
+        const { state } = result.current;
+
+        expect(state.creationMode).toBe('template');
+        expect(state.selectedTemplate?.id).toBe('tpl-api-key');
+        expect(state.form.authType).toBe('api-key');
+        expect(state.form.apiKeyPlanName).toBe('Template API Key Plan');
+        expect(state.step).toBe(0);
+    });
+
+    it('uses the given mode when initialMode is provided', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: modeWrapper });
+
+        expect(result.current.state.creationMode).toBe('scratch');
+        expect(result.current.state.selectedTemplate).toBeNull();
+    });
+});
+
+describe('ApiCreationProvider — reducer actions', () => {
+    it('SELECT_TEMPLATE switches to template mode and applies defaults', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'SELECT_TEMPLATE', template: MOCK_TEMPLATE });
+        });
+
+        expect(result.current.state.creationMode).toBe('template');
+        expect(result.current.state.form.authType).toBe('api-key');
+        expect(result.current.state.form.apiKeyPlanName).toBe('Template API Key Plan');
+        expect(result.current.state.step).toBe(0);
+    });
+
+    it('SELECT_SCRATCH resets to scratch mode and clears the template', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'SELECT_TEMPLATE', template: MOCK_TEMPLATE });
+            result.current.dispatch({ type: 'SELECT_SCRATCH' });
+        });
+
+        expect(result.current.state.creationMode).toBe('scratch');
+        expect(result.current.state.selectedTemplate).toBeNull();
+        expect(result.current.state.step).toBe(0);
+    });
+
+    it('UPDATE_FORM clears only the validation error for the patched field', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'SET_VALIDATION_ERRORS', errors: { apiName: 'Required', targetUrl: 'Required' } });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { apiName: 'My API' } });
+        });
+
+        expect(result.current.state.validationErrors).not.toHaveProperty('apiName');
+        expect(result.current.state.validationErrors).toHaveProperty('targetUrl');
+    });
+
+    it('UPDATE_FORM with virtualHostsEnabled clears contextPath and virtualHosts errors but keeps others', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({
+                type: 'SET_VALIDATION_ERRORS',
+                errors: { contextPath: 'Required', virtualHosts: 'Required', apiName: 'Required' },
+            });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { virtualHostsEnabled: true } });
+        });
+
+        expect(result.current.state.validationErrors).not.toHaveProperty('contextPath');
+        expect(result.current.state.validationErrors).not.toHaveProperty('virtualHosts');
+        expect(result.current.state.validationErrors).toHaveProperty('apiName');
+    });
+
+    it('UPDATE_FORM with authType clears all plan name errors but keeps others', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({
+                type: 'SET_VALIDATION_ERRORS',
+                errors: { apiKeyPlanName: 'Required', jwtPlanName: 'Required', apiName: 'Required' },
+            });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_FORM', patch: { authType: 'jwt' } });
+        });
+
+        expect(result.current.state.validationErrors).not.toHaveProperty('apiKeyPlanName');
+        expect(result.current.state.validationErrors).not.toHaveProperty('jwtPlanName');
+        expect(result.current.state.validationErrors).toHaveProperty('apiName');
+    });
+
+    it('ADD_VIRTUAL_HOST appends a blank row with default host and path', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+        const initialCount = result.current.state.form.virtualHosts.length;
+
+        act(() => {
+            result.current.dispatch({ type: 'ADD_VIRTUAL_HOST' });
+        });
+
+        expect(result.current.state.form.virtualHosts).toHaveLength(initialCount + 1);
+        const newRow = result.current.state.form.virtualHosts[initialCount]!;
+        expect(newRow.host).toBe('');
+        expect(newRow.path).toBe('/');
+    });
+
+    it('REMOVE_VIRTUAL_HOST removes the row at the given index', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'ADD_VIRTUAL_HOST' });
+        });
+        const countBefore = result.current.state.form.virtualHosts.length;
+
+        act(() => {
+            result.current.dispatch({ type: 'REMOVE_VIRTUAL_HOST', index: 0 });
+        });
+
+        expect(result.current.state.form.virtualHosts).toHaveLength(countBefore - 1);
+    });
+
+    it('REMOVE_VIRTUAL_HOST does not remove the last remaining row', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+        expect(result.current.state.form.virtualHosts).toHaveLength(1);
+
+        act(() => {
+            result.current.dispatch({ type: 'REMOVE_VIRTUAL_HOST', index: 0 });
+        });
+
+        expect(result.current.state.form.virtualHosts).toHaveLength(1);
+    });
+
+    it('UPDATE_VIRTUAL_HOST patches only the row at the given index', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'ADD_VIRTUAL_HOST' });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'UPDATE_VIRTUAL_HOST', index: 0, patch: { host: 'api.example.com' } });
+        });
+
+        expect(result.current.state.form.virtualHosts[0]!.host).toBe('api.example.com');
+        expect(result.current.state.form.virtualHosts[1]!.host).toBe('');
+    });
+
+    it('SET_MODE switches creation mode and resets step to 0', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'SET_STEP', step: 3 });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'SET_MODE', mode: 'scratch' });
+        });
+
+        expect(result.current.state.creationMode).toBe('scratch');
+        expect(result.current.state.step).toBe(0);
+    });
+
+    it('SET_STEP advances to the given step index', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'SET_STEP', step: 2 });
+        });
+
+        expect(result.current.state.step).toBe(2);
+    });
+
+    it('SET_TEMPLATES_OPEN toggles the templates panel open/closed', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'SET_TEMPLATES_OPEN', open: true });
+        });
+        expect(result.current.state.templatesOpen).toBe(true);
+
+        act(() => {
+            result.current.dispatch({ type: 'SET_TEMPLATES_OPEN', open: false });
+        });
+        expect(result.current.state.templatesOpen).toBe(false);
+    });
+
+    it('SET_PATH_VERIFYING toggles the isPathVerifying flag', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'SET_PATH_VERIFYING', value: true });
+        });
+        expect(result.current.state.isPathVerifying).toBe(true);
+
+        act(() => {
+            result.current.dispatch({ type: 'SET_PATH_VERIFYING', value: false });
+        });
+        expect(result.current.state.isPathVerifying).toBe(false);
+    });
+
+    it('SET_FIELD_ERROR adds a single field error without clearing others', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'SET_VALIDATION_ERRORS', errors: { apiName: 'Required' } });
+        });
+        act(() => {
+            result.current.dispatch({ type: 'SET_FIELD_ERROR', field: 'contextPath', message: 'Already in use.' });
+        });
+
+        expect(result.current.state.validationErrors['contextPath']).toBe('Already in use.');
+        expect(result.current.state.validationErrors['apiName']).toBe('Required');
+    });
+
+    it('SET_VALIDATION_ERRORS replaces all errors; CLEAR_VALIDATION_ERRORS resets to empty', () => {
+        const { result } = renderHook(() => useApiCreation(), { wrapper: defaultWrapper });
+
+        act(() => {
+            result.current.dispatch({ type: 'SET_VALIDATION_ERRORS', errors: { apiName: 'Required' } });
+        });
+        expect(result.current.state.validationErrors).toEqual({ apiName: 'Required' });
+
+        act(() => {
+            result.current.dispatch({ type: 'CLEAR_VALIDATION_ERRORS' });
+        });
+        expect(result.current.state.validationErrors).toEqual({});
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/store/apiCreationStore.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/store/apiCreationStore.tsx
@@ -16,17 +16,24 @@
 import { createContext, useContext, useReducer } from 'react';
 import type { ReactNode } from 'react';
 
-import type { AuthType, ProxyTemplate, VirtualHostEntry, WizardFormState, WizardMode, WizardState } from '../types/wizard';
+import type {
+    ApiCreationMode,
+    ApiCreationState,
+    ApiProxyDraft,
+    ProxyTemplate,
+    ValidationErrors,
+    VirtualHostEntry,
+} from '../types/apiCreation';
 
 // ─── Initial state ────────────────────────────────────────────────────────────
 
-const INITIAL_FORM: WizardFormState = {
+const INITIAL_FORM: ApiProxyDraft = {
     apiName: '',
     apiVersion: '1.0.0',
     apiDescription: '',
     contextPath: '',
     virtualHostsEnabled: false,
-    virtualHosts: [{ host: '', path: '/', overrideAccess: false }],
+    virtualHosts: [{ id: crypto.randomUUID(), host: '', path: '/', overrideAccess: false }],
     targetUrl: '',
     authType: 'keyless',
     apiKeyPlanName: 'Default API Key plan',
@@ -40,33 +47,39 @@ const INITIAL_FORM: WizardFormState = {
     deployImmediately: true,
 };
 
-const INITIAL_STATE: WizardState = {
-    wizardMode: 'picker',
+const INITIAL_STATE: ApiCreationState = {
+    creationMode: 'picker',
     templatesOpen: false,
     selectedTemplate: null,
     step: 0,
     form: INITIAL_FORM,
+    validationErrors: {},
+    isPathVerifying: false,
 };
 
 // ─── Actions ──────────────────────────────────────────────────────────────────
 
-type WizardAction =
-    | { type: 'SET_MODE'; mode: WizardMode }
+type ApiCreationAction =
+    | { type: 'SET_MODE'; mode: ApiCreationMode }
     | { type: 'SET_STEP'; step: number }
     | { type: 'SET_TEMPLATES_OPEN'; open: boolean }
     | { type: 'SELECT_TEMPLATE'; template: ProxyTemplate }
     | { type: 'SELECT_SCRATCH' }
-    | { type: 'UPDATE_FORM'; patch: Partial<WizardFormState> }
+    | { type: 'UPDATE_FORM'; patch: Partial<ApiProxyDraft> }
     | { type: 'ADD_VIRTUAL_HOST' }
     | { type: 'REMOVE_VIRTUAL_HOST'; index: number }
-    | { type: 'UPDATE_VIRTUAL_HOST'; index: number; patch: Partial<VirtualHostEntry> };
+    | { type: 'UPDATE_VIRTUAL_HOST'; index: number; patch: Omit<Partial<VirtualHostEntry>, 'id'> }
+    | { type: 'SET_VALIDATION_ERRORS'; errors: ValidationErrors }
+    | { type: 'CLEAR_VALIDATION_ERRORS' }
+    | { type: 'SET_PATH_VERIFYING'; value: boolean }
+    | { type: 'SET_FIELD_ERROR'; field: string; message: string };
 
 // ─── Reducer ──────────────────────────────────────────────────────────────────
 
-function wizardReducer(state: WizardState, action: WizardAction): WizardState {
+function apiCreationReducer(state: ApiCreationState, action: ApiCreationAction): ApiCreationState {
     switch (action.type) {
         case 'SET_MODE':
-            return { ...state, wizardMode: action.mode, step: 0 };
+            return { ...state, creationMode: action.mode, step: 0 };
 
         case 'SET_STEP':
             return { ...state, step: action.step };
@@ -78,12 +91,12 @@ function wizardReducer(state: WizardState, action: WizardAction): WizardState {
             const d = action.template.defaults;
             return {
                 ...state,
-                wizardMode: 'template',
+                creationMode: 'template',
                 selectedTemplate: action.template,
                 step: 0,
                 form: {
                     ...state.form,
-                    authType: d.authType as AuthType,
+                    authType: d.authType,
                     ...(d.apiKeyPlanName !== undefined && { apiKeyPlanName: d.apiKeyPlanName }),
                     ...(d.jwtPlanName !== undefined && { jwtPlanName: d.jwtPlanName }),
                     ...(d.jwtSignature !== undefined && { jwtSignature: d.jwtSignature }),
@@ -92,24 +105,36 @@ function wizardReducer(state: WizardState, action: WizardAction): WizardState {
                     ...(d.oauth2PlanName !== undefined && { oauth2PlanName: d.oauth2PlanName }),
                     ...(d.oauth2Resource !== undefined && { oauth2Resource: d.oauth2Resource }),
                     ...(d.mtlsPlanName !== undefined && { mtlsPlanName: d.mtlsPlanName }),
-                    ...(d.descriptionHint !== undefined && { apiDescription: d.descriptionHint }),
                     virtualHostsEnabled: false,
                 },
             };
         }
 
         case 'SELECT_SCRATCH':
-            return { ...state, wizardMode: 'scratch', selectedTemplate: null, step: 0 };
+            return { ...state, creationMode: 'scratch', selectedTemplate: null, step: 0 };
 
-        case 'UPDATE_FORM':
-            return { ...state, form: { ...state.form, ...action.patch } };
+        case 'UPDATE_FORM': {
+            const remaining = { ...state.validationErrors };
+            Object.keys(action.patch).forEach(k => delete remaining[k]);
+            if ('virtualHostsEnabled' in action.patch) {
+                delete remaining['virtualHosts'];
+                delete remaining['contextPath'];
+            }
+            if ('authType' in action.patch) {
+                delete remaining['apiKeyPlanName'];
+                delete remaining['jwtPlanName'];
+                delete remaining['oauth2PlanName'];
+                delete remaining['mtlsPlanName'];
+            }
+            return { ...state, form: { ...state.form, ...action.patch }, validationErrors: remaining };
+        }
 
         case 'ADD_VIRTUAL_HOST':
             return {
                 ...state,
                 form: {
                     ...state.form,
-                    virtualHosts: [...state.form.virtualHosts, { host: '', path: '/', overrideAccess: false }],
+                    virtualHosts: [...state.form.virtualHosts, { id: crypto.randomUUID(), host: '', path: '/', overrideAccess: false }],
                 },
             };
 
@@ -134,6 +159,18 @@ function wizardReducer(state: WizardState, action: WizardAction): WizardState {
                 },
             };
 
+        case 'SET_VALIDATION_ERRORS':
+            return { ...state, validationErrors: action.errors };
+
+        case 'CLEAR_VALIDATION_ERRORS':
+            return { ...state, validationErrors: {} };
+
+        case 'SET_PATH_VERIFYING':
+            return { ...state, isPathVerifying: action.value };
+
+        case 'SET_FIELD_ERROR':
+            return { ...state, validationErrors: { ...state.validationErrors, [action.field]: action.message } };
+
         default:
             return state;
     }
@@ -141,32 +178,34 @@ function wizardReducer(state: WizardState, action: WizardAction): WizardState {
 
 // ─── Context ──────────────────────────────────────────────────────────────────
 
-interface WizardContextValue {
-    state: WizardState;
-    dispatch: React.Dispatch<WizardAction>;
+interface ApiCreationContextValue {
+    state: ApiCreationState;
+    dispatch: React.Dispatch<ApiCreationAction>;
 }
 
-const WizardContext = createContext<WizardContextValue | null>(null);
+const ApiCreationContext = createContext<ApiCreationContextValue | null>(null);
 
-export function WizardProvider({ children }: { children: ReactNode }) {
-    const [state, dispatch] = useReducer(wizardReducer, INITIAL_STATE);
-    return <WizardContext.Provider value={{ state, dispatch }}>{children}</WizardContext.Provider>;
+interface ApiCreationProviderProps {
+    children: ReactNode;
+    initialTemplate?: ProxyTemplate;
+    initialMode?: ApiCreationMode;
 }
 
-export function useWizard(): WizardContextValue {
-    const ctx = useContext(WizardContext);
-    if (!ctx) throw new Error('useWizard must be used inside WizardProvider');
+export function ApiCreationProvider({ children, initialTemplate, initialMode }: ApiCreationProviderProps) {
+    const [state, dispatch] = useReducer(
+        apiCreationReducer,
+        { initialTemplate, initialMode },
+        ({ initialTemplate: tmpl, initialMode: mode }) => {
+            if (tmpl) return apiCreationReducer(INITIAL_STATE, { type: 'SELECT_TEMPLATE', template: tmpl });
+            if (mode) return { ...INITIAL_STATE, creationMode: mode };
+            return INITIAL_STATE;
+        },
+    );
+    return <ApiCreationContext.Provider value={{ state, dispatch }}>{children}</ApiCreationContext.Provider>;
+}
+
+export function useApiCreation(): ApiCreationContextValue {
+    const ctx = useContext(ApiCreationContext);
+    if (!ctx) throw new Error('useApiCreation must be used inside ApiCreationProvider');
     return ctx;
-}
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-export function slugify(name: string): string {
-    return name
-        .toLowerCase()
-        .trim()
-        .replace(/[^a-z0-9\s-]/g, '')
-        .replace(/\s+/g, '-')
-        .replace(/-+/g, '-')
-        .replace(/^-|-$/g, '');
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/templates/proxyTemplates.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/templates/proxyTemplates.ts
@@ -16,7 +16,8 @@
 import { KeyIcon, LockIcon, KeyRoundIcon, ShieldCheckIcon } from '@gravitee/graphene-core/icons';
 import type { CSSProperties } from 'react';
 
-import type { ProxyTemplate } from '../types/wizard';
+import type { ProxyTemplate, TemplateColor } from '../types/apiCreation';
+import { AUTH_ICON_COLORS, TEMPLATE_CARD_BG } from '../utils/securityFormatters';
 
 export const PROXY_TEMPLATES: ProxyTemplate[] = [
     {
@@ -77,26 +78,25 @@ export const PROXY_TEMPLATES: ProxyTemplate[] = [
             'For demos, workshops, and local testing only. The API is publicly reachable without subscriptions or API keys. Do not use for production or sensitive data.',
         defaults: {
             authType: 'keyless',
-            descriptionHint: 'Keyless demo API — open access for evaluation environments only. Not for production.',
         },
     },
 ];
 
-export const TEMPLATE_COLOR_STYLES: Record<string, { iconBg: CSSProperties; iconColor: CSSProperties }> = {
+export const TEMPLATE_COLOR_STYLES: Record<TemplateColor, { iconBg: CSSProperties; iconColor: CSSProperties }> = {
     blue: {
-        iconBg: { backgroundColor: 'rgba(59,130,246,0.1)' },
-        iconColor: { color: '#3b82f6' },
+        iconBg: { backgroundColor: TEMPLATE_CARD_BG.blue },
+        iconColor: { color: AUTH_ICON_COLORS.blue },
     },
     violet: {
-        iconBg: { backgroundColor: 'rgba(139,92,246,0.1)' },
-        iconColor: { color: '#8b5cf6' },
+        iconBg: { backgroundColor: TEMPLATE_CARD_BG.violet },
+        iconColor: { color: AUTH_ICON_COLORS.violet },
     },
     amber: {
-        iconBg: { backgroundColor: 'rgba(245,158,11,0.1)' },
-        iconColor: { color: '#d97706' },
+        iconBg: { backgroundColor: TEMPLATE_CARD_BG.amber },
+        iconColor: { color: AUTH_ICON_COLORS.amber },
     },
     rose: {
-        iconBg: { backgroundColor: 'rgba(244,63,94,0.1)' },
-        iconColor: { color: '#e11d48' },
+        iconBg: { backgroundColor: TEMPLATE_CARD_BG.rose },
+        iconColor: { color: AUTH_ICON_COLORS.rose },
     },
 };

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface PathToVerify {
+    path: string;
+    host?: string;
+}
+
+export interface VerifyApiPathResponse {
+    ok: boolean;
+    reason?: string;
+}
+
+export interface HttpPath {
+    path: string;
+    overrideAccess?: boolean;
+}
+
+export interface VirtualHost {
+    host: string;
+    path: string;
+    overrideAccess?: boolean;
+}
+
+export interface HttpListener {
+    type: 'HTTP';
+    paths?: HttpPath[];
+    hosts?: VirtualHost[];
+    entrypoints?: { type: string }[];
+}
+
+export interface HttpEndpoint {
+    name: string;
+    type: 'http-proxy';
+    weight: number;
+    inheritConfiguration: boolean;
+    configuration: { target: string };
+}
+
+export interface HttpEndpointGroup {
+    name: string;
+    type: 'http-proxy';
+    sharedConfiguration: Record<string, unknown>;
+    endpoints: HttpEndpoint[];
+}
+
+export type PlanSecurityType = 'KEY_LESS' | 'API_KEY' | 'JWT' | 'OAUTH2' | 'MTLS';
+
+export interface PlanSecurity {
+    type: PlanSecurityType;
+    configuration?: Record<string, unknown>;
+}
+
+export interface CreateApiProxyRequest {
+    name: string;
+    apiVersion: string;
+    description: string;
+    type: 'PROXY';
+    definitionVersion: 'V4';
+    allowedInApiProducts: boolean;
+    listeners: HttpListener[];
+    endpointGroups: HttpEndpointGroup[];
+}
+
+export interface ApiProxyCreated {
+    id: string;
+    name: string;
+}
+
+export interface CreateApiPlanRequest {
+    name: string;
+    security: PlanSecurity;
+    definitionVersion: 'V4';
+    mode: 'STANDARD';
+}
+
+export interface ApiPlanCreated {
+    id: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/apiCreation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/apiCreation.ts
@@ -16,9 +16,10 @@
 import type { LucideIcon } from '@gravitee/graphene-core/icons';
 
 export type AuthType = 'keyless' | 'api-key' | 'jwt' | 'oauth2' | 'mtls';
-export type WizardMode = 'picker' | 'template' | 'scratch';
+export type ApiCreationMode = 'picker' | 'template' | 'scratch';
 
 export interface VirtualHostEntry {
+    id: string;
     host: string;
     path: string;
     overrideAccess: boolean;
@@ -34,7 +35,6 @@ export interface ProxyTemplateDefaults {
     oauth2PlanName?: string;
     oauth2Resource?: string;
     mtlsPlanName?: string;
-    descriptionHint?: string;
 }
 
 export type TemplateColor = 'blue' | 'violet' | 'amber' | 'rose';
@@ -52,7 +52,7 @@ export interface ProxyTemplate {
     warningMessage?: string;
 }
 
-export interface WizardFormState {
+export interface ApiProxyDraft {
     apiName: string;
     apiVersion: string;
     apiDescription: string;
@@ -72,10 +72,14 @@ export interface WizardFormState {
     deployImmediately: boolean;
 }
 
-export interface WizardState {
-    wizardMode: WizardMode;
+export type ValidationErrors = Record<string, string>;
+
+export interface ApiCreationState {
+    creationMode: ApiCreationMode;
     templatesOpen: boolean;
     selectedTemplate: ProxyTemplate | null;
     step: number;
-    form: WizardFormState;
+    form: ApiProxyDraft;
+    validationErrors: ValidationErrors;
+    isPathVerifying: boolean;
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiCreationValidation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiCreationValidation.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { validateContextPath, validateDetails, validateEntrypoints, validateEssentials, validateSecurity } from './apiCreationValidation';
+import type { ApiProxyDraft } from '../types/apiCreation';
+
+const BASE: ApiProxyDraft = {
+    apiName: 'My API',
+    apiVersion: '1.0.0',
+    apiDescription: '',
+    contextPath: '/my-api',
+    virtualHostsEnabled: false,
+    virtualHosts: [{ id: '1', host: 'api.example.com', path: '/v1', overrideAccess: false }],
+    targetUrl: 'https://backend.example.com',
+    authType: 'keyless',
+    apiKeyPlanName: 'Default API Key plan',
+    jwtPlanName: 'Default JWT plan',
+    jwtSignature: 'RS256',
+    jwtJwksResolver: 'JWKS_URL',
+    jwtResolverParameter: '',
+    oauth2PlanName: 'Default OAuth2 plan',
+    oauth2Resource: '',
+    mtlsPlanName: 'Default mTLS plan',
+    deployImmediately: true,
+};
+
+function form(overrides: Partial<ApiProxyDraft> = {}): ApiProxyDraft {
+    return { ...BASE, ...overrides };
+}
+
+describe('validateContextPath', () => {
+    it('returns an error when empty', () => {
+        expect(validateContextPath('')).toBe('Context path is required.');
+        expect(validateContextPath('   ')).toBe('Context path is required.');
+    });
+
+    it('returns an error when path is 3 characters or fewer', () => {
+        expect(validateContextPath('/')).toBe('Context path has to be more than 3 characters long.');
+        expect(validateContextPath('/ab')).toBe('Context path has to be more than 3 characters long.');
+        expect(validateContextPath('/ab')).toBe('Context path has to be more than 3 characters long.');
+    });
+
+    it('returns an error for paths containing double slashes', () => {
+        expect(validateContextPath('//api')).toBe('Context path is not valid.');
+        expect(validateContextPath('/my//api')).toBe('Context path is not valid.');
+    });
+
+    it('returns an error for paths with invalid characters', () => {
+        expect(validateContextPath('/my api')).toBe('Context path is not valid.');
+        expect(validateContextPath('/my@api')).toBe('Context path is not valid.');
+        expect(validateContextPath('no-leading-slash')).toBe('Context path is not valid.');
+    });
+
+    it('returns null for valid paths (at least 4 chars, starts with /, allowed chars)', () => {
+        expect(validateContextPath('/abc')).toBeNull();
+        expect(validateContextPath('/my-api')).toBeNull();
+        expect(validateContextPath('/my_api/v2.0')).toBeNull();
+        expect(validateContextPath('/api/v1')).toBeNull();
+    });
+});
+
+describe('validateDetails', () => {
+    it('returns an error for each missing required field', () => {
+        expect(validateDetails(form({ apiName: '' }))).toEqual({ apiName: 'API name is required.' });
+        expect(validateDetails(form({ apiVersion: '' }))).toEqual({ apiVersion: 'Version is required.' });
+        expect(validateDetails(form({ apiName: '', apiVersion: '' }))).toEqual({
+            apiName: 'API name is required.',
+            apiVersion: 'Version is required.',
+        });
+    });
+
+    it('returns no errors when all required fields are filled', () => {
+        expect(validateDetails(form())).toEqual({});
+    });
+});
+
+describe('validateEntrypoints', () => {
+    it('returns errors for missing targetUrl and invalid path / virtual-host values', () => {
+        expect(validateEntrypoints(form({ targetUrl: '' }))).toHaveProperty('targetUrl');
+
+        expect(
+            validateEntrypoints(
+                form({ virtualHostsEnabled: true, virtualHosts: [{ id: '1', host: '', path: '/', overrideAccess: false }] }),
+            ),
+        ).toHaveProperty('virtualHosts');
+
+        expect(validateEntrypoints(form({ contextPath: '' }))).toHaveProperty('contextPath');
+    });
+
+    it('returns no errors for valid entrypoint combinations', () => {
+        expect(validateEntrypoints(form())).toEqual({});
+
+        expect(
+            validateEntrypoints(
+                form({
+                    virtualHostsEnabled: true,
+                    virtualHosts: [{ id: '1', host: 'api.example.com', path: '/v1', overrideAccess: false }],
+                }),
+            ),
+        ).toEqual({});
+    });
+});
+
+describe('validateSecurity', () => {
+    it('returns a plan name error for each non-keyless auth type with an empty plan name', () => {
+        expect(validateSecurity(form({ authType: 'api-key', apiKeyPlanName: '' }))).toHaveProperty('apiKeyPlanName');
+        expect(validateSecurity(form({ authType: 'jwt', jwtPlanName: '' }))).toHaveProperty('jwtPlanName');
+        expect(validateSecurity(form({ authType: 'oauth2', oauth2PlanName: '' }))).toHaveProperty('oauth2PlanName');
+        expect(validateSecurity(form({ authType: 'mtls', mtlsPlanName: '' }))).toHaveProperty('mtlsPlanName');
+    });
+
+    it('returns no errors when auth is keyless or the plan name is filled', () => {
+        expect(validateSecurity(form({ authType: 'keyless' }))).toEqual({});
+        expect(validateSecurity(form({ authType: 'api-key', apiKeyPlanName: 'My Plan' }))).toEqual({});
+        expect(validateSecurity(form({ authType: 'jwt', jwtPlanName: 'My JWT Plan' }))).toEqual({});
+    });
+});
+
+describe('validateEssentials', () => {
+    it('returns exactly the errors for whichever fields are missing', () => {
+        const allMissing = validateEssentials(form({ apiName: '', apiVersion: '', contextPath: '', targetUrl: '' }));
+        expect(Object.keys(allMissing)).toHaveLength(4);
+        expect(allMissing).toHaveProperty('apiName');
+        expect(allMissing).toHaveProperty('apiVersion');
+        expect(allMissing).toHaveProperty('contextPath');
+        expect(allMissing).toHaveProperty('targetUrl');
+
+        expect(validateEssentials(form({ apiName: '' }))).toEqual({ apiName: 'API name is required.' });
+        expect(validateEssentials(form())).toEqual({});
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiCreationValidation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiCreationValidation.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApiProxyDraft, ValidationErrors } from '../types/apiCreation';
+
+const CONTEXT_PATH_PATTERN = /^\/[/.a-zA-Z0-9\-_]*$/;
+
+export function validateContextPath(value: string): string | null {
+    if (!value.trim()) return 'Context path is required.';
+    if (value.includes('//')) return 'Context path is not valid.';
+    if (!CONTEXT_PATH_PATTERN.test(value)) return 'Context path is not valid.';
+    if (value.length <= 3) return 'Context path has to be more than 3 characters long.';
+    return null;
+}
+
+export function validateDetails(form: ApiProxyDraft): ValidationErrors {
+    const errors: ValidationErrors = {};
+    if (!form.apiName.trim()) errors['apiName'] = 'API name is required.';
+    if (!form.apiVersion.trim()) errors['apiVersion'] = 'Version is required.';
+    return errors;
+}
+
+export function validateEntrypoints(form: ApiProxyDraft): ValidationErrors {
+    const errors: ValidationErrors = {};
+    if (!form.targetUrl.trim()) errors['targetUrl'] = 'Target URL is required.';
+    if (form.virtualHostsEnabled) {
+        const hasEmptyHost = form.virtualHosts.some(vh => !vh.host.trim());
+        if (hasEmptyHost) errors['virtualHosts'] = 'All virtual hosts must have a host value.';
+    } else {
+        const pathError = validateContextPath(form.contextPath);
+        if (pathError) errors['contextPath'] = pathError;
+    }
+    return errors;
+}
+
+export function validateSecurity(form: ApiProxyDraft): ValidationErrors {
+    const errors: ValidationErrors = {};
+    if (form.authType === 'api-key' && !form.apiKeyPlanName.trim()) errors['apiKeyPlanName'] = 'Plan name is required.';
+    if (form.authType === 'jwt' && !form.jwtPlanName.trim()) errors['jwtPlanName'] = 'Plan name is required.';
+    if (form.authType === 'oauth2' && !form.oauth2PlanName.trim()) errors['oauth2PlanName'] = 'Plan name is required.';
+    if (form.authType === 'mtls' && !form.mtlsPlanName.trim()) errors['mtlsPlanName'] = 'Plan name is required.';
+    return errors;
+}
+
+export function validateEssentials(form: ApiProxyDraft): ValidationErrors {
+    const errors: ValidationErrors = {};
+    if (!form.apiName.trim()) errors['apiName'] = 'API name is required.';
+    if (!form.apiVersion.trim()) errors['apiVersion'] = 'Version is required.';
+    const pathError = validateContextPath(form.contextPath);
+    if (pathError) errors['contextPath'] = pathError;
+    if (!form.targetUrl.trim()) errors['targetUrl'] = 'Target URL is required.';
+    return errors;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.spec.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    buildPlanName,
+    buildPreviewGatewayUrl,
+    GATEWAY_URL_PLACEHOLDER,
+    mapFormToCreateRequest,
+    mapFormToPlanRequest,
+} from './apiProxyMapper';
+import type { ApiProxyDraft } from '../types/apiCreation';
+
+const BASE: ApiProxyDraft = {
+    apiName: 'My API',
+    apiVersion: '1.0.0',
+    apiDescription: 'A test API',
+    contextPath: '/my-api',
+    virtualHostsEnabled: false,
+    virtualHosts: [{ id: '1', host: 'api.example.com', path: '/v1', overrideAccess: false }],
+    targetUrl: 'https://backend.example.com',
+    authType: 'keyless',
+    apiKeyPlanName: 'API Key Plan',
+    jwtPlanName: 'JWT Plan',
+    jwtSignature: 'RS256',
+    jwtJwksResolver: 'JWKS_URL',
+    jwtResolverParameter: 'https://jwks.example.com/.well-known/jwks.json',
+    oauth2PlanName: 'OAuth2 Plan',
+    oauth2Resource: 'generic-oauth2',
+    mtlsPlanName: 'mTLS Plan',
+    deployImmediately: true,
+};
+
+function form(overrides: Partial<ApiProxyDraft> = {}): ApiProxyDraft {
+    return { ...BASE, ...overrides };
+}
+
+describe('buildPreviewGatewayUrl', () => {
+    it('returns gateway placeholder + context path when virtual hosts are disabled', () => {
+        expect(buildPreviewGatewayUrl(form())).toBe(`${GATEWAY_URL_PLACEHOLDER}/my-api`);
+    });
+
+    it('returns host + path when virtual hosts are enabled with a host value', () => {
+        expect(buildPreviewGatewayUrl(form({ virtualHostsEnabled: true }))).toBe('api.example.com/v1');
+    });
+
+    it('falls back to the gateway placeholder when the virtual host has no host value', () => {
+        const result = buildPreviewGatewayUrl(
+            form({ virtualHostsEnabled: true, virtualHosts: [{ id: '1', host: '', path: '/v1', overrideAccess: false }] }),
+        );
+        expect(result).toBe(`${GATEWAY_URL_PLACEHOLDER}/v1`);
+    });
+
+    it('falls back to "/" when the virtual host has no path value', () => {
+        const result = buildPreviewGatewayUrl(
+            form({ virtualHostsEnabled: true, virtualHosts: [{ id: '1', host: 'api.example.com', path: '', overrideAccess: false }] }),
+        );
+        expect(result).toBe('api.example.com/');
+    });
+
+    it('falls back to "/your-api" placeholder when contextPath is empty and virtual hosts are disabled', () => {
+        expect(buildPreviewGatewayUrl(form({ contextPath: '' }))).toBe(`${GATEWAY_URL_PLACEHOLDER}/your-api`);
+    });
+});
+
+describe('mapFormToCreateRequest', () => {
+    it('produces a path-based listener when virtual hosts are disabled', () => {
+        const req = mapFormToCreateRequest(form());
+        expect(req.listeners[0]).toEqual({ type: 'HTTP', paths: [{ path: '/my-api' }], entrypoints: [{ type: 'http-proxy' }] });
+    });
+
+    it('produces a host-based listener when virtual hosts are enabled', () => {
+        const req = mapFormToCreateRequest(form({ virtualHostsEnabled: true }));
+        expect(req.listeners[0]).toEqual({
+            type: 'HTTP',
+            hosts: [{ host: 'api.example.com', path: '/v1', overrideAccess: false }],
+            entrypoints: [{ type: 'http-proxy' }],
+        });
+    });
+
+    it('wires API name, version, description, and target URL correctly', () => {
+        const req = mapFormToCreateRequest(form());
+        expect(req.name).toBe('My API');
+        expect(req.apiVersion).toBe('1.0.0');
+        expect(req.description).toBe('A test API');
+        expect(req.endpointGroups[0].endpoints[0].configuration.target).toBe('https://backend.example.com');
+    });
+});
+
+describe('mapFormToPlanRequest', () => {
+    it('maps each auth type to the correct security type and configuration', () => {
+        expect(mapFormToPlanRequest(form({ authType: 'keyless' })).security).toEqual({ type: 'KEY_LESS' });
+        expect(mapFormToPlanRequest(form({ authType: 'api-key' })).security).toEqual({ type: 'API_KEY' });
+        expect(mapFormToPlanRequest(form({ authType: 'mtls' })).security).toEqual({ type: 'MTLS' });
+
+        const jwtSecurity = mapFormToPlanRequest(form({ authType: 'jwt' })).security;
+        expect(jwtSecurity.type).toBe('JWT');
+        expect(jwtSecurity.configuration).toMatchObject({
+            signature: 'RS256',
+            publicKeyResolver: 'JWKS_URL',
+            resolverParameter: 'https://jwks.example.com/.well-known/jwks.json',
+        });
+
+        const oauth2Security = mapFormToPlanRequest(form({ authType: 'oauth2' })).security;
+        expect(oauth2Security.type).toBe('OAUTH2');
+        expect(oauth2Security.configuration).toMatchObject({ authorizationServerResource: 'generic-oauth2' });
+    });
+});
+
+describe('buildPlanName', () => {
+    it('returns the correct plan name field for each auth type', () => {
+        expect(buildPlanName(form({ authType: 'keyless' }))).toBe('Default keyless plan');
+        expect(buildPlanName(form({ authType: 'api-key' }))).toBe('API Key Plan');
+        expect(buildPlanName(form({ authType: 'jwt' }))).toBe('JWT Plan');
+        expect(buildPlanName(form({ authType: 'oauth2' }))).toBe('OAuth2 Plan');
+        expect(buildPlanName(form({ authType: 'mtls' }))).toBe('mTLS Plan');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { CreateApiPlanRequest, CreateApiProxyRequest, HttpListener, PlanSecurity } from '../types/api';
+import type { ApiProxyDraft } from '../types/apiCreation';
+
+export const GATEWAY_URL_PLACEHOLDER = 'https://gateway.company.com';
+
+export function buildPreviewGatewayUrl(form: ApiProxyDraft): string {
+    if (form.virtualHostsEnabled && form.virtualHosts.length > 0) {
+        const first = form.virtualHosts[0];
+        const host = first.host || GATEWAY_URL_PLACEHOLDER;
+        const path = first.path || '/';
+        return `${host}${path}`;
+    }
+    const path = form.contextPath || '/your-api';
+    return `${GATEWAY_URL_PLACEHOLDER}${path}`;
+}
+
+function buildListener(form: ApiProxyDraft): HttpListener {
+    if (form.virtualHostsEnabled && form.virtualHosts.length > 0) {
+        return {
+            type: 'HTTP',
+            hosts: form.virtualHosts.map(vh => ({
+                host: vh.host,
+                path: vh.path,
+                overrideAccess: vh.overrideAccess,
+            })),
+            entrypoints: [{ type: 'http-proxy' }],
+        };
+    }
+    return { type: 'HTTP', paths: [{ path: form.contextPath }], entrypoints: [{ type: 'http-proxy' }] };
+}
+
+function buildPlanSecurity(form: ApiProxyDraft): PlanSecurity {
+    switch (form.authType) {
+        case 'keyless':
+            return { type: 'KEY_LESS' };
+        case 'api-key':
+            return { type: 'API_KEY' };
+        case 'jwt':
+            return {
+                type: 'JWT',
+                configuration: {
+                    signature: form.jwtSignature,
+                    publicKeyResolver: form.jwtJwksResolver,
+                    resolverParameter: form.jwtResolverParameter,
+                },
+            };
+        case 'oauth2':
+            return { type: 'OAUTH2', configuration: { authorizationServerResource: form.oauth2Resource } };
+        case 'mtls':
+            return { type: 'MTLS' };
+    }
+}
+
+export function buildPlanName(form: ApiProxyDraft): string {
+    switch (form.authType) {
+        case 'keyless':
+            return 'Default keyless plan';
+        case 'api-key':
+            return form.apiKeyPlanName;
+        case 'jwt':
+            return form.jwtPlanName;
+        case 'oauth2':
+            return form.oauth2PlanName;
+        case 'mtls':
+            return form.mtlsPlanName;
+    }
+}
+
+export function mapFormToCreateRequest(form: ApiProxyDraft): CreateApiProxyRequest {
+    return {
+        name: form.apiName,
+        apiVersion: form.apiVersion,
+        description: form.apiDescription,
+        type: 'PROXY',
+        definitionVersion: 'V4',
+        listeners: [buildListener(form)],
+        allowedInApiProducts: false,
+        endpointGroups: [
+            {
+                name: 'Default endpoint group',
+                type: 'http-proxy',
+                sharedConfiguration: {},
+                endpoints: [
+                    {
+                        name: 'Default endpoint',
+                        type: 'http-proxy',
+                        weight: 1,
+                        inheritConfiguration: false,
+                        configuration: { target: form.targetUrl },
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+export function mapFormToPlanRequest(form: ApiProxyDraft): CreateApiPlanRequest {
+    return {
+        name: buildPlanName(form),
+        security: buildPlanSecurity(form),
+        definitionVersion: 'V4',
+        mode: 'STANDARD',
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/queryKeys.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const apiProxyKeys = {
+    all: ['apiProxy'] as const,
+    create: () => [...apiProxyKeys.all, 'create'] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/securityFormatters.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/securityFormatters.ts
@@ -17,7 +17,21 @@ import { KeyIcon, KeyRoundIcon, LockIcon, ShieldCheckIcon, ShieldIcon } from '@g
 import type { LucideIcon } from '@gravitee/graphene-core/icons';
 import type { CSSProperties } from 'react';
 
-import type { AuthType } from '../types/wizard';
+import type { AuthType } from '../types/apiCreation';
+
+export const AUTH_ICON_COLORS = {
+    blue: '#3b82f6',
+    violet: '#8b5cf6',
+    amber: '#d97706',
+    rose: '#e11d48',
+} as const;
+
+export const TEMPLATE_CARD_BG = {
+    blue: 'rgba(59,130,246,0.1)',
+    violet: 'rgba(139,92,246,0.1)',
+    amber: 'rgba(245,158,11,0.1)',
+    rose: 'rgba(244,63,94,0.1)',
+} as const;
 
 export const AUTH_LABEL: Record<AuthType, string> = {
     keyless: 'Keyless (Open)',
@@ -55,21 +69,21 @@ export const AUTH_OPTIONS: AuthOption[] = [
         label: 'JWT',
         description: 'Validate JSON Web Tokens from your identity provider.',
         Icon: ShieldCheckIcon,
-        iconStyle: { color: '#8b5cf6' },
+        iconStyle: { color: AUTH_ICON_COLORS.violet },
     },
     {
         id: 'oauth2',
         label: 'OAuth 2.0',
         description: 'Enforce OAuth 2.0 access tokens for enterprise security.',
         Icon: LockIcon,
-        iconStyle: { color: '#d97706' },
+        iconStyle: { color: AUTH_ICON_COLORS.amber },
     },
     {
         id: 'mtls',
         label: 'mTLS',
         description: 'Mutual TLS based on the client X.509 certificate.',
         Icon: ShieldIcon,
-        iconStyle: { color: '#e11d48' },
+        iconStyle: { color: AUTH_ICON_COLORS.rose },
     },
 ];
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/CreateApiProxyPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/CreateApiProxyPage.tsx
@@ -83,7 +83,7 @@ function FlowLabel({ children }: { children: React.ReactNode }) {
 
 function ApiKeyFlow() {
     return (
-        <div className="rounded-lg border bg-muted/20 p-3 space-y-2">
+        <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
             <FlowLabel>Request flow</FlowLabel>
             <div style={FLOW_GRID}>
                 <div className="flex justify-center">
@@ -110,7 +110,7 @@ function ApiKeyFlow() {
 
 function JwtFlow() {
     return (
-        <div className="rounded-lg border bg-muted/20 p-3 space-y-2">
+        <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
             <FlowLabel>Request flow</FlowLabel>
             <div style={FLOW_GRID}>
                 <div className="flex justify-center">
@@ -136,7 +136,7 @@ function JwtFlow() {
 
 function OAuthFlow() {
     return (
-        <div className="rounded-lg border bg-muted/20 p-3 space-y-2">
+        <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
             <FlowLabel>Request flow</FlowLabel>
             <div style={FLOW_GRID}>
                 <div className="flex justify-center">
@@ -162,7 +162,7 @@ function OAuthFlow() {
 
 function KeylessFlow() {
     return (
-        <div className="rounded-lg border bg-muted/20 p-3 space-y-2">
+        <div className="rounded-lg border bg-muted/30 p-3 space-y-2">
             <FlowLabel>Request flow</FlowLabel>
             <div style={FLOW_GRID}>
                 <div className="flex justify-center">
@@ -189,7 +189,7 @@ function KeylessFlow() {
 
 // ─── Flow component map ───────────────────────────────────────────────────────
 
-const FLOW_COMPONENTS: Record<string, ReactNode> = {
+const FLOW_COMPONENTS: Partial<Record<string, ReactNode>> = {
     'rest-api-key': <ApiKeyFlow />,
     'rest-jwt': <JwtFlow />,
     'rest-oauth2': <OAuthFlow />,
@@ -201,6 +201,7 @@ const FLOW_COMPONENTS: Record<string, ReactNode> = {
 export function CreateApiProxyPage() {
     const navigate = useNavigate();
     const [templatesOpen, setTemplatesOpen] = useState(false);
+    const [hoveredCardId, setHoveredCardId] = useState<string | null>(null);
 
     return (
         <div className="space-y-6">
@@ -216,11 +217,11 @@ export function CreateApiProxyPage() {
                 <button
                     type="button"
                     onClick={() => navigate('scratch')}
-                    className="group flex flex-col gap-4 rounded-xl border-2 border-primary/30 bg-primary/5 p-6 text-left transition-all hover:border-primary/55 hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                    className="group flex flex-col gap-4 rounded-xl border-2 border-primary/30 bg-primary/5 p-6 text-left transition-all hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
                     style={{ minHeight: '11rem', borderRadius: '0.75rem', boxShadow: '0 1px 4px 0 rgba(0,0,0,0.07)' }}
                 >
                     <div className="flex items-start gap-4">
-                        <div className="rounded-lg bg-primary/15 p-3 shrink-0">
+                        <div className="rounded-lg bg-primary/10 p-3 shrink-0">
                             <PencilIcon className="size-6 text-primary" aria-hidden />
                         </div>
                         <div className="min-w-0 flex-1 space-y-1">
@@ -243,7 +244,7 @@ export function CreateApiProxyPage() {
                     onClick={() => setTemplatesOpen(o => !o)}
                     className={cn(
                         'group flex flex-col gap-4 rounded-xl border-2 bg-card p-6 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
-                        templatesOpen ? 'border-primary/50 bg-primary/5' : 'border-foreground/15 hover:border-primary/35 hover:bg-muted/30',
+                        templatesOpen ? 'border-primary/50 bg-primary/5' : 'border-border hover:border-primary hover:bg-muted',
                     )}
                     style={{ minHeight: '11rem', borderRadius: '0.75rem', boxShadow: '0 1px 4px 0 rgba(0,0,0,0.07)' }}
                 >
@@ -271,7 +272,7 @@ export function CreateApiProxyPage() {
             {/* Collapsible template cards */}
             <Collapsible open={templatesOpen} onOpenChange={setTemplatesOpen}>
                 <CollapsibleContent>
-                    <div className="space-y-4 rounded-xl border border-dashed bg-muted/20 p-5" style={{ borderRadius: '0.75rem' }}>
+                    <div className="space-y-4 rounded-xl border border-dashed bg-muted/30 p-5" style={{ borderRadius: '0.75rem' }}>
                         <p className="text-sm text-muted-foreground">
                             Pick a template to open essentials with the right auth pattern pre-selected.
                         </p>
@@ -284,10 +285,18 @@ export function CreateApiProxyPage() {
                                         type="button"
                                         onClick={() => navigate(`template/${tpl.id}`)}
                                         className={cn(
-                                            'flex flex-col gap-3 rounded-xl border bg-card p-5 text-left transition-all hover:border-primary/50 hover:bg-primary/5',
-                                            tpl.notRecommended ? 'border-amber-500/25 hover:border-amber-500/40' : 'border-foreground/15',
+                                            'flex flex-col gap-3 rounded-xl border bg-card p-5 text-left transition-all',
+                                            tpl.notRecommended ? undefined : 'border-border hover:border-primary',
                                         )}
-                                        style={{ borderRadius: '0.75rem', boxShadow: '0 1px 3px 0 rgba(0,0,0,0.06)' }}
+                                        style={{
+                                            borderRadius: '0.75rem',
+                                            boxShadow: '0 1px 3px 0 rgba(0,0,0,0.06)',
+                                            ...(tpl.notRecommended && {
+                                                borderColor: hoveredCardId === tpl.id ? 'rgba(245,158,11,0.4)' : 'rgba(245,158,11,0.25)',
+                                            }),
+                                        }}
+                                        onMouseEnter={() => setHoveredCardId(tpl.id)}
+                                        onMouseLeave={() => setHoveredCardId(null)}
                                     >
                                         {/* Card header */}
                                         <div className="flex items-start gap-3">
@@ -300,8 +309,12 @@ export function CreateApiProxyPage() {
                                                     {tpl.notRecommended && (
                                                         <Badge
                                                             variant="outline"
-                                                            className="border-amber-500/50 bg-amber-500/10"
-                                                            style={{ fontSize: '10px', color: '#92400e' }}
+                                                            style={{
+                                                                fontSize: '10px',
+                                                                color: '#92400e',
+                                                                borderColor: 'rgba(245,158,11,0.5)',
+                                                                backgroundColor: 'rgba(245,158,11,0.1)',
+                                                            }}
                                                         >
                                                             Not recommended
                                                         </Badge>
@@ -316,7 +329,10 @@ export function CreateApiProxyPage() {
 
                                         {/* Warning for keyless */}
                                         {tpl.notRecommended && tpl.warningMessage && (
-                                            <Alert className="border-amber-500/40 bg-amber-500/5 py-2">
+                                            <Alert
+                                                className="py-2"
+                                                style={{ borderColor: 'rgba(245,158,11,0.4)', backgroundColor: 'rgba(245,158,11,0.05)' }}
+                                            >
                                                 <TriangleAlertIcon className="size-4" style={{ color: '#d97706' }} aria-hidden />
                                                 <AlertTitle className="text-xs font-semibold" style={{ color: '#92400e' }}>
                                                     Demo and testing only
@@ -331,7 +347,7 @@ export function CreateApiProxyPage() {
                                         )}
 
                                         {/* Request flow diagram */}
-                                        {FLOW_COMPONENTS[tpl.id]}
+                                        {FLOW_COMPONENTS[tpl.id] ?? null}
 
                                         {/* Tags */}
                                         <div className="flex flex-wrap gap-1.5">

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ScratchWizardPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ScratchWizardPage.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ApiProxyWizard } from '../features/apis/components/wizard/ApiProxyWizard';
+import { ApiCreationProvider } from '../features/apis/store/apiCreationStore';
+
+export function ScratchWizardPage() {
+    return (
+        <ApiCreationProvider initialMode="scratch">
+            <ApiProxyWizard mode="scratch" />
+        </ApiCreationProvider>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/TemplateWizardPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/TemplateWizardPage.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { ApiProxyWizard } from '../features/apis/components/wizard/ApiProxyWizard';
+import { ApiCreationProvider } from '../features/apis/store/apiCreationStore';
+import { PROXY_TEMPLATES } from '../features/apis/templates/proxyTemplates';
+
+export function TemplateWizardPage() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const template = PROXY_TEMPLATES.find(t => t.id === id);
+
+    useEffect(() => {
+        if (!template) navigate('..', { replace: true });
+    }, [template, navigate]);
+
+    if (!template) return null;
+
+    return (
+        <ApiCreationProvider initialTemplate={template}>
+            <ApiProxyWizard mode="template" />
+        </ApiCreationProvider>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/api/apimClient.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/api/apimClient.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let _managementBaseUrl: string | undefined;
+let _bootstrapPromise: Promise<string> | undefined;
+
+async function resolveManagementBaseUrl(): Promise<string> {
+    if (_managementBaseUrl) return _managementBaseUrl;
+    _bootstrapPromise ??= (async () => {
+        try {
+            const constants = await fetch('/constants.json').then(r => r.json() as Promise<{ gammaBaseURL: string }>);
+            const gammaBase = constants.gammaBaseURL.replace(/\/$/, '');
+            const bootstrap = await fetch(`${gammaBase}/ui/bootstrap`).then(r => r.json() as Promise<{ managementBaseURL: string }>);
+            _managementBaseUrl = bootstrap.managementBaseURL.replace(/\/$/, '');
+            return _managementBaseUrl;
+        } catch (err) {
+            _bootstrapPromise = undefined;
+            throw err;
+        }
+    })();
+    return _bootstrapPromise;
+}
+
+export class ApimApiError extends Error {
+    constructor(
+        public readonly status: number,
+        message: string,
+        public readonly body?: unknown,
+    ) {
+        super(message);
+        this.name = 'ApimApiError';
+    }
+}
+
+async function doFetch<T>(url: string, path: string, init?: RequestInit): Promise<T> {
+    const headers = new Headers(init?.headers);
+    headers.set('X-Requested-With', 'XMLHttpRequest');
+    const csrf = localStorage.getItem('XSRF-TOKEN');
+    if (csrf) headers.set('X-Xsrf-Token', csrf);
+
+    const res = await fetch(url, { ...init, headers, credentials: 'include' });
+
+    const newCsrf = res.headers.get('X-Xsrf-Token');
+    if (newCsrf) localStorage.setItem('XSRF-TOKEN', newCsrf);
+
+    if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(text);
+        } catch {
+            parsed = undefined;
+        }
+        const message = (parsed as Record<string, string> | undefined)?.message ?? text ?? `${path} → ${res.status}`;
+        throw new ApimApiError(res.status, message, parsed);
+    }
+    if (res.status === 204) return undefined as T;
+    const text = await res.text();
+    return text ? (JSON.parse(text) as T) : (undefined as T);
+}
+
+export async function apimFetchJson<T>(organizationId: string, path: string, init?: RequestInit): Promise<T> {
+    const base = await resolveManagementBaseUrl();
+    return doFetch<T>(`${base}/organizations/${organizationId}${path}`, path, init);
+}
+
+export async function apimFetchJsonV2<T>(environmentId: string, path: string, init?: RequestInit): Promise<T> {
+    const base = await resolveManagementBaseUrl();
+    return doFetch<T>(`${base}/v2/environments/${environmentId}${path}`, path, init);
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/gamma-modules-sdk.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/gamma-modules-sdk.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test stub for `@gravitee/gamma-modules-sdk`.
+ * Replaced at runtime by the MF singleton from the host shell.
+ * Individual tests mock specific exports via jest.mock().
+ */
+export const useEnvironment = (): undefined => undefined;
+export const useHasPermission = (): boolean => false;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/test-setup.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/test-setup.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { server } from './testing/server';
+
+// jest-fixed-jsdom does not polyfill crypto.randomUUID
+if (typeof globalThis.crypto.randomUUID !== 'function') {
+    globalThis.crypto.randomUUID = () => {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+            const r = (Math.random() * 16) | 0;
+            return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+        }) as ReturnType<typeof crypto.randomUUID>;
+    };
+}
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/factories.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/factories.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const TEST_CONFIG = {
+    gammaBaseURL: 'http://api.test/gamma',
+    managementBaseURL: 'http://api.test/management',
+    environmentId: 'DEFAULT',
+    organizationId: 'DEFAULT',
+} as const;
+
+/** Base URL for APIM V2 environment-scoped endpoints. */
+export const TEST_V2_BASE = `${TEST_CONFIG.managementBaseURL}/v2/environments/${TEST_CONFIG.environmentId}`;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/handlers/bootstrap.handlers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/handlers/bootstrap.handlers.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { http, HttpResponse } from 'msw';
+
+import { TEST_CONFIG } from '../factories';
+
+export const bootstrapHandlers = [
+    http.get('/constants.json', () => HttpResponse.json({ gammaBaseURL: TEST_CONFIG.gammaBaseURL })),
+    http.get(`${TEST_CONFIG.gammaBaseURL}/ui/bootstrap`, () => HttpResponse.json({ managementBaseURL: TEST_CONFIG.managementBaseURL })),
+];

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/handlers/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/handlers/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { bootstrapHandlers } from './bootstrap.handlers';
+
+export const defaultHandlers = [...bootstrapHandlers];

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/helpers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/helpers.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { http, HttpResponse, type JsonBodyType } from 'msw';
+
+import { server } from './server';
+
+export interface TrackedRequest {
+    url: string;
+    method: string;
+    headers: Headers;
+    body: unknown;
+}
+
+export interface RequestTracker {
+    readonly calls: TrackedRequest[];
+    readonly callCount: number;
+    readonly lastCall: TrackedRequest | null;
+}
+
+/**
+ * Registers an MSW handler that records every request it intercepts.
+ * Returns a tracker to inspect call count, URLs, headers, and bodies.
+ */
+export function trackHandler(
+    method: 'get' | 'post' | 'put' | 'delete',
+    url: string,
+    responseBody: JsonBodyType = undefined,
+    status = 200,
+): RequestTracker {
+    const requests: TrackedRequest[] = [];
+
+    server.use(
+        http[method](url, async ({ request }) => {
+            const cloned = request.clone();
+            requests.push({
+                url: request.url,
+                method: request.method,
+                headers: new Headers(request.headers),
+                body: request.method !== 'GET' ? await cloned.json().catch(() => null) : null,
+            });
+            return status === 204 ? new HttpResponse(null, { status }) : HttpResponse.json(responseBody, { status });
+        }),
+    );
+
+    return {
+        get calls() {
+            return requests;
+        },
+        get callCount() {
+            return requests.length;
+        },
+        get lastCall() {
+            return requests[requests.length - 1] ?? null;
+        },
+    };
+}
+
+export function respondWith(method: 'get' | 'post' | 'put' | 'delete', url: string, body: JsonBodyType, status = 200) {
+    server.use(http[method](url, () => (status === 204 ? new HttpResponse(null, { status }) : HttpResponse.json(body, { status }))));
+}
+
+export function respondWithError(method: 'get' | 'post' | 'put' | 'delete', url: string, status: number) {
+    server.use(http[method](url, () => HttpResponse.json({ message: `Error ${status}` }, { status })));
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/server.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/testing/server.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { setupServer } from 'msw/node';
+
+import { defaultHandlers } from './handlers';
+
+export const server = setupServer(...defaultHandlers);

--- a/gravitee-gamma/gravitee-gamma-module-apim/tsconfig.app.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/tsconfig.app.json
@@ -15,7 +15,10 @@
         "src/**/*.spec.js",
         "src/**/*.test.js",
         "src/**/*.spec.jsx",
-        "src/**/*.test.jsx"
+        "src/**/*.test.jsx",
+        "jest.config.ts",
+        "src/**/test-setup.ts",
+        "src/**/testing/**"
     ],
     "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/tsconfig.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/tsconfig.json
@@ -10,6 +10,9 @@
     "references": [
         {
             "path": "./tsconfig.app.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
         }
     ]
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/tsconfig.spec.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/tsconfig.spec.json
@@ -1,0 +1,18 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node10",
+        "jsx": "react-jsx",
+        "types": ["jest", "node", "@nx/react/typings/cssmodule.d.ts", "@nx/react/typings/image.d.ts"]
+    },
+    "include": [
+        "jest.config.ts",
+        "src/main/ui/**/*.test.ts",
+        "src/main/ui/**/*.spec.ts",
+        "src/main/ui/**/*.test.tsx",
+        "src/main/ui/**/*.spec.tsx",
+        "src/main/ui/**/*.d.ts"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "@ngx-formly/core": "6.3.12",
         "@ngx-formly/material": "6.3.12",
         "@scalar/openapi-parser": "0.11.1",
+        "@tanstack/react-query": "^5.80.1",
         "@toast-ui/editor": "3.2.2",
         "@toast-ui/editor-plugin-code-syntax-highlight": "3.1.0",
         "@webcomponents/webcomponentsjs": "2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11998,6 +11998,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/query-core@npm:5.100.10":
+  version: 5.100.10
+  resolution: "@tanstack/query-core@npm:5.100.10"
+  checksum: 10c0/fd220485b8223d44877324b0229a7d664c5840f3daf177c4a76e67d1d0be1a78a908b0649b3e275b9cfa7a31250c0770688cc37bb439a90c5b1d7a07974d8828
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:^5.80.1":
+  version: 5.100.10
+  resolution: "@tanstack/react-query@npm:5.100.10"
+  dependencies:
+    "@tanstack/query-core": "npm:5.100.10"
+  peerDependencies:
+    react: ^18 || ^19
+  checksum: 10c0/d25e67e78b28463a6db9d48027e194891365e3f21c5278f83f71af6c683951b979853b755388c0eca9e4510bd24c8a59e5d7920c2d7a42bd293bddd2900f901b
+  languageName: node
+  linkType: hard
+
 "@testing-library/dom@npm:10.4.1":
   version: 10.4.1
   resolution: "@testing-library/dom@npm:10.4.1"
@@ -20545,6 +20563,7 @@ __metadata:
     "@storybook/addon-docs": "npm:9.1.17"
     "@storybook/addon-links": "npm:9.1.17"
     "@storybook/angular": "npm:9.1.17"
+    "@tanstack/react-query": "npm:^5.80.1"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:16.3.2"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-101

## Description

## Summary

- Implements a multi-step Create API Proxy wizard with two modes:
  - **Scratch** (4 steps): API Details → Configure Proxy → Secure → Review & Deploy
  - **Template** (2 steps): Essentials → Review & Deploy — pre-fills auth from the selected template
- Replaces the old `wizardStore` / `wizard.ts` with a Context + useReducer store (`apiCreationStore`) covering form state, virtual host management, step navigation, and per-field validation error clearing
- Adds the full service + hook pipeline: `apiProxy.ts` (create API → create plan → publish plan → start), `useCreateApiProxy` mutation, `apimClient` fetch utility
- Adds utils: `apiCreationValidation.ts` (per-step validators), `apiProxyMapper.ts` (form → API/plan request), `securityFormatters.ts`, `queryKeys.ts`
- Adds `ProxyFlowVisualization` sidebar showing the request path through the gateway in real time as the user fills the form
- Wires `ScratchWizardPage` and `TemplateWizardPage` into `AppRoutes`

## Test plan

- [ ] Open Create API Proxy — picker screen shows scratch + template options
- [ ] Scratch mode: step through all 4 steps, validation blocks advance on empty fields, back/cancel navigate correctly
- [ ] Template mode: selecting a template pre-fills auth type and plan name, 2-step flow works
- [ ] Virtual hosts toggle: switching enables host rows, context path field hides, errors clear on toggle
- [ ] Keyless → no plan name field shown; API Key / JWT / OAuth2 / mTLS → correct plan name field shown
- [ ] Review & Deploy step: "Deploy and start API immediately" toggle visible, Create & Deploy / Create API button label matches toggle state
- [ ] Submit with valid data → API created, plan created + published, start called when deploy toggle on, navigate back to API list on success
- [ ] Submit failure → error banner shown with contextual message per failed step


https://github.com/user-attachments/assets/f09ef47e-fc18-436d-9a94-54ccf7e8599b



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

