### PR TITLE
feat(portal): APIM-13767 add application-aware user lookup service

### DIFF
--- a/gravitee-apim-portal-webui-next/src/entities/user/user.fixtures.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/user/user.fixtures.ts
@@ -15,7 +15,7 @@
  */
 import { isFunction } from 'rxjs/internal/util/isFunction';
 
-import { User } from './user';
+import { User, UsersResponse } from './user';
 
 export function fakeUser(modifier?: Partial<User> | ((baseApi: User) => User)): User {
   const base: User = {
@@ -32,6 +32,29 @@ export function fakeUser(modifier?: Partial<User> | ((baseApi: User) => User)): 
     customFields: {},
     display_name: 'admin',
     editable_profile: false,
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+
+export function fakeUsersResponse(modifier?: Partial<UsersResponse> | ((base: UsersResponse) => UsersResponse)): UsersResponse {
+  const base: UsersResponse = {
+    data: [fakeUser({ id: 'user-1' })],
+    metadata: {
+      data: {
+        total: 1,
+      },
+      applicationMembership: {
+        'user-1': false,
+      },
+    },
   };
 
   if (isFunction(modifier)) {

--- a/gravitee-apim-portal-webui-next/src/entities/user/user.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/user/user.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Links } from '../pagination/links';
 import { UserEnvironmentPermissions } from '../permission/permission';
 
 export interface UserConfig {
@@ -52,4 +53,30 @@ export interface User {
   customFields?: { [key: string]: object };
   config?: UserConfig;
   _links?: UserLinks;
+}
+
+export interface UsersSearchFilters {
+  query?: string;
+}
+
+export interface UsersSearchIncludes {
+  applicationMembership?: string;
+}
+
+export interface UsersSearchInput {
+  filters?: UsersSearchFilters;
+  includes?: UsersSearchIncludes;
+}
+
+export interface UsersResponseMetadata {
+  applicationMembership?: Record<string, boolean>;
+  data?: {
+    total?: number;
+  };
+}
+
+export interface UsersResponse {
+  data?: Array<User>;
+  metadata?: UsersResponseMetadata;
+  links?: Links;
 }

--- a/gravitee-apim-portal-webui-next/src/services/users.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/users.service.spec.ts
@@ -18,7 +18,8 @@ import { TestBed } from '@angular/core/testing';
 
 import { FinalizeRegistrationInput, RegisterUserInput, UsersService } from './users.service';
 import { CustomUserField } from '../entities/user/custom-user-field';
-import { User } from '../entities/user/user';
+import { User, UsersResponse } from '../entities/user/user';
+import { fakeUser, fakeUsersResponse } from '../entities/user/user.fixtures';
 import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
 describe('UsersService', () => {
@@ -94,6 +95,41 @@ describe('UsersService', () => {
     const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/users/registration/_finalize`);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual(input);
+
+    req.flush(apiResponse);
+  });
+
+  it('should search users for application membership with default request parameters', done => {
+    const applicationId = 'app-1';
+    const user = fakeUser({ id: 'user-1', email: 'ada@example.com', display_name: 'Ada Lovelace' });
+    const apiResponse: UsersResponse = fakeUsersResponse({
+      data: [user],
+      metadata: {
+        data: { total: 1 },
+        applicationMembership: { 'user-1': true },
+      },
+    });
+
+    service.searchUsersForApplicationMembership(applicationId, 'Ada').subscribe(res => {
+      expect(res).toEqual(apiResponse);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(
+      r =>
+        r.url === `${TESTING_BASE_URL}/users/_search` &&
+        r.method === 'POST' &&
+        r.params.get('page') === '1' &&
+        r.params.get('size') === '20',
+    );
+    expect(req.request.body).toEqual({
+      filters: {
+        query: 'Ada',
+      },
+      includes: {
+        applicationMembership: applicationId,
+      },
+    });
 
     req.flush(apiResponse);
   });

--- a/gravitee-apim-portal-webui-next/src/services/users.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/users.service.ts
@@ -19,7 +19,7 @@ import { Observable } from 'rxjs';
 
 import { ConfigService } from './config.service';
 import { CustomUserField } from '../entities/user/custom-user-field';
-import { User } from '../entities/user/user';
+import { User, UsersResponse, UsersSearchInput } from '../entities/user/user';
 
 export interface RegisterUserInput {
   /**
@@ -82,5 +82,20 @@ export class UsersService {
 
   finalizeRegistration(finalizeInput: FinalizeRegistrationInput) {
     return this.http.post<User>(`${this.configService.baseURL}/users/registration/_finalize`, finalizeInput);
+  }
+
+  searchUsersForApplicationMembership(applicationId: string, query: string, page = 1, size = 20): Observable<UsersResponse> {
+    const input: UsersSearchInput = {
+      filters: {
+        query,
+      },
+      includes: {
+        applicationMembership: applicationId,
+      },
+    };
+
+    return this.http.post<UsersResponse>(`${this.configService.baseURL}/users/_search`, input, {
+      params: { page, size },
+    });
   }
 }


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-13767

## Summary

Adds an application-aware user lookup method to the Portal Next UsersService.
The new service call uses the existing POST /users/_search endpoint with filters.query and includes.applicationMembership, allowing frontend consumers to search platform users while receiving metadata.applicationMembership flags for the current application.

## Changes

- Added typed user search request/response models.
- Added UsersService.searchUsersForApplicationMembership(...).
- Added fakeUsersResponse fixture.
- Added service test for request body, default request params, and membership metadata response shape.