### PR TITLE
fix(management-api): encrypt and propagate properties in PATCH

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
@@ -755,6 +755,26 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
         );
     }
 
+    @Test
+    void should_return_encrypted_value_when_property_marked_encryptable() {
+        var body = "{\"properties\":[{\"key\":\"k1\",\"value\":\"v1\",\"encryptable\":true}]}";
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .extracting(ApiV4::getProperties)
+            .asList()
+            .hasSize(1)
+            .first()
+            .satisfies(p -> {
+                var prop = (Property) p;
+                Assertions.assertThat(prop.getKey()).isEqualTo("k1");
+                Assertions.assertThat(prop.getEncrypted()).isTrue();
+            });
+    }
+
     @ParameterizedTest
     @MethodSource("responseTemplatesUpdateVariants")
     void should_update_response_templates(String body, String contentType) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -25,10 +25,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.property.PropertyDomainService;
 import io.gravitee.apim.core.api.exception.ApiInvalidDefinitionVersionException;
 import io.gravitee.apim.core.api.exception.ApiInvalidTypeException;
 import io.gravitee.apim.core.api.exception.ApiPatchNotAllowedException;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.property.EncryptableProperty;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
@@ -129,6 +131,7 @@ public class PatchApiUseCase {
     private final JsonPatchDomainService jsonPatchDomainService;
     private final WorkflowQueryService workflowQueryService;
     private final ObjectMapper objectMapper;
+    private final PropertyDomainService propertyDomainService;
 
     public Output execute(Input input) {
         var existingApi = apiCrudService.get(input.apiId());
@@ -363,14 +366,15 @@ public class PatchApiUseCase {
             existingApi.isDisableMembershipNotifications()
         );
 
-        var properties = resolvePatchableList(
+        var patchableProperties = resolvePatchableList(
             patchType,
             rawPatchNode,
             patchedNode,
             FIELD_PROPERTIES,
-            Property.class,
-            httpV4.getProperties()
+            PatchableProperty.class,
+            PatchableProperty.fromList(httpV4.getProperties())
         );
+        var properties = encryptProperties(patchableProperties);
         var responseTemplates = resolveResponseTemplates(patchType, rawPatchNode, patchedNode, httpV4.getResponseTemplates());
         var flows = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_FLOWS, Flow.class, httpV4.getFlows());
         var resources = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_RESOURCES, Resource.class, httpV4.getResources());
@@ -698,6 +702,39 @@ public class PatchApiUseCase {
         return "/" + field;
     }
 
+    private List<Property> encryptProperties(List<PatchableProperty> patchableProperties) {
+        if (patchableProperties == null) {
+            return null;
+        }
+        return propertyDomainService.encryptProperties(patchableProperties.stream().map(PatchableProperty::toEncryptable).toList());
+    }
+
+    record PatchableProperty(String key, String value, boolean encrypted, boolean dynamic, boolean encryptable) {
+        static PatchableProperty from(Property p) {
+            if (p == null) {
+                return null;
+            }
+            return new PatchableProperty(p.getKey(), p.getValue(), p.isEncrypted(), p.isDynamic(), false);
+        }
+
+        static List<PatchableProperty> fromList(List<Property> properties) {
+            if (properties == null) {
+                return null;
+            }
+            return properties.stream().map(PatchableProperty::from).toList();
+        }
+
+        EncryptableProperty toEncryptable() {
+            return EncryptableProperty.builder()
+                .key(key)
+                .value(value)
+                .encrypted(encrypted)
+                .dynamic(dynamic)
+                .encryptable(encryptable)
+                .build();
+        }
+    }
+
     public enum PatchType {
         JSON_PATCH,
         MERGE_PATCH,
@@ -789,7 +826,7 @@ public class PatchApiUseCase {
         Boolean allowedInApiProducts,
         boolean allowMultiJwtOauth2Subscriptions,
         boolean disableMembershipNotifications,
-        List<Property> properties,
+        List<PatchableProperty> properties,
         Map<String, Map<String, PatchableResponseTemplate>> responseTemplates,
         List<Flow> flows,
         List<Resource> resources
@@ -811,7 +848,7 @@ public class PatchApiUseCase {
                 httpV4.getAllowedInApiProducts(),
                 api.isAllowMultiJwtOauth2Subscriptions(),
                 api.isDisableMembershipNotifications(),
-                httpV4.getProperties(),
+                PatchableProperty.fromList(httpV4.getProperties()),
                 toPatchableResponseTemplates(httpV4.getResponseTemplates()),
                 httpV4.getFlows(),
                 httpV4.getResources()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
@@ -21,8 +21,11 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.infra.adapter.ApiAdapter;
+import io.gravitee.definition.model.v4.property.Property;
+import io.gravitee.rest.api.model.v4.api.properties.PropertyEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.v4.ApiService;
+import java.util.List;
 import org.springframework.stereotype.Service;
 
 /**
@@ -88,6 +91,7 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
             .allowedInApiProducts(coalesce(sanitized.getAllowedInApiProducts(), originalDefinition.getAllowedInApiProducts()))
             .responseTemplates(coalesce(sanitized.getResponseTemplates(), originalDefinition.getResponseTemplates()))
             .resources(coalesce(sanitized.getResources(), originalDefinition.getResources()))
+            .properties(coalesce(toProperties(sanitized.getProperties()), originalDefinition.getProperties()))
             .build();
         return original
             .toBuilder()
@@ -107,5 +111,15 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
 
     private static <T> T coalesce(T sanitized, T original) {
         return sanitized != null ? sanitized : original;
+    }
+
+    private static List<Property> toProperties(List<PropertyEntity> properties) {
+        if (properties == null) {
+            return null;
+        }
+        return properties
+            .stream()
+            .map(pe -> new Property(pe.getKey(), pe.getValue(), pe.isEncrypted(), pe.isDynamic()))
+            .toList();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.api.use_case;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -28,6 +29,7 @@ import fixtures.core.model.AuditInfoFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.WorkflowQueryServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.property.PropertyDomainService;
 import io.gravitee.apim.core.api.exception.ApiInvalidDefinitionVersionException;
 import io.gravitee.apim.core.api.exception.ApiInvalidTypeException;
 import io.gravitee.apim.core.api.exception.ApiPatchNotAllowedException;
@@ -41,6 +43,7 @@ import io.gravitee.apim.infra.domain_service.json_patch.JsonMergePatchServiceImp
 import io.gravitee.apim.infra.domain_service.json_patch.JsonPatchServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JsonMapperFactory;
 import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.flow.Operator;
@@ -92,18 +95,22 @@ class PatchApiUseCaseTest {
     WorkflowQueryServiceInMemory workflowQueryService = new WorkflowQueryServiceInMemory();
     ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService = mock(ApiPrimaryOwnerDomainService.class);
     UpdateApiDomainService updateApiDomainService = mock(UpdateApiDomainService.class);
+    DataEncryptor dataEncryptor = mock(DataEncryptor.class);
+    PropertyDomainService propertyDomainService = new PropertyDomainService(dataEncryptor);
 
     PatchApiUseCase cut;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
+        when(dataEncryptor.encrypt(anyString())).thenAnswer(inv -> "enc(" + inv.getArgument(0) + ")");
         cut = new PatchApiUseCase(
             apiCrudService,
             apiPrimaryOwnerDomainService,
             updateApiDomainService,
             new JsonPatchDomainService(new JsonMergePatchServiceImpl(), new JsonPatchServiceImpl()),
             workflowQueryService,
-            OBJECT_MAPPER
+            OBJECT_MAPPER,
+            propertyDomainService
         );
 
         var primaryOwner = PrimaryOwnerEntity.builder().id(USER_ID).type(PrimaryOwnerEntity.Type.USER).build();
@@ -1113,6 +1120,129 @@ class PatchApiUseCaseTest {
         @Test
         void from_returns_null_when_domain_is_null() {
             assertThat(PatchApiUseCase.PatchableResponseTemplate.from(null)).isNull();
+        }
+    }
+
+    @Nested
+    class PatchablePropertyFactory {
+
+        @Test
+        void from_returns_null_when_property_is_null() {
+            assertThat(PatchApiUseCase.PatchableProperty.from(null)).isNull();
+        }
+
+        @Test
+        void fromList_returns_null_when_list_is_null() {
+            assertThat(PatchApiUseCase.PatchableProperty.fromList(null)).isNull();
+        }
+    }
+
+    @Nested
+    class PropertiesEncryption {
+
+        @Test
+        void merge_patch_adding_plaintext_property_returns_it_in_real_update_response() {
+            var body = mergePatch("properties", List.of(Map.of("key", "k1", "value", "v1")));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, body, false);
+
+            var properties = httpV4Def(output.api()).getProperties();
+            assertThat(properties).hasSize(1);
+            assertThat(properties.getFirst().getKey()).isEqualTo("k1");
+            assertThat(properties.getFirst().getValue()).isEqualTo("v1");
+        }
+
+        @Test
+        void merge_patch_null_clears_existing_properties_in_real_update_response() {
+            var existing = new Property();
+            existing.setKey("old");
+            existing.setValue("secret");
+            existing.setEncrypted(true);
+            givenExistingApi(apiWithProperties(List.of(existing)));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("properties", null), false);
+
+            assertThat(httpV4Def(output.api()).getProperties()).isNull();
+        }
+
+        @Test
+        void encryptable_property_is_returned_encrypted_on_dry_run() {
+            stubValidateV4ReturnsArgument();
+            var body = mergePatch("properties", List.of(Map.of("key", "secret-key", "value", "plaintext", "encryptable", true)));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, body, true);
+
+            var properties = httpV4Def(output.api()).getProperties();
+            assertThat(properties).hasSize(1);
+            assertThat(properties.getFirst().getKey()).isEqualTo("secret-key");
+            assertThat(properties.getFirst().isEncrypted()).isTrue();
+            assertThat(properties.getFirst().getValue()).isEqualTo("enc(plaintext)");
+        }
+
+        @Test
+        void encryptable_property_is_returned_encrypted_on_real_update() {
+            var body = mergePatch("properties", List.of(Map.of("key", "secret-key", "value", "plaintext", "encryptable", true)));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, body, false);
+
+            var properties = httpV4Def(output.api()).getProperties();
+            assertThat(properties).hasSize(1);
+            assertThat(properties.getFirst().getKey()).isEqualTo("secret-key");
+            assertThat(properties.getFirst().isEncrypted()).isTrue();
+            assertThat(properties.getFirst().getValue()).isEqualTo("enc(plaintext)");
+        }
+
+        @Test
+        void merge_patch_adding_plaintext_property_returns_it_in_dry_run_response() {
+            stubValidateV4ReturnsArgument();
+            var body = mergePatch("properties", List.of(Map.of("key", "k1", "value", "v1")));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, body, true);
+
+            var properties = httpV4Def(output.api()).getProperties();
+            assertThat(properties).hasSize(1);
+            assertThat(properties.getFirst().getKey()).isEqualTo("k1");
+            assertThat(properties.getFirst().getValue()).isEqualTo("v1");
+        }
+
+        @Test
+        void merge_patch_null_clears_existing_properties_in_dry_run_response() {
+            stubValidateV4ReturnsArgument();
+            var existing = new Property();
+            existing.setKey("old");
+            existing.setValue("secret");
+            existing.setEncrypted(true);
+            givenExistingApi(apiWithProperties(List.of(existing)));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("properties", null), true);
+
+            assertThat(httpV4Def(output.api()).getProperties()).isNull();
+        }
+
+        @Test
+        void patching_unrelated_field_does_not_re_encrypt_already_encrypted_property() throws Exception {
+            var encrypted = new Property();
+            encrypted.setKey("secret-key");
+            encrypted.setValue("already-encrypted-value");
+            encrypted.setEncrypted(true);
+            givenExistingApi(apiWithProperties(List.of(encrypted)));
+
+            execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "new-name"), false);
+
+            verify(dataEncryptor, never()).encrypt(any());
+        }
+
+        @Test
+        void json_patch_add_op_with_encryptable_property_encrypts_value() {
+            var body = patch("add", "/properties", List.of(Map.of("key", "secret-key", "value", "plaintext", "encryptable", true)));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, body, false);
+
+            var properties = httpV4Def(output.api()).getProperties();
+            assertThat(properties).hasSize(1);
+            assertThat(properties.getFirst().getKey()).isEqualTo("secret-key");
+            assertThat(properties.getFirst().isEncrypted()).isTrue();
+            assertThat(properties.getFirst().getValue()).isEqualTo("enc(plaintext)");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
@@ -33,9 +33,11 @@ import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
+import io.gravitee.rest.api.model.v4.api.properties.PropertyEntity;
 import io.gravitee.rest.api.service.v4.ApiService;
 import java.util.HashSet;
 import java.util.List;
@@ -288,5 +290,83 @@ class UpdateApiDomainServiceImplTest {
         var result = cut.validateV4(api, auditInfo);
 
         assertThat(result.getApiDefinitionHttpV4().getAllowedInApiProducts()).isTrue();
+    }
+
+    @Test
+    void should_return_sanitized_properties_from_mutated_update_api_entity() {
+        var api = ApiFixtures.aProxyApiV4();
+        var sanitizedProperties = List.of(new PropertyEntity("k1", "v1"));
+        stubValidate(entity -> entity.setProperties(sanitizedProperties));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getProperties())
+            .hasSize(1)
+            .first()
+            .satisfies(p -> {
+                assertThat(p.getKey()).isEqualTo("k1");
+                assertThat(p.getValue()).isEqualTo("v1");
+            });
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_preserve_original_properties_when_validator_returns_null() {
+        var existingProperty = new Property();
+        existingProperty.setKey("k1");
+        existingProperty.setValue("v1");
+        var originalDefinition = ApiFixtures.aProxyApiV4()
+            .getApiDefinitionHttpV4()
+            .toBuilder()
+            .properties(List.of(existingProperty))
+            .build();
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
+        var originalProperties = api.getApiDefinitionHttpV4().getProperties();
+        stubValidate(entity -> entity.setProperties(null));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getProperties()).isEqualTo(originalProperties);
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_return_null_properties_when_erased_definition_has_null_properties() {
+        var erasedDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().properties(null).build();
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(erasedDefinition).build();
+        stubValidate(entity -> entity.setProperties(null));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getProperties()).isNull();
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_preserve_encrypted_and_dynamic_flags_from_mutated_update_api_entity() {
+        var api = ApiFixtures.aProxyApiV4();
+        stubValidate(entity -> entity.setProperties(List.of(new PropertyEntity("k", "v", false, true, true))));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getProperties())
+            .hasSize(1)
+            .first()
+            .satisfies(p -> {
+                assertThat(p.isEncrypted()).isTrue();
+                assertThat(p.isDynamic()).isTrue();
+            });
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_map_sanitized_properties_to_plain_Property_not_PropertyEntity() {
+        var api = ApiFixtures.aProxyApiV4();
+        stubValidate(entity -> entity.setProperties(List.of(new PropertyEntity("k", "v", true, false, false))));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getProperties()).hasSize(1).first().isNotInstanceOf(PropertyEntity.class);
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13785

## Why

The PATCH endpoint for v4 HTTP Proxy APIs had two defects in its properties handling:

1. **Missing encryption on both legs.** `PatchApiUseCase` did not run the property encryption pipeline, so properties marked `encryptable: true` were echoed back as plaintext in the 200 response — on both real-update and dry-run. Every other write path (PUT, CRD update) encrypts via `PropertyDomainService.encryptProperties`; PATCH was the only exception.

2. **Dry-run dropped caller-supplied properties.** `UpdateApiDomainServiceImpl.applySanitizedValues` copied sanitized `tags`, `flows`, `analytics`, and other fields back onto the in-memory projection, but had no corresponding line for `properties`. Any properties supplied in the PATCH body were silently dropped from the dry-run response.

Together these caused the dry-run response to diverge from a real-update response for any API that uses properties.

## What changed

- **`PatchApiUseCase`** — added a `PatchableProperty` inner record (mirrors the existing `PatchableAnalytics` / `PatchableFlowExecution` pattern), injected `PropertyDomainService`, and added an `encryptProperties` step in `applyPatchedValues` after `resolvePatchableList` resolves the patch. Encryption is idempotent: already-encrypted properties pass through unchanged.

- **`UpdateApiDomainServiceImpl.applySanitizedValues`** — added one `coalesce` line for `properties`, matching every other field already propagated in the method.

## User-facing impact

Properties marked `encryptable: true` in a PATCH request now behave identically to a PUT request:
- The 200 response sets `encrypted: true` and returns the ciphertext in `value`.
- The dry-run (`?dryRun=true`) response reflects the same encrypted shape instead of the submitted plaintext.

No API or config changes. No data migration. Properties already stored encrypted continue to round-trip correctly (encryption is idempotent).

## How to test

```
PATCH /management/v2/environments/{envId}/apis/{apiId}
Content-Type: application/merge-patch+json

{"properties":[{"key":"secret","value":"plaintext","encryptable":true}]}
```

Expected: `200` with `properties[0].encrypted = true` and `value` set to the ciphertext — same result with and without `?dryRun=true`.