### PR TITLE
feat(gateway): reject requests containing null bytes

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/index.ts
@@ -28,6 +28,7 @@ export * from './baseApi';
 export * from './cors';
 export * from './definitionContext';
 export * from './definitionVersion';
+export * from './requestValidation';
 export * from './duplicateApiOptions';
 export * from './flowMode';
 export * from './httpMethod';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/requestValidation.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/requestValidation.ts
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-import { EndpointGroupV2 } from './endpointGroupV2';
-import { Failover } from './failover';
-import { LoggingV2 } from './loggingV2';
-import { VirtualHost } from './virtualHost';
-
-import { Cors } from '../cors';
-import { RequestValidation } from '../requestValidation';
-
-export interface Proxy {
-  virtualHosts?: VirtualHost[];
-  groups?: EndpointGroupV2[];
-  failover?: Failover;
-  cors?: Cors;
-  requestValidation?: RequestValidation;
-  logging?: LoggingV2;
-  stripContextPath?: boolean;
-  preserveHost?: boolean;
-  servers?: string[];
+export interface RequestValidation {
+  rejectNullByte?: boolean;
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/httpListener.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/httpListener.ts
@@ -18,9 +18,11 @@ import { BaseListener } from './baseListener';
 import { PathV4 } from './pathV4';
 
 import { Cors } from '../cors';
+import { RequestValidation } from '../requestValidation';
 
 export interface HttpListener extends BaseListener {
   paths?: PathV4[];
   pathMappings?: string[];
   cors?: Cors;
+  requestValidation?: RequestValidation;
 }

--- a/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.html
+++ b/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.html
@@ -176,5 +176,24 @@
     </mat-card-content>
   </mat-card>
 
+  <mat-card class="request-validation-card">
+    <mat-card-header>
+      <mat-card-title>Request validation</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <gio-form-slide-toggle>
+        <gio-form-label>Reject requests containing null bytes</gio-form-label>
+        When enabled, the gateway returns HTTP 400 if any query parameter, header, or path parameter contains a null character
+        (<code>\u0000</code>).
+        <mat-slide-toggle
+          gioFormSlideToggle
+          formControlName="rejectNullByte"
+          aria-label="Reject requests containing null bytes toggle"
+          name="rejectNullByte"
+        ></mat-slide-toggle>
+      </gio-form-slide-toggle>
+    </mat-card-content>
+  </mat-card>
+
   <gio-save-bar [form]="corsForm" [formInitialValues]="initialCorsFormValue" (submitted)="onSubmit()"></gio-save-bar>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/cors/api-cors.component.ts
@@ -25,7 +25,7 @@ import { SnackBarService } from '../../../services-ngx/snack-bar.service';
 import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
 import { CorsUtil } from '../../../shared/utils';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
-import { ApiV4, Cors, HttpListener } from '../../../entities/management-api-v2';
+import { ApiV4, Cors, HttpListener, RequestValidation } from '../../../entities/management-api-v2';
 import { ConnectorPluginsV2Service } from '../../../services-ngx/connector-plugins-v2.service';
 
 @Component({
@@ -60,11 +60,13 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
       .pipe(
         tap(([api, entrypoints]) => {
           let cors: Cors;
+          let requestValidation: RequestValidation;
           if (api.definitionVersion === 'V4') {
-            cors = api.listeners
+            const httpListener: HttpListener | undefined = api.listeners
               .filter((listener) => listener.type === 'HTTP')
-              .map((listener) => listener as HttpListener)
-              .map((httpListener) => httpListener.cors)[0] ?? { enabled: false };
+              .map((listener) => listener as HttpListener)[0];
+            cors = httpListener?.cors ?? { enabled: false };
+            requestValidation = httpListener?.requestValidation ?? { rejectNullByte: false };
 
             const entrypointsSupportingCors = entrypoints.filter(
               (entrypoint) => entrypoint.availableFeatures.find((feature) => feature === 'CORS') != null,
@@ -81,6 +83,7 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
             cors = api.proxy?.cors ?? {
               enabled: false,
             };
+            requestValidation = api.proxy?.requestValidation ?? { rejectNullByte: false };
           }
           const isKubernetesOrigin = api.definitionContext?.origin === 'KUBERNETES';
           const hasUpdatePermission =
@@ -130,6 +133,10 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
             runPolicies: new UntypedFormControl({
               value: cors.runPolicies ?? false,
               disabled: isCorsDisabled,
+            }),
+            rejectNullByte: new UntypedFormControl({
+              value: requestValidation?.rejectNullByte ?? false,
+              disabled: isReadOnly,
             }),
           });
           this.initialCorsFormValue = this.corsForm.getRawValue();
@@ -194,6 +201,7 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
 
   onSubmit() {
     const corsFormValue = this.corsForm.getRawValue();
+    const rejectNullByteDirty = this.corsForm.get('rejectNullByte').dirty;
 
     return this.apiService
       .get(this.activatedRoute.snapshot.params.apiId)
@@ -203,33 +211,41 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
           if (api.definitionVersion === 'V1') {
             this.snackBarService.error('API V1 are deprecated. Please upgrade your API to V2.');
           } else if (api.definitionVersion === 'V2') {
+            const proxy = {
+              ...api.proxy,
+              cors: {
+                ...api.proxy.cors,
+
+                enabled: corsFormValue.enabled,
+                allowOrigin: corsFormValue.allowOrigin,
+                allowMethods: corsFormValue.allowMethods,
+                allowHeaders: corsFormValue.allowHeaders,
+                allowCredentials: corsFormValue.allowCredentials,
+                maxAge: corsFormValue.maxAge,
+                exposeHeaders: corsFormValue.exposeHeaders,
+                allowPrivateNetwork: corsFormValue.allowPrivateNetwork,
+                runPolicies: corsFormValue.runPolicies,
+              },
+            };
+            if (api.proxy?.requestValidation !== undefined || rejectNullByteDirty) {
+              proxy.requestValidation = {
+                ...api.proxy?.requestValidation,
+                rejectNullByte: corsFormValue.rejectNullByte,
+              };
+            }
             apiToUpdate = {
               ...api,
               definitionVersion: 'V2',
-              proxy: {
-                ...api.proxy,
-                cors: {
-                  ...api.proxy.cors,
-
-                  enabled: corsFormValue.enabled,
-                  allowOrigin: corsFormValue.allowOrigin,
-                  allowMethods: corsFormValue.allowMethods,
-                  allowHeaders: corsFormValue.allowHeaders,
-                  allowCredentials: corsFormValue.allowCredentials,
-                  maxAge: corsFormValue.maxAge,
-                  exposeHeaders: corsFormValue.exposeHeaders,
-                  allowPrivateNetwork: corsFormValue.allowPrivateNetwork,
-                  runPolicies: corsFormValue.runPolicies,
-                },
-              },
+              proxy,
             };
           } else {
             apiToUpdate = api;
             apiToUpdate.listeners
               .filter((listener) => listener.type === 'HTTP')
               .forEach((listener) => {
-                listener.cors = {
-                  ...(listener as HttpListener).cors,
+                const httpListener = listener as HttpListener;
+                httpListener.cors = {
+                  ...httpListener.cors,
                   enabled: corsFormValue.enabled,
                   allowOrigin: corsFormValue.allowOrigin,
                   allowMethods: corsFormValue.allowMethods,
@@ -240,6 +256,12 @@ export class ApiCorsComponent implements OnInit, OnDestroy {
                   allowPrivateNetwork: corsFormValue.allowPrivateNetwork,
                   runPolicies: corsFormValue.runPolicies,
                 };
+                if (httpListener.requestValidation !== undefined || rejectNullByteDirty) {
+                  httpListener.requestValidation = {
+                    ...httpListener.requestValidation,
+                    rejectNullByte: corsFormValue.rejectNullByte,
+                  };
+                }
               });
           }
           return this.apiService.update(api.id, apiToUpdate);

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Proxy.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Proxy.java
@@ -44,6 +44,9 @@ public class Proxy implements Serializable {
     @JsonProperty("cors")
     private Cors cors;
 
+    @JsonProperty("request_validation")
+    private RequestValidation requestValidation;
+
     @JsonProperty("logging")
     private Logging logging;
 
@@ -92,6 +95,14 @@ public class Proxy implements Serializable {
 
     public void setCors(Cors cors) {
         this.cors = cors;
+    }
+
+    public RequestValidation getRequestValidation() {
+        return requestValidation;
+    }
+
+    public void setRequestValidation(RequestValidation requestValidation) {
+        this.requestValidation = requestValidation;
     }
 
     public Set<EndpointGroup> getGroups() {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/RequestValidation.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/RequestValidation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/** Per-API request-validation settings. */
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@Builder
+public class RequestValidation implements Serializable {
+
+    @JsonProperty("rejectNullByte")
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    private boolean rejectNullByte;
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/http/HttpListener.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/http/HttpListener.java
@@ -20,6 +20,7 @@ import static java.util.stream.Collectors.toMap;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.gravitee.definition.model.Cors;
 import io.gravitee.definition.model.PathMapping;
+import io.gravitee.definition.model.RequestValidation;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -59,6 +60,8 @@ public class HttpListener extends Listener {
 
     private Cors cors;
 
+    private RequestValidation requestValidation;
+
     public HttpListener() {
         super(ListenerType.HTTP);
     }
@@ -69,6 +72,7 @@ public class HttpListener extends Listener {
         this.pathMappings = b.pathMappings;
         this.pathMappingsPattern = b.pathMappingsPattern;
         this.cors = b.cors;
+        this.requestValidation = b.requestValidation;
     }
 
     public void setPathMappings(final Set<String> pathMappings) {

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-swagger/import-swagger.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-swagger/import-swagger.spec.ts
@@ -81,6 +81,7 @@ describe('API - Imports OpenAPI specification', () => {
         type: 'HTTP',
         servers: [],
         cors: undefined,
+        requestValidation: undefined,
         pathMappings: [],
         entrypoints: [
           {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactory.java
@@ -19,6 +19,7 @@ import static io.gravitee.gateway.handlers.api.ApiReactorHandlerFactory.HANDLERS
 import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.DEFAULT_CLIENT_IDENTIFIER_HEADER;
 
 import io.gravitee.definition.model.Cors;
+import io.gravitee.definition.model.RequestValidation;
 import io.gravitee.gateway.core.logging.utils.LoggingUtils;
 import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.handlers.api.processor.pathparameters.PathParametersExtractor;
@@ -38,6 +39,7 @@ import io.gravitee.gateway.reactive.handlers.api.processor.shutdown.ShutdownProc
 import io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor;
 import io.gravitee.gateway.reactive.handlers.api.processor.transaction.TransactionPostProcessor;
 import io.gravitee.gateway.reactive.handlers.api.processor.transaction.TransactionPostProcessorConfiguration;
+import io.gravitee.gateway.reactive.handlers.api.processor.validation.NullByteRequestProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogInitProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogRequestProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogResponseProcessor;
@@ -99,6 +101,11 @@ public class ApiProcessorChainFactory {
      */
     public ProcessorChain beforeSecurityChain(final Api api, final TracingContext tracingContext) {
         List<Processor> preProcessorList = new ArrayList<>();
+
+        RequestValidation requestValidation = api.getDefinition().getProxy().getRequestValidation();
+        if (requestValidation != null && requestValidation.isRejectNullByte()) {
+            preProcessorList.add(NullByteRequestProcessor.instance());
+        }
 
         Cors cors = api.getDefinition().getProxy().getCors();
         if (cors != null && cors.isEnabled()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/validation/NullByteRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/validation/NullByteRequestProcessor.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.processor.validation;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.ContextAttributes;
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseRequest;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.processor.Processor;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Rejects requests containing a NUL byte ({@code U+0000}) — literal or percent-encoded — in the
+ * URI or any header. Added to the API chain only when {@code RequestValidation.rejectNullByte}
+ * is enabled on the API.
+ */
+@Slf4j
+public class NullByteRequestProcessor implements Processor {
+
+    public static final String ID = "processor-null-byte-request-validation";
+    public static final String NULL_BYTE_REJECTED_KEY = "REQUEST_NULL_BYTE_REJECTED";
+    public static final String NULL_BYTE_REJECTED_MESSAGE = "The request contains invalid characters.";
+
+    static final char NULL_CHAR = '\u0000';
+
+    enum Source {
+        URI("request URI"),
+        HEADER("header");
+
+        private final String label;
+
+        Source(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
+    }
+
+    private NullByteRequestProcessor() {}
+
+    public static NullByteRequestProcessor instance() {
+        return Holder.INSTANCE;
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public Completable execute(final HttpExecutionContextInternal ctx) {
+        return Completable.defer(() -> {
+            final HttpBaseRequest request = ctx.request();
+
+            final Detection detection = scan(request);
+            if (detection == null) {
+                return Completable.complete();
+            }
+
+            log.warn(
+                "Rejected request: null byte detected in {} '{}' (api={}, txn={})",
+                detection.source,
+                detection.name,
+                ctx.getAttribute(ContextAttributes.ATTR_API),
+                ctx.request().transactionId()
+            );
+
+            return ctx.interruptWith(
+                new ExecutionFailure(HttpStatusCode.BAD_REQUEST_400).key(NULL_BYTE_REJECTED_KEY).message(NULL_BYTE_REJECTED_MESSAGE)
+            );
+        });
+    }
+
+    Detection scan(final HttpBaseRequest request) {
+        // Path parameters are populated later in the chain (beforeApiExecution); the URI scan
+        // below catches any null bytes that would surface through them.
+        final String uri = request.uri();
+        if (uri != null && (containsEncodedNullByte(uri) || containsNullByte(uri))) {
+            return new Detection(Source.URI, "query");
+        }
+        return scanHeaders(request.headers());
+    }
+
+    private Detection scanHeaders(final HttpHeaders headers) {
+        if (headers == null) {
+            return null;
+        }
+        for (Map.Entry<String, String> entry : headers) {
+            if (containsNullByte(entry.getKey()) || containsNullByte(entry.getValue()) || containsEncodedNullByte(entry.getValue())) {
+                return new Detection(Source.HEADER, entry.getKey());
+            }
+        }
+        return null;
+    }
+
+    static boolean containsNullByte(final String value) {
+        return value != null && value.indexOf(NULL_CHAR) >= 0;
+    }
+
+    static boolean containsEncodedNullByte(final String value) {
+        if (value == null || value.length() < 3) {
+            return false;
+        }
+        int i = 0;
+        while (true) {
+            int percent = value.indexOf('%', i);
+            if (percent < 0 || percent + 2 >= value.length()) {
+                return false;
+            }
+            if (value.charAt(percent + 1) == '0' && value.charAt(percent + 2) == '0') {
+                return true;
+            }
+            i = percent + 1;
+        }
+    }
+
+    record Detection(Source source, String name) {}
+
+    private static class Holder {
+
+        private static final NullByteRequestProcessor INSTANCE = new NullByteRequestProcessor();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.reactive.handlers.api.v4.processor;
 import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.DEFAULT_CLIENT_IDENTIFIER_HEADER;
 
 import io.gravitee.definition.model.Cors;
+import io.gravitee.definition.model.RequestValidation;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -38,6 +39,7 @@ import io.gravitee.gateway.reactive.handlers.api.processor.shutdown.ShutdownProc
 import io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor;
 import io.gravitee.gateway.reactive.handlers.api.processor.transaction.TransactionPostProcessor;
 import io.gravitee.gateway.reactive.handlers.api.processor.transaction.TransactionPostProcessorConfiguration;
+import io.gravitee.gateway.reactive.handlers.api.processor.validation.NullByteRequestProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogInitProcessor;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.logging.LogRequestProcessor;
@@ -109,8 +111,12 @@ public class ApiProcessorChainFactory {
         final List<Processor> processors = new ArrayList<>();
 
         getHttpListener(api).ifPresent(httpListener -> {
-            final Cors cors = httpListener.getCors();
+            final RequestValidation requestValidation = httpListener.getRequestValidation();
+            if (requestValidation != null && requestValidation.isRejectNullByte()) {
+                processors.add(NullByteRequestProcessor.instance());
+            }
 
+            final Cors cors = httpListener.getCors();
             if (cors != null && cors.isEnabled()) {
                 processors.add(CorsPreflightRequestProcessor.instance());
             }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/validation/NullByteRequestProcessorBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/validation/NullByteRequestProcessorBenchmark.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.processor.validation;
+
+import io.gravitee.common.util.LinkedMultiValueMap;
+import io.gravitee.common.util.MultiValueMap;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 1)
+@State(Scope.Benchmark)
+public class NullByteRequestProcessorBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(NullByteRequestProcessorBenchmark.class.getSimpleName()).forks(1).build();
+        new Runner(opt).run();
+    }
+
+    @Param({ "1", "5", "20", "50" })
+    private int paramCount;
+
+    private MultiValueMap<String, String> cleanParams;
+    private MultiValueMap<String, String> dirtyParams;
+    private String cleanUri;
+    private String dirtyUri;
+
+    @Setup
+    public void setup() {
+        cleanParams = build(paramCount, false);
+        dirtyParams = build(paramCount, true);
+        cleanUri = buildUri(paramCount, false);
+        dirtyUri = buildUri(paramCount, true);
+    }
+
+    @Benchmark
+    public boolean scan_uri_clean() {
+        return (NullByteRequestProcessor.containsEncodedNullByte(cleanUri) || NullByteRequestProcessor.containsNullByte(cleanUri));
+    }
+
+    @Benchmark
+    public boolean scan_uri_dirty() {
+        return (NullByteRequestProcessor.containsEncodedNullByte(dirtyUri) || NullByteRequestProcessor.containsNullByte(dirtyUri));
+    }
+
+    @Benchmark
+    public void scan_clean_params(Blackhole bh) {
+        boolean dirty = false;
+        for (var entry : cleanParams.entrySet()) {
+            if (NullByteRequestProcessor.containsNullByte(entry.getKey())) {
+                dirty = true;
+                break;
+            }
+            for (String value : entry.getValue()) {
+                if (NullByteRequestProcessor.containsNullByte(value)) {
+                    dirty = true;
+                    break;
+                }
+            }
+        }
+        bh.consume(dirty);
+    }
+
+    @Benchmark
+    public void scan_dirty_params(Blackhole bh) {
+        boolean dirty = false;
+        for (var entry : dirtyParams.entrySet()) {
+            if (NullByteRequestProcessor.containsNullByte(entry.getKey())) {
+                dirty = true;
+                break;
+            }
+            for (String value : entry.getValue()) {
+                if (NullByteRequestProcessor.containsNullByte(value)) {
+                    dirty = true;
+                    break;
+                }
+            }
+        }
+        bh.consume(dirty);
+    }
+
+    @Benchmark
+    public void baseline_iterate_only(Blackhole bh) {
+        for (var entry : cleanParams.entrySet()) {
+            bh.consume(entry.getKey());
+            for (String value : entry.getValue()) {
+                bh.consume(value);
+            }
+        }
+    }
+
+    private static MultiValueMap<String, String> build(int count, boolean injectNullByteLast) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        for (int i = 0; i < count; i++) {
+            params.add("param" + i, "value" + i);
+        }
+        if (injectNullByteLast && count > 0) {
+            params.add("evil", "payload\u0000");
+        }
+        return params;
+    }
+
+    private static String buildUri(int count, boolean injectNullByteLast) {
+        StringBuilder sb = new StringBuilder("/api/test?");
+        for (int i = 0; i < count; i++) {
+            if (i > 0) {
+                sb.append('&');
+            }
+            sb.append("param").append(i).append("=value").append(i);
+        }
+        if (injectNullByteLast && count > 0) {
+            sb.append("&evil=payload%00");
+        }
+        return sb.toString();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/validation/NullByteRequestProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/validation/NullByteRequestProcessorTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.processor.validation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
+import io.gravitee.gateway.reactive.handlers.api.processor.AbstractProcessorTest;
+import io.reactivex.rxjava3.observers.TestObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class NullByteRequestProcessorTest extends AbstractProcessorTest {
+
+    private NullByteRequestProcessor processor;
+
+    @BeforeEach
+    public void beforeEach() {
+        processor = NullByteRequestProcessor.instance();
+        lenient().when(mockRequest.uri()).thenReturn("/api/test");
+        lenient().when(mockRequest.transactionId()).thenReturn("tx-test");
+    }
+
+    @Test
+    public void should_complete_when_request_is_clean() {
+        when(mockRequest.uri()).thenReturn("/api/test?prompt=cool&lang=en");
+        spyRequestHeaders.add("X-Custom-Header", "value");
+
+        processor.execute(spyCtx).test().assertResult();
+    }
+
+    @Test
+    public void should_complete_when_uri_has_no_query_string() {
+        when(mockRequest.uri()).thenReturn("/api/test");
+
+        processor.execute(spyCtx).test().assertResult();
+    }
+
+    @Test
+    public void should_reject_with_400_when_encoded_null_byte_in_query_value() {
+        when(mockRequest.uri()).thenReturn("/api/test?prompt=bastard%00");
+
+        TestObserver<Void> observer = processor.execute(spyCtx).test();
+        assertInterruptedWithNullByteFailure(observer);
+    }
+
+    @Test
+    public void should_reject_with_400_when_encoded_null_byte_in_query_key() {
+        when(mockRequest.uri()).thenReturn("/api/test?prompt=cool&prompt%00=bastard");
+
+        TestObserver<Void> observer = processor.execute(spyCtx).test();
+        assertInterruptedWithNullByteFailure(observer);
+    }
+
+    @Test
+    public void should_reject_with_400_when_literal_null_byte_in_uri() {
+        when(mockRequest.uri()).thenReturn("/api/test?prompt=bastard\u0000");
+
+        TestObserver<Void> observer = processor.execute(spyCtx).test();
+        assertInterruptedWithNullByteFailure(observer);
+    }
+
+    @Test
+    public void should_reject_with_400_when_null_byte_in_header_value() {
+        spyRequestHeaders.add("X-Custom-Header", "value\u0000injected");
+
+        TestObserver<Void> observer = processor.execute(spyCtx).test();
+        assertInterruptedWithNullByteFailure(observer);
+    }
+
+    @Test
+    public void should_reject_with_400_when_encoded_null_byte_in_header_value() {
+        spyRequestHeaders.add("Cookie", "session=abc%00def");
+
+        TestObserver<Void> observer = processor.execute(spyCtx).test();
+        assertInterruptedWithNullByteFailure(observer);
+    }
+
+    @Test
+    public void should_reject_with_400_when_null_byte_in_header_name() {
+        spyRequestHeaders.add("X-Custom\u0000Header", "value");
+
+        TestObserver<Void> observer = processor.execute(spyCtx).test();
+        assertInterruptedWithNullByteFailure(observer);
+    }
+
+    @Test
+    public void should_handle_null_uri_without_failing() {
+        when(mockRequest.uri()).thenReturn(null);
+
+        processor.execute(spyCtx).test().assertResult();
+    }
+
+    @Test
+    public void should_detect_uri_null_byte_before_header() {
+        when(mockRequest.uri()).thenReturn("/api/test?prompt=bad%00");
+        spyRequestHeaders.add("X-Bad", "also\u0000bad");
+
+        NullByteRequestProcessor.Detection detection = processor.scan(mockRequest);
+        assertThat(detection).isNotNull();
+        assertThat(detection.source()).isEqualTo(NullByteRequestProcessor.Source.URI);
+    }
+
+    @Test
+    public void contains_null_byte_helper_should_handle_nulls_and_empty() {
+        assertThat(NullByteRequestProcessor.containsNullByte(null)).isFalse();
+        assertThat(NullByteRequestProcessor.containsNullByte("")).isFalse();
+        assertThat(NullByteRequestProcessor.containsNullByte("clean")).isFalse();
+        assertThat(NullByteRequestProcessor.containsNullByte("dir\u0000ty")).isTrue();
+        assertThat(NullByteRequestProcessor.containsNullByte("\u0000")).isTrue();
+    }
+
+    @Test
+    public void contains_encoded_null_byte_helper_should_detect_only_percent_zero_zero() {
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte(null)).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("clean")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("%2F%3F")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("%0")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("%00")).isTrue();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("prefix%00suffix")).isTrue();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("%%00")).isTrue();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("%01%00")).isTrue();
+    }
+
+    @Test
+    public void contains_encoded_null_byte_helper_should_not_throw_on_truncated_percent_at_tail() {
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("a%0")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("ab%0")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("/api/test?p=%0")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("a%")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("ab%")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("/api/test?p=%")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("/api/test?p=%2")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("%%%")).isFalse();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("a%00")).isTrue();
+        assertThat(NullByteRequestProcessor.containsEncodedNullByte("/api/test?p=%00")).isTrue();
+    }
+
+    @Test
+    public void should_have_stable_id() {
+        assertThat(processor.getId()).isEqualTo(NullByteRequestProcessor.ID);
+    }
+
+    private void assertInterruptedWithNullByteFailure(TestObserver<Void> observer) {
+        observer.assertError(InterruptionFailureException.class);
+        observer.assertError(error -> {
+            ExecutionFailure failure = ((InterruptionFailureException) error).getExecutionFailure();
+            assertThat(failure.statusCode()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+            assertThat(failure.key()).isEqualTo(NullByteRequestProcessor.NULL_BYTE_REJECTED_KEY);
+            assertThat(failure.message()).isEqualTo(NullByteRequestProcessor.NULL_BYTE_REJECTED_MESSAGE);
+            return true;
+        });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiCRDMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiCRDMapper.java
@@ -58,6 +58,7 @@ import org.mapstruct.factory.Mappers;
         RuleMapper.class,
         ServiceMapper.class,
         CorsMapper.class,
+        RequestValidationMapper.class,
     }
 )
 public interface ApiCRDMapper {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -99,6 +99,7 @@ import org.slf4j.LoggerFactory;
         RuleMapper.class,
         ServiceMapper.class,
         CorsMapper.class,
+        RequestValidationMapper.class,
         ConfigurationSerializationMapper.class,
     }
 )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ListenerMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ListenerMapper.java
@@ -33,7 +33,7 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(uses = { CorsMapper.class, EndpointMapper.class, EntrypointMapper.class })
+@Mapper(uses = { CorsMapper.class, RequestValidationMapper.class, EndpointMapper.class, EntrypointMapper.class })
 public interface ListenerMapper {
     ListenerMapper INSTANCE = Mappers.getMapper(ListenerMapper.class);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/RequestValidationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/RequestValidationMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.rest.api.management.v2.rest.model.RequestValidation;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface RequestValidationMapper {
+    RequestValidationMapper INSTANCE = Mappers.getMapper(RequestValidationMapper.class);
+
+    io.gravitee.definition.model.RequestValidation map(RequestValidation requestValidation);
+
+    RequestValidation map(io.gravitee.definition.model.RequestValidation requestValidation);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4152,6 +4152,13 @@ components:
                               type: string
                       cors:
                           $ref: "#/components/schemas/Cors"
+                      requestValidation:
+                          $ref: "#/components/schemas/RequestValidation"
+        RequestValidation:
+            type: object
+            properties:
+                rejectNullByte:
+                    type: boolean
         HttpMethod:
             type: string
             description: The method of the selector
@@ -6319,6 +6326,8 @@ components:
                     $ref: "#/components/schemas/Failover"
                 cors:
                     $ref: "#/components/schemas/Cors"
+                requestValidation:
+                    $ref: "#/components/schemas/RequestValidation"
                 logging:
                     $ref: "#/components/schemas/LoggingV2"
                 stripContextPath:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResourceTest.java
@@ -67,6 +67,7 @@ import io.gravitee.rest.api.management.v2.rest.model.ListenerType;
 import io.gravitee.rest.api.management.v2.rest.model.Operator;
 import io.gravitee.rest.api.management.v2.rest.model.PathV4;
 import io.gravitee.rest.api.management.v2.rest.model.Qos;
+import io.gravitee.rest.api.management.v2.rest.model.RequestValidation;
 import io.gravitee.rest.api.management.v2.rest.model.Selector;
 import io.gravitee.rest.api.management.v2.rest.model.StepV4;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiHosts;
@@ -480,20 +481,15 @@ class ApisResourceTest extends AbstractResourceTest {
         }
 
         private static CreateApiV4 aValidV4Api() {
+            HttpListener httpListener = new HttpListener().paths(List.of(new PathV4().path("/path").overrideAccess(false)));
+            httpListener.setType(ListenerType.HTTP);
+            httpListener.setEntrypoints(List.of(new Entrypoint().type("sse").qos(Qos.AUTO)));
+            httpListener.requestValidation(new RequestValidation().rejectNullByte(true));
             return (CreateApiV4) new CreateApiV4()
                 .analytics(new Analytics().enabled(true))
                 .type(ApiType.PROXY)
                 .tags(Set.of("tag1"))
-                .listeners(
-                    List.of(
-                        new Listener(
-                            (HttpListener) new HttpListener()
-                                .paths(List.of(new PathV4().path("/path").overrideAccess(false)))
-                                .type(ListenerType.HTTP)
-                                .entrypoints(List.of(new Entrypoint().type("sse").qos(Qos.AUTO)))
-                        )
-                    )
-                )
+                .listeners(List.of(new Listener(httpListener)))
                 .endpointGroups(
                     List.of(
                         new EndpointGroupV4()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -26,7 +26,10 @@ import io.gravitee.apim.core.integration.model.Integration;
 import io.gravitee.apim.core.integration.model.IntegrationApi;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.RequestValidation;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
@@ -49,9 +52,26 @@ public class ApiModelFactory {
             .environmentId(environmentId)
             .createdAt(now)
             .updatedAt(now)
-            .apiDefinitionHttpV4(newHttpApi.toApiDefinitionBuilder().id(id).build())
+            .apiDefinitionHttpV4(
+                newHttpApi.toApiDefinitionBuilder().id(id).listeners(withRequestValidationDefaults(newHttpApi.getListeners())).build()
+            )
             .lifecycleState(Api.LifecycleState.STOPPED)
             .build();
+    }
+
+    private static List<Listener> withRequestValidationDefaults(List<Listener> listeners) {
+        if (listeners == null) {
+            return null;
+        }
+        return listeners
+            .stream()
+            .map(listener -> {
+                if (listener instanceof HttpListener httpListener && httpListener.getRequestValidation() == null) {
+                    return httpListener.toBuilder().requestValidation(RequestValidation.builder().rejectNullByte(true).build()).build();
+                }
+                return listener;
+            })
+            .collect(Collectors.toList());
     }
 
     public static Api fromNewNativeApi(NewNativeApi newNativeApi, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -403,6 +403,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
         Proxy proxy = new Proxy();
         proxy.setVirtualHosts(singletonList(new VirtualHost(newApiEntity.getContextPath())));
+        proxy.setRequestValidation(RequestValidation.builder().rejectNullByte(true).build());
         EndpointGroup group = new EndpointGroup();
         group.setName("default-group");
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/CreateHttpApiUseCaseTest.java
@@ -70,9 +70,11 @@ import io.gravitee.apim.core.workflow.model.Workflow;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
 import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.definition.model.RequestValidation;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.repository.management.model.ParameterReferenceType;
 import io.gravitee.rest.api.model.parameters.Key;
@@ -241,6 +243,16 @@ class CreateHttpApiUseCaseTest {
         var output = useCase.execute(new Input(newApi, AUDIT_INFO));
 
         // Then
+        var listenersWithRequestValidationDefaults = newApi
+            .getListeners()
+            .stream()
+            .map(listener -> {
+                if (listener instanceof HttpListener httpListener && httpListener.getRequestValidation() == null) {
+                    return httpListener.toBuilder().requestValidation(RequestValidation.builder().rejectNullByte(true).build()).build();
+                }
+                return listener;
+            })
+            .toList();
         var expectedApi = newApi
             .toApiBuilder()
             .id("generated-id")
@@ -250,7 +262,9 @@ class CreateHttpApiUseCaseTest {
             .apiLifecycleState(Api.ApiLifecycleState.CREATED)
             .lifecycleState(Api.LifecycleState.STOPPED)
             .visibility(Api.Visibility.PRIVATE)
-            .apiDefinitionHttpV4(newApi.toApiDefinitionBuilder().id("generated-id").build())
+            .apiDefinitionHttpV4(
+                newApi.toApiDefinitionBuilder().id("generated-id").listeners(listenersWithRequestValidationDefaults).build()
+            )
             .build();
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(output.api()).isEqualTo(new ApiWithFlows(expectedApi, newApi.getFlows()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/V4ApiServiceCockpitTest.java
@@ -54,6 +54,7 @@ import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
 import io.gravitee.apim.infra.template.FreemarkerTemplateProcessor;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.RequestValidation;
 import io.gravitee.definition.model.v4.Api;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
@@ -251,6 +252,7 @@ public class V4ApiServiceCockpitTest {
                                 HttpListener.builder()
                                     .entrypoints(List.of(Entrypoint.builder().type("http-proxy").qos(Qos.AUTO).build()))
                                     .paths(List.of(Path.builder().path("/original/http-proxy/").build()))
+                                    .requestValidation(RequestValidation.builder().rejectNullByte(true).build())
                                     .build()
                             )
                         )


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PEN-36

## Description

### Why
A null byte (U+0000) in a query parameter, header, or path parameter can be used to bypass policy and expression-language checks on the gateway: some downstream stacks (notably PHP) silently strip the byte, so a request like
?prompt=cool&prompt%00=bastard is parsed as two distinct keys by the gateway but collapses to a single key by the backend.

### What

- Adds an opt-in NullByteRequestProcessor that runs at the very top of the API chain (v2 and v4) and returns HTTP 400 when a request contains either the literal NUL char or its percent-encoded form (%00) in the raw URI, the headers, or the path parameters. 
- The toggle is per-API (mirrors CORS) and defaults to true on newly created HTTP APIs; existing APIs and import paths keep their previous behaviour for backwards-compatibility.
- Includes JMH benchmark; production hot path measures 3-62 ns/op depending on URI length, well under the noise floor of a single policy execution.

### Out of scope:
  - Body validation (needs its own design for streaming/buffered)
  - Native (Kafka) and TCP APIs - no HTTP query string

## Additional context

<img width="1747" height="786" alt="image" src="https://github.com/user-attachments/assets/aa08d868-44fb-4859-92e9-f99f3e0f6f2e" />

<img width="936" height="493" alt="image" src="https://github.com/user-attachments/assets/481aa057-63f3-4994-9177-10498bcf3f40" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

