### PR TITLE
feat(api): allow PATCH endpointGroups on v4 HTTP Proxy APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -298,7 +298,7 @@ paths:
                 Partially update a V4 HTTP Proxy API using JSON Patch (RFC 6902) or JSON Merge Patch (RFC 7396).
 
                 Only the following fields are patchable: name, description, apiVersion, visibility, labels, tags,
-                lifecycleState, categories, analytics, failover, flowExecution, flows, services, resources,
+                lifecycleState, categories, analytics, failover, flowExecution, flows, services, resources, endpointGroups,
                 allowedInApiProducts, allowMultiJwtOauth2Subscriptions, disableMembershipNotifications,
                 properties, responseTemplates, listeners.
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiEndpointGroupsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiEndpointGroupsTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static assertions.MAPIAssertions.assertThat;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.core.model.ApiFixtures;
+import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ApiResource_PatchApiEndpointGroupsTest extends ApiResourceTest {
+
+    private static final String MERGE_PATCH_TYPE = "application/merge-patch+json";
+    private static final String JSON_PATCH_TYPE = "application/json-patch+json";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Inject
+    UpdateApiDomainService updateApiDomainService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis";
+    }
+
+    @BeforeEach
+    void setUpApiAndPrimaryOwner() {
+        givenApiWithEndpointGroups(List.of(defaultGroup("default-group")));
+
+        var apiEntity = new ApiEntity();
+        apiEntity.setId(API);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setType(ApiType.PROXY);
+        apiEntity.setUpdatedAt(Date.from(Instant.ofEpochMilli(1000)));
+        when(apiSearchServiceV4.findGenericById(any(), eq(API), any(boolean.class), any(boolean.class), any(boolean.class))).thenReturn(
+            apiEntity
+        );
+
+        roleQueryService.resetSystemRoles(ORGANIZATION);
+        primaryOwnerDomainService.initWith(
+            List.of(Map.entry(API, PrimaryOwnerEntity.builder().id(USER_NAME).type(PrimaryOwnerEntity.Type.USER).build()))
+        );
+        membershipQueryServiceInMemory.initWith(
+            List.of(
+                Membership.builder()
+                    .memberId(USER_NAME)
+                    .referenceId(API)
+                    .roleId("api-po-id-" + ORGANIZATION)
+                    .referenceType(Membership.ReferenceType.API)
+                    .memberType(Membership.Type.USER)
+                    .build()
+            )
+        );
+
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .validateV4(any(), any());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Stream.of(apiCrudService, membershipQueryServiceInMemory, primaryOwnerDomainService).forEach(InMemoryAlternative::reset);
+        reset(updateApiDomainService, apiSearchServiceV4);
+    }
+
+    private void givenApiWithEndpointGroups(List<EndpointGroup> groups) {
+        var base = ApiFixtures.aProxyApiV4();
+        var api = base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().endpointGroups(groups).build()).build();
+        apiCrudService.initWith(List.of(api));
+    }
+
+    private static EndpointGroup defaultGroup(String name) {
+        return EndpointGroup.builder()
+            .name(name)
+            .type("http-proxy")
+            .sharedConfiguration("{}")
+            .endpoints(
+                List.of(
+                    io.gravitee.definition.model.v4.endpointgroup.Endpoint.builder()
+                        .name("default-endpoint")
+                        .type("http-proxy")
+                        .weight(1)
+                        .inheritConfiguration(true)
+                        .configuration("{\"target\":\"https://api.gravitee.io/echo\"}")
+                        .build()
+                )
+            )
+            .build();
+    }
+
+    private static Map<String, Object> groupMap(String name) {
+        return Map.of(
+            "name",
+            name,
+            "type",
+            "http-proxy",
+            "sharedConfiguration",
+            "{}",
+            "endpoints",
+            List.of(
+                Map.of(
+                    "name",
+                    "default-endpoint",
+                    "type",
+                    "http-proxy",
+                    "weight",
+                    1,
+                    "inheritConfiguration",
+                    true,
+                    "configuration",
+                    "{\"target\":\"https://api.gravitee.io/echo\"}"
+                )
+            )
+        );
+    }
+
+    private static String mergePatchEndpointGroups(List<Map<String, Object>> groups) {
+        return "{\"endpointGroups\":" + toJson(groups) + "}";
+    }
+
+    private static String jsonPatchReplaceEndpointGroups(List<Map<String, Object>> groups) {
+        return "[{\"op\":\"replace\",\"path\":\"/endpointGroups\",\"value\":" + toJson(groups) + "}]";
+    }
+
+    private static String toJson(Object value) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void patch_with_empty_endpointGroups_returns_400() {
+        givenApiWithEndpointGroups(List.of(defaultGroup("group-a")));
+        doThrow(new ValidationDomainException("endpointGroups must not be empty", Map.of("location", "/endpointGroups"), "invalidValue"))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"endpointGroups\":[]}", MERGE_PATCH_TYPE));
+
+        var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+        Assertions.assertThat(error.getTechnicalCode()).isEqualTo("invalidValue");
+        Assertions.assertThat(error.getParameters()).containsEntry("location", "/endpointGroups");
+    }
+
+    static Stream<Arguments> validatorRejectionCases() {
+        return Stream.of(
+            Map.entry("endpoint group name must not be blank", "/endpointGroups/0/name"),
+            Map.entry("endpoint type is invalid", "/endpointGroups/0/type")
+        ).flatMap(entry ->
+            Stream.of(MERGE_PATCH_TYPE, JSON_PATCH_TYPE).map(contentType -> Arguments.of(entry.getKey(), entry.getValue(), contentType))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validatorRejectionCases")
+    void post_patch_validator_failure_returns_400_with_invalidValue_envelope_and_location(
+        String message,
+        String location,
+        String contentType
+    ) {
+        givenApiWithEndpointGroups(List.of(defaultGroup("group-a")));
+        doThrow(new ValidationDomainException(message, Map.of("location", location), "invalidValue"))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+
+        var groups = List.of(groupMap("group-a"));
+        var body = contentType.equals(JSON_PATCH_TYPE) ? jsonPatchReplaceEndpointGroups(groups) : mergePatchEndpointGroups(groups);
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+        Assertions.assertThat(error.getTechnicalCode()).isEqualTo("invalidValue");
+        Assertions.assertThat(error.getParameters()).containsEntry("location", location);
+    }
+
+    @Test
+    void dry_run_patch_returns_200_without_persisting_endpointGroups() {
+        givenApiWithEndpointGroups(List.of(defaultGroup("group-a")));
+
+        var response = rootTarget(API)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity("{\"endpointGroups\":" + toJson(List.of(groupMap("group-b"))) + "}", MERGE_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getEndpointGroups().getFirst().getName()).isEqualTo("group-b");
+    }
+
+    @Test
+    void dry_run_validation_failure_returns_400() {
+        givenApiWithEndpointGroups(List.of(defaultGroup("group-a")));
+        doThrow(new ValidationDomainException("invalid endpoint group", Map.of("location", "/endpointGroups/0"), "invalidValue"))
+            .when(updateApiDomainService)
+            .validateV4(any(), any());
+
+        var response = rootTarget(API)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity("{\"endpointGroups\":" + toJson(List.of(groupMap("bad-group"))) + "}", MERGE_PATCH_TYPE));
+
+        var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+        Assertions.assertThat(error.getTechnicalCode()).isEqualTo("invalidValue");
+        Assertions.assertThat(error.getParameters()).containsEntry("location", "/endpointGroups/0");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
@@ -295,9 +295,7 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
     static Stream<Arguments> disallowedFieldCases() {
         return Stream.of(
             Arguments.of("{\"state\":\"STARTED\"}", MERGE_PATCH_TYPE, "state"),
-            Arguments.of("[{\"op\":\"replace\",\"path\":\"/state\",\"value\":\"STARTED\"}]", JSON_PATCH_TYPE, "state"),
-            Arguments.of("{\"endpointGroups\":[]}", MERGE_PATCH_TYPE, "endpointGroups"),
-            Arguments.of("[{\"op\":\"replace\",\"path\":\"/endpointGroups\",\"value\":[]}]", JSON_PATCH_TYPE, "endpointGroups")
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/state\",\"value\":\"STARTED\"}]", JSON_PATCH_TYPE, "state")
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -45,6 +45,7 @@ import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.analytics.sampling.Sampling;
 import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
@@ -90,12 +91,29 @@ public class PatchApiUseCase {
     private static final String FIELD_FLOWS = "flows";
     private static final String FIELD_RESOURCES = "resources";
     private static final String FIELD_LISTENERS = "listeners";
+    private static final String FIELD_ENDPOINT_GROUPS = "endpointGroups";
 
     private static final String JSON_PATCH_PATH_PREFIX = "/";
 
     private static final Pattern RESOURCE_CONFIGURATION_DEEP_PATH = Pattern.compile("/resources/(\\d+|-)/configuration/.+");
     private static final String RESOURCE_CONFIGURATION_DEEP_PATH_MESSAGE =
         "operations under /resources/N/configuration/... are not supported; replace the full configuration object at /resources/N/configuration";
+
+    private static final Pattern ENDPOINT_CONFIGURATION_DEEP_PATH = Pattern.compile(
+        "/endpointGroups/[^/]+/endpoints/[^/]+/configuration/.+"
+    );
+    private static final Pattern ENDPOINT_SHARED_CONFIG_OVERRIDE_DEEP_PATH = Pattern.compile(
+        "/endpointGroups/[^/]+/endpoints/[^/]+/sharedConfigurationOverride/.+"
+    );
+    private static final Pattern ENDPOINT_GROUP_SHARED_CONFIG_DEEP_PATH = Pattern.compile("/endpointGroups/[^/]+/sharedConfiguration/.+");
+    private static final Pattern ENDPOINT_GROUP_SERVICE_CONFIG_DEEP_PATH = Pattern.compile(
+        "/endpointGroups/[^/]+/services/[^/]+/configuration/.+"
+    );
+    private static final Pattern ENDPOINT_SERVICE_CONFIG_DEEP_PATH = Pattern.compile(
+        "/endpointGroups/[^/]+/endpoints/[^/]+/services/[^/]+/configuration/.+"
+    );
+    private static final String ENDPOINT_GROUP_OPAQUE_DEEP_PATH_MESSAGE =
+        "operations under /endpointGroups/N/endpoints/N/configuration/..., /endpointGroups/N/endpoints/N/sharedConfigurationOverride/..., /endpointGroups/N/sharedConfiguration/..., /endpointGroups/N/services/S/configuration/..., or /endpointGroups/N/endpoints/N/services/S/configuration/... are not supported; replace the full configuration object";
 
     private static final Set<String> ALLOWED_FIELDS = Set.of(
         FIELD_NAME,
@@ -117,13 +135,13 @@ public class PatchApiUseCase {
         FIELD_RESPONSE_TEMPLATES,
         FIELD_FLOWS,
         FIELD_RESOURCES,
-        FIELD_LISTENERS
+        FIELD_LISTENERS,
+        FIELD_ENDPOINT_GROUPS
     );
 
     private static final int MAX_PATCH_OPS = 200;
 
     private static final Set<String> BLOCKED_WITH_HINT = Set.of("state");
-    private static final Set<String> BLOCKED_WITHOUT_HINT = Set.of("endpointGroups");
 
     private static final String NULL_NOT_ALLOWED_MESSAGE_FORMAT =
         "'%s' cannot be null; omit the field to leave it unchanged, or send an explicit value";
@@ -156,7 +174,7 @@ public class PatchApiUseCase {
         var primaryOwner = apiPrimaryOwnerDomainService.getApiPrimaryOwner(input.auditInfo().organizationId(), input.apiId());
 
         var workflows = workflowQueryService.findAllByApiIdAndType(input.apiId(), Workflow.Type.REVIEW);
-        var workflowState = workflows.isEmpty() ? null : workflows.get(0).getState();
+        var workflowState = workflows.isEmpty() ? null : workflows.getFirst().getState();
 
         var updatedApi = applyPatchedValues(existingApi, patchedNode, input.patchType(), patchNode);
 
@@ -217,6 +235,9 @@ public class PatchApiUseCase {
             if (isResourceConfigurationDeepPath(rawPath)) {
                 throw new ApiPatchNotAllowedException(rawPath, RESOURCE_CONFIGURATION_DEEP_PATH_MESSAGE);
             }
+            if (isEndpointGroupOpaqueDeepPath(rawPath)) {
+                throw new ApiPatchNotAllowedException(rawPath, ENDPOINT_GROUP_OPAQUE_DEEP_PATH_MESSAGE);
+            }
             var opType = op.path("op").asText();
             if ("move".equals(opType) || "copy".equals(opType)) {
                 validateMoveOrCopyFromField(index, op);
@@ -238,10 +259,24 @@ public class PatchApiUseCase {
         if (isResourceConfigurationDeepPath(rawFrom)) {
             throw new ApiPatchNotAllowedException(rawFrom, RESOURCE_CONFIGURATION_DEEP_PATH_MESSAGE);
         }
+        if (isEndpointGroupOpaqueDeepPath(rawFrom)) {
+            throw new ApiPatchNotAllowedException(rawFrom, ENDPOINT_GROUP_OPAQUE_DEEP_PATH_MESSAGE);
+        }
     }
 
     private static boolean isResourceConfigurationDeepPath(String path) {
         return path != null && RESOURCE_CONFIGURATION_DEEP_PATH.matcher(path).matches();
+    }
+
+    private static boolean isEndpointGroupOpaqueDeepPath(String path) {
+        return (
+            path != null &&
+            (ENDPOINT_CONFIGURATION_DEEP_PATH.matcher(path).matches() ||
+                ENDPOINT_SHARED_CONFIG_OVERRIDE_DEEP_PATH.matcher(path).matches() ||
+                ENDPOINT_GROUP_SHARED_CONFIG_DEEP_PATH.matcher(path).matches() ||
+                ENDPOINT_GROUP_SERVICE_CONFIG_DEEP_PATH.matcher(path).matches() ||
+                ENDPOINT_SERVICE_CONFIG_DEEP_PATH.matcher(path).matches())
+        );
     }
 
     private void validateJsonPatchField(int opIndex, String pointerName, String pointer) {
@@ -293,9 +328,6 @@ public class PatchApiUseCase {
     private void validateField(String field) {
         if (BLOCKED_WITH_HINT.contains(field)) {
             throw new ApiPatchNotAllowedException(field, "use /_start or /_stop endpoints to change runtime state");
-        }
-        if (BLOCKED_WITHOUT_HINT.contains(field)) {
-            throw new ApiPatchNotAllowedException(field, "use PUT to update structural fields");
         }
         if (!ALLOWED_FIELDS.contains(field)) {
             throw new ApiPatchNotAllowedException(field, "field is not patchable");
@@ -382,6 +414,14 @@ public class PatchApiUseCase {
         var flows = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_FLOWS, Flow.class, httpV4.getFlows());
         var resources = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_RESOURCES, Resource.class, httpV4.getResources());
         var listeners = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_LISTENERS, Listener.class, httpV4.getListeners());
+        var endpointGroups = resolvePatchableList(
+            patchType,
+            rawPatchNode,
+            patchedNode,
+            FIELD_ENDPOINT_GROUPS,
+            EndpointGroup.class,
+            httpV4.getEndpointGroups()
+        );
 
         var updatedDefinition = httpV4
             .toBuilder()
@@ -398,6 +438,7 @@ public class PatchApiUseCase {
             .flows(flows)
             .resources(resources)
             .listeners(listeners)
+            .endpointGroups(endpointGroups)
             .build();
 
         return existingApi
@@ -679,7 +720,7 @@ public class PatchApiUseCase {
         }
         try {
             return objectMapper
-                .<List<T>>readerFor(objectMapper.getTypeFactory().constructCollectionType(List.class, elementType))
+                .readerFor(objectMapper.getTypeFactory().constructCollectionType(List.class, elementType))
                 .with(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
                 .readValue(fieldNode);
         } catch (Exception e) {
@@ -835,7 +876,8 @@ public class PatchApiUseCase {
         Map<String, Map<String, PatchableResponseTemplate>> responseTemplates,
         List<Flow> flows,
         List<Resource> resources,
-        List<Listener> listeners
+        List<Listener> listeners,
+        List<EndpointGroup> endpointGroups
     ) {
         static PatchableView from(Api api, io.gravitee.definition.model.v4.Api httpV4) {
             return new PatchableView(
@@ -858,7 +900,8 @@ public class PatchApiUseCase {
                 toPatchableResponseTemplates(httpV4.getResponseTemplates()),
                 httpV4.getFlows(),
                 httpV4.getResources(),
-                httpV4.getListeners()
+                httpV4.getListeners(),
+                httpV4.getEndpointGroups()
             );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
@@ -83,6 +83,7 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
         var sanitizedDefinition = originalDefinition
             .toBuilder()
             .tags(coalesce(sanitized.getTags(), originalDefinition.getTags()))
+            .endpointGroups(coalesce(sanitized.getEndpointGroups(), originalDefinition.getEndpointGroups()))
             .flows(coalesce(sanitized.getFlows(), originalDefinition.getFlows()))
             .analytics(coalesce(sanitized.getAnalytics(), originalDefinition.getAnalytics()))
             .failover(coalesce(sanitized.getFailover(), originalDefinition.getFailover()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -49,6 +49,11 @@ import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.sampling.SamplingType;
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.endpointgroup.loadbalancer.LoadBalancer;
+import io.gravitee.definition.model.v4.endpointgroup.loadbalancer.LoadBalancerType;
+import io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServices;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.flow.execution.FlowMode;
@@ -62,6 +67,7 @@ import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
+import io.gravitee.definition.model.v4.service.Service;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -306,6 +312,11 @@ class PatchApiUseCaseTest {
         return Map.of("name", name, "type", type, "configuration", Map.of(), "enabled", true);
     }
 
+    static Api apiWithEndpointGroups(List<EndpointGroup> groups) {
+        var base = ApiFixtures.aProxyApiV4();
+        return base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().endpointGroups(groups).build()).build();
+    }
+
     private static io.gravitee.definition.model.v4.Api httpV4Def(Api api) {
         return (io.gravitee.definition.model.v4.Api) api.getApiDefinitionValue();
     }
@@ -349,6 +360,7 @@ class PatchApiUseCaseTest {
         assertThat(httpV4.getProperties()).isEqualTo(originalHttpV4.getProperties());
         assertThat(httpV4.getResponseTemplates()).isEqualTo(originalHttpV4.getResponseTemplates());
         assertThat(httpV4.getFlows()).isEqualTo(originalHttpV4.getFlows());
+        assertThat(httpV4.getEndpointGroups()).isEqualTo(originalHttpV4.getEndpointGroups());
     }
 
     @Nested
@@ -500,14 +512,6 @@ class PatchApiUseCaseTest {
                 .isInstanceOf(ApiPatchNotAllowedException.class)
                 .hasMessageContaining("state")
                 .hasMessageContaining("_start");
-        }
-
-        @ParameterizedTest
-        @EnumSource(PatchApiUseCase.PatchType.class)
-        void endpointGroups_field_is_rejected(PatchApiUseCase.PatchType type) {
-            assertThatThrownBy(() -> execute(type, setField(type, "endpointGroups", List.of()), false))
-                .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("endpointGroups");
         }
 
         @ParameterizedTest
@@ -833,37 +837,37 @@ class PatchApiUseCaseTest {
 
         @Test
         void move_op_with_disallowed_from_field_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, movePatch("/endpointGroups/0", "/name"), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, movePatch("/state", "/name"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("endpointGroups");
+                .hasMessageContaining("state");
         }
 
         @Test
         void copy_op_with_disallowed_from_field_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, copyPatch("/endpointGroups/0", "/name"), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, copyPatch("/state", "/name"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("endpointGroups");
+                .hasMessageContaining("state");
         }
 
         @Test
         void move_op_with_disallowed_destination_path_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, movePatch("/name", "/endpointGroups/0"), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, movePatch("/name", "/state"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("endpointGroups");
+                .hasMessageContaining("state");
         }
 
         @Test
         void copy_op_with_disallowed_destination_path_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, copyPatch("/name", "/endpointGroups"), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, copyPatch("/name", "/state"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("endpointGroups");
+                .hasMessageContaining("state");
         }
 
         @Test
         void disallowed_field_via_path_segment_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/endpointGroups/0/name", "x"), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/state/running", "x"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("endpointGroups");
+                .hasMessageContaining("state");
         }
 
         @Test
@@ -925,16 +929,9 @@ class PatchApiUseCaseTest {
 
         @Test
         void add_op_on_blocked_path_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/endpointGroups/0", Map.of()), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/state", "STARTED"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("endpointGroups");
-        }
-
-        @Test
-        void remove_op_on_endpointGroups_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/endpointGroups"), false))
-                .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("endpointGroups");
+                .hasMessageContaining("state");
         }
 
         @Test
@@ -1095,6 +1092,77 @@ class PatchApiUseCaseTest {
         @ParameterizedTest
         @MethodSource("deepPathUnderResourceConfigurationCases")
         void deep_path_under_resource_configuration_is_rejected(String patchJson, String expectedPath) {
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patchJson, false))
+                .isInstanceOf(ApiPatchNotAllowedException.class)
+                .hasMessageContaining(expectedPath);
+        }
+
+        static Stream<Arguments> deepPathUnderEndpointGroupsConfigurationCases() {
+            return Stream.of(
+                Arguments.of(
+                    patch("replace", "/endpointGroups/0/endpoints/0/configuration/someField", "value"),
+                    "/endpointGroups/0/endpoints/0/configuration/someField"
+                ),
+                Arguments.of(
+                    patch("replace", "/endpointGroups/0/endpoints/0/configuration/a/b", "value"),
+                    "/endpointGroups/0/endpoints/0/configuration/a/b"
+                ),
+                Arguments.of(
+                    patch("remove", "/endpointGroups/0/endpoints/0/configuration/someField"),
+                    "/endpointGroups/0/endpoints/0/configuration/someField"
+                ),
+                Arguments.of(
+                    movePatch("/endpointGroups/0/endpoints/0/configuration/key", "/name"),
+                    "/endpointGroups/0/endpoints/0/configuration/key"
+                ),
+                Arguments.of(
+                    copyPatch("/endpointGroups/0/endpoints/0/configuration/key", "/name"),
+                    "/endpointGroups/0/endpoints/0/configuration/key"
+                ),
+                Arguments.of(
+                    patch("add", "/endpointGroups/-/endpoints/-/configuration/someKey", "value"),
+                    "/endpointGroups/-/endpoints/-/configuration/someKey"
+                ),
+                Arguments.of(
+                    patch("replace", "/endpointGroups/0/endpoints/0/sharedConfigurationOverride/someField", "value"),
+                    "/endpointGroups/0/endpoints/0/sharedConfigurationOverride/someField"
+                ),
+                Arguments.of(
+                    patch("remove", "/endpointGroups/0/endpoints/0/sharedConfigurationOverride/someField"),
+                    "/endpointGroups/0/endpoints/0/sharedConfigurationOverride/someField"
+                ),
+                Arguments.of(
+                    movePatch("/endpointGroups/0/endpoints/0/sharedConfigurationOverride/key", "/name"),
+                    "/endpointGroups/0/endpoints/0/sharedConfigurationOverride/key"
+                ),
+                Arguments.of(
+                    copyPatch("/endpointGroups/0/endpoints/0/sharedConfigurationOverride/key", "/name"),
+                    "/endpointGroups/0/endpoints/0/sharedConfigurationOverride/key"
+                ),
+                Arguments.of(
+                    patch("replace", "/endpointGroups/0/sharedConfiguration/someField", "value"),
+                    "/endpointGroups/0/sharedConfiguration/someField"
+                ),
+                Arguments.of(
+                    patch("remove", "/endpointGroups/0/sharedConfiguration/someField"),
+                    "/endpointGroups/0/sharedConfiguration/someField"
+                ),
+                Arguments.of(movePatch("/endpointGroups/0/sharedConfiguration/key", "/name"), "/endpointGroups/0/sharedConfiguration/key"),
+                Arguments.of(copyPatch("/endpointGroups/0/sharedConfiguration/key", "/name"), "/endpointGroups/0/sharedConfiguration/key"),
+                Arguments.of(
+                    patch("replace", "/endpointGroups/0/services/healthCheck/configuration/timeout", "5000"),
+                    "/endpointGroups/0/services/healthCheck/configuration/timeout"
+                ),
+                Arguments.of(
+                    patch("replace", "/endpointGroups/0/endpoints/0/services/healthCheck/configuration/timeout", "5000"),
+                    "/endpointGroups/0/endpoints/0/services/healthCheck/configuration/timeout"
+                )
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("deepPathUnderEndpointGroupsConfigurationCases")
+        void deep_path_under_endpoint_groups_configuration_is_rejected(String patchJson, String expectedPath) {
             assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patchJson, false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
                 .hasMessageContaining(expectedPath);
@@ -1343,11 +1411,11 @@ class PatchApiUseCaseTest {
         void blocked_field_combined_with_allowed_flows_patch_is_still_rejected() {
             var body = OBJECT_MAPPER.createObjectNode();
             body.set("flows", OBJECT_MAPPER.valueToTree(List.of(flowMap("f", List.of()))));
-            body.set("endpointGroups", OBJECT_MAPPER.valueToTree(List.of()));
+            body.set("state", OBJECT_MAPPER.valueToTree("STARTED"));
 
             assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.MERGE_PATCH, body.toString(), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("endpointGroups");
+                .hasMessageContaining("state");
         }
 
         @Test
@@ -2244,6 +2312,573 @@ class PatchApiUseCaseTest {
 
             var stored = apiCrudService.storage().getFirst();
             assertThat(((HttpListener) httpV4Def(stored).getListeners().getFirst()).getPaths().getFirst().getPath()).isEqualTo("/original");
+        }
+    }
+
+    @Nested
+    class EndpointGroupsResolution {
+
+        static EndpointGroup aGroup(String name) {
+            return EndpointGroup.builder()
+                .name(name)
+                .type("http-proxy")
+                .sharedConfiguration("{}")
+                .endpoints(
+                    List.of(
+                        Endpoint.builder()
+                            .name("default-endpoint")
+                            .type("http-proxy")
+                            .weight(1)
+                            .inheritConfiguration(true)
+                            .configuration("{\"target\":\"https://api.gravitee.io/echo\"}")
+                            .build()
+                    )
+                )
+                .build();
+        }
+
+        static Map<String, Object> groupMap(String name) {
+            return Map.of(
+                "name",
+                name,
+                "type",
+                "http-proxy",
+                "sharedConfiguration",
+                "{}",
+                "endpoints",
+                List.of(
+                    Map.of(
+                        "name",
+                        "default-endpoint",
+                        "type",
+                        "http-proxy",
+                        "weight",
+                        1,
+                        "inheritConfiguration",
+                        true,
+                        "configuration",
+                        "{\"target\":\"https://api.gravitee.io/echo\"}"
+                    )
+                )
+            );
+        }
+
+        @Test
+        void merge_patch_appending_endpoint_group_grows_list_by_one() {
+            var existing = aGroup("group-a");
+            givenExistingApi(apiWithEndpointGroups(List.of(existing)));
+
+            var newGroups = List.of(groupMap("group-a"), groupMap("group-b"));
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("endpointGroups", newGroups), false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups()).hasSize(2);
+            assertThat(httpV4Def(output.api()).getEndpointGroups().get(1).getName()).isEqualTo("group-b");
+        }
+
+        @Test
+        void json_patch_add_at_minus_one_appends_endpoint_group() {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/endpointGroups/-", groupMap("group-b")), false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups()).hasSize(2);
+            assertThat(httpV4Def(output.api()).getEndpointGroups().get(1).getName()).isEqualTo("group-b");
+        }
+
+        @Test
+        void merge_patch_with_one_group_removed_persists_shorter_list() {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"), aGroup("group-b"))));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("endpointGroups", List.of(groupMap("group-a"))), false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups()).hasSize(1);
+            assertThat(httpV4Def(output.api()).getEndpointGroups().getFirst().getName()).isEqualTo("group-a");
+        }
+
+        @Test
+        void json_patch_remove_endpoint_group_at_index_persists_shorter_list() {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"), aGroup("group-b"))));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/endpointGroups/1"), false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups()).hasSize(1);
+            assertThat(httpV4Def(output.api()).getEndpointGroups().getFirst().getName()).isEqualTo("group-a");
+        }
+
+        static Stream<Arguments> reorderEndpointGroupsVariants() {
+            var reordered = List.of(groupMap("group-b"), groupMap("group-a"));
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("endpointGroups", reordered)),
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/endpointGroups", reordered))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("reorderEndpointGroupsVariants")
+        void reordering_endpoint_groups_reflects_new_order(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"), aGroup("group-b"))));
+
+            var output = execute(type, body, false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups())
+                .extracting(EndpointGroup::getName)
+                .containsExactly("group-b", "group-a");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void modifying_endpoint_weight_persists_only_that_field(PatchApiUseCase.PatchType type) {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+
+            var body = type == PatchApiUseCase.PatchType.JSON_PATCH
+                ? patch("replace", "/endpointGroups/0/endpoints/0/weight", 5)
+                : mergePatch(
+                    "endpointGroups",
+                    List.of(
+                        Map.of(
+                            "name",
+                            "group-a",
+                            "type",
+                            "http-proxy",
+                            "sharedConfiguration",
+                            "{}",
+                            "endpoints",
+                            List.of(
+                                Map.of(
+                                    "name",
+                                    "default-endpoint",
+                                    "type",
+                                    "http-proxy",
+                                    "weight",
+                                    5,
+                                    "inheritConfiguration",
+                                    true,
+                                    "configuration",
+                                    "{\"target\":\"https://api.gravitee.io/echo\"}"
+                                )
+                            )
+                        )
+                    )
+                );
+
+            var output = execute(type, body, false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups().getFirst().getEndpoints().getFirst().getWeight()).isEqualTo(5);
+            assertThat(httpV4Def(output.api()).getEndpointGroups().getFirst().getEndpoints().getFirst().getName()).isEqualTo(
+                "default-endpoint"
+            );
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void modifying_endpoint_secondary_flag_persists_only_that_field(PatchApiUseCase.PatchType type) {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+
+            var body = type == PatchApiUseCase.PatchType.JSON_PATCH
+                ? patch("replace", "/endpointGroups/0/endpoints/0/secondary", true)
+                : mergePatch(
+                    "endpointGroups",
+                    List.of(
+                        Map.of(
+                            "name",
+                            "group-a",
+                            "type",
+                            "http-proxy",
+                            "sharedConfiguration",
+                            "{}",
+                            "endpoints",
+                            List.of(
+                                Map.of(
+                                    "name",
+                                    "default-endpoint",
+                                    "type",
+                                    "http-proxy",
+                                    "weight",
+                                    1,
+                                    "inheritConfiguration",
+                                    true,
+                                    "secondary",
+                                    true,
+                                    "configuration",
+                                    "{\"target\":\"https://api.gravitee.io/echo\"}"
+                                )
+                            )
+                        )
+                    )
+                );
+
+            var output = execute(type, body, false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups().getFirst().getEndpoints().getFirst().isSecondary()).isTrue();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void modifying_health_check_config_persists_changes(PatchApiUseCase.PatchType type) {
+            var hcService = new Service();
+            hcService.setEnabled(false);
+            var existingServices = EndpointGroupServices.builder().healthCheck(hcService).build();
+            var groupWithHc = aGroup("group-a").toBuilder().services(existingServices).build();
+            givenExistingApi(apiWithEndpointGroups(List.of(groupWithHc)));
+
+            var enabledHc = Map.of("enabled", true, "type", "http-health-check");
+            var body = type == PatchApiUseCase.PatchType.JSON_PATCH
+                ? patch("replace", "/endpointGroups/0/services/healthCheck", enabledHc)
+                : mergePatch(
+                    "endpointGroups",
+                    List.of(
+                        Map.of(
+                            "name",
+                            "group-a",
+                            "type",
+                            "http-proxy",
+                            "sharedConfiguration",
+                            "{}",
+                            "services",
+                            Map.of("healthCheck", enabledHc),
+                            "endpoints",
+                            List.of(
+                                Map.of(
+                                    "name",
+                                    "default-endpoint",
+                                    "type",
+                                    "http-proxy",
+                                    "weight",
+                                    1,
+                                    "inheritConfiguration",
+                                    true,
+                                    "configuration",
+                                    "{\"target\":\"https://api.gravitee.io/echo\"}"
+                                )
+                            )
+                        )
+                    )
+                );
+
+            var output = execute(type, body, false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups().getFirst().getServices().getHealthCheck().isEnabled()).isTrue();
+        }
+
+        @Test
+        void merge_patch_with_empty_endpointGroups_array_propagates_empty_to_definition() {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("endpointGroups", List.of()), false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups()).isEmpty();
+        }
+
+        @Test
+        void domain_service_rejection_of_empty_endpointGroups_propagates_to_caller() {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+            doThrow(
+                new ValidationDomainException("endpointGroups must not be empty", Map.of("location", "/endpointGroups"), "invalidValue")
+            )
+                .when(updateApiDomainService)
+                .updateV4(any(), any());
+
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("endpointGroups", List.of()), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("endpointGroups");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void dry_run_with_endpointGroups_invokes_validate_not_update(PatchApiUseCase.PatchType type) {
+            stubValidateV4ReturnsArgument();
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+
+            var output = execute(type, setField(type, "endpointGroups", List.of(groupMap("group-b"))), true);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups().getFirst().getName()).isEqualTo("group-b");
+            verify(updateApiDomainService).validateV4(any(), any());
+            verify(updateApiDomainService, never()).updateV4(any(), any());
+        }
+
+        @Test
+        void merge_patch_with_endpointGroups_null_clears_endpointGroups_on_rebuilt_definition() {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("endpointGroups", null), false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups()).isNull();
+        }
+
+        @Test
+        void domain_service_rejection_of_null_endpointGroups_propagates_to_caller() {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+            doThrow(new ValidationDomainException("endpointGroups must not be null", Map.of("location", "/endpointGroups"), "invalidValue"))
+                .when(updateApiDomainService)
+                .updateV4(any(), any());
+
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("endpointGroups", null), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("endpointGroups");
+        }
+
+        @Test
+        void json_patch_remove_endpointGroups_clears_endpointGroups_on_rebuilt_definition() {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/endpointGroups"), false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups()).isNull();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void modifying_endpoint_inheritConfiguration_persists_only_that_field(PatchApiUseCase.PatchType type) {
+            var group = EndpointGroup.builder()
+                .name("group-a")
+                .type("http-proxy")
+                .sharedConfiguration("{}")
+                .endpoints(
+                    List.of(
+                        Endpoint.builder()
+                            .name("default-endpoint")
+                            .type("http-proxy")
+                            .weight(1)
+                            .inheritConfiguration(false)
+                            .configuration("{\"target\":\"https://api.gravitee.io/echo\"}")
+                            .build()
+                    )
+                )
+                .build();
+            givenExistingApi(apiWithEndpointGroups(List.of(group)));
+
+            var body = type == PatchApiUseCase.PatchType.JSON_PATCH
+                ? patch("replace", "/endpointGroups/0/endpoints/0/inheritConfiguration", true)
+                : mergePatch(
+                    "endpointGroups",
+                    List.of(
+                        Map.of(
+                            "name",
+                            "group-a",
+                            "type",
+                            "http-proxy",
+                            "sharedConfiguration",
+                            "{}",
+                            "endpoints",
+                            List.of(
+                                Map.of(
+                                    "name",
+                                    "default-endpoint",
+                                    "type",
+                                    "http-proxy",
+                                    "weight",
+                                    1,
+                                    "inheritConfiguration",
+                                    true,
+                                    "configuration",
+                                    "{\"target\":\"https://api.gravitee.io/echo\"}"
+                                )
+                            )
+                        )
+                    )
+                );
+
+            var output = execute(type, body, false);
+
+            var endpoint = httpV4Def(output.api()).getEndpointGroups().getFirst().getEndpoints().getFirst();
+            assertThat(endpoint.isInheritConfiguration()).isTrue();
+            assertThat(endpoint.getName()).isEqualTo("default-endpoint");
+            assertThat(endpoint.getType()).isEqualTo("http-proxy");
+            assertThat(endpoint.getWeight()).isEqualTo(1);
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void modifying_group_name_persists_only_that_field(PatchApiUseCase.PatchType type) {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+
+            var body = type == PatchApiUseCase.PatchType.JSON_PATCH
+                ? patch("replace", "/endpointGroups/0/name", "group-renamed")
+                : mergePatch("endpointGroups", List.of(groupMap("group-renamed")));
+
+            var output = execute(type, body, false);
+
+            var groups = httpV4Def(output.api()).getEndpointGroups();
+            assertThat(groups).hasSize(1);
+            assertThat(groups.getFirst().getName()).isEqualTo("group-renamed");
+            assertThat(groups.getFirst().getType()).isEqualTo("http-proxy");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void modifying_loadBalancer_type_persists_only_that_field(PatchApiUseCase.PatchType type) {
+            var loadBalancer = new LoadBalancer();
+            loadBalancer.setType(LoadBalancerType.ROUND_ROBIN);
+            var group = aGroup("group-a").toBuilder().loadBalancer(loadBalancer).build();
+            givenExistingApi(apiWithEndpointGroups(List.of(group)));
+
+            var body = type == PatchApiUseCase.PatchType.JSON_PATCH
+                ? patch("replace", "/endpointGroups/0/loadBalancer/type", "RANDOM")
+                : mergePatch(
+                    "endpointGroups",
+                    List.of(
+                        Map.of(
+                            "name",
+                            "group-a",
+                            "type",
+                            "http-proxy",
+                            "sharedConfiguration",
+                            "{}",
+                            "loadBalancer",
+                            Map.of("type", "RANDOM"),
+                            "endpoints",
+                            List.of(
+                                Map.of(
+                                    "name",
+                                    "default-endpoint",
+                                    "type",
+                                    "http-proxy",
+                                    "weight",
+                                    1,
+                                    "inheritConfiguration",
+                                    true,
+                                    "configuration",
+                                    "{\"target\":\"https://api.gravitee.io/echo\"}"
+                                )
+                            )
+                        )
+                    )
+                );
+
+            var output = execute(type, body, false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups().getFirst().getLoadBalancer().getType()).isEqualTo(
+                LoadBalancerType.RANDOM
+            );
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void modifying_endpoint_configuration_blob_persists_only_that_field(PatchApiUseCase.PatchType type) {
+            var group = EndpointGroup.builder()
+                .name("group-a")
+                .type("http-proxy")
+                .sharedConfiguration("{}")
+                .endpoints(
+                    List.of(
+                        Endpoint.builder()
+                            .name("default-endpoint")
+                            .type("http-proxy")
+                            .weight(1)
+                            .inheritConfiguration(true)
+                            .configuration("{\"target\":\"https://original.io\"}")
+                            .build()
+                    )
+                )
+                .build();
+            givenExistingApi(apiWithEndpointGroups(List.of(group)));
+
+            var newConfig = Map.of("target", "https://updated.io");
+            var body = type == PatchApiUseCase.PatchType.JSON_PATCH
+                ? patch("replace", "/endpointGroups/0/endpoints/0/configuration", newConfig)
+                : mergePatch(
+                    "endpointGroups",
+                    List.of(
+                        Map.of(
+                            "name",
+                            "group-a",
+                            "type",
+                            "http-proxy",
+                            "sharedConfiguration",
+                            "{}",
+                            "endpoints",
+                            List.of(
+                                Map.of(
+                                    "name",
+                                    "default-endpoint",
+                                    "type",
+                                    "http-proxy",
+                                    "weight",
+                                    1,
+                                    "inheritConfiguration",
+                                    true,
+                                    "configuration",
+                                    newConfig
+                                )
+                            )
+                        )
+                    )
+                );
+
+            var output = execute(type, body, false);
+
+            var endpoint = httpV4Def(output.api()).getEndpointGroups().getFirst().getEndpoints().getFirst();
+            assertThat(endpoint.getConfiguration()).contains("\"target\":\"https://updated.io\"");
+            assertThat(endpoint.getName()).isEqualTo("default-endpoint");
+            assertThat(endpoint.getType()).isEqualTo("http-proxy");
+            assertThat(endpoint.getWeight()).isEqualTo(1);
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void patch_not_addressing_endpointGroups_leaves_existing_list_intact(PatchApiUseCase.PatchType type) {
+            var existing = List.of(aGroup("group-a"), aGroup("group-b"));
+            givenExistingApi(apiWithEndpointGroups(existing));
+
+            var output = execute(type, setField(type, "name", "renamed"), false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups()).isEqualTo(existing);
+        }
+
+        @Test
+        void successful_endpointGroups_only_patch_delegates_to_audited_update_with_old_and_new_state() {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+            var preGroups = httpV4Def(apiCrudService.storage().getFirst()).getEndpointGroups();
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("endpointGroups", List.of(groupMap("group-b"))), false);
+
+            assertThat(httpV4Def(output.api()).getEndpointGroups()).extracting(EndpointGroup::getName).containsExactly("group-b");
+            var captor = ArgumentCaptor.forClass(Api.class);
+            verify(updateApiDomainService).updateV4(captor.capture(), any());
+            assertThat(httpV4Def(captor.getValue()).getEndpointGroups()).extracting(EndpointGroup::getName).containsExactly("group-b");
+            assertThat(httpV4Def(captor.getValue()).getEndpointGroups()).isNotEqualTo(preGroups);
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void malformed_endpointGroups_element_triggers_validation_exception_with_location_pointer(PatchApiUseCase.PatchType type) {
+            givenExistingApi(apiWithEndpointGroups(List.of(aGroup("group-a"))));
+
+            var malformedGroup = Map.of(
+                "name",
+                "group-a",
+                "type",
+                "http-proxy",
+                "sharedConfiguration",
+                "{}",
+                "endpoints",
+                List.of(
+                    Map.of(
+                        "name",
+                        "default-endpoint",
+                        "type",
+                        "http-proxy",
+                        "weight",
+                        Map.of("not", "an-int"),
+                        "inheritConfiguration",
+                        true,
+                        "configuration",
+                        "{}"
+                    )
+                )
+            );
+            var body = type == PatchApiUseCase.PatchType.JSON_PATCH
+                ? patch("replace", "/endpointGroups", List.of(malformedGroup))
+                : mergePatch("endpointGroups", List.of(malformedGroup));
+
+            assertThatThrownBy(() -> execute(type, body, false))
+                .isInstanceOf(ValidationDomainException.class)
+                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.type(ValidationDomainException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getTechnicalCode()).isEqualTo("invalidValue");
+                    assertThat(ex.getParameters()).containsKey("location");
+                    assertThat(ex.getParameters().get("location")).startsWith("/endpointGroups/0");
+                });
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
@@ -30,6 +30,8 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
@@ -283,6 +285,57 @@ class UpdateApiDomainServiceImplTest {
         var result = cut.validateV4(api, auditInfo);
 
         assertThat(result.getApiDefinitionHttpV4().getResources()).containsExactly(existingResource);
+    }
+
+    @Test
+    void should_return_sanitized_endpoint_groups_from_mutated_update_api_entity() {
+        var api = ApiFixtures.aProxyApiV4();
+        var sanitizedGroups = List.of(
+            EndpointGroup.builder()
+                .name("sanitized-group")
+                .type("http-proxy")
+                .sharedConfiguration("{}")
+                .endpoints(List.of(Endpoint.builder().name("ep").type("http-proxy").weight(1).build()))
+                .build()
+        );
+        stubValidate(entity -> entity.setEndpointGroups(sanitizedGroups));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).isEqualTo(sanitizedGroups);
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_preserve_original_endpoint_groups_when_validator_returns_null() {
+        var originalGroups = List.of(
+            EndpointGroup.builder()
+                .name("original-group")
+                .type("http-proxy")
+                .sharedConfiguration("{}")
+                .endpoints(List.of(Endpoint.builder().name("ep").type("http-proxy").weight(1).build()))
+                .build()
+        );
+        var originalDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().endpointGroups(originalGroups).build();
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
+        stubValidate(entity -> entity.setEndpointGroups(null));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).isEqualTo(originalGroups);
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_return_null_endpoint_groups_when_erased_definition_has_null_endpoint_groups() {
+        var erasedDefinition = ApiFixtures.aProxyApiV4().getApiDefinitionHttpV4().toBuilder().endpointGroups(null).build();
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(erasedDefinition).build();
+        stubValidate(entity -> entity.setEndpointGroups(null));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getEndpointGroups()).isNull();
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 
     @Test


### PR DESCRIPTION
## Issue

[APIM-13946](https://gravitee.atlassian.net/browse/APIM-13946)

## Why

The v4 HTTP Proxy API PATCH endpoint blocked `endpointGroups` even though callers needed a way to add, remove, reorder, and edit endpoint groups without resorting to a full PUT. This change unblocks `endpointGroups` in the PATCH allow-list, giving API operators a scoped, non-destructive way to update endpoint configuration.

## What changed

- **`PatchApiUseCase`**: Moved `endpointGroups` from `BLOCKED_WITHOUT_HINT` to `ALLOWED_FIELDS` and wired it through `applyPatchedValues` and `PatchableView`. Also added deep-path guards that reject JSON Patch operations targeting opaque blobs inside endpoint groups (`configuration/...`, `sharedConfigurationOverride/...`, `sharedConfiguration/...`).
- **`UpdateApiDomainServiceImpl`**: Applied the same null-fallback coalesce pattern to `endpointGroups` in `applySanitizedValues` so the dry-run response echoes the validator-sanitised value.
- **`openapi-apis.yaml`**: Added `endpointGroups` to the patchable-fields prose in the `patch:` operation description.

## User-facing impact

API operators can now PATCH `endpointGroups` on v4 HTTP Proxy APIs (merge-patch and JSON Patch). No breaking changes to existing fields or behaviour.

## How to test

Send a PATCH request to `/v2/apis/{apiId}` with a `Content-Type: application/merge-patch+json` body containing `"endpointGroups": [...]`. The groups should be persisted and returned in the subsequent GET response. The dry-run variant (`?dryRun=true`) should echo the sanitised value without persisting.

[APIM-13946]: https://gravitee.atlassian.net/browse/APIM-13946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ