### PR TITLE
Introduce api product hooks

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.spec.ts
@@ -25,6 +25,63 @@ import { fakeNotificationTemplate } from '../../../entities/notification/notific
 import { NotificationTemplate } from '../../../entities/notification/notificationTemplate';
 import { Constants } from '../../../entities/Constants';
 
+const API_PRODUCT_HOOK_REPRESENTATIVES: ReadonlyArray<{
+  readonly hook: string;
+  readonly name: string;
+  readonly description: string;
+}> = [
+  { hook: 'APIKEY_EXPIRED', name: 'API-Key Expired', description: 'Triggered when an API Key is expired.' },
+  { hook: 'APIKEY_RENEWED', name: 'API-Key Renewed', description: 'Triggered when an API Key is renewed.' },
+  { hook: 'APIKEY_REVOKED', name: 'API-Key Revoked', description: 'Triggered when an API Key is revoked.' },
+  { hook: 'SUBSCRIPTION_NEW', name: 'New Subscription', description: 'Triggered when a Subscription is created.' },
+  { hook: 'SUBSCRIPTION_ACCEPTED', name: 'Subscription Accepted', description: 'Triggered when a Subscription is accepted.' },
+  { hook: 'SUBSCRIPTION_CLOSED', name: 'Subscription Closed', description: 'Triggered when a Subscription is closed.' },
+  { hook: 'SUBSCRIPTION_PAUSED', name: 'Subscription Paused', description: 'Triggered when a Subscription is paused.' },
+  { hook: 'SUBSCRIPTION_RESUMED', name: 'Subscription Resumed', description: 'Triggered when a Subscription is resumed.' },
+  { hook: 'SUBSCRIPTION_REJECTED', name: 'Subscription Rejected', description: 'Triggered when a Subscription is rejected.' },
+  { hook: 'SUBSCRIPTION_TRANSFERRED', name: 'Subscription Transferred', description: 'Triggered when a Subscription is transferred.' },
+  { hook: 'SUBSCRIPTION_FAILED', name: 'Subscription Failed', description: 'Triggered when a Subscription fails.' },
+  { hook: 'API_PRODUCT_DEPLOYED', name: 'API Product Deployed', description: 'Triggered when an API Product is deployed.' },
+  { hook: 'API_PRODUCT_UPDATED', name: 'API Product Updated', description: 'Triggered when an API Product is updated.' },
+];
+
+function apiProductHookNotificationTemplates(): NotificationTemplate[] {
+  return API_PRODUCT_HOOK_REPRESENTATIVES.map(row =>
+    fakeNotificationTemplate({
+      description: row.description,
+      hook: row.hook,
+      name: row.name,
+      scope: 'API_PRODUCT',
+      title: row.name,
+      type: 'EMAIL',
+      enabled: false,
+    }),
+  );
+}
+
+function expectedApiProductScopeRows(): Array<{
+  scope: string;
+  humanReadableScope: string;
+  name: string;
+  hook: string;
+  description: string;
+  overridden: boolean;
+  icon: string;
+}> {
+  const icon = 'widgets';
+  return [...API_PRODUCT_HOOK_REPRESENTATIVES]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(row => ({
+      scope: 'API_PRODUCT',
+      humanReadableScope: 'API Product',
+      name: row.name,
+      hook: row.hook,
+      description: row.description,
+      overridden: false,
+      icon,
+    }));
+}
+
 describe('OrgSettingsNotificationTemplatesComponent', () => {
   let fixture: ComponentFixture<OrgSettingsNotificationTemplatesComponent>;
   let component: OrgSettingsNotificationTemplatesComponent;
@@ -55,7 +112,12 @@ describe('OrgSettingsNotificationTemplatesComponent', () => {
         .flush(getNotificationTemplates());
     });
 
-    it('should setup notificationTemplatesByScope ', async () => {
+    it('should use a distinct scope icon for API product templates', () => {
+      expect(component.getScopeIcon('API_PRODUCT')).toBe('widgets');
+      expect(component.getScopeIcon('API')).toBe('dashboard');
+    });
+
+    it('should setup notificationTemplatesByScope ', () => {
       expect(component.groupNotificationTemplatesVMByScope(getNotificationTemplates())).toStrictEqual({
         API: [
           {
@@ -86,17 +148,7 @@ describe('OrgSettingsNotificationTemplatesComponent', () => {
             icon: 'dashboard',
           },
         ],
-        'API Product': [
-          {
-            scope: 'API_PRODUCT',
-            humanReadableScope: 'API Product',
-            name: 'API Product Updated',
-            hook: 'API_PRODUCT_UPDATED',
-            description: 'Triggered when an API Product is updated.',
-            overridden: false,
-            icon: 'dashboard',
-          },
-        ],
+        'API Product': expectedApiProductScopeRows(),
         Application: [
           {
             scope: 'APPLICATION',
@@ -146,7 +198,7 @@ describe('OrgSettingsNotificationTemplatesComponent', () => {
         .flush(getNotificationTemplates());
     });
 
-    it('should setup notificationTemplatesByScope ', async () => {
+    it('should setup notificationTemplatesByScope ', () => {
       expect(component.groupNotificationTemplatesVMByScope(getNotificationTemplates())).toStrictEqual({
         API: [
           {
@@ -177,17 +229,7 @@ describe('OrgSettingsNotificationTemplatesComponent', () => {
             icon: 'dashboard',
           },
         ],
-        'API Product': [
-          {
-            scope: 'API_PRODUCT',
-            humanReadableScope: 'API Product',
-            name: 'API Product Updated',
-            hook: 'API_PRODUCT_UPDATED',
-            description: 'Triggered when an API Product is updated.',
-            overridden: false,
-            icon: 'dashboard',
-          },
-        ],
+        'API Product': expectedApiProductScopeRows(),
         Application: [
           {
             scope: 'APPLICATION',
@@ -234,15 +276,7 @@ describe('OrgSettingsNotificationTemplatesComponent', () => {
         type: 'EMAIL',
         enabled: true,
       }),
-      fakeNotificationTemplate({
-        description: 'Triggered when an API Product is updated.',
-        hook: 'API_PRODUCT_UPDATED',
-        name: 'API Product Updated',
-        scope: 'API_PRODUCT',
-        title: 'API Product updated',
-        type: 'EMAIL',
-        enabled: false,
-      }),
+      ...apiProductHookNotificationTemplates(),
       fakeNotificationTemplate({
         description: 'Triggered when a Subscription is accepted.',
         hook: 'SUBSCRIPTION_ACCEPTED',

--- a/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.spec.ts
@@ -86,6 +86,17 @@ describe('OrgSettingsNotificationTemplatesComponent', () => {
             icon: 'dashboard',
           },
         ],
+        'API Product': [
+          {
+            scope: 'API_PRODUCT',
+            humanReadableScope: 'API Product',
+            name: 'API Product Updated',
+            hook: 'API_PRODUCT_UPDATED',
+            description: 'Triggered when an API Product is updated.',
+            overridden: false,
+            icon: 'dashboard',
+          },
+        ],
         Application: [
           {
             scope: 'APPLICATION',
@@ -166,6 +177,17 @@ describe('OrgSettingsNotificationTemplatesComponent', () => {
             icon: 'dashboard',
           },
         ],
+        'API Product': [
+          {
+            scope: 'API_PRODUCT',
+            humanReadableScope: 'API Product',
+            name: 'API Product Updated',
+            hook: 'API_PRODUCT_UPDATED',
+            description: 'Triggered when an API Product is updated.',
+            overridden: false,
+            icon: 'dashboard',
+          },
+        ],
         Application: [
           {
             scope: 'APPLICATION',
@@ -211,6 +233,15 @@ describe('OrgSettingsNotificationTemplatesComponent', () => {
         title: 'API stopped',
         type: 'EMAIL',
         enabled: true,
+      }),
+      fakeNotificationTemplate({
+        description: 'Triggered when an API Product is updated.',
+        hook: 'API_PRODUCT_UPDATED',
+        name: 'API Product Updated',
+        scope: 'API_PRODUCT',
+        title: 'API Product updated',
+        type: 'EMAIL',
+        enabled: false,
       }),
       fakeNotificationTemplate({
         description: 'Triggered when a Subscription is accepted.',

--- a/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.ts
@@ -115,8 +115,9 @@ export class OrgSettingsNotificationTemplatesComponent implements OnInit {
   getScopeIcon(scope: string): string {
     switch (scope) {
       case 'API':
-      case 'API_PRODUCT':
         return 'dashboard';
+      case 'API_PRODUCT':
+        return 'widgets';
       case 'APPLICATION':
         return 'list';
       case 'PORTAL':

--- a/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.ts
@@ -105,12 +105,17 @@ export class OrgSettingsNotificationTemplatesComponent implements OnInit {
       return 'API';
     }
 
+    if (scope === 'API_PRODUCT') {
+      return 'API Product';
+    }
+
     return capitalize(scope.split('_').join(' '));
   }
 
   getScopeIcon(scope: string): string {
     switch (scope) {
       case 'API':
+      case 'API_PRODUCT':
         return 'dashboard';
       case 'APPLICATION':
         return 'list';

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.management.v2.rest.mapper.ApiProductMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ApiProductSearchQuery;
+import io.gravitee.rest.api.management.v2.rest.model.Hook;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiProductResponse;
 import io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo;
@@ -37,6 +38,7 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -50,6 +52,7 @@ import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -216,5 +219,26 @@ public class ApiProductsResource extends AbstractResource {
                 )
             )
             .build();
+    }
+
+    @GET
+    @Path("hooks")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCT, acls = { RolePermissionAction.READ }) })
+    public List<Hook> getApiProductHooks() {
+        return Arrays.stream(ApiProductHook.values())
+            .filter(hook -> !hook.isHidden())
+            .map(ApiProductsResource::toHook)
+            .toList();
+    }
+
+    private static Hook toHook(ApiProductHook hook) {
+        var dto = new Hook();
+        dto.setId(hook.name());
+        dto.setLabel(hook.getLabel());
+        dto.setDescription(hook.getDescription());
+        dto.setCategory(hook.getCategory());
+        dto.setScope(hook.getScope().name());
+        return dto;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -71,6 +71,33 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /environments/{envId}/api-products/hooks:
+    parameters:
+      - $ref: "#/components/parameters/envIdParam"
+    get:
+      tags:
+        - API Product
+      summary: List available API Product notification hooks
+      description: |-
+        Returns the list of notification hooks available for API Products.
+        Use the hook IDs when configuring notification settings for an API Product.
+      operationId: getApiProductHooks
+      responses:
+        '200':
+          description: List of API Product notification hooks
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Hook'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /environments/{envId}/api-products:
     parameters:
       - $ref: "#/components/parameters/envIdParam"
@@ -1910,6 +1937,32 @@ components:
         default: 10
 
   schemas:
+    Hook:
+      type: object
+      title: "Hook"
+      description: A notification hook available for subscription in notification settings
+      properties:
+        id:
+          type: string
+          description: Unique hook identifier (enum name)
+          example: "API_PRODUCT_UPDATED"
+        label:
+          type: string
+          description: Human-readable label for the hook
+          example: "API Product Updated"
+        description:
+          type: string
+          description: Description of when this hook fires
+          example: "Triggered when an API Product is updated."
+        category:
+          type: string
+          description: Category grouping for the hook
+          example: "LIFECYCLE"
+        scope:
+          type: string
+          description: The scope this hook belongs to
+          example: "API_PRODUCT"
+
     VerifyApiProduct:
       type: object
       title: "VerifyApiProduct"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResourceTest.java
@@ -39,6 +39,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.rest.api.management.v2.rest.model.ApiProductSearchQuery;
 import io.gravitee.rest.api.management.v2.rest.model.CreateApiProduct;
+import io.gravitee.rest.api.management.v2.rest.model.Hook;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiProduct;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiProductResponse;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
@@ -46,9 +47,12 @@ import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.Response;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -164,6 +168,30 @@ class ApiProductsResourceTest extends AbstractResourceTest {
                 .asError()
                 .hasHttpStatus(FORBIDDEN_403)
                 .hasMessage("You do not have sufficient rights to access this resource");
+        }
+    }
+
+    @Nested
+    class GetApiProductHooksTest {
+
+        @Test
+        void should_get_api_product_hooks() {
+            final Response response = rootTarget().path("hooks").request().get();
+
+            assertThat(response.getStatus()).isEqualTo(OK_200);
+            var hooks = response.readEntity(new GenericType<List<Hook>>() {});
+            var expectedIds = Arrays.stream(ApiProductHook.values())
+                .filter(hook -> !hook.isHidden())
+                .map(Enum::name)
+                .toList();
+            assertThat(hooks).extracting(Hook::getId).containsExactlyInAnyOrderElementsOf(expectedIds);
+        }
+
+        @Test
+        public void should_return_403_if_incorrect_permissions() {
+            shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCT, ENV_ID, RolePermissionAction.READ, () ->
+                rootTarget().path("hooks").request().get()
+            );
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/RevokeApiKeyDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/domain_service/RevokeApiKeyDomainService.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.ApiKeyAuditEvent;
 import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
 import io.gravitee.apim.core.notification.model.hook.ApiKeyRevokedApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.ApiKeyRevokedApiProductHookContext;
 import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
@@ -77,20 +78,30 @@ public class RevokeApiKeyDomainService {
                 String referenceId = subscription.getReferenceId();
                 if (referenceId != null) {
                     var referenceType = subscription.getReferenceType();
-                    var context = new ApiKeyRevokedApiHookContext(
-                        referenceType,
-                        referenceId,
-                        subscription.getApplicationId(),
-                        subscription.getPlanId(),
-                        apiKey.getKey()
-                    );
-                    triggerNotificationDomainService.triggerSubscriptionReferenceNotification(
-                        auditInfo.organizationId(),
-                        auditInfo.environmentId(),
-                        referenceType,
-                        referenceId,
-                        context
-                    );
+                    if (SubscriptionReferenceType.API_PRODUCT.equals(referenceType)) {
+                        triggerNotificationDomainService.triggerApiProductNotification(
+                            auditInfo.organizationId(),
+                            auditInfo.environmentId(),
+                            new ApiKeyRevokedApiProductHookContext(
+                                referenceId,
+                                subscription.getApplicationId(),
+                                subscription.getPlanId(),
+                                apiKey.getKey()
+                            )
+                        );
+                    } else {
+                        triggerNotificationDomainService.triggerApiSubscriptionNotification(
+                            auditInfo.organizationId(),
+                            auditInfo.environmentId(),
+                            referenceId,
+                            new ApiKeyRevokedApiHookContext(
+                                referenceId,
+                                subscription.getApplicationId(),
+                                subscription.getPlanId(),
+                                apiKey.getKey()
+                            )
+                        );
+                    }
                 }
             });
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCase.java
@@ -23,12 +23,14 @@ import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
+import io.gravitee.apim.core.notification.model.hook.ApiProductDeployedHookContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Publishes DEPLOY_API_PRODUCT event to trigger gateway sync.
+ * Publishes DEPLOY_API_PRODUCT event to trigger gateway sync and emits deploy notifications.
  * Use when an API Product needs to be deployed or redeployed without updating its definition.
  */
 @UseCase
@@ -39,6 +41,7 @@ public class DeployApiProductUseCase {
     private final LicenseDomainService licenseDomainService;
     private final ValidateApiProductService validateApiProductService;
     private final DeployApiProductDomainService deployApiProductDomainService;
+    private final TriggerNotificationDomainService triggerNotificationDomainService;
 
     public Output execute(Input input) {
         if (!licenseDomainService.isApiProductDeploymentAllowed(input.auditInfo().organizationId())) {
@@ -54,6 +57,11 @@ public class DeployApiProductUseCase {
         }
         validateApiProductService.validateForDeploy(apiProduct);
         deployApiProductDomainService.deploy(input.auditInfo(), apiProduct);
+        triggerNotificationDomainService.triggerApiProductNotification(
+            input.auditInfo().organizationId(),
+            input.auditInfo().environmentId(),
+            new ApiProductDeployedHookContext(apiProduct.getId(), input.auditInfo().actor().userId())
+        );
         return new Output(apiProduct);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
@@ -37,6 +37,8 @@ import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
+import io.gravitee.apim.core.notification.model.hook.ApiProductUpdatedHookContext;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.util.HashSet;
@@ -60,6 +62,7 @@ public class UpdateApiProductUseCase {
     private final ApiProductIndexerDomainService apiProductIndexerDomainService;
     private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
     private final DeployApiProductDomainService deployApiProductDomainService;
+    private final TriggerNotificationDomainService triggerNotificationDomainService;
 
     public Output execute(Input input) {
         if (!licenseDomainService.isApiProductDeploymentAllowed(input.auditInfo().organizationId())) {
@@ -120,6 +123,14 @@ public class UpdateApiProductUseCase {
             log.warn("API Product [{}] was updated but not deployed to the gateway. {}", updated.getId(), e.getMessage());
         }
         createAuditLog(beforeUpdate, updated, input.auditInfo());
+        // The notification fires regardless of whether the subsequent re-deploy succeeded: the
+        // data update (name, description, API list, …) always completes before the deploy attempt,
+        // so "API Product Updated" accurately reflects that the stored record changed.
+        triggerNotificationDomainService.triggerApiProductNotification(
+            input.auditInfo().organizationId(),
+            input.auditInfo().environmentId(),
+            new ApiProductUpdatedHookContext(updated.getId(), input.auditInfo().actor().userId())
+        );
         return new Output(updated);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/domain_service/TriggerNotificationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/domain_service/TriggerNotificationDomainService.java
@@ -17,21 +17,17 @@ package io.gravitee.apim.core.notification.domain_service;
 
 import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.apim.core.notification.model.hook.ApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.ApiProductHookContext;
 import io.gravitee.apim.core.notification.model.hook.ApplicationHookContext;
 import io.gravitee.apim.core.notification.model.hook.portal.PortalHookContext;
-import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import java.util.List;
 
 public interface TriggerNotificationDomainService {
     void triggerApiNotification(String organizationId, String environmentId, final ApiHookContext context);
 
-    void triggerSubscriptionReferenceNotification(
-        String organizationId,
-        String environmentId,
-        SubscriptionReferenceType referenceType,
-        String referenceId,
-        ApiHookContext context
-    );
+    void triggerApiSubscriptionNotification(String organizationId, String environmentId, String referenceId, ApiHookContext context);
+
+    void triggerApiProductNotification(String organizationId, String environmentId, ApiProductHookContext context);
 
     void triggerApplicationNotification(String organizationId, String environmentId, final ApplicationHookContext context);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/config/NotificationConfig.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/config/NotificationConfig.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.notification.model.config;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.notification.HookScope;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -52,10 +53,29 @@ public class NotificationConfig {
     }
 
     public static NotificationConfig defaultMailNotificationConfigForApiProduct(String apiProductId) {
-        return defaultMailNotificationConfigFor(HookScope.API_PRODUCT.name(), apiProductId, "${(apiProduct.primaryOwner.email)!''}");
+        return defaultMailNotificationConfigFor(
+            HookScope.API_PRODUCT.name(),
+            apiProductId,
+            "${(apiProduct.primaryOwner.email)!''}",
+            Arrays.stream(ApiProductHook.values()).map(Enum::name).sorted().toList()
+        );
     }
 
     private static NotificationConfig defaultMailNotificationConfigFor(String referenceType, String referenceId, String recipientConfig) {
+        return defaultMailNotificationConfigFor(
+            referenceType,
+            referenceId,
+            recipientConfig,
+            Arrays.stream(ApiHook.values()).map(Enum::name).sorted().toList()
+        );
+    }
+
+    private static NotificationConfig defaultMailNotificationConfigFor(
+        String referenceType,
+        String referenceId,
+        String recipientConfig,
+        List<String> hooks
+    ) {
         var now = TimeProvider.now();
         return NotificationConfig.builder()
             .type(Type.GENERIC)
@@ -65,7 +85,7 @@ public class NotificationConfig {
             .referenceId(referenceId)
             .notifier("default-email")
             .config(recipientConfig)
-            .hooks(Arrays.stream(ApiHook.values()).map(Enum::name).sorted().toList())
+            .hooks(hooks)
             .createdAt(now)
             .updatedAt(now)
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiHookContext.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.apim.core.notification.model.hook;
 
-import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.rest.api.service.notification.ApiHook;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,27 +29,16 @@ public abstract class ApiHookContext extends AbstractHookContext {
 
     private final ApiHook hook;
 
-    /** Id of the API or API Product this hook refers to (see {@link #referenceType}). */
     private final String referenceId;
 
-    private final SubscriptionReferenceType referenceType;
-
     public ApiHookContext(ApiHook hook, String referenceId) {
-        this(hook, referenceId, null);
-    }
-
-    public ApiHookContext(ApiHook hook, String referenceId, SubscriptionReferenceType referenceType) {
         this.hook = hook;
         this.referenceId = referenceId;
-        this.referenceType = referenceType;
     }
 
     public Map<HookContextEntry, String> getProperties() {
         var props = new HashMap<>(getChildProperties());
-        var referenceKey = referenceType == SubscriptionReferenceType.API_PRODUCT
-            ? HookContextEntry.API_PRODUCT_ID
-            : HookContextEntry.API_ID;
-        props.put(referenceKey, referenceId);
+        props.put(HookContextEntry.API_ID, referenceId);
         return props;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiKeyRevokedApiHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiKeyRevokedApiHookContext.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.apim.core.notification.model.hook;
 
-import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.rest.api.service.notification.ApiHook;
 import java.util.Map;
 import lombok.EqualsAndHashCode;
@@ -27,18 +26,12 @@ import lombok.ToString;
 @ToString(callSuper = true)
 public class ApiKeyRevokedApiHookContext extends ApiHookContext {
 
-    String applicationId;
-    String planId;
-    String apiKey;
+    private String applicationId;
+    private String planId;
+    private String apiKey;
 
-    public ApiKeyRevokedApiHookContext(
-        SubscriptionReferenceType referenceType,
-        String referenceId,
-        String applicationId,
-        String planId,
-        String apiKey
-    ) {
-        super(ApiHook.APIKEY_REVOKED, referenceId, referenceType);
+    public ApiKeyRevokedApiHookContext(String referenceId, String applicationId, String planId, String apiKey) {
+        super(ApiHook.APIKEY_REVOKED, referenceId);
         this.applicationId = applicationId;
         this.planId = planId;
         this.apiKey = apiKey;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiKeyRevokedApiProductHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiKeyRevokedApiProductHookContext.java
@@ -15,41 +15,30 @@
  */
 package io.gravitee.apim.core.notification.model.hook;
 
-import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-public class SubscriptionAcceptedApiHookContext extends ApiHookContext {
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@ToString(callSuper = true)
+public class ApiKeyRevokedApiProductHookContext extends ApiProductHookContext {
 
     private final String applicationId;
     private final String planId;
-    private final String subscriptionId;
-    private final String applicationPrimaryOwner;
+    private final String apiKey;
 
-    public SubscriptionAcceptedApiHookContext(
-        String referenceId,
-        String applicationId,
-        String planId,
-        String subscriptionId,
-        String applicationPrimaryOwner
-    ) {
-        super(ApiHook.SUBSCRIPTION_ACCEPTED, referenceId);
+    public ApiKeyRevokedApiProductHookContext(String apiProductId, String applicationId, String planId, String apiKey) {
+        super(ApiProductHook.APIKEY_REVOKED, apiProductId);
         this.applicationId = applicationId;
         this.planId = planId;
-        this.subscriptionId = subscriptionId;
-        this.applicationPrimaryOwner = applicationPrimaryOwner;
+        this.apiKey = apiKey;
     }
 
     @Override
     protected Map<HookContextEntry, String> getChildProperties() {
-        return Map.of(
-            HookContextEntry.APPLICATION_ID,
-            applicationId,
-            HookContextEntry.PLAN_ID,
-            planId,
-            HookContextEntry.SUBSCRIPTION_ID,
-            subscriptionId,
-            HookContextEntry.OWNER,
-            applicationPrimaryOwner
-        );
+        return Map.of(HookContextEntry.APPLICATION_ID, applicationId, HookContextEntry.PLAN_ID, planId, HookContextEntry.API_KEY, apiKey);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiProductDeployedHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiProductDeployedHookContext.java
@@ -15,26 +15,29 @@
  */
 package io.gravitee.apim.core.notification.model.hook;
 
-import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import java.util.Map;
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-@EqualsAndHashCode(callSuper = true)
 @Getter
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class SubscriptionClosedApiHookContext extends ApiHookContext {
+public class ApiProductDeployedHookContext extends ApiProductHookContext {
 
-    private String applicationId;
-    private String planId;
+    private final String triggeredByUserId;
 
-    public SubscriptionClosedApiHookContext(String referenceId, String applicationId, String planId) {
-        super(ApiHook.SUBSCRIPTION_CLOSED, referenceId);
-        this.applicationId = applicationId;
-        this.planId = planId;
+    public ApiProductDeployedHookContext(String apiProductId, String triggeredByUserId) {
+        super(ApiProductHook.API_PRODUCT_DEPLOYED, apiProductId);
+        this.triggeredByUserId = triggeredByUserId;
     }
 
     @Override
     protected Map<HookContextEntry, String> getChildProperties() {
-        return Map.of(HookContextEntry.APPLICATION_ID, applicationId, HookContextEntry.PLAN_ID, planId);
+        if (triggeredByUserId == null) {
+            return Map.of();
+        }
+        return Map.of(HookContextEntry.USER_ID, triggeredByUserId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiProductHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiProductHookContext.java
@@ -15,26 +15,31 @@
  */
 package io.gravitee.apim.core.notification.model.hook;
 
-import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
+import java.util.HashMap;
 import java.util.Map;
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-@EqualsAndHashCode(callSuper = true)
 @Getter
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class SubscriptionClosedApiHookContext extends ApiHookContext {
+public abstract class ApiProductHookContext extends AbstractHookContext {
 
-    private String applicationId;
-    private String planId;
+    private final ApiProductHook hook;
 
-    public SubscriptionClosedApiHookContext(String referenceId, String applicationId, String planId) {
-        super(ApiHook.SUBSCRIPTION_CLOSED, referenceId);
-        this.applicationId = applicationId;
-        this.planId = planId;
+    private final String apiProductId;
+
+    protected ApiProductHookContext(ApiProductHook hook, String apiProductId) {
+        this.hook = hook;
+        this.apiProductId = apiProductId;
     }
 
     @Override
-    protected Map<HookContextEntry, String> getChildProperties() {
-        return Map.of(HookContextEntry.APPLICATION_ID, applicationId, HookContextEntry.PLAN_ID, planId);
+    public Map<HookContextEntry, String> getProperties() {
+        var childProperties = new HashMap<>(getChildProperties());
+        childProperties.put(HookContextEntry.API_PRODUCT_ID, apiProductId);
+        return childProperties;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiProductUpdatedHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/ApiProductUpdatedHookContext.java
@@ -15,26 +15,29 @@
  */
 package io.gravitee.apim.core.notification.model.hook;
 
-import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import java.util.Map;
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-@EqualsAndHashCode(callSuper = true)
 @Getter
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class SubscriptionClosedApiHookContext extends ApiHookContext {
+public class ApiProductUpdatedHookContext extends ApiProductHookContext {
 
-    private String applicationId;
-    private String planId;
+    private final String triggeredByUserId;
 
-    public SubscriptionClosedApiHookContext(String referenceId, String applicationId, String planId) {
-        super(ApiHook.SUBSCRIPTION_CLOSED, referenceId);
-        this.applicationId = applicationId;
-        this.planId = planId;
+    public ApiProductUpdatedHookContext(String apiProductId, String triggeredByUserId) {
+        super(ApiProductHook.API_PRODUCT_UPDATED, apiProductId);
+        this.triggeredByUserId = triggeredByUserId;
     }
 
     @Override
     protected Map<HookContextEntry, String> getChildProperties() {
-        return Map.of(HookContextEntry.APPLICATION_ID, applicationId, HookContextEntry.PLAN_ID, planId);
+        if (triggeredByUserId == null) {
+            return Map.of();
+        }
+        return Map.of(HookContextEntry.USER_ID, triggeredByUserId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/HookContextEntry.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/HookContextEntry.java
@@ -24,4 +24,5 @@ public enum HookContextEntry {
     API_KEY,
     OWNER,
     INTEGRATION_ID,
+    USER_ID,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionAcceptedApiProductHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionAcceptedApiProductHookContext.java
@@ -15,24 +15,30 @@
  */
 package io.gravitee.apim.core.notification.model.hook;
 
-import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-public class SubscriptionAcceptedApiHookContext extends ApiHookContext {
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class SubscriptionAcceptedApiProductHookContext extends ApiProductHookContext {
 
     private final String applicationId;
     private final String planId;
     private final String subscriptionId;
     private final String applicationPrimaryOwner;
 
-    public SubscriptionAcceptedApiHookContext(
-        String referenceId,
+    public SubscriptionAcceptedApiProductHookContext(
+        String apiProductId,
         String applicationId,
         String planId,
         String subscriptionId,
         String applicationPrimaryOwner
     ) {
-        super(ApiHook.SUBSCRIPTION_ACCEPTED, referenceId);
+        super(ApiProductHook.SUBSCRIPTION_ACCEPTED, apiProductId);
         this.applicationId = applicationId;
         this.planId = planId;
         this.subscriptionId = subscriptionId;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionClosedApiProductHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionClosedApiProductHookContext.java
@@ -15,41 +15,28 @@
  */
 package io.gravitee.apim.core.notification.model.hook;
 
-import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-public class SubscriptionAcceptedApiHookContext extends ApiHookContext {
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@ToString(callSuper = true)
+public class SubscriptionClosedApiProductHookContext extends ApiProductHookContext {
 
     private final String applicationId;
     private final String planId;
-    private final String subscriptionId;
-    private final String applicationPrimaryOwner;
 
-    public SubscriptionAcceptedApiHookContext(
-        String referenceId,
-        String applicationId,
-        String planId,
-        String subscriptionId,
-        String applicationPrimaryOwner
-    ) {
-        super(ApiHook.SUBSCRIPTION_ACCEPTED, referenceId);
+    public SubscriptionClosedApiProductHookContext(String apiProductId, String applicationId, String planId) {
+        super(ApiProductHook.SUBSCRIPTION_CLOSED, apiProductId);
         this.applicationId = applicationId;
         this.planId = planId;
-        this.subscriptionId = subscriptionId;
-        this.applicationPrimaryOwner = applicationPrimaryOwner;
     }
 
     @Override
     protected Map<HookContextEntry, String> getChildProperties() {
-        return Map.of(
-            HookContextEntry.APPLICATION_ID,
-            applicationId,
-            HookContextEntry.PLAN_ID,
-            planId,
-            HookContextEntry.SUBSCRIPTION_ID,
-            subscriptionId,
-            HookContextEntry.OWNER,
-            applicationPrimaryOwner
-        );
+        return Map.of(HookContextEntry.APPLICATION_ID, applicationId, HookContextEntry.PLAN_ID, planId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionRejectedApiHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionRejectedApiHookContext.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.apim.core.notification.model.hook;
 
-import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.rest.api.service.notification.ApiHook;
 import java.util.Map;
 
@@ -27,14 +26,13 @@ public class SubscriptionRejectedApiHookContext extends ApiHookContext {
     private final String applicationPrimaryOwner;
 
     public SubscriptionRejectedApiHookContext(
-        SubscriptionReferenceType referenceType,
         String referenceId,
         String applicationId,
         String planId,
         String subscriptionId,
         String applicationPrimaryOwner
     ) {
-        super(ApiHook.SUBSCRIPTION_REJECTED, referenceId, referenceType);
+        super(ApiHook.SUBSCRIPTION_REJECTED, referenceId);
         this.applicationId = applicationId;
         this.planId = planId;
         this.subscriptionId = subscriptionId;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionRejectedApiProductHookContext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/model/hook/SubscriptionRejectedApiProductHookContext.java
@@ -15,24 +15,30 @@
  */
 package io.gravitee.apim.core.notification.model.hook;
 
-import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import java.util.Map;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
-public class SubscriptionAcceptedApiHookContext extends ApiHookContext {
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class SubscriptionRejectedApiProductHookContext extends ApiProductHookContext {
 
     private final String applicationId;
     private final String planId;
     private final String subscriptionId;
     private final String applicationPrimaryOwner;
 
-    public SubscriptionAcceptedApiHookContext(
-        String referenceId,
+    public SubscriptionRejectedApiProductHookContext(
+        String apiProductId,
         String applicationId,
         String planId,
         String subscriptionId,
         String applicationPrimaryOwner
     ) {
-        super(ApiHook.SUBSCRIPTION_ACCEPTED, referenceId);
+        super(ApiProductHook.SUBSCRIPTION_REJECTED, apiProductId);
         this.applicationId = applicationId;
         this.planId = planId;
         this.subscriptionId = subscriptionId;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainService.java
@@ -37,6 +37,7 @@ import io.gravitee.apim.core.metadata.model.Metadata;
 import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
 import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionAcceptedApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.SubscriptionAcceptedApiProductHookContext;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionAcceptedApplicationHookContext;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.plan.model.Plan;
@@ -319,21 +320,32 @@ public class AcceptSubscriptionDomainService {
 
         String referenceId = acceptedSubscription.getReferenceId();
         var referenceType = acceptedSubscription.getReferenceType();
-        var apiContext = new SubscriptionAcceptedApiHookContext(
-            referenceType,
-            referenceId,
-            acceptedSubscription.getApplicationId(),
-            acceptedSubscription.getPlanId(),
-            acceptedSubscription.getId(),
-            applicationPrimaryOwner.id()
-        );
-        triggerNotificationDomainService.triggerSubscriptionReferenceNotification(
-            organizationId,
-            environmentId,
-            referenceType,
-            referenceId,
-            apiContext
-        );
+        if (SubscriptionReferenceType.API_PRODUCT == referenceType) {
+            triggerNotificationDomainService.triggerApiProductNotification(
+                organizationId,
+                environmentId,
+                new SubscriptionAcceptedApiProductHookContext(
+                    referenceId,
+                    acceptedSubscription.getApplicationId(),
+                    acceptedSubscription.getPlanId(),
+                    acceptedSubscription.getId(),
+                    applicationPrimaryOwner.id()
+                )
+            );
+        } else {
+            triggerNotificationDomainService.triggerApiSubscriptionNotification(
+                organizationId,
+                environmentId,
+                referenceId,
+                new SubscriptionAcceptedApiHookContext(
+                    referenceId,
+                    acceptedSubscription.getApplicationId(),
+                    acceptedSubscription.getPlanId(),
+                    acceptedSubscription.getId(),
+                    applicationPrimaryOwner.id()
+                )
+            );
+        }
         triggerNotificationDomainService.triggerApplicationNotification(
             organizationId,
             environmentId,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/CloseSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/CloseSubscriptionDomainService.java
@@ -30,6 +30,7 @@ import io.gravitee.apim.core.audit.model.event.SubscriptionAuditEvent;
 import io.gravitee.apim.core.integration.service_provider.IntegrationAgent;
 import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionClosedApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.SubscriptionClosedApiProductHookContext;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionClosedApplicationHookContext;
 import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
@@ -147,19 +148,28 @@ public class CloseSubscriptionDomainService {
     private void triggerNotifications(SubscriptionEntity closedSubscriptionEntity, AuditInfo auditInfo) {
         String referenceId = closedSubscriptionEntity.getReferenceId();
         var referenceType = closedSubscriptionEntity.getReferenceType();
-        var apiContext = new SubscriptionClosedApiHookContext(
-            referenceType,
-            referenceId,
-            closedSubscriptionEntity.getApplicationId(),
-            closedSubscriptionEntity.getPlanId()
-        );
-        triggerNotificationDomainService.triggerSubscriptionReferenceNotification(
-            auditInfo.organizationId(),
-            auditInfo.environmentId(),
-            referenceType,
-            referenceId,
-            apiContext
-        );
+        if (SubscriptionReferenceType.API_PRODUCT == referenceType) {
+            triggerNotificationDomainService.triggerApiProductNotification(
+                auditInfo.organizationId(),
+                auditInfo.environmentId(),
+                new SubscriptionClosedApiProductHookContext(
+                    referenceId,
+                    closedSubscriptionEntity.getApplicationId(),
+                    closedSubscriptionEntity.getPlanId()
+                )
+            );
+        } else {
+            triggerNotificationDomainService.triggerApiSubscriptionNotification(
+                auditInfo.organizationId(),
+                auditInfo.environmentId(),
+                referenceId,
+                new SubscriptionClosedApiHookContext(
+                    referenceId,
+                    closedSubscriptionEntity.getApplicationId(),
+                    closedSubscriptionEntity.getPlanId()
+                )
+            );
+        }
         triggerNotificationDomainService.triggerApplicationNotification(
             auditInfo.organizationId(),
             auditInfo.environmentId(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/RejectSubscriptionDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/domain_service/RejectSubscriptionDomainService.java
@@ -27,6 +27,7 @@ import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDo
 import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
 import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionRejectedApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.SubscriptionRejectedApiProductHookContext;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionRejectedApplicationHookContext;
 import io.gravitee.apim.core.subscription.crud_service.SubscriptionCrudService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
@@ -85,21 +86,32 @@ public class RejectSubscriptionDomainService {
 
         String referenceId = rejectedSubscriptionEntity.getReferenceId();
         var referenceType = rejectedSubscriptionEntity.getReferenceType();
-        var apiContext = new SubscriptionRejectedApiHookContext(
-            referenceType,
-            referenceId,
-            rejectedSubscriptionEntity.getApplicationId(),
-            rejectedSubscriptionEntity.getPlanId(),
-            rejectedSubscriptionEntity.getId(),
-            applicationPrimaryOwner.id()
-        );
-        triggerNotificationDomainService.triggerSubscriptionReferenceNotification(
-            organizationId,
-            environmentId,
-            referenceType,
-            referenceId,
-            apiContext
-        );
+        if (SubscriptionReferenceType.API_PRODUCT == referenceType) {
+            triggerNotificationDomainService.triggerApiProductNotification(
+                organizationId,
+                environmentId,
+                new SubscriptionRejectedApiProductHookContext(
+                    referenceId,
+                    rejectedSubscriptionEntity.getApplicationId(),
+                    rejectedSubscriptionEntity.getPlanId(),
+                    rejectedSubscriptionEntity.getId(),
+                    applicationPrimaryOwner.id()
+                )
+            );
+        } else {
+            triggerNotificationDomainService.triggerApiSubscriptionNotification(
+                organizationId,
+                environmentId,
+                referenceId,
+                new SubscriptionRejectedApiHookContext(
+                    referenceId,
+                    rejectedSubscriptionEntity.getApplicationId(),
+                    rejectedSubscriptionEntity.getPlanId(),
+                    rejectedSubscriptionEntity.getId(),
+                    applicationPrimaryOwner.id()
+                )
+            );
+        }
         triggerNotificationDomainService.triggerApplicationNotification(
             organizationId,
             environmentId,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/UserAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/UserAdapter.java
@@ -31,4 +31,5 @@ public interface UserAdapter {
 
     BaseUserEntity fromUser(User user);
     BaseUserEntity fromUser(UserEntity user);
+    UserEntity toUserEntity(BaseUserEntity base);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImpl.java
@@ -18,11 +18,10 @@ package io.gravitee.apim.infra.notification;
 import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
 import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.apim.core.notification.model.hook.ApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.ApiProductHookContext;
 import io.gravitee.apim.core.notification.model.hook.ApplicationHookContext;
 import io.gravitee.apim.core.notification.model.hook.portal.PortalHookContext;
-import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.infra.notification.internal.TemplateDataFetcher;
-import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.rest.api.service.NotifierService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Collections;
@@ -44,32 +43,35 @@ public class TriggerNotificationDomainServiceFacadeImpl implements TriggerNotifi
 
     @Override
     public void triggerApiNotification(String organizationId, String environmentId, ApiHookContext context) {
-        var executionContext = new ExecutionContext(organizationId, environmentId);
-        var notificationParameters = templateDataFetcher.fetchData(organizationId, context);
-        if (context.getReferenceType() != null) {
-            var refType = context.getReferenceType() == SubscriptionReferenceType.API_PRODUCT
-                ? NotificationReferenceType.API_PRODUCT
-                : NotificationReferenceType.API;
-            notifierService.trigger(executionContext, context.getHook(), refType, context.getReferenceId(), notificationParameters);
-        } else {
-            notifierService.trigger(executionContext, context.getHook(), context.getReferenceId(), notificationParameters);
-        }
+        triggerApiHookNotification(organizationId, environmentId, context.getReferenceId(), context);
     }
 
     @Override
-    public void triggerSubscriptionReferenceNotification(
+    public void triggerApiSubscriptionNotification(
         String organizationId,
         String environmentId,
-        SubscriptionReferenceType referenceType,
         String referenceId,
+        ApiHookContext context
+    ) {
+        triggerApiHookNotification(organizationId, environmentId, referenceId, context);
+    }
+
+    private void triggerApiHookNotification(
+        String organizationId,
+        String environmentId,
+        String notifierReferenceId,
         ApiHookContext context
     ) {
         var executionContext = new ExecutionContext(organizationId, environmentId);
         var notificationParameters = templateDataFetcher.fetchData(organizationId, context);
-        var refType = referenceType == SubscriptionReferenceType.API_PRODUCT
-            ? NotificationReferenceType.API_PRODUCT
-            : NotificationReferenceType.API;
-        notifierService.trigger(executionContext, context.getHook(), refType, referenceId, notificationParameters);
+        notifierService.trigger(executionContext, context.getHook(), notifierReferenceId, notificationParameters);
+    }
+
+    @Override
+    public void triggerApiProductNotification(String organizationId, String environmentId, ApiProductHookContext context) {
+        var executionContext = new ExecutionContext(organizationId, environmentId);
+        var notificationParameters = templateDataFetcher.fetchData(organizationId, context);
+        notifierService.trigger(executionContext, context.getHook(), context.getApiProductId(), notificationParameters);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/notification/internal/TemplateDataFetcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/notification/internal/TemplateDataFetcher.java
@@ -36,6 +36,8 @@ import io.gravitee.apim.core.notification.model.SubscriptionNotificationTemplate
 import io.gravitee.apim.core.notification.model.hook.HookContext;
 import io.gravitee.apim.core.notification.model.hook.HookContextEntry;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.infra.adapter.UserAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiProductsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -45,6 +47,7 @@ import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.model.ApiProduct;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.ApiProductTemplateModel;
 import java.util.List;
@@ -136,6 +139,7 @@ public class TemplateDataFetcher {
             case OWNER -> buildOwnerNotificationTemplateData(hookName, entry.getValue()).map(templateData ->
                 Map.entry("owner", (Object) templateData)
             );
+            case USER_ID -> buildUserNotificationTemplateData(entry.getValue());
         };
     }
 
@@ -171,6 +175,16 @@ public class TemplateDataFetcher {
             .name(apiProduct.getName())
             .version(apiProduct.getVersion() != null ? apiProduct.getVersion() : "")
             .build();
+    }
+
+    private Optional<Map.Entry<String, Object>> buildUserNotificationTemplateData(String userId) {
+        if (userId == null || userId.isEmpty()) {
+            return Optional.empty();
+        }
+        return userCrudService
+            .findBaseUserById(userId)
+            .map(UserAdapter.INSTANCE::toUserEntity)
+            .map(user -> Map.entry("user", user));
     }
 
     private Optional<PrimaryOwnerNotificationTemplateData> buildOwnerNotificationTemplateData(String hook, String userId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
@@ -120,6 +120,47 @@ public class EmailNotificationBuilder {
         API_REVIEW_OK(ApiHook.REVIEW_OK, "reviewOk.html", "API review accepted"),
         API_API_DEPRECATED(ApiHook.API_DEPRECATED, "apiDeprecated.html", "API deprecated"),
         API_PLANS_DATA_FIXED(ApiHook.MESSAGE, "apiPlansDataFixed.html", "API plans data have been fixed"),
+        API_PRODUCT_APIKEY_REVOKED(
+            ApiProductHook.APIKEY_REVOKED,
+            "apiKeyRevoked.html",
+            "API Key revoked for ${(api.name)!(apiProduct.name)!''}"
+        ),
+        API_PRODUCT_APIKEY_RENEWED(
+            ApiProductHook.APIKEY_RENEWED,
+            "apiKeyRenewed.html",
+            "API Key renewed for ${(api.name)!(apiProduct.name)!''}"
+        ),
+        API_PRODUCT_APIKEY_EXPIRED(
+            ApiProductHook.APIKEY_EXPIRED,
+            "apiKeyExpired.html",
+            "API Key expiration for ${(api.name)!(apiProduct.name)!''}"
+        ),
+        API_PRODUCT_SUBSCRIPTION_NEW(
+            ApiProductHook.SUBSCRIPTION_NEW,
+            "subscriptionReceived.html",
+            "New subscription for ${(api.name)!(apiProduct.name)!''} with plan ${plan.name}"
+        ),
+        API_PRODUCT_SUBSCRIPTION_ACCEPTED(ApiProductHook.SUBSCRIPTION_ACCEPTED, "subscriptionApproved.html", "Subscription approved"),
+        API_PRODUCT_SUBSCRIPTION_CLOSED(ApiProductHook.SUBSCRIPTION_CLOSED, "subscriptionClosed.html", "Subscription closed"),
+        API_PRODUCT_SUBSCRIPTION_PAUSED(
+            ApiProductHook.SUBSCRIPTION_PAUSED,
+            "subscriptionPaused.html",
+            "Subscription for ${(api.name)!(apiProduct.name)!''} with plan ${plan.name} has been paused"
+        ),
+        API_PRODUCT_SUBSCRIPTION_RESUMED(
+            ApiProductHook.SUBSCRIPTION_RESUMED,
+            "subscriptionResumed.html",
+            "Subscription for ${(api.name)!(apiProduct.name)!''} with plan ${plan.name} has been resumed"
+        ),
+        API_PRODUCT_SUBSCRIPTION_REJECTED(ApiProductHook.SUBSCRIPTION_REJECTED, "subscriptionRejected.html", "Subscription rejected"),
+        API_PRODUCT_SUBSCRIPTION_FAILED(ApiProductHook.SUBSCRIPTION_FAILED, "subscriptionFailed.html", "Subscription failed"),
+        API_PRODUCT_SUBSCRIPTION_TRANSFERRED(
+            ApiProductHook.SUBSCRIPTION_TRANSFERRED,
+            "subscriptionTransferred.html",
+            "Subscription for ${(api.name)!(apiProduct.name)!''} with plan ${plan.name} has been transferred"
+        ),
+        API_PRODUCT_DEPLOYED(ApiProductHook.API_PRODUCT_DEPLOYED, "apiDeployed.html", "API Product Deployed"),
+        API_PRODUCT_UPDATED(ApiProductHook.API_PRODUCT_UPDATED, "apiUpdated.html", "API Product Updated"),
         APPLICATION_SUBSCRIPTION_NEW(
             ApplicationHook.SUBSCRIPTION_NEW,
             "subscriptionCreated.html",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -65,6 +65,7 @@ import io.gravitee.rest.api.service.exceptions.SubscriptionClosedException;
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotActiveException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.notification.ApiProductTemplateModel;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.v4.ApiTemplateService;
@@ -176,6 +177,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             triggerNotifierService(
                 executionContext,
                 ApiHook.APIKEY_RENEWED,
+                ApiProductHook.APIKEY_RENEWED,
                 newApiKey,
                 newApiKeyEntity.getApplication(),
                 newApiKeyEntity.getSubscriptions()
@@ -216,6 +218,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             triggerNotifierService(
                 executionContext,
                 ApiHook.APIKEY_RENEWED,
+                ApiProductHook.APIKEY_RENEWED,
                 newApiKey,
                 newApiKeyEntity.getApplication(),
                 newApiKeyEntity.getSubscriptions()
@@ -659,7 +662,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             if (key.getExpireAt() != null && now.before(key.getExpireAt())) {
                 paramsBuilder.expirationDate(key.getExpireAt());
             }
-            triggerNotifierService(executionContext, ApiHook.APIKEY_EXPIRED, key, paramsBuilder);
+            triggerNotifierService(executionContext, ApiHook.APIKEY_EXPIRED, ApiProductHook.APIKEY_EXPIRED, key, paramsBuilder);
         }
     }
 
@@ -745,27 +748,30 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
     private void triggerNotifierService(
         ExecutionContext executionContext,
         ApiHook apiHook,
+        ApiProductHook apiProductHook,
         ApiKey key,
         NotificationParamsBuilder paramsBuilder
     ) {
         ApplicationEntity application = applicationService.findById(executionContext, key.getApplication());
         Set<SubscriptionEntity> subscriptions = subscriptionService.findByIdIn(key.getSubscriptions());
-        triggerNotifierService(executionContext, apiHook, key, application, subscriptions, paramsBuilder);
+        triggerNotifierService(executionContext, apiHook, apiProductHook, key, application, subscriptions, paramsBuilder);
     }
 
     private void triggerNotifierService(
         ExecutionContext executionContext,
         ApiHook apiHook,
+        ApiProductHook apiProductHook,
         ApiKey key,
         ApplicationEntity application,
         Set<SubscriptionEntity> subscriptions
     ) {
-        triggerNotifierService(executionContext, apiHook, key, application, subscriptions, new NotificationParamsBuilder());
+        triggerNotifierService(executionContext, apiHook, apiProductHook, key, application, subscriptions, new NotificationParamsBuilder());
     }
 
     private void triggerNotifierService(
         ExecutionContext executionContext,
         ApiHook apiHook,
+        ApiProductHook apiProductHook,
         ApiKey key,
         ApplicationEntity application,
         Set<SubscriptionEntity> subscriptions,
@@ -773,7 +779,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
     ) {
         subscriptions.forEach(subscription -> {
             if (isApiProductSubscription(subscription)) {
-                triggerNotifierServiceForApiProductSubscription(executionContext, apiHook, key, application, subscription);
+                triggerNotifierServiceForApiProductSubscription(executionContext, apiProductHook, key, application, subscription);
                 return;
             }
             GenericPlanEntity genericPlanEntity = planSearchService.findById(executionContext, subscription.getPlan());
@@ -792,7 +798,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
 
     private void triggerNotifierServiceForApiProductSubscription(
         ExecutionContext executionContext,
-        ApiHook apiHook,
+        ApiProductHook apiProductHook,
         ApiKey key,
         ApplicationEntity application,
         SubscriptionEntity subscription
@@ -827,7 +833,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             if (key.getExpireAt() != null && now.before(key.getExpireAt())) {
                 freshBuilder.expirationDate(key.getExpireAt());
             }
-            notifierService.trigger(executionContext, apiHook, NotificationReferenceType.API_PRODUCT, apiProductId, freshBuilder.build());
+            notifierService.trigger(executionContext, apiProductHook, apiProductId, freshBuilder.build());
         } catch (TechnicalException e) {
             log.error("Error triggering API key notification for API Product subscription {}", subscription.getId(), e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -93,6 +93,7 @@ import io.gravitee.rest.api.service.exceptions.StillApiProductPrimaryOwnerExcept
 import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.notification.ApiProductTemplateModel;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.search.SearchEngineService;
@@ -1443,8 +1444,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             .build();
         notifierService.trigger(
             executionContext,
-            ApiHook.API_UPDATED,
-            NotificationReferenceType.API_PRODUCT,
+            ApiProductHook.API_PRODUCT_UPDATED,
             apiProduct.getId(),
             new NotificationParamsBuilder()
                 .apiProduct(model)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotificationTemplateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotificationTemplateServiceImpl.java
@@ -53,6 +53,7 @@ import io.gravitee.rest.api.service.exceptions.TemplateProcessingException;
 import io.gravitee.rest.api.service.notification.ActionHook;
 import io.gravitee.rest.api.service.notification.AlertHook;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.notification.ApplicationHook;
 import io.gravitee.rest.api.service.notification.Hook;
 import io.gravitee.rest.api.service.notification.HookScope;
@@ -134,6 +135,7 @@ public class NotificationTemplateServiceImpl extends AbstractService implements 
         List<Hook> allHooks = new ArrayList<>();
         Collections.addAll(allHooks, PortalHook.values());
         Collections.addAll(allHooks, ApiHook.values());
+        Collections.addAll(allHooks, ApiProductHook.values());
         Collections.addAll(allHooks, ApplicationHook.values());
         Collections.addAll(allHooks, ActionHook.values());
         Collections.addAll(allHooks, AlertHook.values());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotifierServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotifierServiceImpl.java
@@ -294,47 +294,54 @@ public class NotifierServiceImpl extends AbstractService implements NotifierServ
             var notificationConfigs = genericNotificationConfigs
                 .stream()
                 .collect(Collectors.groupingBy(GenericNotificationConfig::getNotifier));
-            if (!notificationConfigs.isEmpty()) {
-                list().forEach(notifier -> {
-                    switch (notifier.type()) {
-                        case EMAIL -> {
-                            var recipients = notificationConfigs
-                                .getOrDefault(notifier.getId(), Collections.emptyList())
-                                .stream()
-                                .map(GenericNotificationConfig::getConfig)
-                                .collect(Collectors.toList());
-
-                            if (!CollectionUtils.isEmpty(data.recipients)) {
-                                var emailAdditionalRecipients = data.recipients
-                                    .stream()
-                                    .filter(r -> r.type().equals(DEFAULT_EMAIL_NOTIFIER_ID))
-                                    .map(Recipient::value)
-                                    .toList();
-                                recipients.addAll(emailAdditionalRecipients);
-                            }
-
-                            // extract emails from templated string (eg: ${api.primaryOwner.email})
-                            var processedRecipients = emailRecipientsService.processTemplatedRecipients(recipients, data.params);
-                            // extract emails of opted-in users if trial instance
-                            var validRecipients = parameterService.findAsBoolean(
-                                    executionContext,
-                                    Key.TRIAL_INSTANCE,
-                                    ParameterReferenceType.SYSTEM
-                                )
-                                ? emailRecipientsService.filterRegisteredUser(executionContext, processedRecipients)
-                                : processedRecipients;
-
-                            emailNotifierService.trigger(executionContext, data.hook, data.params, validRecipients);
-                        }
-                        case WEBHOOK -> {
-                            notificationConfigs
-                                .getOrDefault(notifier.getId(), Collections.emptyList())
-                                .forEach(config -> webhookNotifierService.trigger(data.hook, config, data.params));
-                        }
-                        default -> log.error("Unknown notifier {}", notifier.getType());
-                    }
-                });
+            if (notificationConfigs.isEmpty()) {
+                log.debug(
+                    "No GenericNotificationConfig for hook {} (referenceType={}, referenceId={}); email/webhook notifiers are skipped",
+                    data.hook.name(),
+                    data.referenceType,
+                    data.referenceId
+                );
+                return;
             }
+            list().forEach(notifier -> {
+                switch (notifier.type()) {
+                    case EMAIL -> {
+                        var recipients = notificationConfigs
+                            .getOrDefault(notifier.getId(), Collections.emptyList())
+                            .stream()
+                            .map(GenericNotificationConfig::getConfig)
+                            .collect(Collectors.toList());
+
+                        if (!CollectionUtils.isEmpty(data.recipients)) {
+                            var emailAdditionalRecipients = data.recipients
+                                .stream()
+                                .filter(r -> r.type().equals(DEFAULT_EMAIL_NOTIFIER_ID))
+                                .map(Recipient::value)
+                                .toList();
+                            recipients.addAll(emailAdditionalRecipients);
+                        }
+
+                        // extract emails from templated string (eg: ${api.primaryOwner.email})
+                        var processedRecipients = emailRecipientsService.processTemplatedRecipients(recipients, data.params);
+                        // extract emails of opted-in users if trial instance
+                        var validRecipients = parameterService.findAsBoolean(
+                                executionContext,
+                                Key.TRIAL_INSTANCE,
+                                ParameterReferenceType.SYSTEM
+                            )
+                            ? emailRecipientsService.filterRegisteredUser(executionContext, processedRecipients)
+                            : processedRecipients;
+
+                        emailNotifierService.trigger(executionContext, data.hook, data.params, validRecipients);
+                    }
+                    case WEBHOOK -> {
+                        notificationConfigs
+                            .getOrDefault(notifier.getId(), Collections.emptyList())
+                            .forEach(config -> webhookNotifierService.trigger(data.hook, config, data.params));
+                    }
+                    default -> log.error("Unknown notifier {}", notifier.getType());
+                }
+            });
         } catch (TechnicalException e) {
             log.error("Error looking for GenericNotificationConfig with {}", data, e);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -134,6 +134,7 @@ import io.gravitee.rest.api.service.exceptions.SubscriptionNotUpdatableException
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.TransferNotAllowedException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.notification.ApiProductTemplateModel;
 import io.gravitee.rest.api.service.notification.ApplicationHook;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
@@ -817,7 +818,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                         paramSubscription,
                         Optional.of(subscriptionsUrl),
                         true,
-                        ApiHook.SUBSCRIPTION_NEW
+                        ApiProductHook.SUBSCRIPTION_NEW
                     );
                 } else {
                     triggerSubscriptionNotificationsForApi(
@@ -866,21 +867,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         }
     }
 
-    /**
-     * Triggers subscription notifications for both API and API Product. Caller builds params with either "api" or "api-product".
-     */
-    private void triggerSubscriptionNotifications(
-        ExecutionContext executionContext,
-        NotificationReferenceType referenceType,
-        String referenceId,
-        String applicationId,
-        Map<String, Object> params,
-        ApiHook hook
-    ) {
-        notifierService.trigger(executionContext, hook, referenceType, referenceId, params);
-        notifierService.trigger(executionContext, ApplicationHook.valueOf(hook.name()), applicationId, params);
-    }
-
     private void triggerSubscriptionNotificationsForApi(
         ExecutionContext executionContext,
         String apiId,
@@ -918,14 +904,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         if (subscriptionsUrl != null) {
             paramsBuilder.subscriptionsUrl(subscriptionsUrl);
         }
-        triggerSubscriptionNotifications(
-            executionContext,
-            NotificationReferenceType.API,
-            apiId,
-            applicationId,
-            paramsBuilder.build(),
-            hook
-        );
+        triggerSubscriptionNotificationsForApi(executionContext, apiId, applicationId, paramsBuilder.build(), hook);
     }
 
     private Map<String, Object> buildSubscriptionNotificationParamsForApiProduct(
@@ -984,6 +963,17 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         return paramsBuilder.build();
     }
 
+    private void triggerSubscriptionNotificationsForApi(
+        ExecutionContext executionContext,
+        String apiId,
+        String applicationId,
+        Map<String, Object> params,
+        ApiHook hook
+    ) {
+        notifierService.trigger(executionContext, hook, NotificationReferenceType.API, apiId, params);
+        notifierService.trigger(executionContext, ApplicationHook.valueOf(hook.name()), applicationId, params);
+    }
+
     private void triggerSubscriptionNotificationsForApiProduct(
         ExecutionContext executionContext,
         String apiProductId,
@@ -993,7 +983,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         SubscriptionEntity subscriptionEntity,
         Optional<String> subscriptionsUrl,
         boolean includeSubscribedByUser,
-        ApiHook hook
+        ApiProductHook hook
     ) throws TechnicalException {
         Map<String, Object> params = buildSubscriptionNotificationParamsForApiProduct(
             executionContext,
@@ -1005,14 +995,8 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             includeSubscribedByUser
         );
         if (!params.isEmpty()) {
-            triggerSubscriptionNotifications(
-                executionContext,
-                NotificationReferenceType.API_PRODUCT,
-                apiProductId,
-                applicationId,
-                params,
-                hook
-            );
+            notifierService.trigger(executionContext, hook, apiProductId, params);
+            notifierService.trigger(executionContext, ApplicationHook.valueOf(hook.name()), applicationId, params);
         }
     }
 
@@ -1313,7 +1297,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                     result,
                     Optional.empty(),
                     false,
-                    ApiHook.SUBSCRIPTION_FAILED
+                    ApiProductHook.SUBSCRIPTION_FAILED
                 );
             } else if (owner != null) {
                 triggerSubscriptionNotificationsForApi(
@@ -1374,7 +1358,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                     result,
                     Optional.empty(),
                     false,
-                    ApiHook.SUBSCRIPTION_FAILED
+                    ApiProductHook.SUBSCRIPTION_FAILED
                 );
             } else if (owner != null) {
                 triggerSubscriptionNotificationsForApi(
@@ -1504,7 +1488,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                         convert(subscription),
                         Optional.empty(),
                         false,
-                        ApiHook.SUBSCRIPTION_PAUSED
+                        ApiProductHook.SUBSCRIPTION_PAUSED
                     );
                 } else if (owner != null) {
                     triggerSubscriptionNotificationsForApi(
@@ -1716,7 +1700,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                         convert(subscription),
                         Optional.empty(),
                         false,
-                        ApiHook.SUBSCRIPTION_RESUMED
+                        ApiProductHook.SUBSCRIPTION_RESUMED
                     );
                 } else if (owner != null) {
                     triggerSubscriptionNotificationsForApi(
@@ -2103,7 +2087,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                     subscriptionEntity,
                     Optional.empty(),
                     false,
-                    ApiHook.SUBSCRIPTION_TRANSFERRED
+                    ApiProductHook.SUBSCRIPTION_TRANSFERRED
                 );
             } else if (owner != null) {
                 triggerSubscriptionNotificationsForApi(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/ApiProductHook.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/ApiProductHook.java
@@ -23,6 +23,18 @@ package io.gravitee.rest.api.service.notification;
  * @author GraviteeSource Team
  */
 public enum ApiProductHook implements Hook {
+    APIKEY_EXPIRED("API-Key Expired", "Triggered when an API Key is expired.", "API KEY"),
+    APIKEY_RENEWED("API-Key Renewed", "Triggered when an API Key is renewed.", "API KEY"),
+    APIKEY_REVOKED("API-Key Revoked", "Triggered when an API Key is revoked.", "API KEY"),
+    SUBSCRIPTION_NEW("New Subscription", "Triggered when a Subscription is created.", "SUBSCRIPTION"),
+    SUBSCRIPTION_ACCEPTED("Subscription Accepted", "Triggered when a Subscription is accepted.", "SUBSCRIPTION"),
+    SUBSCRIPTION_CLOSED("Subscription Closed", "Triggered when a Subscription is closed.", "SUBSCRIPTION"),
+    SUBSCRIPTION_PAUSED("Subscription Paused", "Triggered when a Subscription is paused.", "SUBSCRIPTION"),
+    SUBSCRIPTION_RESUMED("Subscription Resumed", "Triggered when a Subscription is resumed.", "SUBSCRIPTION"),
+    SUBSCRIPTION_REJECTED("Subscription Rejected", "Triggered when a Subscription is rejected.", "SUBSCRIPTION"),
+    SUBSCRIPTION_TRANSFERRED("Subscription Transferred", "Triggered when a Subscription is transferred.", "SUBSCRIPTION"),
+    SUBSCRIPTION_FAILED("Subscription Failed", "Triggered when a Subscription fails.", "SUBSCRIPTION"),
+    API_PRODUCT_DEPLOYED("API Product Deployed", "Triggered when an API Product is deployed.", "LIFECYCLE"),
     API_PRODUCT_UPDATED("API Product Updated", "Triggered when an API Product is updated.", "LIFECYCLE");
 
     private final String label;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiProductNotificationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiProductNotificationService.java
@@ -24,5 +24,6 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
  * @author GraviteeSource Team
  */
 public interface ApiProductNotificationService {
+    void triggerDeployNotification(ExecutionContext executionContext, ApiProduct apiProduct);
     void triggerUpdateNotification(ExecutionContext executionContext, ApiProduct apiProduct);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiProductNotificationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiProductNotificationServiceImpl.java
@@ -63,10 +63,16 @@ public class ApiProductNotificationServiceImpl extends AbstractService implement
     @Override
     @Async("asyncNotificationThreadPoolTaskExecutor")
     public void triggerUpdateNotification(final ExecutionContext executionContext, final ApiProduct apiProduct) {
-        triggerNotification(executionContext, apiProduct);
+        triggerNotification(executionContext, ApiProductHook.API_PRODUCT_UPDATED, apiProduct);
     }
 
-    private void triggerNotification(final ExecutionContext executionContext, final ApiProduct apiProduct) {
+    @Override
+    @Async("asyncNotificationThreadPoolTaskExecutor")
+    public void triggerDeployNotification(final ExecutionContext executionContext, final ApiProduct apiProduct) {
+        triggerNotification(executionContext, ApiProductHook.API_PRODUCT_DEPLOYED, apiProduct);
+    }
+
+    private void triggerNotification(final ExecutionContext executionContext, final ApiProductHook hook, final ApiProduct apiProduct) {
         UserDetails auth = getAuthenticatedUser();
         if (auth != null && !auth.isSystem()) {
             UserEntity userEntity = userService.findById(executionContext, auth.getUsername());
@@ -79,7 +85,7 @@ public class ApiProductNotificationServiceImpl extends AbstractService implement
                 .build();
             notifierService.trigger(
                 executionContext,
-                ApiProductHook.API_PRODUCT_UPDATED,
+                hook,
                 apiProduct.getId(),
                 new NotificationParamsBuilder().apiProduct(model).user(userEntity).build()
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/TriggerNotificationDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/TriggerNotificationDomainServiceInMemory.java
@@ -18,9 +18,10 @@ package inmemory;
 import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
 import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.apim.core.notification.model.hook.ApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.ApiProductHookContext;
 import io.gravitee.apim.core.notification.model.hook.ApplicationHookContext;
+import io.gravitee.apim.core.notification.model.hook.HookContext;
 import io.gravitee.apim.core.notification.model.hook.portal.PortalHookContext;
-import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -33,24 +34,28 @@ public class TriggerNotificationDomainServiceInMemory implements TriggerNotifica
         }
     }
 
-    private final List<ApiHookContext> apiNotifications = new ArrayList<>();
+    private final List<HookContext> hookNotifications = new ArrayList<>();
     private final List<ApplicationNotification> applicationNotifications = new ArrayList<>();
     private final List<PortalHookContext> portalNotifications = new ArrayList<>();
 
     @Override
     public void triggerApiNotification(String organizationId, String environmentId, ApiHookContext hookContext) {
-        apiNotifications.add(hookContext);
+        hookNotifications.add(hookContext);
     }
 
     @Override
-    public void triggerSubscriptionReferenceNotification(
+    public void triggerApiSubscriptionNotification(
         String organizationId,
         String environmentId,
-        SubscriptionReferenceType referenceType,
         String referenceId,
         ApiHookContext context
     ) {
-        apiNotifications.add(context);
+        hookNotifications.add(context);
+    }
+
+    @Override
+    public void triggerApiProductNotification(String organizationId, String environmentId, ApiProductHookContext context) {
+        hookNotifications.add(context);
     }
 
     @Override
@@ -74,8 +79,8 @@ public class TriggerNotificationDomainServiceInMemory implements TriggerNotifica
         portalNotifications.add(hookContext);
     }
 
-    public List<ApiHookContext> getApiNotifications() {
-        return Collections.unmodifiableList(apiNotifications);
+    public List<HookContext> getHookNotifications() {
+        return Collections.unmodifiableList(hookNotifications);
     }
 
     public List<ApplicationNotification> getApplicationNotifications() {
@@ -87,7 +92,7 @@ public class TriggerNotificationDomainServiceInMemory implements TriggerNotifica
     }
 
     public void reset() {
-        apiNotifications.clear();
+        hookNotifications.clear();
         applicationNotifications.clear();
         portalNotifications.clear();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateNativeApiDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/UpdateNativeApiDomainServiceTest.java
@@ -391,7 +391,7 @@ class UpdateNativeApiDomainServiceTest {
             oneShotIndexation(auditInfo)
         );
 
-        assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
             new ApiUpdatedApiHookContext(apiToUpdate.getId())
         );
     }
@@ -444,7 +444,7 @@ class UpdateNativeApiDomainServiceTest {
             oneShotIndexation(auditInfo)
         );
 
-        assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
             new ApiDeprecatedApiHookContext(apiToUpdate.getId()),
             new ApiUpdatedApiHookContext(apiToUpdate.getId())
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCaseTest.java
@@ -359,7 +359,7 @@ public class UpdateNativeApiUseCaseTest {
         assertThat(flowCrudService.storage()).containsExactly(NativeFlow.builder().id("new").build());
         verify(categoryDomainService, times(1)).updateOrderCategoriesOfApi(eq(existingApi.getId()), eq(Set.of("new")));
         assertThat(auditCrudService.storage()).hasSize(1);
-        assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
             new ApiUpdatedApiHookContext(existingApi.getId())
         );
         verify(categoryDomainService, times(1)).toCategoryKey(eq(apiToUpdate), eq(ENVIRONMENT_ID));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/RevokeApiKeyDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/domain_service/RevokeApiKeyDomainServiceTest.java
@@ -33,6 +33,7 @@ import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.event.ApiKeyAuditEvent;
 import io.gravitee.apim.core.notification.model.hook.ApiKeyRevokedApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.ApiKeyRevokedApiProductHookContext;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
@@ -339,14 +340,14 @@ class RevokeApiKeyDomainServiceTest {
             service.revoke(apiKey, AUDIT_INFO);
 
             // Then
-            assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
-                new ApiKeyRevokedApiHookContext(SubscriptionReferenceType.API, API_ID_1, APPLICATION_ID_1, PLAN_ID_1, apiKey.getKey()),
-                new ApiKeyRevokedApiHookContext(SubscriptionReferenceType.API, API_ID_2, APPLICATION_ID_2, PLAN_ID_2, apiKey.getKey())
+            assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+                new ApiKeyRevokedApiHookContext(API_ID_1, APPLICATION_ID_1, PLAN_ID_1, apiKey.getKey()),
+                new ApiKeyRevokedApiHookContext(API_ID_2, APPLICATION_ID_2, PLAN_ID_2, apiKey.getKey())
             );
         }
 
         @Test
-        void should_trigger_api_notification_with_api_product_reference_type_for_api_product_subscription() {
+        void should_trigger_api_product_notification_for_api_product_subscription() {
             // Given - subscription for API Product
             var subscription = SubscriptionFixtures.aSubscription()
                 .toBuilder()
@@ -363,14 +364,8 @@ class RevokeApiKeyDomainServiceTest {
             service.revoke(apiKey, AUDIT_INFO);
 
             // Then - context uses API_PRODUCT and API_PRODUCT_ID
-            assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
-                new ApiKeyRevokedApiHookContext(
-                    SubscriptionReferenceType.API_PRODUCT,
-                    API_PRODUCT_ID,
-                    APPLICATION_ID_1,
-                    PLAN_ID_1,
-                    apiKey.getKey()
-                )
+            assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+                new ApiKeyRevokedApiProductHookContext(API_PRODUCT_ID, APPLICATION_ID_1, PLAN_ID_1, apiKey.getKey())
             );
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApiSubscriptionApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApiSubscriptionApiKeyUseCaseTest.java
@@ -282,8 +282,8 @@ class RevokeApiSubscriptionApiKeyUseCaseTest {
         usecase.execute(new Input(API_KEY_ID, API_ID, SubscriptionReferenceType.API.name(), SUBSCRIPTION_ID, AUDIT_INFO));
 
         // Then
-        assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
-            new ApiKeyRevokedApiHookContext(SubscriptionReferenceType.API, API_ID, APPLICATION_ID, PLAN_1, apiKey.getKey())
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+            new ApiKeyRevokedApiHookContext(API_ID, APPLICATION_ID, PLAN_1, apiKey.getKey())
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationApiKeyUseCaseTest.java
@@ -39,7 +39,6 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.event.ApiKeyAuditEvent;
 import io.gravitee.apim.core.notification.model.hook.ApiKeyRevokedApiHookContext;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
-import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
@@ -249,9 +248,9 @@ class RevokeApplicationApiKeyUseCaseTest {
         usecase.execute(new Input(API_KEY_ID, APPLICATION_ID, AUDIT_INFO));
 
         // Then
-        assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
-            new ApiKeyRevokedApiHookContext(SubscriptionReferenceType.API, API_1, APPLICATION_ID, PLAN_1, apiKey.getKey()),
-            new ApiKeyRevokedApiHookContext(SubscriptionReferenceType.API, API_2, APPLICATION_ID, PLAN_2, apiKey.getKey())
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+            new ApiKeyRevokedApiHookContext(API_1, APPLICATION_ID, PLAN_1, apiKey.getKey()),
+            new ApiKeyRevokedApiHookContext(API_2, APPLICATION_ID, PLAN_2, apiKey.getKey())
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationSubscriptionApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeApplicationSubscriptionApiKeyUseCaseTest.java
@@ -39,7 +39,6 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.event.ApiKeyAuditEvent;
 import io.gravitee.apim.core.notification.model.hook.ApiKeyRevokedApiHookContext;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
-import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
@@ -265,8 +264,8 @@ class RevokeApplicationSubscriptionApiKeyUseCaseTest {
         usecase.execute(new Input(API_KEY_ID, APPLICATION_ID, SUBSCRIPTION_ID, AUDIT_INFO));
 
         // Then
-        assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
-            new ApiKeyRevokedApiHookContext(SubscriptionReferenceType.API, API_ID, APPLICATION_ID, PLAN_1, apiKey.getKey())
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+            new ApiKeyRevokedApiHookContext(API_ID, APPLICATION_ID, PLAN_1, apiKey.getKey())
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeSubscriptionApiKeyUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_key/use_case/RevokeSubscriptionApiKeyUseCaseTest.java
@@ -39,7 +39,6 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.event.ApiKeyAuditEvent;
 import io.gravitee.apim.core.notification.model.hook.ApiKeyRevokedApiHookContext;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
-import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
@@ -253,8 +252,8 @@ class RevokeSubscriptionApiKeyUseCaseTest {
         usecase.execute(new Input(SUBSCRIPTION_ID, KEY, API_ID, "API", AUDIT_INFO));
 
         // Then
-        assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
-            new ApiKeyRevokedApiHookContext(SubscriptionReferenceType.API, API_ID, APPLICATION_ID, PLAN_1, apiKey.getKey())
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+            new ApiKeyRevokedApiHookContext(API_ID, APPLICATION_ID, PLAN_1, apiKey.getKey())
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -62,6 +62,8 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
+import java.util.Arrays;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -196,6 +198,15 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
         verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
         verify(eventLatestCrudService).createOrPatchLatestEvent(eq(ORG_ID), eq(GENERATED_UUID), any());
         verify(apiProductIndexerDomainService).index(any(), eq(output.apiProduct()), any());
+        assertThat(notificationConfigCrudService.storage())
+            .singleElement()
+            .satisfies(config -> {
+                assertThat(config.getReferenceType()).isEqualTo("API_PRODUCT");
+                assertThat(config.getReferenceId()).isEqualTo(GENERATED_UUID);
+                assertThat(config.getHooks()).containsExactlyInAnyOrderElementsOf(
+                    Arrays.stream(ApiProductHook.values()).map(Enum::name).toList()
+                );
+            });
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/DeployApiProductUseCaseTest.java
@@ -31,6 +31,7 @@ import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import inmemory.TriggerNotificationDomainServiceInMemory;
 import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
@@ -40,6 +41,7 @@ import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
+import io.gravitee.apim.core.notification.model.hook.ApiProductDeployedHookContext;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
@@ -56,6 +58,8 @@ class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
     private final EventCrudService eventCrudService = mock(EventCrudService.class);
     private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
     private final LicenseManager licenseManager = mock(LicenseManager.class);
+    private final TriggerNotificationDomainServiceInMemory triggerNotificationDomainService =
+        new TriggerNotificationDomainServiceInMemory();
     private DeployApiProductUseCase deployApiProductUseCase;
 
     @BeforeEach
@@ -71,7 +75,8 @@ class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
             apiProductQueryService,
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
             validateApiProductService,
-            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService)
+            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService),
+            triggerNotificationDomainService
         );
     }
 
@@ -91,6 +96,9 @@ class DeployApiProductUseCaseTest extends AbstractUseCaseTest {
 
         verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
         verify(eventLatestCrudService).createOrPatchLatestEvent(eq(ORG_ID), eq(productId), any());
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+            new ApiProductDeployedHookContext(productId, USER_ID)
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
@@ -36,6 +36,7 @@ import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import inmemory.TriggerNotificationDomainServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
@@ -50,6 +51,7 @@ import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
+import io.gravitee.apim.core.notification.model.hook.ApiProductUpdatedHookContext;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
@@ -76,12 +78,15 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
     private final ApiStateDomainService apiStateDomainService = mock(ApiStateDomainService.class);
     private final ApiProductIndexerDomainService apiProductIndexerDomainService = mock(ApiProductIndexerDomainService.class);
     private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService = mock(ApiProductPrimaryOwnerDomainService.class);
+    private final TriggerNotificationDomainServiceInMemory triggerNotificationDomainService =
+        new TriggerNotificationDomainServiceInMemory();
 
     private UpdateApiProductUseCase updateApiProductUseCase;
 
     @BeforeEach
     void setUp() {
         planQueryService.reset();
+        triggerNotificationDomainService.reset();
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
         var validateApiProductService = new ValidateApiProductService(
             apiQueryService,
@@ -99,7 +104,8 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
             apiProductIndexerDomainService,
             apiProductPrimaryOwnerDomainService,
-            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService)
+            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService),
+            triggerNotificationDomainService
         );
     }
 
@@ -137,6 +143,56 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
         verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
         verify(eventLatestCrudService).createOrPatchLatestEvent(eq(ORG_ID), eq("api-product-id"), any());
         verify(apiProductIndexerDomainService).index(any(), eq(output.apiProduct()), any());
+    }
+
+    @Test
+    void should_trigger_api_product_updated_notification_after_successful_update() {
+        givenPublishedApiProductPlan();
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("Old Name")
+            .version("1.0.0")
+            .description("desc")
+            .apiIds(Set.of("api-1"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        Api api2 = createV4ProxyApi("api-2", true);
+        apiCrudService.initWith(List.of(api2));
+
+        var toUpdate = UpdateApiProduct.builder().name("New Name").version("2.0.0").description("new desc").apiIds(Set.of("api-2")).build();
+
+        var input = new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO);
+        var output = updateApiProductUseCase.execute(input);
+
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+            new ApiProductUpdatedHookContext(output.apiProduct().getId(), USER_ID)
+        );
+    }
+
+    @Test
+    void should_not_trigger_api_product_updated_notification_when_validation_fails_before_persist() {
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .apiIds(Set.of("api-1"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        Api allowedApi = createV4ProxyApi("api-allowed", true);
+        Api notAllowedApi = createV4ProxyApi("api-not-allowed", false);
+        apiCrudService.initWith(List.of(allowedApi, notAllowedApi));
+
+        var toUpdate = UpdateApiProduct.builder().apiIds(Set.of("api-allowed", "api-not-allowed")).build();
+        var input = new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO);
+
+        Assertions.assertThatThrownBy(() -> updateApiProductUseCase.execute(input)).isInstanceOf(ValidationDomainException.class);
+        assertThat(triggerNotificationDomainService.getHookNotifications()).isEmpty();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/AcceptSubscriptionDomainServiceTest.java
@@ -35,6 +35,7 @@ import io.gravitee.apim.core.audit.model.event.SubscriptionAuditEvent;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
 import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionAcceptedApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.SubscriptionAcceptedApiProductHookContext;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionAcceptedApplicationHookContext;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
@@ -94,6 +95,7 @@ class AcceptSubscriptionDomainServiceTest {
     private static final String REASON = "Subscription accepted";
 
     private static final String APPLICATION_ID = "application-id";
+    private static final String API_PRODUCT_ID = "api-product-id";
 
     private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
 
@@ -343,15 +345,8 @@ class AcceptSubscriptionDomainServiceTest {
         accept(subscription, PLAN_PUBLISHED);
 
         // Then
-        assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
-            new SubscriptionAcceptedApiHookContext(
-                SubscriptionReferenceType.API,
-                "api-id",
-                "application-id",
-                "plan-published",
-                "subscription-id",
-                USER_ID
-            )
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+            new SubscriptionAcceptedApiHookContext("api-id", "application-id", "plan-published", "subscription-id", USER_ID)
         );
 
         assertThat(triggerNotificationDomainService.getApplicationNotifications()).containsExactly(
@@ -366,6 +361,74 @@ class AcceptSubscriptionDomainServiceTest {
                 )
             )
         );
+    }
+
+    @Test
+    void should_trigger_api_product_hooks_and_audits_when_accepting_subscription_on_api_product() {
+        SubscriptionEntity subscription = givenExistingSubscription(
+            SubscriptionFixtures.aSubscription()
+                .toBuilder()
+                .referenceId(API_PRODUCT_ID)
+                .referenceType(SubscriptionReferenceType.API_PRODUCT)
+                .subscribedBy("subscriber")
+                .planId(PLAN_PUBLISHED.getId())
+                .applicationId(APPLICATION_ID)
+                .status(SubscriptionEntity.Status.PENDING)
+                .build()
+        );
+
+        accept(subscription, PLAN_PUBLISHED);
+
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+            new SubscriptionAcceptedApiProductHookContext(
+                API_PRODUCT_ID,
+                APPLICATION_ID,
+                PLAN_PUBLISHED.getId(),
+                "subscription-id",
+                USER_ID
+            )
+        );
+        assertThat(triggerNotificationDomainService.getApplicationNotifications()).containsExactly(
+            new TriggerNotificationDomainServiceInMemory.ApplicationNotification(
+                new SubscriptionAcceptedApplicationHookContext(
+                    APPLICATION_ID,
+                    SubscriptionReferenceType.API_PRODUCT,
+                    API_PRODUCT_ID,
+                    PLAN_PUBLISHED.getId(),
+                    "subscription-id",
+                    USER_ID
+                )
+            )
+        );
+
+        assertThat(auditCrudServiceInMemory.storage())
+            .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt", "patch")
+            .contains(
+                new AuditEntity(
+                    "generated-id",
+                    ORGANIZATION_ID,
+                    ENVIRONMENT_ID,
+                    AuditEntity.AuditReferenceType.API_PRODUCT,
+                    API_PRODUCT_ID,
+                    USER_ID,
+                    Map.of("APPLICATION", "application-id"),
+                    SubscriptionAuditEvent.SUBSCRIPTION_UPDATED.name(),
+                    ZonedDateTime.now(),
+                    ""
+                ),
+                new AuditEntity(
+                    "generated-id",
+                    ORGANIZATION_ID,
+                    ENVIRONMENT_ID,
+                    AuditEntity.AuditReferenceType.APPLICATION,
+                    "application-id",
+                    USER_ID,
+                    Map.of("API_PRODUCT", API_PRODUCT_ID),
+                    SubscriptionAuditEvent.SUBSCRIPTION_UPDATED.name(),
+                    ZonedDateTime.now(),
+                    ""
+                )
+            );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/CloseSubscriptionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/CloseSubscriptionDomainServiceTest.java
@@ -132,13 +132,7 @@ class CloseSubscriptionDomainServiceTest {
         verify(auditDomainService).createApiProductAuditLog(any());
         verify(auditDomainService).createApplicationAuditLog(any());
         verify(triggerNotificationDomainService, never()).triggerApiNotification(anyString(), anyString(), any());
-        verify(triggerNotificationDomainService).triggerSubscriptionReferenceNotification(
-            anyString(),
-            anyString(),
-            eq(SubscriptionReferenceType.API_PRODUCT),
-            eq(API_PRODUCT_ID),
-            any()
-        );
+        verify(triggerNotificationDomainService).triggerApiProductNotification(anyString(), anyString(), any());
         verify(triggerNotificationDomainService).triggerApplicationNotification(anyString(), anyString(), any());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/RejectSubscriptionDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/domain_service/RejectSubscriptionDomainServiceTest.java
@@ -42,6 +42,7 @@ import io.gravitee.apim.core.audit.model.event.SubscriptionAuditEvent;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
 import io.gravitee.apim.core.notification.model.Recipient;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionRejectedApiHookContext;
+import io.gravitee.apim.core.notification.model.hook.SubscriptionRejectedApiProductHookContext;
 import io.gravitee.apim.core.notification.model.hook.SubscriptionRejectedApplicationHookContext;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
@@ -181,15 +182,8 @@ public class RejectSubscriptionDomainServiceTest {
                 softly.assertThat(result.getStatus()).isEqualTo(SubscriptionEntity.Status.REJECTED);
             });
 
-            assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
-                new SubscriptionRejectedApiHookContext(
-                    SubscriptionReferenceType.API,
-                    "api-id",
-                    "application-id",
-                    "plan-published",
-                    "subscription-id",
-                    USER_ID
-                )
+            assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+                new SubscriptionRejectedApiHookContext("api-id", "application-id", "plan-published", "subscription-id", USER_ID)
             );
 
             if (shouldTriggerEmailNotification) {
@@ -298,15 +292,8 @@ public class RejectSubscriptionDomainServiceTest {
                 softly.assertThat(result.getStatus()).isEqualTo(SubscriptionEntity.Status.REJECTED);
             });
 
-            assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
-                new SubscriptionRejectedApiHookContext(
-                    SubscriptionReferenceType.API,
-                    "api-id",
-                    "application-id",
-                    "plan-published",
-                    "subscription-id",
-                    USER_ID
-                )
+            assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+                new SubscriptionRejectedApiHookContext("api-id", "application-id", "plan-published", "subscription-id", USER_ID)
             );
 
             if (shouldTriggerEmailNotification) {
@@ -371,6 +358,74 @@ public class RejectSubscriptionDomainServiceTest {
                         "application-id",
                         USER_ID,
                         Map.of("API", "api-id"),
+                        SubscriptionAuditEvent.SUBSCRIPTION_UPDATED.name(),
+                        ZonedDateTime.now(),
+                        ""
+                    )
+                );
+        }
+    }
+
+    @Nested
+    class When_subscription_targets_an_api_product {
+
+        private static final String API_PRODUCT_ID = "api-product-id";
+
+        @Test
+        void should_route_reject_notifications_and_audits_to_api_product_scope() {
+            SubscriptionEntity subscription = SubscriptionFixtures.aSubscription()
+                .toBuilder()
+                .referenceId(API_PRODUCT_ID)
+                .referenceType(SubscriptionReferenceType.API_PRODUCT)
+                .subscribedBy("subscriber")
+                .planId(PLAN_PUBLISHED)
+                .status(SubscriptionEntity.Status.PENDING)
+                .build();
+            givenExistingSubscription(subscription);
+
+            SubscriptionEntity result = reject(subscription);
+
+            assertThat(result.getStatus()).isEqualTo(SubscriptionEntity.Status.REJECTED);
+
+            assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+                new SubscriptionRejectedApiProductHookContext(API_PRODUCT_ID, APPLICATION_ID, PLAN_PUBLISHED, "subscription-id", USER_ID)
+            );
+            assertThat(triggerNotificationDomainService.getApplicationNotifications()).containsExactly(
+                new ApplicationNotification(
+                    new SubscriptionRejectedApplicationHookContext(
+                        APPLICATION_ID,
+                        SubscriptionReferenceType.API_PRODUCT,
+                        API_PRODUCT_ID,
+                        PLAN_PUBLISHED,
+                        "subscription-id",
+                        USER_ID
+                    )
+                )
+            );
+
+            assertThat(auditCrudServiceInMemory.storage())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("createdAt", "patch")
+                .containsExactly(
+                    new AuditEntity(
+                        "audit-id",
+                        ORGANIZATION_ID,
+                        ENVIRONMENT_ID,
+                        AuditEntity.AuditReferenceType.API_PRODUCT,
+                        API_PRODUCT_ID,
+                        USER_ID,
+                        Map.of("APPLICATION", "application-id"),
+                        SubscriptionAuditEvent.SUBSCRIPTION_UPDATED.name(),
+                        ZonedDateTime.now(),
+                        ""
+                    ),
+                    new AuditEntity(
+                        "audit-id",
+                        ORGANIZATION_ID,
+                        ENVIRONMENT_ID,
+                        AuditEntity.AuditReferenceType.APPLICATION,
+                        APPLICATION_ID,
+                        USER_ID,
+                        Map.of("API_PRODUCT", API_PRODUCT_ID),
                         SubscriptionAuditEvent.SUBSCRIPTION_UPDATED.name(),
                         ZonedDateTime.now(),
                         ""

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/AcceptSubscriptionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/AcceptSubscriptionUseCaseTest.java
@@ -464,15 +464,8 @@ class AcceptSubscriptionUseCaseTest {
         accept(subscription.getId());
 
         // Then
-        assertThat(triggerNotificationDomainService.getApiNotifications()).containsExactly(
-            new SubscriptionAcceptedApiHookContext(
-                SubscriptionReferenceType.API,
-                "api-id",
-                application.getId(),
-                plan.getId(),
-                subscription.getId(),
-                null
-            )
+        assertThat(triggerNotificationDomainService.getHookNotifications()).containsExactly(
+            new SubscriptionAcceptedApiHookContext("api-id", application.getId(), plan.getId(), subscription.getId(), null)
         );
 
         assertThat(triggerNotificationDomainService.getApplicationNotifications()).containsExactly(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/CloseSubscriptionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/CloseSubscriptionUseCaseTest.java
@@ -320,8 +320,8 @@ class CloseSubscriptionUseCaseTest {
         usecase.execute(new Input(SUBSCRIPTION_ID, AUDIT_INFO));
 
         // Then
-        assertThat(triggerNotificationService.getApiNotifications()).containsExactly(
-            new SubscriptionClosedApiHookContext(SubscriptionReferenceType.API, api.getId(), APPLICATION_ID, "plan-id")
+        assertThat(triggerNotificationService.getHookNotifications()).containsExactly(
+            new SubscriptionClosedApiHookContext(api.getId(), APPLICATION_ID, "plan-id")
         );
         assertThat(triggerNotificationService.getApplicationNotifications()).containsExactly(
             new ApplicationNotification(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/RejectSubscriptionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/RejectSubscriptionUseCaseTest.java
@@ -251,15 +251,8 @@ class RejectSubscriptionUseCaseTest {
         reject(subscription.getId());
 
         // Then
-        assertThat(triggerNotificationService.getApiNotifications()).containsExactly(
-            new SubscriptionRejectedApiHookContext(
-                SubscriptionReferenceType.API,
-                "api-id",
-                "application-id",
-                "plan-published",
-                "subscription-id",
-                USER_ID
-            )
+        assertThat(triggerNotificationService.getHookNotifications()).containsExactly(
+            new SubscriptionRejectedApiHookContext("api-id", "application-id", "plan-published", "subscription-id", USER_ID)
         );
 
         assertThat(triggerNotificationService.getApplicationNotifications()).containsExactly(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/notification/TriggerNotificationDomainServiceFacadeImplTest.java
@@ -53,7 +53,6 @@ import io.gravitee.apim.core.notification.model.hook.ApiHookContext;
 import io.gravitee.apim.core.notification.model.hook.ApplicationHookContext;
 import io.gravitee.apim.core.notification.model.hook.HookContextEntry;
 import io.gravitee.apim.core.notification.model.hook.portal.PortalHookContext;
-import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.apim.infra.notification.internal.TemplateDataFetcher;
@@ -72,7 +71,6 @@ import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.repository.management.model.ApplicationType;
 import io.gravitee.repository.management.model.Integration;
-import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.rest.api.service.NotifierService;
@@ -532,62 +530,15 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
         }
 
         @Test
-        public void should_call_notifier_with_4_args_when_context_has_no_reference_type_api() {
-            // Given - context without referenceType (e.g. API_UPDATED, API_DEPRECATED) → facade uses 4-arg overload
+        public void should_call_notifier_with_4_args_for_api_hook_context() {
             final SimpleApiHookContextForTest apiHookContext = new SimpleApiHookContextForTest(API_ID);
             givenExistingApi(anApi().withId(API_ID), PrimaryOwnerEntity.builder().id(USER_ID).build());
 
-            // When
             service.triggerApiNotification(ORGANIZATION_ID, ENVIRONMENT_ID, apiHookContext);
 
-            // Then - 4-arg overload: trigger(execContext, hook, referenceId, params); notifier defaults to API
             verify(notifierService).trigger(
                 eq(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID)),
                 eq(ApiHook.SUBSCRIPTION_CLOSED),
-                eq(API_ID),
-                paramsCaptor.capture()
-            );
-        }
-
-        @Test
-        public void should_call_notifier_with_5_args_and_api_product_type_when_context_has_reference_type_api_product() {
-            // Given - context with referenceType API_PRODUCT (e.g. APIKEY_REVOKED for API Product subscription)
-            givenExistingApiProduct(
-                ApiProduct.builder().id(API_PRODUCT_ID).name("product-name").version("1.0").environmentId(ENVIRONMENT_ID).build()
-            );
-            final SimpleApiHookContextForTest apiHookContext = new SimpleApiHookContextForTest(
-                API_PRODUCT_ID,
-                SubscriptionReferenceType.API_PRODUCT
-            );
-
-            // When
-            service.triggerApiNotification(ORGANIZATION_ID, ENVIRONMENT_ID, apiHookContext);
-
-            // Then - 5-arg overload with NotificationReferenceType.API_PRODUCT
-            verify(notifierService).trigger(
-                eq(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID)),
-                eq(ApiHook.SUBSCRIPTION_CLOSED),
-                eq(NotificationReferenceType.API_PRODUCT),
-                eq(API_PRODUCT_ID),
-                paramsCaptor.capture()
-            );
-            assertThat(paramsCaptor.getValue()).containsKey("apiProduct");
-        }
-
-        @Test
-        public void should_call_notifier_with_5_args_and_api_type_when_context_has_reference_type_api() {
-            // Given - context with explicit referenceType API
-            givenExistingApi(anApi().withId(API_ID), PrimaryOwnerEntity.builder().id(USER_ID).build());
-            final SimpleApiHookContextForTest apiHookContext = new SimpleApiHookContextForTest(API_ID, SubscriptionReferenceType.API);
-
-            // When
-            service.triggerApiNotification(ORGANIZATION_ID, ENVIRONMENT_ID, apiHookContext);
-
-            // Then - 5-arg overload with NotificationReferenceType.API
-            verify(notifierService).trigger(
-                eq(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID)),
-                eq(ApiHook.SUBSCRIPTION_CLOSED),
-                eq(NotificationReferenceType.API),
                 eq(API_ID),
                 paramsCaptor.capture()
             );
@@ -606,11 +557,6 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
                 this.properties = properties;
             }
 
-            public SimpleApiHookContextForTest(String referenceId, SubscriptionReferenceType referenceType) {
-                super(ApiHook.SUBSCRIPTION_CLOSED, referenceId, referenceType);
-                this.properties = new HashMap<>();
-            }
-
             public SimpleApiHookContextForTest(String referenceId, Map<HookContextEntry, String> properties, ApiHook hook) {
                 super(hook, referenceId);
                 this.properties = properties;
@@ -627,47 +573,16 @@ public class TriggerNotificationDomainServiceFacadeImplTest {
     class TriggerSubscriptionReferenceNotification {
 
         @Test
-        public void should_call_notifier_with_api_reference_type_for_api_subscription() {
+        public void should_call_notifier_with_4_args_for_api_subscription_notification() {
             givenExistingApi(anApi().withId(API_ID), PrimaryOwnerEntity.builder().id(USER_ID).build());
             var context = new TriggerApiNotification.SimpleApiHookContextForTest(API_ID);
 
-            service.triggerSubscriptionReferenceNotification(
-                ORGANIZATION_ID,
-                ENVIRONMENT_ID,
-                SubscriptionReferenceType.API,
-                API_ID,
-                context
-            );
+            service.triggerApiSubscriptionNotification(ORGANIZATION_ID, ENVIRONMENT_ID, API_ID, context);
 
             verify(notifierService).trigger(
                 eq(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID)),
                 eq(ApiHook.SUBSCRIPTION_CLOSED),
-                eq(NotificationReferenceType.API),
                 eq(API_ID),
-                any()
-            );
-        }
-
-        @Test
-        public void should_call_notifier_with_api_product_reference_type_for_api_product_subscription() {
-            givenExistingApiProduct(
-                ApiProduct.builder().id(API_PRODUCT_ID).name("product-name").version("1.0").environmentId(ENVIRONMENT_ID).build()
-            );
-            var context = new TriggerApiNotification.SimpleApiHookContextForTest(API_PRODUCT_ID, SubscriptionReferenceType.API_PRODUCT);
-
-            service.triggerSubscriptionReferenceNotification(
-                ORGANIZATION_ID,
-                ENVIRONMENT_ID,
-                SubscriptionReferenceType.API_PRODUCT,
-                API_PRODUCT_ID,
-                context
-            );
-
-            verify(notifierService).trigger(
-                eq(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID)),
-                eq(ApiHook.SUBSCRIPTION_CLOSED),
-                eq(NotificationReferenceType.API_PRODUCT),
-                eq(API_PRODUCT_ID),
                 any()
             );
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -67,6 +67,7 @@ import io.gravitee.rest.api.service.exceptions.InvalidApplicationApiKeyModeExcep
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotActiveException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
@@ -1274,8 +1275,7 @@ public class ApiKeyServiceTest {
         ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
         verify(notifierService).trigger(
             eq(GraviteeContext.getExecutionContext()),
-            eq(ApiHook.APIKEY_EXPIRED),
-            eq(NotificationReferenceType.API_PRODUCT),
+            eq(ApiProductHook.APIKEY_EXPIRED),
             eq(apiProductId),
             paramsCaptor.capture()
         );
@@ -1330,8 +1330,7 @@ public class ApiKeyServiceTest {
         ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
         verify(notifierService).trigger(
             eq(GraviteeContext.getExecutionContext()),
-            eq(ApiHook.APIKEY_EXPIRED),
-            eq(NotificationReferenceType.API_PRODUCT),
+            eq(ApiProductHook.APIKEY_EXPIRED),
             eq(apiProductId),
             paramsCaptor.capture()
         );
@@ -1380,8 +1379,7 @@ public class ApiKeyServiceTest {
 
         verify(notifierService, never()).trigger(
             eq(GraviteeContext.getExecutionContext()),
-            eq(ApiHook.APIKEY_EXPIRED),
-            eq(NotificationReferenceType.API_PRODUCT),
+            eq(ApiProductHook.APIKEY_EXPIRED),
             eq(apiProductId),
             any()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EmailNotifierServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EmailNotifierServiceTest.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.notifiers.impl.EmailNotifierServiceImpl;
 import java.util.List;
 import java.util.Map;
@@ -72,6 +73,26 @@ public class EmailNotifierServiceTest {
                     new EmailNotificationBuilder()
                         .to(recipientEmail)
                         .template(EmailNotificationBuilder.EmailTemplate.API_API_STARTED)
+                        .params(templateData)
+                        .build()
+                )
+            );
+        }
+
+        @Test
+        void should_send_email_based_on_api_product_hook() {
+            var executionContext = new ExecutionContext(null, null);
+            var templateData = Map.<String, Object>of();
+            var recipientEmail = "recipient1@gravitee.io";
+
+            service.trigger(executionContext, ApiProductHook.API_PRODUCT_UPDATED, templateData, List.of(recipientEmail));
+
+            verify(mockEmailService).sendAsyncEmailNotification(
+                same(executionContext),
+                eq(
+                    new EmailNotificationBuilder()
+                        .to(recipientEmail)
+                        .template(EmailNotificationBuilder.EmailTemplate.API_PRODUCT_UPDATED)
                         .params(templateData)
                         .build()
                 )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_AssociateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_AssociateTest.java
@@ -41,6 +41,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import java.util.Optional;
 import java.util.Set;
@@ -172,8 +173,7 @@ public class GroupService_AssociateTest extends TestCase {
         verify(apiProductsRepository, never()).update(product2);
         verify(notifierService, times(1)).trigger(
             eq(executionContext),
-            eq(ApiHook.API_UPDATED),
-            eq(io.gravitee.repository.management.model.NotificationReferenceType.API_PRODUCT),
+            eq(ApiProductHook.API_PRODUCT_UPDATED),
             eq(product1.getId()),
             any()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -134,6 +134,7 @@ import io.gravitee.rest.api.service.exceptions.SubscriptionNotUpdatableException
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.TransferNotAllowedException;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.ApiProductHook;
 import io.gravitee.rest.api.service.notification.ApplicationHook;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.v4.ApiEntrypointService;
@@ -596,6 +597,10 @@ public class SubscriptionServiceTest {
         when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntityV4);
         when(applicationService.findById(GraviteeContext.getExecutionContext(), APPLICATION_ID)).thenReturn(application);
         when(subscriptionRepository.create(any())).thenAnswer(returnsFirstArg());
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId(apiProductId);
+        apiProduct.setName("API Product");
+        when(apiProductsRepository.findById(apiProductId)).thenReturn(Optional.of(apiProduct));
 
         SecurityContextHolder.setContext(generateSecurityContext());
 
@@ -615,9 +620,18 @@ public class SubscriptionServiceTest {
         verify(subscriptionValidationService, times(1)).validateAndSanitize(any(), eq(newSubscriptionEntity));
         // Verify apiTemplateService is NOT called for API Product subscriptions
         verify(apiTemplateService, never()).findByIdForTemplates(any(), anyString());
-        // Verify notifications are NOT triggered for API Product subscriptions
-        verify(notifierService, never()).trigger(any(), any(ApiHook.class), anyString(), anyMap());
-        verify(notifierService, never()).trigger(any(), any(ApplicationHook.class), anyString(), anyMap());
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApiProductHook.SUBSCRIPTION_NEW),
+            eq(apiProductId),
+            anyMap()
+        );
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApplicationHook.SUBSCRIPTION_NEW),
+            eq(APPLICATION_ID),
+            anyMap()
+        );
         assertNotNull(subscriptionEntity.getId());
         assertNotNull(subscriptionEntity.getApplication());
         assertNotNull(subscriptionEntity.getCreatedAt());
@@ -654,15 +668,28 @@ public class SubscriptionServiceTest {
         when(apiKeyService.findBySubscription(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID)).thenReturn(singletonList(apiKey));
         when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntityV4);
         when(applicationService.findById(GraviteeContext.getExecutionContext(), APPLICATION_ID)).thenReturn(application);
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId(apiProductId);
+        apiProduct.setName("API Product");
+        when(apiProductsRepository.findById(apiProductId)).thenReturn(Optional.of(apiProduct));
         application.setPrimaryOwner(new PrimaryOwnerEntity());
 
         subscriptionService.pause(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
 
         verify(apiKeyService).update(GraviteeContext.getExecutionContext(), apiKey);
-        // Verify notifications are NOT triggered for API Product subscriptions
         verify(apiTemplateService, never()).findByIdForTemplates(any(), anyString());
-        verify(notifierService, never()).trigger(any(), any(ApiHook.class), anyString(), anyMap());
-        verify(notifierService, never()).trigger(any(), any(ApplicationHook.class), anyString(), anyMap());
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApiProductHook.SUBSCRIPTION_PAUSED),
+            eq(apiProductId),
+            anyMap()
+        );
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApplicationHook.SUBSCRIPTION_PAUSED),
+            eq(APPLICATION_ID),
+            anyMap()
+        );
     }
 
     @Test
@@ -690,15 +717,28 @@ public class SubscriptionServiceTest {
         when(apiKeyService.findBySubscription(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID)).thenReturn(singletonList(apiKey));
         when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntityV4);
         when(applicationService.findById(GraviteeContext.getExecutionContext(), APPLICATION_ID)).thenReturn(application);
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId(apiProductId);
+        apiProduct.setName("API Product");
+        when(apiProductsRepository.findById(apiProductId)).thenReturn(Optional.of(apiProduct));
         application.setPrimaryOwner(new PrimaryOwnerEntity());
 
         subscriptionService.resume(GraviteeContext.getExecutionContext(), SUBSCRIPTION_ID);
 
         verify(apiKeyService).update(GraviteeContext.getExecutionContext(), apiKey);
-        // Verify notifications are NOT triggered for API Product subscriptions
         verify(apiTemplateService, never()).findByIdForTemplates(any(), anyString());
-        verify(notifierService, never()).trigger(any(), any(ApiHook.class), anyString(), anyMap());
-        verify(notifierService, never()).trigger(any(), any(ApplicationHook.class), anyString(), anyMap());
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApiProductHook.SUBSCRIPTION_RESUMED),
+            eq(apiProductId),
+            anyMap()
+        );
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApplicationHook.SUBSCRIPTION_RESUMED),
+            eq(APPLICATION_ID),
+            anyMap()
+        );
     }
 
     @Test
@@ -765,6 +805,11 @@ public class SubscriptionServiceTest {
         when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntityV4);
         when(applicationService.findById(any(), any())).thenReturn(applicationEntity);
         when(applicationEntity.getPrimaryOwner()).thenReturn(primaryOwnerEntity);
+        when(applicationEntity.getId()).thenReturn(APPLICATION_ID);
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId(apiProductId);
+        apiProduct.setName("API Product");
+        when(apiProductsRepository.findById(apiProductId)).thenReturn(Optional.of(apiProduct));
 
         final String failureCause = "💥 Endpoint not available";
         subscriptionService.fail(SUBSCRIPTION_ID, failureCause);
@@ -778,10 +823,19 @@ public class SubscriptionServiceTest {
         assertThat(subscriptionCaptured.getConsumerStatus()).isEqualTo(Subscription.ConsumerStatus.FAILURE);
         assertThat(subscriptionCaptured.getFailureCause()).isEqualTo(failureCause);
         assertThat(subscriptionCaptured.getUpdatedAt()).isAfter(initialUpdateDate);
-        // Verify notifications are NOT triggered for API Product subscriptions
         verify(apiTemplateService, never()).findByIdForTemplates(any(), anyString());
-        verify(notifierService, never()).trigger(any(), any(ApiHook.class), anyString(), anyMap());
-        verify(notifierService, never()).trigger(any(), any(ApplicationHook.class), anyString(), anyMap());
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApiProductHook.SUBSCRIPTION_FAILED),
+            eq(apiProductId),
+            anyMap()
+        );
+        verify(notifierService).trigger(
+            eq(GraviteeContext.getExecutionContext()),
+            eq(ApplicationHook.SUBSCRIPTION_FAILED),
+            eq(APPLICATION_ID),
+            anyMap()
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductGroupServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductGroupServiceImplTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.v4.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -67,7 +68,10 @@ class ApiProductGroupServiceImplTest {
 
         assertThat(apiProduct.getGroups()).contains("group-1");
         verify(apiProductsRepository).update(apiProduct);
-        verify(apiProductNotificationService).triggerUpdateNotification(EXECUTION_CONTEXT, apiProduct);
+        verify(apiProductNotificationService).triggerUpdateNotification(
+            same(EXECUTION_CONTEXT),
+            argThat(product -> product != null && "api-product-1".equals(product.getId()) && product.getGroups().contains("group-1"))
+        );
     }
 
     @Test
@@ -83,7 +87,16 @@ class ApiProductGroupServiceImplTest {
 
         assertThat(apiProduct.getGroups()).containsExactlyInAnyOrder("existing-group", "group-1");
         verify(apiProductsRepository).update(apiProduct);
-        verify(apiProductNotificationService).triggerUpdateNotification(EXECUTION_CONTEXT, apiProduct);
+        verify(apiProductNotificationService).triggerUpdateNotification(
+            same(EXECUTION_CONTEXT),
+            argThat(
+                product ->
+                    product != null &&
+                    "api-product-1".equals(product.getId()) &&
+                    product.getGroups().contains("existing-group") &&
+                    product.getGroups().contains("group-1")
+            )
+        );
     }
 
     @Test
@@ -114,7 +127,10 @@ class ApiProductGroupServiceImplTest {
 
         assertThat(apiProduct.getGroups()).containsExactly("group-2");
         verify(apiProductsRepository).update(apiProduct);
-        verify(apiProductNotificationService).triggerUpdateNotification(EXECUTION_CONTEXT, apiProduct);
+        verify(apiProductNotificationService).triggerUpdateNotification(
+            same(EXECUTION_CONTEXT),
+            argThat(product -> product != null && "api-product-1".equals(product.getId()) && product.getGroups().contains("group-2"))
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductNotificationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiProductNotificationServiceImplTest.java
@@ -76,6 +76,9 @@ class ApiProductNotificationServiceImplTest {
         assertThat(ApiProductHook.API_PRODUCT_UPDATED.getScope()).isEqualTo(HookScope.API_PRODUCT);
         assertThat(ApiProductHook.API_PRODUCT_UPDATED.getLabel()).isEqualTo("API Product Updated");
         assertThat(ApiProductHook.API_PRODUCT_UPDATED.getCategory()).isEqualTo("LIFECYCLE");
+        assertThat(ApiProductHook.API_PRODUCT_DEPLOYED.getScope()).isEqualTo(HookScope.API_PRODUCT);
+        assertThat(ApiProductHook.API_PRODUCT_DEPLOYED.getLabel()).isEqualTo("API Product Deployed");
+        assertThat(ApiProductHook.API_PRODUCT_DEPLOYED.getCategory()).isEqualTo("LIFECYCLE");
     }
 
     @Test
@@ -176,5 +179,33 @@ class ApiProductNotificationServiceImplTest {
         ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
         verify(notifierService).trigger(eq(CTX), eq(ApiProductHook.API_PRODUCT_UPDATED), eq("ap-x"), paramsCaptor.capture());
         assertThat(((ApiProductTemplateModel) paramsCaptor.getValue().get(PARAM_API_PRODUCT)).getPrimaryOwner()).isNull();
+    }
+
+    @Test
+    void should_trigger_deploy_notification_when_authenticated() {
+        buildService();
+
+        UserEntity actor = new UserEntity();
+        actor.setId("actor-1");
+        actor.setEmail("actor@example.com");
+        authenticateAs(actor);
+        when(userService.findById(CTX, "actor-1")).thenReturn(actor);
+        when(membershipService.getPrimaryOwnerUserId("org-1", MembershipReferenceType.API_PRODUCT, "ap-deploy")).thenReturn(null);
+
+        ApiProduct apiProduct = new ApiProduct();
+        apiProduct.setId("ap-deploy");
+        apiProduct.setName("Deploy Product");
+        apiProduct.setVersion("3.0");
+
+        service.triggerDeployNotification(CTX, apiProduct);
+
+        ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notifierService).trigger(eq(CTX), eq(ApiProductHook.API_PRODUCT_DEPLOYED), eq("ap-deploy"), paramsCaptor.capture());
+        ApiProductTemplateModel model = (ApiProductTemplateModel) paramsCaptor.getValue().get(PARAM_API_PRODUCT);
+        assertThat(model.getId()).isEqualTo("ap-deploy");
+        assertThat(model.getName()).isEqualTo("Deploy Product");
+        assertThat(model.getVersion()).isEqualTo("3.0");
+        assertThat(model.getPrimaryOwner()).isNull();
+        assertThat(paramsCaptor.getValue().get(NotificationParamsBuilder.PARAM_USER)).isSameAs(actor);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiDeployed.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiDeployed.html
@@ -6,7 +6,13 @@
 		<div style="margin-top: 50px; color: #424e5a;">
 			<h3>Hi,</h3>
 			<p>
-				The API <b><code>${api.name}</code></b> was deployed by ${user.displayName}.
+				<#if api??>
+					The API <b><code>${api.name}</code></b> was deployed by ${user.displayName}.
+				<#elseif apiProduct??>
+					The API Product <b><code>${apiProduct.name}</code></b> was deployed by ${user.displayName}.
+				<#else>
+					A resource was deployed by ${user.displayName}.
+				</#if>
 			</p>
 		</div>
 	</body>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiUpdated.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiUpdated.html
@@ -6,7 +6,13 @@
 		<div style="margin-top: 50px; color: #424e5a;">
 			<h3>Hi,</h3>
 			<p>
-				The API <b><code>${api.name}</code></b> was updated by ${user.displayName}.
+				<#if api??>
+					The API <b><code>${api.name}</code></b> was updated by ${user.displayName}.
+				<#elseif apiProduct??>
+					The API Product <b><code>${apiProduct.name}</code></b> was updated by ${user.displayName}.
+				<#else>
+					A resource was updated by ${user.displayName}.
+				</#if>
 			</p>
 		</div>
 	</body>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/subscriptionClosed.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/subscriptionClosed.html
@@ -7,7 +7,7 @@
 	<h3>Hi,</h3>
 	<p>The subscription to plan <b>${plan.name}</b> for <#if api??>API <b>${api.name}</b><#elseif apiProduct??>API Product <b>${apiProduct.name}</b><#else>API/API Product</#if> and application <b>${application.name}</b> has been closed by the API team.</p>
 	<#if (plan.security)?? && (plan.security == "API_KEY")>
-		<p>API Keys have been revoked and cannot be used anymore to consume this API.</p>
+		<p>API Keys have been revoked and cannot be used anymore to consume <#if api??>this API<#elseif apiProduct??>this API Product<#else>this API or API Product</#if>.</p>
 	</#if>
 </div>
 </body>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/subscriptionPaused.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/subscriptionPaused.html
@@ -7,7 +7,7 @@
 	<h3>Hi,</h3>
 	<p>The subscription to plan <b>${plan.name}</b> for <#if api??>API <b>${api.name}</b><#elseif apiProduct??>API Product <b>${apiProduct.name}</b><#else>API/API Product</#if> and application <b>${application.name}</b> has been paused by the API team.</p>
 	<#if (plan.security)?? && (plan.security == "API_KEY")>
-		<p>API Keys have been paused and cannot be used anymore to consume this API.</p>
+		<p>API Keys have been paused and cannot be used anymore to consume <#if api??>this API<#elseif apiProduct??>this API Product<#else>this API or API Product</#if>.</p>
 	</#if>
 </div>
 </body>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/subscriptionResumed.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/subscriptionResumed.html
@@ -7,7 +7,7 @@
 	<h3>Hi,</h3>
 	<p>The subscription to plan <b>${plan.name}</b> for <#if api??>API <b>${api.name}</b><#elseif apiProduct??>API Product <b>${apiProduct.name}</b><#else>API/API Product</#if> and application <b>${application.name}</b> has been resumed by the API team.</p>
 	<#if (plan.security)?? && (plan.security == "API_KEY")>
-		<p>API Keys have been resumed and can be used to consume this API.</p>
+		<p>API Keys have been resumed and can be used to consume <#if api??>this API<#elseif apiProduct??>this API Product<#else>this API or API Product</#if>.</p>
 	</#if>
 </div>
 </body>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13514

## Description

Introduce api product hooks & add API Product templates on Templates page


Area | Location (main paths) | What changed
-- | -- | --
API Product lifecycle | UpdateApiProductUseCase.java | After successful persist + audit (+ deploy attempt), calls ApiProductNotificationService.triggerUpdateNotification so API_PRODUCT_UPDATED fires (aligned with API update notifications).
API Product lifecycle | DeployApiProductUseCase.java | Injects notification service; after deploy, calls triggerDeployNotification for API_PRODUCT_DEPLOYED.
API Product (legacy bridge) | ApiProductNotificationService.java, ApiProductNotificationServiceImpl.java | Service API + impl: @Async update/deploy triggers; builds ApiProductTemplateModel + user params; calls NotifierService.trigger with ApiProductHook.
API Product groups | ApiProductGroupServiceImpl.java | Uses ApiProductNotificationService / API_PRODUCT_UPDATED where group membership changes should notify (per your branch intent).
Hook | ApiProductHook.java | Enum of API_PRODUCT-scoped hooks (subscriptions, API keys, deployed, updated).
Hook contexts (new) | ApiProductHookContext.java, SubscriptionAcceptedApiProductHookContext.java, SubscriptionRejectedApiProductHookContext.java, SubscriptionClosedApiProductHookContext.java, ApiKeyRevokedApiProductHookContext.java | New ApiProductHook-backed contexts so notifiers resolve NotificationReferenceType.API_PRODUCT.
Hook contexts (API-only cleanup) | ApiHookContext.java, SubscriptionAcceptedApiHookContext.java, SubscriptionRejectedApiHookContext.java, SubscriptionClosedApiHookContext.java, ApiKeyRevokedApiHookContext.java | API subscription/key hooks stay ApiHook / API reference only (no API Product leakage on API hooks).
Core subscription accept | AcceptSubscriptionDomainService.java | If referenceType == API_PRODUCT, triggerApiProductNotification + SubscriptionAcceptedApiProductHookContext; application hook still fired with API_PRODUCT reference.
Core subscription reject | RejectSubscriptionDomainService.java | Same pattern for SUBSCRIPTION_REJECTED + API product audit vs API audit.
Core subscription close | CloseSubscriptionDomainService.java | Product subscriptions: triggerApiProductNotification + SubscriptionClosedApiProductHookContext (and related audit path).
Core API key revoke | RevokeApiKeyDomainService.java | For API_PRODUCT subscription keys, ApiKeyRevokedApiProductHookContext / triggerApiProductNotification.
Core notification port | TriggerNotificationDomainService.java | Adds triggerApiProductNotification to the domain port.
Infra notification facade | TriggerNotificationDomainServiceFacadeImpl.java | Implements product path: TemplateDataFetcher.fetchData + NotifierService.trigger with ApiProductHook.
Notification config | NotificationConfig.java | Registers ApiProductHook values for configurable hooks / portal settings.
Email templates mapping | EmailNotificationBuilder.java | Maps ApiProductHook events to templates (e.g. subscription approved/closed/rejected, API key events, product deployed/updated).
Legacy subscription / notifier | SubscriptionServiceImpl.java, NotifierServiceImpl.java, NotificationTemplateServiceImpl.java | SubscriptionServiceImpl: API Product branches use ApiProductHook for new / pause / resume / transfer / fail, etc. NotifierServiceImpl: @Async overload for ApiProductHook. Templates: hook lists include product hooks.
Legacy API keys | ApiKeyServiceImpl.java | Product-scoped key events route to ApiProductHook where applicable (e.g. renew / expire alongside API).
Legacy groups | GroupServiceImpl.java | Triggers API_PRODUCT_UPDATED when group changes affect API products (per branch).
Management REST v2 | ApiProductsResource.java (and related resource if touched) | Wiring or behaviour aligned with product notifications / existence checks (per your branch).
Build / module | gravitee-apim-rest-api-management-rest/pom.xml | Dependency or packaging adjustment supporting the above (exact line depends on your diff).
Distribution email HTML | gravitee-apim-rest-api-standalone-distribution/.../templates/ (apiDeployed.html, apiUpdated.html, subscriptionClosed.html, subscriptionPaused.html, subscriptionResumed.html, …)



Deploy API Product:
<img width="1321" height="504" alt="image" src="https://github.com/user-attachments/assets/aead6ba3-562b-4d77-93a5-b8a2d24232ec" />

Update API Product:
<img width="1321" height="504" alt="image" src="https://github.com/user-attachments/assets/b733d358-b558-4f4a-b810-2cbcdc14d4c4" />

Paused Subscription:
<img width="1321" height="504" alt="image" src="https://github.com/user-attachments/assets/a0d17b23-06fa-4d13-995b-fe0502429260" />

Resumed Subscription:
<img width="1321" height="504" alt="image" src="https://github.com/user-attachments/assets/6aa95aeb-1c9f-4e97-b6db-af9ac4c91242" />

Approve Subscription:
<img width="1321" height="504" alt="image" src="https://github.com/user-attachments/assets/abb16fef-1db5-4c73-a657-58bdaac21eb4" />

Close Subscription:
<img width="1321" height="504" alt="image" src="https://github.com/user-attachments/assets/7c8a181e-58cf-4e12-87c7-007212e7e4ab" />

Renew API key:
<img width="1446" height="550" alt="image" src="https://github.com/user-attachments/assets/21912377-404b-444e-9b4a-f9ed73da22f1" />

Expire API key:
<img width="1321" height="504" alt="image" src="https://github.com/user-attachments/assets/5e9c52cf-70f2-41b3-9653-b017792f29f0" />

Revoke API key:
<img width="1321" height="504" alt="image" src="https://github.com/user-attachments/assets/810a0f75-4d2d-46b3-b717-a6440d0ddd36" />

API Product Subscription Transfer(Custom message):
<img width="1321" height="504" alt="image" src="https://github.com/user-attachments/assets/4bdb9fb5-e6ed-457e-9616-7bf89f1ce5a6" />


https://github.com/user-attachments/assets/c768dd90-8c45-4aaa-ae56-d324b6707f00
