### PR TITLE
fix(env-logs): hide API Product row in details view for standalone APIs

### DIFF
--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.html
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.html
@@ -79,9 +79,11 @@
                 <dl class="card__section__kv">
                   <env-logs-details-row label="Application">{{ log.application ?? '—' }}</env-logs-details-row>
                   <env-logs-details-row label="Plan">{{ log.plan?.name ?? '—' }}</env-logs-details-row>
-                  <env-logs-details-row label="API Product" dataTestId="more-details-api-product">{{
-                    log.apiProductName ?? '—'
-                  }}</env-logs-details-row>
+                  @if (isInApiProduct()) {
+                    <env-logs-details-row label="API Product" dataTestId="more-details-api-product">{{
+                      log.apiProductName ?? '—'
+                    }}</env-logs-details-row>
+                  }
                   <env-logs-details-row label="Endpoint">{{ log.endpoint ?? '—' }}</env-logs-details-row>
                 </dl>
               </mat-expansion-panel>

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.spec.ts
@@ -26,6 +26,7 @@ import { GioTestingModule } from '../../../../../shared/testing/gio-testing.modu
 import { fakeConnectionLogDetail } from '../../../../../entities/management-api-v2/log/connectionLog.fixture';
 import { fakeApiMetricResponse } from '../../../../../entities/management-api-v2/analytics/apiMetricsDetailResponse.fixture';
 import { SearchLogsResponse } from '../../../../../services-ngx/environment-logs.service';
+import { STANDALONE_API_PRODUCT_NAME } from '../../models/env-log.model';
 
 describe('EnvLogsDetailsComponent', () => {
   const logId = 'req-abc-123';
@@ -321,7 +322,7 @@ describe('EnvLogsDetailsComponent', () => {
     expect(await harness.getApiProductName()).toBe('My API Product');
   });
 
-  it('should show a dash in the API Product row in the More Details panel when absent', async () => {
+  it('should hide the API Product row in the More Details panel when apiProductName is absent', async () => {
     const { fixture: f, harness } = await createComponent();
 
     flushRequests();
@@ -330,7 +331,26 @@ describe('EnvLogsDetailsComponent', () => {
     await harness.expandMoreDetails();
     f.detectChanges();
 
-    expect(await harness.getApiProductName()).toBe('—');
+    expect(await harness.getApiProductName()).toBeNull();
+  });
+
+  it('should hide the API Product row in the More Details panel when the API is standalone', async () => {
+    const { fixture: f, harness } = await createComponent();
+
+    const standaloneResponse: SearchLogsResponse = {
+      ...MOCK_SEARCH_RESPONSE,
+      data: [{ ...MOCK_SEARCH_RESPONSE.data[0], apiProductName: STANDALONE_API_PRODUCT_NAME }],
+    };
+
+    expectSearchRequest().flush(standaloneResponse);
+    expectDetailRequest().flush(MOCK_DETAIL);
+    expectMetricsRequest().flush(MOCK_METRICS);
+    f.detectChanges();
+
+    await harness.expandMoreDetails();
+    f.detectChanges();
+
+    expect(await harness.getApiProductName()).toBeNull();
   });
 
   it('should resolve api display name from apiName when present', async () => {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-details/env-logs-details.component.ts
@@ -28,7 +28,7 @@ import { GioBannerModule, GioClipboardModule, GioMonacoEditorModule } from '@gra
 import { forkJoin, Observable, of } from 'rxjs';
 import { catchError, map, switchMap, tap } from 'rxjs/operators';
 
-import { EnvLog } from '../../models/env-log.model';
+import { EnvLog, STANDALONE_API_PRODUCT_NAME } from '../../models/env-log.model';
 import { EnvLogsDetailsRowComponent } from '../env-logs-details-row/env-logs-details-row.component';
 import { GioHeaderComponent } from '../../../../../shared/components/gio-header/gio-header.component';
 import { EnvironmentLogsService } from '../../../../../services-ngx/environment-logs.service';
@@ -86,6 +86,10 @@ export class EnvLogsDetailsComponent {
   hasDetailData = computed(() => {
     const log = this.log();
     return !!log?.entrypointRequest || !!log?.endpointRequest || !!log?.entrypointResponse || !!log?.endpointResponse;
+  });
+  isInApiProduct = computed(() => {
+    const apiProductName = this.log()?.apiProductName;
+    return !!apiProductName && apiProductName !== STANDALONE_API_PRODUCT_NAME;
   });
 
   readonly monacoEditorOptions: editor.IStandaloneEditorConstructionOptions = {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-table/env-logs-table.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/components/env-logs-table/env-logs-table.component.spec.ts
@@ -23,6 +23,7 @@ import { EnvLogsTableComponent } from './env-logs-table.component';
 import { EnvLogsTableHarness } from './env-logs-table.harness';
 
 import { fakeEnvLog, fakeEnvLogs } from '../../models/env-log.fixture';
+import { STANDALONE_API_PRODUCT_NAME } from '../../models/env-log.model';
 import { Constants } from '../../../../../entities/Constants';
 import { CONSTANTS_TESTING } from '../../../../../shared/testing';
 
@@ -134,7 +135,7 @@ describe('EnvLogsTableComponent', () => {
 
   it('should display "Standalone API" as subtitle when backend sends it explicitly (log-1)', async () => {
     const subtitle = await logsTableHarness.getApiProductSubtitle(0);
-    expect(subtitle).toEqual('Standalone API');
+    expect(subtitle).toEqual(STANDALONE_API_PRODUCT_NAME);
   });
 
   it('should display nothing as subtitle when api product name is absent (orphaned product, log-2)', async () => {

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/models/env-log.fixture.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/models/env-log.fixture.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EnvLog } from './env-log.model';
+import { EnvLog, STANDALONE_API_PRODUCT_NAME } from './env-log.model';
 
 const DEFAULT_REQUEST_HEADERS = {
   'sec-fetch-site': ['none'],
@@ -177,7 +177,7 @@ export const fakeEnvLogs = (): EnvLog[] => {
       timestamp: '15/06/2025 12:00:00',
       api: 'Pokémon API',
       apiId: 'api-pokemon',
-      apiProductName: 'Standalone API',
+      apiProductName: STANDALONE_API_PRODUCT_NAME,
       path: '/api/v1/event-types',
       method: 'PATCH',
       status: 200,

--- a/gravitee-apim-console-webui/src/management/observability/env-logs/models/env-log.model.ts
+++ b/gravitee-apim-console-webui/src/management/observability/env-logs/models/env-log.model.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/** Sentinel value sent by the backend in `apiProductName` when the API is not part of any API Product. */
+export const STANDALONE_API_PRODUCT_NAME = 'Standalone API';
+
 export type ApiLogRequestContent = {
   method: string;
   uri: string;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12446
## Description

A small description of what you did in that PR.
<img width="970" height="382" alt="Screenshot 2026-05-13 at 9 26 33 AM" src="https://github.com/user-attachments/assets/f0ba5d3d-9f1d-46e4-969e-0941d34137a6" />

<img width="963" height="563" alt="Screenshot 2026-05-13 at 9 26 54 AM" src="https://github.com/user-attachments/assets/90af442a-611e-4cf1-a4ad-d148f5bc621c" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

